### PR TITLE
[Enhancement] Extend `[ExternalStats]` structured logging to the full external-table stats pipeline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTask.java
@@ -78,7 +78,8 @@ public class ConnectorAnalyzeTask {
         // check table update time is after last analyzed time
         if (tableUpdateTime != null) {
             if (lastAnalyzedTime.isAfter(tableUpdateTime)) {
-                LOG.info("Table {}.{}.{} column {} last update time: {}, last analyzed time: {}, skip analyze",
+                LOG.info("[ExternalStats] trigger skip | catalog={} db={} table={} column={} reason=col_uptodate " +
+                                "table_update={} last_analyze={}",
                         catalogName, db.getFullName(), table.getName(), column, tableUpdateTime, lastAnalyzedTime);
                 return false;
             }
@@ -100,8 +101,8 @@ public class ConnectorAnalyzeTask {
             StatsConstants.ScheduleStatus lastScheduleStatus = lastAnalyzedStatus.get().getStatus();
             if (lastScheduleStatus == StatsConstants.ScheduleStatus.PENDING ||
                     lastScheduleStatus == StatsConstants.ScheduleStatus.RUNNING) {
-                LOG.info("Table {}.{}.{} analyze status is {}, skip it", catalogName, db.getFullName(),
-                        table.getName(), lastScheduleStatus);
+                LOG.info("[ExternalStats] trigger skip | catalog={} db={} table={} reason=analyzing status={}",
+                        catalogName, db.getFullName(), table.getName(), lastScheduleStatus);
                 return Optional.empty();
             }
         }
@@ -135,8 +136,8 @@ public class ConnectorAnalyzeTask {
         }
 
         if (columns.isEmpty()) {
-            LOG.info("Table {}.{}.{} columns {} are all up to date, skip analyze", catalogName, db.getFullName(),
-                    table.getName(), columns.stream().map(Object::toString).collect(Collectors.joining(",")));
+            LOG.info("[ExternalStats] trigger skip | catalog={} db={} table={} reason=all_uptodate",
+                    catalogName, db.getFullName(), table.getName());
             return Optional.empty();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
@@ -51,8 +51,8 @@ public class ConnectorAnalyzeTaskQueue {
         wLock.lock();
         try {
             if (pendingTasks.size() >= Config.connector_table_query_trigger_analyze_max_pending_task_num) {
-                LOG.warn("Connector Analyze TaskQueue pending task num reach limit: {}, current: {}",
-                        Config.connector_table_query_trigger_analyze_max_pending_task_num, pendingTasks.size());
+                LOG.warn("[ExternalStats] trigger drop | table_uuid={} reason=pending_queue_full queue_size={}",
+                        tableUUID, pendingTasks.size());
                 return false;
             }
 
@@ -61,7 +61,7 @@ public class ConnectorAnalyzeTaskQueue {
                 // there is a running task for this table, remove columns which are already in running task
                 task.removeColumns(runningTask.getColumns());
                 if (task.getColumns().isEmpty()) {
-                    LOG.info("Table {} has a running task, skip this task", tableUUID);
+                    LOG.info("[ExternalStats] trigger skip | table_uuid={} reason=running_task", tableUUID);
                     return true;
                 }
             }
@@ -94,8 +94,8 @@ public class ConnectorAnalyzeTaskQueue {
     public void schedulePendingTask() {
         // do not dispatch task if max running concurrency reached or no pending task
         if (isMaxRunningConcurrencyReached()) {
-            LOG.info("Connector Analyze TaskQueue running task num reach limit: {}, current: {}",
-                    Config.connector_table_query_trigger_analyze_max_running_task_num, runningTasks.size());
+            LOG.info("[ExternalStats] running limit | running={} limit={}",
+                    runningTasks.size(), Config.connector_table_query_trigger_analyze_max_running_task_num);
             return;
         }
 
@@ -111,7 +111,7 @@ public class ConnectorAnalyzeTaskQueue {
                 runningTasks.put(entry.getKey(), task);
                 CompletableFuture.supplyAsync(task::run, taskRunPool).whenComplete((result, e) -> {
                     if (e != null) {
-                        LOG.warn("Table {} analyze task failed", entry.getKey(), e);
+                        LOG.warn("[ExternalStats] trigger fail | table_uuid={} error={}", entry.getKey(), e.getMessage(), e);
                     }
                     runningTasks.remove(entry.getKey());
                 });

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorTableTriggerAnalyzeMgr.java
@@ -99,7 +99,7 @@ public class ConnectorTableTriggerAnalyzeMgr {
                     tableExist = true;
                     tableUUID = columnKey.tableUUID;
                 } catch (Exception e) {
-                    LOG.warn("Table {} is not existed", columnKey.tableUUID);
+                    LOG.warn("[ExternalStats] trigger skip | table_uuid={} reason=table_not_found", columnKey.tableUUID);
                     return;
                 }
             }
@@ -127,10 +127,7 @@ public class ConnectorTableTriggerAnalyzeMgr {
 
         if (!analyzeColumns.isEmpty()) {
             // need to execute analyze
-            if (!this.connectorAnalyzeTaskQueue.
-                    addPendingTask(tableUUID, new ConnectorAnalyzeTask(tableTriple, analyzeColumns))) {
-                LOG.warn("Add analyze pending task {} failed.", tableUUID);
-            }
+            this.connectorAnalyzeTaskQueue.addPendingTask(tableUUID, new ConnectorAnalyzeTask(tableTriple, analyzeColumns));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -107,7 +107,7 @@ public class StatisticAutoCollector extends LeaderDaemon {
             allExternalAnalyzeJobs.sort((o1, o2) -> Long.compare(o2.getId(), o1.getId()));
             String jobIds = allExternalAnalyzeJobs.stream().map(j -> String.valueOf(j.getId()))
                     .collect(Collectors.joining(", "));
-            LOG.info("auto collect external statistic on analyze job[{}] start", jobIds);
+            LOG.info("[ExternalStats] auto collect start | jobIds={}", jobIds);
             for (ExternalAnalyzeJob externalAnalyzeJob : allExternalAnalyzeJobs) {
                 ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
                 try (var scope = statsConnectCtx.bindScope()) {
@@ -116,7 +116,7 @@ public class StatisticAutoCollector extends LeaderDaemon {
                     externalAnalyzeJob.run(statsConnectCtx, STATISTIC_EXECUTOR, jobs);
                 }
             }
-            LOG.info("auto collect external statistic on analyze job[{}] end", jobIds);
+            LOG.info("[ExternalStats] auto collect end   | jobIds={}", jobIds);
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -399,7 +399,7 @@ public class StatisticsCollectJobFactory {
                                                    List<Type> columnTypes) {
         // get updated partitions
         Set<String> updatedPartitions = StatisticUtils.getUpdatedPartitionNames(table, statisticsUpdateTime);
-        LOG.info("create external full statistics job for table: {}, partitions: {}",
+        LOG.info("[ExternalStats] create full job | table={} partitions={}",
                 table.getName(), updatedPartitions);
         allTableJobMap.add(buildExternalStatisticsCollectJob(job.getCatalogName(), db, table,
                 updatedPartitions == null ? null : Lists.newArrayList(updatedPartitions),
@@ -411,7 +411,7 @@ public class StatisticsCollectJobFactory {
                                                      List<String> columnNames, List<Type> columnTypes) {
         // get updated partitions
         Set<String> updatedPartitions = StatisticUtils.getUpdatedPartitionNames(table, statisticsUpdateTime);
-        LOG.info("create external sa,ple statistics job for table: {}, partitions: {}",
+        LOG.info("[ExternalStats] create sample job | table={} partitions={}",
                 table.getName(), updatedPartitions);
         allTableJobMap.add(buildExternalStatisticsCollectJob(job.getCatalogName(), db, table,
                 null, columnNames, columnTypes, StatsConstants.AnalyzeType.SAMPLE, job.getScheduleType(),


### PR DESCRIPTION
## Why I'm doing:
The previous PR (#75335) added `[ExternalStats]` prefix logging inside `ExternalFullStatisticsCollectJob` (the execution side), but the upstream trigger and scheduling layers still used scattered, inconsistently formatted log messages. This made it impossible to grep a single prefix and see the complete lifecycle of an external-table stats collection event — from queue admission, through scheduling decisions, to execution result.

## What I'm doing:
Extend the `[ExternalStats]` structured log format to all remaining entry points across both the **query-trigger path** and the **periodic path**, so that `grep '\[ExternalStats\]'` covers the full pipeline end-to-end.

**Query-trigger path** (`ConnectorAnalyzeTaskQueue`, `ConnectorAnalyzeTask`, `ConnectorTableTriggerAnalyzeMgr`):

```
Query arrives
  └─ checkAndUpdateTableStats()
       ├─ table not found           → [ExternalStats] trigger skip | reason=table_not_found
       ├─ addPendingTask()
       │    ├─ pending queue full   → [ExternalStats] trigger drop | reason=pending_queue_full
       │    └─ all cols in running  → [ExternalStats] trigger skip | reason=running_task
       └─ schedulePendingTask()
            ├─ concurrency limit    → [ExternalStats] running limit
            └─ task throws          → [ExternalStats] trigger fail
                 └─ ConnectorAnalyzeTask.run()
                      ├─ already analyzing  → [ExternalStats] trigger skip | reason=analyzing
                      ├─ col not expired    → [ExternalStats] trigger skip | reason=col_uptodate
                      ├─ all cols current   → [ExternalStats] trigger skip | reason=all_uptodate
                      └─ executes           → [ExternalStats] collect start/end  (PR #75335)
```

**Periodic path** (`StatisticAutoCollector`, `StatisticsCollectJobFactory`):
- Job-level start/end now use `[ExternalStats] auto collect start/end`
- Job creation logs now use `[ExternalStats] create full/sample job`

**Also fixed**: a longstanding typo `"sa,ple"` → `"sample"` in `StatisticsCollectJobFactory`.

**Removed**: the redundant `"Add analyze pending task {} failed"` warn in `ConnectorTableTriggerAnalyzeMgr` — the queue layer already emits `trigger drop` at the same point, so the caller's warn was pure duplication.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
