### PR TITLE
[Refactor] Move ComputeEnv lifecycle out of ExecEnv

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -279,12 +279,6 @@ void ExecEnv::stop() {
         _lookup_dispatcher_mgr->close();
     }
 
-    if (_query_context_mgr) {
-        start = MonotonicMillis();
-        _query_context_mgr->clear();
-        component_times.emplace_back("query_context_mgr", MonotonicMillis() - start);
-    }
-
     if (_batch_write_mgr) {
         start = MonotonicMillis();
         _batch_write_mgr->stop();
@@ -309,6 +303,15 @@ void ExecEnv::stop() {
         summary += ")";
     }
     LOG(INFO) << summary;
+}
+
+void ExecEnv::clear_query_contexts() {
+    if (_query_context_mgr == nullptr) {
+        return;
+    }
+    int64_t start = MonotonicMillis();
+    _query_context_mgr->clear();
+    LOG(INFO) << strings::Substitute("[ExecEnv::clear_query_contexts] Total: $0 ms", MonotonicMillis() - start);
 }
 
 void ExecEnv::destroy() {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -34,8 +34,8 @@
 
 #include "runtime/exec_env.h"
 
+#include <algorithm>
 #include <memory>
-#include <thread>
 
 #include "agent/agent_server.h"
 #include "base/time/time.h"
@@ -53,16 +53,12 @@
 #include "connector/builtin_connector_registry.h"
 #include "connector/connector_registry.h"
 #include "connector/connector_sink_executor.h"
-#include "exec/pipeline/driver_executor_factory.h"
-#include "exec/pipeline/driver_queue_factory.h"
 #include "exec/pipeline/primitives/driver_executor.h"
-#include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/runtime/query_context_manager.h"
 #include "gutil/strings/join.h"
 #include "gutil/strings/substitute.h"
 #include "platform/platform_env.h"
-#include "platform/store_path.h"
 #include "runtime/batch_write/batch_write_mgr.h"
 #include "runtime/lookup_stream_mgr.h"
 #include "runtime/mem_tracker.h"
@@ -91,7 +87,7 @@ ExecEnv* ExecEnv::GetInstance() {
     return &s_exec_env;
 }
 
-ExecEnv::ExecEnv() : _global_env(GlobalEnv::GetInstance()), _compute_env(std::make_unique<ComputeEnv>()) {
+ExecEnv::ExecEnv() : _global_env(GlobalEnv::GetInstance()) {
     _refresh_service_contexts();
 }
 ExecEnv::~ExecEnv() = default;
@@ -173,14 +169,18 @@ void ExecEnv::set_agent_server(AgentServer* agent_server) {
     _refresh_service_contexts();
 }
 
+void ExecEnv::set_compute_env(ComputeEnv* compute_env) {
+    _compute_env = compute_env;
+    _refresh_service_contexts();
+}
+
 void ExecEnv::set_runtime_filter_services(RuntimeFilterSender* sender, RuntimeFilterQueryLifecycle* query_lifecycle) {
     _runtime_filter_sender = sender;
     _runtime_filter_query_lifecycle = query_lifecycle;
     _refresh_service_contexts();
 }
 
-Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRegistry* process_metrics_registry,
-                     GlobalEnv* global_env, bool as_cn) {
+Status ExecEnv::init(ProcessMetricsRegistry* process_metrics_registry, GlobalEnv* global_env) {
     DCHECK(process_metrics_registry != nullptr);
     DCHECK(global_env != nullptr);
     _global_env = global_env;
@@ -190,6 +190,9 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
         platform_env->brpc_stub_cache() == nullptr || platform_env->small_file_mgr() == nullptr) {
         return Status::InternalError("PlatformEnv is not initialized");
     }
+    if (_compute_env == nullptr) {
+        return Status::InternalError("ComputeEnv is not attached");
+    }
     RETURN_IF_ERROR(connector::install_builtin_connectors(connector::ConnectorRegistry::default_instance()));
     _process_metrics_registry = process_metrics_registry;
     auto* process_metrics = process_metrics_registry->root_registry();
@@ -198,29 +201,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
     // query_context_mgr keeps slotted map with 64 slot to reduce contention
     _query_context_mgr = new pipeline::QueryContextManager(6);
     RETURN_IF_ERROR(_query_context_mgr->init(process_metrics));
-    RETURN_IF_ERROR(global_env->init_execution_thread_pools(process_metrics));
-
-    // register the metrics to monitor the task queue len
-    pipeline::PipelineExecutorMetrics::instance()->register_pipe_prepare_pool_queue_len_hook([global_env] {
-        auto pool = global_env->pipeline_prepare_pool();
-        return (pool == nullptr) ? 0U : pool->get_queue_size();
-    });
-
-    std::vector<std::string> compute_store_paths;
-    compute_store_paths.reserve(store_paths.size());
-    for (const auto& store_path : store_paths) {
-        compute_store_paths.emplace_back(store_path.path);
-    }
-
-    ComputeEnvOptions compute_env_options;
-    compute_env_options.global_env = global_env;
-    compute_env_options.metrics = process_metrics;
-    compute_env_options.store_paths = std::move(compute_store_paths);
-    compute_env_options.as_cn = as_cn;
-    compute_env_options.query_cache_capacity = std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024);
-    compute_env_options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
-    compute_env_options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
-    RETURN_IF_ERROR(_compute_env->init(compute_env_options));
 
     _stream_load_executor = new StreamLoadExecutor(this);
     _transaction_mgr = new TransactionMgr(this);
@@ -242,8 +222,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, ProcessMetricsRe
 
     _runtime_filter_cache = new RuntimeFilterCache(8);
     RETURN_IF_ERROR(_runtime_filter_cache->init());
-
-    RETURN_IF_ERROR(global_env->init_lake_thread_pools(process_metrics));
 
 #ifdef STARROCKS_JIT_ENABLE
     auto jit_engine = JITEngine::get_instance();
@@ -296,94 +274,9 @@ void ExecEnv::stop() {
     int64_t total_start = MonotonicMillis();
     int64_t start;
     std::vector<std::pair<std::string, int64_t>> component_times;
-    auto* global_env = _global_env;
-    DCHECK(global_env != nullptr);
 
-    if (_compute_env != nullptr) {
-        start = MonotonicMillis();
-        _compute_env->stop();
-        component_times.emplace_back("compute_env", MonotonicMillis() - start);
-    }
     if (_lookup_dispatcher_mgr != nullptr) {
         _lookup_dispatcher_mgr->close();
-    }
-
-    if (global_env->pipeline_sink_io_pool()) {
-        start = MonotonicMillis();
-        global_env->pipeline_sink_io_pool()->shutdown();
-        component_times.emplace_back("pipeline_sink_io_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->put_aggregate_metadata_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->put_aggregate_metadata_thread_pool()->shutdown();
-        component_times.emplace_back("put_aggregate_metadata_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->lake_metadata_fetch_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->lake_metadata_fetch_thread_pool()->shutdown();
-        component_times.emplace_back("lake_metadata_fetch_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->lake_vector_index_build_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->lake_vector_index_build_thread_pool()->shutdown();
-        component_times.emplace_back("lake_vector_index_build_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->pk_index_execution_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->pk_index_execution_thread_pool()->shutdown();
-        component_times.emplace_back("pk_index_execution_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->pk_index_memtable_flush_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->pk_index_memtable_flush_thread_pool()->shutdown();
-        component_times.emplace_back("pk_index_memtable_flush_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->lake_partial_update_thread_pool()) {
-        start = MonotonicMillis();
-        global_env->lake_partial_update_thread_pool()->shutdown();
-        component_times.emplace_back("lake_partial_update_thread_pool", MonotonicMillis() - start);
-    }
-
-    if (profile_report_worker()) {
-        start = MonotonicMillis();
-        _compute_env->stop_profile_report_worker();
-        component_times.emplace_back("profile_report_worker", MonotonicMillis() - start);
-    }
-
-    if (global_env->automatic_partition_pool()) {
-        start = MonotonicMillis();
-        global_env->automatic_partition_pool()->shutdown();
-        component_times.emplace_back("automatic_partition_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->query_rpc_pool()) {
-        start = MonotonicMillis();
-        global_env->query_rpc_pool()->shutdown();
-        component_times.emplace_back("query_rpc_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->datacache_rpc_pool()) {
-        start = MonotonicMillis();
-        global_env->datacache_rpc_pool()->shutdown();
-        component_times.emplace_back("datacache_rpc_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->load_rpc_pool()) {
-        start = MonotonicMillis();
-        global_env->load_rpc_pool()->shutdown();
-        component_times.emplace_back("load_rpc_pool", MonotonicMillis() - start);
-    }
-
-    if (global_env->thread_pool()) {
-        start = MonotonicMillis();
-        global_env->thread_pool()->shutdown();
-        component_times.emplace_back("thread_pool", MonotonicMillis() - start);
     }
 
     if (_query_context_mgr) {
@@ -396,12 +289,6 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _batch_write_mgr->stop();
         component_times.emplace_back("batch_write_mgr", MonotonicMillis() - start);
-    }
-
-    if (global_env->dictionary_cache_pool()) {
-        start = MonotonicMillis();
-        global_env->dictionary_cache_pool()->shutdown();
-        component_times.emplace_back("dictionary_cache_pool", MonotonicMillis() - start);
     }
 
     start = MonotonicMillis();
@@ -425,29 +312,18 @@ void ExecEnv::stop() {
 }
 
 void ExecEnv::destroy() {
-    if (_compute_env != nullptr) {
-        _compute_env->destroy_profile_report_worker();
-    }
     delete_and_null(_transaction_mgr);
     delete_and_null(_stream_load_executor);
     delete_and_null(_connector_sink_spill_executor);
     delete_and_null(_query_context_mgr);
-    // Query/workgroup teardown can release FragmentContext state that still uses
-    // ComputeEnv-owned timers, pass-through stream buffers, and workgroup resources.
-    if (_compute_env) {
-        _compute_env->destroy();
-    }
 
-    // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate
-    // _query_pool_mem_tracker.
     delete_and_null(_runtime_filter_cache);
     delete_and_null(_lookup_dispatcher_mgr);
     delete_and_null(_batch_write_mgr);
-    DCHECK(_global_env != nullptr);
-    _global_env->destroy_thread_pools();
-    _query_execution_services.process_metrics = nullptr;
     _table_metrics_mgr = nullptr;
     _process_metrics_registry = nullptr;
+    _compute_env = nullptr;
+    _refresh_service_contexts();
 }
 
 uint32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -95,6 +95,7 @@ public:
     // Initial exec environment. must call this to init all
     Status init(ProcessMetricsRegistry* process_metrics_registry, GlobalEnv* global_env);
     void stop();
+    void clear_query_contexts();
     void destroy();
     /// Returns the first created exec env instance. In a normal starrocks, this is
     /// the only instance. In test setups with multiple ExecEnv's per process,

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -34,10 +34,7 @@
 
 #pragma once
 
-#include <atomic>
-#include <memory>
-#include <unordered_map>
-#include <vector>
+#include <cstdint>
 
 #include "common/status.h"
 #include "common/thread/threadpool.h"
@@ -52,7 +49,6 @@
 // So please consider use forward declaration as much as possible.
 
 namespace starrocks {
-struct StorePath;
 class AgentServer;
 class ComputeEnv;
 class DataStreamMgr;
@@ -97,8 +93,7 @@ class ConnectorSinkSpillExecutor;
 class ExecEnv {
 public:
     // Initial exec environment. must call this to init all
-    Status init(const std::vector<StorePath>& store_paths, ProcessMetricsRegistry* process_metrics_registry,
-                GlobalEnv* global_env, bool as_cn = false);
+    Status init(ProcessMetricsRegistry* process_metrics_registry, GlobalEnv* global_env);
     void stop();
     void destroy();
     /// Returns the first created exec env instance. In a normal starrocks, this is
@@ -152,7 +147,7 @@ public:
 
     pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
 
-    ComputeEnv* compute_env() const { return _compute_env.get(); }
+    ComputeEnv* compute_env() const { return _compute_env; }
 
     int64_t max_executor_threads() const { return _global_env->max_executor_threads(); }
 
@@ -162,6 +157,7 @@ public:
 
     AgentServer* agent_server() const { return _agent_server; }
     void set_agent_server(AgentServer* agent_server);
+    void set_compute_env(ComputeEnv* compute_env);
 
     query_cache::CacheManagerRawPtr cache_mgr() const;
 
@@ -172,7 +168,7 @@ private:
     ProcessMetricsRegistry* _process_metrics_registry = nullptr;
     TableMetricsManager* _table_metrics_mgr = nullptr;
     pipeline::QueryContextManager* _query_context_mgr = nullptr;
-    std::unique_ptr<ComputeEnv> _compute_env;
+    ComputeEnv* _compute_env = nullptr;
 
     TransactionMgr* _transaction_mgr = nullptr;
     BatchWriteMgr* _batch_write_mgr = nullptr;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -472,6 +472,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     compute_env->stop();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": compute env stop successfully";
 
+    exec_env->clear_query_contexts();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": query contexts clear successfully";
+
     global_env->shutdown_thread_pools();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": global env thread pools shutdown successfully";
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -18,6 +18,8 @@
 #include <sanitizer/lsan_interface.h>
 #endif
 
+#include <algorithm>
+
 #include "agent/agent_server.h"
 #include "agent/heartbeat_server.h"
 #include "backend_service.h"
@@ -25,6 +27,7 @@
 #include "cache/datacache.h"
 #include "cache/disk_cache/block_cache.h"
 #include "common/config_cache_fwd.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_network_fwd.h"
@@ -33,9 +36,17 @@
 #include "common/process_exit.h"
 #include "common/status.h"
 #include "common/system/backend_options.h"
+#include "common/thread/priority_thread_pool.hpp"
+#include "compute_env/compute_env.h"
+#include "compute_env/staros/staros_worker_runtime.h"
 #include "connector/connector_bootstrap.h"
 #include "data_workflows/data_workflows_env.h"
+#include "exec/pipeline/driver_executor_factory.h"
+#include "exec/pipeline/driver_queue_factory.h"
+#include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "orchestration/orchestration_env.h"
+#include "platform/platform_env.h"
+#include "platform/store_path.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/jdbc_driver_manager.h"
@@ -52,10 +63,6 @@
 #include "cache/datacache_metrics.h"
 #include "common/system/mem_info.h"
 #include "common/util/thrift_server.h"
-#include "compute_env/compute_env.h"
-#include "compute_env/staros/staros_worker_runtime.h"
-#include "platform/platform_env.h"
-#include "platform/store_path.h"
 #include "storage/storage_engine.h"
 
 #ifdef WITH_STARCACHE
@@ -108,14 +115,40 @@ StorageEnvOptions make_storage_env_options(GlobalEnv* global_env, PlatformEnv* p
     return storage_env_options;
 }
 
-Status init_storage_env(GlobalEnv* global_env, PlatformEnv* platform_env, ExecEnv* exec_env) {
-    DCHECK(exec_env != nullptr);
+ComputeEnvOptions make_compute_env_options(GlobalEnv* global_env, MetricRegistry* metrics,
+                                           const std::vector<StorePath>& paths, bool as_cn) {
+    DCHECK(global_env != nullptr);
+
+    std::vector<std::string> compute_store_paths;
+    compute_store_paths.reserve(paths.size());
+    for (const auto& path : paths) {
+        compute_store_paths.emplace_back(path.path);
+    }
+
+    ComputeEnvOptions options;
+    options.global_env = global_env;
+    options.metrics = metrics;
+    options.store_paths = std::move(compute_store_paths);
+    options.as_cn = as_cn;
+    options.query_cache_capacity = std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024);
+    options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
+    options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
+    return options;
+}
+
+void register_pipeline_prepare_pool_metric_hook(GlobalEnv* global_env) {
+    pipeline::PipelineExecutorMetrics::instance()->register_pipe_prepare_pool_queue_len_hook([global_env] {
+        auto pool = global_env->pipeline_prepare_pool();
+        return pool == nullptr ? 0L : static_cast<int64_t>(pool->get_queue_size());
+    });
+}
+
+Status init_storage_env(GlobalEnv* global_env, PlatformEnv* platform_env, ComputeEnv* compute_env) {
+    DCHECK(compute_env != nullptr);
 
     RETURN_IF_ERROR_WITH_WARN(StorageEnv::GetInstance()->init(make_storage_env_options(global_env, platform_env)),
                               "init StorageEnv failed");
-    if (exec_env->compute_env() != nullptr) {
-        StorageEnv::GetInstance()->set_spill_dir_mgr(exec_env->compute_env()->spill_dir_mgr());
-    }
+    StorageEnv::GetInstance()->set_spill_dir_mgr(compute_env->spill_dir_mgr());
     return Status::OK();
 }
 
@@ -182,10 +215,20 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     auto* exec_env = ExecEnv::GetInstance();
     EXIT_IF_ERROR(connector::bootstrap_builtin_connectors());
-    EXIT_IF_ERROR(exec_env->init(paths, process_metrics_registry, global_env, as_cn));
+    auto* process_metrics = process_metrics_registry->root_registry();
+    EXIT_IF_ERROR(global_env->init_execution_thread_pools(process_metrics));
+    register_pipeline_prepare_pool_metric_hook(global_env);
+
+    auto compute_env = std::make_unique<ComputeEnv>();
+    EXIT_IF_ERROR(compute_env->init(make_compute_env_options(global_env, process_metrics, paths, as_cn)));
+    LOG(INFO) << process_name << " start step " << start_step++ << ": compute env init successfully";
+
+    exec_env->set_compute_env(compute_env.get());
+    EXIT_IF_ERROR(global_env->init_lake_thread_pools(process_metrics));
+    EXIT_IF_ERROR(exec_env->init(process_metrics_registry, global_env));
     LOG(INFO) << process_name << " start step " << start_step++ << ": exec env init successfully";
 
-    EXIT_IF_ERROR(init_storage_env(global_env, platform_env, exec_env));
+    EXIT_IF_ERROR(init_storage_env(global_env, platform_env, compute_env.get()));
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage env init successfully";
 
     auto data_workflows_env = std::make_unique<DataWorkflowsEnv>();
@@ -426,6 +469,12 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     exec_env->stop();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env stop successfully";
 
+    compute_env->stop();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": compute env stop successfully";
+
+    global_env->shutdown_thread_pools();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": global env thread pools shutdown successfully";
+
     storage_engine->stop();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": storage engine exit successfully";
 
@@ -465,6 +514,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     exec_env->destroy();
     LOG(INFO) << process_name << " exit step " << exit_step++ << ": exec env destroy successfully";
+
+    compute_env->destroy();
+    compute_env.reset();
+    LOG(INFO) << process_name << " exit step " << exit_step++ << ": compute env destroy successfully";
 
     delete storage_engine;
 

--- a/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
+++ b/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
@@ -18,6 +18,7 @@
 #include <butil/files/file_path.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <utility>
 
 #include "base/path/file_util.h"
@@ -26,6 +27,7 @@
 #include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_path_fwd.h"
@@ -36,7 +38,11 @@
 #include "common/system/cpu_info.h"
 #include "common/system/disk_info.h"
 #include "common/system/mem_info.h"
+#include "common/thread/priority_thread_pool.hpp"
 #include "compute_env/compute_env.h"
+#include "exec/pipeline/driver_executor_factory.h"
+#include "exec/pipeline/driver_queue_factory.h"
+#include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "exec/pipeline/query_context.h"
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
@@ -812,7 +818,32 @@ int main(int argc, char** argv) {
         return -1;
     }
     auto* exec_env = starrocks::ExecEnv::GetInstance();
-    CHECK_OK(exec_env->init(paths, process_metrics_registry, global_env));
+    auto* process_metrics = process_metrics_registry->root_registry();
+    CHECK_OK(global_env->init_execution_thread_pools(process_metrics));
+    starrocks::pipeline::PipelineExecutorMetrics::instance()->register_pipe_prepare_pool_queue_len_hook([global_env] {
+        auto pool = global_env->pipeline_prepare_pool();
+        return pool == nullptr ? 0L : static_cast<int64_t>(pool->get_queue_size());
+    });
+
+    std::vector<std::string> compute_store_paths;
+    compute_store_paths.reserve(paths.size());
+    for (const auto& path : paths) {
+        compute_store_paths.emplace_back(path.path);
+    }
+    starrocks::ComputeEnvOptions compute_env_options;
+    compute_env_options.global_env = global_env;
+    compute_env_options.metrics = process_metrics;
+    compute_env_options.store_paths = std::move(compute_store_paths);
+    compute_env_options.query_cache_capacity =
+            std::max<size_t>(starrocks::config::query_cache_capacity, 4L * 1024 * 1024);
+    compute_env_options.driver_queue_factory = starrocks::pipeline::create_query_shared_driver_queue;
+    compute_env_options.driver_executor_factory = starrocks::pipeline::create_workgroup_driver_executor;
+    auto compute_env = std::make_unique<starrocks::ComputeEnv>();
+    CHECK_OK(compute_env->init(compute_env_options));
+
+    exec_env->set_compute_env(compute_env.get());
+    CHECK_OK(global_env->init_lake_thread_pools(process_metrics));
+    CHECK_OK(exec_env->init(process_metrics_registry, global_env));
     starrocks::StorageEnvOptions storage_env_options;
     storage_env_options.store_path_registry = platform_env->store_path_registry();
     storage_env_options.update_mem_tracker = global_env->update_mem_tracker();
@@ -825,9 +856,7 @@ int main(int argc, char** argv) {
     storage_env_options.lake_location_provider_mode = starrocks::LakeLocationProviderMode::kFixed;
 #endif
     CHECK_OK(starrocks::StorageEnv::GetInstance()->init(storage_env_options));
-    if (exec_env->compute_env() != nullptr) {
-        starrocks::StorageEnv::GetInstance()->set_spill_dir_mgr(exec_env->compute_env()->spill_dir_mgr());
-    }
+    starrocks::StorageEnv::GetInstance()->set_spill_dir_mgr(compute_env->spill_dir_mgr());
     int r = RUN_ALL_TESTS();
 
     sleep(10);
@@ -842,12 +871,16 @@ int main(int argc, char** argv) {
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     starrocks::StorageEnv::GetInstance()->stop();
     exec_env->stop();
+    compute_env->stop();
+    global_env->shutdown_thread_pools();
 #ifdef USE_STAROS
     starrocks::StorageEnv::GetInstance()->stop_lake_tablet_manager();
 #endif
     starrocks::StorageEnv::GetInstance()->set_spill_dir_mgr(nullptr);
     starrocks::StorageEnv::GetInstance()->destroy();
     exec_env->destroy();
+    compute_env->destroy();
+    compute_env.reset();
     global_env->stop();
     platform_env->destroy();
 

--- a/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
+++ b/be/test/data_workflows/migration/engine_storage_migration_task_test.cpp
@@ -872,6 +872,7 @@ int main(int argc, char** argv) {
     starrocks::StorageEnv::GetInstance()->stop();
     exec_env->stop();
     compute_env->stop();
+    exec_env->clear_query_contexts();
     global_env->shutdown_thread_pools();
 #ifdef USE_STAROS
     starrocks::StorageEnv::GetInstance()->stop_lake_tablet_manager();

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -135,7 +135,8 @@ public:
         config::streaming_load_max_mb = 1;
 
         ASSERT_OK(init_platform_env_for_stream_load_test(&_metrics, &_owns_platform_env));
-        ASSERT_OK(_env.compute_env()->init(make_stream_load_compute_env_options(&_metrics)));
+        ASSERT_OK(_compute_env.init(make_stream_load_compute_env_options(&_metrics)));
+        _env.set_compute_env(&_compute_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
         _env._refresh_service_contexts();
         ASSERT_NE(nullptr, _env.load_stream_mgr());
@@ -148,7 +149,8 @@ public:
     void TearDown() override {
         delete _env._stream_load_executor;
         _env._stream_load_executor = nullptr;
-        _env.compute_env()->destroy();
+        _env.set_compute_env(nullptr);
+        _compute_env.destroy();
         if (_owns_platform_env) {
             PlatformEnv::GetInstance()->destroy();
             PlatformEnv::GetInstance()->reset_store_paths_for_test();
@@ -162,6 +164,7 @@ public:
 
 private:
     ExecEnv _env;
+    ComputeEnv _compute_env;
     orchestration::StreamLoadOrchestrator _stream_load_orchestrator{&_env, nullptr};
     evhttp_request* _evhttp_req = nullptr;
     std::unique_ptr<ConcurrentLimiter> _limiter;

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -115,7 +115,8 @@ public:
         config::streaming_load_max_mb = 1;
 
         ASSERT_OK(init_platform_env_for_stream_load_test(&_metrics, &_owns_platform_env));
-        ASSERT_OK(_env.compute_env()->init(make_stream_load_compute_env_options(&_metrics)));
+        ASSERT_OK(_compute_env.init(make_stream_load_compute_env_options(&_metrics)));
+        _env.set_compute_env(&_compute_env);
         _env._stream_load_executor = new StreamLoadExecutor(&_env);
         _env._transaction_mgr = new TransactionMgr(&_env);
         _env._refresh_service_contexts();
@@ -130,7 +131,8 @@ public:
         _env._transaction_mgr = nullptr;
         delete _env._stream_load_executor;
         _env._stream_load_executor = nullptr;
-        _env.compute_env()->destroy();
+        _env.set_compute_env(nullptr);
+        _compute_env.destroy();
         if (_owns_platform_env) {
             PlatformEnv::GetInstance()->destroy();
             PlatformEnv::GetInstance()->reset_store_paths_for_test();
@@ -144,6 +146,7 @@ public:
 
 protected:
     ExecEnv _env;
+    ComputeEnv _compute_env;
     orchestration::StreamLoadOrchestrator _stream_load_orchestrator{&_env, nullptr};
     evhttp_request* _evhttp_req = nullptr;
     MetricRegistry _metrics{"transaction_stream_load_action_test"};

--- a/be/test/orchestration/external_scan_context_mgr_test.cpp
+++ b/be/test/orchestration/external_scan_context_mgr_test.cpp
@@ -113,7 +113,8 @@ protected:
         options.query_cache_capacity = 4 * 1024 * 1024;
         options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
         options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
-        ASSERT_TRUE(_exec_env.compute_env()->init(options).ok());
+        ASSERT_TRUE(_compute_env.init(options).ok());
+        _exec_env.set_compute_env(&_compute_env);
         _fragment_mgr = std::make_unique<FragmentMgr>(&_exec_env, nullptr);
         _exec_env._query_context_mgr = new pipeline::QueryContextManager(5);
         _exec_env._refresh_service_contexts();
@@ -123,11 +124,13 @@ protected:
         _fragment_mgr.reset();
         delete _exec_env._query_context_mgr;
         _exec_env._query_context_mgr = nullptr;
-        _exec_env.compute_env()->destroy();
+        _exec_env.set_compute_env(nullptr);
+        _compute_env.destroy();
     }
 
 private:
     ExecEnv _exec_env;
+    ComputeEnv _compute_env;
     std::unique_ptr<FragmentMgr> _fragment_mgr;
     static std::shared_ptr<MemTracker> _previous_process_mem_tracker;
     static std::shared_ptr<MemTracker> _previous_query_pool_mem_tracker;

--- a/be/test/orchestration/external_scan_orchestrator_test.cpp
+++ b/be/test/orchestration/external_scan_orchestrator_test.cpp
@@ -91,7 +91,8 @@ protected:
         options.query_cache_capacity = 4 * 1024 * 1024;
         options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
         options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
-        ASSERT_TRUE(_exec_env.compute_env()->init(options).ok());
+        ASSERT_TRUE(_compute_env.init(options).ok());
+        _exec_env.set_compute_env(&_compute_env);
         _fragment_mgr = std::make_unique<FragmentMgr>(&_exec_env, nullptr);
         _exec_env._query_context_mgr = new pipeline::QueryContextManager(5);
         _exec_env._refresh_service_contexts();
@@ -101,10 +102,12 @@ protected:
         _fragment_mgr.reset();
         delete _exec_env._query_context_mgr;
         _exec_env._query_context_mgr = nullptr;
-        _exec_env.compute_env()->destroy();
+        _exec_env.set_compute_env(nullptr);
+        _compute_env.destroy();
     }
 
     ExecEnv _exec_env;
+    ComputeEnv _compute_env;
     std::unique_ptr<FragmentMgr> _fragment_mgr;
     static std::shared_ptr<MemTracker> _previous_process_mem_tracker;
     static std::shared_ptr<MemTracker> _previous_query_pool_mem_tracker;

--- a/be/test/runtime/exec_env_test.cpp
+++ b/be/test/runtime/exec_env_test.cpp
@@ -64,6 +64,7 @@ TEST(ExecEnvTest, refresh_service_contexts_keeps_context_views_in_sync) {
     EXPECT_EQ(env.runtime_services().global_spill_manager, nullptr);
     EXPECT_EQ(env.runtime_services().runtime_filter_sender, nullptr);
     EXPECT_EQ(env.runtime_services().runtime_filter_query_lifecycle, nullptr);
+    EXPECT_EQ(env.compute_env(), nullptr);
 
     std::error_code ec;
     std::filesystem::create_directories(config::spill_local_storage_dir, ec);
@@ -76,7 +77,9 @@ TEST(ExecEnvTest, refresh_service_contexts_keeps_context_views_in_sync) {
     compute_env_options.query_cache_capacity = 4 * 1024 * 1024;
     compute_env_options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
     compute_env_options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
-    ASSERT_OK(env.compute_env()->init(compute_env_options));
+    ComputeEnv compute_env;
+    ASSERT_OK(compute_env.init(compute_env_options));
+    env.set_compute_env(&compute_env);
 
     ProfileReportWorkerOptions profile_report_worker_options;
     profile_report_worker_options.start_worker_thread = false;
@@ -141,7 +144,22 @@ TEST(ExecEnvTest, refresh_service_contexts_keeps_context_views_in_sync) {
     EXPECT_EQ(env.admin_services().runtime, &env.runtime_services());
     EXPECT_EQ(env.admin_services().agent, &env.agent_services());
 
-    env.compute_env()->destroy();
+    env.set_compute_env(nullptr);
+    EXPECT_EQ(env.compute_env(), nullptr);
+    EXPECT_EQ(env.execution_services().workgroup_manager, nullptr);
+    EXPECT_EQ(env.execution_services().driver_limiter, nullptr);
+    EXPECT_EQ(env.execution_services().pipeline_timer, nullptr);
+    EXPECT_EQ(env.runtime_services().stream_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().result_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().result_queue_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().load_path_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().load_stream_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().profile_report_worker, nullptr);
+    EXPECT_EQ(env.runtime_services().spill_dir_mgr, nullptr);
+    EXPECT_EQ(env.runtime_services().global_spill_manager, nullptr);
+
+    env._query_context_mgr = nullptr;
+    compute_env.destroy();
 }
 
 } // namespace starrocks

--- a/be/test/testutil/init_test_env.h
+++ b/be/test/testutil/init_test_env.h
@@ -17,6 +17,7 @@
 #include <butil/file_util.h>
 #include <butil/files/file_path.h>
 
+#include <algorithm>
 #include <memory>
 
 #include "agent/agent_server.h"
@@ -24,6 +25,7 @@
 #include "base/time/timezone_utils.h"
 #include "cache/datacache.h"
 #include "common/config_cache_fwd.h"
+#include "common/config_exec_env_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_path_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -32,9 +34,13 @@
 #include "common/system/cpu_info.h"
 #include "common/system/disk_info.h"
 #include "common/system/mem_info.h"
+#include "common/thread/priority_thread_pool.hpp"
 #include "compute_env/compute_env.h"
 #include "connector/connector_bootstrap.h"
 #include "data_workflows/data_workflows_env.h"
+#include "exec/pipeline/driver_executor_factory.h"
+#include "exec/pipeline/driver_queue_factory.h"
+#include "exec/pipeline/primitives/pipeline_metrics.h"
 #include "exec/pipeline/query_context.h"
 #include "fs/fs_provider_bootstrap.h"
 #include "gtest/gtest.h"
@@ -149,7 +155,34 @@ int init_test_env(int argc, char** argv) {
     auto* exec_env = ExecEnv::GetInstance();
     st = connector::bootstrap_builtin_connectors();
     CHECK(st.ok()) << st;
-    st = exec_env->init(paths, process_metrics_registry, global_env);
+    auto* process_metrics = process_metrics_registry->root_registry();
+    st = global_env->init_execution_thread_pools(process_metrics);
+    CHECK(st.ok()) << st;
+    pipeline::PipelineExecutorMetrics::instance()->register_pipe_prepare_pool_queue_len_hook([global_env] {
+        auto pool = global_env->pipeline_prepare_pool();
+        return pool == nullptr ? 0L : static_cast<int64_t>(pool->get_queue_size());
+    });
+
+    std::vector<std::string> compute_store_paths;
+    compute_store_paths.reserve(paths.size());
+    for (const auto& path : paths) {
+        compute_store_paths.emplace_back(path.path);
+    }
+    ComputeEnvOptions compute_env_options;
+    compute_env_options.global_env = global_env;
+    compute_env_options.metrics = process_metrics;
+    compute_env_options.store_paths = std::move(compute_store_paths);
+    compute_env_options.query_cache_capacity = std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024);
+    compute_env_options.driver_queue_factory = pipeline::create_query_shared_driver_queue;
+    compute_env_options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
+    auto compute_env = std::make_unique<ComputeEnv>();
+    st = compute_env->init(compute_env_options);
+    CHECK(st.ok()) << st;
+
+    exec_env->set_compute_env(compute_env.get());
+    st = global_env->init_lake_thread_pools(process_metrics);
+    CHECK(st.ok()) << st;
+    st = exec_env->init(process_metrics_registry, global_env);
     CHECK(st.ok()) << st;
 
     StorageEnvOptions storage_env_options;
@@ -165,9 +198,7 @@ int init_test_env(int argc, char** argv) {
 #endif
     st = StorageEnv::GetInstance()->init(storage_env_options);
     CHECK(st.ok()) << st;
-    if (exec_env->compute_env() != nullptr) {
-        StorageEnv::GetInstance()->set_spill_dir_mgr(exec_env->compute_env()->spill_dir_mgr());
-    }
+    StorageEnv::GetInstance()->set_spill_dir_mgr(compute_env->spill_dir_mgr());
 
     auto data_workflows_env = std::make_unique<DataWorkflowsEnv>();
     DataWorkflowsEnvOptions data_workflows_env_options;
@@ -207,6 +238,8 @@ int init_test_env(int argc, char** argv) {
     data_workflows_env->stop();
     StorageEnv::GetInstance()->stop();
     exec_env->stop();
+    compute_env->stop();
+    global_env->shutdown_thread_pools();
     engine->stop();
 #ifdef USE_STAROS
     StorageEnv::GetInstance()->stop_lake_tablet_manager();
@@ -219,6 +252,8 @@ int init_test_env(int argc, char** argv) {
     StorageEnv::GetInstance()->set_spill_dir_mgr(nullptr);
     StorageEnv::GetInstance()->destroy();
     exec_env->destroy();
+    compute_env->destroy();
+    compute_env.reset();
     agent_server.reset();
     cache_env->destroy();
     global_env->stop();

--- a/be/test/testutil/init_test_env.h
+++ b/be/test/testutil/init_test_env.h
@@ -239,6 +239,7 @@ int init_test_env(int argc, char** argv) {
     StorageEnv::GetInstance()->stop();
     exec_env->stop();
     compute_env->stop();
+    exec_env->clear_query_contexts();
     global_env->shutdown_thread_pools();
     engine->stop();
 #ifdef USE_STAROS


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
