### PR TITLE
[BugFix] Fix spurious comma before first load-desc clause in SHOW CREATE ROUTINE LOAD

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1560,13 +1560,15 @@ public class ShowExecutor {
                 throw new SemanticException(e.getMessage());
             }
 
+            boolean hasLoadDesc = false;
             if (routineLoadJob.getColumnSeparator() != null) {
                 createRoutineLoadSql.append("\n COLUMNS TERMINATED BY ")
                         .append(routineLoadJob.getColumnSeparator().toSql(true));
+                hasLoadDesc = true;
             }
 
             if (routineLoadJob.getColumnDescs() != null) {
-                createRoutineLoadSql.append(",\nCOLUMNS (");
+                createRoutineLoadSql.append(hasLoadDesc ? ",\n" : "\n").append("COLUMNS (");
                 List<ImportColumnDesc> descs = routineLoadJob.getColumnDescs();
                 for (int i = 0; i < descs.size(); i++) {
                     ImportColumnDesc desc = descs.get(i);
@@ -1581,13 +1583,15 @@ public class ShowExecutor {
                         createRoutineLoadSql.append(", ");
                     }
                 }
+                hasLoadDesc = true;
             }
             if (routineLoadJob.getPartitions() != null) {
-                createRoutineLoadSql.append(",\n");
+                createRoutineLoadSql.append(hasLoadDesc ? ",\n" : "\n");
                 createRoutineLoadSql.append(routineLoadJob.getPartitions().toString());
+                hasLoadDesc = true;
             }
             if (routineLoadJob.getWhereExpr() != null) {
-                createRoutineLoadSql.append(",\nWHERE ");
+                createRoutineLoadSql.append(hasLoadDesc ? ",\n" : "\n").append("WHERE ");
                 createRoutineLoadSql.append(ExprToSql.toSql(routineLoadJob.getWhereExpr()));
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
@@ -15,12 +15,31 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionNames;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import com.starrocks.load.routineload.RoutineLoadJob;
+import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultMetaFactory;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.ColumnSeparator;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.LabelName;
 import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,5 +86,94 @@ public class ShowCreateRoutineLoadStmtTest {
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assertions.assertEquals("testJob2", stmt.getName());
         Assertions.assertEquals("testDb2", stmt.getDbFullName());
+    }
+
+    // ===== The generated DDL must not contain a spurious comma before the first load-desc
+    // clause (COLUMNS / PARTITION / WHERE) when no COLUMNS TERMINATED BY precedes it, otherwise
+    // SHOW CREATE ROUTINE LOAD output is non-runnable. =====
+
+    // Build a KafkaRoutineLoadJob whose data-source getters are stubbed so the test only
+    // exercises the load-desc clause assembly in visitShowCreateRoutineLoadStatement.
+    private KafkaRoutineLoadJob baseJob() {
+        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob();
+        new Expectations(job) {
+            {
+                job.getDataSourceTypeName();
+                minTimes = 0;
+                result = "KAFKA";
+
+                job.jobPropertiesToSql();
+                minTimes = 0;
+                result = "(\n\"desired_concurrent_number\" = \"1\"\n)\n";
+
+                job.dataSourcePropertiesToSql();
+                minTimes = 0;
+                result = "(\n\"kafka_broker_list\" = \"localhost:9092\",\n\"kafka_topic\" = \"topic\"\n)";
+            }
+        };
+        return job;
+    }
+
+    // Resolve the job and its db/table through the shared ctx's real GlobalStateMgr. The mocks
+    // live inside the calling test method and expire when it returns.
+    private String buildDDL(RoutineLoadJob job) {
+        Database db = new Database(10000L, "testDb");
+        OlapTable table = new OlapTable();
+        table.setName("testTbl");
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Database getDb(long dbId) {
+                return db;
+            }
+
+            @Mock
+            public Table getTable(Long dbId, Long tableId) {
+                return table;
+            }
+        };
+        new MockUp<RoutineLoadMgr>() {
+            @Mock
+            public List<RoutineLoadJob> getJob(String dbFullName, String jobName, boolean includeHistory) {
+                return Lists.newArrayList(job);
+            }
+        };
+        ShowCreateRoutineLoadStmt stmt = new ShowCreateRoutineLoadStmt(new LabelName("testDb", "testJob"));
+        ShowResultSet rs = ShowExecutor.execute(stmt, ctx);
+        return rs.getResultRows().get(0).get(1);
+    }
+
+    @Test
+    public void testShowCreateRoutineLoadClauseSeparators() {
+        // COLUMNS is the first load-desc clause (no COLUMNS TERMINATED BY): the table name must
+        // not be followed by a comma.
+        KafkaRoutineLoadJob columnsOnly = baseJob();
+        Deencapsulation.setField(columnsOnly, "columnDescs",
+                Lists.newArrayList(new ImportColumnDesc("col1"), new ImportColumnDesc("col2")));
+        String columnsDdl = buildDDL(columnsOnly);
+        Assertions.assertFalse(columnsDdl.contains("testTbl,"), columnsDdl);
+        Assertions.assertTrue(columnsDdl.contains("on testTbl\nCOLUMNS (col1, col2)"), columnsDdl);
+
+        // COLUMNS TERMINATED BY precedes COLUMNS(...): the comma separator is required.
+        KafkaRoutineLoadJob columnsAfterSeparator = baseJob();
+        Deencapsulation.setField(columnsAfterSeparator, "columnSeparator", new ColumnSeparator(","));
+        Deencapsulation.setField(columnsAfterSeparator, "columnDescs",
+                Lists.newArrayList(new ImportColumnDesc("col1")));
+        String separatorDdl = buildDDL(columnsAfterSeparator);
+        Assertions.assertTrue(separatorDdl.contains(",\nCOLUMNS (col1)"), separatorDdl);
+
+        // PARTITION is the first clause: no comma after the table name.
+        KafkaRoutineLoadJob partitionOnly = baseJob();
+        Deencapsulation.setField(partitionOnly, "partitions",
+                new PartitionNames(false, Lists.newArrayList("p1", "p2")));
+        String partitionDdl = buildDDL(partitionOnly);
+        Assertions.assertFalse(partitionDdl.contains("testTbl,"), partitionDdl);
+        Assertions.assertTrue(partitionDdl.contains("on testTbl\nPARTITIONS (p1, p2)"), partitionDdl);
+
+        // WHERE is the only clause: no comma after the table name.
+        KafkaRoutineLoadJob whereOnly = baseJob();
+        Deencapsulation.setField(whereOnly, "whereExpr", SqlParser.parseSqlToExpr("k1 > 100", 0));
+        String whereDdl = buildDDL(whereOnly);
+        Assertions.assertFalse(whereDdl.contains("testTbl,"), whereDdl);
+        Assertions.assertTrue(whereDdl.contains("on testTbl\nWHERE "), whereDdl);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`SHOW CREATE ROUTINE LOAD` could emit a DDL string with a stray comma right
after the table name, which makes the output non-runnable.

When assembling the statement, the `COLUMNS (...)`, `PARTITION` and `WHERE`
load-desc clauses each unconditionally prepended a `,`. That comma is only
correct when a previous clause (e.g. `COLUMNS TERMINATED BY`) was already
appended. For jobs that have no `COLUMNS TERMINATED BY` — most notably
JSON-format Kafka jobs that rely on `jsonpaths` — the first load-desc clause
follows the table name directly, producing invalid SQL such as (Demandbase
hit this):

```sql
CREATE ROUTINE LOAD db.job on tbl,
COLUMNS (...)
```

Copying that output and re-running it fails with a syntax error.

## What I'm doing:

- In `ShowExecutor#visitShowCreateRoutineLoadStatement`, track whether any
  load-desc clause has already been appended via a `hasLoadDesc` flag, and
  only prepend the `,\n` separator when it has; otherwise emit just `\n`.
  `COLUMNS TERMINATED BY`, `COLUMNS (...)` and `PARTITION` each set the flag
  after appending, so the comma is emitted only between clauses, never right
  after the table name. No change to the clause contents or ordering.
- Add `ShowCreateRoutineLoadDDLTest` covering the four boundary cases: a
  leading `COLUMNS (...)` (no separator), a leading `PARTITION`, a leading
  `WHERE`, and `COLUMNS (...)` after `COLUMNS TERMINATED BY` (comma still
  required). All assert the table name is not followed by a comma where it
  should not be.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
