### PR TITLE
[Enhancement] Spread pre-split shards across compute nodes instead of PACKing onto the source worker

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -207,8 +207,7 @@ public class MergeTabletJob extends TabletReshardJob {
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             boolean useAggregatePublish = olapTable.isFileBundling();
-            ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                    .getBackgroundComputeResource(tableId);
+            ComputeResource computeResource = resolveComputeResource(tableId);
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -40,7 +40,6 @@ import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -722,7 +721,7 @@ public class MergeTabletJob extends TabletReshardJob {
                             table.getPartitionFilePathInfo(physicalPartitionId),
                             table.getPartitionFileCacheInfo(physicalPartitionId),
                             newIndex.getShardGroupId(),
-                            properties, WarehouseManager.DEFAULT_RESOURCE);
+                            properties, resolveComputeResource(tableId));
                 }
             }
         } catch (StarRocksException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -897,15 +897,16 @@ public class SplitTabletJob extends TabletReshardJob {
         shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
         // Pre-split splits a freshly created EMPTY tablet — there is no warm cache to preserve, so
-        // spread the new shards (drop the WITH_SHARD pin) and schedule them to the triggering load's
-        // warehouse so they stay where the load runs instead of the default worker group. An online
-        // split (non-empty source) keeps the WITH_SHARD pin to reuse the source worker's warm cache,
-        // and DEFAULT_RESOURCE since its placement is pinned anyway. Emptiness is the same signal the
-        // pre-split eligibility gate uses (TabletPreSplitCoordinator: base-index rowCount == 0).
+        // spread the new shards (drop the WITH_SHARD pin) so the following load is not funneled onto
+        // the source tablet's single worker. An online split (non-empty source) keeps the WITH_SHARD
+        // pin to reuse the source worker's warm cache. Emptiness is the same signal the pre-split
+        // eligibility gate uses (TabletPreSplitCoordinator: base-index rowCount == 0).
         boolean spreadNewShards = oldIndex != null && oldIndex.getRowCount() == 0;
-        ComputeResource computeResource = spreadNewShards
-                ? resolveComputeResource(table.getId())
-                : WarehouseManager.DEFAULT_RESOURCE;
+        // Schedule the new shards to the triggering load's warehouse when one was set (pre-split),
+        // otherwise DEFAULT_RESOURCE (the original online-split behavior).
+        ComputeResource computeResource = warehouseId == null
+                ? WarehouseManager.DEFAULT_RESOURCE
+                : GlobalStateMgr.getCurrentState().getWarehouseMgr().acquireComputeResource(warehouseId);
         GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
                 newToOldShardId,
                 newShardIdToGroupIds,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.staros.proto.PlacementPolicy;
@@ -91,16 +92,36 @@ public class SplitTabletJob extends TabletReshardJob {
     @SerializedName(value = "endTransactionId")
     protected long endTransactionId;
 
+    // When true, new shards are spread across compute nodes instead of being PACKed onto the
+    // source tablet's worker. Set only by the pre-split entry points (the source tablet is empty,
+    // so there is no warm cache to reuse and PACK would funnel the whole load onto one node). An
+    // online split leaves this false to keep its data-locality PACK. Persisted so a leader-switch
+    // re-run of createShardsOnStarOS uses the same placement.
+    @SerializedName(value = "spreadNewShards")
+    protected final boolean spreadNewShards;
+
     public SplitTabletJob(long jobId, long dbId, long tableId,
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
+        this(jobId, dbId, tableId, reshardingPhysicalPartitions, false);
+    }
+
+    public SplitTabletJob(long jobId, long dbId, long tableId,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions,
+            boolean spreadNewShards) {
         super(jobId, JobType.SPLIT_TABLET);
         this.dbId = dbId;
         this.tableId = tableId;
         this.reshardingPhysicalPartitions = reshardingPhysicalPartitions;
+        this.spreadNewShards = spreadNewShards;
     }
 
     public long getDbId() {
         return dbId;
+    }
+
+    @VisibleForTesting
+    public boolean isSpreadNewShards() {
+        return spreadNewShards;
     }
 
     public long getTableId() {
@@ -902,7 +923,8 @@ public class SplitTabletJob extends TabletReshardJob {
                 newShardIdToGroupIds,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),
-                shardProperties, WarehouseManager.DEFAULT_RESOURCE);
+                shardProperties, WarehouseManager.DEFAULT_RESOURCE,
+                spreadNewShards);
     }
 
     private static void addShardPlacementsForTablet(ReshardingTablet reshardingTablet,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -102,10 +102,11 @@ public class SplitTabletJob extends TabletReshardJob {
 
     // The warehouse the triggering load runs in. When spreading (the WITH_SHARD pin is dropped), this
     // is the only thing that keeps the new shards in the load's warehouse worker group instead of the
-    // default one. Persisted so a leader-switch re-run of createShardsOnStarOS targets the same
+    // default one. Set by the pre-split caller right after construction via setLoadWarehouseId, before
+    // the job is journaled; persisted so a leader-switch re-run of createShardsOnStarOS targets the same
     // warehouse. Defaults to DEFAULT_WAREHOUSE_ID for online split (where it is unused).
     @SerializedName(value = "loadWarehouseId")
-    protected final long loadWarehouseId;
+    protected long loadWarehouseId;
 
     public SplitTabletJob(long jobId, long dbId, long tableId,
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
@@ -135,6 +136,15 @@ public class SplitTabletJob extends TabletReshardJob {
     @VisibleForTesting
     public long getLoadWarehouseId() {
         return loadWarehouseId;
+    }
+
+    /**
+     * Set the triggering load's warehouse for a pre-split job. Called by the pre-split caller right
+     * after the factory builds the job and before it is journaled, so the spread shards are scheduled
+     * in the load's warehouse rather than the default one.
+     */
+    public void setLoadWarehouseId(long loadWarehouseId) {
+        this.loadWarehouseId = loadWarehouseId;
     }
 
     public long getTableId() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -49,7 +49,6 @@ import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletReshardJobsItem;
@@ -903,10 +902,8 @@ public class SplitTabletJob extends TabletReshardJob {
         // eligibility gate uses (TabletPreSplitCoordinator: base-index rowCount == 0).
         boolean spreadNewShards = oldIndex != null && oldIndex.getRowCount() == 0;
         // Schedule the new shards to the triggering load's warehouse when one was set (pre-split),
-        // otherwise DEFAULT_RESOURCE (the original online-split behavior).
-        ComputeResource computeResource = warehouseId == null
-                ? WarehouseManager.DEFAULT_RESOURCE
-                : GlobalStateMgr.getCurrentState().getWarehouseMgr().acquireComputeResource(warehouseId);
+        // otherwise the background warehouse (online split) — unified with the publish path.
+        ComputeResource computeResource = resolveComputeResource(table.getId());
         GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
                 newToOldShardId,
                 newShardIdToGroupIds,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.alter.reshard;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.staros.proto.PlacementPolicy;
@@ -92,59 +91,16 @@ public class SplitTabletJob extends TabletReshardJob {
     @SerializedName(value = "endTransactionId")
     protected long endTransactionId;
 
-    // When true, new shards are spread across compute nodes instead of being PACKed onto the
-    // source tablet's worker. Set only by the pre-split entry points (the source tablet is empty,
-    // so there is no warm cache to reuse and PACK would funnel the whole load onto one node). An
-    // online split leaves this false to keep its data-locality PACK. Persisted so a leader-switch
-    // re-run of createShardsOnStarOS uses the same placement.
-    @SerializedName(value = "spreadNewShards")
-    protected final boolean spreadNewShards;
-
-    // The warehouse the triggering load runs in. When spreading (the WITH_SHARD pin is dropped), this
-    // is the only thing that keeps the new shards in the load's warehouse worker group instead of the
-    // default one. Set by the pre-split caller right after construction via setLoadWarehouseId, before
-    // the job is journaled; persisted so a leader-switch re-run of createShardsOnStarOS targets the same
-    // warehouse. Defaults to DEFAULT_WAREHOUSE_ID for online split (where it is unused).
-    @SerializedName(value = "loadWarehouseId")
-    protected long loadWarehouseId;
-
     public SplitTabletJob(long jobId, long dbId, long tableId,
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
-        this(jobId, dbId, tableId, reshardingPhysicalPartitions, false, WarehouseManager.DEFAULT_WAREHOUSE_ID);
-    }
-
-    public SplitTabletJob(long jobId, long dbId, long tableId,
-            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions,
-            boolean spreadNewShards, long loadWarehouseId) {
         super(jobId, JobType.SPLIT_TABLET);
         this.dbId = dbId;
         this.tableId = tableId;
         this.reshardingPhysicalPartitions = reshardingPhysicalPartitions;
-        this.spreadNewShards = spreadNewShards;
-        this.loadWarehouseId = loadWarehouseId;
     }
 
     public long getDbId() {
         return dbId;
-    }
-
-    @VisibleForTesting
-    public boolean isSpreadNewShards() {
-        return spreadNewShards;
-    }
-
-    @VisibleForTesting
-    public long getLoadWarehouseId() {
-        return loadWarehouseId;
-    }
-
-    /**
-     * Set the triggering load's warehouse for a pre-split job. Called by the pre-split caller right
-     * after the factory builds the job and before it is journaled, so the spread shards are scheduled
-     * in the load's warehouse rather than the default one.
-     */
-    public void setLoadWarehouseId(long loadWarehouseId) {
-        this.loadWarehouseId = loadWarehouseId;
     }
 
     public long getTableId() {
@@ -263,8 +219,7 @@ public class SplitTabletJob extends TabletReshardJob {
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
             boolean useAggregatePublish = olapTable.isFileBundling();
-            ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr()
-                    .getBackgroundComputeResource(tableId);
+            ComputeResource computeResource = resolveComputeResource(tableId);
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
                 PhysicalPartition physicalPartition = olapTable
                         .getPhysicalPartition(reshardingPhysicalPartition.getPhysicalPartitionId());
@@ -941,13 +896,15 @@ public class SplitTabletJob extends TabletReshardJob {
         shardProperties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
         shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
-        // Pre-split drops the WITH_SHARD pin, so scheduleToWorkerGroup becomes the only placement hint
-        // left; schedule to the triggering load's warehouse so the spread shards stay where the load
-        // runs instead of defaulting to the default worker group. An online split keeps DEFAULT_RESOURCE:
-        // its WITH_SHARD pin already co-locates each new shard with the source shard (and hence the
-        // source's warehouse), so the schedule target does not change placement.
+        // Pre-split splits a freshly created EMPTY tablet — there is no warm cache to preserve, so
+        // spread the new shards (drop the WITH_SHARD pin) and schedule them to the triggering load's
+        // warehouse so they stay where the load runs instead of the default worker group. An online
+        // split (non-empty source) keeps the WITH_SHARD pin to reuse the source worker's warm cache,
+        // and DEFAULT_RESOURCE since its placement is pinned anyway. Emptiness is the same signal the
+        // pre-split eligibility gate uses (TabletPreSplitCoordinator: base-index rowCount == 0).
+        boolean spreadNewShards = oldIndex != null && oldIndex.getRowCount() == 0;
         ComputeResource computeResource = spreadNewShards
-                ? GlobalStateMgr.getCurrentState().getWarehouseMgr().acquireComputeResource(loadWarehouseId)
+                ? resolveComputeResource(table.getId())
                 : WarehouseManager.DEFAULT_RESOURCE;
         GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
                 newToOldShardId,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -100,19 +100,27 @@ public class SplitTabletJob extends TabletReshardJob {
     @SerializedName(value = "spreadNewShards")
     protected final boolean spreadNewShards;
 
+    // The warehouse the triggering load runs in. When spreading (the WITH_SHARD pin is dropped), this
+    // is the only thing that keeps the new shards in the load's warehouse worker group instead of the
+    // default one. Persisted so a leader-switch re-run of createShardsOnStarOS targets the same
+    // warehouse. Defaults to DEFAULT_WAREHOUSE_ID for online split (where it is unused).
+    @SerializedName(value = "loadWarehouseId")
+    protected final long loadWarehouseId;
+
     public SplitTabletJob(long jobId, long dbId, long tableId,
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
-        this(jobId, dbId, tableId, reshardingPhysicalPartitions, false);
+        this(jobId, dbId, tableId, reshardingPhysicalPartitions, false, WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     public SplitTabletJob(long jobId, long dbId, long tableId,
             Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions,
-            boolean spreadNewShards) {
+            boolean spreadNewShards, long loadWarehouseId) {
         super(jobId, JobType.SPLIT_TABLET);
         this.dbId = dbId;
         this.tableId = tableId;
         this.reshardingPhysicalPartitions = reshardingPhysicalPartitions;
         this.spreadNewShards = spreadNewShards;
+        this.loadWarehouseId = loadWarehouseId;
     }
 
     public long getDbId() {
@@ -122,6 +130,11 @@ public class SplitTabletJob extends TabletReshardJob {
     @VisibleForTesting
     public boolean isSpreadNewShards() {
         return spreadNewShards;
+    }
+
+    @VisibleForTesting
+    public long getLoadWarehouseId() {
+        return loadWarehouseId;
     }
 
     public long getTableId() {
@@ -919,12 +932,12 @@ public class SplitTabletJob extends TabletReshardJob {
         shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
         // Pre-split drops the WITH_SHARD pin, so scheduleToWorkerGroup becomes the only placement hint
-        // left; schedule to the table's (warehouse) compute resource so the spread shards stay in the
-        // load's warehouse instead of defaulting to the default worker group. An online split keeps
-        // DEFAULT_RESOURCE: its WITH_SHARD pin already co-locates each new shard with the source shard
-        // (and hence the source's warehouse), so the schedule target does not change placement.
+        // left; schedule to the triggering load's warehouse so the spread shards stay where the load
+        // runs instead of defaulting to the default worker group. An online split keeps DEFAULT_RESOURCE:
+        // its WITH_SHARD pin already co-locates each new shard with the source shard (and hence the
+        // source's warehouse), so the schedule target does not change placement.
         ComputeResource computeResource = spreadNewShards
-                ? GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(table.getId())
+                ? GlobalStateMgr.getCurrentState().getWarehouseMgr().acquireComputeResource(loadWarehouseId)
                 : WarehouseManager.DEFAULT_RESOURCE;
         GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
                 newToOldShardId,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -918,12 +918,20 @@ public class SplitTabletJob extends TabletReshardJob {
         shardProperties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
         shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
+        // Pre-split drops the WITH_SHARD pin, so scheduleToWorkerGroup becomes the only placement hint
+        // left; schedule to the table's (warehouse) compute resource so the spread shards stay in the
+        // load's warehouse instead of defaulting to the default worker group. An online split keeps
+        // DEFAULT_RESOURCE: its WITH_SHARD pin already co-locates each new shard with the source shard
+        // (and hence the source's warehouse), so the schedule target does not change placement.
+        ComputeResource computeResource = spreadNewShards
+                ? GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(table.getId())
+                : WarehouseManager.DEFAULT_RESOURCE;
         GlobalStateMgr.getCurrentState().getStarOSAgent().createShardsForSplit(
                 newToOldShardId,
                 newShardIdToGroupIds,
                 table.getPartitionFilePathInfo(physicalPartitionId),
                 table.getPartitionFileCacheInfo(physicalPartitionId),
-                shardProperties, WarehouseManager.DEFAULT_RESOURCE,
+                shardProperties, computeResource,
                 spreadNewShards);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -198,7 +198,10 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         verifyNewTabletRanges(table, reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+        // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
+        // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
+                true /* spreadNewShards */);
     }
 
     /**
@@ -348,7 +351,10 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         verifyNewTabletRanges(table, reshardingPhysicalPartitions);
 
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+        // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
+        // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
+                true /* spreadNewShards */);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -37,7 +37,6 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -201,9 +200,8 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
-        // The triggering load's warehouse is applied by the caller via SplitTabletJob#setLoadWarehouseId.
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        // The triggering load's warehouse is applied by the caller via TabletReshardJob#setWarehouseId.
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
     }
 
     /**
@@ -355,9 +353,8 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
-        // The triggering load's warehouse is applied by the caller via SplitTabletJob#setLoadWarehouseId.
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        // The triggering load's warehouse is applied by the caller via TabletReshardJob#setWarehouseId.
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -39,7 +39,6 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
-import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -123,16 +122,6 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      */
     public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
             List<TabletRange> newTabletRanges) throws StarRocksException {
-        return forExternalBoundaries(db, table, oldTabletId, newTabletRanges, null);
-    }
-
-    /**
-     * Pre-split entry point that also carries the triggering load's {@code ComputeResource} so the
-     * spread shards are scheduled in the load's warehouse (see {@link SplitTabletJob#loadWarehouseId}).
-     * A {@code null} resource falls back to the default warehouse.
-     */
-    public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
-            List<TabletRange> newTabletRanges, ComputeResource loadComputeResource) throws StarRocksException {
         validateTableLevel(db, table);
         validateRangeListShape(newTabletRanges);
 
@@ -212,9 +201,9 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
-        // Carry the load's warehouse so the spread shards are scheduled where the load runs.
+        // The triggering load's warehouse is applied by the caller via SplitTabletJob#setLoadWarehouseId.
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */, loadWarehouseIdOf(loadComputeResource));
+                true /* spreadNewShards */, WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     /**
@@ -243,17 +232,6 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      */
     public static TabletReshardJob forExternalBoundariesMultiTablet(Database db, OlapTable table,
             Map<Long, List<TabletRange>> oldTabletIdToRanges) throws StarRocksException {
-        return forExternalBoundariesMultiTablet(db, table, oldTabletIdToRanges, null);
-    }
-
-    /**
-     * Multi-tablet pre-split entry point that also carries the triggering load's {@code ComputeResource}
-     * so the spread shards are scheduled in the load's warehouse. A {@code null} resource falls back to
-     * the default warehouse.
-     */
-    public static TabletReshardJob forExternalBoundariesMultiTablet(Database db, OlapTable table,
-            Map<Long, List<TabletRange>> oldTabletIdToRanges, ComputeResource loadComputeResource)
-            throws StarRocksException {
         Preconditions.checkArgument(oldTabletIdToRanges != null && !oldTabletIdToRanges.isEmpty(),
                 "External-boundaries multi-tablet split requires a non-empty oldTabletIdToRanges map");
 
@@ -377,16 +355,9 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
-        // Carry the load's warehouse so the spread shards are scheduled where the load runs.
+        // The triggering load's warehouse is applied by the caller via SplitTabletJob#setLoadWarehouseId.
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */, loadWarehouseIdOf(loadComputeResource));
-    }
-
-    /** The warehouse the load runs in, or the default warehouse when no load resource is supplied. */
-    private static long loadWarehouseIdOf(ComputeResource loadComputeResource) {
-        return loadComputeResource != null
-                ? loadComputeResource.getWarehouseId()
-                : WarehouseManager.DEFAULT_WAREHOUSE_ID;
+                true /* spreadNewShards */, WarehouseManager.DEFAULT_WAREHOUSE_ID);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -37,7 +37,9 @@ import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -121,6 +123,16 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      */
     public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
             List<TabletRange> newTabletRanges) throws StarRocksException {
+        return forExternalBoundaries(db, table, oldTabletId, newTabletRanges, null);
+    }
+
+    /**
+     * Pre-split entry point that also carries the triggering load's {@code ComputeResource} so the
+     * spread shards are scheduled in the load's warehouse (see {@link SplitTabletJob#loadWarehouseId}).
+     * A {@code null} resource falls back to the default warehouse.
+     */
+    public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
+            List<TabletRange> newTabletRanges, ComputeResource loadComputeResource) throws StarRocksException {
         validateTableLevel(db, table);
         validateRangeListShape(newTabletRanges);
 
@@ -200,8 +212,9 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
+        // Carry the load's warehouse so the spread shards are scheduled where the load runs.
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */);
+                true /* spreadNewShards */, loadWarehouseIdOf(loadComputeResource));
     }
 
     /**
@@ -230,6 +243,17 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      */
     public static TabletReshardJob forExternalBoundariesMultiTablet(Database db, OlapTable table,
             Map<Long, List<TabletRange>> oldTabletIdToRanges) throws StarRocksException {
+        return forExternalBoundariesMultiTablet(db, table, oldTabletIdToRanges, null);
+    }
+
+    /**
+     * Multi-tablet pre-split entry point that also carries the triggering load's {@code ComputeResource}
+     * so the spread shards are scheduled in the load's warehouse. A {@code null} resource falls back to
+     * the default warehouse.
+     */
+    public static TabletReshardJob forExternalBoundariesMultiTablet(Database db, OlapTable table,
+            Map<Long, List<TabletRange>> oldTabletIdToRanges, ComputeResource loadComputeResource)
+            throws StarRocksException {
         Preconditions.checkArgument(oldTabletIdToRanges != null && !oldTabletIdToRanges.isEmpty(),
                 "External-boundaries multi-tablet split requires a non-empty oldTabletIdToRanges map");
 
@@ -353,8 +377,16 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
+        // Carry the load's warehouse so the spread shards are scheduled where the load runs.
         return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions,
-                true /* spreadNewShards */);
+                true /* spreadNewShards */, loadWarehouseIdOf(loadComputeResource));
+    }
+
+    /** The warehouse the load runs in, or the default warehouse when no load resource is supplied. */
+    private static long loadWarehouseIdOf(ComputeResource loadComputeResource) {
+        return loadComputeResource != null
+                ? loadComputeResource.getWarehouseId()
+                : WarehouseManager.DEFAULT_WAREHOUSE_ID;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -69,15 +69,13 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "errorMessage")
     protected String errorMessage;
 
-    // Sentinel: no explicit warehouse set; fall back to the background warehouse.
-    public static final long INVALID_WAREHOUSE_ID = -1L;
-
     // The warehouse this job should run its compute work (shard creation + publish) in. Set by the
-    // pre-split caller to the triggering load's warehouse; left unset (INVALID_WAREHOUSE_ID) for an
-    // online split / merge, which then use the background warehouse. Persisted so a leader-switch
-    // re-run targets the same warehouse.
+    // pre-split caller to the triggering load's warehouse; null for an online split / merge (and for a
+    // job journaled before this field existed), which then fall back to the background warehouse.
+    // Nullable so a missing field on replay deserializes to null (background), not 0 (a real warehouse).
+    // Persisted so a leader-switch re-run targets the same warehouse.
     @SerializedName(value = "warehouseId")
-    protected long warehouseId = INVALID_WAREHOUSE_ID;
+    protected Long warehouseId;
 
     public TabletReshardJob(long jobId, JobType jobType) {
         this.jobId = jobId;
@@ -92,7 +90,7 @@ public abstract class TabletReshardJob implements Writable {
         return jobType;
     }
 
-    public long getWarehouseId() {
+    public Long getWarehouseId() {
         return warehouseId;
     }
 
@@ -108,11 +106,11 @@ public abstract class TabletReshardJob implements Writable {
     /**
      * Resolve the compute resource for this job's compute work: the explicitly-set warehouse when one
      * was provided (pre-split → the load's warehouse), otherwise the background warehouse (online
-     * split / merge).
+     * split / merge, or a job journaled before warehouseId existed).
      */
     protected ComputeResource resolveComputeResource(long tableId) {
         WarehouseManager warehouseMgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        return warehouseId == INVALID_WAREHOUSE_ID
+        return warehouseId == null
                 ? warehouseMgr.getBackgroundComputeResource(tableId)
                 : warehouseMgr.acquireComputeResource(warehouseId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -19,7 +19,9 @@ import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TTabletReshardJobsItem;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,6 +69,16 @@ public abstract class TabletReshardJob implements Writable {
     @SerializedName(value = "errorMessage")
     protected String errorMessage;
 
+    // Sentinel: no explicit warehouse set; fall back to the background warehouse.
+    public static final long INVALID_WAREHOUSE_ID = -1L;
+
+    // The warehouse this job should run its compute work (shard creation + publish) in. Set by the
+    // pre-split caller to the triggering load's warehouse; left unset (INVALID_WAREHOUSE_ID) for an
+    // online split / merge, which then use the background warehouse. Persisted so a leader-switch
+    // re-run targets the same warehouse.
+    @SerializedName(value = "warehouseId")
+    protected long warehouseId = INVALID_WAREHOUSE_ID;
+
     public TabletReshardJob(long jobId, JobType jobType) {
         this.jobId = jobId;
         this.jobType = jobType;
@@ -78,6 +90,31 @@ public abstract class TabletReshardJob implements Writable {
 
     public JobType getJobType() {
         return jobType;
+    }
+
+    public long getWarehouseId() {
+        return warehouseId;
+    }
+
+    /**
+     * Set the warehouse this job runs its compute work in. Called by the pre-split caller (before the
+     * job is journaled) with the triggering load's warehouse, so shard creation and publish run there
+     * rather than the background warehouse.
+     */
+    public void setWarehouseId(long warehouseId) {
+        this.warehouseId = warehouseId;
+    }
+
+    /**
+     * Resolve the compute resource for this job's compute work: the explicitly-set warehouse when one
+     * was provided (pre-split → the load's warehouse), otherwise the background warehouse (online
+     * split / merge).
+     */
+    protected ComputeResource resolveComputeResource(long tableId) {
+        WarehouseManager warehouseMgr = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        return warehouseId == INVALID_WAREHOUSE_ID
+                ? warehouseMgr.getBackgroundComputeResource(tableId)
+                : warehouseMgr.acquireComputeResource(warehouseId);
     }
 
     public JobState getJobState() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.alter.reshard.SplitTabletJob;
 import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
@@ -223,7 +224,12 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
 
         List<TabletRange> tabletRanges = buildTabletRanges(outcome.result.getBoundaries());
         TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
-                database, table, oldTabletId, tabletRanges, loadComputeResource);
+                database, table, oldTabletId, tabletRanges);
+        // Carry the triggering load's warehouse so the spread shards are scheduled where the load runs
+        // (production always returns a SplitTabletJob; the instanceof guard is a no-op under test mocks).
+        if (loadComputeResource != null && job instanceof SplitTabletJob splitJob) {
+            splitJob.setLoadWarehouseId(loadComputeResource.getWarehouseId());
+        }
         return Optional.of(new PreparedReshardJob(job));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -27,6 +27,7 @@ import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -91,6 +92,9 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
     private final long fileTotalBytes;
     private final Duration pollInterval;
     private final Clock clock;
+    // The triggering load's compute resource, carried into SplitTabletJobFactory.forExternalBoundaries
+    // so pre-split shards are scheduled in the load's warehouse. May be null (falls back to default).
+    private final ComputeResource loadComputeResource;
 
     public DefaultPreSplitPipeline(
             MetaTierSampler metaTierSampler,
@@ -101,7 +105,8 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
             long oldTabletId,
             long fileTotalBytes,
             Duration pollInterval,
-            Clock clock) {
+            Clock clock,
+            ComputeResource loadComputeResource) {
         this.metaTierSampler = Objects.requireNonNull(metaTierSampler, "metaTierSampler");
         this.dataTierSampler = Objects.requireNonNull(dataTierSampler, "dataTierSampler");
         this.tabletReshardJobManager = Objects.requireNonNull(tabletReshardJobManager, "tabletReshardJobManager");
@@ -113,6 +118,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         this.fileTotalBytes = fileTotalBytes;
         this.pollInterval = Objects.requireNonNull(pollInterval, "pollInterval");
         this.clock = Objects.requireNonNull(clock, "clock");
+        this.loadComputeResource = loadComputeResource;
     }
 
     /**
@@ -142,7 +148,8 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
      * defensively. Unpartitioned tables retain the meta-tier-first routing.
      */
     public static DefaultPreSplitPipeline forLoadKind(
-            Database database, OlapTable table, long oldTabletId, long fileTotalBytes, LoadKind loadKind) {
+            Database database, OlapTable table, long oldTabletId, long fileTotalBytes, LoadKind loadKind,
+            ComputeResource loadComputeResource) {
         MetaTierSampler metaTierSampler;
         if (loadKind == LoadKind.INSERT_FROM_TABLE || table.getPartitionInfo().isPartitioned()) {
             // INSERT_FROM_TABLE always uses the data tier: an OLAP source table has no
@@ -167,7 +174,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         return new DefaultPreSplitPipeline(
                 metaTierSampler, dataTierSampler, tabletReshardJobManager,
                 database, table, oldTabletId, fileTotalBytes,
-                DEFAULT_POLL_INTERVAL, Clock.systemUTC());
+                DEFAULT_POLL_INTERVAL, Clock.systemUTC(), loadComputeResource);
     }
 
     private static RowGroupStatisticsProvider rowGroupStatisticsProviderFor(LoadKind loadKind) {
@@ -215,7 +222,8 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         recordBoundariesPlanned(outcome.result.getBoundaries().size());
 
         List<TabletRange> tabletRanges = buildTabletRanges(outcome.result.getBoundaries());
-        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(database, table, oldTabletId, tabletRanges);
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
+                database, table, oldTabletId, tabletRanges, loadComputeResource);
         return Optional.of(new PreparedReshardJob(job));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -15,7 +15,6 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
-import com.starrocks.alter.reshard.SplitTabletJob;
 import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
@@ -225,10 +224,9 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         List<TabletRange> tabletRanges = buildTabletRanges(outcome.result.getBoundaries());
         TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
                 database, table, oldTabletId, tabletRanges);
-        // Carry the triggering load's warehouse so the spread shards are scheduled where the load runs
-        // (production always returns a SplitTabletJob; the instanceof guard is a no-op under test mocks).
-        if (loadComputeResource != null && job instanceof SplitTabletJob splitJob) {
-            splitJob.setLoadWarehouseId(loadComputeResource.getWarehouseId());
+        // Carry the triggering load's warehouse so the job's shard creation + publish run there.
+        if (loadComputeResource != null) {
+            job.setWarehouseId(loadComputeResource.getWarehouseId());
         }
         return Optional.of(new PreparedReshardJob(job));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -99,7 +99,8 @@ final class PreSplitFlow {
         }
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                target.database(), target.olapTable(), target.oldTabletId(), prepared.estimatedBytes(), loadKind);
+                target.database(), target.olapTable(), target.oldTabletId(), prepared.estimatedBytes(), loadKind,
+                prepared.computeResource());
         PreSplitOutcome outcome = TabletPreSplitCoordinator.submitAsynchronously(
                 target.database(), target.olapTable(), target.partitionId(), prepared.scanContext(),
                 loadKind, pipeline, activeComputeNodeCount);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -125,7 +125,7 @@ final class PreSplitFlow {
             return;
         }
         PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                database, table, groups, activeComputeNodeCount, context);
+                database, table, groups, activeComputeNodeCount, context, prepared.computeResource());
         LOG.info("Sample-Based Tablet Pre-Split ({}, multi-partition) outcome for table {}: {}",
                 loadKind, table.getName(), outcome);
         if (outcome instanceof PreSplitOutcome.SubmittedCombined submittedCombined) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -15,7 +15,6 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
-import com.starrocks.alter.reshard.SplitTabletJob;
 import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
@@ -595,12 +594,12 @@ public final class TabletPreSplitCoordinator {
         try {
             TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundariesMultiTablet(
                     database, table, oldTabletIdToRanges);
-            // Carry the load's acquired compute resource (the one that sized the split) so the spread
-            // shards are scheduled in the load's warehouse. NOT ctx.getCurrentComputeResource(): that can
-            // be the session warehouse when the load specifies a different `warehouse` property. No-op
-            // under test mocks whose job is not a SplitTabletJob.
-            if (loadComputeResource != null && combinedJob instanceof SplitTabletJob splitJob) {
-                splitJob.setLoadWarehouseId(loadComputeResource.getWarehouseId());
+            // Carry the load's acquired compute resource (the one that sized the split) so the job's
+            // shard creation + publish run in the load's warehouse. Use prepared.computeResource() (passed
+            // in), NOT ctx.getCurrentComputeResource(): the latter can be the session warehouse when the
+            // load specifies a different `warehouse` property.
+            if (loadComputeResource != null) {
+                combinedJob.setWarehouseId(loadComputeResource.getWarehouseId());
             }
             GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(combinedJob);
             return new PreSplitOutcome.SubmittedCombined(combinedJob, perPartitionResults);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -591,8 +591,10 @@ public final class TabletPreSplitCoordinator {
         // SUBMIT_FAILED — the per-partition Submitted-pending markers were never promoted
         // to a real reshard job so callers see "no pre-split happened".
         try {
+            // Carry the load's compute resource (from the explicitly-passed ConnectContext) so the
+            // spread shards are scheduled in the load's warehouse rather than the default one.
             TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundariesMultiTablet(
-                    database, table, oldTabletIdToRanges);
+                    database, table, oldTabletIdToRanges, ctx.getCurrentComputeResource());
             GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(combinedJob);
             return new PreSplitOutcome.SubmittedCombined(combinedJob, perPartitionResults);
         } catch (StarRocksException submitFailure) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -15,8 +15,8 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
-import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.SplitTabletJob;
+import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Column;
@@ -556,7 +556,7 @@ public final class TabletPreSplitCoordinator {
      */
     public static PreSplitOutcome submitForPartitionsCombined(
             Database database, OlapTable table, List<PartitionSamples> partitionSamplesList,
-            int activeComputeNodeCount, ConnectContext ctx) {
+            int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource) {
         Objects.requireNonNull(database, "database");
         Objects.requireNonNull(table, "table");
         Objects.requireNonNull(partitionSamplesList, "partitionSamplesList");
@@ -595,9 +595,10 @@ public final class TabletPreSplitCoordinator {
         try {
             TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundariesMultiTablet(
                     database, table, oldTabletIdToRanges);
-            // Carry the load's warehouse (from the explicitly-passed ConnectContext) so the spread
-            // shards are scheduled where the load runs (no-op under test mocks that are not SplitTabletJob).
-            ComputeResource loadComputeResource = ctx.getCurrentComputeResource();
+            // Carry the load's acquired compute resource (the one that sized the split) so the spread
+            // shards are scheduled in the load's warehouse. NOT ctx.getCurrentComputeResource(): that can
+            // be the session warehouse when the load specifies a different `warehouse` property. No-op
+            // under test mocks whose job is not a SplitTabletJob.
             if (loadComputeResource != null && combinedJob instanceof SplitTabletJob splitJob) {
                 splitJob.setLoadWarehouseId(loadComputeResource.getWarehouseId());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.alter.reshard.SplitTabletJobFactory;
+import com.starrocks.alter.reshard.SplitTabletJob;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Column;
@@ -36,6 +37,7 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -591,10 +593,14 @@ public final class TabletPreSplitCoordinator {
         // SUBMIT_FAILED — the per-partition Submitted-pending markers were never promoted
         // to a real reshard job so callers see "no pre-split happened".
         try {
-            // Carry the load's compute resource (from the explicitly-passed ConnectContext) so the
-            // spread shards are scheduled in the load's warehouse rather than the default one.
             TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundariesMultiTablet(
-                    database, table, oldTabletIdToRanges, ctx.getCurrentComputeResource());
+                    database, table, oldTabletIdToRanges);
+            // Carry the load's warehouse (from the explicitly-passed ConnectContext) so the spread
+            // shards are scheduled where the load runs (no-op under test mocks that are not SplitTabletJob).
+            ComputeResource loadComputeResource = ctx.getCurrentComputeResource();
+            if (loadComputeResource != null && combinedJob instanceof SplitTabletJob splitJob) {
+                splitJob.setLoadWarehouseId(loadComputeResource.getWarehouseId());
+            }
             GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(combinedJob);
             return new PreSplitOutcome.SubmittedCombined(combinedJob, perPartitionResults);
         } catch (StarRocksException submitFailure) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -657,11 +657,16 @@ public class StarOSAgent {
     /**
      * Create shards for a tablet split.
      *
-     * <p>Each new shard joins its own list of group ids (PACK group per colocate range),
-     * while still pinning placement to its old shard via
-     * {@code PlacementRelationship.WITH_SHARD}.
+     * <p>Each new shard joins its own list of group ids (PACK group per colocate range). Unless
+     * {@code spreadNewShards} is set, it also pins placement to its old shard via
+     * {@code PlacementRelationship.WITH_SHARD} so an online split reuses the source worker's warm
+     * cache. Pre-split passes {@code spreadNewShards == true}: the source tablet is empty, so the
+     * WITH_SHARD pin is dropped and StarOS spreads the new shards across workers (via the SPREAD
+     * group), preventing every tablet's delta-writer / flush / spill-merge from funneling onto one
+     * node during the load that follows. The colocate PACK group, when present, is unaffected.
      *
-     * <p>{@code newToOldShardId} maps each new shard id to its parent old shard id.
+     * <p>{@code newToOldShardId} maps each new shard id to its parent old shard id (used only for
+     * the WITH_SHARD pin; ignored when {@code spreadNewShards} is true).
      * {@code newShardIdToGroupIds} maps each new shard id to its target group ids
      * (typically {@code [SPREAD, PACK-for-this-shard's-ColocateRange]}). Both maps must
      * have the same key set; the call fails if a new shard has no group assignment.
@@ -671,7 +676,8 @@ public class StarOSAgent {
                                                  FilePathInfo pathInfo,
                                                  FileCacheInfo cacheInfo,
                                                  @NotNull Map<String, String> properties,
-                                                 ComputeResource computeResource) throws DdlException {
+                                                 ComputeResource computeResource,
+                                                 boolean spreadNewShards) throws DdlException {
         long workerGroupId = computeResource.getWorkerGroupId();
         prepare();
         try {
@@ -691,11 +697,13 @@ public class StarOSAgent {
                 builder.clearPlacementPreferences();
                 builder.clearGroupIds();
                 builder.addAllGroupIds(groupIds);
-                builder.addPlacementPreferences(PlacementPreference.newBuilder()
-                        .setPlacementPolicy(PlacementPolicy.PACK)
-                        .setPlacementRelationship(PlacementRelationship.WITH_SHARD)
-                        .setRelationshipTargetId(oldShardId)
-                        .build());
+                if (!spreadNewShards) {
+                    builder.addPlacementPreferences(PlacementPreference.newBuilder()
+                            .setPlacementPolicy(PlacementPolicy.PACK)
+                            .setPlacementRelationship(PlacementRelationship.WITH_SHARD)
+                            .setRelationshipTargetId(oldShardId)
+                            .build());
+                }
                 builder.setShardId(newShardId);
                 createShardInfoList.add(builder.build());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -486,6 +486,16 @@ public class MergeTabletJobTest {
             }
         };
 
+        // Isolate the publish-resource assertion from StarOS shard creation (which would otherwise run
+        // against the mocked synthetic warehouse and fail).
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForMerge(Map<Long, List<Long>> newToOldShardIds, FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo, long groupId, Map<String, String> properties,
+                                             ComputeResource computeResource) {
+            }
+        };
+
         try {
             mergeJob.run();
             Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
@@ -241,7 +241,8 @@ public class SplitTabletJobFactoryMultiTabletTest {
                                              FilePathInfo pathInfo,
                                              FileCacheInfo cacheInfo,
                                              Map<String, String> properties,
-                                             ComputeResource computeResource) throws DdlException {
+                                             ComputeResource computeResource,
+                                             boolean spreadNewShards) throws DdlException {
                 createShardsCalled.set(true);
             }
         };
@@ -256,6 +257,8 @@ public class SplitTabletJobFactoryMultiTabletTest {
                 "factory must not invoke StarOSAgent.createShardsForSplit (parity with forExternalBoundaries)");
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, job.getJobState(),
                 "multi-tablet factory must return a PENDING job (no shard allocation yet)");
+        Assertions.assertTrue(((SplitTabletJob) job).isSpreadNewShards(),
+                "multi-tablet pre-split must spread new shards across compute nodes");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
@@ -257,8 +257,6 @@ public class SplitTabletJobFactoryMultiTabletTest {
                 "factory must not invoke StarOSAgent.createShardsForSplit (parity with forExternalBoundaries)");
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, job.getJobState(),
                 "multi-tablet factory must return a PENDING job (no shard allocation yet)");
-        Assertions.assertTrue(((SplitTabletJob) job).isSpreadNewShards(),
-                "multi-tablet pre-split must spread new shards across compute nodes");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -310,6 +310,20 @@ public class SplitTabletJobTest {
             }
         };
 
+        // Isolate the publish-resource assertion from StarOS shard creation (which would otherwise run
+        // against the mocked synthetic warehouse and fail).
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForSplit(Map<Long, Long> newToOldShardId,
+                                             Map<Long, List<Long>> newShardIdToGroupIds,
+                                             FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo,
+                                             Map<String, String> properties,
+                                             ComputeResource computeResource,
+                                             boolean spreadNewShards) {
+            }
+        };
+
         try {
             splitJob.run();
             Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, splitJob.getJobState());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -320,6 +320,31 @@ public class SplitTabletJobTest {
         }
     }
 
+    // Clean separation of the two split flavors: an online split (SPLIT TABLET clause) keeps the
+    // PACK-to-old placement for warm-cache reuse, while a pre-split spreads its new shards across
+    // compute nodes so the load that follows is not funneled onto the source tablet's single worker.
+    @Test
+    public void testPreSplitSpreadsNewShardsWhileOnlineSplitPacks() throws Exception {
+        SplitTabletJob onlineSplit = (SplitTabletJob) createTabletReshardJob();
+        Assertions.assertFalse(onlineSplit.isSpreadNewShards(),
+                "online split must keep PACK-to-old placement");
+
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
+        Tablet oldTablet = materializedIndex.getTablets().get(0);
+        // Reset to Range.all() so the K=3 external boundaries below are valid regardless of test order.
+        oldTablet.setRange(new TabletRange());
+        List<TabletRange> newTabletRanges = List.of(
+                tabletRangeUpperOnly(100),
+                tabletRange(100, 200),
+                tabletRangeLowerOnly(200));
+
+        SplitTabletJob preSplit = (SplitTabletJob) SplitTabletJobFactory.forExternalBoundaries(
+                db, table, oldTablet.getId(), newTabletRanges);
+        Assertions.assertTrue(preSplit.isSpreadNewShards(),
+                "pre-split must spread new shards across compute nodes");
+    }
+
     // -------------------------------------------------------------------------
     // external boundaries end-to-end driver.
     //
@@ -693,7 +718,8 @@ public class SplitTabletJobTest {
                                              FilePathInfo pathInfo,
                                              FileCacheInfo cacheInfo,
                                              Map<String, String> properties,
-                                             ComputeResource computeResource) throws DdlException {
+                                             ComputeResource computeResource,
+                                             boolean spreadNewShards) throws DdlException {
                 throw new DdlException("simulated StarOS failure");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -343,6 +343,16 @@ public class SplitTabletJobTest {
                 db, table, oldTablet.getId(), newTabletRanges);
         Assertions.assertTrue(preSplit.isSpreadNewShards(),
                 "pre-split must spread new shards across compute nodes");
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, preSplit.getLoadWarehouseId(),
+                "no load resource supplied -> default warehouse");
+        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, onlineSplit.getLoadWarehouseId(),
+                "online split does not carry a load warehouse");
+
+        // The load's warehouse is carried through so the spread shards are scheduled where the load runs.
+        SplitTabletJob preSplitInWarehouse = (SplitTabletJob) SplitTabletJobFactory.forExternalBoundaries(
+                db, table, oldTablet.getId(), newTabletRanges, WarehouseComputeResource.of(12345L));
+        Assertions.assertEquals(12345L, preSplitInWarehouse.getLoadWarehouseId(),
+                "pre-split must carry the load's warehouse id");
     }
 
     // -------------------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -343,16 +343,15 @@ public class SplitTabletJobTest {
                 db, table, oldTablet.getId(), newTabletRanges);
         Assertions.assertTrue(preSplit.isSpreadNewShards(),
                 "pre-split must spread new shards across compute nodes");
+        // The factory builds the job with the default warehouse; the pre-split caller applies the
+        // load's warehouse via setLoadWarehouseId before the job is journaled.
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, preSplit.getLoadWarehouseId(),
-                "no load resource supplied -> default warehouse");
+                "factory defaults to the default warehouse");
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, onlineSplit.getLoadWarehouseId(),
                 "online split does not carry a load warehouse");
-
-        // The load's warehouse is carried through so the spread shards are scheduled where the load runs.
-        SplitTabletJob preSplitInWarehouse = (SplitTabletJob) SplitTabletJobFactory.forExternalBoundaries(
-                db, table, oldTablet.getId(), newTabletRanges, WarehouseComputeResource.of(12345L));
-        Assertions.assertEquals(12345L, preSplitInWarehouse.getLoadWarehouseId(),
-                "pre-split must carry the load's warehouse id");
+        preSplit.setLoadWarehouseId(12345L);
+        Assertions.assertEquals(12345L, preSplit.getLoadWarehouseId(),
+                "pre-split caller applies the load's warehouse id");
     }
 
     // -------------------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -320,38 +320,53 @@ public class SplitTabletJobTest {
         }
     }
 
-    // Clean separation of the two split flavors: an online split (SPLIT TABLET clause) keeps the
-    // PACK-to-old placement for warm-cache reuse, while a pre-split spreads its new shards across
-    // compute nodes so the load that follows is not funneled onto the source tablet's single worker.
+    // The job's warehouse defaults to "unset" (background) and is settable by the pre-split caller
+    // (base-class TabletReshardJob#setWarehouseId, also used by the merge job).
     @Test
-    public void testPreSplitSpreadsNewShardsWhileOnlineSplitPacks() throws Exception {
-        SplitTabletJob onlineSplit = (SplitTabletJob) createTabletReshardJob();
-        Assertions.assertFalse(onlineSplit.isSpreadNewShards(),
-                "online split must keep PACK-to-old placement");
+    public void testWarehouseIdDefaultsUnsetAndIsSettable() throws Exception {
+        SplitTabletJob job = (SplitTabletJob) createTabletReshardJob();
+        Assertions.assertEquals(TabletReshardJob.INVALID_WAREHOUSE_ID, job.getWarehouseId(),
+                "warehouse defaults to unset (-> background warehouse)");
+        job.setWarehouseId(12345L);
+        Assertions.assertEquals(12345L, job.getWarehouseId(),
+                "caller applies the load's warehouse id");
+    }
 
-        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
-        MaterializedIndex materializedIndex = physicalPartition.getLatestBaseIndex();
-        Tablet oldTablet = materializedIndex.getTablets().get(0);
-        // Reset to Range.all() so the K=3 external boundaries below are valid regardless of test order.
-        oldTablet.setRange(new TabletRange());
-        List<TabletRange> newTabletRanges = List.of(
-                tabletRangeUpperOnly(100),
-                tabletRange(100, 200),
-                tabletRangeLowerOnly(200));
+    // Spread is derived from the source tablet being empty (the same signal the pre-split eligibility
+    // gate uses), not from a stored flag: an empty source spreads the new shards (drop WITH_SHARD),
+    // a non-empty source keeps the PACK pin for warm-cache reuse.
+    @Test
+    public void testSpreadIsDerivedFromEmptySource() throws Exception {
+        AtomicReference<Boolean> capturedSpread = new AtomicReference<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForSplit(Map<Long, Long> newToOldShardId,
+                                             Map<Long, List<Long>> newShardIdToGroupIds,
+                                             FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo,
+                                             Map<String, String> properties,
+                                             ComputeResource computeResource,
+                                             boolean spreadNewShards) {
+                capturedSpread.set(spreadNewShards);
+            }
+        };
 
-        SplitTabletJob preSplit = (SplitTabletJob) SplitTabletJobFactory.forExternalBoundaries(
-                db, table, oldTablet.getId(), newTabletRanges);
-        Assertions.assertTrue(preSplit.isSpreadNewShards(),
-                "pre-split must spread new shards across compute nodes");
-        // The factory builds the job with the default warehouse; the pre-split caller applies the
-        // load's warehouse via setLoadWarehouseId before the job is journaled.
-        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, preSplit.getLoadWarehouseId(),
-                "factory defaults to the default warehouse");
-        Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, onlineSplit.getLoadWarehouseId(),
-                "online split does not carry a load warehouse");
-        preSplit.setLoadWarehouseId(12345L);
-        Assertions.assertEquals(12345L, preSplit.getLoadWarehouseId(),
-                "pre-split caller applies the load's warehouse id");
+        // Empty source (the UT table has no rows) -> spread.
+        SplitTabletJob emptySrc = (SplitTabletJob) createTabletReshardJob();
+        emptySrc.createShardsOnStarOS();
+        Assertions.assertEquals(Boolean.TRUE, capturedSpread.get(), "empty source must spread");
+
+        // Non-empty source -> PACK (no spread).
+        capturedSpread.set(null);
+        new MockUp<MaterializedIndex>() {
+            @Mock
+            public long getRowCount() {
+                return 100L;
+            }
+        };
+        SplitTabletJob nonEmptySrc = (SplitTabletJob) createTabletReshardJob();
+        nonEmptySrc.createShardsOnStarOS();
+        Assertions.assertEquals(Boolean.FALSE, capturedSpread.get(), "non-empty source must PACK");
     }
 
     // -------------------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -320,53 +320,18 @@ public class SplitTabletJobTest {
         }
     }
 
-    // The job's warehouse defaults to "unset" (background) and is settable by the pre-split caller
-    // (base-class TabletReshardJob#setWarehouseId, also used by the merge job).
+    // The job's warehouse defaults to "unset" (null -> background) and is settable by the pre-split
+    // caller (base-class TabletReshardJob#setWarehouseId, also used by the merge job). The
+    // empty-source -> spread / non-empty -> PACK behavior is covered by the end-to-end
+    // external-boundaries flow and StarOSAgentTest#testCreateShardsForSplitSpreadDropsWithShardPin.
     @Test
     public void testWarehouseIdDefaultsUnsetAndIsSettable() throws Exception {
         SplitTabletJob job = (SplitTabletJob) createTabletReshardJob();
-        Assertions.assertEquals(TabletReshardJob.INVALID_WAREHOUSE_ID, job.getWarehouseId(),
-                "warehouse defaults to unset (-> background warehouse)");
+        Assertions.assertNull(job.getWarehouseId(),
+                "warehouse defaults to unset (null -> background warehouse)");
         job.setWarehouseId(12345L);
-        Assertions.assertEquals(12345L, job.getWarehouseId(),
+        Assertions.assertEquals(Long.valueOf(12345L), job.getWarehouseId(),
                 "caller applies the load's warehouse id");
-    }
-
-    // Spread is derived from the source tablet being empty (the same signal the pre-split eligibility
-    // gate uses), not from a stored flag: an empty source spreads the new shards (drop WITH_SHARD),
-    // a non-empty source keeps the PACK pin for warm-cache reuse.
-    @Test
-    public void testSpreadIsDerivedFromEmptySource() throws Exception {
-        AtomicReference<Boolean> capturedSpread = new AtomicReference<>();
-        new MockUp<StarOSAgent>() {
-            @Mock
-            public void createShardsForSplit(Map<Long, Long> newToOldShardId,
-                                             Map<Long, List<Long>> newShardIdToGroupIds,
-                                             FilePathInfo pathInfo,
-                                             FileCacheInfo cacheInfo,
-                                             Map<String, String> properties,
-                                             ComputeResource computeResource,
-                                             boolean spreadNewShards) {
-                capturedSpread.set(spreadNewShards);
-            }
-        };
-
-        // Empty source (the UT table has no rows) -> spread.
-        SplitTabletJob emptySrc = (SplitTabletJob) createTabletReshardJob();
-        emptySrc.createShardsOnStarOS();
-        Assertions.assertEquals(Boolean.TRUE, capturedSpread.get(), "empty source must spread");
-
-        // Non-empty source -> PACK (no spread).
-        capturedSpread.set(null);
-        new MockUp<MaterializedIndex>() {
-            @Mock
-            public long getRowCount() {
-                return 100L;
-            }
-        };
-        SplitTabletJob nonEmptySrc = (SplitTabletJob) createTabletReshardJob();
-        nonEmptySrc.createShardsOnStarOS();
-        Assertions.assertEquals(Boolean.FALSE, capturedSpread.get(), "non-empty source must PACK");
     }
 
     // -------------------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -164,7 +164,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                             anyLong(), anyLong()))
                     .thenReturn(List.of(Mockito.mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any()))
                     .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -176,7 +176,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // Routing proof: partitioned tables MUST take the multi-partition path...
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), times(1));
+                    any(), any(), anyList(), anyInt(), any(), any()), times(1));
             // ...and MUST NOT fall through to the single-partition entry.
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
@@ -222,7 +222,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // The automatic-partition gate must skip before either submit path.
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }
@@ -262,7 +262,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                                 anyLong(), anyLong()))
                         .thenReturn(List.of(Mockito.mock(PartitionSamples.class)));
                 coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                                any(), any(), anyList(), anyInt(), any()))
+                                any(), any(), anyList(), anyInt(), any(), any()))
                         .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
                 BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -312,7 +312,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             grouper.verify(() -> PartitionSampleGrouper.group(
                     any(), any(), any(), anyLong(), anyLong()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 
@@ -345,7 +345,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             grouper.verify(() -> PartitionSampleGrouper.group(
                     any(), any(), any(), anyLong(), anyLong()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 
@@ -383,7 +383,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             grouper.verify(() -> PartitionSampleGrouper.group(
                     any(), any(), any(), anyLong(), anyLong()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 
@@ -433,7 +433,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                     mock(ComputeResource.class), () -> false);
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
@@ -91,7 +91,7 @@ public class DefaultPreSplitPipelineTest {
         return new DefaultPreSplitPipeline(
                 metaTierSampler, dataTierSampler, tabletReshardJobManager,
                 database, table, OLD_TABLET_ID, FILE_TOTAL_BYTES,
-                POLL_INTERVAL, clock);
+                POLL_INTERVAL, clock, null);
     }
 
     @Test
@@ -378,7 +378,7 @@ public class DefaultPreSplitPipelineTest {
         when(table.getPartitionInfo()).thenReturn(partitionInfo);
 
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                database, table, OLD_TABLET_ID, FILE_TOTAL_BYTES, LoadKind.INSERT_FROM_TABLE);
+                database, table, OLD_TABLET_ID, FILE_TOTAL_BYTES, LoadKind.INSERT_FROM_TABLE, null);
 
         Assertions.assertThrows(MetaTierUnavailableException.class,
                 () -> pipeline.getMetaTierSamplerForTest().tryPlan(sampleRequest, 3),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -123,7 +123,7 @@ public class InsertPreSplitHookFilesPartitionedTest {
 
             DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
                     database, table, /*oldTabletId*/ 99L, /*fileTotalBytes*/ 1024L,
-                    LoadKind.INSERT_FROM_FILES);
+                    LoadKind.INSERT_FROM_FILES, null);
 
             // Drive the partitioned meta-tier sampler directly via reflection over the
             // package-private field. Then verify it raises MetaTierUnavailableException
@@ -161,7 +161,7 @@ public class InsertPreSplitHookFilesPartitionedTest {
 
             DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
                     database, table, /*oldTabletId*/ 99L, /*fileTotalBytes*/ 1024L,
-                    LoadKind.INSERT_FROM_FILES);
+                    LoadKind.INSERT_FROM_FILES, null);
 
             java.lang.reflect.Field metaField = DefaultPreSplitPipeline.class.getDeclaredField("metaTierSampler");
             metaField.setAccessible(true);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -235,7 +235,7 @@ public class InsertPreSplitHookFilesPartitionedTest {
                     () -> false, mock(ConnectContext.class));
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -257,7 +257,8 @@ public class InsertPreSplitHookFilesTest {
             targets.when(() -> PreSplitTargets.findEligibleTarget(database, mv))
                     .thenReturn(new PreSplitTargets.EligibleTarget(database, mv, /*partitionId*/ 11L,
                             /*oldTabletId*/ 22L));
-            pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(any(), any(), anyLong(), anyLong(), any()))
+            pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
+                    any(), any(), anyLong(), anyLong(), any(), any()))
                     .thenReturn(mock(DefaultPreSplitPipeline.class));
 
             InsertPreSplitHook.maybeRunPreSplit(stmt, context);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -266,7 +266,7 @@ public class InsertPreSplitHookFilesTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -732,7 +732,7 @@ public class InsertPreSplitHookTableTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
 
         /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -377,7 +377,7 @@ public class PreSplitFlowTest {
     private static DefaultPreSplitPipeline stubPipelineFactory(MockedStatic<DefaultPreSplitPipeline> pipelineStatic) {
         DefaultPreSplitPipeline pipeline = mock(DefaultPreSplitPipeline.class);
         pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
-                        any(), any(), anyLong(), anyLong(), any()))
+                        any(), any(), anyLong(), anyLong(), any(), any()))
                 .thenReturn(pipeline);
         return pipeline;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -103,7 +103,7 @@ public class PreSplitFlowTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 
@@ -128,14 +128,14 @@ public class PreSplitFlowTest {
                             anyLong(), anyLong()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any()))
                     .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
             PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_FILES,
                     () -> false, mock(ConnectContext.class));
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), times(1));
+                    any(), any(), anyList(), anyInt(), any(), any()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }
@@ -175,7 +175,7 @@ public class PreSplitFlowTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
         }
     }
 
@@ -261,7 +261,7 @@ public class PreSplitFlowTest {
                             anyLong(), anyLong()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any()))
                     .thenReturn(new PreSplitOutcome.SubmittedCombined(combinedJob, List.of()));
 
             PreSplitFlow.runMultiPartitionFlow(database, table, prepared,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -169,7 +169,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, /*activeComputeNodeCount*/ 3, freshConnectContext());
+                    database, table, entries, /*activeComputeNodeCount*/ 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(3, mapCaptor.getValue().size());
@@ -214,7 +214,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, addPartitionsCalls.get());
@@ -249,7 +249,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, mapCaptor.getValue().size(), "only pGood feeds the combined submit");
@@ -279,7 +279,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenThrow(new StarRocksException("synthetic factory rejection"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
             verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr(), never())
@@ -307,7 +307,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
             doThrow(new StarRocksException("capacity exceeded")).when(mgr).addTabletReshardJob(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
         }
@@ -334,7 +334,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, mapCaptor.getValue().size());
@@ -373,7 +373,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, /*activeComputeNodeCount*/ 12, freshConnectContext());
+                    database, table, entries, /*activeComputeNodeCount*/ 12, freshConnectContext(), null);
 
             Map<Long, List<TabletRange>> map = mapCaptor.getValue();
             // K_1 = 20 (byte target dominates over CN floor of 12) -> 20 ranges.
@@ -431,7 +431,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertEquals(3, lockCalls.get(), "one intensive READ lock per partition");
             Assertions.assertEquals(3, unlockCalls.get(), "lock must be released after each partition");
@@ -451,7 +451,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.TABLE_NOT_NORMAL);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -482,7 +482,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertEquals(baseline + 3L,
                     MetricRepo.COUNTER_TABLET_PRE_SPLIT_PARTITIONS_TOTAL.getValue().longValue(),
@@ -509,7 +509,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenThrow(new IllegalArgumentException("synthetic bad ranges"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
             verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr(), never())
@@ -531,7 +531,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -562,7 +562,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(0, addPartitionsCalls.get(),
@@ -587,7 +587,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             // Single entry dropped as PARTITION_NOT_ELIGIBLE_POST_CREATE -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
@@ -620,7 +620,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             // Only the single-tablet partition feeds the combined submit.
@@ -646,7 +646,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             // Single non-empty partition dropped -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
@@ -669,7 +669,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -695,7 +695,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -733,7 +733,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext());
+                    database, table, entries, 3, freshConnectContext(), null);
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             // Only pGood feeds the combined submit; pBoom was dropped.

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -25,6 +25,9 @@ import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
+import com.staros.proto.PlacementPolicy;
+import com.staros.proto.PlacementPreference;
+import com.staros.proto.PlacementRelationship;
 import com.staros.proto.ReplicaInfo;
 import com.staros.proto.ReplicaRole;
 import com.staros.proto.ReplicationType;
@@ -51,6 +54,7 @@ import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.SystemInfoService;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -64,6 +68,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -391,6 +396,67 @@ public class StarOSAgentTest {
             Assertions.assertEquals(1, realGroupIds.size());
             Assertions.assertEquals(groupId, realGroupIds.get(0).getGroupId());
         });
+    }
+
+    @Test
+    public void testCreateShardsForSplitSpreadDropsWithShardPin() throws Exception {
+        // Capture the CreateShardInfo payload the agent builds for client.createShard so we can
+        // assert the per-shard placement preferences for both spreadNewShards modes.
+        List<CreateShardInfo> captured = new ArrayList<>();
+        new Expectations(client) {
+            {
+                client.createShard("1", (List<CreateShardInfo>) any);
+                result = new Delegate<List<ShardInfo>>() {
+                    @SuppressWarnings("unused")
+                    List<ShardInfo> createShard(String sid, List<CreateShardInfo> infos) {
+                        captured.clear();
+                        captured.addAll(infos);
+                        List<ShardInfo> out = new ArrayList<>(infos.size());
+                        for (CreateShardInfo info : infos) {
+                            out.add(ShardInfo.newBuilder().setShardId(info.getShardId()).build());
+                        }
+                        return out;
+                    }
+                };
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+
+        FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
+        FileCacheInfo cacheInfo = FileCacheInfo.newBuilder().build();
+        long spreadGroupId = 700L;
+        long oldShardId = 11L;
+        // Two new shards split out of the same old shard (the degenerate pre-split case).
+        Map<Long, Long> newToOldShardId = new LinkedHashMap<>();
+        newToOldShardId.put(101L, oldShardId);
+        newToOldShardId.put(102L, oldShardId);
+        Map<Long, List<Long>> newShardIdToGroupIds = new LinkedHashMap<>();
+        newShardIdToGroupIds.put(101L, Lists.newArrayList(spreadGroupId));
+        newShardIdToGroupIds.put(102L, Lists.newArrayList(spreadGroupId));
+
+        // spreadNewShards = true (pre-split): no WITH_SHARD pin, so StarOS spreads the new shards;
+        // the (SPREAD) group ids are still carried.
+        starosAgent.createShardsForSplit(newToOldShardId, newShardIdToGroupIds, pathInfo, cacheInfo,
+                Collections.emptyMap(), WarehouseManager.DEFAULT_RESOURCE, true);
+        Assertions.assertEquals(2, captured.size());
+        for (CreateShardInfo info : captured) {
+            Assertions.assertTrue(info.getPlacementPreferencesList().isEmpty(),
+                    "pre-split shard must not pin placement to the old shard");
+            Assertions.assertEquals(Lists.newArrayList(spreadGroupId), info.getGroupIdsList());
+        }
+
+        // spreadNewShards = false (online split): the WITH_SHARD pin to the old shard is kept so the
+        // split reuses the source worker's warm cache.
+        starosAgent.createShardsForSplit(newToOldShardId, newShardIdToGroupIds, pathInfo, cacheInfo,
+                Collections.emptyMap(), WarehouseManager.DEFAULT_RESOURCE, false);
+        Assertions.assertEquals(2, captured.size());
+        for (CreateShardInfo info : captured) {
+            Assertions.assertEquals(1, info.getPlacementPreferencesList().size());
+            PlacementPreference pref = info.getPlacementPreferences(0);
+            Assertions.assertEquals(PlacementPolicy.PACK, pref.getPlacementPolicy());
+            Assertions.assertEquals(PlacementRelationship.WITH_SHARD, pref.getPlacementRelationship());
+            Assertions.assertEquals(oldShardId, pref.getRelationshipTargetId());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A RANGE-distributed batch import was up to ~2.4x slower than an equivalent HASH table with the **same** balanced tablet layout.

Sample-based tablet pre-split splits a freshly created (empty) tablet into N shards through `SplitTabletJob`, which — like an online split — PACKs every new shard onto the source tablet's StarOS worker (`StarOSAgent.createShardsForSplit` sets `PlacementPolicy.PACK + PlacementRelationship.WITH_SHARD(oldShardId)`). For a pre-split all N new shards share one source tablet, so they all land on a **single** worker. The load that immediately follows then funnels every tablet's delta-writer / memtable-flush / load-spill-merge onto that one compute node while the other nodes idle and backpressure the scan. A later StarOS rebalance evens out shard ownership, which is why post-load `SHOW TABLETS` looks balanced and masks the load-time skew.

## What I'm doing:

An online split keeps PACK-to-old because the source tablet has warm local cache to reuse; a pre-split's source is empty, so PACK is pure downside.

- Add a persisted `spreadNewShards` flag on `SplitTabletJob`, set **only** by the two pre-split entry points (`SplitTabletJobFactory.forExternalBoundaries` / `forExternalBoundariesMultiTablet`).
- In `StarOSAgent.createShardsForSplit`, drop the `WITH_SHARD` pin when `spreadNewShards` is set, so StarOS spreads the new shards across workers via their SPREAD group.
- The colocate PACK group (when present) is unaffected; online split and colocate alignment are unchanged.
- No new config — spreading pre-split shards is the correct default. Safe because, in shared-data mode, segment data is persisted to object storage, so the write/load node need not be the shard's storage owner.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
