### PR TITLE
[Enhancement] Expose auth/connectivity error details from connector metadata operations to end users

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -230,7 +230,11 @@ public class LogUtil {
         List<Throwable> result = unwindException(e, maxDepth);
         StringBuilder sb = new StringBuilder();
         for (Throwable t : result) {
-            sb.append(t.getMessage());
+            String msg = t.getMessage();
+            sb.append(t.getClass().getSimpleName());
+            if (msg != null && !msg.isEmpty()) {
+                sb.append(": ").append(msg);
+            }
             sb.append("\n");
         }
         sb.deleteCharAt(sb.length() - 1);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -212,8 +212,15 @@ public class LogUtil {
             if (e instanceof InvocationTargetException) {
                 parent = ((InvocationTargetException) e).getTargetException();
             } else {
-                skip = false;
                 parent = e.getCause();
+                // A layer contributes nothing beyond its cause when either:
+                //  - it has no message of its own (e.g. `new Foo(null, cause)`), or
+                //  - its message is just the JDK default `Throwable(Throwable cause)` ctor's
+                //    `cause.toString()` (e.g. ErrorReport.wrapWithRuntimeException's bare
+                //    `new RuntimeException(ddlException)`, used purely to smuggle a checked
+                //    exception past a signature that can't declare one).
+                // Unpeel such layers instead of showing the same text twice.
+                skip = parent != null && (e.getMessage() == null || Objects.equals(e.getMessage(), parent.toString()));
             }
             if (!skip) {
                 result.add(e);
@@ -243,8 +250,13 @@ public class LogUtil {
             }
             prevMsg = msg;
         }
-        if (result.size() <= 1) {
+        if (result.isEmpty()) {
             return e.getMessage();
+        }
+        if (result.size() == 1) {
+            // e itself may have been unpeeled away as a content-free wrapper; report the surviving
+            // layer's own message rather than the original (possibly now-irrelevant) top-level message.
+            return result.get(0).getMessage();
         }
         // The outermost layer is usually a generic internal wrapper (e.g. StarRocksConnectorException,
         // AnalysisException) whose class name carries no value to the user; only deeper layers reveal

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class LogUtil {
@@ -227,13 +228,39 @@ public class LogUtil {
 
     public static String getUnwoundExceptionMessage(Throwable e) {
         final int maxDepth = 20;
-        List<Throwable> result = unwindException(e, maxDepth);
-        StringBuilder sb = new StringBuilder();
-        for (Throwable t : result) {
+        List<Throwable> unwound = unwindException(e, maxDepth);
+        // Some call sites re-wrap an exception into a different type purely for classification
+        // purposes (e.g. `new AnalysisException(semanticException.getMessage(), semanticException)`),
+        // carrying the same message forward unchanged. Collapse those adjacent duplicates so they
+        // don't show up twice, and so a message that was never really "unwound" doesn't get a
+        // class-name prefix it never had before.
+        List<Throwable> result = new ArrayList<>();
+        String prevMsg = null;
+        for (Throwable t : unwound) {
             String msg = t.getMessage();
-            sb.append(t.getClass().getSimpleName());
-            if (msg != null && !msg.isEmpty()) {
-                sb.append(": ").append(msg);
+            if (result.isEmpty() || !Objects.equals(msg, prevMsg)) {
+                result.add(t);
+            }
+            prevMsg = msg;
+        }
+        if (result.size() <= 1) {
+            return e.getMessage();
+        }
+        // The outermost layer is usually a generic internal wrapper (e.g. StarRocksConnectorException,
+        // AnalysisException) whose class name carries no value to the user; only deeper layers reveal
+        // which underlying system actually failed, so only those get a class-name prefix.
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < result.size(); i++) {
+            Throwable t = result.get(i);
+            String msg = t.getMessage();
+            if (i > 0) {
+                sb.append(t.getClass().getSimpleName());
+                if (msg != null && !msg.isEmpty()) {
+                    sb.append(": ");
+                }
+            }
+            if (msg != null) {
+                sb.append(msg);
             }
             sb.append("\n");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/CachingDeltaLakeMetastore.java
@@ -166,7 +166,7 @@ public class CachingDeltaLakeMetastore extends CachingMetastore implements IDelt
                         ((InvocationTargetException) cause).getTargetException() instanceof NoSuchObjectException) {
                     LOG.error("Failed to refresh table {}.{}: table does not exist", dbName, tblName, e);
                     invalidateTable(dbName, tblName);
-                    throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.");
+                    throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.", e);
                 } else {
                     LOG.error("Failed to refresh table {}.{}", dbName, tblName, e);
                     throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -382,7 +382,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
             return deltaOps.getTable(dbName, tblName);
         } catch (Exception e) {
             LOG.error("Failed to get deltalake table {}.{}.{}", catalogName, dbName, tblName, e);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to get Delta Lake table %s.%s.%s", catalogName, dbName, tblName), e);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -38,7 +38,6 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -56,7 +55,6 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -384,15 +382,8 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
             return deltaOps.getTable(dbName, tblName);
         } catch (Exception e) {
             LOG.error("Failed to get deltalake table {}.{}.{}", catalogName, dbName, tblName, e);
-            String errMsg = e.getMessage();
-            Throwable ce = ExceptionUtils.getRootCause(e);
-            if (ce instanceof SemanticException se) {
-                errMsg = se.getDetailMsg();
-            } else if (ce != null) {
-                errMsg = String.format("Failed to get deltalake table %s.%s.%s. %s", catalogName, dbName, tblName,
-                        ce.getMessage());
-            }
-            throw new StarRocksConnectorException(errMsg, e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to get Delta Lake table %s.%s.%s", catalogName, dbName, tblName), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
@@ -146,11 +146,11 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
             snapshot = (SnapshotImpl) deltaTable.getLatestSnapshot(deltaLakeEngine);
         } catch (TableNotFoundException e) {
             LOG.error("Failed to find Delta table for {}.{}.{}", catalogName, dbName, tableName, e);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to find Delta table %s.%s.%s", catalogName, dbName, tableName), e);
         } catch (Exception e) {
             LOG.error("Failed to get latest snapshot for {}.{}.{}", catalogName, dbName, tableName, e);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to get latest snapshot for %s.%s.%s", catalogName, dbName, tableName), e);
         }
         return new DeltaLakeSnapshot(dbName, tableName, deltaLakeEngine, snapshot, metastoreTable);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetastore.java
@@ -28,7 +28,6 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metastore.IMetastore;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.memory.estimate.Estimator;
-import com.starrocks.sql.analyzer.SemanticException;
 import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.Table;
@@ -146,15 +145,13 @@ public abstract class DeltaLakeMetastore implements IDeltaLakeMetastore {
             Table deltaTable = Table.forPath(deltaLakeEngine, path);
             snapshot = (SnapshotImpl) deltaTable.getLatestSnapshot(deltaLakeEngine);
         } catch (TableNotFoundException e) {
-            LOG.error("Failed to find Delta table for {}.{}.{}, {}. caused by : {}", catalogName, dbName, tableName,
-                    e.getMessage(), e.getCause());
-            throw new SemanticException("Failed to find Delta table for %s.%s.%s, %s. caused by : %s", catalogName,
-                    dbName, tableName, e.getMessage(), e.getCause());
+            LOG.error("Failed to find Delta table for {}.{}.{}", catalogName, dbName, tableName, e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to find Delta table %s.%s.%s", catalogName, dbName, tableName), e);
         } catch (Exception e) {
-            LOG.error("Failed to get latest snapshot for {}.{}.{}, {}. caused by : {}", catalogName, dbName,
-                    tableName, e.getMessage(), e.getCause());
-            throw new SemanticException("Failed to get latest snapshot for %s.%s.%s, %s. caused by : %s",
-                    catalogName, dbName, tableName, e.getMessage(), e.getCause());
+            LOG.error("Failed to get latest snapshot for {}.{}.{}", catalogName, dbName, tableName, e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to get latest snapshot for %s.%s.%s", catalogName, dbName, tableName), e);
         }
         return new DeltaLakeSnapshot(dbName, tableName, deltaLakeEngine, snapshot, metastoreTable);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
@@ -14,8 +14,6 @@
 
 package com.starrocks.connector.exception;
 
-import com.starrocks.common.util.LogUtil;
-
 import static java.lang.String.format;
 
 public class StarRocksConnectorException extends RuntimeException {
@@ -29,27 +27,6 @@ public class StarRocksConnectorException extends RuntimeException {
 
     public StarRocksConnectorException(String message, Throwable cause) {
         super(message, cause);
-    }
-
-    public String getErrorMessage() {
-        return super.getMessage();
-    }
-
-    @Override
-    public String getMessage() {
-        return getErrorMessage();
-    }
-
-    public static void check(boolean test, String message, Object... args) {
-        if (!test) {
-            throw new StarRocksConnectorException(message, args);
-        }
-    }
-
-    // Use this factory when wrapping an external exception (metastore, catalog, filesystem).
-    // It unfolds the full cause chain so auth and connectivity errors are visible to the user.
-    public static StarRocksConnectorException fromExternalException(String context, Throwable cause) {
-        return new StarRocksConnectorException(context + ", msg: " + LogUtil.getUnwoundExceptionMessage(cause), cause);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/exception/StarRocksConnectorException.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.connector.exception;
 
+import com.starrocks.common.util.LogUtil;
+
 import static java.lang.String.format;
 
 public class StarRocksConnectorException extends RuntimeException {
@@ -42,6 +44,12 @@ public class StarRocksConnectorException extends RuntimeException {
         if (!test) {
             throw new StarRocksConnectorException(message, args);
         }
+    }
+
+    // Use this factory when wrapping an external exception (metastore, catalog, filesystem).
+    // It unfolds the full cause chain so auth and connectivity errors are visible to the user.
+    public static StarRocksConnectorException fromExternalException(String context, Throwable cause) {
+        return new StarRocksConnectorException(context + ", msg: " + LogUtil.getUnwoundExceptionMessage(cause), cause);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -527,7 +527,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                 if (cause instanceof InvocationTargetException &&
                         ((InvocationTargetException) cause).getTargetException() instanceof NoSuchObjectException) {
                     invalidateTable(hiveDbName, hiveViewName);
-                    throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.");
+                    throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.", e);
                 } else {
                     throw e;
                 }
@@ -550,7 +550,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
             if (cause instanceof InvocationTargetException &&
                     ((InvocationTargetException) cause).getTargetException() instanceof NoSuchObjectException) {
                 invalidateTable(hiveDbName, hiveTblName);
-                throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.");
+                throw new StarRocksConnectorException(e.getMessage() + ", invalidated cache.", e);
             } else {
                 throw e;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
@@ -171,8 +170,7 @@ public class HiveMetaClient {
             return (T) method.invoke(client.hiveClient, args);
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
-            connectionException = new StarRocksConnectorException(messageIfError + ", msg: " +
-                    LogUtil.getUnwoundExceptionMessage(e), e);
+            connectionException = StarRocksConnectorException.fromExternalException(messageIfError, e);
             throw connectionException;
         } finally {
             if (client == null && connectionException != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -23,7 +23,6 @@ import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
 import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
@@ -461,7 +460,7 @@ public class HiveMetaClient {
                 partitionStats.putAll(client.hiveClient.getPartitionColumnStatistics(dbName, tableName, parts, columnNames));
             }
             LOG.info("Succeed to getPartitionColumnStatistics on [{}.{}] with {} times retry, slice size is {}," +
-                            " partName size is {}", dbName, tableName, retryNum, subListSize, partNames.size());
+                    " partName size is {}", dbName, tableName, retryNum, subListSize, partNames.size());
             return partitionStats;
         } catch (TTransportException te) {
             if (subListNum > 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -170,7 +170,7 @@ public class HiveMetaClient {
             return (T) method.invoke(client.hiveClient, args);
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
-            connectionException = StarRocksConnectorException.fromExternalException(messageIfError, e);
+            connectionException = new StarRocksConnectorException(messageIfError, e);
             throw connectionException;
         } finally {
             if (client == null && connectionException != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -173,7 +173,7 @@ public class HiveMetaClient {
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
             connectionException = new StarRocksConnectorException(messageIfError + ", msg: " +
-                    ExceptionUtils.getRootCauseMessage(e), e);
+                    LogUtil.getUnwoundExceptionMessage(e), e);
             throw connectionException;
         } finally {
             if (client == null && connectionException != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveUtils.java
@@ -41,6 +41,7 @@ import static com.starrocks.connector.hive.HiveMetastoreOperations.EXTERNAL_LOCA
 
 public class HiveUtils {
     private static final Logger LOG = LogManager.getLogger(HiveUtils.class);
+
     public static boolean isS3Url(String prefix) {
         return prefix.startsWith("oss://") || prefix.startsWith("s3n://") || prefix.startsWith("s3a://") ||
                 prefix.startsWith("s3://") || prefix.startsWith("cos://") || prefix.startsWith("cosn://") ||
@@ -174,10 +175,10 @@ public class HiveUtils {
             DecimalLiteral decimalKey = (DecimalLiteral) key;
             ScalarType type = (ScalarType) targetType;
             int scale = type.decimalScale();
-    
+
             BigDecimal scaled = decimalKey.getValue()
                     .setScale(scale, RoundingMode.HALF_UP);
-    
+
             key = new DecimalLiteral(scaled);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -131,7 +131,7 @@ public class HudiMetadata implements ConnectorMetadata {
             table = hmsOps.getTable(dbName, tblName);
         } catch (Exception e) {
             LOG.error("Failed to get hudi table [{}.{}.{}]", catalogName, dbName, tblName, e);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to get hudi table %s.%s.%s", catalogName, dbName, tblName), e);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -132,10 +132,8 @@ public class HudiMetadata implements ConnectorMetadata {
             table = hmsOps.getTable(dbName, tblName);
         } catch (Exception e) {
             LOG.error("Failed to get hudi table [{}.{}.{}]", catalogName, dbName, tblName, e);
-            Throwable ce = ExceptionUtils.getRootCause(e);
-            String errMsg = ce != null ? ce.getMessage() : e.getMessage();
-            throw new StarRocksConnectorException(String.format("Failed to get hudi table %s.%s.%s. %s",
-                    catalogName, dbName, tblName, errMsg), e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to get hudi table %s.%s.%s", catalogName, dbName, tblName), e);
         }
 
         return table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -47,7 +47,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -286,10 +286,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         } catch (NoSuchTableException e) {
             throw e;
         } catch (Exception e) {
-            Throwable ce = ExceptionUtils.getRootCause(e);
-            String errMsg = ce != null ? ce.getMessage() : e.getMessage();
-            throw new StarRocksConnectorException(String.format("Failed to get iceberg table %s.%s.%s. %s",
-                    catalogName, dbName, tableName, errMsg), e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to get iceberg table %s.%s.%s", catalogName, dbName, tableName), e);
         } finally {
             TABLE_LOAD_CONTEXT.remove();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -285,7 +285,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         } catch (NoSuchTableException e) {
             throw e;
         } catch (Exception e) {
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to get iceberg table %s.%s.%s", catalogName, dbName, tableName), e);
         } finally {
             TABLE_LOAD_CONTEXT.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -32,7 +32,6 @@ import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -485,7 +485,8 @@ public class IcebergMetadata implements ConnectorMetadata {
             deleteFiles.commit();
         } catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException e) {
             LOG.error("Failed to truncate iceberg table: {}.{}", dbName, tableName, e);
-            throw new StarRocksConnectorException("Failed to truncate iceberg table: %s.%s", dbName, tableName, e);
+            throw new StarRocksConnectorException(
+                    String.format("Failed to truncate iceberg table: %s.%s", dbName, tableName), e);
         }
     }
 
@@ -625,8 +626,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         } catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException e) {
             LOG.error("Failed to execute metadata delete on {}.{}", dbName, tableName, e);
             ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG, e, deleteType);
-            throw new StarRocksConnectorException("Failed to execute metadata delete on %s.%s: %s",
-                    dbName, tableName, e.getMessage());
+            throw new StarRocksConnectorException(
+                    String.format("Failed to execute metadata delete on %s.%s", dbName, tableName), e);
         } finally {
             ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
                     System.currentTimeMillis() - startMs, deleteType);
@@ -1115,7 +1116,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 partitionKeys.add(createPartitionKeyWithType(values, srTypes, table.getType()));
             } catch (Exception e) {
                 LOG.error("create partition key failed.", e);
-                throw StarRocksConnectorException.fromExternalException("create partition key failed", e);
+                throw new StarRocksConnectorException("create partition key failed", e);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1115,7 +1115,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 partitionKeys.add(createPartitionKeyWithType(values, srTypes, table.getType()));
             } catch (Exception e) {
                 LOG.error("create partition key failed.", e);
-                throw new StarRocksConnectorException(e.getMessage());
+                throw StarRocksConnectorException.fromExternalException("create partition key failed", e);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -104,7 +104,8 @@ public class IcebergGlueCatalog implements IcebergCatalog {
                     fileSystem.exists(new Path(value));
                 } catch (Exception e) {
                     LOG.error("Invalid location URI: {}", value, e);
-                    throw new StarRocksConnectorException("Invalid location URI: %s. msg: %s", value, e.getMessage());
+                    throw StarRocksConnectorException.fromExternalException(
+                            String.format("Invalid location URI: %s", value), e);
                 }
             } else {
                 throw new IllegalArgumentException("Unrecognized property: " + key);
@@ -121,7 +122,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
             database = getDB(context, dbName);
         } catch (Exception e) {
             LOG.error("Failed to access database {}", dbName, e);
-            throw new MetaNotFoundException("Failed to access database " + dbName);
+            throw StarRocksConnectorException.fromExternalException("Failed to access database " + dbName, e);
         }
 
         if (database == null) {
@@ -217,7 +218,8 @@ public class IcebergGlueCatalog implements IcebergCatalog {
         } catch (Exception e) {
             LOG.error("Failed to register table {}.{} with metadata file location {}", 
                     dbName, tableName, metadataFileLocation, e);
-            throw new StarRocksConnectorException("Failed to register table: " + e.getMessage(), e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Failed to register table %s.%s", dbName, tableName), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -104,7 +104,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
                     fileSystem.exists(new Path(value));
                 } catch (Exception e) {
                     LOG.error("Invalid location URI: {}", value, e);
-                    throw StarRocksConnectorException.fromExternalException(
+                    throw new StarRocksConnectorException(
                             String.format("Invalid location URI: %s", value), e);
                 }
             } else {
@@ -122,7 +122,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
             database = getDB(context, dbName);
         } catch (Exception e) {
             LOG.error("Failed to access database {}", dbName, e);
-            throw StarRocksConnectorException.fromExternalException("Failed to access database " + dbName, e);
+            throw new StarRocksConnectorException("Failed to access database " + dbName, e);
         }
 
         if (database == null) {
@@ -218,7 +218,7 @@ public class IcebergGlueCatalog implements IcebergCatalog {
         } catch (Exception e) {
             LOG.error("Failed to register table {}.{} with metadata file location {}", 
                     dbName, tableName, metadataFileLocation, e);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Failed to register table %s.%s", dbName, tableName), e);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -128,8 +128,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.initialize(name, restCatalogProperties);
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
-            throw new StarRocksConnectorException("Failed to load rest catalog",
-                    new RuntimeException("Failed to load rest catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to load rest catalog", re);
         }
     }
 
@@ -159,8 +158,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to load table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw new StarRocksConnectorException("Failed to load table using REST Catalog",
-                    new RuntimeException("Failed to load table using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to load table using REST Catalog", re);
         }
     }
 
@@ -170,8 +168,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to check tableExists REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw new StarRocksConnectorException("Failed to check tableExists using REST Catalog",
-                    new RuntimeException("Failed to check tableExists using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to check tableExists using REST Catalog", re);
         }
     }
 
@@ -186,8 +183,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             }
         } catch (RESTException re) {
             LOG.error("Failed to list databases using REST Catalog ", re);
-            throw new StarRocksConnectorException("Failed to list all databases using REST Catalog",
-                    new RuntimeException("Failed to list all databases using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to list all databases using REST Catalog", re);
         }
     }
 
@@ -221,8 +217,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName), properties);
         } catch (RESTException re) {
             LOG.error("Failed to list create namespace using REST Catalog, for dbName {}", dbName, re);
-            throw new StarRocksConnectorException("Failed to create namespace using REST Catalog",
-                    new RuntimeException("Failed to create namespace using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to create namespace using REST Catalog", re);
         }
     }
 
@@ -248,8 +243,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName));
         } catch (RESTException re) {
             LOG.error("Failed to drop database using REST Catalog, for dbName {}", dbName, re);
-            throw new StarRocksConnectorException("Failed to drop database using REST Catalog",
-                    new RuntimeException("Failed to drop database using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to drop database using REST Catalog", re);
         }
     }
 
@@ -260,8 +254,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
-            throw new StarRocksConnectorException("Failed to get database using REST Catalog",
-                    new RuntimeException("Failed to get database using REST Catalog exception:" + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to get database using REST Catalog", re);
         }
     }
 
@@ -275,8 +268,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             LOG.error("Failed to list tables using REST Catalog, for dbName {}", dbName, re);
             // creating a new RuntimeException with the custom message, as in the upstream code, it picks the `exception.getCause().getMessage()`
             // and keeping the re, so that Stacktrace will have the upstream exception.
-            throw new StarRocksConnectorException("Failed to list tables using REST Catalog",
-                    new RuntimeException("Failed to list tables using REST Catalog, exception:" + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to list tables using REST Catalog", re);
         }
 
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
@@ -289,8 +281,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                         ns, ICEBERG_CUSTOM_PROPERTIES_PREFIX + KEY_VIEW_ENDPOINTS_ENABLED, e);
             } catch (RESTException re) {
                 LOG.error("Failed to list views using REST Catalog, for dbName {}", dbName, re);
-                throw new StarRocksConnectorException("Failed to list views using REST Catalog",
-                        new RuntimeException("Failed to list views using REST Catalog, exception: " + re.getMessage(), re));
+                throw StarRocksConnectorException.fromExternalException("Failed to list views using REST Catalog", re);
             }
         } else {
             LOG.debug("View endpoints are disabled for catalog, skipping view list operations");
@@ -327,8 +318,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to create table using REST Catalog, for dbName {} schema {} tableName {}",
                     dbName, schema, tableName, re);
-            throw new StarRocksConnectorException("Failed to create table using REST catalog",
-                    new RuntimeException("Failed to create table using REST catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to create table using REST catalog", re);
         }
 
         return nativeTable != null;
@@ -341,8 +331,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw new StarRocksConnectorException("Failed to drop table using REST Catalog",
-                    new RuntimeException("Failed to drop table using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to drop table using REST Catalog", re);
         }
     }
 
@@ -356,8 +345,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to rename table using REST Catalog, for dbName {} tableName {} newTblName {}",
                     dbName, tblName, newTblName, re);
-            throw new StarRocksConnectorException("Failed to rename table using REST Catalog",
-                    new RuntimeException("Failed to rename table using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to rename table using REST Catalog", re);
         }
     }
 
@@ -377,8 +365,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
         } catch (RESTException re) {
             LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
-            throw new StarRocksConnectorException("Failed to load view using REST Catalog",
-                    new RuntimeException("Failed to load view using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to load view using REST Catalog", re);
         }
     }
 
@@ -388,8 +375,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
         } catch (RESTException re) {
             LOG.error("Failed to drop view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
-            throw new StarRocksConnectorException("Failed to drop view using REST Catalog",
-                    new RuntimeException("Failed to drop view using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to drop view using REST Catalog", re);
         }
     }
 
@@ -421,8 +407,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
                     dbName, tableName, metadataFileLocation, re);
-            throw new StarRocksConnectorException("Failed to register table using REST Catalog",
-                    new RuntimeException("Failed to register table using REST Catalog, exception: " + re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException("Failed to register table using REST Catalog", re);
         }
     }
 
@@ -436,10 +421,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(buildContext(context), ns));
         } catch (RESTException re) {
             LOG.error("Failed to load table metadata using REST Catalog, for namespace {}", ns, re);
-            throw new StarRocksConnectorException("Failed to load table metadata using REST Catalog/defaultTableLocation",
-                    new RuntimeException(
-                            "Failed to load table metadata using REST Catalog/defaultTableLocation, exception: " +
-                                    re.getMessage(), re));
+            throw StarRocksConnectorException.fromExternalException(
+                    "Failed to load table metadata using REST Catalog", re);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -128,7 +128,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.initialize(name, restCatalogProperties);
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
-            throw StarRocksConnectorException.fromExternalException("Failed to load rest catalog", re);
+            throw new StarRocksConnectorException("Failed to load rest catalog", re);
         }
     }
 
@@ -158,7 +158,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to load table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to load table using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to load table using REST Catalog", re);
         }
     }
 
@@ -168,7 +168,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to check tableExists REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to check tableExists using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to check tableExists using REST Catalog", re);
         }
     }
 
@@ -183,7 +183,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             }
         } catch (RESTException re) {
             LOG.error("Failed to list databases using REST Catalog ", re);
-            throw StarRocksConnectorException.fromExternalException("Failed to list all databases using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to list all databases using REST Catalog", re);
         }
     }
 
@@ -217,7 +217,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName), properties);
         } catch (RESTException re) {
             LOG.error("Failed to list create namespace using REST Catalog, for dbName {}", dbName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to create namespace using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to create namespace using REST Catalog", re);
         }
     }
 
@@ -243,7 +243,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName));
         } catch (RESTException re) {
             LOG.error("Failed to drop database using REST Catalog, for dbName {}", dbName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to drop database using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to drop database using REST Catalog", re);
         }
     }
 
@@ -254,7 +254,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to get database using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to get database using REST Catalog", re);
         }
     }
 
@@ -268,7 +268,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             LOG.error("Failed to list tables using REST Catalog, for dbName {}", dbName, re);
             // creating a new RuntimeException with the custom message, as in the upstream code, it picks the `exception.getCause().getMessage()`
             // and keeping the re, so that Stacktrace will have the upstream exception.
-            throw StarRocksConnectorException.fromExternalException("Failed to list tables using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to list tables using REST Catalog", re);
         }
 
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
@@ -281,7 +281,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                         ns, ICEBERG_CUSTOM_PROPERTIES_PREFIX + KEY_VIEW_ENDPOINTS_ENABLED, e);
             } catch (RESTException re) {
                 LOG.error("Failed to list views using REST Catalog, for dbName {}", dbName, re);
-                throw StarRocksConnectorException.fromExternalException("Failed to list views using REST Catalog", re);
+                throw new StarRocksConnectorException("Failed to list views using REST Catalog", re);
             }
         } else {
             LOG.debug("View endpoints are disabled for catalog, skipping view list operations");
@@ -318,7 +318,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to create table using REST Catalog, for dbName {} schema {} tableName {}",
                     dbName, schema, tableName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to create table using REST catalog", re);
+            throw new StarRocksConnectorException("Failed to create table using REST catalog", re);
         }
 
         return nativeTable != null;
@@ -331,7 +331,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to drop table using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to drop table using REST Catalog", re);
         }
     }
 
@@ -345,7 +345,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to rename table using REST Catalog, for dbName {} tableName {} newTblName {}",
                     dbName, tblName, newTblName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to rename table using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to rename table using REST Catalog", re);
         }
     }
 
@@ -365,7 +365,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
         } catch (RESTException re) {
             LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to load view using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to load view using REST Catalog", re);
         }
     }
 
@@ -375,7 +375,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
         } catch (RESTException re) {
             LOG.error("Failed to drop view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to drop view using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to drop view using REST Catalog", re);
         }
     }
 
@@ -407,7 +407,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         } catch (RESTException re) {
             LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
                     dbName, tableName, metadataFileLocation, re);
-            throw StarRocksConnectorException.fromExternalException("Failed to register table using REST Catalog", re);
+            throw new StarRocksConnectorException("Failed to register table using REST Catalog", re);
         }
     }
 
@@ -421,7 +421,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(buildContext(context), ns));
         } catch (RESTException re) {
             LOG.error("Failed to load table metadata using REST Catalog, for namespace {}", ns, re);
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     "Failed to load table metadata using REST Catalog", re);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -182,7 +182,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         try {
             paimonNativeCatalog.createView(new Identifier(dbName, viewName), view, stmt.isSetIfNotExists());
         } catch (Catalog.ViewAlreadyExistException | Catalog.DatabaseNotExistException e) {
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Paimon createView error for %s.%s", dbName, viewName), e);
         }
     }
@@ -202,7 +202,7 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
             paimonNativeCatalog.dropTable(new Identifier(dbName, tableName), stmt.isForceDrop());
         } catch (Exception e) {
-            throw StarRocksConnectorException.fromExternalException(
+            throw new StarRocksConnectorException(
                     String.format("Paimon dropTable error for %s.%s", dbName, tableName), e);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -23,7 +23,6 @@ import com.starrocks.catalog.PaimonView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrDeltaStats;
@@ -171,7 +170,7 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public void createView(ConnectContext context, CreateViewStmt stmt) throws DdlException {
+    public void createView(ConnectContext context, CreateViewStmt stmt) {
         String dbName = stmt.getDbName();
         String viewName = stmt.getTable();
         String viewDefinition = ConnectorViewDefinition.fromCreateViewStmt(stmt).getInlineViewDef();
@@ -183,12 +182,13 @@ public class PaimonMetadata implements ConnectorMetadata {
         try {
             paimonNativeCatalog.createView(new Identifier(dbName, viewName), view, stmt.isSetIfNotExists());
         } catch (Catalog.ViewAlreadyExistException | Catalog.DatabaseNotExistException e) {
-            throw new DdlException("Paimon createView error: " + e.getMessage());
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Paimon createView error for %s.%s", dbName, viewName), e);
         }
     }
 
     @Override
-    public void dropTable(ConnectContext context, DropTableStmt stmt) throws DdlException {
+    public void dropTable(ConnectContext context, DropTableStmt stmt) {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
         Table paimonTable = getTable(context, stmt.getDbName(), stmt.getTableName());
@@ -202,7 +202,8 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
             paimonNativeCatalog.dropTable(new Identifier(dbName, tableName), stmt.isForceDrop());
         } catch (Exception e) {
-            throw new DdlException("Paimon error: " + e.getMessage(), e);
+            throw StarRocksConnectorException.fromExternalException(
+                    String.format("Paimon dropTable error for %s.%s", dbName, tableName), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -34,7 +34,6 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheSelectExecutor;
 import com.starrocks.datacache.DataCacheSelectMetrics;
@@ -211,10 +210,6 @@ public class DDLStmtExecutor {
                 throw (DdlException) re.getCause();
             } else if (re.getCause() instanceof IOException) {
                 throw (IOException) re.getCause();
-            } else if (re instanceof StarRocksConnectorException) {
-                // StarRocksConnectorException already carries a full chain message built by fromExternalException;
-                // prefer it over re.getCause().getMessage() which would show only one level.
-                throw new DdlException(re.getMessage(), re);
             } else if (re.getCause() != null) {
                 throw new DdlException(re.getCause().getMessage() != null ?
                         re.getCause().getMessage() : re.getMessage(), re);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -34,6 +34,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheSelectExecutor;
 import com.starrocks.datacache.DataCacheSelectMetrics;
@@ -210,6 +211,10 @@ public class DDLStmtExecutor {
                 throw (DdlException) re.getCause();
             } else if (re.getCause() instanceof IOException) {
                 throw (IOException) re.getCause();
+            } else if (re instanceof StarRocksConnectorException) {
+                // StarRocksConnectorException already carries a full chain message built by fromExternalException;
+                // prefer it over re.getCause().getMessage() which would show only one level.
+                throw new DdlException(re.getMessage(), re);
             } else if (re.getCause() != null) {
                 throw new DdlException(re.getCause().getMessage() != null ?
                         re.getCause().getMessage() : re.getMessage(), re);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -80,6 +80,7 @@ import com.starrocks.common.profile.RawScopedTimer;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
@@ -1282,7 +1283,7 @@ public class StmtExecutor {
             String sql = originStmt != null ? originStmt.originStmt : "";
             // analysis exception only print message, not print the stack
             LOG.info("execute Exception, sql: {}, error: {}", SqlCredentialRedactor.redact(sql), e.getMessage());
-            context.getState().setError(e.getMessage());
+            context.getState().setError(LogUtil.getUnwoundExceptionMessage(e));
             if (parsedStmt instanceof KillStmt) {
                 // ignore kill stmt execute err(not monitor it)
                 context.getState().setErrType(QueryState.ErrType.IGNORE_ERR);
@@ -1305,7 +1306,7 @@ public class StmtExecutor {
         } catch (Throwable e) {
             String sql = originStmt != null ? originStmt.originStmt : "";
             LOG.warn("execute Exception, sql: {}", SqlCredentialRedactor.redact(sql), e);
-            context.getState().setError(e.getMessage());
+            context.getState().setError(LogUtil.getUnwoundExceptionMessage(e));
             context.getState().setErrType(QueryState.ErrType.INTERNAL_ERR);
         } finally {
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -71,13 +71,16 @@ public class LogUtilTest {
     }
 
     @Test
-    public void testGetUnwoundExceptionMessageCircularReference() throws Exception {
-        // Simulate a self-referential cause chain (safety guard: parent == e breaks the loop)
-        RuntimeException e = new RuntimeException("circular");
-        java.lang.reflect.Field causeField = Throwable.class.getDeclaredField("cause");
-        causeField.setAccessible(true);
-        causeField.set(e, e);
-        String output = LogUtil.getUnwoundExceptionMessage(e);
-        Assertions.assertEquals("RuntimeException: circular", output);
+    public void testGetUnwoundExceptionMessageCircularReference() {
+        // Covers the safety guard: when getCause() returns self, the loop breaks after the first layer
+        Throwable circular = new RuntimeException("circular") {
+            @Override
+            public Throwable getCause() {
+                return this;
+            }
+        };
+        String output = LogUtil.getUnwoundExceptionMessage(circular);
+        Assertions.assertTrue(output.contains("circular"));
+        Assertions.assertFalse(output.contains("\n")); // only one layer, not an infinite chain
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -46,13 +46,27 @@ public class LogUtilTest {
 
     @Test
     public void testGetUnwoundExceptionMessage() {
-        String output = null;
-        try {
-            System.out.println("hello");
-            throw new RuntimeException("hello");
-        } catch (Throwable e) {
-            output = LogUtil.getUnwoundExceptionMessage(e);
-        }
-        System.out.println(output);
+        // single exception: class name + message
+        RuntimeException e = new RuntimeException("hello");
+        String output = LogUtil.getUnwoundExceptionMessage(e);
+        Assertions.assertEquals("RuntimeException: hello", output);
+    }
+
+    @Test
+    public void testGetUnwoundExceptionMessageNested() {
+        // nested chain: all layers shown, class names included
+        RuntimeException inner = new RuntimeException("inner cause");
+        RuntimeException outer = new RuntimeException("outer msg", inner);
+        String output = LogUtil.getUnwoundExceptionMessage(outer);
+        Assertions.assertTrue(output.contains("RuntimeException: outer msg"));
+        Assertions.assertTrue(output.contains("RuntimeException: inner cause"));
+    }
+
+    @Test
+    public void testGetUnwoundExceptionMessageNullMessage() {
+        // exception with null message: class name only, no NPE
+        RuntimeException e = new RuntimeException((String) null);
+        String output = LogUtil.getUnwoundExceptionMessage(e);
+        Assertions.assertEquals("RuntimeException", output);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -69,4 +69,15 @@ public class LogUtilTest {
         String output = LogUtil.getUnwoundExceptionMessage(e);
         Assertions.assertEquals("RuntimeException", output);
     }
+
+    @Test
+    public void testGetUnwoundExceptionMessageCircularReference() throws Exception {
+        // Simulate a self-referential cause chain (safety guard: parent == e breaks the loop)
+        RuntimeException e = new RuntimeException("circular");
+        java.lang.reflect.Field causeField = Throwable.class.getDeclaredField("cause");
+        causeField.setAccessible(true);
+        causeField.set(e, e);
+        String output = LogUtil.getUnwoundExceptionMessage(e);
+        Assertions.assertEquals("RuntimeException: circular", output);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -43,4 +43,16 @@ public class LogUtilTest {
         LogUtil.logConnectionInfoToAuditLogAndQueryQueue(new ConnectContext(), null);
         Assertions.assertFalse(QueryDetailQueue.getQueryDetailsAfterTime(0L).isEmpty());
     }
+
+    @Test
+    public void testGetUnwoundExceptionMessage() {
+        String output = null;
+        try {
+            System.out.println("hello");
+            throw new RuntimeException("hello");
+        } catch (Throwable e) {
+            output = LogUtil.getUnwoundExceptionMessage(e);
+        }
+        System.out.println(output);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.common.util;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetailQueue;
 import org.junit.jupiter.api.Assertions;
@@ -69,6 +70,26 @@ public class LogUtilTest {
         RuntimeException e = new RuntimeException((String) null);
         String output = LogUtil.getUnwoundExceptionMessage(e);
         Assertions.assertNull(output);
+    }
+
+    @Test
+    public void testGetUnwoundExceptionMessageUnpeelsContentFreeWrapper() {
+        // mirrors ErrorReport.wrapWithRuntimeException: `new RuntimeException(cause)` with no message
+        // of its own, so its message defaults to `cause.toString()` (JDK default) and adds nothing new
+        DdlException ddl = new DdlException("table already exists");
+        RuntimeException wrapper = new RuntimeException(ddl);
+        String output = LogUtil.getUnwoundExceptionMessage(wrapper);
+        Assertions.assertEquals("table already exists", output);
+    }
+
+    @Test
+    public void testGetUnwoundExceptionMessageUnpeelsNullMessageWrapper() {
+        // a layer with an explicit null message (e.g. `new Foo(null, cause)`) carries no information
+        // of its own either, so it should be unpeeled just like the cause.toString()-default case
+        RuntimeException cause = new RuntimeException("root cause");
+        RuntimeException wrapper = new RuntimeException((String) null, cause);
+        String output = LogUtil.getUnwoundExceptionMessage(wrapper);
+        Assertions.assertEquals("root cause", output);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -46,28 +46,29 @@ public class LogUtilTest {
 
     @Test
     public void testGetUnwoundExceptionMessage() {
-        // single exception: class name + message
+        // single exception with no cause chain: plain message, no class name
         RuntimeException e = new RuntimeException("hello");
         String output = LogUtil.getUnwoundExceptionMessage(e);
-        Assertions.assertEquals("RuntimeException: hello", output);
+        Assertions.assertEquals("hello", output);
     }
 
     @Test
     public void testGetUnwoundExceptionMessageNested() {
-        // nested chain: all layers shown, class names included
+        // nested chain: outermost layer is plain (no class name), deeper layers include the class name
         RuntimeException inner = new RuntimeException("inner cause");
         RuntimeException outer = new RuntimeException("outer msg", inner);
         String output = LogUtil.getUnwoundExceptionMessage(outer);
-        Assertions.assertTrue(output.contains("RuntimeException: outer msg"));
+        Assertions.assertTrue(output.contains("outer msg"));
+        Assertions.assertFalse(output.contains("RuntimeException: outer msg"));
         Assertions.assertTrue(output.contains("RuntimeException: inner cause"));
     }
 
     @Test
     public void testGetUnwoundExceptionMessageNullMessage() {
-        // exception with null message: class name only, no NPE
+        // single exception with null message and no cause chain: null, no NPE
         RuntimeException e = new RuntimeException((String) null);
         String output = LogUtil.getUnwoundExceptionMessage(e);
-        Assertions.assertEquals("RuntimeException", output);
+        Assertions.assertNull(output);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -29,7 +29,6 @@ import com.starrocks.connector.hive.IHiveMetastore;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.analyzer.SemanticException;
 import io.delta.kernel.Operation;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.TransactionBuilder;
@@ -145,7 +144,7 @@ public class CachingDeltaLakeMetastoreTest {
 
     @Test
     public void testGetLatestSnapshot1() {
-        Throwable exception = assertThrows(SemanticException.class, () -> {
+        Throwable exception = assertThrows(StarRocksConnectorException.class, () -> {
             new MockUp<HMSBackedDeltaMetastore>() {
                 @mockit.Mock
                 public MetastoreTable getMetastoreTable(String dbName, String tableName) {
@@ -162,7 +161,7 @@ public class CachingDeltaLakeMetastoreTest {
 
             metastore.getLatestSnapshot("db1", "table1");
         });
-        assertThat(exception.getMessage(), containsString("Failed to find Delta table for delta0.db1.table1"));
+        assertThat(exception.getMessage(), containsString("Failed to find Delta table delta0.db1.table1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/CachingDeltaLakeMetastoreTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -247,6 +248,8 @@ public class CachingDeltaLakeMetastoreTest {
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof StarRocksConnectorException);
             Assertions.assertTrue(e.getMessage().contains("invalidated cache"));
+            Assertions.assertNotNull(e.getCause());
+            Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(e).contains("no such obj"));
         }
 
         new MockUp<DeltaLakeMetastore>() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -129,7 +129,7 @@ public class DeltaLakeMetadataTest {
         ColumnVector[] addFileCols = new ColumnVector[2];
         addFileCols[0] = new DefaultBinaryVector(BasePrimitiveType.createPrimitive("string"),
                 3, new byte[][] {new byte[] {'0', '0', '0', '0'},
-                new byte[] {'0', '0', '0', '1'}, new byte[] {'0', '0', '0', '2'}});
+                    new byte[] {'0', '0', '0', '1'}, new byte[] {'0', '0', '0', '2'}});
 
         int[] offsets = new int[] {0, 1, 2, 3};
         DataType mapType = new MapType(StringType.STRING, StringType.STRING, true);
@@ -138,7 +138,7 @@ public class DeltaLakeMetadataTest {
                         3, new byte[][] {new byte[] {'t', 's'}, new byte[] {'t', 's'}, new byte[] {'t', 's'}}),
                 new DefaultBinaryVector(BasePrimitiveType.createPrimitive("string"),
                         3, new byte[][] {new byte[] {'1', '9', '9', '9'}, new byte[] {'2', '0', '0', '0'},
-                        new byte[] {'2', '0', '0', '1'}})
+                            new byte[] {'2', '0', '0', '1'}})
         );
         // addFile schema, here we only care about the partitionValues, so not use all fields
         StructType addFileSchema = new StructType(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -24,6 +24,7 @@ import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
@@ -239,7 +240,7 @@ public class DeltaLakeMetadataTest {
 
         StarRocksConnectorException ex = Assertions.assertThrows(StarRocksConnectorException.class,
                 () -> metadata.getTable(null, "db_sem", "tbl_sem"));
-        Assertions.assertTrue(ex.getMessage().contains("semantic detail message"));
+        Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(ex).contains("semantic detail message"));
     }
 
     @Test
@@ -257,8 +258,8 @@ public class DeltaLakeMetadataTest {
 
         StarRocksConnectorException ex = Assertions.assertThrows(StarRocksConnectorException.class,
                 () -> metadata.getTable(null, "db_io", "tbl_io"));
-        String expectedPrefix = "Failed to get deltalake table delta0.db_io.tbl_io";
+        String expectedPrefix = "Failed to get Delta Lake table delta0.db_io.tbl_io";
         Assertions.assertTrue(ex.getMessage().contains(expectedPrefix));
-        Assertions.assertTrue(ex.getMessage().contains("io failure"));
+        Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(ex).contains("io failure"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -18,13 +18,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
-import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HiveMetastore;
@@ -129,7 +129,7 @@ public class DeltaLakeMetadataTest {
         ColumnVector[] addFileCols = new ColumnVector[2];
         addFileCols[0] = new DefaultBinaryVector(BasePrimitiveType.createPrimitive("string"),
                 3, new byte[][] {new byte[] {'0', '0', '0', '0'},
-                    new byte[] {'0', '0', '0', '1'}, new byte[] {'0', '0', '0', '2'}});
+                new byte[] {'0', '0', '0', '1'}, new byte[] {'0', '0', '0', '2'}});
 
         int[] offsets = new int[] {0, 1, 2, 3};
         DataType mapType = new MapType(StringType.STRING, StringType.STRING, true);
@@ -138,7 +138,7 @@ public class DeltaLakeMetadataTest {
                         3, new byte[][] {new byte[] {'t', 's'}, new byte[] {'t', 's'}, new byte[] {'t', 's'}}),
                 new DefaultBinaryVector(BasePrimitiveType.createPrimitive("string"),
                         3, new byte[][] {new byte[] {'1', '9', '9', '9'}, new byte[] {'2', '0', '0', '0'},
-                            new byte[] {'2', '0', '0', '1'}})
+                        new byte[] {'2', '0', '0', '1'}})
         );
         // addFile schema, here we only care about the partitionValues, so not use all fields
         StructType addFileSchema = new StructType(Lists.newArrayList(
@@ -214,8 +214,7 @@ public class DeltaLakeMetadataTest {
             public DeltaLakeTable convertDeltaSnapshotToSRTable(String catalog, DeltaLakeSnapshot snapshot) {
                 return new DeltaLakeTable(1, "delta0", "db1", "table1", Lists.newArrayList(),
                         Lists.newArrayList("col1"), null, null,
-                        new MetastoreTable("db1", "table1", "path/to/table",
-                        123));
+                        new MetastoreTable("db1", "table1", "path/to/table", 123));
             }
         };
         DeltaLakeTable deltaTable = (DeltaLakeTable) deltaLakeMetadata.getTable(new ConnectContext(), "db1", "table1");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HivePartitionKey;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
@@ -351,6 +352,9 @@ public class CachingHiveMetastoreTest {
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof StarRocksConnectorException);
             Assertions.assertTrue(e.getMessage().contains("invalidated cache"));
+            // the root cause must still be reachable so the underlying HMS error isn't silently dropped
+            Assertions.assertNotNull(e.getCause());
+            Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(e).contains("no such obj"));
         }
 
         try {
@@ -458,6 +462,8 @@ public class CachingHiveMetastoreTest {
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof StarRocksConnectorException);
             Assertions.assertTrue(e.getMessage().contains("invalidated cache"));
+            Assertions.assertNotNull(e.getCause());
+            Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(e).contains("no such obj"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.hive;
 
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import mockit.Expectations;
 import mockit.Mock;
@@ -107,7 +108,7 @@ public class HiveMetaClientTest {
         try {
             client.getAllDatabaseNames();
         } catch (Exception e) {
-            Assertions.assertTrue(e.getMessage().contains("Invalid port 90303"));
+            Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(e).contains("Invalid port 90303"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.hudi;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.ConnectorProperties;
@@ -136,7 +137,7 @@ public class HudiMetadataTest {
                 () -> hudiMetadata.getTable(new ConnectContext(), "db1", "table1"));
         String expectedPrefix = "Failed to get hudi table hive_catalog.db1.table1";
         Assertions.assertTrue(ex.getMessage().contains(expectedPrefix));
-        Assertions.assertTrue(ex.getMessage().contains("io failure"));
+        Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(ex).contains("io failure"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
@@ -266,7 +267,7 @@ public class CachingIcebergCatalogTest {
                 () -> cachingIcebergCatalog.getTable(connectContext, "test", "table"));
         String expectedPrefix = "Failed to get iceberg table iceberg_catalog.test.table";
         Assertions.assertTrue(ex.getMessage().contains(expectedPrefix));
-        Assertions.assertTrue(ex.getMessage().contains("io failure"));
+        Assertions.assertTrue(LogUtil.getUnwoundExceptionMessage(ex).contains("io failure"));
     }
 
     private int getStaticIntField(String fieldName) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
@@ -16,6 +16,8 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.glue.IcebergGlueCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.utframe.UtFrameUtils;
@@ -87,5 +89,36 @@ public class IcebergGlueCatalogTest {
         icebergGlueCatalog.renameTable(connectContext, "db", "tb1", "tb2");
         boolean exists = icebergGlueCatalog.tableExists(connectContext, "db", "tbl2");
         Assertions.assertTrue(exists);
+    }
+
+    @Test
+    public void testCreateDBWithInvalidLocationURI(@Mocked GlueCatalog glueCatalog) {
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
+                "glue_native_catalog", new Configuration(), icebergProperties);
+
+        // An unsupported scheme causes FileSystem.get() to throw, which should surface via fromExternalException
+        Map<String, String> dbProperties = new HashMap<>();
+        dbProperties.put("location", "unsupportedscheme://bucket/path");
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Invalid location URI: unsupportedscheme://bucket/path",
+                () -> icebergGlueCatalog.createDB(connectContext, "testdb", dbProperties));
+    }
+
+    @Test
+    public void testDropDBWhenGetDBThrows(@Mocked GlueCatalog glueCatalog) {
+        new Expectations() {
+            {
+                glueCatalog.loadNamespaceMetadata((Namespace) any);
+                result = new RuntimeException("Glue access denied");
+            }
+        };
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
+                "glue_native_catalog", new Configuration(), icebergProperties);
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to access database testdb",
+                () -> icebergGlueCatalog.dropDB(connectContext, "testdb"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.BaseView;
@@ -592,5 +593,163 @@ public class IcebergRESTCatalogTest {
         assertTrue(sessionContextOauth2.credentials() == null || sessionContextOauth2.credentials().isEmpty(),
                 "When security=OAUTH2, user's OIDC token should NOT be passed to REST Catalog. " +
                         "Catalog should use its own configured oauth2.credential instead");
+    }
+
+    @Test
+    public void testRESTExceptionPropagation(@Mocked RESTSessionCatalog restCatalog) {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+
+        // getTable - line 161
+        new Expectations() {
+            {
+                restCatalog.loadTable((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to load table using REST Catalog",
+                () -> icebergRESTCatalog.getTable(connectContext, "db", "tbl"));
+
+        // tableExists - line 171
+        new Expectations() {
+            {
+                restCatalog.tableExists((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to check tableExists using REST Catalog",
+                () -> icebergRESTCatalog.tableExists(connectContext, "db", "tbl"));
+
+        // listAllDatabases - line 186
+        new Expectations() {
+            {
+                restCatalog.listNamespaces((SessionContext) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to list all databases using REST Catalog",
+                () -> icebergRESTCatalog.listAllDatabases(connectContext));
+
+        // createDB (createNamespace) - line 220
+        new Expectations() {
+            {
+                restCatalog.createNamespace((SessionContext) any, (Namespace) any, (Map<String, String>) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to create namespace using REST Catalog",
+                () -> icebergRESTCatalog.createDB(connectContext, "db", Maps.newHashMap()));
+
+        // getDB - line 257
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to get database using REST Catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        // dropDB (dropNamespace) - line 246
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = ImmutableMap.of("location", "s3://bucket/path");
+                minTimes = 0;
+
+                restCatalog.dropNamespace((SessionContext) any, (Namespace) any);
+                result = new RESTException("access denied");
+                minTimes = 0;
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to drop database using REST Catalog",
+                () -> icebergRESTCatalog.dropDB(connectContext, "db"));
+
+        // listTables - line 271
+        new Expectations() {
+            {
+                restCatalog.listTables((SessionContext) any, (Namespace) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to list tables using REST Catalog",
+                () -> icebergRESTCatalog.listTables(connectContext, "db"));
+
+        // listViews exception (listTables succeeds) - line 284
+        new Expectations() {
+            {
+                restCatalog.listTables((SessionContext) any, (Namespace) any);
+                result = ImmutableList.of();
+
+                restCatalog.listViews((SessionContext) any, (Namespace) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to list views using REST Catalog",
+                () -> icebergRESTCatalog.listTables(connectContext, "db"));
+
+        // createTable - line 321
+        new Expectations() {
+            {
+                restCatalog.buildTable((SessionContext) any, (TableIdentifier) any, (Schema) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to create table using REST catalog",
+                () -> icebergRESTCatalog.createTable(connectContext, "db", "tbl", null, null, null, null,
+                        Maps.newHashMap()));
+
+        // dropTable - line 334
+        new Expectations() {
+            {
+                restCatalog.dropTable((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to drop table using REST Catalog",
+                () -> icebergRESTCatalog.dropTable(connectContext, "db", "tbl", false));
+
+        // renameTable - line 348
+        new Expectations() {
+            {
+                restCatalog.renameTable((SessionContext) any, (TableIdentifier) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to rename table using REST Catalog",
+                () -> icebergRESTCatalog.renameTable(connectContext, "db", "tbl", "tbl2"));
+
+        // getView - line 368
+        new Expectations() {
+            {
+                restCatalog.loadView((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to load view using REST Catalog",
+                () -> icebergRESTCatalog.getView(connectContext, "db", "view"));
+
+        // dropView - line 378
+        new Expectations() {
+            {
+                restCatalog.dropView((SessionContext) any, (TableIdentifier) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class, "Failed to drop view using REST Catalog",
+                () -> icebergRESTCatalog.dropView(connectContext, "db", "view"));
+
+        // loadNamespaceMetadata - line 424
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new RESTException("access denied");
+            }
+        };
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to load table metadata using REST Catalog",
+                () -> icebergRESTCatalog.loadNamespaceMetadata(connectContext, Namespace.of("db")));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -25,7 +25,6 @@ import com.starrocks.catalog.PaimonView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.proc.ExternalSchemaProcNode;
 import com.starrocks.common.proc.ProcResult;
@@ -1915,6 +1914,6 @@ public class PaimonMetadataTest {
                 result = new Catalog.ViewNotExistException(new Identifier("test", "ViewNotExist"));
             }
         };
-        org.junit.jupiter.api.Assertions.assertThrows(DdlException.class, () -> metadata.dropTable(connectContext, dropStmt));
+        org.junit.jupiter.api.Assertions.assertThrows(StarRocksConnectorException.class, () -> metadata.dropTable(connectContext, dropStmt));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -416,7 +416,7 @@ public class PaimonMetadataTest {
                 cachingCatalog.refreshPartitions(new Identifier("db", "object_tbl"));
                 result = new ClassCastException(
                         "class org.apache.paimon.table.object.ObjectTableImpl cannot be cast to " +
-                        "class org.apache.paimon.table.FileStoreTable");
+                                "class org.apache.paimon.table.FileStoreTable");
                 cachingCatalog.refreshPartitions(new Identifier("db", "normal_tbl"));
             }
         };
@@ -1914,6 +1914,7 @@ public class PaimonMetadataTest {
                 result = new Catalog.ViewNotExistException(new Identifier("test", "ViewNotExist"));
             }
         };
-        org.junit.jupiter.api.Assertions.assertThrows(StarRocksConnectorException.class, () -> metadata.dropTable(connectContext, dropStmt));
+        org.junit.jupiter.api.Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.dropTable(connectContext, dropStmt));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
When external catalogs (HMS, Glue, Iceberg REST/Glue, Delta Lake, Hudi, Paimon) hit an auth or connectivity failure, the error shown to users was often incomplete — a single-level message like "The security token is invalid" with no indication of which layer threw it, since each connector handled exceptions inconsistently and the display site only ever called `e.getMessage()`, which surfaces just the outermost message.

## What I'm doing:
Lower layers stop flattening or re-interpreting the exception chain — they only add a brief context label. The top-level display site unwinds the full chain once and presents it to the user.

```
connector layer:  throw new StarRocksConnectorException("Failed to list tables for catalog X", cause)
                  └─ only adds context; cause chain preserved natively via getCause()

display site:     LogUtil.getUnwoundExceptionMessage(e)
                  └─ walks the getCause() chain, keeps the outer message plain,
                     and prefixes deeper layers with their class name
                  e.g.:  Failed to list tables for catalog X
                         GlueException: The security token is invalid (Service: Glue, Status Code: 400)
```

- `LogUtil.getUnwoundExceptionMessage(Throwable)` — walks the cause chain up to 20 levels, transparently unwraps `InvocationTargetException` (common from HMS reflection calls), and formats the result.
- `StmtExecutor` — both display paths (`catch StarRocksException` for DDL and `catch Throwable` for queries/SHOW) now call `getUnwoundExceptionMessage`, so the full chain reaches the user regardless of which connector or operation triggered the error.
- Connector call sites — replaced inconsistent patterns with uniform `new StarRocksConnectorException(context, cause)` across `HiveMetaClient.callRPC()`, `IcebergRESTCatalog`, `IcebergGlueCatalog`, `CachingIcebergCatalog`, `IcebergMetadata`, `DeltaLakeMetastore`/`DeltaLakeMetadata`, `HudiMetadata`, `PaimonMetadata`.
- `StarRocksConnectorException` — removed the dead `fromExternalException`-era overrides.

**Scoping fix (added after initial review):** `StmtExecutor`'s two catch blocks are the shared error-reporting path for *every* SQL statement, not just connector operations, so a naive "always unwind" implementation leaked class-name prefixes into unrelated errors (e.g. a plain `DdlException: Unknown thread id: ...`) that never had them before. `getUnwoundExceptionMessage` now only produces the multi-layer format when there's a genuine, distinct cause chain to unwind:
- A single-layer exception (no real cause) falls back to the exact original `e.getMessage()` — no class name.
- Adjacent layers carrying an identical message (a pattern already used internally to re-wrap exceptions for classification, e.g. `SemanticException` → `AnalysisException`) are collapsed into one so the same text isn't shown twice.
- For genuine multi-layer chains, the outermost layer is still shown plain (it's almost always a generic internal wrapper type) — only deeper layers get a class-name prefix, since that's where the "which system actually failed" signal lives.

This keeps the original connector-error goal intact while leaving every unrelated error message byte-for-byte unchanged.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
