### PR TITLE
[BugFix] Fix NPE for MCV-only join histograms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Histogram.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.statistics;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.statistic.StatisticUtils;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +29,8 @@ public class Histogram {
     private final Map<String, Long> mcv;
 
     public Histogram(List<Bucket> buckets, Map<String, Long> mcv) {
-        this.buckets = buckets;
-        this.mcv = mcv;
-
+        this.buckets = buckets == null ? Collections.emptyList() : buckets;
+        this.mcv = mcv == null ? Collections.emptyMap() : mcv;
     }
 
     public long getTotalRows() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -19,6 +19,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
@@ -488,6 +489,39 @@ public class HistogramStatisticsTest {
         Assertions.assertEquals(0.0, estimated.getColumnStatistic(columnRefOperator).getNullsFraction(), 0.001);
     }
 
+    @Test
+    public void testOrPredicateWithMcvOnlyJoinHistogram() {
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.getSessionVariable().setCboEnableHistogramJoinEstimation(true);
+
+        Map<String, Long> leftMcv = Maps.newHashMap();
+        leftMcv.put("10", 300L);
+        leftMcv.put("22", 100L);
+        Histogram leftHistogram = new Histogram(new ArrayList<>(), leftMcv);
+        ColumnRefOperator leftColumn = new ColumnRefOperator(0, IntegerType.BIGINT, "left_v1", true);
+        ColumnStatistic leftStatistic = new ColumnStatistic(1, 50, 0, 4, 500,
+                leftHistogram, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Map<String, Long> rightMcv = Maps.newHashMap();
+        rightMcv.put("22", 80L);
+        rightMcv.put("9", 50L);
+        Histogram rightHistogram = new Histogram(new ArrayList<>(), rightMcv);
+        ColumnRefOperator rightColumn = new ColumnRefOperator(1, IntegerType.BIGINT, "right_v1", true);
+        ColumnStatistic rightStatistic = new ColumnStatistic(1, 50, 0, 4, 500,
+                rightHistogram, ColumnStatistic.StatisticType.ESTIMATE);
+
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(leftColumn, leftStatistic)
+                .addColumnStatistic(rightColumn, rightStatistic)
+                .build();
+        CompoundPredicateOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR,
+                new BinaryPredicateOperator(BinaryType.EQ, leftColumn, rightColumn),
+                new BinaryPredicateOperator(BinaryType.EQ, rightColumn, ConstantOperator.createBigint(0)));
+
+        Assertions.assertDoesNotThrow(() -> PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics));
+    }
 
     @Test
     public void testUpdateHistWithJoin() {
@@ -534,7 +568,7 @@ public class HistogramStatisticsTest {
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithJoin(
                 columnStatisticLeft, IntegerType.BIGINT, columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertNull(exist.get().getBuckets());
+        Assertions.assertTrue(exist.get().getBuckets().isEmpty());
         Assertions.assertEquals(exist.get().getMCV().size(), 1);
         Assertions.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
 


### PR DESCRIPTION
## Why I'm doing:

This fixes #75463, a 4.1.1 regression I hit after upgrading.

The query fails during CBO stats estimation with:

```text
Cannot invoke "java.util.List.size()" because "this.buckets" is null
```

The failing shape is a join histogram that only has MCVs. Later, while estimating an OR predicate in the join condition, the equality-to-constant path calls `Histogram.getRowCountInBucket()`, which assumes `buckets` is non-null.

## What I'm doing:

Make `Histogram` normalize null constructor inputs to empty collections. That keeps "no buckets" represented as an empty list once a `Histogram` object exists, which matches how the stats code already uses it in most places.

I also added a regression test for the MCV-only join histogram plus OR predicate path.

Validation:

`mise exec java@temurin-17 maven@3.9.16 -- ./run-fe-ut.sh --test com.starrocks.sql.optimizer.statistics.HistogramStatisticsTest`

Result: 9 tests, 0 failures, build success.

Fixes #75463

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
