### PR TITLE
[BugFix] Fix NullPointerException in NativeAccessController for unqualified external-catalog tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
@@ -90,10 +90,15 @@ public class NativeAccessController implements AccessController {
     public void checkTableAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType)
             throws AccessDeniedException {
         String catalog = tableName.getCatalog() == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
-        Preconditions.checkNotNull(tableName.getDb());
+        // An unqualified table reference can reach this check with a null db (for example a table over an
+        // external catalog whose database was not resolved onto the TableName). Fall back to the session's
+        // current database, mirroring the null-catalog handling above. Keep the check fail-closed: if neither
+        // is available the privilege check still throws rather than letting a null db flow downstream.
+        String db = tableName.getDb() != null ? tableName.getDb() : context.getDatabase();
+        Preconditions.checkNotNull(db);
 
         checkObjectTypeAction(context, privilegeType, ObjectType.TABLE,
-                Arrays.asList(catalog, tableName.getDb(), tableName.getTbl()));
+                Arrays.asList(catalog, db, tableName.getTbl()));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/NativeAccessController.java
@@ -89,11 +89,12 @@ public class NativeAccessController implements AccessController {
     @Override
     public void checkTableAction(ConnectContext context, TableName tableName, PrivilegeType privilegeType)
             throws AccessDeniedException {
-        String catalog = tableName.getCatalog() == null ? InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME : tableName.getCatalog();
-        // An unqualified table reference can reach this check with a null db (for example a table over an
-        // external catalog whose database was not resolved onto the TableName). Fall back to the session's
-        // current database, mirroring the null-catalog handling above. Keep the check fail-closed: if neither
-        // is available the privilege check still throws rather than letting a null db flow downstream.
+        // An unqualified table reference can reach this check with a null catalog and/or db (for example a
+        // table over an external catalog whose catalog/database was not resolved onto the TableName). Fall
+        // back to the session's current catalog and database so the privilege check runs against the objects
+        // the unqualified name actually resolves to. Keep the check fail-closed: if the db is still not
+        // available the privilege check throws rather than letting a null db flow downstream.
+        String catalog = tableName.getCatalog() != null ? tableName.getCatalog() : context.getCurrentCatalog();
         String db = tableName.getDb() != null ? tableName.getDb() : context.getDatabase();
         Preconditions.checkNotNull(db);
 

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/AuthorizationMgrTest.java
@@ -303,6 +303,33 @@ public class AuthorizationMgrTest {
     }
 
     @Test
+    public void checkTableActionResolvesNullDbToCurrentDatabase() throws Exception {
+        // Regression: an unqualified table reference can reach NativeAccessController.checkTableAction with a
+        // null TableName db (for example a table over an external catalog whose database was not resolved onto
+        // the TableName). It must fall back to the session's current database instead of throwing an NPE.
+        AuthorizationMgr manager = ctx.getGlobalStateMgr().getAuthorizationMgr();
+        GrantPrivilegeStmt grantStmt = (GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                "grant select on table db.tbl1 to test_user", ctx);
+        manager.grant(grantStmt);
+
+        setCurrentUserAndRoles(ctx, testUser);
+        ctx.setDatabase(DB_NAME);
+        NativeAccessController controller = new NativeAccessController();
+
+        // Null db resolves to the current database ("db"), where SELECT on tbl1 is granted -> no exception.
+        controller.checkTableAction(ctx, new TableName(null, TABLE_NAME_1), PrivilegeType.SELECT);
+
+        // A null-db table the user has no privilege on still denies (fail-closed) rather than NPE-ing.
+        Assertions.assertThrows(AccessDeniedException.class, () ->
+                controller.checkTableAction(ctx, new TableName(null, "tbl_no_priv"), PrivilegeType.SELECT));
+
+        setCurrentUserAndRoles(ctx, UserIdentity.ROOT);
+        RevokePrivilegeStmt revokeStmt = (RevokePrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                "revoke select on table db.tbl1 from test_user", ctx);
+        manager.revoke(revokeStmt);
+    }
+
+    @Test
     public void testPersist() throws Exception {
         GlobalStateMgr masterGlobalStateMgr = ctx.getGlobalStateMgr();
 


### PR DESCRIPTION
## Why I'm doing:

An unqualified table reference over an external (e.g. Iceberg) catalog can reach
`NativeAccessController.checkTableAction` with a `TableName` whose `db` is `null`. The
unconditional `Preconditions.checkNotNull(tableName.getDb())` then throws a
`NullPointerException` during planning, which surfaces to clients as the opaque
`1064 (HY000): Unknown error`.

## What I'm doing:

Resolve a `null` db to the session's current database (`context.getDatabase()`) before the
privilege check, mirroring the existing null-catalog fallback on the line above. The check
stays fail-closed: if neither the `TableName` db nor the current database is set it still
throws via `Preconditions.checkNotNull(db)`, rather than letting a `null` db flow into
`checkObjectTypeAction`. Privilege enforcement is unchanged — the check runs against the
database the unqualified name resolves to.

Test: `AuthorizationMgrTest.checkTableActionResolvesNullDbToCurrentDatabase` covers null-db
resolution to the current database (`SELECT` granted → allowed) and the fail-closed path
(no privilege → `AccessDeniedException`, not NPE).

Note: the sibling `checkAnyActionOnTable` has the identical `checkNotNull(getDb())` pattern;
left unchanged as I could not reproduce a `null` db reaching it — happy to follow up if a
maintainer prefers.

## What type of PR is this:

- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool
- [x] BugFix

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
