### PR TITLE
[Refactor] Move runtime filter metrics into orchestration

### DIFF
--- a/be/src/orchestration/CMakeLists.txt
+++ b/be/src/orchestration/CMakeLists.txt
@@ -18,6 +18,7 @@ set(ORCHESTRATION_FILES
     external_scan_context_mgr.cpp
     external_scan_orchestrator.cpp
     fragment_executor.cpp
+    orchestration_metrics.cpp
     orchestration_env.cpp
     query_orchestrator.cpp
     routine_load_task_executor.cpp

--- a/be/src/orchestration/orchestration_env.cpp
+++ b/be/src/orchestration/orchestration_env.cpp
@@ -19,8 +19,11 @@
 #include "common/logging.h"
 #include "orchestration/external_scan_context_mgr.h"
 #include "orchestration/external_scan_orchestrator.h"
+#include "orchestration/orchestration_metrics.h"
 #include "orchestration/routine_load_task_executor.h"
 #include "orchestration/stream_load_orchestrator.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_filter_worker.h"
 
 namespace starrocks::orchestration {
 
@@ -32,6 +35,12 @@ OrchestrationEnv::~OrchestrationEnv() {
 
 Status OrchestrationEnv::init(ExecEnv* exec_env, MetricRegistry* metrics) {
     DCHECK(exec_env != nullptr);
+
+    _metrics = std::make_unique<OrchestrationMetrics>();
+    _metrics->install(metrics, [exec_env] {
+        auto* runtime_filter_worker = exec_env->runtime_filter_worker();
+        return runtime_filter_worker == nullptr ? nullptr : runtime_filter_worker->metrics();
+    });
 
     _external_scan_context_mgr = std::make_unique<ExternalScanContextMgr>(exec_env, metrics);
     _external_scan_orchestrator =
@@ -55,6 +64,7 @@ void OrchestrationEnv::stop() {
 
 void OrchestrationEnv::destroy() {
     stop();
+    _metrics.reset();
     _routine_load_task_executor.reset();
     _stream_load_orchestrator.reset();
     _external_scan_orchestrator.reset();

--- a/be/src/orchestration/orchestration_env.h
+++ b/be/src/orchestration/orchestration_env.h
@@ -27,6 +27,7 @@ namespace orchestration {
 
 class ExternalScanContextMgr;
 class ExternalScanOrchestrator;
+class OrchestrationMetrics;
 class RoutineLoadTaskExecutor;
 class StreamLoadOrchestrator;
 
@@ -47,6 +48,7 @@ public:
     const ExternalScanOrchestrator* external_scan_orchestrator() const { return _external_scan_orchestrator.get(); }
 
 private:
+    std::unique_ptr<OrchestrationMetrics> _metrics;
     std::unique_ptr<ExternalScanContextMgr> _external_scan_context_mgr;
     std::unique_ptr<ExternalScanOrchestrator> _external_scan_orchestrator;
     std::unique_ptr<StreamLoadOrchestrator> _stream_load_orchestrator;

--- a/be/src/orchestration/orchestration_metrics.cpp
+++ b/be/src/orchestration/orchestration_metrics.cpp
@@ -43,12 +43,6 @@ void OrchestrationMetrics::install(MetricRegistry* registry,
         DCHECK_EQ(_registry, registry);
         return;
     }
-    if (!registry->register_hook(kRuntimeFilterMetricsHookName, [this] { update_runtime_filter_metrics(); })) {
-        LOG(WARNING) << "failed to register orchestration runtime filter metrics hook";
-        return;
-    }
-
-    _registry = registry;
     _runtime_filter_metrics_provider = std::move(runtime_filter_metrics_provider);
     for (int i = 0; i < EventType::MAX_COUNT; i++) {
         auto event_metrics = std::make_unique<RuntimeFilterEventMetrics>();
@@ -60,6 +54,11 @@ void OrchestrationMetrics::install(MetricRegistry* registry,
                                   &event_metrics->runtime_filter_bytes_in_queue);
         _runtime_filter_event_metrics[i] = std::move(event_metrics);
     }
+    if (!registry->register_hook(kRuntimeFilterMetricsHookName, [this] { update_runtime_filter_metrics(); })) {
+        LOG(WARNING) << "failed to register orchestration runtime filter metrics hook";
+        return;
+    }
+    _registry = registry;
 }
 
 void OrchestrationMetrics::update_runtime_filter_metrics() {

--- a/be/src/orchestration/orchestration_metrics.cpp
+++ b/be/src/orchestration/orchestration_metrics.cpp
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "orchestration/orchestration_metrics.h"
+
+#include <atomic>
+#include <utility>
+
+#include "common/logging.h"
+
+namespace starrocks::orchestration {
+
+namespace {
+
+const char* const kRuntimeFilterMetricsHookName = "orchestration_runtime_filter_metrics";
+
+} // namespace
+
+OrchestrationMetrics::~OrchestrationMetrics() {
+    if (_registry != nullptr) {
+        _registry->deregister_hook(kRuntimeFilterMetricsHookName);
+        _registry = nullptr;
+    }
+}
+
+void OrchestrationMetrics::install(MetricRegistry* registry,
+                                   RuntimeFilterMetricsProvider runtime_filter_metrics_provider) {
+    if (registry == nullptr) {
+        return;
+    }
+    if (_registry != nullptr) {
+        DCHECK_EQ(_registry, registry);
+        return;
+    }
+    if (!registry->register_hook(kRuntimeFilterMetricsHookName, [this] { update_runtime_filter_metrics(); })) {
+        LOG(WARNING) << "failed to register orchestration runtime filter metrics hook";
+        return;
+    }
+
+    _registry = registry;
+    _runtime_filter_metrics_provider = std::move(runtime_filter_metrics_provider);
+    for (int i = 0; i < EventType::MAX_COUNT; i++) {
+        auto event_metrics = std::make_unique<RuntimeFilterEventMetrics>();
+        const auto& type = EventTypeToString(static_cast<EventType>(i));
+        auto labels = MetricLabels().add("type", type);
+        registry->register_metric("runtime_filter_events_in_queue", labels,
+                                  &event_metrics->runtime_filter_events_in_queue);
+        registry->register_metric("runtime_filter_bytes_in_queue", labels,
+                                  &event_metrics->runtime_filter_bytes_in_queue);
+        _runtime_filter_event_metrics[i] = std::move(event_metrics);
+    }
+}
+
+void OrchestrationMetrics::update_runtime_filter_metrics() {
+    if (!_runtime_filter_metrics_provider) {
+        return;
+    }
+    const auto* runtime_filter_metrics = _runtime_filter_metrics_provider();
+    if (runtime_filter_metrics == nullptr) {
+        return;
+    }
+    for (int i = 0; i < EventType::MAX_COUNT; i++) {
+        auto* event_metrics = _runtime_filter_event_metrics[i].get();
+        if (event_metrics == nullptr) {
+            continue;
+        }
+        event_metrics->runtime_filter_events_in_queue.set_value(
+                runtime_filter_metrics->event_nums[i].load(std::memory_order_relaxed));
+        event_metrics->runtime_filter_bytes_in_queue.set_value(
+                runtime_filter_metrics->runtime_filter_bytes[i].load(std::memory_order_relaxed));
+    }
+}
+
+} // namespace starrocks::orchestration

--- a/be/src/orchestration/orchestration_metrics.h
+++ b/be/src/orchestration/orchestration_metrics.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+
+#include "base/metrics.h"
+#include "runtime/runtime_filter_worker_event.h"
+
+namespace starrocks::orchestration {
+
+class OrchestrationMetrics {
+public:
+    using RuntimeFilterMetricsProvider = std::function<const RuntimeFilterWorkerMetrics*()>;
+
+    OrchestrationMetrics() = default;
+    ~OrchestrationMetrics();
+
+    void install(MetricRegistry* registry, RuntimeFilterMetricsProvider runtime_filter_metrics_provider);
+    void update_runtime_filter_metrics();
+
+private:
+    struct RuntimeFilterEventMetrics {
+        METRIC_DEFINE_INT_GAUGE(runtime_filter_events_in_queue, MetricUnit::NOUNIT);
+        METRIC_DEFINE_INT_GAUGE(runtime_filter_bytes_in_queue, MetricUnit::BYTES);
+    };
+
+    MetricRegistry* _registry = nullptr;
+    RuntimeFilterMetricsProvider _runtime_filter_metrics_provider;
+    std::array<std::unique_ptr<RuntimeFilterEventMetrics>, EventType::MAX_COUNT> _runtime_filter_event_metrics;
+};
+
+} // namespace starrocks::orchestration

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -26,7 +26,6 @@
 #include "common/config_cache_fwd.h"
 #include "compute_env/query_cache/cache_manager.h"
 #include "jemalloc/jemalloc.h"
-#include "runtime/runtime_filter_worker.h"
 
 namespace starrocks {
 
@@ -61,12 +60,6 @@ private:
     uint64_t _previous_hit_count = 0;
 };
 
-class RuntimeFilterMetrics {
-public:
-    METRIC_DEFINE_INT_GAUGE(runtime_filter_events_in_queue, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(runtime_filter_bytes_in_queue, MetricUnit::BYTES);
-};
-
 SystemMetrics::SystemMetrics() = default;
 
 SystemMetrics* SystemMetrics::instance() {
@@ -82,9 +75,6 @@ SystemMetrics::~SystemMetrics() {
         _registry->deregister_hook(_s_hook_name);
         _registry = nullptr;
     }
-    for (auto& it : _runtime_filter_metrics) {
-        delete it.second;
-    }
 }
 
 void SystemMetrics::install(MetricRegistry* registry) {
@@ -97,7 +87,6 @@ void SystemMetrics::install(MetricRegistry* registry) {
     }
     _install_memory_metrics(registry);
     _install_query_cache_metrics(registry);
-    _install_runtime_filter_metrics(registry);
     _install_vector_index_cache_metrics(registry);
     _registry = registry;
 }
@@ -112,7 +101,6 @@ void SystemMetrics::update() {
 
     update_memory_metrics();
     _update_query_cache_metrics();
-    _update_runtime_filter_metrics();
     _update_vector_index_cache_metrics();
 }
 
@@ -280,36 +268,6 @@ void SystemMetrics::_install_query_cache_metrics(MetricRegistry* registry) {
     registry->register_metric("query_cache_lookup_count", &_query_cache_metrics->query_cache_lookup_count);
     registry->register_metric("query_cache_hit_count", &_query_cache_metrics->query_cache_hit_count);
     registry->register_metric("query_cache_hit_ratio", &_query_cache_metrics->query_cache_hit_ratio);
-}
-
-void SystemMetrics::_install_runtime_filter_metrics(MetricRegistry* registry) {
-    for (int i = 0; i < EventType::MAX_COUNT; i++) {
-        auto* metrics = new RuntimeFilterMetrics();
-        const auto& type = EventTypeToString((EventType)i);
-#define REGISTER_RUNTIME_FILTER_METRIC(name) \
-    registry->register_metric(#name, MetricLabels().add("type", type), &metrics->name)
-        REGISTER_RUNTIME_FILTER_METRIC(runtime_filter_events_in_queue);
-        REGISTER_RUNTIME_FILTER_METRIC(runtime_filter_bytes_in_queue);
-        _runtime_filter_metrics.emplace(type, metrics);
-#undef REGISTER_RUNTIME_FILTER_METRIC
-    }
-}
-
-void SystemMetrics::_update_runtime_filter_metrics() {
-    auto* runtime_filter_worker = ExecEnv::GetInstance()->runtime_filter_worker();
-    if (UNLIKELY(runtime_filter_worker == nullptr)) {
-        return;
-    }
-    const auto* metrics = runtime_filter_worker->metrics();
-    for (int i = 0; i < EventType::MAX_COUNT; i++) {
-        const auto& event_name = EventTypeToString((EventType)i);
-        auto iter = _runtime_filter_metrics.find(event_name);
-        if (iter == _runtime_filter_metrics.end()) {
-            continue;
-        }
-        iter->second->runtime_filter_events_in_queue.set_value(metrics->event_nums[i]);
-        iter->second->runtime_filter_bytes_in_queue.set_value(metrics->runtime_filter_bytes[i]);
-    }
 }
 
 void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry) {

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <mutex>
 
@@ -27,7 +26,6 @@ namespace starrocks {
 
 class QueryCacheMetrics;
 class VectorIndexCacheMetrics;
-class RuntimeFilterMetrics;
 
 class MemoryMetrics {
 public:
@@ -95,10 +93,6 @@ private:
 
     void _update_query_cache_metrics();
 
-    void _install_runtime_filter_metrics(MetricRegistry* registry);
-
-    void _update_runtime_filter_metrics();
-
     void _install_vector_index_cache_metrics(MetricRegistry* registry);
 
     void _update_vector_index_cache_metrics();
@@ -112,7 +106,6 @@ private:
     std::unique_ptr<MemoryMetrics> _memory_metrics;
     std::unique_ptr<QueryCacheMetrics> _query_cache_metrics;
     std::unique_ptr<VectorIndexCacheMetrics> _vector_index_cache_metrics;
-    std::map<std::string, RuntimeFilterMetrics*> _runtime_filter_metrics;
 
     std::mutex _update_mutex;
     MetricRegistry* _registry = nullptr;

--- a/be/test/orchestration/CMakeLists.txt
+++ b/be/test/orchestration/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(orchestration_test
     external_scan_context_mgr_test.cpp
     external_scan_orchestrator_test.cpp
     fragment_executor_test.cpp
+    orchestration_metrics_test.cpp
     query_orchestrator_test.cpp
     stream_load_orchestrator_test.cpp
 )

--- a/be/test/orchestration/orchestration_metrics_test.cpp
+++ b/be/test/orchestration/orchestration_metrics_test.cpp
@@ -1,0 +1,97 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "orchestration/orchestration_metrics.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+
+#include "runtime/runtime_filter_worker_event.h"
+
+namespace starrocks::orchestration {
+
+namespace {
+
+MetricLabels runtime_filter_event_labels(EventType type) {
+    return MetricLabels().add("type", EventTypeToString(type));
+}
+
+Metric* runtime_filter_events_metric(MetricRegistry* registry, EventType type) {
+    return registry->get_metric("runtime_filter_events_in_queue", runtime_filter_event_labels(type));
+}
+
+Metric* runtime_filter_bytes_metric(MetricRegistry* registry, EventType type) {
+    return registry->get_metric("runtime_filter_bytes_in_queue", runtime_filter_event_labels(type));
+}
+
+} // namespace
+
+TEST(OrchestrationMetricsTest, RegistersRuntimeFilterMetricsForEveryEventType) {
+    MetricRegistry registry("test_registry");
+    RuntimeFilterWorkerMetrics runtime_filter_metrics;
+    OrchestrationMetrics metrics;
+
+    metrics.install(&registry, [&runtime_filter_metrics] { return &runtime_filter_metrics; });
+
+    for (int i = 0; i < EventType::MAX_COUNT; i++) {
+        auto type = static_cast<EventType>(i);
+        auto* events_metric = runtime_filter_events_metric(&registry, type);
+        ASSERT_NE(nullptr, events_metric) << EventTypeToString(type);
+        EXPECT_EQ(MetricType::GAUGE, events_metric->type());
+        EXPECT_EQ(MetricUnit::NOUNIT, events_metric->unit());
+
+        auto* bytes_metric = runtime_filter_bytes_metric(&registry, type);
+        ASSERT_NE(nullptr, bytes_metric) << EventTypeToString(type);
+        EXPECT_EQ(MetricType::GAUGE, bytes_metric->type());
+        EXPECT_EQ(MetricUnit::BYTES, bytes_metric->unit());
+    }
+}
+
+TEST(OrchestrationMetricsTest, UpdatesRuntimeFilterMetricsFromProvider) {
+    MetricRegistry registry("test_registry");
+    RuntimeFilterWorkerMetrics runtime_filter_metrics;
+    OrchestrationMetrics metrics;
+    metrics.install(&registry, [&runtime_filter_metrics] { return &runtime_filter_metrics; });
+
+    runtime_filter_metrics.event_nums[RECEIVE_TOTAL_RF].store(7, std::memory_order_relaxed);
+    runtime_filter_metrics.runtime_filter_bytes[RECEIVE_TOTAL_RF].store(2048, std::memory_order_relaxed);
+    runtime_filter_metrics.event_nums[SEND_PART_RF].store(3, std::memory_order_relaxed);
+    runtime_filter_metrics.runtime_filter_bytes[SEND_PART_RF].store(4096, std::memory_order_relaxed);
+
+    registry.trigger_hook();
+
+    EXPECT_STREQ("7", runtime_filter_events_metric(&registry, RECEIVE_TOTAL_RF)->to_string().c_str());
+    EXPECT_STREQ("2048", runtime_filter_bytes_metric(&registry, RECEIVE_TOTAL_RF)->to_string().c_str());
+    EXPECT_STREQ("3", runtime_filter_events_metric(&registry, SEND_PART_RF)->to_string().c_str());
+    EXPECT_STREQ("4096", runtime_filter_bytes_metric(&registry, SEND_PART_RF)->to_string().c_str());
+}
+
+TEST(OrchestrationMetricsTest, DeregistersRuntimeFilterMetricsOnDestruction) {
+    MetricRegistry registry("test_registry");
+    RuntimeFilterWorkerMetrics runtime_filter_metrics;
+
+    {
+        OrchestrationMetrics metrics;
+        metrics.install(&registry, [&runtime_filter_metrics] { return &runtime_filter_metrics; });
+        ASSERT_NE(nullptr, runtime_filter_events_metric(&registry, RECEIVE_TOTAL_RF));
+        ASSERT_NE(nullptr, runtime_filter_bytes_metric(&registry, RECEIVE_TOTAL_RF));
+    }
+
+    EXPECT_EQ(nullptr, runtime_filter_events_metric(&registry, RECEIVE_TOTAL_RF));
+    EXPECT_EQ(nullptr, runtime_filter_bytes_metric(&registry, RECEIVE_TOTAL_RF));
+    registry.trigger_hook();
+}
+
+} // namespace starrocks::orchestration


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
