### PR TITLE
[Refactor] Decouple runtime filter port from worker

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -49,7 +49,6 @@
 #include "exprs/expr_factory.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/RuntimeFilter_types.h"
-#include "runtime/runtime_filter_worker.h"
 
 namespace starrocks {
 

--- a/be/src/exec/pipeline/aggregate/aggregate_operators.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_operators.cpp
@@ -23,7 +23,6 @@
 #include "aggregate_streaming_sink_operator.cpp"
 #include "aggregate_streaming_source_operator.cpp"
 #include "exec/pipeline/fragment_context.h"
-#include "runtime/runtime_filter_worker.h"
 #include "sorted_aggregate_streaming_sink_operator.cpp"
 #include "sorted_aggregate_streaming_source_operator.cpp"
 #include "spillable_aggregate_blocking_sink_operator.cpp"

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -160,7 +160,7 @@ void ExecEnv::_refresh_service_contexts() {
     _runtime_services.batch_write_mgr = _batch_write_mgr;
     _runtime_services.stream_load_executor = _stream_load_executor;
     _runtime_services.small_file_mgr = _small_file_mgr;
-    _runtime_services.runtime_filter_worker = _runtime_filter_worker;
+    _runtime_services.runtime_filter_sender = _runtime_filter_worker;
     _runtime_services.runtime_filter_query_lifecycle = _runtime_filter_worker;
     _runtime_services.runtime_filter_cache = _runtime_filter_cache;
     _runtime_services.profile_report_worker = profile_report_worker();

--- a/be/src/runtime/runtime_filter_event_type.h
+++ b/be/src/runtime/runtime_filter_event_type.h
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+namespace starrocks {
+
+enum EventType {
+    RECEIVE_TOTAL_RF = 0,
+    CLOSE_QUERY = 1,
+    OPEN_QUERY = 2,
+    RECEIVE_PART_RF = 3,
+    SEND_PART_RF = 4,
+    SEND_BROADCAST_GRF = 5,
+    SEND_SKEW_JOIN_BROADCAST_RF = 6,
+    RECEIVE_SKEW_JOIN_BROADCAST_RF = 7,
+    MAX_COUNT
+};
+
+inline std::string EventTypeToString(EventType type) {
+    switch (type) {
+    case RECEIVE_TOTAL_RF:
+        return "RECEIVE_TOTAL_RF";
+    case CLOSE_QUERY:
+        return "CLOSE_QUERY";
+    case OPEN_QUERY:
+        return "OPEN_QUERY";
+    case RECEIVE_PART_RF:
+        return "RECEIVE_PART_RF";
+    case SEND_SKEW_JOIN_BROADCAST_RF:
+        return "SEND_SKEW_JOIN_BROADCAST_RF";
+    case SEND_PART_RF:
+        return "SEND_PART_RF";
+    case SEND_BROADCAST_GRF:
+        return "SEND_BROADCAST_GRF";
+    case RECEIVE_SKEW_JOIN_BROADCAST_RF:
+        return "RECEIVE_SKEW_JOIN_BROADCAST_RF";
+    default:
+        break;
+    }
+    __builtin_unreachable();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/runtime_filter_port.cpp
+++ b/be/src/runtime/runtime_filter_port.cpp
@@ -24,9 +24,8 @@
 #include "exec/runtime_filter/runtime_filter_registry.h"
 #include "runtime/runtime_filter.h"
 #include "runtime/runtime_filter_cache.h"
+#include "runtime/runtime_filter_sender.h"
 #include "runtime/runtime_filter_serde.h"
-#include "runtime/runtime_filter_worker.h"
-#include "runtime/runtime_filter_worker_event.h"
 #include "runtime/runtime_state.h"
 #include "runtime/service_contexts.h"
 #include "types/type_descriptor.h"
@@ -147,11 +146,11 @@ void RuntimeFilterPort::publish_runtime_filters(const std::list<RuntimeFilterBui
                     std::min_element(rf_desc->broadcast_grf_senders().begin(), rf_desc->broadcast_grf_senders().end(),
                                      [](const auto& a, const auto& b) { return a.lo < b.lo; });
             if (passthrough_delivery || *sender_id == state->fragment_instance_id()) {
-                runtime_services(state).runtime_filter_worker->send_broadcast_runtime_filter(
+                runtime_services(state).runtime_filter_sender->send_broadcast_runtime_filter(
                         std::move(params), rf_desc->broadcast_grf_destinations(), timeout_ms, rpc_http_min_size);
             }
         } else {
-            runtime_services(state).runtime_filter_worker->send_part_runtime_filter(
+            runtime_services(state).runtime_filter_sender->send_part_runtime_filter(
                     std::move(params), rf_desc->merge_nodes(), timeout_ms, rpc_http_min_size, EventType::SEND_PART_RF);
         }
     }
@@ -198,7 +197,7 @@ void RuntimeFilterPort::publish_skew_broadcast_join_key_columns(RuntimeFilterBui
     RETURN_IF(!actual_size.status().ok(), (void)nullptr);
     rf_data->resize(actual_size.value());
     *(params.mutable_columntype()) = type_desc.to_protobuf();
-    runtime_services(state).runtime_filter_worker->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
+    runtime_services(state).runtime_filter_sender->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
                                                                             timeout_ms, rpc_http_min_size,
                                                                             EventType::SEND_SKEW_JOIN_BROADCAST_RF);
 }

--- a/be/src/runtime/runtime_filter_sender.h
+++ b/be/src/runtime/runtime_filter_sender.h
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "gen_cpp/RuntimeFilter_types.h"
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/internal_service.pb.h"
+#include "runtime/runtime_filter_event_type.h"
+
+namespace starrocks {
+
+class RuntimeFilterSender {
+public:
+    virtual ~RuntimeFilterSender() = default;
+
+    virtual void send_part_runtime_filter(PTransmitRuntimeFilterParams&& params,
+                                          const std::vector<TNetworkAddress>& addrs, int timeout_ms,
+                                          int64_t rpc_http_min_size, EventType type) = 0;
+    virtual void send_broadcast_runtime_filter(PTransmitRuntimeFilterParams&& params,
+                                               const std::vector<TRuntimeFilterDestination>& destinations,
+                                               int timeout_ms, int64_t rpc_http_min_size) = 0;
+};
+
+} // namespace starrocks

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -26,6 +26,7 @@
 #include "runtime/runtime_filter_delivery.h"
 #include "runtime/runtime_filter_merger.h"
 #include "runtime/runtime_filter_query_lifecycle.h"
+#include "runtime/runtime_filter_sender.h"
 #include "runtime/runtime_filter_worker_event.h"
 
 namespace starrocks {
@@ -33,7 +34,7 @@ namespace starrocks {
 struct RuntimeServices;
 struct RpcServices;
 
-class RuntimeFilterWorker : public RuntimeFilterQueryLifecycle {
+class RuntimeFilterWorker : public RuntimeFilterQueryLifecycle, public RuntimeFilterSender {
 public:
     RuntimeFilterWorker(const RuntimeServices* runtime_services, const RpcServices* rpc_services);
     ~RuntimeFilterWorker();
@@ -46,10 +47,10 @@ public:
     void execute();
     void send_part_runtime_filter(PTransmitRuntimeFilterParams&& params,
                                   const std::vector<starrocks::TNetworkAddress>& addrs, int timeout_ms,
-                                  int64_t rpc_http_min_size, EventType type);
+                                  int64_t rpc_http_min_size, EventType type) override;
     void send_broadcast_runtime_filter(PTransmitRuntimeFilterParams&& params,
                                        const std::vector<TRuntimeFilterDestination>& destinations, int timeout_ms,
-                                       int64_t rpc_http_min_size);
+                                       int64_t rpc_http_min_size) override;
 
     size_t queue_size() const;
     const RuntimeFilterWorkerMetrics* metrics() const { return _metrics; }

--- a/be/src/runtime/runtime_filter_worker_event.h
+++ b/be/src/runtime/runtime_filter_worker_event.h
@@ -17,51 +17,15 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
-#include <string>
 #include <type_traits>
 #include <vector>
 
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "runtime/runtime_filter_event_type.h"
 
 namespace starrocks {
-
-enum EventType {
-    RECEIVE_TOTAL_RF = 0,
-    CLOSE_QUERY = 1,
-    OPEN_QUERY = 2,
-    RECEIVE_PART_RF = 3,
-    SEND_PART_RF = 4,
-    SEND_BROADCAST_GRF = 5,
-    SEND_SKEW_JOIN_BROADCAST_RF = 6,
-    RECEIVE_SKEW_JOIN_BROADCAST_RF = 7,
-    MAX_COUNT
-};
-
-inline std::string EventTypeToString(EventType type) {
-    switch (type) {
-    case RECEIVE_TOTAL_RF:
-        return "RECEIVE_TOTAL_RF";
-    case CLOSE_QUERY:
-        return "CLOSE_QUERY";
-    case OPEN_QUERY:
-        return "OPEN_QUERY";
-    case RECEIVE_PART_RF:
-        return "RECEIVE_PART_RF";
-    case SEND_SKEW_JOIN_BROADCAST_RF:
-        return "SEND_SKEW_JOIN_BROADCAST_RF";
-    case SEND_PART_RF:
-        return "SEND_PART_RF";
-    case SEND_BROADCAST_GRF:
-        return "SEND_BROADCAST_GRF";
-    case RECEIVE_SKEW_JOIN_BROADCAST_RF:
-        return "RECEIVE_SKEW_JOIN_BROADCAST_RF";
-    default:
-        break;
-    }
-    __builtin_unreachable();
-}
 
 // RuntimeFilterWorker works in a separated thread, and does following jobs:
 // 1. deserialize runtime filters.

--- a/be/src/runtime/service_contexts.h
+++ b/be/src/runtime/service_contexts.h
@@ -36,7 +36,7 @@ class ResultBufferMgr;
 class ResultQueueMgr;
 class RuntimeFilterCache;
 class RuntimeFilterQueryLifecycle;
-class RuntimeFilterWorker;
+class RuntimeFilterSender;
 class SmallFileMgr;
 class StorePathRegistry;
 class StreamContextMgr;
@@ -135,7 +135,7 @@ struct RuntimeServices {
     BatchWriteMgr* batch_write_mgr = nullptr;
     StreamLoadExecutor* stream_load_executor = nullptr;
     SmallFileMgr* small_file_mgr = nullptr;
-    RuntimeFilterWorker* runtime_filter_worker = nullptr;
+    RuntimeFilterSender* runtime_filter_sender = nullptr;
     RuntimeFilterQueryLifecycle* runtime_filter_query_lifecycle = nullptr;
     RuntimeFilterCache* runtime_filter_cache = nullptr;
     ProfileReportWorker* profile_report_worker = nullptr;

--- a/be/src/service/service_be/internal_service.cpp
+++ b/be/src/service/service_be/internal_service.cpp
@@ -46,7 +46,6 @@
 #include "runtime/closure_guard.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
-#include "runtime/runtime_filter_worker.h"
 #include "storage/local_tablet_reader.h"
 #include "storage/storage_engine.h"
 

--- a/be/test/runtime/exec_env_test.cpp
+++ b/be/test/runtime/exec_env_test.cpp
@@ -28,6 +28,7 @@
 #include "exec/pipeline/driver_queue_factory.h"
 #include "platform/platform_env.h"
 #include "runtime/env/global_env.h"
+#include "runtime/runtime_filter_worker.h"
 #include "storage/storage_env.h"
 
 namespace starrocks {
@@ -46,6 +47,8 @@ TEST(ExecEnvTest, refresh_service_contexts_keeps_context_views_in_sync) {
     EXPECT_EQ(env.runtime_services().cache_mgr, nullptr);
     EXPECT_EQ(env.runtime_services().spill_dir_mgr, nullptr);
     EXPECT_EQ(env.runtime_services().global_spill_manager, nullptr);
+    EXPECT_EQ(env.runtime_services().runtime_filter_sender, nullptr);
+    EXPECT_EQ(env.runtime_services().runtime_filter_query_lifecycle, nullptr);
 
     ComputeEnvOptions compute_env_options;
     compute_env_options.max_num_pipeline_drivers = 2;
@@ -113,6 +116,10 @@ TEST(ExecEnvTest, refresh_service_contexts_keeps_context_views_in_sync) {
     EXPECT_EQ(env.runtime_services().profile_report_worker, env.compute_env()->profile_report_worker());
     EXPECT_EQ(env.runtime_services().spill_dir_mgr, env.compute_env()->spill_dir_mgr());
     EXPECT_EQ(env.runtime_services().global_spill_manager, env.compute_env()->global_spill_manager());
+    EXPECT_EQ(env.runtime_services().runtime_filter_sender,
+              static_cast<RuntimeFilterSender*>(env._runtime_filter_worker));
+    EXPECT_EQ(env.runtime_services().runtime_filter_query_lifecycle,
+              static_cast<RuntimeFilterQueryLifecycle*>(env._runtime_filter_worker));
 
     EXPECT_EQ(env.agent_services().agent_server, agent_server);
     EXPECT_EQ(env.agent_services().heartbeat_flags, env._heartbeat_flags);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
