### PR TITLE
[Tool] Add release notes generation skill for Claude Code

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: release-notes
+description: Draft StarRocks release notes for a patch version from the PRs merged into its release branch, then open a [Doc] PR that hands off to the /translate workflow for Chinese and Japanese. Use when a new patch release (e.g. 3.5.19) has been tagged and English release notes are not yet written.
+argument-hint: "[version] e.g. 3.5.19"
+allowed-tools: Read, Edit, Grep, Glob, Bash, Agent
+---
+
+# StarRocks Release Notes
+
+Generate the **English** release-notes section for a tagged StarRocks patch release,
+open a `[Doc]` PR for it, and hand off Chinese/Japanese translation to the existing
+`/translate` workflow. English only — never edit `docs/zh/**` or `docs/ja/**`.
+
+Read `references/format.md` (exact output format) and `references/categorization.md`
+(how to map and rewrite PRs) before drafting. The PR is the human review gate, so favor a
+complete, accurate draft with uncertain items flagged over silent guessing.
+
+## Inputs
+
+- `$ARGUMENTS` = the new patch version, e.g. `3.5.19`. If absent, ask for it.
+- Derive once and reuse:
+  - minor = `3.5`, **branch** = `branch-3.5`
+  - **file** = `docs/en/release_notes/release-3.5.md`
+  - **prev tag** = the previous patch, `3.5.18` (the newest `## X.Y.Z` already in the file;
+    read it to confirm rather than assuming).
+
+## Workflow
+
+### 1. Collect the changes
+Run the collector and capture its JSON:
+
+```bash
+bash .claude/skills/release-notes/scripts/collect-prs.sh <prev_tag> <new_tag>
+# e.g. collect-prs.sh 3.5.18 3.5.19
+```
+
+It returns
+`{ release_date_raw, pr_count, prs: [{number,title,url,base,resolved_to_main,labels,body_excerpt}],
+unresolved_count, unresolved: [...] }` for every PR backported between the two tags. If
+`pr_count` is 0, stop and report — the tags likely don't exist yet or the order is wrong
+(`gh api repos/StarRocks/starrocks/tags`).
+
+Each PR's `number` is already resolved to the **original `main` PR** (release notes always
+cite the main PR). `release_date_raw` is only a **suggestion** (the tag/commit date) — see
+step 4 for the actual release date.
+
+`unresolved` lists any PR whose backport chain did **not** trace back to `main`
+(`resolved_to_main: false`, e.g. a fix authored directly against a release branch). These
+need a PR-quality warning — see step 7.
+
+### 2. Mirror the existing format
+Read the top of the target `file` — the frontmatter, the `:::warning` block, and the
+current newest `## X.Y.Z` section. Match its heading casing, the
+`The following issues have been fixed:` line, and the PR-link style. Do not change
+frontmatter.
+
+### 3. Categorize and rewrite
+Apply `references/categorization.md`:
+- Map each PR to `Behavior Changes` / `Improvements` / `Bug fixes`; exclude
+  `[Doc]`/`[UT]`/`[Tool]` and behavior-neutral `[Refactor]`.
+- Rewrite each title into a user-facing sentence (strip prefixes/scope, backtick
+  identifiers), grouping closely related PRs with space-separated links.
+- Build a **"Needs reviewer confirmation"** list for uncertain section choices, terse
+  titles, or possible upgrade/downgrade-warning items. This list goes in the PR body, not
+  the release notes.
+- **Release date — always ask the user.** The official release date is set by QA and
+  product management and is **not** necessarily the tag/commit date. Prompt the user:
+  "What is the official release date for `<new_tag>`?", offering the detected
+  `release_date_raw` (formatted `Month D, YYYY`) only as a suggested default. Use the
+  user's answer for the `Release date:` line. Do not proceed to write the section until
+  the date is confirmed.
+
+### 4. Write the section
+Insert the new `## X.Y.Z` section into `file` per `references/format.md`: directly below
+the closing `:::` of the `:::warning` block and above the current newest patch section.
+Omit empty subsections. English file only.
+
+### 5. Lint (required so the translation comment appears)
+The `Translation Status Check` workflow only posts the language checkboxes after
+`markdownlint` passes, so the diff must be clean:
+
+```bash
+vale --config=.vale.ini docs/en/release_notes/release-3.5.md
+```
+
+Also run the repo's markdownlint if configured (check `package.json` / `.markdownlint*`).
+Fix any issues. Re-confirm frontmatter/`description` is unchanged.
+
+### 6. Open the PR
+```bash
+git checkout -b release-notes-<new_tag>           # e.g. release-notes-3.5.19
+git add docs/en/release_notes/release-3.5.md
+git commit -s -m "[Doc] Add release notes for StarRocks v<new_tag>"
+git push -u origin release-notes-<new_tag>
+gh pr create --title "[Doc] Add release notes for StarRocks v<new_tag>" --body-file <body>
+```
+
+Fill `.github/PULL_REQUEST_TEMPLATE.md` for the body:
+- **What type of PR**: check `- [x] Doc`.
+- **Change in behavior**: check `- [x] No` (the notes themselves don't change product
+  behavior).
+- **Checklist**: this PR *is* the user documentation; leave test-case boxes unchecked.
+- **Bugfix cherry-pick branch check**: this is a docs PR, not a code backport — leave the
+  version boxes (`4.1`/`4.0`/`3.5`) unchecked unless the user says otherwise.
+- Append the **"Needs reviewer confirmation"** list under "What I'm doing" so reviewers
+  verify the flagged entries.
+
+### 7. Flag PR-quality issues (when `unresolved_count > 0`)
+If the collector reported any `unresolved` PRs (backport chain that never reached `main`),
+post a **single warning comment** on the release-note PR so reviewers can act on it. Do not
+silently drop it — these often indicate a fix that **skipped `main`** and may be missing
+from `main`/future releases (a regression risk), not just a citation quirk.
+
+```bash
+gh pr comment <pr-number> --repo StarRocks/starrocks --body-file <warning>
+```
+
+For each unresolved PR, state in the comment: the number cited in the notes and its `base`
+branch (not `main`), that no `main` PR was found, and the two impacts — (1) the citation is
+inconsistent with the other entries, and (2) verify the fix exists on `main`; forward-port
+if missing. Ask the author to confirm the correct PR number to cite. (Skip this step
+entirely when `unresolved_count` is 0.)
+
+### 8. Hand off translation
+Stop and tell the user:
+- Only `docs/en/release_notes/release-3.5.md` changed.
+- Once `CI DOC Checker → markdownlint` passes on the PR, the
+  **"🌎 Translation Required?"** comment will auto-post with `zh` and `ja` checkboxes.
+- A **docs-maintainer** checks the desired boxes and replies **`/translate`**; the
+  `Translation Runner` workflow (`StarRocks/doc-translator` v1.0.1) then commits the
+  Chinese and Japanese versions into the same PR.
+
+## Notes and limits
+
+- **Whole-file translation**: `/translate` re-translates the entire file, not just the new
+  section. This is the existing established behavior — rely on it; do not change the
+  pipeline or pre-edit `zh`/`ja`.
+- **Behavior changes** are detected heuristically; the "Needs reviewer confirmation" list
+  plus PR review is the safety net (`docs/CLAUDE.md`: never assert unverified technical
+  facts).
+- **Portability**: the only release-specific values are version, branch, file path, and
+  repo. The same skill structure serves other StarRocks lines (e.g. a commercial product)
+  by swapping those constants — author original content, do not copy notes across products.
+- Commits must use `git commit -s` (DCO sign-off).

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -18,11 +18,13 @@ complete, accurate draft with uncertain items flagged over silent guessing.
 ## Inputs
 
 - `$ARGUMENTS` = the new patch version, e.g. `3.5.19`. If absent, ask for it.
-- Derive once and reuse:
-  - minor = `3.5`, **branch** = `branch-3.5`
-  - **file** = `docs/en/release_notes/release-3.5.md`
-  - **prev tag** = the previous patch, `3.5.18` (the newest `## X.Y.Z` already in the file;
-    read it to confirm rather than assuming).
+- Derive once and reuse (examples shown for `3.5.19`):
+  - **minor** = `<MAJOR>.<MINOR>` (e.g. `3.5`), **branch** = `branch-<minor>` (e.g. `branch-3.5`)
+  - **file** = `docs/en/release_notes/release-<minor>.md` (e.g. `docs/en/release_notes/release-3.5.md`)
+  - **prev tag** = the previous patch (e.g. `3.5.18`) — the newest `## X.Y.Z` already in
+    **file**; read it to confirm rather than assuming.
+
+Use the derived **file** path everywhere below — do not hardcode `release-3.5.md`.
 
 ## Workflow
 
@@ -77,19 +79,22 @@ Omit empty subsections. English file only.
 
 ### 5. Lint (required so the translation comment appears)
 The `Translation Status Check` workflow only posts the language checkboxes after
-`markdownlint` passes, so the diff must be clean:
+`markdownlint` passes, so the diff must be clean. Lint the **derived file**, and note the
+Vale config lives at `docs/.vale.ini` and resolves its styles relative to `docs/` — run
+Vale from the `docs/` directory:
 
 ```bash
-vale --config=.vale.ini docs/en/release_notes/release-3.5.md
+# from the docs/ directory, using the version-derived file (e.g. release-3.5.md)
+cd docs && vale --config=.vale.ini en/release_notes/release-<minor>.md
 ```
 
-Also run the repo's markdownlint if configured (check `package.json` / `.markdownlint*`).
-Fix any issues. Re-confirm frontmatter/`description` is unchanged.
+Also run the repo's markdownlint (`docs/.markdownlint.json`) if available. Fix any issues.
+Re-confirm frontmatter/`description` is unchanged.
 
 ### 6. Open the PR
 ```bash
 git checkout -b release-notes-<new_tag>           # e.g. release-notes-3.5.19
-git add docs/en/release_notes/release-3.5.md
+git add docs/en/release_notes/release-<minor>.md  # the derived file, e.g. release-3.5.md
 git commit -s -m "[Doc] Add release notes for StarRocks v<new_tag>"
 git push -u origin release-notes-<new_tag>
 gh pr create --title "[Doc] Add release notes for StarRocks v<new_tag>" --body-file <body>
@@ -123,7 +128,7 @@ entirely when `unresolved_count` is 0.)
 
 ### 8. Hand off translation
 Stop and tell the user:
-- Only `docs/en/release_notes/release-3.5.md` changed.
+- Only the derived English file (e.g. `docs/en/release_notes/release-3.5.md`) changed.
 - Once `CI DOC Checker → markdownlint` passes on the PR, the
   **"🌎 Translation Required?"** comment will auto-post with `zh` and `ja` checkboxes.
 - A **docs-maintainer** checks the desired boxes and replies **`/translate`**; the

--- a/.claude/skills/release-notes/references/categorization.md
+++ b/.claude/skills/release-notes/references/categorization.md
@@ -1,0 +1,75 @@
+# Categorizing and Rewriting PRs into Release-Note Entries
+
+The collector (`scripts/collect-prs.sh`) returns each PR's `number`, `title`, `labels`,
+and a `body_excerpt`. This page defines how the skill turns that raw data into clean,
+user-facing release-note entries. **All prose is the model's job** — the script makes no
+wording decisions.
+
+## Section mapping (by PR title prefix)
+
+StarRocks PR titles start with a bracketed type prefix (enforced by
+`.github/pr-title-checker-config.json`). Map them as follows:
+
+| PR title prefix          | Release-note section | Notes |
+|--------------------------|----------------------|-------|
+| `[BugFix]`               | **Bug fixes**        | Default home for fixes. |
+| `[Enhancement]`          | **Improvements**     | Performance, diagnostics, optimizations. |
+| `[Feature]`              | **Improvements**     | New user-visible capability ("Supports …"). |
+| `[Refactor]`             | *(usually omit)*     | Include only if user-observable; otherwise drop. |
+| `[Doc]`, `[UT]`, `[Tool]`| *(exclude)*          | Internal — never appears in release notes. |
+
+If a PR has no recognizable prefix, fall back to its labels and `body_excerpt` to decide,
+and flag it for reviewer confirmation (see below).
+
+## Behavior Changes (cross-cutting)
+
+`Behavior Changes` is **not** a title prefix — it is a cross-cutting category that overrides
+the table above. Promote an entry to `### Behavior Changes` when the change alters
+**existing observable behavior**, regardless of whether the PR was `[BugFix]` or
+`[Enhancement]`. Signals:
+
+- The **`behavior_changed` label** on the PR. Treat this as authoritative: a PR carrying
+  `behavior_changed` MUST appear in the release notes under `### Behavior Changes` and must
+  never be silently dropped during curation. (These are the entries most often missed in
+  hand-written drafts.)
+- Title/body mentions: changed **default value**, changed **syntax**/parsing, changed
+  **type conversion** or display, a **policy** now enabled/disabled by default, a
+  feature **removed**, or upgrade/downgrade **compatibility**.
+- The PR template's "change in behavior" section is checked with a non-Miscellaneous type.
+
+These mirror the categories in `.github/PULL_REQUEST_TEMPLATE.md`. Behavior-change
+detection is **best-effort**: when unsure whether something is a behavior change vs. a
+plain improvement/fix, place it in the most likely section **and add it to the
+"Needs reviewer confirmation" list** in the PR body. Never silently guess on a
+user-facing behavior claim.
+
+## Rewrite rules (PR title → entry)
+
+1. **Strip the type prefix and any scope.** `[BugFix] Fix NPE in foo(bar)` →
+   describe the user-visible effect, not "Fix …(#)". Drop `module:`/`scope:` noise.
+2. **Write a complete, user-facing sentence**, present tense, ending in a period before
+   the link(s). Prefer the effect on the user over the internal mechanism.
+   - `[Enhancement] add mysql_send_packet_timeout_ms` →
+     "Added a configurable FE write timeout `mysql_send_packet_timeout_ms` …"
+3. **Wrap identifiers in backticks**: config keys, session variables, SQL keywords,
+   function names, type names, table/column names.
+4. **Group closely related PRs** into a single entry when they address the same
+   feature/area, with all PR links space-separated. Do not over-merge unrelated changes.
+5. **Do not fabricate technical detail.** Use only what the PR title/body supports
+   (`docs/CLAUDE.md`: never assert unverified StarRocks technical facts). If the title is
+   too terse to write a meaningful entry, keep it minimal and add it to the
+   "Needs reviewer confirmation" list rather than inventing specifics.
+6. **Order within a section**: Behavior Changes and Improvements roughly by impact;
+   Bug fixes may be grouped thematically (as the existing files do — e.g. "Materialized
+   view issues involving …" followed by several links).
+
+## "Needs reviewer confirmation" list
+
+Collect into a markdown list (for the PR body, not the release notes file) any entry where:
+
+- the section choice (esp. Behavior Changes) was uncertain,
+- the PR title was too terse to confidently describe, or
+- the change might belong in the `:::warning` upgrade/downgrade block.
+
+Each line: the PR number, the chosen section, and the one-line reason. This is the human
+review gate — the PR reviewer confirms or corrects before merge.

--- a/.claude/skills/release-notes/references/format.md
+++ b/.claude/skills/release-notes/references/format.md
@@ -1,0 +1,116 @@
+# StarRocks Release Notes — Format Specification
+
+This is the exact format the `release-notes` skill must follow. It is derived from the
+existing `docs/en/release_notes/release-*.md` files. When in doubt, open the target file
+and copy the style of the most recent `## X.Y.Z` section rather than relying on this page.
+
+## File layout
+
+- **One file per minor version**: `docs/en/release_notes/release-<MAJOR>.<MINOR>.md`
+  (e.g. release `3.5.19` → `docs/en/release_notes/release-3.5.md`).
+- The file already exists for active minor versions. A **patch release is a new
+  `## X.Y.Z` section added to that file** — never a new file.
+- English only. Do **not** create or edit `docs/zh/...` or `docs/ja/...`; the `/translate`
+  workflow produces those.
+
+## Frontmatter — do not modify
+
+The file opens with frontmatter that already exists:
+
+```markdown
+---
+displayed_sidebar: docs
+description: "..."
+---
+```
+
+Leave it exactly as-is. Adding a patch section does **not** change the `description`
+(`docs/CLAUDE.md`: do not change existing frontmatter unless explicitly instructed).
+
+## Document structure
+
+```
+---  (frontmatter)
+# StarRocks version X.Y          <- single H1
+
+:::warning
+**Upgrade Notes** / **Downgrade Notes** ...
+:::
+
+## X.Y.<newest>                  <- newest patch first
+## X.Y.<older>
+...
+```
+
+## Where to insert a new patch section
+
+Insert the new `## X.Y.Z` section **immediately below the closing `:::` of the
+upgrade/downgrade `:::warning` block** and **above the current newest patch section**.
+Patch sections are ordered newest-first. Do not touch the `:::warning` block unless the
+release introduces a new upgrade/downgrade constraint that belongs there (rare; confirm
+with the reviewer rather than inventing one).
+
+## Section template
+
+```markdown
+## X.Y.Z
+
+Release date: Month D, YYYY
+
+### Behavior Changes
+
+- <user-facing description of the change>. [#NNNNN](https://github.com/StarRocks/starrocks/pull/NNNNN)
+
+### Improvements
+
+- <user-facing description>. [#NNNNN](https://github.com/StarRocks/starrocks/pull/NNNNN)
+
+### Bug fixes
+
+The following issues have been fixed:
+
+- <user-facing description>. [#NNNNN](https://github.com/StarRocks/starrocks/pull/NNNNN) [#MMMMM](https://github.com/StarRocks/starrocks/pull/MMMMM)
+```
+
+Rules:
+
+- Use the heading text exactly: `### Behavior Changes`, `### Improvements`, `### Bug fixes`
+  (note the lowercase "fixes" — match the existing file; some older sections use
+  `### Bug Fixes`, but follow the most recent section's casing).
+- **Omit any subsection that has no entries.** Do not emit an empty heading.
+- The `### Bug fixes` section is conventionally preceded by the line
+  `The following issues have been fixed:` — keep it if the existing file uses it.
+- Each entry is a single `-` bullet, a complete sentence ending in a period **before** the
+  PR link(s).
+- **PR links**: `[#NNNNN](https://github.com/StarRocks/starrocks/pull/NNNNN)`. When one
+  entry covers several related PRs, list every link **space-separated** after the sentence.
+- **Release date**: the official date is provided by the user (set by QA/product
+  management), not the detected tag/commit date. Format it as `Month D, YYYY`
+  (e.g. `June 26, 2026`) on a `Release date:` line. The collector's `release_date_raw` is
+  only a suggested default to offer the user.
+- Inline code: wrap identifiers, config keys, SQL keywords, and function names in
+  backticks (e.g. `mysql_send_packet_timeout_ms`, `SHOW`, `get_json_string`).
+- Code fences must declare a language (e.g. ```` ```SQL ````), per docs markdown rules.
+
+## Worked example (modeled on the real `## 3.5.18` section)
+
+```markdown
+## 3.5.19
+
+Release date: June 26, 2026
+
+### Behavior Changes
+
+- `SHOW` statements are now allowed inside explicit transactions. [#72954](https://github.com/StarRocks/starrocks/pull/72954)
+
+### Improvements
+
+- Added a configurable FE write timeout `mysql_send_packet_timeout_ms` for the MySQL result send path to prevent indefinitely blocked result sending to slow clients. [#73646](https://github.com/StarRocks/starrocks/pull/73646)
+- Reduced metadata and lock overhead in load balancing and compaction scheduling paths. [#73555](https://github.com/StarRocks/starrocks/pull/73555) [#72218](https://github.com/StarRocks/starrocks/pull/72218)
+
+### Bug fixes
+
+The following issues have been fixed:
+
+- NPE in Iceberg `getPartitionLastUpdatedTime` when the snapshot is expired. [#68925](https://github.com/StarRocks/starrocks/pull/68925)
+```

--- a/.claude/skills/release-notes/scripts/collect-prs.sh
+++ b/.claude/skills/release-notes/scripts/collect-prs.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# collect-prs.sh — gather the PRs that make up a StarRocks patch release.
+#
+# StarRocks patch releases are cut as backports onto a release branch (branch-X.Y).
+# Each squash-merged commit subject carries its PR number as "(#NNNNN)". This script
+# diffs the previous tag against the new tag via the GitHub compare API, extracts those
+# PR numbers, and enriches each with title/labels/body so the skill can categorize and
+# rewrite them into release-note entries.
+#
+# Read-only. Does NOT write release notes or make any prose decisions — that is the
+# skill's job. Output is JSON on stdout.
+#
+# Usage:
+#   collect-prs.sh <prev_tag> <new_tag> [repo]
+#
+# Examples:
+#   collect-prs.sh 3.5.18 3.5.19
+#   collect-prs.sh v3.5.18 v3.5.19 StarRocks/starrocks
+#
+# Requires: gh (authenticated), jq.
+
+set -euo pipefail
+
+PREV_TAG="${1:?usage: collect-prs.sh <prev_tag> <new_tag> [repo]}"
+NEW_TAG="${2:?usage: collect-prs.sh <prev_tag> <new_tag> [repo]}"
+REPO="${3:-StarRocks/starrocks}"
+
+for bin in gh jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "error: '$bin' is required" >&2; exit 1; }
+done
+
+# Resolve the release date. Prefer the published GitHub release for the new tag; fall back
+# to the tag's commit date when no release is published yet. gh emits an error JSON body on
+# a 404, so accept the value only if it looks like an ISO-8601 timestamp.
+iso_re='^[0-9]{4}-[0-9]{2}-[0-9]{2}T'
+
+release_date="$(
+  gh api "repos/${REPO}/releases/tags/${NEW_TAG}" --jq '.published_at' 2>/dev/null || true
+)"
+if ! [[ "${release_date}" =~ ${iso_re} ]]; then
+  release_date="$(
+    gh api "repos/${REPO}/commits/${NEW_TAG}" --jq '.commit.committer.date' 2>/dev/null || true
+  )"
+fi
+if ! [[ "${release_date}" =~ ${iso_re} ]]; then
+  release_date=""
+fi
+
+# List commits between the two tags and resolve each to the ORIGINAL main PR number.
+#
+# Patch releases are backports onto branch-X.Y. A backport's squash subject looks like:
+#   "<title> (backport #70072) (#74494)"
+# where #70072 is the original PR merged to main and #74494 is the backport PR on the
+# release branch. Release notes cite the ORIGINAL main PR (#70072) — that is the number
+# StarRocks release notes have always used and what reviewers expect — so we extract the
+# first "backport #N" reference (the root original). For a commit with no backport marker
+# (a change merged directly to the branch), we fall back to its own trailing "(#N)".
+#
+# Compare API caps at 250 commits per page; patch releases are well under that.
+# Use a read loop (not mapfile) so this works on macOS bash 3.2.
+pr_numbers=()
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+  # First "backport #N" = the original PR on main (leftmost in a chained backport).
+  # `|| true` keeps a no-match grep from tripping `set -e`.
+  n="$(printf '%s' "$subject" | grep -oiE 'backport #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)"
+  if [[ -z "$n" ]]; then
+    # No backport marker: use the trailing "(#N)" (direct merge to the branch).
+    n="$(printf '%s' "$subject" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)"
+  fi
+  [[ -n "$n" ]] && pr_numbers+=("$n")
+done < <(
+  gh api "repos/${REPO}/compare/${PREV_TAG}...${NEW_TAG}" \
+    --jq '.commits[].commit.message | split("\n")[0]' 2>/dev/null
+)
+# Dedupe while preserving uniqueness (guard against an empty array under set -u).
+if [[ "${#pr_numbers[@]}" -gt 0 ]]; then
+  pr_numbers=($(printf '%s\n' "${pr_numbers[@]}" | sort -un))
+fi
+
+if [[ "${#pr_numbers[@]}" -eq 0 ]]; then
+  echo "warning: no PR numbers found between ${PREV_TAG} and ${NEW_TAG} in ${REPO}." >&2
+  echo "         check that both tags exist (gh api repos/${REPO}/tags) and the order is prev...new." >&2
+fi
+
+# Enrich each PR and resolve it to the ROOT main PR.
+#
+# The candidate number above is usually the original main PR, but in a multi-level backport
+# chain (main -> branch-4.1 -> branch-4.0 -> branch-3.5) the leftmost "backport #N" on the
+# branch-3.5 commit can point at an intermediate release-branch PR rather than main. So when
+# the fetched PR's base branch is not `main`, follow its own "backport #M" reference toward
+# the root (capped at a few hops). This keeps the cited number consistent with how StarRocks
+# release notes reference PRs (always the main PR). PRs that 404 are skipped.
+prs_json="[]"
+for n in "${pr_numbers[@]}"; do
+  cur="$n"
+  pr=""
+  base=""
+  for _hop in 1 2 3 4; do
+    pr="$(gh pr view "$cur" --repo "$REPO" \
+          --json number,title,labels,body,url,baseRefName 2>/dev/null || true)"
+    [[ -z "$pr" ]] && break
+    base="$(jq -r '.baseRefName' <<<"$pr")"
+    [[ "$base" == "main" ]] && break
+    parent="$(jq -r '.title' <<<"$pr" | grep -oiE 'backport #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)"
+    # Stop if there is no parent backport reference or it would loop.
+    [[ -z "$parent" || "$parent" == "$cur" ]] && break
+    cur="$parent"
+  done
+  [[ -z "$pr" ]] && continue
+  # `base` is the base branch of the PR we resolved to. When it is not `main`, the backport
+  # chain did not trace back to a main PR -- usually because the fix was authored directly
+  # against a release branch (or its chain metadata is broken). Flag it so the skill can warn.
+  pr="$(jq -c --arg base "$base" '{
+          number,
+          title,
+          url,
+          base: $base,
+          resolved_to_main: ($base == "main"),
+          labels: [.labels[].name],
+          body_excerpt: ((.body // "") | gsub("\r";"") | .[0:600])
+        }' <<<"$pr")"
+  prs_json="$(jq -c --argjson p "$pr" '. + [$p]' <<<"$prs_json")"
+done
+# Resolution can map two branch PRs onto the same main PR; keep one entry per number.
+prs_json="$(jq -c 'unique_by(.number)' <<<"$prs_json")"
+# PRs whose chain never reached main -- the skill surfaces these as a PR-quality warning.
+unresolved_json="$(jq -c '[.[] | select(.resolved_to_main == false)]' <<<"$prs_json")"
+
+jq -n \
+  --arg repo "$REPO" \
+  --arg prev "$PREV_TAG" \
+  --arg new "$NEW_TAG" \
+  --arg date "$release_date" \
+  --argjson prs "$prs_json" \
+  --argjson unresolved "$unresolved_json" \
+  '{repo: $repo, prev_tag: $prev, new_tag: $new, release_date_raw: $date,
+    pr_count: ($prs | length), prs: $prs,
+    unresolved_count: ($unresolved | length), unresolved: $unresolved}'

--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,9 @@ be/tags
 build/
 cmake-build-debug/
 CMakeLists.txt
-.claude
+# Ignore local Claude Code state, but track shared project skills
+.claude/*
+!.claude/skills/
 !docs/.claude/
 !docs/.claude/**
 docs/.claude/settings.local.json


### PR DESCRIPTION
## Why I'm doing:

Writing StarRocks patch release notes by hand is slow and error-prone: someone has to read every PR merged into a release branch, categorize it, rewrite it into user-facing prose, and cite the right PR. This adds a reusable Claude Code skill that automates the English draft and hands off translation to the existing `/translate` workflow.

## What I'm doing:

Adds a project skill at `.claude/skills/release-notes/`:
- `SKILL.md` — the workflow (collect → categorize → write EN → lint → open PR → hand off zh/ja).
- `references/format.md` — the exact release-notes format spec.
- `references/categorization.md` — PR-prefix/label → section mapping and rewrite rules; treats the `behavior_changed` label as authoritative.
- `scripts/collect-prs.sh` — `gh`/`jq` collector that lists the PRs between two tags, resolves each backport chain to its **original `main` PR**, and reports any PR whose chain does not reach `main` so the skill can post a PR-quality warning (these often indicate a fix that skipped `main`).

Also carves `.claude/skills/` out of the `.gitignore` `.claude` rule so the skill is shared via the repo, while local state (`settings.local.json`) stays ignored.

No product code or docs content changes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr
