### PR TITLE
[BugFix] Fix nested dict expr exchange translation (backport #75246)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
@@ -110,6 +111,18 @@ class DecodeContext {
         rewriteStringAggregations();
     }
 
+    private ColumnRefOperator getUseStringRef(ScalarOperator operator) {
+        if (operator.isColumnRef()) {
+            return (ColumnRefOperator) operator;
+        }
+        List<ColumnRefOperator> useStringRefs = operator.getColumnRefs();
+        if (useStringRefs.isEmpty()) {
+            return null;
+        }
+        Preconditions.checkState(useStringRefs.stream().distinct().count() == 1);
+        return useStringRefs.get(0);
+    }
+
     private void rewriteStringRefToDictRef() {
         // rewrite string column to dict column
         DictExprRewrite exprRewriter = new DictExprRewrite();
@@ -144,6 +157,28 @@ class DecodeContext {
         }
     }
 
+    private boolean isNullSensitiveToRef(ScalarOperator op, int refId) {
+        if (!op.getUsedColumns().contains(refId)) {
+            return false;
+        }
+        if (op instanceof IsNullPredicateOperator) {
+            return true;
+        }
+        if (op instanceof CallOperator) {
+            String fn = ((CallOperator) op).getFnName();
+            if (FunctionSet.IFNULL.equalsIgnoreCase(fn) || FunctionSet.COALESCE.equalsIgnoreCase(fn)
+                    || FunctionSet.NULLIF.equalsIgnoreCase(fn) || FunctionSet.CONCAT_WS.equalsIgnoreCase(fn)) {
+                return true;
+            }
+        }
+        for (ScalarOperator child : op.getChildren()) {
+            if (isNullSensitiveToRef(child, refId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void rewriteGlobalDict() {
         GlobalDictRewriter dictRewriter = new GlobalDictRewriter();
         for (Integer stringId : stringRefToDefineExprMap.keySet()) {
@@ -158,6 +193,21 @@ class DecodeContext {
             // decode A: dictMapping(B, upper(B)) -> dictMapping(C, upper(lower(C)))
             ColumnRefOperator dictRef = stringRefToDictRefMap.get(factory.getColumnRef(stringId));
             ScalarOperator stringDefineExpr = stringRefToDefineExprMap.get(stringId);
+
+            // Check before flattening: if a NULL-sensitive expression is built on a DERIVED dict
+            // (one defined by another expression, not a base column), do NOT flatten it through the
+            // child define. Keep it referencing the intermediate dict directly, so producer and
+            // consumer build the dictionary the same way (a derived dict carries a synthetic NULL
+            // code that flattening would drop).
+            ColumnRefOperator keepUseRef = getUseStringRef(stringDefineExpr);
+            if (keepUseRef != null && !stringRefToDicts.containsKey(keepUseRef.getId())
+                    && stringRefToDefineExprMap.containsKey(keepUseRef.getId())
+                    && isNullSensitiveToRef(stringDefineExpr, keepUseRef.getId())) {
+                ColumnRefOperator keepDictRef = stringRefToDictRefMap.get(keepUseRef);
+                globalDictsExpr.put(dictRef.getId(),
+                        new DictMappingOperator(keepDictRef, stringDefineExpr.clone(), dictRef.getType()));
+                continue;
+            }
 
             ScalarOperator defineExpr = stringDefineExpr.accept(dictRewriter, null);
             List<ColumnRefOperator> defineUsedStringRef = defineExpr.getColumnRefs();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -53,15 +53,18 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /*
@@ -351,14 +354,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
             if (context.stringRefToDicts.containsKey(sid)) {
                 dictMap.put(dictRef.getId(), context.stringRefToDicts.get(sid));
             } else {
-                // compute expressions depend-on dict
-                for (ColumnRefOperator useRefs : context.globalDictsExpr.get(dictRef.getId()).getColumnRefs()) {
-
-                    if (context.stringRefToDicts.containsKey(useRefs.getId())) {
-                        dictMap.put(context.stringRefToDictRefMap.get(useRefs).getId(),
-                                context.stringRefToDicts.get(useRefs.getId()));
-                    }
-                }
+                // follow the dict-expr chain down to the base dictionaries it ultimately needs
+                collectBaseDictChain(dictRef.getId(), dictMap, new HashSet<>());
             }
         }
         List<Pair<Integer, ColumnDict>> dicts = Lists.newArrayList();
@@ -554,6 +551,40 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         return rewriteOptExpression(optExpression, builder.build(), info.outputStringColumns);
     }
 
+    // Recursively collect a dict expr and every intermediate dict expr it references.
+    private void collectDictExprChain(int dictId, Map<Integer, ScalarOperator> out) {
+        if (out.containsKey(dictId)) {
+            return;
+        }
+        ScalarOperator expr = context.globalDictsExpr.get(dictId);
+        if (expr == null) {
+            return;
+        }
+        if (expr instanceof DictMappingOperator) {
+            collectDictExprChain(((DictMappingOperator) expr).getDictColumn().getId(), out);
+        }
+        out.put(dictId, expr);
+    }
+
+    // Recursively collect the base dictionaries a (possibly chained) dict expr ultimately needs.
+    private void collectBaseDictChain(int dictId, Map<Integer, ColumnDict> dictMap, Set<Integer> visited) {
+        if (!visited.add(dictId)) {
+            return;
+        }
+        ScalarOperator expr = context.globalDictsExpr.get(dictId);
+        if (expr == null) {
+            return;
+        }
+        for (ColumnRefOperator ref : expr.getColumnRefs()) {
+            if (context.stringRefToDicts.containsKey(ref.getId())) {
+                dictMap.put(context.stringRefToDictRefMap.get(ref).getId(),
+                        context.stringRefToDicts.get(ref.getId()));
+            } else if (context.stringRefToDictRefMap.containsKey(ref)) {
+                collectBaseDictChain(context.stringRefToDictRefMap.get(ref).getId(), dictMap, visited);
+            }
+        }
+    }
+
     @NotNull
     private Map<Integer, ScalarOperator> computeDictExpr(ColumnRefSet fragmentUseDictExprs) {
         Map<Integer, ScalarOperator> dictExprs = Maps.newHashMap();
@@ -564,9 +595,10 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 continue;
             }
             ColumnRefOperator dictRef = context.stringRefToDictRefMap.get(strRef);
-            if (context.globalDictsExpr.containsKey(dictRef.getId())) {
-                dictExprs.put(dictRef.getId(), context.globalDictsExpr.get(dictRef.getId()));
-            }
+            // A kept (non-flattened) dict expr can reference an intermediate dict, which can
+            // reference another, etc. Collect the whole chain so the fragment that decodes the
+            // top dict also has every intermediate dict expr it depends on.
+            collectDictExprChain(dictRef.getId(), dictExprs);
         }
         return dictExprs;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1230,6 +1230,21 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testNestedNullSensitiveDictKeepsIntermediate() throws Exception {
+        // A NULL-sensitive outer expression (IS NULL) over a derived dict (the inner CASE result)
+        // must keep the intermediate dict instead of being flattened through the child define.
+        // Flattening would drop the derived dict's synthetic NULL code and the query would fail at
+        // runtime with "Dict Decode failed, Dict can't take cover all key".
+        String sql = "select distinct case when subq.x is null then '-' else subq.x end as x "
+                + "from (select distinct case when S_ADDRESS = 'a' then 'A' else 'B' end as x "
+                + "from supplier_nullable) subq";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "if(<place-holder> = 'a', 'A', 'B')");
+        assertContains(plan, "if(<place-holder> IS NULL, '-', <place-holder>)");
+        assertNotContains(plan, "if(if(");
+    }
+
+    @Test
     public void testGroupByWithOrderBy() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         try {

--- a/test/sql/test_low_cardinality/R/test_nested_dict_expr_exchange
+++ b/test/sql/test_low_cardinality/R/test_nested_dict_expr_exchange
@@ -1,0 +1,50 @@
+-- name: test_nested_dict_expr_exchange
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = true;
+-- result:
+-- !result
+CREATE TABLE `dict_expr_exchange` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into dict_expr_exchange
+select
+    generate_series,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+[UC] analyze full table dict_expr_exchange;
+function: wait_global_dict_ready('lot_state', 'dict_expr_exchange')
+-- result:
+
+-- !result
+function: assert_explain_contains('select case when subq.wip_status is null then \'-\' else subq.wip_status end as wip_status from (select distinct case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as wip_status from dict_expr_exchange) subq order by wip_status', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select
+    case when subq.wip_status is null then '-' else subq.wip_status end as wip_status
+from (
+    select distinct
+        case when lot_state in ('created') then 'Created' else 'WIP' end as wip_status
+    from dict_expr_exchange
+) subq
+order by wip_status;
+-- result:
+Created
+WIP
+-- !result

--- a/test/sql/test_low_cardinality/T/test_nested_dict_expr_exchange
+++ b/test/sql/test_low_cardinality/T/test_nested_dict_expr_exchange
@@ -1,0 +1,39 @@
+-- name: test_nested_dict_expr_exchange
+
+set cbo_enable_low_cardinality_optimize = true;
+set low_cardinality_optimize_v2 = true;
+
+CREATE TABLE `dict_expr_exchange` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into dict_expr_exchange
+select
+    generate_series,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+
+[UC] analyze full table dict_expr_exchange;
+
+function: wait_global_dict_ready('lot_state', 'dict_expr_exchange')
+
+function: assert_explain_contains('select case when subq.wip_status is null then \'-\' else subq.wip_status end as wip_status from (select distinct case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as wip_status from dict_expr_exchange) subq order by wip_status', 'Decode')
+
+[ORDER]select
+    case when subq.wip_status is null then '-' else subq.wip_status end as wip_status
+from (
+    select distinct
+        case when lot_state in ('created') then 'Created' else 'WIP' end as wip_status
+    from dict_expr_exchange
+) subq
+order by wip_status;


### PR DESCRIPTION
## Why I'm doing:

Nested derived dictionary expressions can be rebuilt differently across exchange fragments when the expression chain is flattened to the base string column.

For null-sensitive expressions such as nested `CASE`/`IF`, the producer may build a derived dictionary through an intermediate dict expression, while the consumer rebuilds the same output slot from the original string column. With `NULL` inputs, those two paths can produce incompatible dictionary translations and cause runtime dict decode failures such as `Dict Decode failed, Dict can't take cover all key`.

For example:

```sql
SELECT CASE WHEN subq.wip_status IS NULL THEN '-' ELSE subq.wip_status END AS wip_status
FROM (
    SELECT DISTINCT CASE WHEN lot_state IN ('created') THEN 'Created' ELSE 'WIP' END AS wip_status
    FROM t_wip_lot
) subq;
```

The derived slots are roughly:

```text
slot13 = CASE WHEN lot_state IN ('created') THEN 'Created' ELSE 'WIP' END
slot14 = IF(slot13 IS NULL, '-', slot13)
```

If the producer keeps the intermediate dict expression, it builds `slot14` from `slot13`:

```text
slot13 code 0 -> NULL      -> IF(NULL IS NULL, '-', NULL)           -> '-'       // enters slot14 dict
slot13 code 2 -> 'Created' -> IF('Created' IS NULL, '-', 'Created') -> 'Created'
slot13 code 3 -> 'WIP'     -> IF('WIP' IS NULL, '-', 'WIP')         -> 'WIP'
```

If the consumer flattens `slot14` to the base `lot_state` dictionary, the synthetic NULL takes a different path:

```text
lot_state code 0 -> NULL      -> CASE(NULL)      -> 'WIP'     -> IF('WIP' IS NULL, '-', 'WIP')         -> 'WIP'
lot_state code 7 -> 'created' -> CASE('created') -> 'Created' -> IF('Created' IS NULL, '-', 'Created') -> 'Created'
```

So the producer-side `slot14` dictionary can contain `'-'`, while the consumer-side flattened dictionary does not. That mismatch makes cross-fragment dictionary translation fail. The numeric codes above are illustrative; the important part is that the intermediate dictionary's synthetic NULL is evaluated by different expression chains.

## What I'm doing:

- Prevent null-sensitive nested global dictionary expressions from being flattened to the base string column.
- Preserve dependent derived dictionary expressions across exchange boundaries so both producer and consumer build the same dictionary chain.
- Fix verbose explain fallback printing for missing dict-expression dependencies so nested dict exprs show their source slot clearly.
- Add FE plan coverage and an end-to-end SQL regression for nested `CASE` dictionary expressions across exchange.

Backport of https://github.com/StarRocks/starrocks/pull/75246

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
