### PR TITLE
[BugFix] Fix incorrect assignment for isKey and aggregationType for modify column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -727,6 +727,33 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
+    private void fillKeyAndAggregationTypeForModColumn(OlapTable olapTable, Column modColumn) {
+        if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
+            Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
+            if (baseColumn != null) {
+                if (baseColumn.isKey()) {
+                    // backward compatibility: if user does not specify key attribute in modify column clause for pk table,
+                    // we will keep it as a key column which is the same as before.
+                    modColumn.setIsKey(baseColumn.isKey());
+                }
+                modColumn.setAggregationType(baseColumn.getAggregationType(), baseColumn.isAggregationTypeImplicit());
+            }
+        } else if (KeysType.AGG_KEYS == olapTable.getKeysType()) {
+            if (null == modColumn.getAggregationType()) {
+                // in aggregate key table, no aggregation method indicate key column
+                modColumn.setIsKey(true);
+            }
+        } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
+            if (!modColumn.isKey() && null == modColumn.getAggregationType()) {
+                modColumn.setAggregationType(AggregateType.REPLACE, true);
+            }
+        } else {
+            if (!modColumn.isKey() && null == modColumn.getAggregationType()) {
+                modColumn.setAggregationType(AggregateType.NONE, true);
+            }
+        }
+    }
+
     // Returns true when the MODIFY COLUMN clause changes nothing but the column comment, so it can take the
     // lightweight ModifyColumnComment path instead of spawning a schema change job.
     private boolean isCommentOnlyModification(ModifyColumnClause alterClause, OlapTable olapTable) {
@@ -741,25 +768,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // Leave the "column does not exist" error to processModifyColumn.
             return false;
         }
-        // The KEY designation is table-level and is not repeated in the MODIFY COLUMN clause, so a rebuilt
-        // column inherits the stored key flag the same way processModifyColumn does.
-        if (!modColumn.isKey()) {
-            modColumn.setIsKey(oriColumn.isKey());
-        }
-        if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
-            // AlterTableClauseAnalyzer force-injects REPLACE on PK value columns (and keeps key columns as
-            // keys), so modColumn always carries an aggregation type here. Mirror the PK branch in
-            // processModifyColumn, which unconditionally realigns the type + implicit flag from the stored
-            // column, so an explicitly-typed clause still compares as comment-only.
-            modColumn.setAggregationType(oriColumn.getAggregationType(), oriColumn.isAggregationTypeImplicit());
-        } else if (oriColumn.isAggregationTypeImplicit() && modColumn.getAggregationType() == null) {
-            // For DUP/UNIQUE the value column's aggregation (NONE/REPLACE) is implied by the table model and
-            // the user omits it; inherit it as implicit so the comparison matches. If the user *explicitly*
-            // wrote an aggregation method, leave it explicit so the comparison fails and processModifyColumn
-            // raises the proper "Can not assign aggregation method" error instead of being silently dropped
-            // into the lightweight comment path.
-            modColumn.setAggregationType(oriColumn.getAggregationType(), oriColumn.isAggregationTypeImplicit());
-        }
+        fillKeyAndAggregationTypeForModColumn(olapTable, modColumn);
         return oriColumn.equalsIgnoreComment(modColumn);
     }
 
@@ -774,20 +783,14 @@ public class SchemaChangeHandler extends AlterHandler {
         Column modColumn = buildColumnForModify(alterClause.getColumnDef(), olapTable);
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
             Column baseColumn = olapTable.getBaseColumn(modColumn.getName());
-            if (baseColumn != null) {
-                modColumn.setAggregationType(baseColumn.getAggregationType(), baseColumn.isAggregationTypeImplicit());
-                if (baseColumn.isKey()) {
-                    // backward compatibility: if user does not specify key attribute in modify column clause for pk table,
-                    // we will keep it as a key column which is the same as before.
-                    modColumn.setIsKey(baseColumn.isKey());
-                    if (!isVarcharLengthIncrease(baseColumn, modColumn)) {
-                        throw new DdlException(
-                            "Can not modify key column: " + modColumn.getName() +
-                                " for primary key table except for increasing varchar length");
-                    }
-                    if (modColumn.isAllowNull()) {
-                        throw new DdlException("primary key column[" + modColumn.getName() + "] cannot be nullable");
-                    }
+            if (baseColumn != null && baseColumn.isKey()) {
+                if (!isVarcharLengthIncrease(baseColumn, modColumn)) {
+                    throw new DdlException(
+                        "Can not modify key column: " + modColumn.getName() +
+                            " for primary key table except for increasing varchar length");
+                }
+                if (modColumn.isAllowNull()) {
+                    throw new DdlException("primary key column[" + modColumn.getName() + "] cannot be nullable");
                 }
             }
 
@@ -807,26 +810,19 @@ public class SchemaChangeHandler extends AlterHandler {
                 throw new DdlException("Can not assign aggregation method on key column: " + modColumn.getName());
             } else if (null == modColumn.getAggregationType()) {
                 Preconditions.checkArgument(modColumn.getType().isScalarType());
-                // in aggregate key table, no aggregation method indicate key column
-                modColumn.setIsKey(true);
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
             if (null != modColumn.getAggregationType()) {
                 throw new DdlException("Can not assign aggregation method on column in Unique data model table: " +
                         modColumn.getName());
             }
-            if (!modColumn.isKey()) {
-                modColumn.setAggregationType(AggregateType.REPLACE, true);
-            }
         } else {
             if (null != modColumn.getAggregationType()) {
                 throw new DdlException("Can not assign aggregation method on column in Duplicate data model table: " +
                         modColumn.getName());
             }
-            if (!modColumn.isKey()) {
-                modColumn.setAggregationType(AggregateType.NONE, true);
-            }
         }
+        fillKeyAndAggregationTypeForModColumn(olapTable, modColumn);
 
         if (!modColumn.isGeneratedColumn() && olapTable.hasGeneratedColumn()) {
             for (Column column : olapTable.getFullSchema()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -1041,23 +1041,64 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
                 "v1", "pk value comment");
     }
 
-    // The KEY designation is table-level and is not repeated in MODIFY COLUMN k1 INT COMMENT '...', so the
-    // rebuilt column comes back with isKey=false; isCommentOnlyModification must inherit the key flag from the
-    // stored column, otherwise a comment-only change on a key column would fall through and be rejected on a
-    // single-key table (leaving no key column) or create an unnecessary schema change job.
+    // On an AGGREGATE table the aggregation method is omitted for key columns, so MODIFY COLUMN k1 INT COMMENT '...'
+    // rebuilds k1 with no aggregation type; isCommentOnlyModification must infer the key flag from "no aggregation
+    // method == key column" (the AGG_KEYS branch), otherwise the comment-only change on the key column would be
+    // misclassified and spawn a schema change job.
     @Test
-    public void testModifyColumnCommentOnlyForKeyColumnOfDuplicateAndUniqueTables() throws Exception {
+    public void testModifyColumnCommentOnlyForKeyColumnOfAggregateTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_agg_key (k1 INT, v1 INT SUM) AGGREGATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertCommentOnlyModify("cmt_agg_key",
+                "ALTER TABLE test.cmt_agg_key MODIFY COLUMN k1 INT COMMENT 'agg key comment';",
+                "k1", "agg key comment");
+    }
+
+    // On a DUPLICATE table the helper only treats a MODIFY COLUMN target as a key column when the clause carries the
+    // KEY keyword (otherwise it fills in the NONE value-column aggregation). So a comment-only change on a key column
+    // must spell out KEY -- "MODIFY COLUMN k1 INT KEY COMMENT '...'" -- for the rebuilt column to match the stored key
+    // column and take the lightweight path.
+    @Test
+    public void testModifyColumnCommentOnlyForKeyColumnOfDuplicateTable() throws Exception {
         createTable("CREATE TABLE test.cmt_dup_key (k1 INT, v1 INT) DUPLICATE KEY(k1) "
                 + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
         assertCommentOnlyModify("cmt_dup_key",
-                "ALTER TABLE test.cmt_dup_key MODIFY COLUMN k1 INT COMMENT 'dup key comment';",
+                "ALTER TABLE test.cmt_dup_key MODIFY COLUMN k1 INT KEY COMMENT 'dup key comment';",
                 "k1", "dup key comment");
+    }
 
+    // Same as the DUPLICATE case: on a UNIQUE table a key column omitting KEY would be rebuilt as a REPLACE value
+    // column, so the comment-only clause has to carry the KEY keyword to stay on the lightweight path.
+    @Test
+    public void testModifyColumnCommentOnlyForKeyColumnOfUniqueTable() throws Exception {
         createTable("CREATE TABLE test.cmt_uniq_key (k1 INT, v1 INT) UNIQUE KEY(k1) "
                 + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
         assertCommentOnlyModify("cmt_uniq_key",
-                "ALTER TABLE test.cmt_uniq_key MODIFY COLUMN k1 INT COMMENT 'uniq key comment';",
+                "ALTER TABLE test.cmt_uniq_key MODIFY COLUMN k1 INT KEY COMMENT 'uniq key comment';",
                 "k1", "uniq key comment");
+    }
+
+    // Reverse of testModifyColumnCommentOnlyForKeyColumnOfDuplicateTable: omitting the KEY keyword makes the helper
+    // rebuild k1 as a NONE value column, so the modify is no longer comment-only and demoting the sole key column is
+    // rejected. The comment must stay unchanged.
+    @Test
+    public void testModifyKeyColumnCommentWithoutKeyKeywordFailsForDuplicateTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_dup_key_nokey (k1 INT, v1 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertModifyColumnFails("cmt_dup_key_nokey",
+                "ALTER TABLE test.cmt_dup_key_nokey MODIFY COLUMN k1 INT COMMENT 'dup key comment';",
+                "k1");
+    }
+
+    // Reverse of testModifyColumnCommentOnlyForKeyColumnOfUniqueTable: omitting the KEY keyword makes the helper
+    // rebuild k1 as a REPLACE value column, so the modify is rejected and the comment stays unchanged.
+    @Test
+    public void testModifyKeyColumnCommentWithoutKeyKeywordFailsForUniqueTable() throws Exception {
+        createTable("CREATE TABLE test.cmt_uniq_key_nokey (k1 INT, v1 INT) UNIQUE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        assertModifyColumnFails("cmt_uniq_key_nokey",
+                "ALTER TABLE test.cmt_uniq_key_nokey MODIFY COLUMN k1 INT COMMENT 'uniq key comment';",
+                "k1");
     }
 
     @Test
@@ -1129,6 +1170,24 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         Assertions.assertTrue(handler.getUnfinishedAlterJobV2ByTableId(table.getId()).isEmpty());
         Assertions.assertEquals(OlapTableState.NORMAL, table.getState());
         Assertions.assertEquals(expectedComment, table.getColumn(columnName).getComment());
+    }
+
+    private void assertModifyColumnFails(String tableName, String alterSql, String columnName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Assertions.assertNotNull(table);
+        String originalComment = table.getColumn(columnName).getComment();
+
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(alterSql);
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> handler.process(alterTableStmt.getAlterClauseList(), db, table));
+
+        // The rejected modify must not have been routed to the comment-only path: the comment stays unchanged, no
+        // schema change job is created, and the table remains NORMAL.
+        Assertions.assertEquals(originalComment, table.getColumn(columnName).getComment(), exception.getMessage());
+        Assertions.assertTrue(handler.getUnfinishedAlterJobV2ByTableId(table.getId()).isEmpty());
+        Assertions.assertEquals(OlapTableState.NORMAL, table.getState());
     }
 
     private void assertSortKey(OlapTable tbl, List<Integer> expectedSortKeyIndexes) {


### PR DESCRIPTION
## Why I'm doing:

`isCommentOnlyModification` (added in #75325) decides whether a `MODIFY COLUMN`
clause changes nothing but the column comment, so it can take the lightweight
`ModifyColumnComment` path instead of spawning a full schema change job. To make
that comparison correct it must normalize the rebuilt column's `isKey` /
`aggregationType` exactly the way `processModifyColumn` does. The previous logic
diverged from `processModifyColumn`, so the inferred key flag and aggregation
type could be assigned incorrectly, leading to wrong comment-only detection for
some key/aggregation column combinations.

## What I'm doing:

Align the `isKey` / `aggregationType` assignment in `isCommentOnlyModification`
with `processModifyColumn` for every table model:

- **PRIMARY_KEYS**: inherit the stored key flag only when the original column is
  a key, then realign the aggregation type + implicit flag from the stored column.
- **AGG_KEYS**: a column with no aggregation method is a key column.
- **UNIQUE_KEYS**: a non-key column with no aggregation method gets implicit
  `REPLACE`.
- **DUP_KEYS (default)**: a non-key column with no aggregation method gets
  implicit `NONE`.

This keeps the fast-path comparison consistent with the real modify path so
comment-only modifications are routed correctly and genuine changes still go
through the schema change job.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
