### PR TITLE
[BugFix] Exclude NULL rows from NOT MATCH answered by GIN inverted index

### DIFF
--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -356,7 +356,7 @@ Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string_
 }
 
 Status BuiltinInvertedIndexIterator::read_null(const std::string_view column_name, roaring::Roaring* bitmap) {
-    return Status::InternalError("Unsupported");
+    return _bitmap_itr->read_null_bitmap(bitmap);
 }
 
 } // namespace starrocks

--- a/be/src/storage/primitive/column_expr_predicate.cpp
+++ b/be/src/storage/primitive/column_expr_predicate.cpp
@@ -390,6 +390,9 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
 
     if (with_not) {
         *row_bitmap -= roaring_opt.value();
+        roaring::Roaring null_roaring;
+        RETURN_IF_ERROR(iterator->read_null(column_name, &null_roaring));
+        *row_bitmap -= null_roaring;
     } else {
         *row_bitmap &= roaring_opt.value();
     }

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -657,11 +657,67 @@ TEST_F(BuiltinInvertedIndexTest, test_iterator_unsupported_ops) {
     ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
 
     roaring::Roaring bitmap;
-    ASSERT_TRUE(iter->read_null("c0", &bitmap).is_internal_error());
+    ASSERT_OK(iter->read_null("c0", &bitmap));
+    ASSERT_TRUE(bitmap.isEmpty());
 
     Slice query("test");
     ASSERT_TRUE(iter->read_from_inverted_index("c0", &query, static_cast<InvertedIndexQueryType>(-1), &bitmap)
                         .is_invalid_argument());
+
+    delete iter;
+}
+
+// Test BuiltinInvertedIndexIterator::read_null returns exactly the NULL rowids.
+TEST_F(BuiltinInvertedIndexTest, test_iterator_read_null) {
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+
+    std::string file_name = kTestDir + "/read_null";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        // Interleave values and NULLs so NULL rows land at rowids 2 and 4:
+        //   rowid 0,1 -> "apple","banana"; rowid 2 -> NULL; rowid 3 -> "cherry"; rowid 4 -> NULL.
+        std::vector<std::string> head = {"apple", "banana"};
+        std::vector<Slice> head_slices;
+        for (auto& v : head) {
+            head_slices.emplace_back(v.data(), v.size());
+        }
+        writer->add_values(head_slices.data(), head_slices.size());
+        writer->add_nulls(1);
+        std::string tail = "cherry";
+        Slice tail_slice(tail.data(), tail.size());
+        writer->add_values(&tail_slice, 1);
+        writer->add_nulls(1);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    _opts.segment_rows = 5;
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    roaring::Roaring bitmap;
+    ASSERT_OK(iter->read_null("c0", &bitmap));
+    ASSERT_EQ(2, bitmap.cardinality());
+    ASSERT_TRUE(bitmap.contains(2));
+    ASSERT_TRUE(bitmap.contains(4));
+    ASSERT_FALSE(bitmap.contains(0));
+    ASSERT_FALSE(bitmap.contains(1));
+    ASSERT_FALSE(bitmap.contains(3));
 
     delete iter;
 }

--- a/test/sql/test_index/R/test_gin_index
+++ b/test/sql/test_index/R/test_gin_index
@@ -251,3 +251,60 @@ PROPERTIES (
 drop database test_gin_index;
 -- result:
 -- !result
+-- name: test_gin_not_match_excludes_null @native
+create database test_gin_null_${uuid0};
+-- result:
+-- !result
+use test_gin_null_${uuid0};
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE t_null (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_null values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
+-- result:
+-- !result
+[ORDER] select id, c from t_null where c match 'hello';
+-- result:
+1	hello
+-- !result
+[ORDER] select id, c from t_null where c not match 'hello';
+-- result:
+2	world
+4	hxllo
+-- !result
+CREATE TABLE t_null_builtin (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("imp_lib" = "builtin", "parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_null_builtin values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
+-- result:
+-- !result
+[ORDER] select id, c from t_null_builtin where c match 'hello';
+-- result:
+1	hello
+-- !result
+[ORDER] select id, c from t_null_builtin where c not match 'hello';
+-- result:
+2	world
+4	hxllo
+-- !result
+drop database test_gin_null_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_index/T/test_gin_index
+++ b/test/sql/test_index/T/test_gin_index
@@ -126,11 +126,44 @@ show create table t2_primary;
 
 drop database test_gin_index;
 
+-- name: test_gin_not_match_excludes_null @native
+create database test_gin_null_${uuid0};
+use test_gin_null_${uuid0};
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
 
+CREATE TABLE t_null (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
 
+insert into t_null values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
 
+-- 基线/回归：正向 MATCH 不应返回 NULL 行（期望 1 hello）
+[ORDER] select id, c from t_null where c match 'hello';
 
+-- Bug-1：NOT MATCH 必须排除 NULL 行 id=3（期望 2 world / 4 hxllo，不含 3）
+[ORDER] select id, c from t_null where c not match 'hello';
 
+-- builtin 变体：imp_lib=builtin，覆盖 builtin 版本的 NOT MATCH 同样排除 NULL 行
+CREATE TABLE t_null_builtin (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("imp_lib" = "builtin", "parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
 
+insert into t_null_builtin values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
 
+-- builtin 正向 MATCH（期望 1 hello）
+[ORDER] select id, c from t_null_builtin where c match 'hello';
 
+-- builtin NOT MATCH 必须排除 NULL 行 id=3（期望 2 world / 4 hxllo，不含 3）
+[ORDER] select id, c from t_null_builtin where c not match 'hello';
+
+drop database test_gin_null_${uuid0};

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -577,7 +577,6 @@ SELECT * FROM t_gin_index_single_predicate_english WHERE text_column not match "
 1	ABC
 2	abc
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_single_predicate_english WHERE text_column <= "this";
 -- result:
@@ -736,7 +735,6 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 1	ABC
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column match_any "abc ABC";
 -- result:
@@ -747,14 +745,12 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 1	ABC
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_all "abc ABC";
 -- result:
 1	ABC
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "This Index";
 -- result:
@@ -762,7 +758,6 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 2	abc
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 DROP TABLE t_gin_index_multiple_predicate_none;
 -- result:
@@ -815,12 +810,10 @@ SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column match_any
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match "this" AND text_column not match "abc";
 -- result:
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match_any "this abc";
 -- result:
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column LIKE "this" OR text_column LIKE "abc";
 -- result:


### PR DESCRIPTION
## Why I'm doing:

On a column with a GIN inverted index, a NOT MATCH predicate returns NULL rows
that it should not.

- Before: SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' AND the NULL row
- After:  SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' (NULL excluded)

NULL rows are kept in a separate null bitmap, not in the term postings. The NOT
path subtracted only the matched rows from the candidate set, so NULL rows
survived. Under SQL three-valued logic, NOT MATCH over a NULL value is NULL (not
TRUE), so those rows must not be returned.

## What I'm doing:

In ColumnExprPredicate::seek_inverted_index, the NOT branch now also reads the
null bitmap via iterator->read_null(...) and subtracts it (after subtracting the
matched rows), mirroring ColumnNotNullPredicate::seek_inverted_index. The
positive branch is unchanged.

Added a SQL regression test (test/sql/test_index/test_gin_index, case
test_gin_not_match_excludes_null) for NOT MATCH over a GIN column with a NULL row.

Fixes #75577 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
