### PR TITLE
[BugFix] Fix sync MV rewrite losing a rollup column for same-column min/max

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -48,13 +48,30 @@ import java.util.Map;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
 
-public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression, MaterializedViewRule.RewriteContext> {
+/**
+ * Rewrites a query plan to read a sync materialized view (rollup) index.
+ *
+ * <p>The unit of rewrite is a group of {@link MaterializedViewRule.RewriteContext} that all share the
+ * same base query column (their {@code queryColumnRef} is identical). All aggregates on that base column
+ * are rewritten together, so the base column is removed from the scan exactly once and every rollup column
+ * derived from it is added in the same pass. Handling them one-by-one used to break when two aggregates
+ * referenced the same base column (e.g. {@code min(c)} and {@code max(c)}): the first context removed the
+ * base column from the scan/project, after which the sibling context could no longer find it and its rollup
+ * column was never projected.
+ */
+public class MaterializedViewRewriter
+        extends OptExpressionVisitor<OptExpression, List<MaterializedViewRule.RewriteContext>> {
 
     public MaterializedViewRewriter() {
     }
 
+    public OptExpression rewrite(OptExpression optExpression, List<MaterializedViewRule.RewriteContext> contexts) {
+        return optExpression.getOp().accept(this, optExpression, contexts);
+    }
+
+    // Convenience overload for rewriting a single context (one aggregate on a base column).
     public OptExpression rewrite(OptExpression optExpression, MaterializedViewRule.RewriteContext context) {
-        return optExpression.getOp().accept(this, optExpression, context);
+        return rewrite(optExpression, Lists.newArrayList(context));
     }
 
     public static boolean isCaseWhenScalarOperator(ScalarOperator operator) {
@@ -67,39 +84,49 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
     }
 
     @Override
-    public OptExpression visit(OptExpression optExpression, MaterializedViewRule.RewriteContext context) {
+    public OptExpression visit(OptExpression optExpression, List<MaterializedViewRule.RewriteContext> contexts) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
-            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), context));
+            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), contexts));
         }
 
         return OptExpression.create(optExpression.getOp(), optExpression.getInputs());
     }
 
     @Override
-    public OptExpression visitLogicalProject(OptExpression optExpression, MaterializedViewRule.RewriteContext context) {
+    public OptExpression visitLogicalProject(OptExpression optExpression,
+                                             List<MaterializedViewRule.RewriteContext> contexts) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
-            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), context));
+            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), contexts));
         }
 
         LogicalProjectOperator projectOperator = (LogicalProjectOperator) optExpression.getOp();
+        ColumnRefOperator queryColumnRef = contexts.get(0).queryColumnRef;
 
         Map<ColumnRefOperator, ScalarOperator> newProjectMap = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, ScalarOperator> kv : projectOperator.getColumnRefMap().entrySet()) {
             ColumnRefOperator queryColRef = kv.getKey();
             ScalarOperator queryScalarOperator = kv.getValue();
-            if (queryScalarOperator.getUsedColumns().contains(context.queryColumnRef)) {
+            if (queryScalarOperator.getUsedColumns().contains(queryColumnRef)) {
                 if (queryScalarOperator instanceof ColumnRefOperator) {
-                    newProjectMap.put(context.mvColumnRef, context.mvColumnRef);
+                    // The base column is projected as-is; project every rollup column derived from it so all
+                    // sibling aggregates (e.g. min(c) and max(c)) can read their own column above.
+                    for (MaterializedViewRule.RewriteContext context : contexts) {
+                        newProjectMap.put(context.mvColumnRef, context.mvColumnRef);
+                    }
                 } else if (isCaseWhenScalarOperator(queryScalarOperator)) {
                     // rewrite query column ref into mv agg column ref,
                     // eg: sum(case when a > 1 then b else 0 end), rewrite to sum(case when mv_column > 1 then b else 0 end)
-                    Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
-                    replaceMap.put(context.queryColumnRef, context.mvColumnRef);
-                    ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
-                    newProjectMap.put(queryColRef, replaceColumnRefRewriter.rewrite(kv.getValue()));
+                    for (MaterializedViewRule.RewriteContext context : contexts) {
+                        Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
+                        replaceMap.put(context.queryColumnRef, context.mvColumnRef);
+                        ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                        newProjectMap.put(queryColRef, replaceColumnRefRewriter.rewrite(kv.getValue()));
+                    }
                 } else {
                     // eg: bitmap_union(to_bitmap(a)), still rewrite to bitmap_union(to_bitmap(a))
-                    newProjectMap.put(queryColRef, context.mvColumnRef);
+                    for (MaterializedViewRule.RewriteContext context : contexts) {
+                        newProjectMap.put(queryColRef, context.mvColumnRef);
+                    }
                 }
             } else {
                 newProjectMap.put(queryColRef, queryScalarOperator);
@@ -110,18 +137,23 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
 
     @Override
     public OptExpression visitLogicalTableScan(OptExpression optExpression,
-                                               MaterializedViewRule.RewriteContext context) {
+                                               List<MaterializedViewRule.RewriteContext> contexts) {
         if (!OperatorType.LOGICAL_OLAP_SCAN.equals(optExpression.getOp().getOpType())) {
             return optExpression;
         }
 
         LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) optExpression.getOp();
+        ColumnRefOperator queryColumnRef = contexts.get(0).queryColumnRef;
 
-        if (olapScanOperator.getColRefToColumnMetaMap().containsKey(context.queryColumnRef)) {
+        if (olapScanOperator.getColRefToColumnMetaMap().containsKey(queryColumnRef)) {
             Map<ColumnRefOperator, Column> columnRefOperatorColumnMap =
                     new HashMap<>(olapScanOperator.getColRefToColumnMetaMap());
-            columnRefOperatorColumnMap.remove(context.queryColumnRef);
-            columnRefOperatorColumnMap.put(context.mvColumnRef, context.mvColumn);
+            // Replace the base column with every rollup column derived from it in a single pass, so two
+            // aggregates on the same base column (e.g. min(c), max(c)) both get their column projected.
+            columnRefOperatorColumnMap.remove(queryColumnRef);
+            for (MaterializedViewRule.RewriteContext context : contexts) {
+                columnRefOperatorColumnMap.put(context.mvColumnRef, context.mvColumn);
+            }
 
             LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
             LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
@@ -193,30 +225,33 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
 
     @Override
     public OptExpression visitLogicalAggregate(OptExpression optExpression,
-                                               MaterializedViewRule.RewriteContext context) {
+                                               List<MaterializedViewRule.RewriteContext> contexts) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
-            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), context));
+            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), contexts));
         }
 
         LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) optExpression.getOp();
-
-        Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
-        replaceMap.put(context.queryColumnRef, context.mvColumnRef);
-        ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
 
         Map<ColumnRefOperator, CallOperator> newAggMap = new HashMap<>(aggregationOperator.getAggregations());
         for (Map.Entry<ColumnRefOperator, CallOperator> kv : aggregationOperator.getAggregations().entrySet()) {
             CallOperator queryAggFunc = kv.getValue();
             if (queryAggFunc.getUsedColumns().isEmpty()) {
-                break;
+                continue;
             }
 
-            String functionName = queryAggFunc.getFnName();
-            if (functionName.equals(context.aggCall.getFnName())
-                    && queryAggFunc.getUsedColumns().getFirstId() == context.queryColumnRef.getId()) {
-                CallOperator newAggFunc = rewriteAggregateFunc(replaceColumnRefRewriter, context.mvColumn, queryAggFunc);
-                if (newAggFunc != null) {
-                    newAggMap.put(kv.getKey(), newAggFunc);
+            // Each aggregate is rewritten by the context whose function name and base column match it; the
+            // group can hold several (e.g. min and max on the same base column), so every aggregate is visited.
+            for (MaterializedViewRule.RewriteContext context : contexts) {
+                if (queryAggFunc.getFnName().equals(context.aggCall.getFnName())
+                        && queryAggFunc.getUsedColumns().getFirstId() == context.queryColumnRef.getId()) {
+                    Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
+                    replaceMap.put(context.queryColumnRef, context.mvColumnRef);
+                    ReplaceColumnRefRewriter replaceColumnRefRewriter = new ReplaceColumnRefRewriter(replaceMap);
+                    CallOperator newAggFunc =
+                            rewriteAggregateFunc(replaceColumnRefRewriter, context.mvColumn, queryAggFunc);
+                    if (newAggFunc != null) {
+                        newAggMap.put(kv.getKey(), newAggFunc);
+                    }
                     break;
                 }
             }
@@ -233,16 +268,21 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
 
     @Override
     public OptExpression visitLogicalTableFunction(OptExpression optExpression,
-                                                   MaterializedViewRule.RewriteContext context) {
+                                                   List<MaterializedViewRule.RewriteContext> contexts) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
-            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), context));
+            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), contexts));
         }
 
+        ColumnRefOperator queryColumnRef = contexts.get(0).queryColumnRef;
         List<ColumnRefOperator> newOuterColumns = Lists.newArrayList();
         LogicalTableFunctionOperator tableFunctionOperator = (LogicalTableFunctionOperator) optExpression.getOp();
         for (ColumnRefOperator col : tableFunctionOperator.getOuterColRefs()) {
-            if (col.equals(context.queryColumnRef)) {
-                newOuterColumns.add(context.mvColumnRef);
+            if (col.equals(queryColumnRef)) {
+                // The base column may be consumed by several aggregates (e.g. min(c), max(c)); forward
+                // every rollup column derived from it so all of them stay available above.
+                for (MaterializedViewRule.RewriteContext context : contexts) {
+                    newOuterColumns.add(context.mvColumnRef);
+                }
             } else {
                 newOuterColumns.add(col);
             }
@@ -257,9 +297,10 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
     }
 
     @Override
-    public OptExpression visitLogicalJoin(OptExpression optExpression, MaterializedViewRule.RewriteContext context) {
+    public OptExpression visitLogicalJoin(OptExpression optExpression,
+                                          List<MaterializedViewRule.RewriteContext> contexts) {
         for (int childIdx = 0; childIdx < optExpression.arity(); ++childIdx) {
-            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), context));
+            optExpression.setChild(childIdx, rewrite(optExpression.inputAt(childIdx), contexts));
         }
 
         LogicalJoinOperator joinOperator = (LogicalJoinOperator) optExpression.getOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -57,6 +57,7 @@ import com.starrocks.sql.util.Box;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -236,9 +237,18 @@ public class MaterializedViewRule extends Rule {
                 }
                 rewriteContext.removeAll(percentileContexts);
 
+                // Group the contexts by their shared base query column so that all aggregates on the same
+                // base column (e.g. min(c) and max(c)) are rewritten together. Otherwise rewriting them one
+                // by one removes that base column from the scan on the first context, after which the sibling
+                // context can no longer find it and its rollup column is never projected.
+                Map<ColumnRefOperator, List<RewriteContext>> contextsByQueryColumn = new LinkedHashMap<>();
+                for (RewriteContext rc : rewriteContext) {
+                    contextsByQueryColumn.computeIfAbsent(rc.queryColumnRef, k -> Lists.newArrayList()).add(rc);
+                }
+
                 MaterializedViewRewriter rewriter = new MaterializedViewRewriter();
-                for (MaterializedViewRule.RewriteContext rc : rewriteContext) {
-                    optExpression = rewriter.rewrite(optExpression, rc);
+                for (List<RewriteContext> group : contextsByQueryColumn.values()) {
+                    optExpression = rewriter.rewrite(optExpression, group);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -320,6 +320,67 @@ public class MVRewriteTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testAggQueryOnAggMVMinMaxSameColumn() throws Exception {
+        // min(salary) and max(salary) reference the SAME base column. Each aggregate produces its
+        // own RewriteContext that shares the base salary column ref but maps to a different rollup
+        // column (mv_min_salary / mv_max_salary). The scan must project BOTH rollup columns. Before
+        // the fix the first applied context removed the shared base column from the scan, so the
+        // second context could no longer locate the scan and its rollup column was never projected;
+        // the rewritten aggregate then referenced a column with no statistics and the optimizer
+        // threw "missing statistic of col: mv_min_salary" while costing the plan.
+        String createMVSQL = "create materialized view " + EMPS_MV_NAME
+                + " as select deptno, min(salary), max(salary) from " + EMPS_TABLE_NAME + " group by deptno;";
+        String query = "select deptno, min(salary), max(salary) from " + EMPS_TABLE_NAME + " group by deptno;";
+        starRocksAssert.withMaterializedView(createMVSQL).query(query)
+                .explainContains(QUERY_USE_EMPS_MV, "mv_min_salary", "mv_max_salary");
+    }
+
+    @Test
+    public void testAggQueryOnAggMVMinMaxControls() throws Exception {
+        // Regression controls: none of these throw before the fix, and all must keep hitting the
+        // rollup after it. They differ from the broken case in that no two aggregates share the
+        // same base column (or only a single aggregate references a given column).
+        String createMVSQL = "create materialized view " + EMPS_MV_NAME
+                + " as select deptno, min(salary), max(salary), min(commission), max(commission), sum(salary) from "
+                + EMPS_TABLE_NAME + " group by deptno;";
+        starRocksAssert.withMaterializedView(createMVSQL);
+
+        // single min
+        starRocksAssert.query("select deptno, min(salary) from " + EMPS_TABLE_NAME + " group by deptno;")
+                .explainContains(QUERY_USE_EMPS_MV, "mv_min_salary");
+        // single max
+        starRocksAssert.query("select deptno, max(salary) from " + EMPS_TABLE_NAME + " group by deptno;")
+                .explainContains(QUERY_USE_EMPS_MV, "mv_max_salary");
+        // min and max on DIFFERENT base columns
+        starRocksAssert.query("select deptno, min(salary), max(commission) from " + EMPS_TABLE_NAME
+                        + " group by deptno;")
+                .explainContains(QUERY_USE_EMPS_MV, "mv_min_salary", "mv_max_commission");
+        // two min on different base columns
+        starRocksAssert.query("select deptno, min(salary), min(commission) from " + EMPS_TABLE_NAME
+                        + " group by deptno;")
+                .explainContains(QUERY_USE_EMPS_MV, "mv_min_salary", "mv_min_commission");
+        // min and sum on the same base column (different functions, both have a rollup column)
+        starRocksAssert.query("select deptno, min(salary), sum(salary) from " + EMPS_TABLE_NAME
+                        + " group by deptno;")
+                .explainContains(QUERY_USE_EMPS_MV, "mv_min_salary", "mv_sum_salary");
+    }
+
+    @Test
+    public void testAggQueryOnAggMVMultiMinMaxPairs() throws Exception {
+        // Two independent shared-column pairs in one query: min/max(salary) and min/max(commission).
+        // Each pair triggers the same sibling-context interaction the fix addresses, so all four
+        // rollup columns must be projected by the scan.
+        String createMVSQL = "create materialized view " + EMPS_MV_NAME
+                + " as select deptno, min(salary), max(salary), min(commission), max(commission) from "
+                + EMPS_TABLE_NAME + " group by deptno;";
+        String query = "select deptno, min(salary), max(salary), min(commission), max(commission) from "
+                + EMPS_TABLE_NAME + " group by deptno;";
+        starRocksAssert.withMaterializedView(createMVSQL).query(query)
+                .explainContains(QUERY_USE_EMPS_MV,
+                        "mv_min_salary", "mv_max_salary", "mv_min_commission", "mv_max_commission");
+    }
+
+    @Test
     public void testJoinOnLeftProjectToJoin() throws Exception {
         String createEmpsMVSQL = "create materialized view " + EMPS_MV_NAME
                 + " as select deptno, sum(salary), sum(commission) from " + EMPS_TABLE_NAME + " group by deptno;";


### PR DESCRIPTION
## Why I'm doing:

When a query takes two aggregates on the **same base column** of a sync materialized view / rollup (e.g. `min(c)` and `max(c)`), the optimizer fails during cost estimation with `missing statistic of col: ... mv_min_c` (also surfaces as `Invalid plan: ... required cols cannot obtain from input cols`).

Each aggregate produces its own `RewriteContext` that shares the base column ref but maps to a different rollup column (`mv_min_c` / `mv_max_c`). The contexts are applied **sequentially**: the first one removes the shared base column from the `LogicalOlapScanOperator` (and replaces it in the intermediate `LogicalProjectOperator`). The second (sibling) context can then no longer find the base column, so its rollup column is never projected. The rewritten aggregate ends up referencing a column the scan/project does not produce, and the optimizer throws while costing the plan.

## What I'm doing:

Rewrite all aggregates that share the same base column as **one group, in a single pass**, instead of one context at a time:

- `MaterializedViewRule`: group the rewrite contexts by their shared base query column, and rewrite each group in a single pass.
- `MaterializedViewRewriter`: a rewrite now operates on the whole group, so the scan removes the base column **once** and adds **every** rollup column derived from it together (`mv_min_c` + `mv_max_c`); the project and aggregate likewise rewrite all aggregates of the group. Because the base column is no longer removed out from under a sibling, the scan/project rewrite stays at the plain "base column present -> replace" form, with no per-operator fallback.
- Add plan UTs in `MVRewriteTest`: same-column `min(c), max(c)`; regression controls (single min, single max, different-column min/max, two mins, min+sum); and two `min/max` pairs.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
