### PR TITLE
[Enhancement] Build vector index for shared-data bundle segments

### DIFF
--- a/be/src/storage/index/vector/vector_index_writer.cpp
+++ b/be/src/storage/index/vector/vector_index_writer.cpp
@@ -14,7 +14,11 @@
 
 #include "storage/index/vector/vector_index_writer.h"
 
+#include <algorithm>
+#include <cerrno>
 #include <cmath>
+#include <cstdlib>
+#include <limits>
 
 #include "column/nullable_column.h"
 #include "column/raw_data_visitor.h"
@@ -46,30 +50,10 @@ void VectorIndexWriter::create(const std::shared_ptr<TabletIndex>& tablet_index,
 }
 
 Status VectorIndexWriter::init() {
-    // Step 1: enforce minimum threshold by algorithm type.
-    // IVFPQ requires training points >= nlist. If the input is below this,
-    // faiss will throw, so we floor the threshold at nlist to skip the build
-    // rather than crash. Other algorithms (HNSW etc.) keep the default
-    // threshold from config so callers that want "build immediately" must
-    // explicitly request it via index_build_threshold below.
-    auto index_type_it = _tablet_index->common_properties().find("index_type");
-    if (index_type_it != _tablet_index->common_properties().end()) {
-        std::string index_type = index_type_it->second;
-        std::transform(index_type.begin(), index_type.end(), index_type.begin(), ::tolower);
-        if (index_type == "ivfpq") {
-            auto nlist_it = _tablet_index->index_properties().find("nlist");
-            if (nlist_it != _tablet_index->index_properties().end()) {
-                auto nlist = static_cast<uint32_t>(std::atoi(nlist_it->second.c_str()));
-                _start_vector_index_build_threshold = std::max(_start_vector_index_build_threshold, nlist);
-            }
-        }
-    }
-
-    // Step 2: user-specified property has final control over threshold.
-    auto find_result = _tablet_index->common_properties().find("index_build_threshold");
-    if (find_result != _tablet_index->common_properties().end()) {
-        _start_vector_index_build_threshold = std::atoi(find_result->second.c_str());
-    }
+    // Threshold resolution is the single source of truth shared with the async build
+    // path (lake::get_vector_index_build_threshold); see resolve_vector_index_build_threshold
+    // for the precedence rules (config default -> user override -> IVFPQ nlist floor).
+    _start_vector_index_build_threshold = resolve_vector_index_build_threshold(*_tablet_index);
     return Status::OK();
 }
 
@@ -230,6 +214,54 @@ Status validate_vector_index_input(const ArrayColumn& array_col, size_t dim, boo
     }
 
     return Status::OK();
+}
+
+namespace {
+// Checked parse of a property value into uint32_t; returns false when the key is absent
+// or the value is malformed / out of range, so callers keep their default rather than
+// silently using atoi()'s 0 or a wrapped-negative value.
+bool parse_u32_property(const std::map<std::string, std::string>& props, const std::string& key, uint32_t* out) {
+    auto it = props.find(key);
+    if (it == props.end()) {
+        return false;
+    }
+    char* end = nullptr;
+    errno = 0;
+    unsigned long parsed = std::strtoul(it->second.c_str(), &end, 10);
+    if (errno != 0 || end == it->second.c_str() || *end != '\0' || parsed > std::numeric_limits<uint32_t>::max()) {
+        return false;
+    }
+    *out = static_cast<uint32_t>(parsed);
+    return true;
+}
+} // namespace
+
+uint32_t resolve_vector_index_build_threshold(const TabletIndex& index) {
+    const auto& common = index.common_properties();
+
+    // 1. config default.
+    uint32_t threshold = static_cast<uint32_t>(config::config_vector_index_default_build_threshold);
+
+    // 2. user-specified property overrides the default.
+    uint32_t user_threshold = 0;
+    if (parse_u32_property(common, "index_build_threshold", &user_threshold)) {
+        threshold = user_threshold;
+    }
+
+    // 3. IVFPQ needs at least `nlist` training points or faiss throws, so floor the threshold
+    //    at nlist. Applied LAST so a user override can never drop the threshold below nlist.
+    auto type_it = common.find("index_type");
+    if (type_it != common.end()) {
+        std::string index_type = type_it->second;
+        std::transform(index_type.begin(), index_type.end(), index_type.begin(), ::tolower);
+        if (index_type == "ivfpq") {
+            uint32_t nlist = 0;
+            if (parse_u32_property(index.index_properties(), "nlist", &nlist)) {
+                threshold = std::max(threshold, nlist);
+            }
+        }
+    }
+    return threshold;
 }
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_writer.h
+++ b/be/src/storage/index/vector/vector_index_writer.h
@@ -40,6 +40,19 @@ class VectorIndexFileWriter;
 // valid_input_vector logic in tenann_index_builder.cpp.
 Status validate_vector_index_input(const ArrayColumn& array_col, size_t dim, bool is_input_normalized);
 
+// Resolve the row-count threshold at/above which a real vector index is built for a
+// segment (below it the build is skipped and reads fall back to brute-force). Single
+// source of truth shared by the inline build (VectorIndexWriter::init, sync OLAP/lake
+// path) and the async build registration (lake::get_vector_index_build_threshold), so
+// the two never diverge.
+//
+// Precedence:
+//   1. config_vector_index_default_build_threshold
+//   2. user property `index_build_threshold` overrides (1)
+//   3. for IVFPQ, floor at `nlist` -- applied LAST so a user override can never drop
+//      below nlist (faiss requires at least nlist training points or it throws).
+uint32_t resolve_vector_index_build_threshold(const TabletIndex& index);
+
 class VectorIndexWriter {
 public:
     static void create(const std::shared_ptr<TabletIndex>& tablet_index, const std::string& vector_index_file_path,

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -103,28 +103,33 @@ inline std::string gen_segment_filename(int64_t txn_id) {
     return fmt::format("{:016x}_{}.dat", txn_id, generate_uuid_string());
 }
 
-// Generate vector index filename from segment filename.
-// e.g. "0123_abcd.dat" + index_id 123 -> "0123_abcd_123.vi"
-inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t index_id) {
+// Generate vector index filename from segment filename. The tablet_id disambiguates
+// segments that share a physical file across tablets (file bundling), where the recorded
+// segment filename is the shared bundle name and the offset alone is not on the read path;
+// without it those tablets would collide on the same .vi path and overwrite each other.
+// Non-bundled segments carry it too (redundant but keeps naming uniform, no special-casing).
+// e.g. "0123_abcd.dat" + tablet 9 + index 123 -> "0123_abcd_9_123.vi"
+inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t tablet_id, int64_t index_id) {
     if (segment_filename.ends_with(".dat")) {
-        return fmt::format("{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), index_id);
+        return fmt::format("{}_{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), tablet_id, index_id);
     }
-    return fmt::format("{}_{}.vi", segment_filename, index_id);
+    return fmt::format("{}_{}_{}.vi", segment_filename, tablet_id, index_id);
 }
 
 // Compute the vector-index file path that sits next to a segment file in shared-data
 // layout: split |segment_path| into directory + basename, compute the .vi filename
 // from the basename, then re-join under the original directory.
 //
-//   "data/000_abcd.dat"  + 0  -> "data/000_abcd_0.vi"
-//   "/foo/bar/seg.dat"   + 5  -> "/foo/bar/seg_5.vi"
-//   "seg.dat"            + 7  -> "seg_7.vi"            (no directory part)
-//   "/seg.dat"           + 1  -> "seg_1.vi"            (root-only directory)
-inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t index_id) {
+//   "data/000_abcd.dat"  + tablet 9 + 0  -> "data/000_abcd_9_0.vi"
+//   "/foo/bar/seg.dat"   + tablet 9 + 5  -> "/foo/bar/seg_9_5.vi"
+//   "seg.dat"            + tablet 9 + 7  -> "seg_9_7.vi"            (no directory part)
+//   "/seg.dat"           + tablet 9 + 1  -> "seg_9_1.vi"            (root-only directory)
+inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t tablet_id,
+                                                           int64_t index_id) {
     const size_t last_slash = segment_path.find_last_of('/');
     std::string_view basename =
             (last_slash == std::string_view::npos) ? segment_path : segment_path.substr(last_slash + 1);
-    std::string vi_filename = gen_vector_index_filename(basename, index_id);
+    std::string vi_filename = gen_vector_index_filename(basename, tablet_id, index_id);
     if (last_slash == std::string_view::npos) {
         return vi_filename;
     }

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -31,6 +31,7 @@
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "runtime/current_thread.h"
+#include "storage/index/vector/vector_index_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
@@ -80,23 +81,9 @@ uint32_t get_vector_index_build_threshold(const TabletSchemaCSPtr& schema) {
         if (it == tablet_index.end()) {
             continue;
         }
-        const auto& props = it->second.common_properties();
-        auto threshold_it = props.find("index_build_threshold");
-        if (threshold_it != props.end()) {
-            // Use a checked parse: atoi() silently treats malformed strings as 0 and would
-            // wrap a negative int into a huge uint32_t after the cast, neither of which is
-            // a sensible build threshold. Fall back to the config default on parse failure
-            // or out-of-range values.
-            char* end = nullptr;
-            errno = 0;
-            unsigned long parsed = std::strtoul(threshold_it->second.c_str(), &end, 10);
-            if (errno == 0 && end != threshold_it->second.c_str() && *end == '\0' &&
-                parsed <= std::numeric_limits<uint32_t>::max()) {
-                return static_cast<uint32_t>(parsed);
-            }
-            LOG(WARNING) << "ignoring invalid index_build_threshold='" << threshold_it->second
-                         << "', falling back to config_vector_index_default_build_threshold";
-        }
+        // Single source of truth shared with the inline build path so async and sync resolve
+        // the same threshold, including the IVFPQ nlist floor.
+        return resolve_vector_index_build_threshold(it->second);
     }
     return config::config_vector_index_default_build_threshold;
 }
@@ -125,7 +112,7 @@ Status fill_vector_index_file_paths(const TabletSchemaCSPtr& schema, int64_t tab
                                 column.unique_id()));
         }
         int64_t index_id = it->second.index_id();
-        std::string vi_name = gen_vector_index_filename(segment_name, index_id);
+        std::string vi_name = gen_vector_index_filename(segment_name, tablet_id, index_id);
         std::string full_path;
         if (location_provider && fs) {
             full_path = location_provider->segment_location(tablet_id, vi_name);
@@ -291,10 +278,17 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
         // then we will create a shared file for this segment writer.
         RETURN_IF_ERROR(_bundle_file_context->try_create_bundle_file(create_file_fn));
         of = std::make_unique<BundleWritableFile>(_bundle_file_context, wopts.encryption_info);
-        // Bundle segments skip vector index: the segment filename in metadata is the
-        // shared bundle filename, which differs from the independent segment name used
-        // to generate .vi file paths. Vector indexes will be built after compaction.
-        opts.skip_vector_index = true;
+        // Bundle segments share one physical file across the partition's tablets, so the .vi
+        // path must derive from the shared bundle filename (what metadata records) -- not the
+        // independent `name`. gen_vector_index_filename adds this tablet's id so tablets sharing
+        // the bundle get distinct .vi files instead of overwriting each other.
+        RETURN_IF_ERROR(fill_vector_index_file_paths(_schema, _tablet_id, basename(_bundle_file_context->filename()),
+                                                     _tablet_mgr, _location_provider.get(), _fs.get(), opts));
+        // Async mode defers the build to the lake build task (no inline write into the bundle
+        // path); sync mode builds the .vi inline now, which the unambiguous naming makes safe.
+        if (opts.defer_vector_index_build) {
+            opts.skip_vector_index = true;
+        }
     } else {
         ASSIGN_OR_RETURN(of, create_file_fn());
         RETURN_IF_ERROR(fill_vector_index_file_paths(_schema, _tablet_id, name, _tablet_mgr, _location_provider.get(),
@@ -314,10 +308,10 @@ void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileI
     // silently diverge: the PK override previously omitted this, dropping vector index builds
     // for shared-data primary-key tables.
     if (seg_writer->defer_vector_index_build()) {
-        // Async: skip bundle-file segments (.vi doesn't support the bundle format yet, so the
-        // index is rebuilt after compaction) and segments below the deferred-build threshold.
-        bool is_bundled = segment_file_info.bundle_file_offset.has_value();
-        if (is_bundled || segment_file_info.num_rows < seg_writer->vector_index_build_threshold()) {
+        // Async: only skip segments below the deferred-build threshold. Bundle-file segments are
+        // supported now -- their .vi is named per-tablet (gen_vector_index_filename includes the
+        // tablet id) and built by the deferred task from this tablet's bundle slice.
+        if (segment_file_info.num_rows < seg_writer->vector_index_build_threshold()) {
             return;
         }
     } else if (!seg_writer->has_vector_index_written()) {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -285,8 +285,10 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
                                                const SegmentMetadataPB& src_seg_meta, const std::string& src_path,
                                                const std::string& dest_path, FileInfo* file_info) {
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
-        auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, index_id));
-        auto dest_vi = params.tablet->segment_location(gen_vector_index_filename(dest_path, index_id));
+        auto src_vi =
+                params.tablet->segment_location(gen_vector_index_filename(src_path, params.tablet->id(), index_id));
+        auto dest_vi =
+                params.tablet->segment_location(gen_vector_index_filename(dest_path, params.tablet->id(), index_id));
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
         file_info->vector_index_ids.push_back(index_id);
     }
@@ -589,7 +591,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         if (!defer_vector_index_build) {
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 FileMetaPB vi_meta;
-                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), index_id));
+                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), params.tablet->id(), index_id));
                 orphan_files->push_back(std::move(vi_meta));
             }
         }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -769,7 +769,7 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
     auto collect_vi_files = [&](const RowsetMetadataPB& rowset) {
         for (const auto& segment_meta : rowset.segment_metas()) {
             for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_id);
+                auto vi_name = gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }
@@ -796,7 +796,7 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
             files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segment_name));
             // Delete .vi files for this new segment
             for (int64_t vi_id : segment_metas[idx].vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_name, vi_id);
+                auto vi_name = gen_vector_index_filename(segment_name, tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -157,11 +157,11 @@ int64_t calculate_retry_delay(int64_t last_delay, int64_t base, int64_t max_retr
 namespace {
 
 // Delete .vi files for segments in a rowset using segment_metas metadata.
-static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, const std::string& base_dir,
+static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, const std::string& base_dir, int64_t tablet_id,
                                      const RowsetMetadataPB& rowset) {
     for (const auto& segment_meta : rowset.segment_metas()) {
         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_id);
+            auto vi_name = gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id);
             RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, vi_name)));
         }
     }
@@ -326,7 +326,7 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
             }
         }
         // Delete associated .vi files using per-segment vector index metadata
-        RETURN_IF_ERROR(delete_rowset_vi_files(deleter, base_dir, rowset));
+        RETURN_IF_ERROR(delete_rowset_vi_files(deleter, base_dir, metadata.id(), rowset));
 
         for (const auto& del_file : rowset.del_files()) {
             if (del_file.shared() && shared_file_deleter != nullptr) {
@@ -1187,7 +1187,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                         }
                     }
                     // Delete associated .vi files using per-segment vector index metadata
-                    RETURN_IF_ERROR(delete_rowset_vi_files(&deleter, data_dir, rowset));
+                    RETURN_IF_ERROR(delete_rowset_vi_files(&deleter, data_dir, latest_metadata->id(), rowset));
                 }
                 if (latest_metadata->has_delvec_meta()) {
                     for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {
@@ -1455,7 +1455,7 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
             // Protect associated .vi files using per-segment vector index metadata
             for (const auto& segment_meta : rowset.segment_metas()) {
                 for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                    auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_id);
+                    auto vi_name = gen_vector_index_filename(segment_meta.filename(), check_meta->id(), vi_id);
                     data_files.erase(vi_name);
                     data_files_in_metadatas.emplace(vi_name);
                 }

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -115,7 +115,7 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
                 // Skip indexes whose .vi file already exists (partial retry recovery).
                 // This only runs for segments in the current batch (bounded by
                 // max_rowsets_per_batch), so S3 HEAD cost is minimal.
-                std::string vi_name = gen_vector_index_filename(seg_name, idx_id);
+                std::string vi_name = gen_vector_index_filename(seg_name, _tablet_id, idx_id);
                 std::string vi_path = _tablet_mgr->segment_location(_tablet_id, vi_name);
                 if (fs::path_exist(vi_path)) {
                     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id
@@ -290,7 +290,7 @@ Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& se
         if (auto pos = seg_basename.rfind('/'); pos != std::string_view::npos) {
             seg_basename = seg_basename.substr(pos + 1);
         }
-        std::string vi_name = gen_vector_index_filename(seg_basename, index_id);
+        std::string vi_name = gen_vector_index_filename(seg_basename, _tablet_id, index_id);
         std::string vi_path = _tablet_mgr->segment_location(tablet_id, vi_name);
 
         ASSIGN_OR_RETURN(auto builder_type,

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1110,8 +1110,8 @@ Status SegmentIterator::_init_ann_reader() {
 #ifdef WITH_TENANN
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
-            index_path =
-                    lake::gen_vector_index_path_from_segment_path(_segment->file_name(), tablet_index_meta->index_id());
+            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(), _opts.tablet_id,
+                                                                       tablet_index_meta->index_id());
         } else {
             index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                                  segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -397,13 +397,12 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
             _has_vector_index_written = true;
         } else if (!_has_vector_index_written &&
                    _tablet_schema->has_index(_tablet_schema->column(column_index).unique_id(), IndexType::VECTOR)) {
-            // No .vi was produced inline. In async mode, the deferred build task will
-            // produce one later iff this segment has enough rows and isn't a bundle
-            // (bundle segments don't carry .vi). Mark STANDALONE in that case so the
-            // read path looks for the .vi when it lands; otherwise mark NONE so
-            // readers fall back to brute-force scan instead of waiting forever.
-            const bool will_build_async = _opts.defer_vector_index_build && !_opts.skip_vector_index &&
-                                          _num_rows >= _opts.vector_index_build_threshold;
+            // No .vi was produced inline. In async/deferred mode the build task will produce one
+            // later iff this segment has enough rows (bundle segments included now -- their .vi is
+            // named per-tablet). Mark STANDALONE so the read path looks for the .vi when it lands;
+            // otherwise mark NONE so readers fall back to brute-force instead of waiting forever.
+            const bool will_build_async =
+                    _opts.defer_vector_index_build && _num_rows >= _opts.vector_index_build_threshold;
             _footer.set_vector_index_storage_type(will_build_async ? VECTOR_INDEX_STORAGE_STANDALONE
                                                                    : VECTOR_INDEX_STORAGE_NONE);
         }

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -6167,7 +6167,7 @@ protected:
         opts.is_compaction = false;
         opts.defer_vector_index_build = true;
 
-        auto vi_name = lake::gen_vector_index_filename(seg_name, kIndexId);
+        auto vi_name = lake::gen_vector_index_filename(seg_name, kTabletId, kIndexId);
         opts.vector_index_file_paths[kIndexId] = _tablet_mgr->segment_location(kTabletId, vi_name);
 
         ASSIGN_OR_RETURN(auto wfile, fs::new_writable_file(seg_path));
@@ -6242,7 +6242,8 @@ TEST_F(LakeServiceVectorIndexBuildTest, test_build_vector_index_full_path) {
     ASSERT_TRUE(response.has_new_built_version());
     EXPECT_EQ(2, response.new_built_version());
 
-    auto vi_path = _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_name, kIndexId));
+    auto vi_path =
+            _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_name, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path)) << "deferred .vi should have been built by the RPC";
 }
 
@@ -6272,9 +6273,9 @@ TEST_F(LakeServiceVectorIndexBuildTest, test_build_vector_index_partial_failure)
     EXPECT_EQ(2, response.new_built_version());
 
     EXPECT_TRUE(fs::path_exist(
-            _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_ok, kIndexId))));
+            _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_ok, kTabletId, kIndexId))));
     EXPECT_FALSE(fs::path_exist(
-            _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_bad, kIndexId))));
+            _tablet_mgr->segment_location(kTabletId, lake::gen_vector_index_filename(seg_bad, kTabletId, kIndexId))));
 }
 
 TEST_F(LakeServiceTest, test_build_vector_index_missing_tablet_id) {

--- a/be/test/storage/index/vector_index_test.cpp
+++ b/be/test/storage/index/vector_index_test.cpp
@@ -343,6 +343,72 @@ TEST_F(VectorIndexWriterTest, get_vector_meta_unknown_quantizer_returns_error) {
 
 #endif // WITH_TENANN
 
+// ---- resolve_vector_index_build_threshold: single source of truth, B semantics ----
+// Pure logic; no tenann needed, so these run regardless of WITH_TENANN.
+TEST(VectorIndexBuildThresholdTest, default_when_no_properties) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    EXPECT_EQ(10000u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, user_override_for_non_ivfpq) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_build_threshold", "500");
+    EXPECT_EQ(500u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, ivfpq_nlist_floors_default_when_larger) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_type", "ivfpq");
+    idx.add_index_properties("nlist", "20000");
+    EXPECT_EQ(20000u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, ivfpq_default_wins_when_nlist_smaller) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_type", "ivfpq");
+    idx.add_index_properties("nlist", "100");
+    EXPECT_EQ(10000u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, ivfpq_user_override_above_nlist) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_type", "ivfpq");
+    idx.add_common_properties("index_build_threshold", "2000");
+    idx.add_index_properties("nlist", "1024");
+    EXPECT_EQ(2000u, resolve_vector_index_build_threshold(idx));
+}
+
+// Core B semantics: a user override BELOW nlist is floored back up to nlist,
+// because faiss IVFPQ training needs at least nlist points or it throws.
+TEST(VectorIndexBuildThresholdTest, ivfpq_user_override_below_nlist_is_floored) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_type", "ivfpq");
+    idx.add_common_properties("index_build_threshold", "500");
+    idx.add_index_properties("nlist", "1024");
+    EXPECT_EQ(1024u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, invalid_user_override_falls_back_to_default) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_build_threshold", "not_a_number");
+    EXPECT_EQ(10000u, resolve_vector_index_build_threshold(idx));
+}
+
+TEST(VectorIndexBuildThresholdTest, ivfpq_index_type_is_case_insensitive) {
+    config::config_vector_index_default_build_threshold = 10000;
+    TabletIndex idx;
+    idx.add_common_properties("index_type", "IVFPQ");
+    idx.add_index_properties("nlist", "20000");
+    EXPECT_EQ(20000u, resolve_vector_index_build_threshold(idx));
+}
+
 TEST_F(VectorIndexWriterTest, testwrite_with_empty_mark) {
     config::config_vector_index_default_build_threshold = 100;
     auto tablet_index = prepare_tablet_index();

--- a/be/test/storage/lake/filenames_test.cpp
+++ b/be/test/storage/lake/filenames_test.cpp
@@ -161,25 +161,32 @@ TEST_F(FilenamesTest, gen_segment_filename_from) {
 }
 
 TEST_F(FilenamesTest, gen_vector_index_filename) {
-    // Standard segment filename with .dat extension: strip the extension and append _{index_id}.vi
+    // Standard segment filename with .dat extension: strip the extension and append _{tablet_id}_{index_id}.vi
     {
         std::string segment_filename = "0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
-        std::string vi_filename = gen_vector_index_filename(segment_filename, 123);
-        ASSERT_EQ("0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi", vi_filename);
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 7, 123);
+        ASSERT_EQ("0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_7_123.vi", vi_filename);
     }
 
-    // Different index_id
+    // Different tablet_id / index_id
     {
         std::string segment_filename = "0123_abcd.dat";
-        std::string vi_filename = gen_vector_index_filename(segment_filename, 456);
-        ASSERT_EQ("0123_abcd_456.vi", vi_filename);
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 8, 456);
+        ASSERT_EQ("0123_abcd_8_456.vi", vi_filename);
     }
 
-    // Segment filename without .dat: append _{index_id}.vi to the raw name (fallback branch).
+    // Segment filename without .dat: append _{tablet_id}_{index_id}.vi to the raw name (fallback branch).
     {
         std::string segment_filename = "0123_abcd";
-        std::string vi_filename = gen_vector_index_filename(segment_filename, 789);
-        ASSERT_EQ("0123_abcd_789.vi", vi_filename);
+        std::string vi_filename = gen_vector_index_filename(segment_filename, 9, 789);
+        ASSERT_EQ("0123_abcd_9_789.vi", vi_filename);
+    }
+
+    // Two tablets sharing the same (bundle) segment filename get distinct .vi names.
+    {
+        std::string segment_filename = "bundle_shared.dat";
+        ASSERT_NE(gen_vector_index_filename(segment_filename, 100, 1),
+                  gen_vector_index_filename(segment_filename, 200, 1));
     }
 }
 
@@ -188,37 +195,37 @@ TEST_F(FilenamesTest, gen_vector_index_path_from_segment_path) {
     // the .dat suffix on the basename with _{index_id}.vi.
     {
         std::string seg_path = "/foo/bar/0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
-        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 0);
-        ASSERT_EQ("/foo/bar/0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_0.vi", vi_path);
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 5, 0);
+        ASSERT_EQ("/foo/bar/0000000000000003_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_5_0.vi", vi_path);
     }
 
     // Single-level directory.
     {
         std::string seg_path = "data/0123_abcd.dat";
-        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 42);
-        ASSERT_EQ("data/0123_abcd_42.vi", vi_path);
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 5, 42);
+        ASSERT_EQ("data/0123_abcd_5_42.vi", vi_path);
     }
 
     // No directory part: return just the .vi filename.
     {
         std::string seg_path = "0123_abcd.dat";
-        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 7);
-        ASSERT_EQ("0123_abcd_7.vi", vi_path);
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 5, 7);
+        ASSERT_EQ("0123_abcd_5_7.vi", vi_path);
     }
 
     // Root-only directory (leading slash, nothing before it): treat as no parent dir.
     {
         std::string seg_path = "/seg.dat";
-        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 1);
-        ASSERT_EQ("seg_1.vi", vi_path);
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 5, 1);
+        ASSERT_EQ("seg_5_1.vi", vi_path);
     }
 
     // Segment basename without .dat suffix falls through gen_vector_index_filename's
-    // fallback branch: append _{index_id}.vi to the raw name.
+    // fallback branch: append _{tablet_id}_{index_id}.vi to the raw name.
     {
         std::string seg_path = "/foo/bar/0123_abcd";
-        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 9);
-        ASSERT_EQ("/foo/bar/0123_abcd_9.vi", vi_path);
+        std::string vi_path = gen_vector_index_path_from_segment_path(seg_path, 5, 9);
+        ASSERT_EQ("/foo/bar/0123_abcd_5_9.vi", vi_path);
     }
 }
 

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -251,7 +251,8 @@ protected:
     }
 
     std::string vi_location(const std::string& segment_name) {
-        return _tablet_mgr->segment_location(_tablet_metadata->id(), gen_vector_index_filename(segment_name, kIndexId));
+        return _tablet_mgr->segment_location(_tablet_metadata->id(),
+                                             gen_vector_index_filename(segment_name, _tablet_metadata->id(), kIndexId));
     }
 
     SegmentFooterPB read_footer(const std::string& segment_name) {

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1440,9 +1440,9 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_write_vi_files) {
     EXPECT_TRUE(contains("seg1.dat"));
     EXPECT_TRUE(contains("seg2.dat"));
     EXPECT_TRUE(contains("del1.del"));
-    EXPECT_TRUE(contains(gen_vector_index_filename("seg1.dat", 100)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("seg1.dat", 200)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("seg2.dat", 100)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("seg1.dat", _tablet_metadata->id(), 100)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("seg1.dat", _tablet_metadata->id(), 200)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("seg2.dat", _tablet_metadata->id(), 100)));
 }
 
 // Test: collect_files_in_log collects .vi files only for new segments in op_compaction abort
@@ -1486,15 +1486,15 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_vi_files) {
     // New segments and their vi files should be collected
     EXPECT_TRUE(contains("new_x.dat"));
     EXPECT_TRUE(contains("new_y.dat"));
-    EXPECT_TRUE(contains(gen_vector_index_filename("new_x.dat", 100)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("new_x.dat", 200)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("new_y.dat", 100)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("new_x.dat", _tablet_metadata->id(), 100)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("new_x.dat", _tablet_metadata->id(), 200)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("new_y.dat", _tablet_metadata->id(), 100)));
 
     // Reused segments and their vi files must NOT be collected
     EXPECT_FALSE(contains("reused_a.dat"));
     EXPECT_FALSE(contains("reused_b.dat"));
-    EXPECT_FALSE(contains(gen_vector_index_filename("reused_a.dat", 100)));
-    EXPECT_FALSE(contains(gen_vector_index_filename("reused_b.dat", 100)));
+    EXPECT_FALSE(contains(gen_vector_index_filename("reused_a.dat", _tablet_metadata->id(), 100)));
+    EXPECT_FALSE(contains(gen_vector_index_filename("reused_b.dat", _tablet_metadata->id(), 100)));
 }
 
 // Test: collect_files_in_log collects .vi files for op_schema_change abort
@@ -1527,9 +1527,9 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_schema_change_vi_files) {
     };
     EXPECT_TRUE(contains("sc_seg1.dat"));
     EXPECT_TRUE(contains("sc_seg2.dat"));
-    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg1.dat", 300)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg2.dat", 300)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg2.dat", 400)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg1.dat", _tablet_metadata->id(), 300)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg2.dat", _tablet_metadata->id(), 300)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("sc_seg2.dat", _tablet_metadata->id(), 400)));
 }
 
 // Test: collect_files_in_log collects .vi files for op_replication abort
@@ -1558,7 +1558,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_replication_vi_files) {
     };
     EXPECT_TRUE(contains("repl_seg1.dat"));
     EXPECT_TRUE(contains("repl_del1.del"));
-    EXPECT_TRUE(contains(gen_vector_index_filename("repl_seg1.dat", 500)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("repl_seg1.dat", _tablet_metadata->id(), 500)));
 }
 
 // Test: collect_files_in_log handles empty vector_index_ids gracefully
@@ -1611,8 +1611,8 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_partial_segment_metas) {
     EXPECT_TRUE(contains("seg_a.dat"));
     EXPECT_TRUE(contains("seg_b.dat"));
     EXPECT_TRUE(contains("seg_c.dat"));
-    EXPECT_TRUE(contains(gen_vector_index_filename("seg_a.dat", 100)));
-    EXPECT_TRUE(contains(gen_vector_index_filename("seg_a.dat", 200)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("seg_a.dat", _tablet_metadata->id(), 100)));
+    EXPECT_TRUE(contains(gen_vector_index_filename("seg_a.dat", _tablet_metadata->id(), 200)));
     // No phantom .vi entries fabricated for seg_b / seg_c which lack metas.
     EXPECT_FALSE(contains("seg_b.dat_"));
     EXPECT_FALSE(contains("seg_c.dat_"));
@@ -1658,7 +1658,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_partial_segment_m
     EXPECT_FALSE(contains("reused.dat"));
     // The one segment_meta entry sits at index 0; the new-segment window starts
     // at idx=1 and never reads segment_metas(0), so no spurious .vi paths.
-    EXPECT_FALSE(contains(gen_vector_index_filename("reused.dat", 100)));
+    EXPECT_FALSE(contains(gen_vector_index_filename("reused.dat", _tablet_metadata->id(), 100)));
 }
 
 // Regression: the lake read-options propagation chain must carry has_predicate_above_iterator

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -21,6 +21,7 @@
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
 #include "common/config_vector_index_fwd.h"
+#include "fs/bundle_file.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "gutil/walltime.h"
@@ -118,7 +119,7 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_write_shared_data_path) {
     const int64_t index_id = 0;
     const std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
 
-    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vi_filename = gen_vector_index_filename(segment_name, tablet_id, index_id);
     std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
 
     auto tablet_index = create_tablet_index(index_id);
@@ -150,11 +151,11 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_write_shared_data_path) {
 // Test that gen_vector_index_filename produces correct filename for shared-data segment names.
 TEST_F(SharedDataVectorIndexTest, test_vector_index_filename_for_shared_data_segment) {
     std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
-    std::string vi_name = gen_vector_index_filename(segment_name, 0);
-    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_0.vi");
+    std::string vi_name = gen_vector_index_filename(segment_name, 7, 0);
+    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_7_0.vi");
 
-    vi_name = gen_vector_index_filename(segment_name, 123);
-    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_123.vi");
+    vi_name = gen_vector_index_filename(segment_name, 7, 123);
+    ASSERT_EQ(vi_name, "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b_7_123.vi");
 
     // Verify full path from LocationProvider matches expected layout
     const int64_t tablet_id = 1;
@@ -173,7 +174,7 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_empty_mark_shared_data_path)
     const int64_t tablet_id = 999;
     const int64_t index_id = 0;
     std::string segment_name = "0000000000000002_abc12345-6789-0def-1234-567890abcdef.dat";
-    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vi_filename = gen_vector_index_filename(segment_name, tablet_id, index_id);
     std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
 
     // Build an ivfpq tablet_index from scratch — using create_tablet_index() and then
@@ -361,7 +362,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
 
     std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(seg_path));
     EXPECT_TRUE(fs::path_exist(vi_path));
 
@@ -395,7 +397,50 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_location_prov
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
 
-    std::string vi_path = _lp->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path = _lp->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
+    EXPECT_TRUE(fs::path_exist(vi_path));
+
+    writer->close();
+}
+
+// A bundle-file segment must now build its vector index (previously bundle segments skipped it
+// entirely and relied on compaction to rewrite them first). The .vi is named with the tablet id
+// via gen_vector_index_filename so tablets sharing one bundle never collide; here a single writer
+// drives the bundle path (is_bundle requires a BundleWritableFileContext + single segment + eos)
+// and we assert the bundle segment records its index id and produces the .vi inline (sync mode).
+TEST_F(SharedDataTabletWriterVITest, test_bundle_segment_builds_vector_index) {
+    ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
+
+    auto schema_pb = create_vi_schema_pb(); // sync hnsw vector index
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    int64_t txn_id = 2100;
+    // One physical bundle file shared by the partition's tablets; mirror DeltaWriter's
+    // active-writer lifecycle so the shared file is finalized on the last writer.
+    auto bundle_ctx = std::make_unique<BundleWritableFileContext>();
+    bundle_ctx->increase_active_writers();
+
+    auto writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), kTabletId, tablet_schema, txn_id,
+                                                                  /*is_compaction=*/false, /*flush_pool=*/nullptr,
+                                                                  bundle_ctx.get());
+    ASSERT_OK(writer->open());
+    auto chunk = build_chunk(tablet_schema, 3);
+    // eos=true so the first reset_segment_writer takes the bundle branch
+    // (is_bundle requires a context + no prior segment + eos).
+    ASSERT_OK(writer->write(*chunk, /*segment=*/nullptr, /*eos=*/true));
+    ASSERT_OK(writer->finish());
+    ASSERT_OK(bundle_ctx->decrease_active_writers());
+
+    ASSERT_EQ(writer->segments().size(), 1);
+    const auto& seg = writer->segments().front();
+    // Confirm the write really went through the bundle path (a slice in the shared file).
+    ASSERT_TRUE(seg.bundle_file_offset.has_value());
+    // Bundle segment now records its vector index id (no longer skipped).
+    ASSERT_EQ(seg.vector_index_ids.size(), 1);
+    EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+    // The .vi is built inline and named from the shared bundle filename + this tablet's id.
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
 
     writer->close();
@@ -430,7 +475,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_inde
     EXPECT_EQ(5, seg.num_rows);
     ASSERT_EQ(1u, seg.vector_index_ids.size());
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
     writer->close();
 }
@@ -492,7 +538,8 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
 
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
 
     writer->close();
@@ -556,7 +603,7 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_read_shared_data_path) {
     const int64_t index_id = 0;
     const std::string segment_name = "0000000000000001_6bc1edf0-fba6-4aa1-b0d4-ee5b88ef156b.dat";
 
-    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vi_filename = gen_vector_index_filename(segment_name, tablet_id, index_id);
     std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
 
     // Write vector index first
@@ -593,7 +640,7 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_read_empty_mark_shared_data_
     const int64_t tablet_id = 999;
     const int64_t index_id = 0;
     std::string segment_name = "0000000000000002_abc12345-6789-0def-1234-567890abcdef.dat";
-    std::string vi_filename = gen_vector_index_filename(segment_name, index_id);
+    std::string vi_filename = gen_vector_index_filename(segment_name, tablet_id, index_id);
     std::string vector_index_path = _location_provider->segment_location(tablet_id, vi_filename);
 
     // Write empty mark file directly (the current writer skips file generation
@@ -634,16 +681,11 @@ TEST_F(SharedDataVectorIndexTest, test_vector_index_read_not_found) {
 // vector column. With skip_vector_index=true, no .vi path is configured,
 // no .vi file is produced, and _has_vector_index_written stays false.
 //
-// HorizontalGeneralTabletWriter sets this flag for bundle-file segments
-// (segments that share a single underlying data file across the rowset)
-// because the segment filename in metadata is the bundle filename, not
-// the per-segment name used to derive .vi paths. Producing .vi files for
-// bundle segments would generate paths that don't match what readers
-// look up, so the writer suppresses them.
-//
-// This test pins down the SegmentWriter-level contract directly, without
-// the BundleWritableFileContext scaffolding, so a regression that drops
-// the `&& !_opts.skip_vector_index` guard would fail here.
+// The async/deferred bundle path sets this flag: the .vi is produced later by the
+// lake build task from the bundle slice, not inline. This test pins down the
+// SegmentWriter-level contract directly, without the BundleWritableFileContext
+// scaffolding -- skip_vector_index=true must leave no inline .vi artifact behind.
+// (End-to-end bundle .vi creation is covered by test_bundle_segment_builds_vector_index.)
 TEST_F(SharedDataTabletWriterVITest, test_segment_writer_skip_vector_index_no_vi_artifact) {
     ConfigResetGuard<int32_t> threshold_guard(&config::config_vector_index_default_build_threshold, 1);
 
@@ -762,7 +804,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_async_above_threshol
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
 
     // Async: no .vi inline; the deferred build task is responsible for producing it.
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_FALSE(fs::path_exist(vi_path));
     writer->close();
 }
@@ -793,7 +836,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_force_inline_builds_
 
     // Force-inline overrides async deferral: the .vi must exist right after the write
     // (a non-TenANN build still writes the empty-mark placeholder, like the sync tests above).
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path)) << "force-inline build should produce .vi inline despite async mode";
     writer->close();
 }
@@ -846,7 +890,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_async_above_thres
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
 
     // Async: no .vi inline; the deferred build task produces it later.
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_FALSE(fs::path_exist(vi_path));
     writer->close();
 }
@@ -927,7 +972,8 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_async_above_threshold_
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
 
     // Async: no .vi inline.
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_FALSE(fs::path_exist(vi_path));
     writer->close();
 }

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3001,11 +3001,11 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
     create_data_file("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat");
     create_data_file("00000000000a59e5_cccc3333-3333-3333-3333-333333333333.dat");
     // .vi files for the compaction input segments
-    create_data_file("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_100.vi");
-    create_data_file("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_200.vi");
-    create_data_file("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222_100.vi");
+    create_data_file("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_5000_100.vi");
+    create_data_file("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_5000_200.vi");
+    create_data_file("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222_5000_100.vi");
     // .vi file for the alive segment (should NOT be deleted)
-    create_data_file("00000000000a59e5_cccc3333-3333-3333-3333-333333333333_100.vi");
+    create_data_file("00000000000a59e5_cccc3333-3333-3333-3333-333333333333_5000_100.vi");
 
     // Version 2: has the old segments (will become compaction_inputs in v3)
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
@@ -3096,13 +3096,13 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
         // Compaction input segments and their .vi files should be deleted
         EXPECT_FALSE(file_exist("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111.dat"));
         EXPECT_FALSE(file_exist("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat"));
-        EXPECT_FALSE(file_exist("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_100.vi"));
-        EXPECT_FALSE(file_exist("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_200.vi"));
-        EXPECT_FALSE(file_exist("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222_100.vi"));
+        EXPECT_FALSE(file_exist("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_5000_100.vi"));
+        EXPECT_FALSE(file_exist("00000000000a59e4_aaaa1111-1111-1111-1111-111111111111_5000_200.vi"));
+        EXPECT_FALSE(file_exist("00000000000a59e4_bbbb2222-2222-2222-2222-222222222222_5000_100.vi"));
 
         // Alive segment and its .vi file should survive
         EXPECT_TRUE(file_exist("00000000000a59e5_cccc3333-3333-3333-3333-333333333333.dat"));
-        EXPECT_TRUE(file_exist("00000000000a59e5_cccc3333-3333-3333-3333-333333333333_100.vi"));
+        EXPECT_TRUE(file_exist("00000000000a59e5_cccc3333-3333-3333-3333-333333333333_5000_100.vi"));
     }
 }
 
@@ -3113,7 +3113,7 @@ TEST_P(LakeVacuumTest, test_vacuum_no_blind_vi_deletion) {
     create_data_file("00000000000b59e5_eeee5555-5555-5555-5555-555555555555.dat");
     // A .vi file that happens to match the naming pattern but is NOT tracked in segment_metas
     // (e.g., leftover from a different operation). It should NOT be deleted by vacuum.
-    create_data_file("00000000000b59e4_dddd4444-4444-4444-4444-444444444444_999.vi");
+    create_data_file("00000000000b59e4_dddd4444-4444-4444-4444-444444444444_5100_999.vi");
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -3179,7 +3179,7 @@ TEST_P(LakeVacuumTest, test_vacuum_no_blind_vi_deletion) {
         // Segment should be deleted
         EXPECT_FALSE(file_exist("00000000000b59e4_dddd4444-4444-4444-4444-444444444444.dat"));
         // .vi file is NOT tracked in segment_metas, so vacuum should NOT delete it
-        EXPECT_TRUE(file_exist("00000000000b59e4_dddd4444-4444-4444-4444-444444444444_999.vi"));
+        EXPECT_TRUE(file_exist("00000000000b59e4_dddd4444-4444-4444-4444-444444444444_5100_999.vi"));
     }
 }
 
@@ -3201,11 +3201,11 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
     create_data_file("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005.dat"); // m - new
 
     // .vi files for all segments
-    create_data_file("00000000000e59e4_aaaa0001-0001-0001-0001-000000000001_100.vi"); // a - must survive
-    create_data_file("00000000000e59e4_bbbb0002-0002-0002-0002-000000000002_100.vi"); // b - must be deleted
-    create_data_file("00000000000e59e4_cccc0003-0003-0003-0003-000000000003_100.vi"); // c - must be deleted
-    create_data_file("00000000000e59e4_dddd0004-0004-0004-0004-000000000004_100.vi"); // d - must survive
-    create_data_file("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005_100.vi"); // m - must survive
+    create_data_file("00000000000e59e4_aaaa0001-0001-0001-0001-000000000001_5400_100.vi"); // a - must survive
+    create_data_file("00000000000e59e4_bbbb0002-0002-0002-0002-000000000002_5400_100.vi"); // b - must be deleted
+    create_data_file("00000000000e59e4_cccc0003-0003-0003-0003-000000000003_5400_100.vi"); // c - must be deleted
+    create_data_file("00000000000e59e4_dddd0004-0004-0004-0004-000000000004_5400_100.vi"); // d - must survive
+    create_data_file("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005_5400_100.vi"); // m - must survive
 
     // Version 2: original rowset
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
@@ -3324,18 +3324,18 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
         // Consumed segments and their .vi files should be deleted
         EXPECT_FALSE(file_exist("00000000000e59e4_bbbb0002-0002-0002-0002-000000000002.dat"));
         EXPECT_FALSE(file_exist("00000000000e59e4_cccc0003-0003-0003-0003-000000000003.dat"));
-        EXPECT_FALSE(file_exist("00000000000e59e4_bbbb0002-0002-0002-0002-000000000002_100.vi"));
-        EXPECT_FALSE(file_exist("00000000000e59e4_cccc0003-0003-0003-0003-000000000003_100.vi"));
+        EXPECT_FALSE(file_exist("00000000000e59e4_bbbb0002-0002-0002-0002-000000000002_5400_100.vi"));
+        EXPECT_FALSE(file_exist("00000000000e59e4_cccc0003-0003-0003-0003-000000000003_5400_100.vi"));
 
         // Reused segments and their .vi files must survive
         EXPECT_TRUE(file_exist("00000000000e59e4_aaaa0001-0001-0001-0001-000000000001.dat"));
         EXPECT_TRUE(file_exist("00000000000e59e4_dddd0004-0004-0004-0004-000000000004.dat"));
-        EXPECT_TRUE(file_exist("00000000000e59e4_aaaa0001-0001-0001-0001-000000000001_100.vi"));
-        EXPECT_TRUE(file_exist("00000000000e59e4_dddd0004-0004-0004-0004-000000000004_100.vi"));
+        EXPECT_TRUE(file_exist("00000000000e59e4_aaaa0001-0001-0001-0001-000000000001_5400_100.vi"));
+        EXPECT_TRUE(file_exist("00000000000e59e4_dddd0004-0004-0004-0004-000000000004_5400_100.vi"));
 
         // New compacted segment and its .vi file must survive
         EXPECT_TRUE(file_exist("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005.dat"));
-        EXPECT_TRUE(file_exist("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005_100.vi"));
+        EXPECT_TRUE(file_exist("00000000000e59e5_mmmm0005-0005-0005-0005-000000000005_5400_100.vi"));
     }
 }
 
@@ -3346,13 +3346,13 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
     create_data_file("00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.dat");
     create_data_file("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.dat");
     // .vi files for alive rowsets
-    create_data_file("00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_300.vi");
-    create_data_file("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_300.vi");
-    create_data_file("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_400.vi");
+    create_data_file("00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_5200_300.vi");
+    create_data_file("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_5200_300.vi");
+    create_data_file("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_5200_400.vi");
     // Segments in compaction_inputs
     create_data_file("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc.dat");
     // .vi files for compaction_inputs
-    create_data_file("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc_300.vi");
+    create_data_file("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc_5200_300.vi");
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -3408,10 +3408,10 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
         EXPECT_FALSE(file_exist("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc.dat"));
 
         // All .vi files should be deleted (tracked in segment_metas)
-        EXPECT_FALSE(file_exist("00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_300.vi"));
-        EXPECT_FALSE(file_exist("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_300.vi"));
-        EXPECT_FALSE(file_exist("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_400.vi"));
-        EXPECT_FALSE(file_exist("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc_300.vi"));
+        EXPECT_FALSE(file_exist("00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa_5200_300.vi"));
+        EXPECT_FALSE(file_exist("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_5200_300.vi"));
+        EXPECT_FALSE(file_exist("00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb_5200_400.vi"));
+        EXPECT_FALSE(file_exist("00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc_5200_300.vi"));
 
         // Metadata should be deleted
         EXPECT_FALSE(file_exist(tablet_metadata_filename(5200, 2)));
@@ -3423,9 +3423,9 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
 TEST_P(LakeVacuumTest, test_find_orphan_vi_files) {
     // Referenced segment and its .vi file
     create_data_file("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111.dat");
-    create_data_file("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_500.vi");
+    create_data_file("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_5300_500.vi");
     // Orphan .vi file (not tracked in any segment_metas)
-    create_data_file("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_999.vi");
+    create_data_file("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_5300_999.vi");
 
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         {
@@ -3462,11 +3462,11 @@ TEST_P(LakeVacuumTest, test_find_orphan_vi_files) {
                                                               bundle_meta_files, nullptr /*audit_ostream*/));
 
     // The referenced .vi file should NOT be in orphan list
-    EXPECT_EQ(orphan_files.count("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_500.vi"), 0);
+    EXPECT_EQ(orphan_files.count("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_5300_500.vi"), 0);
     // The referenced segment should NOT be in orphan list
     EXPECT_EQ(orphan_files.count("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111.dat"), 0);
     // The untracked .vi file SHOULD be in orphan list
-    EXPECT_EQ(orphan_files.count("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_999.vi"), 1);
+    EXPECT_EQ(orphan_files.count("00000000000d59e4_aaaa1111-1111-1111-1111-111111111111_5300_999.vi"), 1);
 }
 
 // Test: vacuum honours the `i < segment_metas_size()` defensive guard in
@@ -3482,7 +3482,7 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
     // .vi entry; seg_b does not. Vacuum should delete seg_a's .vi only.
     create_data_file("00000000000e59e4_p1111111-1111-1111-1111-111111111111.dat");
     create_data_file("00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat");
-    create_data_file("00000000000e59e4_p1111111-1111-1111-1111-111111111111_700.vi");
+    create_data_file("00000000000e59e4_p1111111-1111-1111-1111-111111111111_5400_700.vi");
     // The fresh-version segment (alive after compaction).
     create_data_file("00000000000e59e5_p3333333-3333-3333-3333-333333333333.dat");
 
@@ -3565,7 +3565,7 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
     EXPECT_FALSE(exists("00000000000e59e4_p1111111-1111-1111-1111-111111111111.dat"));
     EXPECT_FALSE(exists("00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat"));
     // The .vi tracked by segment_metas[0] is deleted.
-    EXPECT_FALSE(exists("00000000000e59e4_p1111111-1111-1111-1111-111111111111_700.vi"));
+    EXPECT_FALSE(exists("00000000000e59e4_p1111111-1111-1111-1111-111111111111_5400_700.vi"));
     // The alive segment must still exist; vacuum did not crash on the partial-metas rowset.
     EXPECT_TRUE(exists("00000000000e59e5_p3333333-3333-3333-3333-333333333333.dat"));
 }

--- a/be/test/storage/lake/vector_index_build_task_test.cpp
+++ b/be/test/storage/lake/vector_index_build_task_test.cpp
@@ -113,7 +113,7 @@ protected:
         opts.defer_vector_index_build = true;
 
         // Fill vector_index_file_paths so metadata is populated
-        std::string vi_name = gen_vector_index_filename(seg_name, kIndexId);
+        std::string vi_name = gen_vector_index_filename(seg_name, kTabletId, kIndexId);
         std::string vi_path = _tablet_mgr->segment_location(kTabletId, vi_name);
         opts.vector_index_file_paths[kIndexId] = vi_path;
 
@@ -185,7 +185,7 @@ TEST_F(VectorIndexBuildTaskTest, test_basic_build) {
     create_metadata(schema_pb, 2, {{2, seg_name}});
 
     // Verify .vi does NOT exist before build
-    std::string vi_name = gen_vector_index_filename(seg_name, kIndexId);
+    std::string vi_name = gen_vector_index_filename(seg_name, kTabletId, kIndexId);
     std::string vi_path = _tablet_mgr->segment_location(kTabletId, vi_name);
     ASSERT_FALSE(fs::path_exist(vi_path));
 
@@ -224,8 +224,8 @@ TEST_F(VectorIndexBuildTaskTest, test_skip_built_rowsets) {
     ASSERT_EQ(response.new_built_version(), 3);
 
     // Only seg2's .vi should be built, seg1 was skipped
-    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kIndexId));
-    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kIndexId));
+    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kTabletId, kIndexId));
+    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kTabletId, kIndexId));
     ASSERT_FALSE(fs::path_exist(vi1));
     ASSERT_TRUE(fs::path_exist(vi2));
 }
@@ -253,9 +253,9 @@ TEST_F(VectorIndexBuildTaskTest, test_batch_limit) {
     // Should have processed rowsets at version 2 and 3 (sorted by version, first 2)
     ASSERT_EQ(response.new_built_version(), 3);
 
-    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kIndexId));
-    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kIndexId));
-    std::string vi3 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg3, kIndexId));
+    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kTabletId, kIndexId));
+    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kTabletId, kIndexId));
+    std::string vi3 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg3, kTabletId, kIndexId));
     ASSERT_TRUE(fs::path_exist(vi1));
     ASSERT_TRUE(fs::path_exist(vi2));
     ASSERT_FALSE(fs::path_exist(vi3)); // Not processed yet
@@ -283,8 +283,8 @@ TEST_F(VectorIndexBuildTaskTest, test_request_built_version) {
     ASSERT_EQ(response.new_built_version(), 3);
 
     // Only seg2 should be built; seg1 skipped via request built_version
-    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kIndexId));
-    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kIndexId));
+    std::string vi1 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg1, kTabletId, kIndexId));
+    std::string vi2 = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg2, kTabletId, kIndexId));
     ASSERT_FALSE(fs::path_exist(vi1));
     ASSERT_TRUE(fs::path_exist(vi2));
 }
@@ -299,7 +299,7 @@ TEST_F(VectorIndexBuildTaskTest, test_skip_existing_vi_files) {
     create_metadata(schema_pb, 2, {{2, seg_name}});
 
     // Pre-create .vi file to simulate a previous partial build success
-    std::string vi_name = gen_vector_index_filename(seg_name, kIndexId);
+    std::string vi_name = gen_vector_index_filename(seg_name, kTabletId, kIndexId);
     std::string vi_path = _tablet_mgr->segment_location(kTabletId, vi_name);
     ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(vi_path));
     ASSERT_OK(wf->append("dummy"));
@@ -464,9 +464,10 @@ TEST_F(VectorIndexBuildTaskTest, test_partial_failure_watermark_stops_at_failed_
     EXPECT_EQ(2, response.new_built_version()) << "watermark should advance through v=2 and pause at v=3";
 
     // v=2's .vi was actually built; v=3's was not.
-    EXPECT_TRUE(fs::path_exist(_tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_ok, kIndexId))));
-    EXPECT_FALSE(
-            fs::path_exist(_tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_bad, kIndexId))));
+    EXPECT_TRUE(fs::path_exist(
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_ok, kTabletId, kIndexId))));
+    EXPECT_FALSE(fs::path_exist(
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_bad, kTabletId, kIndexId))));
 }
 
 // Persist segment_size and segment_encryption_metas on the rowset and verify they
@@ -501,7 +502,8 @@ TEST_F(VectorIndexBuildTaskTest, test_prepare_carries_segment_size_and_encryptio
     ASSERT_OK(task.execute(request, &response));
     ASSERT_EQ(response.new_built_version(), 2);
 
-    std::string vi_path = _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_name, kIndexId));
+    std::string vi_path =
+            _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg_name, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
 }
 


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, small-batch loads trigger file bundling: each tablet in a partition writes its single segment as a slice into one shared physical file. Bundle segments previously skipped vector index creation entirely, so their data fell back to brute-force vector search until compaction later rewrote them into standalone segments.

The root cause was a `.vi` filename collision. The `.vi` name was derived from the segment filename, but for a bundle that filename is the shared bundle file (identical across the tablets sharing it), so multiple tablets resolved to the same `.vi` path and would overwrite each other. To avoid that, the writer simply skipped index creation for bundle segments.

## What I'm doing:

Make the `.vi` filename include the tablet id: `gen_vector_index_filename` and `gen_vector_index_path_from_segment_path` now take a required `tablet_id`, so each tablet's bundle slice gets a distinct `.vi` (`<segment_base>_<tablet_id>_<index_id>.vi`). With naming unambiguous, the writer now builds bundle vector indexes for both modes — sync inline, and async via the deferred lake build task — always deriving the `.vi` path from the shared bundle filename so the writer, reader, vacuum/GC, txn-abort cleanup, and the build task all agree on the path. Making `tablet_id` a required parameter (no default) forces every call site to update, so a missed site fails to compile rather than silently mis-naming a `.vi` (which could let GC delete a live index).

It also unifies build-threshold resolution into a single `resolve_vector_index_build_threshold` shared by the inline (`VectorIndexWriter`) and async (lake) paths, applying the IVFPQ `nlist` floor last so a user-supplied `index_build_threshold` can never drop below `nlist`, which faiss requires to train (the async path previously lacked this floor). Shared-nothing naming (`IndexDescriptor::vector_index_file_path`) is untouched, and there are no FE, proto, or scheduler changes.

Covered by unit tests under `be/test/storage/lake` (filenames, rowset, shared-data vector index, vector index build task, lake service) and `be/test/storage/index`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5