### PR TITLE
[BugFix] Prevent SQL injection in information_schema.task_runs predicate lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlUtils.java
@@ -56,6 +56,24 @@ public class SqlUtils {
     }
 
     /**
+     * Escape a value so it can be safely embedded as the body of a single-quoted SQL string literal.
+     *
+     * <p>The StarRocks lexer decodes both backslash escape sequences ({@code \'}) and doubled quotes
+     * ({@code ''}) inside string literals (see {@code StarRocksLex.g4} SINGLE_QUOTED_TEXT and
+     * {@code AstBuilder.escapeBackSlash}). Doubling single quotes alone (e.g.
+     * {@code StringEscapeUtils.escapeSql}) is therefore insufficient: a value carrying a backslash can
+     * neutralize the doubling and re-open the literal, enabling SQL injection. Escape backslashes first,
+     * then single quotes.
+     *
+     * <p>This returns only the escaped body; callers must wrap it in single quotes, e.g.
+     * {@code "'" + escapeSqlString(value) + "'"}. For SQL identifiers (db/table/column names) use
+     * {@link #getIdentSql(String)} instead.
+     */
+    public static String escapeSqlString(String value) {
+        return value.replace("\\", "\\\\").replace("'", "''");
+    }
+
+    /**
      * Return the prefix of a sql if it's too long
      */
     public static String sqlPrefix(String sql) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistoryTable.java
@@ -20,6 +20,7 @@ import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.SqlUtils;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.TaskRun;
@@ -190,6 +191,17 @@ public class TaskRunHistoryTable {
         }
     }
 
+    /**
+     * Quote a value as a SQL string literal, escaping embedded backslashes and quotes so a value
+     * carrying a quote (or a backslash that would escape the closing quote) cannot close the literal
+     * and inject additional SQL. These predicates are concatenated into a query executed over the
+     * privileged internal repository connection, so an unescaped value here is a second-order SQL
+     * injection. See {@link SqlUtils#escapeSqlString} for why quote-doubling alone is insufficient.
+     */
+    private static String quoteLiteral(String value) {
+        return "'" + SqlUtils.escapeSqlString(value) + "'";
+    }
+
     public List<TaskRunStatus> lookup(TGetTasksParams params) {
         if (params == null) {
             return Lists.newArrayList();
@@ -198,16 +210,16 @@ public class TaskRunHistoryTable {
         List<String> predicates = Lists.newArrayList("TRUE");
         if (StringUtils.isNotEmpty(params.getDb())) {
             predicates.add(" get_json_string(" + CONTENT_COLUMN + ", 'dbName') = "
-                    + Strings.quote(ClusterNamespace.getFullName(params.getDb())));
+                    + quoteLiteral(ClusterNamespace.getFullName(params.getDb())));
         }
         if (StringUtils.isNotEmpty(params.getTask_name())) {
-            predicates.add(" task_name = " + Strings.quote(params.getTask_name()));
+            predicates.add(" task_name = " + quoteLiteral(params.getTask_name()));
         }
         if (StringUtils.isNotEmpty(params.getQuery_id())) {
-            predicates.add(" task_run_id = " + Strings.quote(params.getQuery_id()));
+            predicates.add(" task_run_id = " + quoteLiteral(params.getQuery_id()));
         }
         if (StringUtils.isNotEmpty(params.getState())) {
-            predicates.add(" task_state = " + Strings.quote(params.getState()));
+            predicates.add(" task_state = " + quoteLiteral(params.getState()));
         }
         sql += Joiner.on(" AND ").join(predicates);
         // If user explicitly specify the LIMIT in sql, we don't apply default limit
@@ -228,10 +240,10 @@ public class TaskRunHistoryTable {
         List<String> predicates = Lists.newArrayList("TRUE");
         if (StringUtils.isNotEmpty(dbName)) {
             predicates.add(" get_json_string(" + CONTENT_COLUMN + ", 'dbName') = "
-                    + Strings.quote(ClusterNamespace.getFullName(dbName)));
+                    + quoteLiteral(ClusterNamespace.getFullName(dbName)));
         }
         if (CollectionUtils.isNotEmpty(taskNames)) {
-            String values = taskNames.stream().sorted().map(Strings::quote).collect(Collectors.joining(","));
+            String values = taskNames.stream().sorted().map(TaskRunHistoryTable::quoteLiteral).collect(Collectors.joining(","));
             predicates.add(" task_name IN (" + values + ")");
         }
 
@@ -267,10 +279,10 @@ public class TaskRunHistoryTable {
         List<String> predicates = Lists.newArrayList("TRUE");
         if (StringUtils.isNotEmpty(dbName)) {
             predicates.add(" get_json_string(" + CONTENT_COLUMN + ", 'dbName') = "
-                    + Strings.quote(ClusterNamespace.getFullName(dbName)));
+                    + quoteLiteral(ClusterNamespace.getFullName(dbName)));
         }
         if (CollectionUtils.isNotEmpty(taskNames)) {
-            String values = taskNames.stream().sorted().map(Strings::quote).collect(Collectors.joining(","));
+            String values = taskNames.stream().sorted().map(TaskRunHistoryTable::quoteLiteral).collect(Collectors.joining(","));
             predicates.add(" task_name IN (" + values + ")");
         }
         String where = Joiner.on(" AND ").join(predicates);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlUtilsTest.java
@@ -14,11 +14,54 @@
 package com.starrocks.common.util;
 
 import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.parser.SqlParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SqlUtilsTest {
+
+    @Test
+    public void testEscapeSqlString() {
+        // Exact escaped body: backslash escaped first, then single quote doubled.
+        Assertions.assertEquals("a''b", SqlUtils.escapeSqlString("a'b"));
+        Assertions.assertEquals("a\\\\b", SqlUtils.escapeSqlString("a\\b"));
+        Assertions.assertEquals("a\\\\''b", SqlUtils.escapeSqlString("a\\'b"));
+        Assertions.assertEquals("plain", SqlUtils.escapeSqlString("plain"));
+    }
+
+    @Test
+    public void testEscapeSqlStringRoundTrips() {
+        // The security property: whatever the input, embedding escapeSqlString(input) inside a
+        // single-quoted literal must parse back to exactly input - i.e. the value can never break
+        // out of the literal. Doubling quotes alone would fail the backslash cases below.
+        String[] payloads = {
+                "t1' OR '1'='1",
+                "q1' UNION SELECT 1 -- ",
+                "x\\",                       // trailing backslash - the escapeSql bypass
+                "x\\' OR 1=1 -- ",
+                "a'b\\c'd",
+                "'; DROP TABLE x; --",
+                "no_special_chars",
+        };
+        for (String payload : payloads) {
+            String literal = "'" + SqlUtils.escapeSqlString(payload) + "'";
+            Assertions.assertEquals(payload, parseStringLiteralValue(literal),
+                    "value escaped into a SQL literal must round-trip unchanged: " + payload);
+        }
+    }
+
+    private static String parseStringLiteralValue(String singleQuotedLiteral) {
+        StatementBase stmt =
+                SqlParser.parseSingleStatement("select " + singleQuotedLiteral, SqlModeHelper.MODE_DEFAULT);
+        SelectRelation select = (SelectRelation) ((QueryStatement) stmt).getQueryRelation();
+        Expr expr = select.getSelectList().getItems().get(0).getExpr();
+        return ((StringLiteral) expr).getStringValue();
+    }
 
     @Test
     public void testIsPreQuerySQL() {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -109,7 +109,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_state = 'SUCCESS'" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         params.setDb(null);
@@ -120,7 +120,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 't1'" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         params.setDb(null);
@@ -132,7 +132,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_run_id = 'q1'" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         params.setDb(null);
@@ -459,7 +459,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 't1'' OR ''1''=''1'" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         TGetTasksParams params = new TGetTasksParams();
@@ -471,7 +471,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_run_id = 'q1'' UNION SELECT 1 -- '" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         TGetTasksParams params2 = new TGetTasksParams();
@@ -494,7 +494,7 @@ public class TaskRunHistoryTest {
             {
                 repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
                         "task_name = 'x\\\\' AND  task_run_id = ' UNION SELECT 1 -- '" +
-                        " ORDER BY create_time DESC LIMIT 10000");
+                        " ORDER BY create_time DESC LIMIT " + Config.task_runs_max_history_number);
             }
         };
         TGetTasksParams params3 = new TGetTasksParams();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryTest.java
@@ -448,4 +448,58 @@ public class TaskRunHistoryTest {
             Assertions.assertEquals(9 - i, result.get(i).getCreateTime());
         }
     }
+
+    @Test
+    public void testLookupEscapesSqlLiteral(@Mocked SimpleExecutor repo) {
+        TaskRunHistoryTable history = new TaskRunHistoryTable();
+
+        // A TASK_NAME value carrying single quotes must have them doubled so it cannot close the
+        // string literal and inject SQL into the privileged internal repository (root) query.
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
+                        "task_name = 't1'' OR ''1''=''1'" +
+                        " ORDER BY create_time DESC LIMIT 10000");
+            }
+        };
+        TGetTasksParams params = new TGetTasksParams();
+        params.setTask_name("t1' OR '1'='1");
+        history.lookup(params);
+
+        // Same hardening for the QUERY_ID predicate (maps to task_run_id).
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
+                        "task_run_id = 'q1'' UNION SELECT 1 -- '" +
+                        " ORDER BY create_time DESC LIMIT 10000");
+            }
+        };
+        TGetTasksParams params2 = new TGetTasksParams();
+        params2.setQuery_id("q1' UNION SELECT 1 -- ");
+        history.lookup(params2);
+
+        // And for the IN-list path used by lookupByTaskNames.
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
+                        "task_name IN ('a'',''b')");
+            }
+        };
+        history.lookupByTaskNames("", Set.of("a','b"));
+
+        // Backslash must also be escaped: a value ending in '\' would otherwise escape the closing
+        // quote (StarRocks honors backslash escapes in string literals), so the following predicate
+        // could be smuggled out of the literal. Quote-doubling alone is not enough here.
+        new Expectations() {
+            {
+                repo.executeDQL("SELECT history_content_json FROM _statistics_.task_run_history WHERE TRUE AND  " +
+                        "task_name = 'x\\\\' AND  task_run_id = ' UNION SELECT 1 -- '" +
+                        " ORDER BY create_time DESC LIMIT 10000");
+            }
+        };
+        TGetTasksParams params3 = new TGetTasksParams();
+        params3.setTask_name("x\\");
+        params3.setQuery_id(" UNION SELECT 1 -- ");
+        history.lookup(params3);
+    }
 }

--- a/test/sql/test_information_schema/R/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/R/test_task_runs_sql_injection
@@ -1,4 +1,7 @@
 -- name: test_task_runs_sql_injection @sequential
+admin set frontend config('task_check_interval_second' = '1');
+-- result:
+-- !result
 create database db_${uuid0};
 -- result:
 -- !result
@@ -22,8 +25,8 @@ function: assert_query_contains("submit task task_inj_${uuid0} as insert into ss
 None
 -- !result
 LOOP {
-  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for task run to appear"}
-  result=select count(*) from information_schema.task_runs where task_name='task_inj_${uuid0}';
+  PROPERTY: {"timeout": 120, "interval": 3, "desc": "wait for task run to be archived"}
+  result=select count(*) from _statistics_.task_run_history where task_name='task_inj_${uuid0}';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 
@@ -55,6 +58,9 @@ select count(1) from information_schema.task_runs where task_name = 'no_such'' O
 0
 -- !result
 admin set frontend config('enable_task_run_fe_evaluation'='true');
+-- result:
+-- !result
+admin set frontend config('task_check_interval_second' = '60');
 -- result:
 -- !result
 drop database db_${uuid0};

--- a/test/sql/test_information_schema/R/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/R/test_task_runs_sql_injection
@@ -1,4 +1,4 @@
--- name: test_task_runs_sql_injection @sequential
+-- name: test_task_runs_sql_injection @sequential @slow
 admin set frontend config('task_check_interval_second' = '1');
 -- result:
 -- !result

--- a/test/sql/test_information_schema/R/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/R/test_task_runs_sql_injection
@@ -1,0 +1,62 @@
+-- name: test_task_runs_sql_injection @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE secret_${uuid0}(v INT) DUPLICATE KEY(v) DISTRIBUTED BY HASH(v) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into secret_${uuid0} values (1),(2),(3);
+-- result:
+-- !result
+CREATE TABLE ss(event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into ss values('2020-01-14', 1), ('2020-01-15', 2);
+-- result:
+-- !result
+function: assert_query_contains("submit task task_inj_${uuid0} as insert into ss select * from ss;", "SUBMITTED")
+-- result:
+None
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_inj_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+
+select if(count(*) > 0, "OK", "FAILED") from information_schema.task_runs where task_name='task_inj_${uuid0}';
+-- result:
+OK
+-- !result
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR ''1''=''1';
+-- result:
+0
+-- !result
+select count(1) from information_schema.task_runs where task_name = 'a''';
+-- result:
+0
+-- !result
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR (SELECT count(*) FROM db_${uuid0}.secret_${uuid0}) = 3 OR ''1''=''1';
+-- result:
+0
+-- !result
+select count(1) from information_schema.task_runs where task_name = 'x\\';
+-- result:
+0
+-- !result
+admin set frontend config('enable_task_run_fe_evaluation'='false');
+-- result:
+-- !result
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR ''1''=''1';
+-- result:
+0
+-- !result
+admin set frontend config('enable_task_run_fe_evaluation'='true');
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_information_schema/T/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/T/test_task_runs_sql_injection
@@ -1,5 +1,17 @@
 -- name: test_task_runs_sql_injection @sequential
 
+-- The only SQL-built lookup sink is TaskRunHistoryTable.lookup(), which queries
+-- the archived _statistics_.task_run_history table over the privileged internal
+-- repo connection. The pending/running/in-memory-history paths feeding
+-- information_schema.task_runs use a Java equality filter and can NOT be injected.
+-- So the regression below is only meaningful once the run has actually been
+-- archived; otherwise the tautology payloads scan an empty archive table and
+-- return 0 even on vulnerable code (a false pass).
+--
+-- Shrink the task-run archive daemon interval (default 60s) so archival happens
+-- quickly during the test, then wait on the archive table directly below.
+admin set frontend config('task_check_interval_second' = '1');
+
 create database db_${uuid0};
 use db_${uuid0};
 
@@ -15,9 +27,15 @@ insert into ss values('2020-01-14', 1), ('2020-01-15', 2);
 -- Populate task_run_history with at least one archived run so a successful
 -- injection (tautology) would have rows to return.
 function: assert_query_contains("submit task task_inj_${uuid0} as insert into ss select * from ss;", "SUBMITTED")
+
+-- Wait until the run is ARCHIVED into _statistics_.task_run_history, not merely
+-- visible via information_schema.task_runs (which also serves in-memory history
+-- that never reaches the privileged SQL lookup). Querying the archive table
+-- directly is the definitive "archived" signal; the LOOP harmlessly retries while
+-- the table/row does not yet exist.
 LOOP {
-  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for task run to appear"}
-  result=select count(*) from information_schema.task_runs where task_name='task_inj_${uuid0}';
+  PROPERTY: {"timeout": 120, "interval": 3, "desc": "wait for task run to be archived"}
+  result=select count(*) from _statistics_.task_run_history where task_name='task_inj_${uuid0}';
   CHECK: int(${result}[-1][0]) > 0
 } END LOOP
 
@@ -27,8 +45,9 @@ select if(count(*) > 0, "OK", "FAILED") from information_schema.task_runs where 
 -- ============================================================================
 -- SQL injection regression (FE evaluation path).
 -- Each payload returns 0 only because the value is treated as a single literal
--- task name. On vulnerable code the OR-tautology/subquery would execute and the
--- WHERE would become true (returning rows) or the internal SQL would error.
+-- task name. On vulnerable code the OR-tautology/subquery would execute against
+-- the archived run(s) and the WHERE would become true (returning rows) or the
+-- internal SQL would error.
 -- ============================================================================
 
 -- (1) Quote tautology: closes the literal and ORs a true condition.
@@ -51,5 +70,8 @@ select count(1) from information_schema.task_runs where task_name = 'x\\';
 admin set frontend config('enable_task_run_fe_evaluation'='false');
 select count(1) from information_schema.task_runs where task_name = 'no_such'' OR ''1''=''1';
 admin set frontend config('enable_task_run_fe_evaluation'='true');
+
+-- Restore the default archive interval.
+admin set frontend config('task_check_interval_second' = '60');
 
 drop database db_${uuid0};

--- a/test/sql/test_information_schema/T/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/T/test_task_runs_sql_injection
@@ -1,4 +1,4 @@
--- name: test_task_runs_sql_injection @sequential
+-- name: test_task_runs_sql_injection @sequential @slow
 
 -- The only SQL-built lookup sink is TaskRunHistoryTable.lookup(), which queries
 -- the archived _statistics_.task_run_history table over the privileged internal

--- a/test/sql/test_information_schema/T/test_task_runs_sql_injection
+++ b/test/sql/test_information_schema/T/test_task_runs_sql_injection
@@ -1,0 +1,55 @@
+-- name: test_task_runs_sql_injection @sequential
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- A "secret" table that an injected predicate would try to read through the
+-- privileged internal repo lookup (runs as an internal principal, not the caller).
+-- A user-controlled TASK_NAME/QUERY_ID value must NEVER be able to execute SQL.
+CREATE TABLE secret_${uuid0}(v INT) DUPLICATE KEY(v) DISTRIBUTED BY HASH(v) BUCKETS 1 PROPERTIES("replication_num" = "1");
+insert into secret_${uuid0} values (1),(2),(3);
+
+CREATE TABLE ss(event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 1 PROPERTIES("replication_num" = "1");
+insert into ss values('2020-01-14', 1), ('2020-01-15', 2);
+
+-- Populate task_run_history with at least one archived run so a successful
+-- injection (tautology) would have rows to return.
+function: assert_query_contains("submit task task_inj_${uuid0} as insert into ss select * from ss;", "SUBMITTED")
+LOOP {
+  PROPERTY: {"timeout": 30, "interval": 2, "desc": "wait for task run to appear"}
+  result=select count(*) from information_schema.task_runs where task_name='task_inj_${uuid0}';
+  CHECK: int(${result}[-1][0]) > 0
+} END LOOP
+
+-- Sanity: a legitimate equality lookup still works after escaping.
+select if(count(*) > 0, "OK", "FAILED") from information_schema.task_runs where task_name='task_inj_${uuid0}';
+
+-- ============================================================================
+-- SQL injection regression (FE evaluation path).
+-- Each payload returns 0 only because the value is treated as a single literal
+-- task name. On vulnerable code the OR-tautology/subquery would execute and the
+-- WHERE would become true (returning rows) or the internal SQL would error.
+-- ============================================================================
+
+-- (1) Quote tautology: closes the literal and ORs a true condition.
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR ''1''=''1';
+
+-- (2) Lone trailing quote: would leave the internal string unterminated (parse error) on vulnerable code.
+select count(1) from information_schema.task_runs where task_name = 'a''';
+
+-- (3) Privileged cross-table read: the subquery would run as the internal principal on vulnerable code.
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR (SELECT count(*) FROM db_${uuid0}.secret_${uuid0}) = 3 OR ''1''=''1';
+
+-- (4) Backslash bypass: quote-doubling alone is insufficient because StarRocks honors backslash escapes;
+--     a value ending in a backslash would escape the closing quote. The fix escapes backslash too.
+select count(1) from information_schema.task_runs where task_name = 'x\\';
+
+-- ============================================================================
+-- Same lookup sink via the non-FE-evaluation path (BE scan -> FE getTaskRuns RPC).
+-- Disabling FE evaluation must NOT change the outcome: the value is still a literal.
+-- ============================================================================
+admin set frontend config('enable_task_run_fe_evaluation'='false');
+select count(1) from information_schema.task_runs where task_name = 'no_such'' OR ''1''=''1';
+admin set frontend config('enable_task_run_fe_evaluation'='true');
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing

`information_schema.task_runs` supports pushing an equality predicate on `TASK_NAME` / `QUERY_ID` down to an FE-side lookup against the internal `_statistics_.task_run_history` table. The predicate value was wrapped with log4j's `Strings.quote()` (which only does `"'" + value + "'"` and performs **no escaping**) and concatenated straight into the SQL. A value containing a single quote therefore closes the intended string literal, and the rest is parsed as additional SQL — a **second-order SQL injection**.

The internal lookup is executed over the privileged internal repository connection (`SimpleExecutor.getRepoExecutor()`, an internal principal that bypasses the caller's authorization), so an authenticated user with only the ability to query a system table can read internal tables they could never otherwise reach (e.g. via `... OR (SELECT ... FROM <other_db>) ...`).

**Note:** even quote-doubling alone (`StringEscapeUtils.escapeSql`) is insufficient here, because the StarRocks lexer also honors backslash escapes inside string literals (see `AstBuilder.escapeBackSlash` / `StarRocksLex.g4` `SINGLE_QUOTED_TEXT`). A value ending in a backslash can escape the closing quote and re-open the injection. Both `\` and `'` must be escaped.

## What I'm doing

- Add a canonical string-literal escaper `SqlUtils.escapeSqlString(value)` that escapes backslash first, then single quote (pairs with the existing identifier escaper `SqlUtils.getIdentSql`).
- Replace all `Strings.quote(...)` calls used to build the internal lookup SQL in `TaskRunHistoryTable` (`lookup`, `lookupByTaskNames`, `lookupLastJobOfTasks` — covering the `db` / `task_name` / `task_run_id` / `state` predicates) with a backslash-and-quote-safe `quoteLiteral`.
- The fix lands at the shared sink `TaskRunHistoryTable`, so it protects both the FE-evaluation path and the BE-scan → FE `getTaskRuns` RPC path (toggling `enable_task_run_fe_evaluation` is **not** a mitigation; both reach the same lookup).

Legitimate queries are unaffected (normal task names match exactly as before); only crafted values are now treated as literal data instead of executable SQL.

Fixes # (internal security finding)

## How to reproduce / verify

Setup — a "secret" table the caller has no access to, plus an archived task run so a successful injection has rows to return:

```sql
CREATE DATABASE secret_db;
CREATE TABLE secret_db.s (v INT) PROPERTIES ('replication_num'='1');
INSERT INTO secret_db.s VALUES (1),(2),(3);   -- the "secret": 3 rows

CREATE DATABASE test_inject;
CREATE TABLE test_inject.t (k INT) PROPERTIES ('replication_num'='1');
SUBMIT TASK test_inject_task AS INSERT INTO test_inject.t SELECT 1;   -- wait until archived

-- low-privilege user, no access to secret_db
CREATE USER inject_user IDENTIFIED BY 'inject_pwd';
GRANT SELECT ON test_inject.t TO inject_user;
```

As `inject_user`, a direct read is denied:

```sql
SELECT count(*) FROM secret_db.s;     -- ERROR: access denied
```

But a boolean-oracle injection through `task_runs` leaks it (the subquery runs as the privileged internal principal):

```sql
-- correct guess (=3): WHERE becomes true
SELECT count(*) FROM information_schema.task_runs
WHERE TASK_NAME = 'no_such'' OR (SELECT count(*) FROM secret_db.s) = 3 -- ';

-- wrong guess (=999)
SELECT count(*) FROM information_schema.task_runs
WHERE TASK_NAME = 'no_such'' OR (SELECT count(*) FROM secret_db.s) = 999 -- ';
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
