### PR TITLE
[BugFix] Refactoring  UNION ALL dictification to work correctly with SplitWindowSkewToUnion rewrite. (backport #74977)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -373,6 +373,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             info.outputStringColumns.intersect(alls);
             info.decodeStringColumns.intersect(alls);
             info.inputStringColumns.intersect(alls);
+            info.usedStringColumns.intersect(alls);
             if (!info.isEmpty()) {
                 context.operatorDecodeInfo.put(operator, info);
                 if (operator instanceof PhysicalHashAggregateOperator hashAgg) {
@@ -711,17 +712,16 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 List<Integer> childColumnIds = childColumns.stream().map(ColumnRefOperator::getId).toList();
                 boolean isCandidate = childColumns.stream().allMatch(
                         c -> context.outputStringColumns.contains(c) || unionDictionaryManager.isSupportedConstant(c));
-                int outputColumnId = setOp.getOutputColumnRefOp().get(i).getId();
+                ColumnRefOperator outputColumn = setOp.getOutputColumnRefOp().get(i);
                 Integer useChildId;
                 if (isCandidate && (useChildId = unionDictionaryManager.mergeDictionaries(childColumnIds)) != null) {
                     childColumnIds.stream().filter(context.outputStringColumns::contains).forEach(c -> {
                         result.usedStringColumns.union(c);
                         expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
                     });
-                    stringRefToDefineExprMap.put(outputColumnId, childColumns.stream()
-                            .filter(c -> c.getId() == useChildId).findAny().orElseThrow());
-                    expressionStringRefCounter.put(outputColumnId, 1);
-                    result.outputStringColumns.union(outputColumnId);
+                    setDefineExpr(outputColumn, childColumns.stream()
+                            .filter(c -> c.getId() == useChildId).findAny().orElseThrow(), 1);
+                    result.outputStringColumns.union(outputColumn);
                 } else {
                     childColumns.stream().filter(c -> context.outputStringColumns.contains(c))
                             .forEach(result.decodeStringColumns::union);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -244,10 +244,17 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
     @Override
     public OptExpression visitPhysicalUnion(OptExpression optExpression, ColumnRefSet fragmentUseDictExprs) {
         PhysicalUnionOperator unionOp = optExpression.getOp().cast();
-        DecodeInfo info = context.operatorDecodeInfo.getOrDefault(unionOp, DecodeInfo.empty());
+        DecodeInfo info = context.operatorDecodeInfo.get(unionOp);
+        if (info == null) {
+            info = DecodeInfo.empty();
+        }
+        ColumnRefSet encodedUnionColumns = new ColumnRefSet();
+        final DecodeInfo finalInfo = info;
+        encodedUnionColumns.union(unionOp.getOutputColumnRefOp().stream().filter(
+                c -> finalInfo.outputStringColumns.contains(c) || finalInfo.usedStringColumns.contains(c)).toList());
         List<Map<ColumnRefOperator, ConstantOperator>> constantMappings =
                 context.unionDictionaryManager.generateConstantEncodingMap(
-                        unionOp.getOutputColumnRefOp(), unionOp.getChildOutputColumns(), context.allStringColumns);
+                        unionOp.getOutputColumnRefOp(), unionOp.getChildOutputColumns(), encodedUnionColumns);
         List<List<ColumnRefOperator>> newChildOutputColumns = Lists.newArrayList();
         for (int i = 0; i < optExpression.arity(); ++i) {
             Map<ColumnRefOperator, ConstantOperator> constantMapping = constantMappings.get(i);
@@ -255,7 +262,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             constantMapping.forEach((key, value) ->
                     columnMapping.put(key, factory.create(value, value.getType(), value.isNullable())));
             unionOp.getChildOutputColumns().get(i).forEach(c -> columnMapping.putIfAbsent(c,
-                    info.inputStringColumns.contains(c.getId()) ? context.stringRefToDictRefMap.getOrDefault(c, c) : c)
+                    finalInfo.inputStringColumns.contains(c.getId()) ? context.stringRefToDictRefMap.getOrDefault(c, c) : c)
             );
             newChildOutputColumns.add(unionOp.getChildOutputColumns().get(i).stream().map(columnMapping::get).toList());
             if (constantMapping.isEmpty()) {
@@ -274,15 +281,10 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             optExpression.setChild(i, newChild);
         }
         List<ColumnRefOperator> newColumnRefOp = unionOp.getOutputColumnRefOp().stream().map(
-                c -> context.allStringColumns.contains(c.getId())
-                        ? context.stringRefToDictRefMap.get(c) : c).toList();
+                c -> encodedUnionColumns.contains(c) ? context.stringRefToDictRefMap.get(c) : c).toList();
 
-        ColumnRefSet inputColumns = new ColumnRefSet();
-        inputColumns.union(info.inputStringColumns);
-        unionOp.getOutputColumnRefOp().stream().map(ColumnRefOperator::getId).filter(context.allStringColumns::contains)
-                .forEach(inputColumns::union);
-        ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), inputColumns);
-        Projection newProjection = rewriteProjection(unionOp.getProjection(), inputColumns);
+        ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), encodedUnionColumns);
+        Projection newProjection = rewriteProjection(unionOp.getProjection(), encodedUnionColumns);
 
         PhysicalUnionOperator newUnionOp = new PhysicalUnionOperator(newColumnRefOp, newChildOutputColumns,
                 unionOp.isUnionAll(), unionOp.getLimit(), newPredicate, newProjection,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UnionFind;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -181,7 +182,7 @@ public class UnionDictionaryManager {
 
     List<Map<ColumnRefOperator, ConstantOperator>> generateConstantEncodingMap(List<ColumnRefOperator> outputColumns,
                                                                                List<List<ColumnRefOperator>> childColumns,
-                                                                               Set<Integer> allStringColumns) {
+                                                                               ColumnRefSet allStringColumns) {
         List<Map<ColumnRefOperator, ConstantOperator>> result = Lists.newArrayList();
         childColumns.forEach(c -> result.add(Maps.newHashMap()));
         for (int i = 0; i < outputColumns.size(); ++i) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -275,7 +276,8 @@ class UnionDictionaryManagerTest {
         stringRefToDefineExprMap.put(6, col3);
         List<Map<ColumnRefOperator, ConstantOperator>> constantEncodingMap =
                 unionDictionaryManager.generateConstantEncodingMap(List.of(col4, col5, col6),
-                        List.of(List.of(col1, col8, col3), List.of(col7, col2, col9)), Set.of(1, 2, 4, 5));
+                        List.of(List.of(col1, col8, col3), List.of(col7, col2, col9)),
+                        new ColumnRefSet(List.of(col1, col2, col4, col5)));
 
         Assertions.assertEquals(2, constantEncodingMap.size());
         Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -15,12 +15,17 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.ColumnId;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector;
 import com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeInfo;
+import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.sql.optimizer.statistics.StatisticStorage;
+import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -30,6 +35,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 public class LowCardinalityTest2 extends PlanTestBase {
@@ -2811,5 +2817,62 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  16 <-> DictDefine(15: c_user, [upper(<place-holder>)])\n" +
                 "  |  cardinality: 1", plan);
+    }
+
+    @Test
+    void testWindowSkewWithLowCardStringPassthrough() throws Exception {
+        starRocksAssert.withTable(
+                    "CREATE TABLE IF NOT EXISTS window_skew_lc (" +
+                            "  p int NULL, c varchar(50) NULL) " +
+                            "ENGINE=OLAP DUPLICATE KEY(p) " +
+                            "DISTRIBUTED BY HASH(p) BUCKETS 3 PROPERTIES (\"replication_num\"=\"1\");");
+        StatisticStorage prevStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        try {
+            connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(true);
+            FeConstants.runningUnitTest = true;
+            if (!starRocksAssert.databaseExist("_statistics_")) {
+                StatisticsMetaManager m = new StatisticsMetaManager();
+                m.createStatisticsTablesForTest();
+            }
+            final OlapTable t = getOlapTable("window_skew_lc");
+            setTableStatistics(t, 1000);
+            CachedStatisticStorage storage = new CachedStatisticStorage();
+            final List<String> cols = List.of("p", "c");
+            storage.refreshColumnStatistics(t, cols, true);
+            storage.addColumnStatistic(t, "c", ColumnStatistic.builder().setNullsFraction(0.3).build());
+            storage.addColumnStatistic(t, "p", ColumnStatistic.builder().setNullsFraction(0.3).build());
+            storage.getColumnStatistics(t, cols);
+            connectContext.getGlobalStateMgr().setStatisticStorage(storage);
+
+            String sql = """
+                    WITH T AS (
+                      SELECT
+                        c,
+                        ROW_NUMBER()  over (PARTITION BY (CASE WHEN p IS NULL THEN 1 ELSE 0 END) ORDER BY p DESC )
+                      FROM
+                        window_skew_lc
+                    )
+                    SELECT c FROM T
+                    UNION ALL
+                    SELECT NULL FROM T
+                    """;
+
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "24:Decode\n" +
+                    "  |  <dict id 36> : <string id 21>\n" +
+                    "  |  cardinality: 2000\n" +
+                    "  |  \n" +
+                    "  0:UNION\n" +
+                    "  |  output exprs:\n" +
+                    "  |      [36, INT, true]\n" +
+                    "  |  child exprs:\n" +
+                    "  |      [37: c, INT, true]\n" +
+                    "  |      [39: expr, INT, true]");
+        } finally {
+            FeConstants.runningUnitTest = false;
+            starRocksAssert.dropTable("window_skew_lc");
+            connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
+            connectContext.getGlobalStateMgr().setStatisticStorage(prevStorage);
+        }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 1c756ce4ae3993a8d70f980dc0293bbceacea8b6)

## Why I'm doing:
SplitWindowSkewToUnion creates PhysicalUnionOperators with the same output column ids as one of its input branches. This behavior is inconsistent with the current implementation of UNOIN ALL dictification.

## What I'm doing:
DecodeCollector:
Using setDefineExpr() instead of directly registering UNION ALL output columns so that it doesn't overwrite the column definition expressoin incase it was registered before.
DecodeRewriter:
Tracking the output columns generated by this operator instead of relying on context.allStringColumns

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

