### PR TITLE
[BugFix] Apply CAST semantics for string->number schema-change conversion

### DIFF
--- a/be/src/column/type_converter.cpp
+++ b/be/src/column/type_converter.cpp
@@ -14,12 +14,14 @@
 
 #include "column/type_converter.h"
 
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
 #include "base/hash/unaligned_access.h"
+#include "base/string/string_parser.hpp"
 #include "column/type_converter_detail.h"
 #include "gutil/strings/substitute.h"
 #include "types/datetime_value.h"
@@ -29,8 +31,6 @@
 #include "types/storage_type_traits.h"
 #include "types/timestamp_value.h"
 #include "types/type_info.h"
-#include "base/string/string_parser.hpp"
-#include <cmath>
 
 namespace starrocks {
 
@@ -572,8 +572,8 @@ public:
         // overflows the target width or is not parseable must become NULL, not a silently wrapped
         // value ('99999999999'->INT -> 1215752191) or a 0 sentinel ('abc'->INT). TypeInfo::from_string
         // is lenient and would store those wrong non-NULL values (Bug 15 / numeric part of Bug 22).
-        if constexpr (Type == TYPE_TINYINT || Type == TYPE_SMALLINT || Type == TYPE_INT ||
-                      Type == TYPE_BIGINT || Type == TYPE_LARGEINT) {
+        if constexpr (Type == TYPE_TINYINT || Type == TYPE_SMALLINT || Type == TYPE_INT || Type == TYPE_BIGINT ||
+                      Type == TYPE_LARGEINT) {
             StringParser::ParseResult presult;
             CppType value = StringParser::string_to_int<CppType>(slice.data, slice.size, &presult);
             if (presult != StringParser::PARSE_SUCCESS) {

--- a/be/src/column/type_converter.cpp
+++ b/be/src/column/type_converter.cpp
@@ -29,6 +29,8 @@
 #include "types/storage_type_traits.h"
 #include "types/timestamp_value.h"
 #include "types/type_info.h"
+#include "base/string/string_parser.hpp"
+#include <cmath>
 
 namespace starrocks {
 
@@ -565,12 +567,37 @@ public:
             dst->set_null();
             return Status::OK();
         }
-        std::string source = src.get_slice().to_string();
-
-        CppType value;
-        RETURN_IF_ERROR(dst_typeinfo->from_string(&value, source));
-        dst->set(value);
-        return Status::OK();
+        Slice slice = src.get_slice();
+        // Match query-time CAST semantics for lossy string->number schema changes: a value that
+        // overflows the target width or is not parseable must become NULL, not a silently wrapped
+        // value ('99999999999'->INT -> 1215752191) or a 0 sentinel ('abc'->INT). TypeInfo::from_string
+        // is lenient and would store those wrong non-NULL values (Bug 15 / numeric part of Bug 22).
+        if constexpr (Type == TYPE_TINYINT || Type == TYPE_SMALLINT || Type == TYPE_INT ||
+                      Type == TYPE_BIGINT || Type == TYPE_LARGEINT) {
+            StringParser::ParseResult presult;
+            CppType value = StringParser::string_to_int<CppType>(slice.data, slice.size, &presult);
+            if (presult != StringParser::PARSE_SUCCESS) {
+                dst->set_null();
+                return Status::OK();
+            }
+            dst->set(value);
+            return Status::OK();
+        } else if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
+            StringParser::ParseResult presult;
+            CppType value = StringParser::string_to_float<CppType>(slice.data, slice.size, &presult);
+            if (presult != StringParser::PARSE_SUCCESS || std::isnan(value) || std::isinf(value)) {
+                dst->set_null();
+                return Status::OK();
+            }
+            dst->set(value);
+            return Status::OK();
+        } else {
+            std::string source = slice.to_string();
+            CppType value;
+            RETURN_IF_ERROR(dst_typeinfo->from_string(&value, source));
+            dst->set(value);
+            return Status::OK();
+        }
     }
 };
 

--- a/test/sql/test_fast_schema_evolution/R/test_schema_change_string_to_num_null
+++ b/test/sql/test_fast_schema_evolution/R/test_schema_change_string_to_num_null
@@ -1,0 +1,54 @@
+-- name: test_schema_change_string_to_num_null
+drop database if exists test_schema_change_string_to_num_null;
+-- result:
+-- !result
+create database test_schema_change_string_to_num_null;
+-- result:
+-- !result
+use test_schema_change_string_to_num_null;
+-- result:
+-- !result
+CREATE TABLE cc1 (k INT, v VARCHAR(32) NOT NULL) DUPLICATE KEY(k)
+  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("fast_schema_evolution"="true","replication_num"="1");
+-- result:
+-- !result
+INSERT INTO cc1 VALUES (1,'100'),(2,'99999999999'),(3,'abc');
+-- result:
+-- !result
+ALTER TABLE cc1 MODIFY COLUMN v INT;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT k,v FROM cc1 ORDER BY k;
+-- result:
+1	100
+2	None
+3	None
+-- !result
+CREATE TABLE cc2 (k INT, v VARCHAR(32)) DUPLICATE KEY(k)
+  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("fast_schema_evolution"="true","replication_num"="1");
+-- result:
+-- !result
+INSERT INTO cc2 VALUES (1,'7'),(2,'1.5'),(3,'xyz'),(4,NULL);
+-- result:
+-- !result
+ALTER TABLE cc2 MODIFY COLUMN v DOUBLE;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT k,v FROM cc2 ORDER BY k;
+-- result:
+1	7.0
+2	1.5
+3	None
+4	None
+-- !result
+drop database test_schema_change_string_to_num_null;
+-- result:
+-- !result

--- a/test/sql/test_fast_schema_evolution/T/test_schema_change_string_to_num_null
+++ b/test/sql/test_fast_schema_evolution/T/test_schema_change_string_to_num_null
@@ -1,0 +1,26 @@
+-- name: test_schema_change_string_to_num_null
+-- Bug 15 / numeric Bug 22: ALTER MODIFY COLUMN from VARCHAR to an integer/float type must apply
+-- CAST semantics for unconvertible values (overflow / unparseable -> NULL), matching query-time CAST
+-- and INSERT. Previously the schema-change converter used the lenient TypeInfo::from_string, which
+-- stored a 32-bit-wrapped value ('99999999999'->1215752191) or a 0 sentinel ('abc'->0) as non-NULL.
+drop database if exists test_schema_change_string_to_num_null;
+create database test_schema_change_string_to_num_null;
+use test_schema_change_string_to_num_null;
+
+CREATE TABLE cc1 (k INT, v VARCHAR(32) NOT NULL) DUPLICATE KEY(k)
+  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("fast_schema_evolution"="true","replication_num"="1");
+INSERT INTO cc1 VALUES (1,'100'),(2,'99999999999'),(3,'abc');
+ALTER TABLE cc1 MODIFY COLUMN v INT;
+function: wait_alter_table_finish()
+-- '100'->100, overflow '99999999999'->NULL, unparseable 'abc'->NULL (matches CAST)
+SELECT k,v FROM cc1 ORDER BY k;
+
+CREATE TABLE cc2 (k INT, v VARCHAR(32)) DUPLICATE KEY(k)
+  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES("fast_schema_evolution"="true","replication_num"="1");
+INSERT INTO cc2 VALUES (1,'7'),(2,'1.5'),(3,'xyz'),(4,NULL);
+ALTER TABLE cc2 MODIFY COLUMN v DOUBLE;
+function: wait_alter_table_finish()
+-- '7'->7.0, '1.5'->1.5, unparseable 'xyz'->NULL, source NULL stays NULL
+SELECT k,v FROM cc2 ORDER BY k;
+
+drop database test_schema_change_string_to_num_null;


### PR DESCRIPTION
## Why I'm doing:

ALTER TABLE ... MODIFY COLUMN from VARCHAR to an integer/float type went through StringToOtherTypeConverter, which used the lenient TypeInfo::from_string. That silently 32-bit-wrapped out-of-range values ('99999999999' -> 1215752191) and defaulted unparseable ones ('abc' -> 0), storing them as NON-NULL — diverging from query-time CAST and INSERT, which yield NULL for the same inputs.

Parse integer/float targets with StringParser (mirroring cast_int_from_string_fn / cast_float_from_string_fn) and store NULL on parse-failure/overflow. The converted column is nullable, so NULL is representable. Fixes the VARCHAR->INT case  and the numeric part of the VARCHAR->numeric generalization.


## What I'm doing:

Fixes #issue

```
source VARCHAR value   target T    query-time CAST   stored after MODIFY COLUMN (WRONG)
'not-a-date'           DATE        NULL              1400-01-01
'9999-99-99'           DATE        NULL              1400-01-01
''                     DATE        NULL              1400-01-01
NULL                   DATE        NULL              NULL          (correct)
'abc'                  INT         NULL              0
'99999999999999999999' INT         NULL (overflow)   -1
'xyz'                  DOUBLE      NULL              0
''                     DOUBLE      NULL              0
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
