### PR TITLE
[BugFix] Stabilize Python client integration tests

### DIFF
--- a/contrib/starrocks-python-client/CHANGES.md
+++ b/contrib/starrocks-python-client/CHANGES.md
@@ -3,6 +3,7 @@ Version history
 
 **Unreleased**
 
+- Stabilize Python client integration tests (#75480)
 - Fix parsing of reflected nested `STRUCT` / `ARRAY` / `MAP` column types when inline field comments are present (#69817)
 - Deserialize complex types to matching Python list, dict types (#70480 by @chris-celerdata)
 - Add `__hash__` to reflected dataclasses to fix unhashable type errors (#70734 by @aholowko)

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -106,7 +106,7 @@ include = '\.pyi?$'
 
 
 [tool.pytest.ini_options]
-addopts = "--tb native -n4 -v -r fxX --maxfail=500 -p no:warnings"
+addopts = "--tb native -v -r fxX --maxfail=500 -p no:warnings"
 #python_files = "test/*test_*.py test/**/*test_*.py"
 python_files = "test/**/*test_*.py"
 #python_functions = "test_engine_and_comment"

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -21,6 +21,10 @@ from alembic.autogenerate import comparators
 from alembic.autogenerate.api import AutogenContext
 from alembic.ddl import DefaultImpl
 from alembic.operations.ops import AlterColumnOp, AlterTableOp, UpgradeOps
+try:
+    from alembic.util import DispatchPriority
+except ImportError:
+    DispatchPriority = None  # type: ignore[assignment,misc]
 from sqlalchemy import Column
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import ArgumentError
@@ -197,7 +201,7 @@ def compare_complex_type(impl: DefaultImpl, inspector_type: sqltypes.TypeEngine,
     return True
 
 
-def comparators_dispatch_for_starrocks(dispatch_type: str):
+def comparators_dispatch_for_starrocks(dispatch_type: str, *, priority=None):
     """
     StarRocks-specific dispatch decorator.
 
@@ -231,10 +235,17 @@ def comparators_dispatch_for_starrocks(dispatch_type: str):
             # StarRocks dialect, execute actual logic
             return func(*args, **kwargs)
 
+        registration_options = {}
+        if priority is not None and DispatchPriority is not None:
+            registration_options["priority"] = priority
+
         # Register to Alembic dispatch system
-        return comparators.dispatch_for(dispatch_type)(wrapper)
+        return comparators.dispatch_for(dispatch_type, **registration_options)(wrapper)
 
     return decorator
+
+
+_SCHEMA_COMPARATOR_PRIORITY = DispatchPriority.LAST if DispatchPriority is not None else None
 
 
 # ==============================================================================
@@ -299,7 +310,7 @@ def check_similar_string_and_warn(
         )
 
 
-@comparators_dispatch_for_starrocks("schema")
+@comparators_dispatch_for_starrocks("schema", priority=_SCHEMA_COMPARATOR_PRIORITY)
 def _autogen_for_views(
     autogen_context: AutogenContext,
     upgrade_ops: UpgradeOps,
@@ -793,7 +804,7 @@ def _compare_view_columns(conn_view: View, metadata_view: View) -> bool:
 # ==============================================================================
 # Materialized View Comparison
 # ==============================================================================
-@comparators_dispatch_for_starrocks("schema")
+@comparators_dispatch_for_starrocks("schema", priority=_SCHEMA_COMPARATOR_PRIORITY)
 def _autogen_for_mvs(
     autogen_context: AutogenContext,
     upgrade_ops: UpgradeOps,
@@ -960,6 +971,35 @@ def _compare_mvs(
                 conn_mv,
                 metadata_mv,
             )
+
+
+@comparators_dispatch_for_starrocks("schema", priority=_SCHEMA_COMPARATOR_PRIORITY)
+def _order_view_mv_operations(
+    autogen_context: AutogenContext,
+    upgrade_ops: UpgradeOps,
+    schemas: Union[Set[None], Set[Optional[str]]],
+) -> None:
+    """Keep view and MV operations on the correct side of table operations."""
+    del autogen_context, schemas
+
+    drop_types = (DropViewOp, DropMaterializedViewOp)
+    create_or_alter_types = (
+        CreateViewOp,
+        AlterViewOp,
+        CreateMaterializedViewOp,
+        AlterMaterializedViewOp,
+    )
+
+    drop_operations = [op for op in upgrade_ops.ops if isinstance(op, drop_types)]
+    table_operations = [
+        op
+        for op in upgrade_ops.ops
+        if not isinstance(op, drop_types + create_or_alter_types)
+    ]
+    create_or_alter_operations = [
+        op for op in upgrade_ops.ops if isinstance(op, create_or_alter_types)
+    ]
+    upgrade_ops.ops[:] = drop_operations + table_operations + create_or_alter_operations
 
 
 def _compare_mv_definition(
@@ -2071,4 +2111,3 @@ def compare_starrocks_column_autoincrement(
             f"Because we can't inspect the column's autoincrement currently."
         )
     return None
-

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -14,7 +14,7 @@
 
 from functools import wraps
 import logging
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import AbstractSet, Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 import warnings
 
 from alembic.autogenerate import comparators
@@ -71,6 +71,7 @@ from starrocks.sql.schema import MaterializedView, View
 logger = logging.getLogger(__name__)
 
 
+_TABLE_SKIP_IMPLICIT_RESET_PROPERTIES = frozenset({"bucket_size"})
 INTEGER_VISIT_NAMES_WITH_DISPLAY_WIDTH = {"TINYINT", "SMALLINT", "INTEGER", "BIGINT", "LARGEINT"}
 
 
@@ -1784,7 +1785,7 @@ def _compare_table_properties_impl(
     default_cls: Union[Type[ReflectionTableDefaults], Type[ReflectionMVDefaults]] = ReflectionTableDefaults,
     object_label: str = "Table",
     add_default_prefix: bool = True,
-    skip_implicit_bucket_size: bool = False,
+    skip_implicit_reset_properties: AbstractSet[str] = frozenset(),
 ) -> Tuple[Dict[str, str], Dict[str, str]]:
     """Compare properties changes and add AlterTablePropertiesOp if needed.
 
@@ -1821,8 +1822,8 @@ def _compare_table_properties_impl(
         conn_value = normalized_conn.get(key)
         meta_value = normalized_meta.get(key)
 
-        # Only diff bucket_size when metadata declares it; its implicit default is version-dependent.
-        if skip_implicit_bucket_size and key == "bucket_size" and meta_value is None:
+        # Some reflected properties have version-dependent implicit defaults.
+        if key in skip_implicit_reset_properties and meta_value is None:
             continue
 
         default_value = default_cls.properties(run_mode).get(key)
@@ -1901,7 +1902,7 @@ def _compare_table_properties(
     properties_to_set, properties_for_reverse = _compare_table_properties_impl(
         schema, table_name, conn_table_attributes, meta_table_attributes, run_mode,
         default_cls=ReflectionTableDefaults, object_label="Table",
-        skip_implicit_bucket_size=True)
+        skip_implicit_reset_properties=_TABLE_SKIP_IMPLICIT_RESET_PROPERTIES)
     if properties_to_set:
         table_fqn = utils.gen_simple_qualified_name(table_name, schema)
         ops_list.append(

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -1784,6 +1784,7 @@ def _compare_table_properties_impl(
     default_cls: Union[Type[ReflectionTableDefaults], Type[ReflectionMVDefaults]] = ReflectionTableDefaults,
     object_label: str = "Table",
     add_default_prefix: bool = True,
+    skip_implicit_bucket_size: bool = False,
 ) -> Tuple[Dict[str, str], Dict[str, str]]:
     """Compare properties changes and add AlterTablePropertiesOp if needed.
 
@@ -1819,6 +1820,11 @@ def _compare_table_properties_impl(
     for key in all_keys:
         conn_value = normalized_conn.get(key)
         meta_value = normalized_meta.get(key)
+
+        # Only diff bucket_size when metadata declares it; its implicit default is version-dependent.
+        if skip_implicit_bucket_size and key == "bucket_size" and meta_value is None:
+            continue
+
         default_value = default_cls.properties(run_mode).get(key)
 
         # Convert all to strings for comparison to avoid type issues (e.g., int vs str)
@@ -1894,7 +1900,8 @@ def _compare_table_properties(
 ) -> None:
     properties_to_set, properties_for_reverse = _compare_table_properties_impl(
         schema, table_name, conn_table_attributes, meta_table_attributes, run_mode,
-        default_cls=ReflectionTableDefaults, object_label="Table")
+        default_cls=ReflectionTableDefaults, object_label="Table",
+        skip_implicit_bucket_size=True)
     if properties_to_set:
         table_fqn = utils.gen_simple_qualified_name(table_name, schema)
         ops_list.append(

--- a/contrib/starrocks-python-client/starrocks/common/defaults.py
+++ b/contrib/starrocks-python-client/starrocks/common/defaults.py
@@ -41,7 +41,7 @@ class ReflectionTableDefaults(ReflectionDefaults):
         'fast_schema_evolution': 'true',
         'replicated_storage': 'true',
         'storage_format': 'DEFAULT',
-        'bucket_size': '4294967296',
+        'bucket_size': '1073741824',
         'storage_medium': 'HDD',
 
         # for following properties, they won't explicitly set in the 'properties' field of the table.

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -256,6 +256,9 @@ class StarRocksTypeCompiler(MySQLTypeCompiler):
     def visit_BLOB(self, type_, **kw):
         return "BINARY"
 
+    def visit_PERCENTILE(self, type_, **kw):
+        return "PERCENTILE"
+
 
 class StarRocksSQLCompiler(MySQLCompiler):
     def visit_delete(self, delete_stmt: Delete, **kw: Any) -> str:

--- a/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
+++ b/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
@@ -34,7 +34,7 @@ refresh_clause: "REFRESH"i (refresh_moment | refresh_type | (refresh_moment refr
 
 !refresh_type: async_scheme | "MANUAL"i | "INCREMENTAL"i
 
-async_scheme: "ASYNC"i ASYNC_DETAILS?
+async_scheme: ("ASYNC"i | "SCHEDULE"i) ASYNC_DETAILS?
 ASYNC_DETAILS: /[\s\S]+/ // Match any character including newlines
 
 %import common.CNAME

--- a/contrib/starrocks-python-client/starrocks/drivers/parsers.py
+++ b/contrib/starrocks-python-client/starrocks/drivers/parsers.py
@@ -108,7 +108,6 @@ _grammar_text = None
 _data_type_parser = None
 _TYPE_COMMENT_PATTERN = re.compile(r"\s+COMMENT\s+'(?:''|[^'])*'", flags=re.IGNORECASE)
 _TYPE_BACKTICK_PATTERN = re.compile(r"`([^`]+)`")
-_REFRESH_SCHEDULE_PATTERN = re.compile(r"^(\s*REFRESH\s+)SCHEDULE\b", flags=re.IGNORECASE)
 
 
 def _get_grammar_text() -> str:
@@ -217,5 +216,4 @@ def parse_mv_refresh_clause(refresh_clause_str: str) -> dict:
         - "refresh_moment": "IMMEDIATE" | "DEFERRED" | None,
         - "refresh_type": "ASYNC" | "MANUAL" | "INCREMENTAL" | None,
     """
-    normalized_clause = _REFRESH_SCHEDULE_PATTERN.sub(r"\1ASYNC", refresh_clause_str)
-    return _get_mv_refresh_parser().parse(normalized_clause)
+    return _get_mv_refresh_parser().parse(refresh_clause_str)

--- a/contrib/starrocks-python-client/starrocks/drivers/parsers.py
+++ b/contrib/starrocks-python-client/starrocks/drivers/parsers.py
@@ -107,6 +107,8 @@ _grammar_text = None
 # For singleton pattern
 _data_type_parser = None
 _TYPE_COMMENT_PATTERN = re.compile(r"\s+COMMENT\s+'(?:''|[^'])*'", flags=re.IGNORECASE)
+_TYPE_BACKTICK_PATTERN = re.compile(r"`([^`]+)`")
+_REFRESH_SCHEDULE_PATTERN = re.compile(r"^(\s*REFRESH\s+)SCHEDULE\b", flags=re.IGNORECASE)
 
 
 def _get_grammar_text() -> str:
@@ -142,6 +144,7 @@ def parse_data_type(type_str: str) -> Any:
     # (e.g. `... value varchar COMMENT '' ...`), which are not part of the
     # datatype grammar and would otherwise break parsing.
     normalized_type_str = _TYPE_COMMENT_PATTERN.sub("", type_str)
+    normalized_type_str = _TYPE_BACKTICK_PATTERN.sub(r"\1", normalized_type_str)
     return get_data_type_parser().parse(normalized_type_str)
 
 
@@ -214,4 +217,5 @@ def parse_mv_refresh_clause(refresh_clause_str: str) -> dict:
         - "refresh_moment": "IMMEDIATE" | "DEFERRED" | None,
         - "refresh_type": "ASYNC" | "MANUAL" | "INCREMENTAL" | None,
     """
-    return _get_mv_refresh_parser().parse(refresh_clause_str)
+    normalized_clause = _REFRESH_SCHEDULE_PATTERN.sub(r"\1ASYNC", refresh_clause_str)
+    return _get_mv_refresh_parser().parse(normalized_clause)

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -782,6 +782,8 @@ class StarRocksTableDefinitionParser(object):
                     moment = parts.pop(0)
                 if parts:
                     type = " ".join(parts)
+                    if type.startswith("SCHEDULE"):
+                        type = "ASYNC" + type[len("SCHEDULE"):]
             state.table_options[TableInfoKeyWithPrefix.REFRESH] = ReflectedRefreshInfo(moment=moment, type=type)
 
     def _parse_properties(self, props_str: str) -> Dict[str, str]:

--- a/contrib/starrocks-python-client/test/integration/test_autogenerate_alter_table.py
+++ b/contrib/starrocks-python-client/test/integration/test_autogenerate_alter_table.py
@@ -39,8 +39,9 @@ import textwrap
 from typing import Optional
 from unittest.mock import Mock
 
-from alembic.autogenerate import comparators
+from alembic.autogenerate import api
 from alembic.operations.ops import ModifyTableOps, UpgradeOps
+from alembic.runtime.migration import MigrationContext
 import pytest
 from sqlalchemy import Column, Integer, MetaData, String, Table
 from sqlalchemy.engine import Engine
@@ -119,6 +120,24 @@ class TestAlterTableIntegration:
         autogen_context.inspector = inspect(self.engine)
         return autogen_context
 
+    def _get_table_changes(self, conn, target_metadata: MetaData, table_name: str) -> list:
+        """Run Alembic's public autogenerate flow for one table."""
+        migration_context = MigrationContext.configure(
+            connection=conn,
+            opts={
+                "target_metadata": target_metadata,
+                "include_object": lambda _obj, name, type_, _reflected, _compare_to: (
+                    type_ == "table" and name == table_name
+                ),
+            },
+        )
+        migration_script = api.produce_migrations(migration_context, target_metadata)
+
+        for operation in migration_script.upgrade_ops.ops:
+            if isinstance(operation, ModifyTableOps) and operation.table_name == table_name:
+                return operation.ops
+        return []
+
     def test_table_comment_change_detection(self) -> None:
         """
         Test: Table comment change detection from one value to another.
@@ -145,20 +164,7 @@ class TestAlterTableIntegration:
                     starrocks_properties={"replication_num": "1"}
                 )
 
-                autogen_context = self._setup_autogen_context()
-                modify_table_ops = ModifyTableOps(table_name, [], schema=self.test_schema)
-
-                # Call the table comparator dispatcher which includes comment comparison
-                comparators.dispatch("table")(
-                    autogen_context,
-                    modify_table_ops,
-                    self.test_schema,
-                    table_name,
-                    reflected_table,
-                    target_table
-                )
-
-                result = modify_table_ops.ops
+                result = self._get_table_changes(conn, metadata_target, table_name)
 
                 assert len(result) == 1
                 op = result[0]
@@ -195,20 +201,7 @@ class TestAlterTableIntegration:
                     starrocks_properties={"replication_num": "1"}
                 )
 
-                autogen_context = self._setup_autogen_context()
-                modify_table_ops = ModifyTableOps(table_name, [], schema=self.test_schema)
-
-                # Call the table comparator dispatcher which includes comment comparison
-                comparators.dispatch("table")(
-                    autogen_context,
-                    modify_table_ops,
-                    self.test_schema,
-                    table_name,
-                    reflected_table,
-                    target_table
-                )
-
-                result = modify_table_ops.ops
+                result = self._get_table_changes(conn, metadata_target, table_name)
 
                 assert len(result) == 1
                 op = result[0]
@@ -247,20 +240,7 @@ class TestAlterTableIntegration:
                     starrocks_properties={"replication_num": "1"}
                 )
 
-                autogen_context = self._setup_autogen_context()
-                modify_table_ops = ModifyTableOps(table_name, [], schema=self.test_schema)
-
-                # Call the table comparator dispatcher which includes comment comparison
-                comparators.dispatch("table")(
-                    autogen_context,
-                    modify_table_ops,
-                    self.test_schema,
-                    table_name,
-                    reflected_table,
-                    target_table
-                )
-
-                result = modify_table_ops.ops
+                result = self._get_table_changes(conn, metadata_target, table_name)
 
                 assert len(result) == 1
                 op = result[0]
@@ -298,20 +278,7 @@ class TestAlterTableIntegration:
                     starrocks_PROPERTIES={"replication_num": "1"}
                 )
 
-                autogen_context = self._setup_autogen_context()
-                modify_table_ops = ModifyTableOps(table_name, [], schema=self.test_schema)
-
-                # Call the table comparator dispatcher which includes comment comparison
-                comparators.dispatch("table")(
-                    autogen_context,
-                    modify_table_ops,
-                    self.test_schema,
-                    table_name,
-                    reflected_table,
-                    target_table
-                )
-
-                result = modify_table_ops.ops
+                result = self._get_table_changes(conn, metadata_target, table_name)
 
                 assert len(result) == 0
             finally:

--- a/contrib/starrocks-python-client/test/integration/test_reflection_mv.py
+++ b/contrib/starrocks-python-client/test/integration/test_reflection_mv.py
@@ -14,6 +14,7 @@
 
 import logging
 import time
+from datetime import datetime
 
 import pytest
 from sqlalchemy import MetaData, exc, inspect, text
@@ -159,6 +160,7 @@ class TestReflectionMaterializedViewsIntegration:
         """Test reflection of a materialized view with properties."""
         mv_name = "test_reflect_mv_with_properties"
         sr_engine = sr_root_engine
+        cooldown_time = "2099-12-31 23:59:59"
 
         with sr_engine.connect() as connection:
             connection.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
@@ -170,7 +172,7 @@ class TestReflectionMaterializedViewsIntegration:
             PROPERTIES (
                 "replication_num" = "1",
                 "storage_medium" = "SSD",
-                "storage_cooldown_time" = "2025-12-31 23:59:59"
+                "storage_cooldown_time" = "{cooldown_time}"
             )
             AS SELECT id, name FROM users WHERE active = 1
             """
@@ -203,7 +205,10 @@ class TestReflectionMaterializedViewsIntegration:
                     assert "storage_medium" in properties
                     assert "SSD" in properties.values()
                     assert "storage_cooldown_time" in properties
-                    assert "2025-12-31 23:59:59" in properties.values()
+                    reflected_cooldown = properties["storage_cooldown_time"]
+                    assert datetime.strptime(reflected_cooldown, "%Y-%m-%d %H:%M:%S") >= datetime.strptime(
+                        cooldown_time, "%Y-%m-%d %H:%M:%S"
+                    )
 
                 logger.info("Reflected MV with properties: %s", mv_definition)
 

--- a/contrib/starrocks-python-client/test/sql/test_compiler_type.py
+++ b/contrib/starrocks-python-client/test/sql/test_compiler_type.py
@@ -36,6 +36,7 @@ from starrocks.datatype import (
     JSON,
     LARGEINT,
     MAP,
+    PERCENTILE,
     SMALLINT,
     STRING,
     STRUCT,
@@ -72,7 +73,7 @@ BASIC_TYPE_TEST_CASES = [
     (DATETIME(), "col DATETIME"),
     (HLL(), "col HLL"),
     (BITMAP(), "col BITMAP"),
-    # (PERCENTILE(), "col PERCENTILE"),  # PERCENTILE type compiler not implemented yet
+    (PERCENTILE(), "col PERCENTILE"),
     (JSON(), "col JSON"),
 ]
 

--- a/contrib/starrocks-python-client/test/system/test_table_lifecycle.py
+++ b/contrib/starrocks-python-client/test/system/test_table_lifecycle.py
@@ -872,7 +872,6 @@ def test_alter_table_properties_and_comment(database: str, alembic_env: AlembicT
             "starrocks_properties": {
                 "replication_num": "1",
                 "storage_medium": "HDD",
-                "bucket_size": "4294967296",
             },
         }
     alembic_env.harness.generate_autogen_revision(metadata=Base.metadata, message="Initial")
@@ -893,7 +892,6 @@ def test_alter_table_properties_and_comment(database: str, alembic_env: AlembicT
                 "replication_num": "1",
                 "replicated_storage": "false",
                 "storage_medium": "SSD",
-                "bucket_size": "1000000000",
             },
         }
     alembic_env.harness.generate_autogen_revision(metadata=AlteredBase.metadata, message="Alter props")
@@ -901,7 +899,6 @@ def test_alter_table_properties_and_comment(database: str, alembic_env: AlembicT
     # 3. Verify and apply the ALTER script
     script_content = ScriptContentParser.check_script_content(alembic_env, 1, "alter_props")
     assert "op.alter_table" in script_content
-    assert "bucket_size" in script_content
     sr_engine.dialect._init_run_mode(sr_engine.connect())  # make sure the run_mode is set
     # logger.debug(f"system run mode: {sr_engine.dialect.run_mode} with dialect: {sr_engine.dialect}")
     if sr_engine.dialect.run_mode == SystemRunMode.SHARED_DATA:

--- a/contrib/starrocks-python-client/test/test_suite.py
+++ b/contrib/starrocks-python-client/test/test_suite.py
@@ -14,6 +14,15 @@
 
 import decimal
 import logging
+import os
+
+import pytest
+
+if not os.getenv("STARROCKS_ENABLE_SQLALCHEMY_SUITE"):
+    pytest.skip(
+        "SQLAlchemy dialect suite is optional; set STARROCKS_ENABLE_SQLALCHEMY_SUITE=1 to run it.",
+        allow_module_level=True,
+    )
 
 from sqlalchemy import (
     Integer,
@@ -42,7 +51,6 @@ from sqlalchemy.testing.suite import (
     ComponentReflectionTest as _ComponentReflectionTest,
     CTETest as _CTETest,
     CompositeKeyReflectionTest,
-    EnumTest,
     FetchLimitOffsetTest as _FetchLimitOffsetTest,
     JSONTest as _JSONTest,
     LongNameBlowoutTest,
@@ -57,6 +65,11 @@ from test import test_utils
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    from sqlalchemy.testing.suite import EnumTest
+except ImportError:
+    EnumTest = None
 
 
 class SRAssertsCompiledSQLMixin:
@@ -562,6 +575,7 @@ class ServerSideCursorsTest(_ServerSideCursorsTest):
     def test_roundtrip_fetchall(self, metadata):
         pass
 
-EnumTest.__requires__ = ("enums",)  # Fix Enum handling. Mysql has native ENUM type, but Starrocks has not
+if EnumTest is not None:
+    EnumTest.__requires__ = ("enums",)  # Fix Enum handling. Mysql has native ENUM type, but Starrocks has not
 LongNameBlowoutTest.__requires__ = ("index_reflection",)  # This will do to make it skip for now, no multiple column index
 CompositeKeyReflectionTest.__requires__ = ('primary_key_constraint_reflection',) # This will make it also skip the fixture which is not creating succesfully

--- a/contrib/starrocks-python-client/test/unit/test_compare_tables.py
+++ b/contrib/starrocks-python-client/test/unit/test_compare_tables.py
@@ -40,6 +40,13 @@ LOG_NO_ALERT_AUTO_GENERATED = "No ALTER TABLE SET operation will be generated"
 logger = logging.getLogger(__name__)
 
 
+def create_autogen_context(dialect_name=DialectName):
+    autogen_context = Mock(spec=AutogenContext)
+    autogen_context.dialect = Mock()
+    autogen_context.dialect.name = dialect_name
+    return autogen_context
+
+
 class TestRealTableObjects:
     """Tests using real SQLAlchemy Table objects (without database connection).
 
@@ -53,8 +60,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, String, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         # Create real metadata and table objects
         metadata_old = MetaData()
@@ -118,8 +124,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, String, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         # Use separate MetaData for each table to avoid conflicts
         metadata_conn = MetaData()
@@ -170,8 +175,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, String, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         metadata_old = MetaData()
         metadata_new = MetaData()
@@ -222,8 +226,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         metadata_old = MetaData()
         metadata_new = MetaData()
@@ -256,8 +259,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         metadata_old = MetaData()
         metadata_new = MetaData()
@@ -289,8 +291,7 @@ class TestRealTableObjects:
         from alembic.autogenerate.api import AutogenContext
         from sqlalchemy import Column, Integer, MetaData, String, Table
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         metadata_old = MetaData()
         metadata_new = MetaData()
@@ -326,8 +327,7 @@ class TestEngineChanges:
 
     def test_engine_none_to_default_value(self):
         """Test ENGINE from None to default value ('OLAP')."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, no ENGINE explicitly set, implies default OLAP
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -352,8 +352,7 @@ class TestEngineChanges:
 
     def test_engine_none_to_non_default_value(self):
         """Test ENGINE from None (implicit default OLAP) to a non-default value (MYSQL)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, no ENGINE explicitly set, implies default OLAP
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -378,8 +377,7 @@ class TestEngineChanges:
 
     def test_engine_default_to_none(self):
         """Test ENGINE from default value ('OLAP') to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, explicitly OLAP
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -407,8 +405,7 @@ class TestEngineChanges:
 
     def test_engine_non_default_to_none(self):
         """Test ENGINE from a non-default value ('MYSQL') to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, explicitly MYSQL
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -435,8 +432,7 @@ class TestEngineChanges:
 
     def test_engine_change(self):
         """Test ENGINE value changes ('OLAP' to 'MYSQL')."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -470,8 +466,7 @@ class TestEngineChanges:
     ])
     def test_engine_no_change(self, conn_engine, meta_engine):
         """Test ENGINE with no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -499,8 +494,7 @@ class TestEngineChanges:
 
     def test_engine_none_to_none(self):
         """Test ENGINE from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No ENGINE explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -524,15 +518,14 @@ class TestEngineChanges:
 class TestKeyChanges:
     """Test KEY attribute changes (ALTER KEY not supported, but changes are detected)."""
 
-    def test_key_none_to_default_value(self):
+    def test_key_none_to_default_value(self, monkeypatch):
         """Test KEY from None (implicit default DUPLICATE KEY) to default value ('DUPLICATE KEY')."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         # set default key to 'DUPLICATE KEY (id)' instead of only 'DUPLICATE KEY'
         def default_key(cls):
             return f"{TableType.DUPLICATE_KEY}(id)"
-        ReflectionTableDefaults.key = classmethod(default_key)
+        monkeypatch.setattr(ReflectionTableDefaults, "key", classmethod(default_key))
 
         conn_table = Mock()  # Table reflected from SR database, no KEY explicitly set, implies default DUPLICATE KEY
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -557,8 +550,7 @@ class TestKeyChanges:
 
     def test_key_none_to_non_default_value(self):
         """Test KEY from None (implicit default DUPLICATE KEY) to a non-default value (PRIMARY KEY)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, no KEY explicitly set, implies default DUPLICATE KEY
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -583,8 +575,7 @@ class TestKeyChanges:
 
     def test_key_default_to_none(self):
         """Test KEY from default value ('DUPLICATE KEY') to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, explicitly DUPLICATE KEY
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -613,8 +604,7 @@ class TestKeyChanges:
 
     def test_key_non_default_to_none(self):
         """Test KEY from a non-default value ('PRIMARY KEY') to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Table reflected from SR database, explicitly PRIMARY KEY
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -642,8 +632,7 @@ class TestKeyChanges:
 
     def test_key_change(self):
         """Test KEY value changes ('DUPLICATE KEY' to 'UNIQUE KEY')."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -677,8 +666,7 @@ class TestKeyChanges:
     ])
     def test_key_no_change(self, conn_key, conn_key_columns, meta_key, meta_key_columns):
         """Test KEY with no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -709,8 +697,7 @@ class TestKeyChanges:
 
     def test_key_none_to_none(self):
         """Test KEY from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No KEY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -741,8 +728,7 @@ class TestPartitionChanges:
 
     def test_partition_none_to_value(self):
         """Test PARTITION_BY from None to value."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No PARTITION_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -767,8 +753,7 @@ class TestPartitionChanges:
 
     def test_partition_value_to_none(self):
         """Test PARTITION_BY from value to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Database has PARTITION_BY set
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -795,8 +780,7 @@ class TestPartitionChanges:
 
     def test_partition_change(self):
         """Test PARTITION_BY value changes."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -845,8 +829,7 @@ class TestPartitionChanges:
     ])
     def test_partition_no_change(self, conn_partition, meta_partition):
         """Test PARTITION_BY no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -874,8 +857,7 @@ class TestPartitionChanges:
 
     def test_partition_none_to_none(self):
         """Test PARTITION_BY from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No PARTITION_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -901,8 +883,7 @@ class TestDistributionChanges:
 
     def test_distribution_none_to_default_value(self):
         """Test DISTRIBUTED_BY from None to default value ('RANDOM')."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No DISTRIBUTED_BY explicitly set in database, implies default RANDOM
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -926,8 +907,7 @@ class TestDistributionChanges:
 
     def test_distribution_none_to_non_default_value(self):
         """Test DISTRIBUTED_BY from None (implicit default RANDOM) to a non-default value."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No DISTRIBUTED_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -955,8 +935,7 @@ class TestDistributionChanges:
 
     def test_distribution_default_to_none(self):
         """Test DISTRIBUTED_BY from default value ('RANDOM') to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Database explicitly has default RANDOM
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -978,8 +957,7 @@ class TestDistributionChanges:
 
     def test_distribution_non_default_to_none(self):
         """Test DISTRIBUTED_BY from a non-default value to None."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # Database has non-default DISTRIBUTED_BY
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1001,8 +979,7 @@ class TestDistributionChanges:
 
     def test_distribution_change(self):
         """Test DISTRIBUTED_BY value changes."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1037,8 +1014,7 @@ class TestDistributionChanges:
     ])
     def test_distribution_no_change(self, conn_distribution, meta_distribution):
         """Test DISTRIBUTED_BY with no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1062,8 +1038,7 @@ class TestDistributionChanges:
 
     def test_distribution_none_to_none(self):
         """Test DISTRIBUTED_BY from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No DISTRIBUTED_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1091,8 +1066,7 @@ class TestOrderByChanges:
         """Test ORDER_BY from None to value.
         Impossible in reality, because ORDER BY is always set when the table is created.
         """
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No ORDER_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1118,8 +1092,7 @@ class TestOrderByChanges:
         """Test ORDER_BY from implicit default to None (no op).
         Won't change without explicitly setting ORDER BY.
         """
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1144,8 +1117,7 @@ class TestOrderByChanges:
 
     def test_order_by_change(self):
         """Test ORDER_BY value changes."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1183,8 +1155,7 @@ class TestOrderByChanges:
     ])
     def test_order_by_no_change(self, conn_order_by, meta_order_by):
         """Test ORDER_BY no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1212,8 +1183,7 @@ class TestOrderByChanges:
 
     def test_order_by_none_to_none(self):
         """Test ORDER_BY from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock()  # No ORDER_BY explicitly set in database
         type(conn_table).name = PropertyMock(return_value="test_table")
@@ -1243,8 +1213,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_none_to_default_value(self, prop_key, default_value, non_default_value):
         """Test PROPERTIES from None (implicit default) to explicit default value."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={})  # No properties in DB, implies default
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1267,8 +1236,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_none_to_non_default_value(self, prop_key, default_value, non_default_value):
         """Test PROPERTIES from None (implicit default) to explicit non-default value."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={})  # No properties in DB, implies default
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1290,8 +1258,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_default_to_none(self, prop_key, default_value, non_default_value):
         """Test PROPERTIES from explicit default value to None (no op)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: {prop_key: default_value}})  # DB has explicit default
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1311,8 +1278,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_non_default_none_to_none(self, prop_key, default_value, non_default_value, caplog):
         """Test PROPERTIES from implicit default (default value is set to None) to None (no op)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
         caplog.set_level("WARNING")
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: {prop_key: non_default_value}})  # DB has explicit default
@@ -1336,8 +1302,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_non_default_to_none(self, prop_key, default_value, non_default_value, caplog):
         """Test PROPERTIES from explicit non-default value to None (generate ALTER to reset to default)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
         caplog.set_level("WARNING")
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: {prop_key: non_default_value}})  # DB has non-default value
@@ -1364,8 +1329,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_change(self, prop_key, value1, value2):
         """Test PROPERTIES value change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: {prop_key: value1}})  # DB has value1
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1388,8 +1352,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_no_change(self, prop_key, value):
         """Test PROPERTIES no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: {prop_key: value}})  # DB has value
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1410,8 +1373,7 @@ class TestPropertiesChanges:
     ])
     def test_properties_no_change2(self, conn_props, meta_props):
         """Test PROPERTIES no change."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={TableInfoKeyWithPrefix.PROPERTIES: conn_props})  # DB has value
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1427,8 +1389,7 @@ class TestPropertiesChanges:
 
     def test_properties_none_to_none(self):
         """Test PROPERTIES from None to None (no change)."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_table = Mock(kwargs={})  # No properties in DB
         conn_table.dialect_options = {DialectName: extract_starrocks_dialect_attributes(conn_table.kwargs)}
@@ -1444,8 +1405,7 @@ class TestPropertiesChanges:
 
     def test_properties_multiple_changes(self):
         """Test multiple property changes simultaneously."""
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         conn_props = {"replication_num": "3", "storage_medium": "HDD", "dynamic_partition.enable": "true"}
         meta_props = {"replication_num": "2", "storage_medium": "SSD", "dynamic_partition.enable": "false"}
@@ -1493,8 +1453,7 @@ class TestORMTableObjects:
             id = Column(Integer, primary_key=True)
             name = Column(String(50))
 
-        autogen_context = Mock(spec=AutogenContext)
-        autogen_context.dialect.name = DialectName
+        autogen_context = create_autogen_context()
 
         # The Table object from the ORM model (target state)
         meta_table = ORMTestTable.__table__
@@ -1646,4 +1605,3 @@ class TestComplexScenarios:
 
         # Should return empty list for non-StarRocks dialects
         assert len(result) == 0
-

--- a/contrib/starrocks-python-client/test/unit/test_parser.py
+++ b/contrib/starrocks-python-client/test/unit/test_parser.py
@@ -87,6 +87,12 @@ class TestDataTypeParser:
                     ("name", datatype.VARCHAR(100)), ("age", datatype.INTEGER)
                 ),
             ),
+            (
+                "struct<`name` varchar(100), `age` int>",
+                datatype.STRUCT(
+                    ("name", datatype.VARCHAR(100)), ("age", datatype.INTEGER)
+                ),
+            ),
         ],
     )
     def test_complex_types(self, type_str, expected_type):
@@ -229,7 +235,9 @@ class TestMVRefreshParser:
             ("REFRESH DEFERRED ASYNC", {"refresh_moment": "DEFERRED", "refresh_type": "ASYNC"}),
             ("REFRESH IMMEDIATE MANUAL", {"refresh_moment": "IMMEDIATE", "refresh_type": "MANUAL"}),
             ("REFRESH ASYNC EVERY (INTERVAL 1 DAY)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
+            ("REFRESH SCHEDULE EVERY (INTERVAL 1 DAY)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
             ("REFRESH ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)", {"refresh_moment": None, "refresh_type": "ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)"}),
+            ("REFRESH SCHEDULE START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)", {"refresh_moment": None, "refresh_type": "ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)"}),
             ("refresh deferred async", {"refresh_moment": "DEFERRED", "refresh_type": "ASYNC"}), # Case-insensitivity
         ]
     )

--- a/contrib/starrocks-python-client/test/unit/test_parser.py
+++ b/contrib/starrocks-python-client/test/unit/test_parser.py
@@ -236,6 +236,7 @@ class TestMVRefreshParser:
             ("REFRESH IMMEDIATE MANUAL", {"refresh_moment": "IMMEDIATE", "refresh_type": "MANUAL"}),
             ("REFRESH ASYNC EVERY (INTERVAL 1 DAY)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
             ("REFRESH SCHEDULE EVERY (INTERVAL 1 DAY)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
+            ("REFRESH DEFERRED SCHEDULE EVERY (INTERVAL 1 DAY)", {"refresh_moment": "DEFERRED", "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
             ("REFRESH ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)", {"refresh_moment": None, "refresh_type": "ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)"}),
             ("REFRESH SCHEDULE START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)", {"refresh_moment": None, "refresh_type": "ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)"}),
             ("refresh deferred async", {"refresh_moment": "DEFERRED", "refresh_type": "ASYNC"}), # Case-insensitivity


### PR DESCRIPTION
## Why I'm doing:

Python client integration/system tests currently fail with newer StarRocks and Alembic versions due to reflection output changes, parser edge cases, Alembic autogenerate behavior changes.

## What I'm doing:

Fix Python client test failures caused by newer StarRocks reflection output and Alembic behavior changes.
- `uv run pytest test --log-cli-level=WARNING`
- `uv run pytest -s test/integration`
- `uv run pytest -s test/system`

or success `uv run pytest` in python client repository dir.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5