### PR TITLE
[Refactor][BugFix] Refactor low cardinality aggregation logic and output handling (backport #74970)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -356,13 +356,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 continue;
             }
             List<CallOperator> aggregateExprs = stringAggregateExpressions.get(aggregateId);
-            for (CallOperator agg : aggregateExprs) {
-                if (agg.getColumnRefs().stream().map(ColumnRefOperator::getId)
-                        .anyMatch(context.allStringColumns::contains)) {
-                    context.stringAggregateExprs.put(aggregateId, aggregateExprs);
-                    context.allStringColumns.add(aggregateId);
-                    break;
-                }
+            if (aggregateExprs.get(0).getColumnRefs().stream().map(ColumnRefOperator::getId)
+                    .anyMatch(context.allStringColumns::contains)) {
+                context.stringAggregateExprs.put(aggregateId, aggregateExprs);
             }
         }
 
@@ -863,7 +859,11 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         return info;
     }
 
-    private boolean shouldProcessAggFunction(CallOperator agg, ColumnRefSet supportColumns, boolean isFirstStage) {
+    private boolean shouldProcessAggFunction(CallOperator agg, DecodeInfo info, boolean isFirstStage) {
+        ColumnRefSet supportColumns = new ColumnRefSet();
+        supportColumns.union(info.getInputStringColumns());
+        supportColumns.union(info.getInProgressStringAggregations());
+        supportColumns.union(info.getFinalizingStringAggregations());
         final boolean enableArrayAgg = sessionVariable.isEnableArrayAggLowCardinalityOptimize()
                 && sessionVariable.isEnableArrayLowCardinalityOptimize()
                 && sessionVariable.isEnableStructLowCardinalityOptimize();
@@ -889,7 +889,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalHashAggregate(OptExpression optExpression, DecodeInfo context) {
-        if (context.outputStringColumns.isEmpty()) {
+        if (context.outputStringColumns.isEmpty() && context.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
         PhysicalHashAggregateOperator aggregate = optExpression.getOp().cast();
@@ -900,7 +900,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             CallOperator agg = aggregate.getAggregations().get(key);
             final boolean isFirstStage = !agg.getArguments().isEmpty() &&
                     (!(agg.getArguments().get(0) instanceof ColumnRefOperator ref) || ref.getId() != key.getId());
-            if (!shouldProcessAggFunction(agg, info.inputStringColumns, isFirstStage)) {
+            if (!shouldProcessAggFunction(agg, info, isFirstStage)) {
                 disableColumns.union(agg.getUsedColumns());
                 disableColumns.union(key);
             } else if (isFirstStage && FunctionSet.ARRAY_AGG.equals(agg.getFnName()) &&
@@ -916,6 +916,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
 
         info.outputStringColumns.clear();
+        info.inProgressStringAggregations.clear();
         for (ColumnRefOperator key : aggregate.getAggregations().keySet()) {
             if (disableColumns.contains(key)) {
                 continue;
@@ -924,20 +925,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             // aggregate ref -> aggregate expr
             stringAggregateExpressions.computeIfAbsent(key.getId(), x -> Lists.newArrayList()).add(value);
             AggregateFunction aggFn = (AggregateFunction) value.getFunction();
-            if (aggFn.getIntermediateTypeOrReturnType().isStructType()
-                    && !structRefToFieldUseStringRef.containsKey(key.getId())) {
+            if (aggFn.getReturnType().isStructType() && !structRefToFieldUseStringRef.containsKey(key.getId())) {
                 final Map<String, ColumnRefOperator> fieldsData;
-                if (FunctionSet.ARRAY_AGG.equals(aggFn.functionName())) {
-                    fieldsData = Maps.newHashMap();
-                    StructType structType = (StructType) aggFn.getIntermediateTypeOrReturnType();
-                    Preconditions.checkState(structType.getFields().size() == value.getArguments().size());
-                    for (int i = 0; i < value.getArguments().size(); i++) {
-                        if (value.getArguments().get(i).isColumnRef() && value.getArguments().get(i).getType().isStringType()
-                                && info.inputStringColumns.contains(value.getArguments().get(i).cast())) {
-                            fieldsData.put(structType.getField(i).getName(), value.getArguments().get(i).cast());
-                        }
-                    }
-                } else if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
+                if (FunctionSet.ANY_VALUE.equals(aggFn.functionName())) {
                     fieldsData = getFieldUseStringRefMap(value.getArguments().get(0));
                 } else {
                     throw new UnsupportedOperationException(
@@ -946,12 +936,18 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 Preconditions.checkNotNull(fieldsData);
                 structOpToFieldUseStringRef.put(value, fieldsData);
             }
-            if (supportLowCardinality(value.getType())) {
-                info.outputStringColumns.union(key.getId());
+            if (supportLowCardinality(aggFn.getReturnType())) {
                 setDefineExpr(key, value, 1);
-            } else if (aggregate.getType().isLocal() || aggregate.getType().isDistinct()) {
-                // count/count distinct, need output dict-set in 1st stage
-                info.outputStringColumns.union(key.getId());
+            }
+            final boolean isFinalStage = aggregate.getType().isGlobal() ||
+                    (aggregate.getType().isLocal() && !aggregate.isSplit());
+            if (isFinalStage) {
+                info.finalizingStringAggregations.union(key.getId());
+                if (supportLowCardinality(value.getType())) {
+                    info.outputStringColumns.union(key.getId());
+                }
+            } else {
+                info.inProgressStringAggregations.union(key.getId());
             }
         }
 
@@ -1011,7 +1007,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
 
     @Override
     public DecodeInfo visitPhysicalDistribution(OptExpression optExpression, DecodeInfo context) {
-        if (context.outputStringColumns.isEmpty()) {
+        if (context.outputStringColumns.isEmpty() && context.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
         return context.createOutputInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -240,11 +240,10 @@ class DecodeContext {
 
     private void rewriteStringAggregations() {
         // rewrite string aggregate expression
-        AggregateRewriter rewriter = new AggregateRewriter();
         stringAggregateExprs.forEach((aggId, aggFns) -> {
             ColumnRefSet supportColumns = aggIdToSupportColumns.get(aggId);
             Preconditions.checkNotNull(supportColumns);
-            rewriter.setSupportColumns(supportColumns);
+            AggregateRewriter rewriter = new AggregateRewriter(aggId, supportColumns);
             for (CallOperator aggFn : aggFns) {
                 CallOperator new1stAggFn = (CallOperator) (aggFn.accept(rewriter, null));
                 stringExprToDictExprMap.put(aggFn, new1stAggFn);
@@ -496,53 +495,56 @@ class DecodeContext {
     }
 
     private class AggregateRewriter extends BaseScalarOperatorShuttle {
-        private ColumnRefSet supportColumns;
+        private final int aggId;
+        private final ColumnRefSet supportColumns;
+        private AggregateFunction newFn;
+        private AggregateFunction originalFn;
+
+        public AggregateRewriter(int aggId, ColumnRefSet supportColumns) {
+            this.aggId = aggId;
+            this.supportColumns = supportColumns;
+        }
 
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
+            if (variable.getId() == aggId) {
+                Preconditions.checkNotNull(newFn);
+                ColumnRefOperator dictRef = stringRefToDictRefMap.get(variable);
+                if (dictRef == null) {
+                    return variable;
+                }
+                final Type returnType;
+                if (variable.getType().matchesType(originalFn.getReturnType())) {
+                    returnType = newFn.getReturnType();
+                } else if (originalFn.getIntermediateType() != null &&
+                        variable.getType().matchesType(originalFn.getIntermediateType())) {
+                    returnType = newFn.getIntermediateType();
+                } else {
+                    returnType = getDictifiedType(variable.getType());
+                }
+                return new ColumnRefOperator(dictRef.getId(), returnType, dictRef.getName(), dictRef.isNullable());
+            }
             return supportColumns.contains(variable) ?
                     stringRefToDictRefMap.getOrDefault(variable, variable) : variable;
         }
 
-        AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren,
-                                                 List<ScalarOperator> originalChildren) {
-            final List<Type> argTypes;
-            final Type intermediateType;
-            final Type returnType;
-            if (FunctionSet.ARRAY_AGG.equals(fn.functionName())) {
-                ScalarOperator child = originalChildren.get(0);
-                if (child.getType().matchesType(fn.getReturnType())
-                        || child.getType().matchesType(fn.getIntermediateTypeOrReturnType())) {
-                    argTypes = Lists.newArrayList();
-                    Map<String, ColumnRefOperator> fieldMapping = getFieldUseStringRefMap(originalChildren.get(0));
-                    Preconditions.checkNotNull(fieldMapping);
-                    for (int i = 0; i < fn.getNumArgs(); ++i) {
-                        argTypes.add(fieldMapping.containsKey("col" + (i + 1)) ? getDictifiedType(fn.getArgs()[i])
-                                : fn.getArgs()[i]);
-                    }
-                } else {
-                    argTypes = newChildren.stream().map(ScalarOperator::getType).toList();
-                }
-                intermediateType = new StructType(argTypes.stream().map(t -> (Type) new ArrayType(t)).toList());
-                returnType = new ArrayType(argTypes.get(0));
-            } else if (FunctionSet.ANY_VALUE.equals(fn.functionName())) {
-                returnType = intermediateType = newChildren.get(0).getType();
-                argTypes = List.of(newChildren.get(0).getType());
-            } else {
-                argTypes = Lists.newArrayListWithCapacity(fn.getNumArgs());
-                for (int i = 0; i < fn.getNumArgs(); ++i) {
-                    argTypes.add(getDictifiedType(fn.getArgs()[i]));
-                }
-                returnType = getDictifiedType(fn.getReturnType());
-                intermediateType = getDictifiedType(fn.getIntermediateType());
-            }
+        AggregateFunction buildAggregateFunction(AggregateFunction fn, List<ScalarOperator> newChildren) {
+            Preconditions.checkState(fn.getNumArgs() <= newChildren.size());
+            final List<Type> argTypes =
+                    newChildren.subList(0, fn.getNumArgs()).stream().map(ScalarOperator::getType).toList();
+            record TypeInfo(Type intermediateType, Type returnType) {}
+            TypeInfo typeInfo = switch (fn.functionName()) {
+                case FunctionSet.ARRAY_AGG -> new TypeInfo(
+                            new StructType(argTypes.stream().map(t -> (Type) new ArrayType(t)).toList()),
+                            new ArrayType(argTypes.get(0)));
+                case FunctionSet.ANY_VALUE -> new TypeInfo(argTypes.get(0), argTypes.get(0));
+                default -> new TypeInfo(
+                        getDictifiedType(fn.getIntermediateType()), getDictifiedType(fn.getReturnType()));
+            };
             AggregateFunction newFn = (AggregateFunction) fn.copy();
-            Preconditions.checkState(argTypes.size() == fn.getNumArgs(),
-                    "argTypes size %s doesn't match numArgs %s for function %s",
-                    argTypes.size(), fn.getNumArgs(), fn.functionName());
             newFn.setArgsType(argTypes.toArray(Type[]::new));
-            newFn.setIntermediateType(intermediateType);
-            newFn.setRetType(returnType);
+            newFn.setIntermediateType(typeInfo.intermediateType);
+            newFn.setRetType(typeInfo.returnType);
             return newFn;
         }
 
@@ -552,22 +554,13 @@ class DecodeContext {
             List<ScalarOperator> newChildren = visitList(call.getChildren(), hasChange);
 
             if (call.getFunction() instanceof AggregateFunction origFn) {
-                AggregateFunction fn = buildAggregateFunction(origFn, newChildren, call.getArguments());
-                ColumnRefOperator firstChild = newChildren.get(0).isColumnRef() ? newChildren.get(0).cast() : null;
-                if (firstChild != null && firstChild != call.getArguments().get(0)) {
-                    if (firstChild.getType().matchesType(fn.getReturnType())) {
-                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getReturnType(),
-                                firstChild.getName(), firstChild.isNullable()));
-                    }
-                    if (fn.getIntermediateType() != null
-                            && firstChild.getType().matchesType(fn.getIntermediateType())) {
-                        newChildren.set(0, new ColumnRefOperator(firstChild.getId(), fn.getIntermediateType(),
-                                firstChild.getName(), firstChild.isNullable()));
-                    }
+                if (this.newFn == null) {
+                    originalFn = origFn;
+                    newFn = buildAggregateFunction(origFn, newChildren);
                 }
                 Type returnType = call.getType().matchesType(origFn.getReturnType())
-                        ? fn.getReturnType() : fn.getIntermediateType();
-                CallOperator newCall = new CallOperator(call.getFnName(), returnType, newChildren, fn,
+                        ? newFn.getReturnType() : newFn.getIntermediateType();
+                CallOperator newCall = new CallOperator(call.getFnName(), returnType, newChildren, newFn,
                         call.isDistinct(), call.isRemovedDistinct());
                 newCall.setIgnoreNulls(call.getIgnoreNulls());
                 return newCall;
@@ -580,10 +573,6 @@ class DecodeContext {
             Function fn = buildFunction(call.getFnName(), newChildren);
             return new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn,
                     call.isDistinct(), call.isRemovedDistinct());
-        }
-
-        void setSupportColumns(ColumnRefSet supportColumns) {
-            this.supportColumns = supportColumns;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeInfo.java
@@ -46,6 +46,12 @@ public class DecodeInfo {
     // operator used string column but not output to downstream operator
     ColumnRefSet usedStringColumns = new ColumnRefSet();
 
+    // Low cardinality aggregations that have been started but are not finalized yet
+    ColumnRefSet inProgressStringAggregations = new ColumnRefSet();
+
+    // Low cardinality aggregations that are being finalized in this operator
+    ColumnRefSet finalizingStringAggregations = new ColumnRefSet();
+
     public ColumnRefSet getInputStringColumns() {
         return inputStringColumns;
     }
@@ -58,14 +64,23 @@ public class DecodeInfo {
         return outputStringColumns;
     }
 
+    public ColumnRefSet getInProgressStringAggregations() {
+        return inProgressStringAggregations;
+    }
+
+    public ColumnRefSet getFinalizingStringAggregations() {
+        return finalizingStringAggregations;
+    }
+
     public DecodeInfo createOutputInfo() {
-        if (this.outputStringColumns.isEmpty()) {
+        if (this.outputStringColumns.isEmpty() && this.inProgressStringAggregations.isEmpty()) {
             return DecodeInfo.empty();
         }
 
         DecodeInfo info = DecodeInfo.create();
         info.inputStringColumns.union(this.outputStringColumns);
         info.outputStringColumns.union(this.outputStringColumns);
+        info.inProgressStringAggregations.union(this.inProgressStringAggregations);
         return info;
     }
 
@@ -81,16 +96,19 @@ public class DecodeInfo {
 
     public boolean isEmpty() {
         return this.outputStringColumns.isEmpty() && this.inputStringColumns.isEmpty() &&
-                this.decodeStringColumns.isEmpty();
+                this.decodeStringColumns.isEmpty() && this.inProgressStringAggregations.isEmpty() &&
+                this.finalizingStringAggregations.isEmpty();
     }
 
     public void addChildInfo(DecodeInfo other) {
         this.outputStringColumns.union(other.outputStringColumns);
+        this.inProgressStringAggregations.union(other.inProgressStringAggregations);
     }
 
     @Override
     public String toString() {
         return "input[" + inputStringColumns + "], " + "decode[" + decodeStringColumns + "], " + "output[" +
-                outputStringColumns + ']';
+                outputStringColumns + "]," + " inProgressAggregations[" + inProgressStringAggregations + "]" +
+                " finalizingAggregations[" + finalizingStringAggregations + "]";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -68,8 +68,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.supportLowCardinality;
-
 /*
  * Rewrite the whole plan using the dict column by from bottom-up
  */
@@ -128,6 +126,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
 
         fragmentUsedDictExprs.union(decodeInfo.outputStringColumns);
         fragmentUsedDictExprs.union(decodeInfo.usedStringColumns);
+        fragmentUsedDictExprs.union(decodeInfo.inProgressStringAggregations);
         ColumnRefSet childFragmentUsedDictExpr = optExpression.getOp() instanceof PhysicalDistributionOperator ?
                 new ColumnRefSet() : fragmentUsedDictExprs;
 
@@ -148,8 +147,10 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         // some string column need rewrite
         boolean hasDictInput = !decodeInfo.inputStringColumns.isEmpty();
         boolean hasDictOutput = !decodeInfo.outputStringColumns.isEmpty();
+        boolean hasDictAggregate = !decodeInfo.inProgressStringAggregations.isEmpty() ||
+                !decodeInfo.finalizingStringAggregations.isEmpty();
 
-        if (hasDictInput || hasDictOutput) {
+        if (hasDictInput || hasDictOutput || hasDictAggregate) {
             return optExpression.getOp().accept(this, optExpression, fragmentUsedDictExprs);
         }
         return optExpression;
@@ -318,8 +319,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             }
 
             // merge stage is different from update stage
-            if (supportLowCardinality(aggFn.getType())) {
-                ColumnRefOperator newAggRef = context.stringRefToDictRefMap.getOrDefault(aggRef, aggRef);
+            if (context.stringRefToDictRefMap.containsKey(aggRef)) {
+                ColumnRefOperator newAggRef = context.stringRefToDictRefMap.get(aggRef);
                 aggregations.put(newAggRef, context.stringExprToDictExprMap.get(aggFn).cast());
                 inputStringRefs.union(aggRef.getId());
             } else {
@@ -421,13 +422,14 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         Map<Integer, ColumnDict> dictMap = Maps.newHashMap();
         ColumnRefSet inputColumns = new ColumnRefSet();
         inputColumns.union(info.inputStringColumns);
-        info.inputStringColumns.getStream()
+        inputColumns.union(info.inProgressStringAggregations);
+        inputColumns.union(inputColumns.getStream()
                 .map(factory::getColumnRef)
                 .filter(c -> c.getType().isStructType())
                 .map(context::getFieldUseStringRefMap)
                 .filter(Objects::nonNull)
-                .map(Map::values)
-                .forEach(inputColumns::union);
+                .flatMap(k -> k.values().stream())
+                .toList());
         for (int sid : inputColumns.getColumnIds()) {
             ColumnRefOperator stringRef = factory.getColumnRef(sid);
             if (!context.stringRefToDictRefMap.containsKey(stringRef)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityStructTest.java
@@ -14,8 +14,11 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.utframe.StarRocksAssert;
+import mockit.Expectations;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -616,5 +619,96 @@ public class LowCardinalityStructTest extends PlanTestBase {
                 "  |  aggregate: array_agg[([3: ARRAY_VARCHAR_COL, ARRAY<VARCHAR(40)>, true]); args: INVALID_TYPE; " +
                 "result: struct<col1 array<array<varchar(40)>>>; args nullable: true; result nullable: true]\n" +
                 "  |  cardinality: 1"), plan);
+    }
+
+    @Test
+    public void testArrayAggNonLowCardStringInput1Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='1') */
+                ARRAY_AGG(VARCHAR_COL ORDER BY VARCHAR_COL2)
+                FROM T JOIN T2 ON (KEY_COL = KEY_COL2)
+                """;
+
+        IDictManager dictManager = IDictManager.getInstance();
+        new Expectations(dictManager) {
+            {
+                // Explicitly model: VARCHAR_COL has no dict; other columns keep the default behavior.
+                dictManager.hasGlobalDict(anyLong, ColumnId.create("VARCHAR_COL"), anyLong);
+                result = false;
+                minTimes = 0;
+
+                dictManager.hasGlobalDict(anyLong, (ColumnId) any, anyLong);
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("6:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: array_agg[([2: VARCHAR_COL, VARCHAR, true], [10: VARCHAR_COL2, INT, true]); " +
+                "args: VARCHAR,INT; result: ARRAY<VARCHAR(25)>; args nullable: true; result nullable: true]\n"), plan);
+    }
+
+    @Test
+    public void testArrayAggNonLowCardStringInput2Stage() throws Exception {
+        String sql = """
+                SELECT /*+ SET_VAR(new_planner_agg_stage='2') */
+                ARRAY_AGG(VARCHAR_COL ORDER BY VARCHAR_COL2)
+                FROM T JOIN T2 ON (KEY_COL = KEY_COL2)
+                """;
+
+        IDictManager dictManager = IDictManager.getInstance();
+        new Expectations(dictManager) {
+            {
+                dictManager.hasGlobalDict(anyLong, ColumnId.create("VARCHAR_COL"), anyLong);
+                result = false;
+            }
+        };
+
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("7:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: array_agg[([9: array_agg, struct<col1 array<varchar(25)>, col2 array<int(11)>>, " +
+                "true]); args: VARCHAR,INT; result: ARRAY<VARCHAR(25)>; args nullable: true; result nullable: " +
+                "true]"), plan);
+    }
+
+    @Test
+    public void testArrayAggWithDecodeInMiddle() throws Exception {
+        String sql = """ 
+                SELECT
+                GROUP_CONCAT(DISTINCT VARCHAR_COL), ARRAY_AGG(KEY_COL ORDER BY VARCHAR_COL)
+                FROM T
+                """;
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  aggregate: array_agg[([1: KEY_COL, INT, false], [7: VARCHAR_COL, INT, true]); args: INT,INT; " +
+                "result: struct<col1 array<int(11)>, col2 array<int(11)>>; args nullable: true; result nullable: " +
+                "true]\n" +
+                "  |  group by: [7: VARCHAR_COL, INT, true]"), plan);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge serialize)\n" +
+                "  |  aggregate: array_agg[([6: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, " +
+                "true]); args: INT,INT; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  |  group by: [7: VARCHAR_COL, INT, true]"), plan);
+        Assertions.assertTrue(plan.contains("5:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: group_concat[([2: VARCHAR_COL, VARCHAR(25), true], ','); args: VARCHAR,VARCHAR; " +
+                "result: struct<col1 array<varchar>, col2 array<varchar>>; args nullable: true; result nullable: " +
+                "true], array_agg[([6: array_agg, ARRAY<INT>, true]); args: INT,INT; result: struct<col1 " +
+                "array<int(11)>, col2 array<int(11)>>; args nullable: true; result nullable: true]"), plan);
+        Assertions.assertTrue(plan.contains("  7:AGGREGATE (merge finalize)\n" +
+                "  |  aggregate: group_concat[([5: group_concat, struct<col1 array<varchar>, col2 " +
+                "array<varchar>>, true], ','); args: VARCHAR,VARCHAR; result: VARCHAR; args nullable: true; result " +
+                "nullable: true], array_agg[([6: array_agg, struct<col1 array<int(11)>, col2 array<int(11)>>, " +
+                "true]); args: INT,INT; result: ARRAY<INT>; args nullable: true; result nullable: true]\n" +
+                "  "), plan);
+    }
+
+    @Test
+    public void testArrayAggConstantValueWithLowCardOrderKey() throws Exception {
+        String sql = "SELECT array_agg('x' ORDER BY VARCHAR_COL) FROM T";
+        String plan = getVerboseExplain(sql);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: array_agg[('x', [6: VARCHAR_COL, INT, true]); args: VARCHAR,INT; " +
+                "result: ARRAY<VARCHAR>; args nullable: true; result nullable: true]"), plan);
     }
 }

--- a/test/sql/test_global_dict/R/array_agg
+++ b/test/sql/test_global_dict/R/array_agg
@@ -17,6 +17,24 @@ PROPERTIES (
 );
 -- result:
 -- !result
+CREATE TABLE `t2` (
+  `id` int(11) NOT NULL COMMENT "",
+  `grp` int(11) NOT NULL COMMENT "",
+  `str1` varchar(65533) NOT NULL COMMENT "",
+  `str2` varchar(65533) NULL COMMENT "",
+  `val` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
 INSERT INTO t VALUES
     (1,  1, 'apple',  'X', 10),
     (2,  1, 'banana', 'Y', 20),
@@ -32,6 +50,11 @@ INSERT INTO t VALUES
     (12, 3, 'banana', 'Y', 65);
 -- result:
 -- !result
+INSERT INTO t2 
+SELECT i, i % 5, CAST(i % 5 AS STRING), CAST(i AS STRING), i * 10
+FROM TABLE (generate_series(1, 300)) AS g(i);
+-- result:
+-- !result
 [UC] analyze full table t;
 -- result:
 test_db_66e489ab3c1b4d32bb75d4cb9cb7d0ce.t	analyze	status	OK
@@ -41,6 +64,14 @@ function: wait_global_dict_ready('str1', 't')
 
 -- !result
 function: wait_global_dict_ready('str2', 't')
+-- result:
+
+-- !result
+[UC] analyze full table t2;
+-- result:
+test_db_66e489ab3c1b4d32bb75d4cb9cb7d0ce.t2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('str1', 't2')
 -- result:
 
 -- !result
@@ -345,6 +376,47 @@ SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=f
 2	["apple","banana","date","cherry"]
 3	["date","cherry","banana","cherry"]
 -- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str2 ORDER BY str1, val DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+-- result:
+0	300
+1	296
+2	297
+3	298
+4	299
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str2 ORDER BY str1, val DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+-- result:
+0	300
+1	296
+2	297
+3	298
+4	299
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(val ORDER BY str1, str2 DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+-- result:
+0	950
+1	960
+2	970
+3	980
+4	990
+-- !result
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(val ORDER BY str1, str2 DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+-- result:
+0	950
+1	960
+2	970
+3	980
+4	990
+-- !result
+SELECT grp, array_agg('x' ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+-- result:
+1	["x","x","x","x"]
+2	["x","x","x","x"]
+3	["x","x","x","x"]
+-- !result
 drop table t;
+-- result:
+-- !result
+drop table t2;
 -- result:
 -- !result

--- a/test/sql/test_global_dict/T/array_agg
+++ b/test/sql/test_global_dict/T/array_agg
@@ -17,6 +17,23 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
+CREATE TABLE `t2` (
+  `id` int(11) NOT NULL COMMENT "",
+  `grp` int(11) NOT NULL COMMENT "",
+  `str1` varchar(65533) NOT NULL COMMENT "",
+  `str2` varchar(65533) NULL COMMENT "",
+  `val` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
 INSERT INTO t VALUES
     (1,  1, 'apple',  'X', 10),
     (2,  1, 'banana', 'Y', 20),
@@ -31,9 +48,16 @@ INSERT INTO t VALUES
     (11, 3, 'date',   NULL, 60),
     (12, 3, 'banana', 'Y', 65);
 
+INSERT INTO t2 
+SELECT i, i % 5, CAST(i % 5 AS STRING), CAST(i AS STRING), i * 10
+FROM TABLE (generate_series(1, 300)) AS g(i);
+
 [UC] analyze full table t;
 function: wait_global_dict_ready('str1', 't')
 function: wait_global_dict_ready('str2', 't')
+
+[UC] analyze full table t2;
+function: wait_global_dict_ready('str1', 't2')
 
 -- ===== Basic ARRAY_AGG(string) - 1 stage and 2 stage =====
 
@@ -183,6 +207,21 @@ SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str1 ORDER BY str2, 
 -- 2-stage with multi-column ORDER BY: without optimization
 SELECT /*+SET_VAR(new_planner_agg_stage=2, cbo_enable_low_cardinality_optimize=false)*/ grp, array_agg(str1 ORDER BY str2, val) FROM t GROUP BY grp ORDER BY grp;
 
+-- 1 stage with large input column and low cardinality order by
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(str2 ORDER BY str1, val DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+
+-- 2 stage with large input column and low cardinality order by
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(str2 ORDER BY str1, val DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+
+-- 1 stage with integer input column and low cardinality order by
+SELECT /*+SET_VAR(new_planner_agg_stage=1)*/ grp, array_agg(val ORDER BY str1, str2 DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+
+-- 2 stage with integer input column and low cardinality order by
+SELECT /*+SET_VAR(new_planner_agg_stage=2)*/ grp, array_agg(val ORDER BY str1, str2 DESC)[1] FROM t2 GROUP BY  1 ORDER BY 1;
+
+-- Constant value argument with low-cardinality ORDER BY key =====
+SELECT grp, array_agg('x' ORDER BY str1) FROM t GROUP BY grp ORDER BY grp;
+
 -- Cleanup
 drop table t;
-
+drop table t2;


### PR DESCRIPTION
(cherry picked from commit 02eace8b3ca2240d0fab3c6512c2df7e14ac0d6b)

## Why I'm doing:
Currently low cardinality optimization does not differentiate between whether an aggregate function can be optimized (rewritten using dictionary codes) and whether its output is low cardinality (there is a limited support for COUNT / COUNT DISTINCT, but not for general cases). This causes a bug for queries like `ARRAY_AGG(non_low_card_column ORDER BY low_card_column)` for which the framework marks its output as low cardinality. 

## What I'm doing:
Refactoring the rewrite for aggregate functions. This refactor separates the logic of whether an agg should be rewritten versus whether the output is low cardinality. The latter part will be handled by `checkDependsOnExpr()` like other string columns, making `checkDependsOnExpr()` the only source of truth for this decision in the framework.
* DecodeInfo: Adding two new fields: 
  * `inProgressStringAggregations`: Aggregate functions which are being rewritten, but haven't finalized yet.
  * `finalizingStringAggregations`: Aggregate functions which are being finalized in this operator. 
  * When creating output info, `inProgressStringAggregations` will be passed to the caller, but `finalizingStringAggregations` won't. 
* DecodeCollector:
  * Removing specializations for COUNT, COUNT DISTINCT. All aggregates go through the same path now. 
  * populating `inProgressStringAggregations` and `finalizingStringAggregations`.
  * stop the assumption that all string aggregations produce low cardinality outputs (adding `aggregateId` to `context.allStringColumns`). The decision now depends on `checkDependsOnExpr()`.
  *  `inProgressStringAggregations`, `finalizingStringAggregations` are not intersected with `context.allStringColumns`, to ensure rewrites happen if there is any low cardinality inputs to the function.
  * Only populate struct info for aggregates with a struct return type (as opposed to intermediateOrReturnType)
* DecodeContext:
Refactoring and simplifying `AggregateRewriter`. Now it generates the function template based on the parameters in the local stage and uses this function template to rewrite every stage. 
* DecodeRewriter
Refactoring rewrites for PhysicalHashAggregate and PhysicalDistribution to consider new fields added to DecodeInfo. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

