### PR TITLE
[BugFix] Release global meta lock on dumpImage partial db-lock failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2957,26 +2957,36 @@ public class GlobalStateMgr {
                 lockedDbMap.put(dbId, db);
             }
 
-            // lock all dbs
-            for (Database db : lockedDbMap.values()) {
-                locker.lockDatabase(db.getId(), LockType.READ);
-            }
-            LOG.info("acquired all the dbs' read lock.");
-
-            long journalId = getMaxJournalId();
-            File dumpFile = new File(Config.meta_dir, "image." + journalId);
-            dumpFilePath = dumpFile.getAbsolutePath();
+            // Track the dbs actually locked. lockDatabase() can throw (deadlock victim / interrupt),
+            // so on a partial acquisition we must release only what we hold. Releasing a never-locked
+            // db throws IllegalMonitorStateException, which would abort the finally before unlock()
+            // runs and strand the global meta lock indefinitely.
+            List<Database> lockedDbs = new ArrayList<>();
             try {
-                LOG.info("begin to dump {}", dumpFilePath);
-                saveImage(new ImageWriter(Config.meta_dir, journalId), dumpFile);
-            } catch (IOException e) {
-                LOG.error("failed to dump image to {}", dumpFilePath, e);
+                // lock all dbs
+                for (Database db : lockedDbMap.values()) {
+                    locker.lockDatabase(db.getId(), LockType.READ);
+                    lockedDbs.add(db);
+                }
+                LOG.info("acquired all the dbs' read lock.");
+
+                long journalId = getMaxJournalId();
+                File dumpFile = new File(Config.meta_dir, "image." + journalId);
+                dumpFilePath = dumpFile.getAbsolutePath();
+                try {
+                    LOG.info("begin to dump {}", dumpFilePath);
+                    saveImage(new ImageWriter(Config.meta_dir, journalId), dumpFile);
+                } catch (IOException e) {
+                    LOG.error("failed to dump image to {}", dumpFilePath, e);
+                }
+            } finally {
+                // unlock only the dbs we actually locked
+                for (Database db : lockedDbs) {
+                    locker.unLockDatabase(db.getId(), LockType.READ);
+                }
             }
         } finally {
-            // unlock all
-            for (Database db : lockedDbMap.values()) {
-                locker.unLockDatabase(db.getId(), LockType.READ);
-            }
+            // Always release the global meta lock, even if db-lock acquisition or release above threw.
             unlock();
         }
 


### PR DESCRIPTION
dumpImage() acquired the per-db READ locks inside the try block and released every db in lockedDbMap in the finally. If lockDatabase() threw mid-loop (deadlock victim or interrupt), the finally's unlock loop reached a db that was never locked and threw IllegalMonitorStateException, aborting the finally before unlock() ran. This stranded the global meta lock indefinitely, blocking all future checkpoints and DDL.

Track only the dbs actually locked and release just those in an inner finally; move the global unlock() into an outer finally that always runs, so the global lock is released even if db-lock acquisition or release throws.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
