### PR TITLE
[Enhancement] Adding ColumnStatisitics to date and time related functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -662,6 +662,8 @@ public class ExpressionStatisticCalculator {
                     distinctValue = 12;
                     break;
                 case FunctionSet.MONTHNAME:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
                     distinctValue = 12;
                     break;
                 case FunctionSet.WEEKOFYEAR:
@@ -697,6 +699,10 @@ public class ExpressionStatisticCalculator {
                     minValue = 0;
                     maxValue = 59;
                     distinctValue = 60;
+                    break;
+                case FunctionSet.FROM_UNIXTIME:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
                     break;
                 case FunctionSet.TO_DATE, FunctionSet.DATE:
                     if (minMaxValueInfinite) {
@@ -742,6 +748,8 @@ public class ExpressionStatisticCalculator {
                     }
                     break;
                 case FunctionSet.DAYNAME:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
                     distinctValue = 7;
                     break;
                 case FunctionSet.TIMESTAMP:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -661,6 +661,9 @@ public class ExpressionStatisticCalculator {
                     maxValue = 12;
                     distinctValue = 12;
                     break;
+                case FunctionSet.MONTHNAME:
+                    distinctValue = 12;
+                    break;
                 case FunctionSet.WEEKOFYEAR:
                 case FunctionSet.WEEK_ISO:
                     minValue = 1;
@@ -695,7 +698,7 @@ public class ExpressionStatisticCalculator {
                     maxValue = 59;
                     distinctValue = 60;
                     break;
-                case FunctionSet.TO_DATE:
+                case FunctionSet.TO_DATE, FunctionSet.DATE:
                     if (minMaxValueInfinite) {
                         break;
                     }
@@ -738,7 +741,12 @@ public class ExpressionStatisticCalculator {
                         }
                     }
                     break;
+                case FunctionSet.DAYNAME:
+                    distinctValue = 7;
+                    break;
                 case FunctionSet.TIMESTAMP:
+                    break;
+                case FunctionSet.TIME_TO_SEC:
                     break;
                 case FunctionSet.ABS:
                     double absMinValue;
@@ -898,6 +906,11 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.SECONDS_DIFF:
                     minValue = left.getMinValue() - right.getMaxValue();
                     maxValue = left.getMaxValue() - right.getMinValue();
+                    break;
+                case FunctionSet.FROM_UNIXTIME:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
+                    distinctValues = left.getDistinctValuesCount();
                     break;
                 case FunctionSet.YEARS_DIFF:
                     interval = 3600L * 24L * 365L;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -747,6 +747,8 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.TIMESTAMP:
                     break;
                 case FunctionSet.TIME_TO_SEC:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
                     break;
                 case FunctionSet.ABS:
                     double absMinValue;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -355,8 +355,8 @@ public class ExpressionStatisticsCalculatorTest {
         // test time_to_sec function
         callOperator = new CallOperator(FunctionSet.TIME_TO_SEC, IntegerType.BIGINT, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
-        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
-        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), distinctValue);
         // test abs function
         callOperator = new CallOperator(FunctionSet.ABS, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -233,8 +233,8 @@ public class ExpressionStatisticsCalculatorTest {
         callOperator = new CallOperator(FunctionSet.MONTHNAME, VarcharType.VARCHAR, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), 12);
-        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
-        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), Double.POSITIVE_INFINITY, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), Double.NEGATIVE_INFINITY, 0.001);
         // test weekofyear function
         callOperator = new CallOperator(FunctionSet.WEEKOFYEAR, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
@@ -285,6 +285,12 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), 59, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
+        // test from_unix function
+        callOperator = new CallOperator(FunctionSet.FROM_UNIXTIME, VarcharType.VARCHAR, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), columnStatistic.getDistinctValuesCount(), 0.001);
         // test to_date function - columnStatistics for a date column are calculated.
         // Input provided as date+time. Function strips the time part.
         List<LocalDateTime> toDateValues = Lists.newArrayList(
@@ -332,8 +338,8 @@ public class ExpressionStatisticsCalculatorTest {
         // test DAYNAME function
         callOperator = new CallOperator(FunctionSet.DAYNAME, VarcharType.VARCHAR, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
-        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
-        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), Double.POSITIVE_INFINITY, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), Double.NEGATIVE_INFINITY, 0.001);
         Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), 7);
         // test to_days function
         callOperator = new CallOperator(FunctionSet.TO_DAYS, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableList;
@@ -158,6 +157,7 @@ public class ExpressionStatisticsCalculatorTest {
         ColumnRefOperator columnRefOperator = new ColumnRefOperator(0, IntegerType.INT, "id", true);
         CallOperator callOperator = new CallOperator(FunctionSet.MAX, IntegerType.INT, Lists.newArrayList(columnRefOperator));
 
+        LocalDate epochDay = LocalDate.of(1970, 1, 1);
         Statistics.Builder builder = Statistics.builder();
         double min = 0.0;
         double max = 100.0;
@@ -229,6 +229,12 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), 12, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), 1, 0.001);
+        // test monthname function
+        callOperator = new CallOperator(FunctionSet.MONTHNAME, VarcharType.VARCHAR, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), 12);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
         // test weekofyear function
         callOperator = new CallOperator(FunctionSet.WEEKOFYEAR, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
@@ -279,14 +285,56 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), 59, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), 0, 0.001);
-        // test to_date function
-        callOperator = new CallOperator(FunctionSet.TO_DATE, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));
-        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
-        LocalDate epochDay = LocalDate.of(1970, 1, 1);
-        Assertions.assertEquals(columnStatistic.getMaxValue(),
-                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        // test to_date function - columnStatistics for a date column are calculated.
+        // Input provided as date+time. Function strips the time part.
+        List<LocalDateTime> toDateValues = Lists.newArrayList(
+                LocalDateTime.of(2021, 1, 10, 8, 30, 0),
+                LocalDateTime.of(2021, 12, 25, 23, 59, 59));
+        LocalDateTime toDateMinInput = Collections.min(toDateValues);
+        LocalDateTime toDateMaxInput = Collections.max(toDateValues);
+        double toDateDistinctValues = 5;
+        ColumnRefOperator toDateColumn = new ColumnRefOperator(1, DateType.DATETIME, "to_date_col", true);
+        Statistics toDateStatistics = builder.addColumnStatistic(toDateColumn,
+                        ColumnStatistic.builder().setMinValue(getLongFromDateTime(toDateMinInput))
+                                .setMaxValue(getLongFromDateTime(toDateMaxInput))
+                                .setDistinctValuesCount(toDateDistinctValues)
+                                .setNullsFraction(0).setAverageRowSize(10).build())
+                .build();
+        callOperator = new CallOperator(FunctionSet.TO_DATE, DateType.DATE, Lists.newArrayList(toDateColumn));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, toDateStatistics);
         Assertions.assertEquals(columnStatistic.getMinValue(),
-                epochDay.atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+                toDateMinInput.toLocalDate().atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(),
+                toDateMaxInput.toLocalDate().atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assertions.assertEquals(5, columnStatistic.getDistinctValuesCount(), 0.001);
+        // test date function - columnStatistics for date column are calculated.
+        // Input provided as date+time. Function strips the time part.
+        List<LocalDateTime> dateValues = Lists.newArrayList(
+                LocalDateTime.of(2022, 1, 10, 8, 30, 0),
+                LocalDateTime.of(2022, 12, 25, 23, 59, 59));
+        LocalDateTime dateMinInput = Collections.min(dateValues);
+        LocalDateTime dateMaxInput = Collections.max(dateValues);
+        double dateDistinctValues = 5;
+        ColumnRefOperator dateColumn = new ColumnRefOperator(1, DateType.DATETIME, "to_date_col", true);
+        Statistics dateStatistics = builder.addColumnStatistic(dateColumn,
+                        ColumnStatistic.builder().setMinValue(getLongFromDateTime(dateMinInput))
+                                .setMaxValue(getLongFromDateTime(dateMaxInput))
+                                .setDistinctValuesCount(dateDistinctValues)
+                                .setNullsFraction(0).setAverageRowSize(10).build())
+                .build();
+        callOperator = new CallOperator(FunctionSet.DATE, DateType.DATE, Lists.newArrayList(dateColumn));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, dateStatistics);
+        Assertions.assertEquals(columnStatistic.getMinValue(),
+                dateMinInput.toLocalDate().atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assertions.assertEquals(columnStatistic.getMaxValue(),
+                dateMaxInput.toLocalDate().atStartOfDay(ZoneId.systemDefault()).toEpochSecond(), 0.001);
+        Assertions.assertEquals(5, columnStatistic.getDistinctValuesCount(), 0.001);
+        // test DAYNAME function
+        callOperator = new CallOperator(FunctionSet.DAYNAME, VarcharType.VARCHAR, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), 7);
         // test to_days function
         callOperator = new CallOperator(FunctionSet.TO_DAYS, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
@@ -304,6 +352,12 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
         Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
         Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        // test time_to_sec function
+        callOperator = new CallOperator(FunctionSet.TIME_TO_SEC, IntegerType.BIGINT, Lists.newArrayList(columnRefOperator));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
+        Assertions.assertEquals(columnStatistic.getMaxValue(), max, 0.001);
+        Assertions.assertEquals(columnStatistic.getMinValue(), min, 0.001);
+        Assertions.assertEquals(columnStatistic.getDistinctValuesCount(), distinctValue);
         // test abs function
         callOperator = new CallOperator(FunctionSet.ABS, FloatType.DOUBLE, Lists.newArrayList(columnRefOperator));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, statistics);
@@ -526,6 +580,12 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assertions.assertEquals(-300, columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(0, columnStatistic.getMaxValue(), 0.001);
+        // test from_unix function
+        callOperator = new CallOperator(FunctionSet.FROM_UNIXTIME, VarcharType.VARCHAR, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(leftStatistic.getDistinctValuesCount(), columnStatistic.getDistinctValuesCount(), 0.001);
         // test years_diff function
         callOperator = new CallOperator(FunctionSet.YEARS_DIFF, IntegerType.BIGINT, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
@@ -601,7 +661,7 @@ public class ExpressionStatisticsCalculatorTest {
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assertions.assertEquals(-1, columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(1, columnStatistic.getMaxValue(), 0.001);
-        
+
         callOperator = new CallOperator(FunctionSet.LIKE, BooleanType.BOOLEAN, Lists.newArrayList(left, right));
         columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
         Assertions.assertEquals(0, columnStatistic.getMinValue(), 0.001);
@@ -1189,7 +1249,6 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(700_000L, isNullStat.getHistogram().getMCV().get("0"));
     }
 
-
     @Test
     public void testArrayMapWithDependentLambda() {
         // GIVEN
@@ -1260,7 +1319,6 @@ public class ExpressionStatisticsCalculatorTest {
                         .setDistinctValuesCount(2) //
                         .build())
                 .build();
-
 
         final var arrayMap = new CallOperator(FunctionSet.ARRAY_MAP, ArrayType.ARRAY_INT,
                 Lists.newArrayList(lambda, arrayCol));
@@ -2293,7 +2351,6 @@ public class ExpressionStatisticsCalculatorTest {
         ColumnRefOperator col1 = new ColumnRefOperator(0, IntegerType.INT, "col1", true);
         ColumnRefOperator col2 = new ColumnRefOperator(1, IntegerType.INT, "col2", true);
 
-
         Map<String, Long> integerMcvs = Map.of("1", 200L, "20", 300L, "30", 500L);
         Histogram intHistogram = new Histogram(Collections.emptyList(), integerMcvs);
 
@@ -2369,6 +2426,7 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertNotNull(stat.getHistogram());
         assertBooleanDistribution(stat, 750, 250, 0.0);
     }
+
     @Test
     public void testNonBooleanZeroOneColumnDoesNotUseBooleanMcvFastPath() {
         final var col = new ColumnRefOperator(0, IntegerType.INT, "flag", true);
@@ -2428,7 +2486,6 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(0, result.getMinValue(), 0.0);
         Assertions.assertEquals(1, result.getMaxValue(), 0.0);
     }
-
 
     @Test
     public void testCompoundPredicateOrIgnoresNonBooleanChildMcvs() {


### PR DESCRIPTION
## Why I'm doing:
The optimizer uses column statistics (min, max, NDV, null fraction) to design an optimal query. The following functions returned unknown column statistics which was detrimental to optimizer performance.

The functions are:

DATE
DAYNAME
MONTHNAME
FROM_UNIXTIME
TIME_TO_SEC

## What I'm doing:
Adding column statistics for the functions listed above and unit tests.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
