### PR TITLE
[BugFix] Bound-check SPARSE register index in HyperLogLog deserialize

### DIFF
--- a/be/src/types/hll.cpp
+++ b/be/src/types/hll.cpp
@@ -450,7 +450,17 @@ bool HyperLogLog::is_valid(const Slice& slice) {
             return false;
         }
         uint32_t num_registers = decode_fixed32_le(ptr);
-        ptr += 4 + 3 * num_registers;
+        ptr += 4;
+        if (ptr + 3 * static_cast<size_t>(num_registers) > end) {
+            return false;
+        }
+        for (uint32_t i = 0; i < num_registers; ++i) {
+            // each entry: 2-byte register index + 1-byte value; the index must be in range
+            if (decode_fixed16_le(ptr) >= HLL_REGISTERS_COUNT) {
+                return false;
+            }
+            ptr += 3;
+        }
         break;
     }
     case HLL_DATA_FULL: {
@@ -516,6 +526,12 @@ bool HyperLogLog::deserialize(const Slice& slice) {
             // 1 byte: register value
             uint16_t register_idx = decode_fixed16_le(ptr);
             ptr += 2;
+            // register_idx is an attacker-controlled uint16 (0..65535) but _registers.data
+            // only holds HLL_REGISTERS_COUNT (16384) bytes. Reject out-of-range indices to
+            // avoid an out-of-bounds heap write from a malformed SPARSE payload.
+            if (register_idx >= HLL_REGISTERS_COUNT) {
+                return false;
+            }
             _registers.data[register_idx] = *ptr++;
         }
         break;

--- a/test/sql/test_function/R/test_hll_deserialize_sparse_oob
+++ b/test/sql/test_function/R/test_hll_deserialize_sparse_oob
@@ -1,0 +1,18 @@
+-- name: test_hll_deserialize_sparse_oob @sequential
+CREATE TABLE t_hll (k INT, b VARBINARY)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_hll SELECT generate_series, unhex("0201000000FFFF01") FROM TABLE(generate_series(1, 20000));
+-- result:
+-- !result
+[UC] SELECT count(hll_cardinality(hll_deserialize(b))) FROM t_hll;
+SELECT hll_cardinality(hll_deserialize(hll_serialize(hll_hash(123))));
+-- result:
+1
+-- !result
+SELECT count(*) FROM t_hll;
+-- result:
+20000
+-- !result

--- a/test/sql/test_function/T/test_hll_deserialize_sparse_oob
+++ b/test/sql/test_function/T/test_hll_deserialize_sparse_oob
@@ -1,0 +1,17 @@
+-- name: test_hll_deserialize_sparse_oob @sequential
+-- Regression: hll_deserialize() deserializes user-supplied bytes directly. A SPARSE
+-- payload (type 0x02) whose register index is >= HLL_REGISTERS_COUNT (16384) wrote
+-- past the end of the 16384-byte register array (heap out-of-bounds write). A single
+-- row silently corrupted memory; in bulk it crashed the BE. The fix bound-checks the
+-- register index in both HyperLogLog::deserialize and HyperLogLog::is_valid.
+-- Blob 0201000000FFFF01 = SPARSE, num_registers=1, register_idx=0xFFFF, value=0x01.
+CREATE TABLE t_hll (k INT, b VARBINARY)
+  DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1
+  PROPERTIES("replication_num" = "1");
+INSERT INTO t_hll SELECT generate_series, unhex("0201000000FFFF01") FROM TABLE(generate_series(1, 20000));
+-- malformed SPARSE bytes must not crash the BE (deserialize rejects the bad index)
+[UC] SELECT count(hll_cardinality(hll_deserialize(b))) FROM t_hll;
+-- a valid serialize/deserialize roundtrip still works
+SELECT hll_cardinality(hll_deserialize(hll_serialize(hll_hash(123))));
+-- BE must still be serving queries
+SELECT count(*) FROM t_hll;


### PR DESCRIPTION
## Why I'm doing:

HyperLogLog::deserialize parsed a SPARSE payload by reading a 2-byte register index (0..65535) and writing _registers.data[register_idx], but the register array only holds HLL_REGISTERS_COUNT (16384) bytes and the index was never range-checked. hll_deserialize() feeds user-supplied bytes straight into deserialize (ignoring its return), so a malformed SPARSE blob with a register index >= 16384 wrote out of bounds of the heap register buffer: a single row silently corrupted memory and a bulk query crashed the BE (SIGSEGV). is_valid likewise only checked the byte length, not the indices.

Bound-check register_idx in the deserialize SPARSE loop (reject the payload before the write) and validate every register index plus the byte span in is_valid. This protects both SQL entry points (hll_deserialize and the HyperLogLog(Slice) constructor used by hll_cardinality(VARCHAR)).

Add regression test test_hll_deserialize_sparse_oob (@sequential, crash-recovery style): 20000 rows of a malformed SPARSE blob (register_idx=0xFFFF) that previously crashed the BE now deserialize harmlessly, a valid roundtrip is unchanged, and a following query confirms the BE is still serving.

## What I'm doing:

Fixes #issue

```
==21042==ERROR: AddressSanitizer: heap-use-after-free on address 0x52a000c6afff at pc 0x00002d0b88c3 bp 0x7f05845ccf30 sp 0x7f05845ccf28
WRITE of size 1 at 0x52a000c6afff thread T767
    #0 0x2d0b88c2 in starrocks::HyperLogLog::deserialize(starrocks::Slice const&) ../../../src/types/hll.cpp:519
    #1 0x2c2dd350 in starrocks::HyperloglogFunctions::hll_deserialize(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std
::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) ../../../src/exprs/hyperloglog_functions.cpp:101
    #2 0x2470c4e8 in starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > std::__invoke_impl<starrocks::StatusOr<starrocks::Cow<starrocks::Column>
::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow
<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vec
tor<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&>(std::__invoke_other,
 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<st
arrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*&&, std::vector<starrocks::Cow<starrocks::
Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke
.h:61
    #3 0x2470b76f in std::enable_if<is_invocable_r_v<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<star
rocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starroc
ks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std:
:allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&>, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > >::typ
e std::__invoke_r<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> >, starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks:
:Column> > (*&)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPt
r<starrocks::Column> > > const&), starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks
::Column>::ImmutPtr<starrocks::Column> > > const&>(starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*&)(starrocks::FunctionContext*, std::vec
tor<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::Function
Context*&&, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) 
/opt/gcc-toolset-14/include/c++/14.3.0/bits/invoke.h:116
    #4 0x2470ac1c in std::_Function_handler<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starroc
ks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&), starrocks::StatusOr<starrocks:
:Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (*)(starrocks::FunctionContext*, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator
<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)>::_M_invoke(std::_Any_data const&, starrocks::FunctionContext*&&, std::vector<starrocks::Cow<starrocks
::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) /opt/gcc-toolset-14/include/c++/14.3.0/bits/std_
function.h:291
    #5 0x24bd6cad in std::function<starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > (starrocks::FunctionContext*, std::vector<starrocks::Cow<s
tarrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&)>::operator()(starrocks::FunctionContext*
, std::vector<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>, std::allocator<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > > const&) const /opt
/gcc-toolset-14/include/c++/14.3.0/bits/std_function.h:591
    #6 0x24e4bef1 in starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) ../../../src/exprs/function_call_expr.cpp:212
    #7 0x2a51e4f2 in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) ../../../src/exprs/expr_context.cpp:190
    #8 0x24e4b66a in starrocks::VectorizedFunctionCallExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*) ../../../src/exprs/function_call_expr.cpp:188
    #9 0x2a51e4f2 in starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*) ../../../src/exprs/expr_context.cpp:190
    #10 0x2a51dd23 in starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*) ../../../src/exprs/expr_context.cpp:166

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
