### PR TITLE
[Enhancement] Balance load-primary compute nodes for skewed shared-data shards

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1236,6 +1236,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean lake_enable_tablet_creation_optimization = false;
 
+    @ConfField(mutable = true, comment = "In shared-data mode, balance per-tablet load-primary compute " +
+            "nodes across alive nodes when the natural (StarOS shard owner) assignment is skewed, e.g. a " +
+            "freshly presplit/reshard RANGE table whose new shards all live on one worker. Prevents the " +
+            "whole load write phase (delta-writer/flush/spill-merge) from concentrating on one node.")
+    public static boolean lake_balance_load_primary_compute_nodes = true;
+
     @ConfField(mutable = true, comment = "Max retry times for failed create tablet tasks in shared-data mode. " +
             "Only explicitly failed tasks are retried (not timeouts). Set 0 to disable retry.")
     public static int lake_create_tablet_max_retries = 1;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -98,6 +98,7 @@ import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -1034,6 +1035,62 @@ public class OlapTableSink extends DataSink {
         return -1L;
     }
 
+    /**
+     * Balance the per-tablet load-primary compute nodes across the alive compute nodes.
+     *
+     * <p>In shared-data mode the write node need not be the tablet's StarOS shard owner — segment data
+     * is persisted to object storage, so any alive compute node can serve as the load primary. The
+     * natural assignment ({@code naturalNodes}, one shard owner per tablet) can be heavily skewed for
+     * freshly created shards (e.g. a presplit/reshard RANGE table whose new shards all live on one
+     * worker), which would funnel every tablet's delta-writer, memtable flush and spill merge onto a
+     * single node during a load. When the natural assignment is more skewed than an even spread, this
+     * reassigns the primaries round-robin over the alive nodes so the write phase is parallelized.
+     * Already-balanced assignments (e.g. HASH bucketing) are returned unchanged.
+     *
+     * <p>Disabled (returns {@code naturalNodes}) when
+     * {@code Config.lake_balance_load_primary_compute_nodes} is false.
+     */
+    @VisibleForTesting
+    static List<Long> balanceCloudNativeLoadPrimaries(List<Long> naturalNodes, List<ComputeNode> aliveNodes) {
+        if (!Config.lake_balance_load_primary_compute_nodes) {
+            return naturalNodes;
+        }
+        int n = naturalNodes.size();
+        if (aliveNodes == null || aliveNodes.size() <= 1 || n == 0) {
+            return naturalNodes;
+        }
+        // Deterministic node order so the assignment is stable across FE restarts / replays.
+        List<Long> nodeIds = new ArrayList<>();
+        for (ComputeNode node : aliveNodes) {
+            nodeIds.add(node.getId());
+        }
+        Collections.sort(nodeIds);
+        int k = nodeIds.size();
+
+        // Skew check: keep the natural assignment unless some node owns more tablets than an even
+        // spread (ceil(n/k)) would give it.
+        Map<Long, Integer> perNode = new HashMap<>();
+        for (Long id : naturalNodes) {
+            perNode.merge(id, 1, Integer::sum);
+        }
+        int idealMax = (n + k - 1) / k;
+        int observedMax = 0;
+        for (int c : perNode.values()) {
+            observedMax = Math.max(observedMax, c);
+        }
+        if (observedMax <= idealMax) {
+            return naturalNodes;
+        }
+
+        List<Long> balanced = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            balanced.add(nodeIds.get(i % k));
+        }
+        LOG.info("rebalanced {} cloud-native load primaries from skewed natural assignment "
+                + "(max {} per node) to round-robin over {} alive nodes", n, observedMax, k);
+        return balanced;
+    }
+
     public static TOlapTableLocationParam createLocation(OlapTable table, TOlapTablePartitionParam partitionParam,
                                                          boolean enableReplicatedStorage,
                                                          TransactionState txnState) throws StarRocksException {
@@ -1079,6 +1136,11 @@ public class OlapTableSink extends DataSink {
                 }
             }
         }
+        // For cloud-native (shared-data) tables we collect each tablet's natural load-primary
+        // compute node first, then balance them across the alive nodes below (see
+        // balanceCloudNativeLoadPrimaries) before populating locationParam.
+        List<Long> cloudNativeTabletIds = new ArrayList<>();
+        List<Long> cloudNativePrimaryNodes = new ArrayList<>();
         for (TOlapTablePartition tPhysicalPartition : partitionParam.getPartitions()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(tPhysicalPartition.getId());
             int quorum = table.getPartitionInfo().getQuorumNum(physicalPartition.getParentId(), table.writeQuorum());
@@ -1101,7 +1163,8 @@ public class OlapTableSink extends DataSink {
                             computeNodeId = warehouseManager
                                     .getComputeNodeAssignedToTablet(computeResource, tablet.getId()).getId();
                         }
-                        locationParam.addToTablets(new TTabletLocation(tablet.getId(), Lists.newArrayList(computeNodeId)));
+                        cloudNativeTabletIds.add(tablet.getId());
+                        cloudNativePrimaryNodes.add(computeNodeId);
                     } else {
                         // we should ensure the replica backend is alive
                         // otherwise, there will be a 'unknown node id, id=xxx' error for stream load
@@ -1140,6 +1203,20 @@ public class OlapTableSink extends DataSink {
                         }
                     }
                 }
+            }
+        }
+
+        // Shared-data: each tablet's natural load primary is its StarOS shard owner. Freshly created
+        // shards (e.g. presplit/reshard of a RANGE-distributed table) can all land on one worker, which
+        // then runs every tablet's delta-writer / memtable-flush / spill-merge during a load while the
+        // other compute nodes sit idle. Balance the load primaries across the alive nodes when the
+        // natural assignment is skewed; balanced assignments (the common HASH case) are left untouched.
+        if (!cloudNativeTabletIds.isEmpty()) {
+            List<Long> balancedNodes = balanceCloudNativeLoadPrimaries(
+                    cloudNativePrimaryNodes, warehouseManager.getAliveComputeNodes(computeResource));
+            for (int i = 0; i < cloudNativeTabletIds.size(); i++) {
+                locationParam.addToTablets(new TTabletLocation(
+                        cloudNativeTabletIds.get(i), Lists.newArrayList(balancedNodes.get(i))));
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkBalanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkBalanceTest.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.system.ComputeNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OlapTableSinkBalanceTest {
+
+    private static List<ComputeNode> nodes(long... ids) {
+        List<ComputeNode> nodes = Lists.newArrayList();
+        for (long id : ids) {
+            nodes.add(new ComputeNode(id, "127.0.0.1", 9050));
+        }
+        return nodes;
+    }
+
+    private static int maxPerNode(List<Long> assignment) {
+        Map<Long, Integer> cnt = new HashMap<>();
+        int max = 0;
+        for (Long id : assignment) {
+            int c = cnt.merge(id, 1, Integer::sum);
+            max = Math.max(max, c);
+        }
+        return max;
+    }
+
+    @Test
+    public void testSkewedAssignmentIsRebalanced() {
+        // All 6 tablets' natural primary is node 10001 (the presplit/reshard skew case).
+        List<Long> natural = Lists.newArrayList(10001L, 10001L, 10001L, 10001L, 10001L, 10001L);
+        List<Long> balanced = OlapTableSink.balanceCloudNativeLoadPrimaries(natural, nodes(10001L, 10002L, 10003L));
+        // 6 tablets over 3 nodes -> exactly 2 per node.
+        Assertions.assertEquals(2, maxPerNode(balanced));
+        Assertions.assertEquals(6, balanced.size());
+    }
+
+    @Test
+    public void testBalancedAssignmentIsUntouched() {
+        // HASH case: already 2 per node -> returned unchanged (same list instance).
+        List<Long> natural = Lists.newArrayList(10001L, 10002L, 10003L, 10001L, 10002L, 10003L);
+        List<Long> result = OlapTableSink.balanceCloudNativeLoadPrimaries(natural, nodes(10001L, 10002L, 10003L));
+        Assertions.assertSame(natural, result);
+    }
+
+    @Test
+    public void testPartiallySkewedUsesAllNodes() {
+        // 6 tablets on only 2 of 3 alive nodes (3 each) is more skewed than ceil(6/3)=2 -> rebalance to all 3.
+        List<Long> natural = Lists.newArrayList(10001L, 10001L, 10001L, 10002L, 10002L, 10002L);
+        List<Long> balanced = OlapTableSink.balanceCloudNativeLoadPrimaries(natural, nodes(10001L, 10002L, 10003L));
+        Assertions.assertEquals(2, maxPerNode(balanced));
+    }
+
+    @Test
+    public void testSingleNodeNoOp() {
+        List<Long> natural = Lists.newArrayList(10001L, 10001L);
+        List<Long> result = OlapTableSink.balanceCloudNativeLoadPrimaries(natural, nodes(10001L));
+        Assertions.assertSame(natural, result);
+    }
+
+    @Test
+    public void testDisabledByConfig() {
+        boolean old = Config.lake_balance_load_primary_compute_nodes;
+        Config.lake_balance_load_primary_compute_nodes = false;
+        try {
+            List<Long> natural = Lists.newArrayList(10001L, 10001L, 10001L);
+            List<Long> result =
+                    OlapTableSink.balanceCloudNativeLoadPrimaries(natural, nodes(10001L, 10002L, 10003L));
+            Assertions.assertSame(natural, result);
+        } finally {
+            Config.lake_balance_load_primary_compute_nodes = old;
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, the load-primary compute node for each tablet is chosen as its
StarOS shard owner (`OlapTableSink.createLocation` → `getAllComputeNodeIdsAssignToTablets`
/ `getPrimaryComputeNodeIdByShard`). Freshly created shards — e.g. the presplit/reshard
shards of a RANGE-distributed Primary-Key table — can all land on a single worker at
creation time. A load that runs immediately afterwards then routes **every** tablet's
delta-writer, memtable flush and load-spill merge to that one node, while the other
compute nodes sit idle and backpressure the scan.

This was measured on a 3-BE shared-data cluster loading a 1.5B-row PK table via
`INSERT INTO ... SELECT * FROM FILES()`: with 6 tablets balanced 2-per-BE in storage,
the RANGE table's write phase still ran entirely on one BE (~2× CPU, all 6 tablets'
spill-merge there, the other two BEs ~98% idle), making the import ~2.4× slower than
the equivalent HASH table (~1507s vs ~627s) even though both had an identical balanced
tablet layout. The post-load `SHOW TABLETS` ownership was balanced 2/BE — the skew is
purely at *load time*, because the load-primary follows the (skewed) shard owner.

## What I'm doing:

In shared-data mode the write node need not be the shard owner — segment data is
persisted to object storage, so any alive compute node can serve as the load primary.
`createLocation` now collects the natural per-tablet load primaries and, when that
assignment is more skewed than an even spread (some node owns more than `ceil(n/k)`
tablets over `k` alive nodes), reassigns them round-robin across the alive compute
nodes. Already-balanced assignments (the common HASH-bucketing case) are returned
unchanged, so HASH loads are unaffected. Guarded by a new mutable FE config
`lake_balance_load_primary_compute_nodes` (default `true`) for easy rollback.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
