### PR TITLE
[BugFix] Fix primitive array elem_type overwrite in ClassAnalyzer:: get_udaf_method_desc

### DIFF
--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -1143,7 +1143,6 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                 default:
                     break;
                 }
-                // elem_type is now set by the switch above; do not overwrite it.
             }
 
             desc->emplace_back(MethodTypeDescriptor{elem_type, elem_is_box, true});

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -1118,10 +1118,10 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                 }
                 // i now points to ';', loop will increment it
             } else {
-                // Primitive array: [Z [B [S [I [J [F [D
+                // Primitive array (e.g. [Z [B [S [I [J [F [D) or multi-dimensional primitive array (e.g. [[J [[I)
                 // Multi-dimensional primitive arrays (num_dims > 1) are unsupported; leave elem_type as TYPE_UNKNOWN.
                 elem_is_box = false;
-                switch (num_dims == 1 ? sign[i] : '\0') {
+                switch (sign[i]) {
                 case 'Z':
                     elem_type = TYPE_BOOLEAN;
                     break;
@@ -1145,6 +1145,9 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                     break;
                 default:
                     break;
+                }
+                if (num_dims > 1) {
+                    elem_type = TYPE_UNKNOWN;
                 }
             }
 

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -1143,7 +1143,7 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                 default:
                     break;
                 }
-                elem_type = TYPE_UNKNOWN;
+                // elem_type is now set by the switch above; do not overwrite it.
             }
 
             desc->emplace_back(MethodTypeDescriptor{elem_type, elem_is_box, true});

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -1067,8 +1067,10 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
         // Handle array types
         if (sign[i] == '[') {
             // Consume all leading '[' (for multi-dimensional arrays)
+            int num_dims = 0;
             while (i < sign.size() && sign[i] == '[') {
                 ++i;
+                ++num_dims;
             }
 
             if (i >= sign.size()) {
@@ -1117,8 +1119,9 @@ Status ClassAnalyzer::get_udaf_method_desc(const std::string& sign, std::vector<
                 // i now points to ';', loop will increment it
             } else {
                 // Primitive array: [Z [B [S [I [J [F [D
+                // Multi-dimensional primitive arrays (num_dims > 1) are unsupported; leave elem_type as TYPE_UNKNOWN.
                 elem_is_box = false;
-                switch (sign[i]) {
+                switch (num_dims == 1 ? sign[i] : '\0') {
                 case 'Z':
                     elem_type = TYPE_BOOLEAN;
                     break;

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -465,6 +465,7 @@ TEST(GetUdafMethodDescTest, PrimitiveBooleanArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_BOOLEAN); // param boolean[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveByteArray) {
@@ -475,6 +476,7 @@ TEST(GetUdafMethodDescTest, PrimitiveByteArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_TINYINT); // param byte[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveShortArray) {
@@ -485,6 +487,7 @@ TEST(GetUdafMethodDescTest, PrimitiveShortArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
     EXPECT_EQ(desc[1].type, TYPE_SMALLINT); // param short[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveIntArray) {
@@ -497,6 +500,7 @@ TEST(GetUdafMethodDescTest, PrimitiveIntArray) {
     EXPECT_EQ(desc[1].type, TYPE_INT);     // param int
     EXPECT_EQ(desc[2].type, TYPE_INT);     // param int[]
     EXPECT_EQ(desc[2].is_array, true);
+    EXPECT_EQ(desc[2].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveLongArray) {
@@ -507,6 +511,7 @@ TEST(GetUdafMethodDescTest, PrimitiveLongArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_BIGINT);  // param long[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveFloatArray) {
@@ -517,6 +522,7 @@ TEST(GetUdafMethodDescTest, PrimitiveFloatArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_FLOAT);   // param float[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 TEST(GetUdafMethodDescTest, PrimitiveDoubleArray) {
@@ -527,6 +533,7 @@ TEST(GetUdafMethodDescTest, PrimitiveDoubleArray) {
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_DOUBLE);  // param double[]
     EXPECT_EQ(desc[1].is_array, true);
+    EXPECT_EQ(desc[1].is_box, false);
 }
 
 // Test: Multi-dimensional primitive array — [[J (long[][])

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -462,8 +462,8 @@ TEST(GetUdafMethodDescTest, PrimitiveBooleanArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([Z)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
-    EXPECT_EQ(desc[1].type, TYPE_BOOLEAN);  // param boolean[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_BOOLEAN); // param boolean[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 
@@ -472,8 +472,8 @@ TEST(GetUdafMethodDescTest, PrimitiveByteArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([B)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);   // return V
-    EXPECT_EQ(desc[1].type, TYPE_TINYINT);   // param byte[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_TINYINT); // param byte[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 
@@ -482,8 +482,8 @@ TEST(GetUdafMethodDescTest, PrimitiveShortArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([S)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);   // return V
-    EXPECT_EQ(desc[1].type, TYPE_SMALLINT);  // param short[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
+    EXPECT_EQ(desc[1].type, TYPE_SMALLINT); // param short[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 
@@ -504,8 +504,8 @@ TEST(GetUdafMethodDescTest, PrimitiveLongArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([J)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
-    EXPECT_EQ(desc[1].type, TYPE_BIGINT);   // param long[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_BIGINT);  // param long[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 
@@ -514,8 +514,8 @@ TEST(GetUdafMethodDescTest, PrimitiveFloatArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([F)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
-    EXPECT_EQ(desc[1].type, TYPE_FLOAT);    // param float[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_FLOAT);   // param float[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 
@@ -524,8 +524,8 @@ TEST(GetUdafMethodDescTest, PrimitiveDoubleArray) {
     std::vector<MethodTypeDescriptor> desc;
     ASSERT_OK(analyzer.get_udaf_method_desc("([D)V", &desc));
     ASSERT_EQ(desc.size(), 2);
-    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
-    EXPECT_EQ(desc[1].type, TYPE_DOUBLE);   // param double[]
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
+    EXPECT_EQ(desc[1].type, TYPE_DOUBLE);  // param double[]
     EXPECT_EQ(desc[1].is_array, true);
 }
 

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -453,7 +453,40 @@ TEST(GetUdafMethodDescTest, UDTFCrashScenarioSignature) {
     EXPECT_EQ(desc[3].type, TYPE_ARRAY);   // param List
 }
 
-// Test: Primitive array parsing — [I, [J, etc. don't end with ';'.
+// Tests: primitive element-type preservation after the elem_type overwrite bug fix.
+// Before the fix, the switch correctly set elem_type but the line immediately after
+// it unconditionally reset it to TYPE_UNKNOWN, so every primitive array appeared
+// as TYPE_UNKNOWN regardless of its actual element type.
+TEST(GetUdafMethodDescTest, PrimitiveBooleanArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([Z)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
+    EXPECT_EQ(desc[1].type, TYPE_BOOLEAN);  // param boolean[]
+    EXPECT_EQ(desc[1].is_array, true);
+}
+
+TEST(GetUdafMethodDescTest, PrimitiveByteArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([B)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);   // return V
+    EXPECT_EQ(desc[1].type, TYPE_TINYINT);   // param byte[]
+    EXPECT_EQ(desc[1].is_array, true);
+}
+
+TEST(GetUdafMethodDescTest, PrimitiveShortArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([S)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);   // return V
+    EXPECT_EQ(desc[1].type, TYPE_SMALLINT);  // param short[]
+    EXPECT_EQ(desc[1].is_array, true);
+}
+
 TEST(GetUdafMethodDescTest, PrimitiveIntArray) {
     ClassAnalyzer analyzer;
     std::vector<MethodTypeDescriptor> desc;
@@ -462,7 +495,38 @@ TEST(GetUdafMethodDescTest, PrimitiveIntArray) {
     ASSERT_EQ(desc.size(), 3);
     EXPECT_EQ(desc[0].type, TYPE_UNKNOWN); // return V
     EXPECT_EQ(desc[1].type, TYPE_INT);     // param int
-    EXPECT_EQ(desc[2].type, TYPE_UNKNOWN); // param int[] (array)
+    EXPECT_EQ(desc[2].type, TYPE_INT);     // param int[]
+    EXPECT_EQ(desc[2].is_array, true);
+}
+
+TEST(GetUdafMethodDescTest, PrimitiveLongArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([J)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
+    EXPECT_EQ(desc[1].type, TYPE_BIGINT);   // param long[]
+    EXPECT_EQ(desc[1].is_array, true);
+}
+
+TEST(GetUdafMethodDescTest, PrimitiveFloatArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([F)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
+    EXPECT_EQ(desc[1].type, TYPE_FLOAT);    // param float[]
+    EXPECT_EQ(desc[1].is_array, true);
+}
+
+TEST(GetUdafMethodDescTest, PrimitiveDoubleArray) {
+    ClassAnalyzer analyzer;
+    std::vector<MethodTypeDescriptor> desc;
+    ASSERT_OK(analyzer.get_udaf_method_desc("([D)V", &desc));
+    ASSERT_EQ(desc.size(), 2);
+    EXPECT_EQ(desc[0].type, TYPE_UNKNOWN);  // return V
+    EXPECT_EQ(desc[1].type, TYPE_DOUBLE);   // param double[]
+    EXPECT_EQ(desc[1].is_array, true);
 }
 
 // Test: Multi-dimensional primitive array — [[J (long[][])


### PR DESCRIPTION
## Why I'm doing:
In ClassAnalyzer:: get_udaf_method_desc, after the switch resolved the element type for primitive arrays ([Z [B [S [I [J [F [D), an unconditional assignment reset it back to TYPE_UNKNOWN, causing primitive array parameters to always appear as unknown type regardless of their actual element type.

## What I'm doing:

Fixes #75478

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
