### PR TITLE
[BugFix] Serve flat-JSON subfield reads for keys whose name contains '.'

### DIFF
--- a/be/src/column/flat_json/json_flat_path.cpp
+++ b/be/src/column/flat_json/json_flat_path.cpp
@@ -22,17 +22,17 @@
 namespace starrocks {
 
 std::pair<std::string_view, std::string_view> JsonFlatPath::split_path(const std::string_view& path) {
-    size_t pos = 0;
-    pos = path.find('.', pos);
-    std::string_view key;
-    std::string_view next;
-    if (pos == std::string::npos) {
-        key = path;
-    } else {
-        key = path.substr(0, pos);
-        next = path.substr(pos + 1);
+    // A quoted level like "a.b" is a single key whose interior '.' is part of the name (the FE wraps a
+    // key containing the '.' separator in quotes, see SubfieldAccessPathNormalizer.formatJsonPath);
+    // resume the separator search after the closing quote, then strip the wrapping quotes so the level
+    // key equals the raw vpack object key, which carries none.
+    size_t scan = (!path.empty() && path.front() == '"') ? path.find('"', 1) : 0;
+    size_t dot = path.find('.', scan);
+    std::string_view key = path.substr(0, dot);
+    std::string_view next = (dot == std::string_view::npos) ? std::string_view{} : path.substr(dot + 1);
+    if (key.size() >= 2 && key.front() == '"' && key.back() == '"') {
+        key = key.substr(1, key.size() - 2); // strip the wrapping quotes
     }
-
     return {key, next};
 }
 

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -540,17 +540,19 @@ static StatusOr<ColumnPtr> _extract_with_hyper(NativeJsonState* state, const std
                     state->real_path.paths.emplace_back(p);
                     continue;
                 }
-                if (p.key.find('.') != std::string::npos) {
-                    in_flat = false;
-                }
-                if (in_flat) {
-                    flat_path += "." + p.key;
+                // A key containing the '.' separator is still a valid flat level once wrapped in
+                // quotes (the inverse of JsonFlatPath::split_path, matching SubfieldAccessPathNormalizer
+                // on the FE); only a key whose name itself contains a '"' is unrepresentable and falls
+                // back to extraction from the reconstructed JSON via real_path.
+                if (in_flat && p.key.find('"') == std::string::npos) {
+                    flat_path += (p.key.find('.') == std::string::npos) ? "." + p.key : ".\"" + p.key + "\"";
                     if (p.array_selector->type != NONE) {
                         state->real_path.paths.emplace_back("", p.array_selector);
                         in_flat = false;
                     }
                     continue;
                 }
+                in_flat = false;
                 state->real_path.paths.emplace_back(p);
             }
 

--- a/test/sql/test_json/R/test_json_subfield_prune_wrong_result
+++ b/test/sql/test_json/R/test_json_subfield_prune_wrong_result
@@ -1,0 +1,68 @@
+-- name: test_json_subfield_prune_wrong_result
+-- The FE subfield-prune rule (cbo_prune_json_subfield) pushes a typed flat-JSON sub-field
+-- read into the scan. A JSON key whose name contains a literal '.' cannot be a flat
+-- sub-column (the flat scheme uses '.' as the level separator), so it is kept in `remain`.
+-- The BE flat read must still serve such a key from `remain`; before the fix it returned
+-- NULL, which -- because the read also drives the pushed-down predicate -- silently dropped
+-- rows. This test asserts rule-on == rule-off for the dotted key (cases b / b').
+--
+-- NOTE: case (a) below (a path ending at an intermediate OBJECT, $.o) is a SEPARATE,
+-- still-open issue: rule-on returns NULL where rule-off returns the sub-object. The
+-- rule-on result recorded here is the current (incorrect) behavior, NOT the desired one;
+-- it is kept only to pin the contrast and will be updated when the intermediate-object
+-- case is fixed.
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values
+ (1, parse_json('{"o":{"inner":10},"a.b":7}')),
+ (2, parse_json('{"o":{"inner":20},"a.b":8}'));
+-- result:
+-- !result
+set cbo_prune_json_subfield = false;
+-- result:
+-- !result
+select id, cast(json_query(j,'$.o') as string) from t order by id;
+-- result:
+1	{"inner": 10}
+2	{"inner": 20}
+-- !result
+set cbo_prune_json_subfield = true;
+-- result:
+-- !result
+select id, cast(json_query(j,'$.o') as string) from t order by id;
+-- result:
+1	None
+2	None
+-- !result
+set cbo_prune_json_subfield = false;
+-- result:
+-- !result
+select id, get_json_int(j,'$."a.b"') from t order by id;
+-- result:
+1	7
+2	8
+-- !result
+set cbo_prune_json_subfield = true;
+-- result:
+-- !result
+select id, get_json_int(j,'$."a.b"') from t order by id;
+-- result:
+1	7
+2	8
+-- !result
+set cbo_prune_json_subfield = false;
+-- result:
+-- !result
+select count(*) from t where get_json_int(j,'$."a.b"') > 0;
+-- result:
+2
+-- !result
+set cbo_prune_json_subfield = true;
+-- result:
+-- !result
+select count(*) from t where get_json_int(j,'$."a.b"') > 0;
+-- result:
+2
+-- !result

--- a/test/sql/test_json/T/test_json_subfield_prune_wrong_result
+++ b/test/sql/test_json/T/test_json_subfield_prune_wrong_result
@@ -1,0 +1,37 @@
+-- name: test_json_subfield_prune_wrong_result
+-- The FE subfield-prune rule (cbo_prune_json_subfield) pushes a typed flat-JSON sub-field
+-- read into the scan. A JSON key whose name contains a literal '.' cannot be a flat
+-- sub-column (the flat scheme uses '.' as the level separator), so it is kept in `remain`.
+-- The BE flat read must still serve such a key from `remain`; before the fix it returned
+-- NULL, which -- because the read also drives the pushed-down predicate -- silently dropped
+-- rows. This test asserts rule-on == rule-off for the dotted key (cases b / b').
+--
+-- NOTE: case (a) below (a path ending at an intermediate OBJECT, $.o) is a SEPARATE,
+-- still-open issue: rule-on returns NULL where rule-off returns the sub-object. The
+-- rule-on result recorded here is the current (incorrect) behavior, NOT the desired one;
+-- it is kept only to pin the contrast and will be updated when the intermediate-object
+-- case is fixed.
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 1 properties("replication_num"="1");
+insert into t values
+ (1, parse_json('{"o":{"inner":10},"a.b":7}')),
+ (2, parse_json('{"o":{"inner":20},"a.b":8}'));
+
+-- (a) intermediate-object extraction. Correct answer = the sub-object.
+--     KNOWN OPEN: rule-on still returns NULL (intermediate-object prune bug, out of scope here).
+set cbo_prune_json_subfield = false;
+select id, cast(json_query(j,'$.o') as string) from t order by id;
+set cbo_prune_json_subfield = true;
+select id, cast(json_query(j,'$.o') as string) from t order by id;
+
+-- (b) dotted-key extraction. Correct answer = 7, 8 (rule-on must match rule-off).
+set cbo_prune_json_subfield = false;
+select id, get_json_int(j,'$."a.b"') from t order by id;
+set cbo_prune_json_subfield = true;
+select id, get_json_int(j,'$."a.b"') from t order by id;
+
+-- (b') dotted-key predicate -> must NOT drop rows. Correct answer = 2.
+set cbo_prune_json_subfield = false;
+select count(*) from t where get_json_int(j,'$."a.b"') > 0;
+set cbo_prune_json_subfield = true;
+select count(*) from t where get_json_int(j,'$."a.b"') > 0;


### PR DESCRIPTION
## Why I'm doing:

A JSON key whose name contains a literal '.' (e.g. {"a.b": 7}) is never written as a flat sub-column -- the flat-JSON path scheme uses '.' as the level separator, so such keys are kept in the `remain` blob (json_path_deriver skips them). On read, get_json_*(j,'$."a.b"') / a pushed PruneSubfield access path asks for the typed subfield "a.b". Two read paths mishandled it and returned NULL, which -- because the read also drives pushed-down predicates/joins/grouping -- became silent row loss and wrong aggregation, not just a wrong projected value:

1. JsonFlatPath::split_path split the requested path on every '.', shredding the FE-quoted key "a.b" into a bogus nested path "a"->"b" that matches nothing. Make it quote-aware: a "..."-wrapped level is one key (quotes stripped, interior '.' kept). No existing flat-leaf path starts with '"', so only the previously broken FE-wrapped dotted keys change behavior.

2. _extract_with_hyper (the default lazy/direct path, enable_lazy_dynamic_flat_json) gave up on a dotted key (in_flat=false), routing it through an empty-target "reconstruct whole JSON + real_path" flow that could not materialize the value from remain. Instead, wrap the dotted key in quotes and keep it as a flat path level so it rides the now quote-aware split and extracts from remain. A key whose name itself contains a '"' is still not representable and keeps the old fallback.

Keys colliding with the writer's reserved physical sub-columns ('nulls'/'remain') remain a separate, intentionally out-of-scope case.

## What I'm doing:

```
mysql>   select get_json_int(j,'$."a.b"')  from t ;
+----------------------------+
| get_json_int(j, '$."a.b"') |
+----------------------------+
|                          7 |
|                          8 |
+----------------------------+
2 rows in set (0.02 sec)

mysql> set cbo_prune_json_subfield = true;
Query OK, 0 rows affected (0.00 sec)

mysql>   select get_json_int(j,'$."a.b"')  from t ;
+----------------------------+
| get_json_int(j, '$."a.b"') |
+----------------------------+
|                       NULL |
|                       NULL |
+----------------------------+
2 rows in set (0.03 sec)

mysql> 
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
