### PR TITLE
[Refactor] Decouple runtime filter lifecycle from executors

### DIFF
--- a/be/src/orchestration/fragment_executor.cpp
+++ b/be/src/orchestration/fragment_executor.cpp
@@ -70,7 +70,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/descriptors_ext.h"
 #include "runtime/exec_env.h"
-#include "runtime/runtime_filter_worker.h"
+#include "runtime/runtime_filter_query_lifecycle.h"
 #include "runtime/runtime_state_helper.h"
 
 namespace starrocks::orchestration {
@@ -276,7 +276,8 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
     }
     if (runtime_filter_params != nullptr) {
         _query_ctx->set_is_runtime_filter_coordinator(true);
-        exec_env->runtime_filter_worker()->open_query(query_id, query_options, *runtime_filter_params, true);
+        exec_env->runtime_services().runtime_filter_query_lifecycle->open_query(query_id, query_options,
+                                                                                *runtime_filter_params, true);
     }
     _fragment_ctx->prepare_pass_through_chunk_buffer();
     _fragment_ctx->set_report_when_finish(request.unique().params.__isset.report_when_finish &&

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -60,7 +60,7 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/message_body_sink.h"
 #include "runtime/runtime_filter_cache.h"
-#include "runtime/runtime_filter_worker.h"
+#include "runtime/runtime_filter_query_lifecycle.h"
 
 namespace starrocks {
 
@@ -133,8 +133,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     if (params.__isset.runtime_filter_params && params.runtime_filter_params.id_to_prober_params.size() != 0) {
         _is_runtime_filter_merge_node = true;
         runtime_services(_query_execution_services)
-                .runtime_filter_worker->open_query(_query_id, request.query_options, params.runtime_filter_params,
-                                                   false);
+                .runtime_filter_query_lifecycle->open_query(_query_id, request.query_options,
+                                                            params.runtime_filter_params, false);
     }
     runtime_services(_query_execution_services).stream_mgr->prepare_pass_through_chunk_buffer(_query_id);
 
@@ -417,7 +417,7 @@ void PlanFragmentExecutor::cancel() {
             _runtime_state->fragment_instance_id());
 
     if (_is_runtime_filter_merge_node) {
-        _runtime_state->query_execution_services()->runtime->runtime_filter_worker->close_query(_query_id);
+        _runtime_state->query_execution_services()->runtime->runtime_filter_query_lifecycle->close_query(_query_id);
     }
 }
 
@@ -451,7 +451,7 @@ void PlanFragmentExecutor::close() {
     _chunk.reset();
 
     if (_is_runtime_filter_merge_node) {
-        runtime_services(_query_execution_services).runtime_filter_worker->close_query(_query_id);
+        runtime_services(_query_execution_services).runtime_filter_query_lifecycle->close_query(_query_id);
     }
     runtime_services(_query_execution_services).stream_mgr->destroy_pass_through_chunk_buffer(_query_id);
 

--- a/be/src/runtime/runtime_filter_query_lifecycle.h
+++ b/be/src/runtime/runtime_filter_query_lifecycle.h
@@ -14,14 +14,18 @@
 
 #pragma once
 
-#include "gen_cpp/Types_types.h"
-
 namespace starrocks {
+
+class TQueryOptions;
+class TRuntimeFilterParams;
+class TUniqueId;
 
 class RuntimeFilterQueryLifecycle {
 public:
     virtual ~RuntimeFilterQueryLifecycle() = default;
 
+    virtual void open_query(const TUniqueId& query_id, const TQueryOptions& query_options,
+                            const TRuntimeFilterParams& params, bool is_pipeline) = 0;
     virtual void close_query(const TUniqueId& query_id) = 0;
 };
 

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -41,7 +41,7 @@ public:
     void close();
     // open query for creating runtime filter merger.
     void open_query(const TUniqueId& query_id, const TQueryOptions& query_options, const TRuntimeFilterParams& params,
-                    bool is_pipeline);
+                    bool is_pipeline) override;
     void close_query(const TUniqueId& query_id) override;
     void receive_runtime_filter(const PTransmitRuntimeFilterParams& params);
     void execute();

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -25,7 +25,6 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "runtime/runtime_filter_delivery.h"
 #include "runtime/runtime_filter_merger.h"
-#include "runtime/runtime_filter_port.h"
 #include "runtime/runtime_filter_query_lifecycle.h"
 #include "runtime/runtime_filter_worker_event.h"
 

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -371,13 +371,24 @@ TEST(QueryContextManagerTest, testReadStats) {
 
 class MockRuntimeFilterQueryLifecycle final : public RuntimeFilterQueryLifecycle {
 public:
+    void open_query(const TUniqueId& query_id, const TQueryOptions& query_options, const TRuntimeFilterParams& params,
+                    bool is_pipeline) override {
+        (void)query_options;
+        (void)params;
+        ++num_opened_queries;
+        last_query_id = query_id;
+        last_is_pipeline = is_pipeline;
+    }
+
     void close_query(const TUniqueId& query_id) override {
         ++num_closed_queries;
         last_query_id = query_id;
     }
 
+    int num_opened_queries = 0;
     int num_closed_queries = 0;
     TUniqueId last_query_id;
+    bool last_is_pipeline = false;
 };
 
 TEST(QueryContextManagerTest, testRuntimeFilterCoordinatorClosedOnQueryContextDestruction) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
