### PR TITLE
[Enhancement] Bound tablet pre-split by a minimum tablet size

### DIFF
--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -563,6 +563,15 @@ This topic introduces the following types of FE configurations:
 - Description: The maximum number of new tablets that an old tablet can be split into.
 - Introduced in: v4.1.0
 
+### `tablet_reshard_min_split_size`
+
+- Default: 2147483648 (2 GB)
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: The minimum size of a tablet produced by tablet pre-split. It bounds compute-node alignment during pre-split so that a small load on a large cluster is not split into many tiny tablets. Should be no larger than `tablet_reshard_target_size`.
+- Introduced in: v4.1.0
+
 ### `tablet_reshard_history_job_max_keep_ms`
 
 - Default: 259200000 (72 hours)

--- a/docs/ja/administration/management/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/FE_parameters/stats_storage.md
@@ -563,6 +563,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：古いタブレットを分割できる新しいタブレットの最大数。
 - 導入時期：v4.1.0
 
+### `tablet_reshard_min_split_size`
+
+- デフォルト：2147483648 (2 GB)
+- タイプ：Long
+- 単位：Bytes
+- 変更可能：Yes
+- 説明：タブレットのプリスプリットで生成されるタブレットの最小サイズ。プリスプリット時のコンピュートノード数へのアライメントを制限し、ノード数の多いクラスターで小さなロードが多数の極小タブレットに分割されないようにします。`tablet_reshard_target_size` 以下にする必要があります。
+- 導入時期：v4.1.0
+
 ### `tablet_reshard_history_job_max_keep_ms`
 
 - デフォルト：259200000 (72 hours)

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -563,6 +563,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 旧 Tablet 最多可分割成多少个新 Tablet。
 - 引入版本: v4.1.0
 
+### `tablet_reshard_min_split_size`
+
+- 默认值: 2147483648 (2 GB)
+- 类型: Long
+- 单位: Bytes
+- 是否可变: Yes
+- 描述: Tablet 预分裂（pre-split）产生的 Tablet 的最小大小。该参数用于约束预分裂时按计算节点数对齐的行为，避免在节点较多的集群上将数据量较小的导入分裂成大量过小的 Tablet。其值不应大于 `tablet_reshard_target_size`。
+- 引入版本: v4.1.0
+
 ### `tablet_reshard_history_job_max_keep_ms`
 
 - 默认值: 259200000 (72 hours)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -483,6 +483,13 @@ public final class TabletPreSplitCoordinator {
      * The {@code max_split_count} cap takes precedence, so a clamped result is not
      * necessarily a multiple of the node count.
      *
+     * <p>The compute-node count used for the rounding/floor is itself bounded by how
+     * many {@code tablet_reshard_min_split_size} tablets the input can fill
+     * ({@code estimatedTotalBytes / tablet_reshard_min_split_size}). This stops a small
+     * load on a large cluster from being split into one tiny tablet per node — without
+     * it, the node-count floor alone would force {@code activeComputeNodeCount} tablets
+     * regardless of how little data there is.
+     *
      * @param estimates              full-input estimates from the sampler. Only
      *                               {@link Estimates#totalBytes} is read.
      * @param activeComputeNodeCount total provisioned compute nodes in the load's warehouse.
@@ -495,10 +502,13 @@ public final class TabletPreSplitCoordinator {
 
         long targetSize = Config.tablet_reshard_target_size;
         int maxSplitCount = Config.tablet_reshard_max_split_count;
+        long minSplitSize = Config.tablet_reshard_min_split_size;
         Preconditions.checkState(targetSize > 0,
                 "tablet_reshard_target_size must be > 0, was %s", targetSize);
         Preconditions.checkState(maxSplitCount >= 2,
                 "tablet_reshard_max_split_count must be >= 2, was %s", maxSplitCount);
+        Preconditions.checkState(minSplitSize > 0,
+                "tablet_reshard_min_split_size must be > 0, was %s", minSplitSize);
 
         // Integer ceil-divide written as (n - 1) / d + 1 with a zero-case guard so it
         // does not overflow when totalBytes is near Long.MAX_VALUE.
@@ -509,15 +519,23 @@ public final class TabletPreSplitCoordinator {
         // arithmetic (+ activeComputeNodeCount) from overflowing on a near-
         // Long.MAX_VALUE estimate (tiny target_size + huge input).
         long boundedByteTarget = Math.min(byteTargetTabletCount, maxSplitCount);
-        // Round the byte-volume estimate up to a whole multiple of the compute-node
-        // count so the tablets distribute evenly. A count that is not a multiple of
-        // the node count leaves some nodes owning one more tablet than the rest (e.g.
-        // 4 tablets on 3 nodes -> 2/1/1), skewing load-write and scan parallelism
-        // toward the heavier nodes.
+        // Bound the node count we align to by how many min-split-size tablets the input can
+        // fill (totalBytes / tablet_reshard_min_split_size). Without this, the rounding and
+        // node-count floor below would split a small load into one tiny tablet per node on a
+        // large cluster. effectiveMinSize is clamped to targetSize so the bound never forces
+        // tablets larger than the byte-volume target already implies; max(1, ...) keeps the
+        // divisor positive (and yields the minimum 2 after clamping for an empty input).
+        long effectiveMinSize = Math.min(minSplitSize, targetSize);
+        long maxTabletsByMinSize = totalBytes / effectiveMinSize;
+        long alignmentNodeCount = Math.min(activeComputeNodeCount, Math.max(1L, maxTabletsByMinSize));
+        // Round the byte-volume estimate up to a whole multiple of the (size-bounded) node
+        // count so the tablets distribute evenly. A count that is not a multiple of that node
+        // count leaves some nodes owning one more tablet than the rest (e.g. 4 tablets on 3
+        // nodes -> 2/1/1), skewing load-write and scan parallelism toward the heavier nodes.
         long nodeAlignedCount =
-                ((boundedByteTarget + activeComputeNodeCount - 1) / activeComputeNodeCount)
-                        * activeComputeNodeCount;
-        long proposed = Math.max(activeComputeNodeCount, nodeAlignedCount);
+                ((boundedByteTarget + alignmentNodeCount - 1) / alignmentNodeCount)
+                        * alignmentNodeCount;
+        long proposed = Math.max(alignmentNodeCount, nodeAlignedCount);
         long clamped = Math.max(2L, Math.min(proposed, maxSplitCount));
         return (int) clamped;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4595,6 +4595,16 @@ public class Config extends ConfigBase {
             + "repeated calls); values < 1 are treated as 1.")
     public static int tablet_reshard_colocate_checker_convergence_batch_size = 64;
 
+    /**
+     * The minimum size of a tablet produced by pre-split. Bounds the compute-node alignment
+     * during pre-split so that splitting a small load across many compute nodes does not
+     * carve tablets smaller than this value. Should be <= tablet_reshard_target_size.
+     */
+    @ConfField(mutable = true, comment = "The minimum size of a tablet produced by tablet pre-split. "
+            + "Bounds compute-node alignment so a small load on a large cluster is not split into many tiny tablets. "
+            + "Should be no larger than tablet_reshard_target_size.")
+    public static long tablet_reshard_min_split_size = 2L * 1024L * 1024L * 1024L;
+
     @ConfField(mutable = true, comment = "Whether to enable tablet merge in tablet reshard. " +
             "Only takes effect for tables in clusters with run_mode=shared_data.")
     public static boolean tablet_reshard_enable_tablet_merge = false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -99,14 +99,20 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
 
     private long savedConfigReshardTargetSize;
     private int savedConfigReshardMaxSplitCount;
+    private long savedConfigReshardMinSplitSize;
 
     @BeforeEach
     public void setUp() {
         // Pin tablet-count-selection inputs so the test arithmetic stays valid if defaults move.
         savedConfigReshardTargetSize = Config.tablet_reshard_target_size;
         savedConfigReshardMaxSplitCount = Config.tablet_reshard_max_split_count;
+        savedConfigReshardMinSplitSize = Config.tablet_reshard_min_split_size;
         Config.tablet_reshard_target_size = 50L * DebugUtil.MEGABYTE;
         Config.tablet_reshard_max_split_count = 1024;
+        // These tests exercise per-partition K selection and orchestration at MB scale, not the
+        // min-split-size bound (covered in TabletPreSplitCoordinatorTest). Disable it (1 byte) so
+        // compute-node alignment still drives K as the assertions below expect.
+        Config.tablet_reshard_min_split_size = 1L;
 
         // Wire a fresh PARTITIONS_TOTAL counter; MetricRepo.init() is not run inside unit
         // tests so the static field is otherwise null and a hasInit=true bump would NPE.
@@ -143,6 +149,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         MetricRepo.COUNTER_TABLET_PRE_SPLIT_PARTITIONS_TOTAL = savedPartitionsTotal;
         Config.tablet_reshard_target_size = savedConfigReshardTargetSize;
         Config.tablet_reshard_max_split_count = savedConfigReshardMaxSplitCount;
+        Config.tablet_reshard_min_split_size = savedConfigReshardMinSplitSize;
     }
 
     // ---------- Tests ----------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
@@ -62,6 +62,7 @@ public class TabletPreSplitCoordinatorTest {
     private boolean savedConfigBrokerLoad;
     private long savedConfigReshardTargetSize;
     private int savedConfigReshardMaxSplitCount;
+    private long savedConfigReshardMinSplitSize;
     private long savedConfigSampleByteLimit;
 
     @BeforeEach
@@ -70,12 +71,14 @@ public class TabletPreSplitCoordinatorTest {
         savedConfigBrokerLoad = Config.enable_tablet_pre_split_for_broker_load;
         savedConfigReshardTargetSize = Config.tablet_reshard_target_size;
         savedConfigReshardMaxSplitCount = Config.tablet_reshard_max_split_count;
+        savedConfigReshardMinSplitSize = Config.tablet_reshard_min_split_size;
         savedConfigSampleByteLimit = Config.tablet_pre_split_sample_byte_limit;
         Config.enable_tablet_pre_split_for_insert_from_files = true;
         Config.enable_tablet_pre_split_for_broker_load = false;
         // Pin tablet-count-selection inputs so the test arithmetic stays valid if defaults move.
         Config.tablet_reshard_target_size = 10L * DebugUtil.GIGABYTE;
         Config.tablet_reshard_max_split_count = 1024;
+        Config.tablet_reshard_min_split_size = 2L * DebugUtil.GIGABYTE;
         Config.tablet_pre_split_sample_byte_limit = 16L * DebugUtil.MEGABYTE;
 
         // Bind a fresh ConnectContext so the coordinator's session-var check finds one.
@@ -133,6 +136,7 @@ public class TabletPreSplitCoordinatorTest {
         Config.enable_tablet_pre_split_for_broker_load = savedConfigBrokerLoad;
         Config.tablet_reshard_target_size = savedConfigReshardTargetSize;
         Config.tablet_reshard_max_split_count = savedConfigReshardMaxSplitCount;
+        Config.tablet_reshard_min_split_size = savedConfigReshardMinSplitSize;
         Config.tablet_pre_split_sample_byte_limit = savedConfigSampleByteLimit;
     }
 
@@ -291,8 +295,10 @@ public class TabletPreSplitCoordinatorTest {
 
     @Test
     public void testTabletCountSmallLoadOnThreeComputeNodes() {
-        // 1 GB / 10 GB target rounds up to 1 tablet by bytes; compute-node floor of 3 wins.
-        Assertions.assertEquals(3, selectTabletCount(DebugUtil.GIGABYTE, 3));
+        // 1 GB load fills zero whole 2 GB min-split-size tablets, so the node count used for
+        // alignment collapses to 1 instead of 3. Clamp lifts the result to the minimum 2 —
+        // far better than 3 tablets of ~340 MB each.
+        Assertions.assertEquals(2, selectTabletCount(DebugUtil.GIGABYTE, 3));
     }
 
     @Test
@@ -317,7 +323,33 @@ public class TabletPreSplitCoordinatorTest {
 
     @Test
     public void testTabletCountSmallLoadOnTwelveComputeNodes() {
-        Assertions.assertEquals(12, selectTabletCount(DebugUtil.GIGABYTE, 12));
+        // A small load on a large cluster must NOT become one tiny tablet per node: 1 GB fills
+        // zero whole 2 GB tablets, so alignment collapses to 1 and the result clamps to 2
+        // (was 12 tablets of ~85 MB each before the min-split-size bound).
+        Assertions.assertEquals(2, selectTabletCount(DebugUtil.GIGABYTE, 12));
+    }
+
+    @Test
+    public void testTabletCountMinSplitSizeBoundsComputeNodeAlignment() {
+        // 30 GB on 100 nodes: the byte target is 3 tablets and node alignment would otherwise
+        // round/floor up to 100. The 2 GB min-split-size lets the input fill only 30 GB / 2 GB
+        // = 15 tablets, so alignment is bounded to 15 nodes -> 15 tablets of 2 GB each.
+        Assertions.assertEquals(15, selectTabletCount(30L * DebugUtil.GIGABYTE, 100));
+    }
+
+    @Test
+    public void testTabletCountMinSplitSizeCapKeepsNodeMultiple() {
+        // 5 GB on 10 nodes: fills only 5 GB / 2 GB = 2 whole min-split-size tablets, so
+        // alignment collapses from 10 to 2 nodes -> 2 tablets of 2.5 GB rather than 10 of 512 MB.
+        Assertions.assertEquals(2, selectTabletCount(5L * DebugUtil.GIGABYTE, 10));
+    }
+
+    @Test
+    public void testTabletCountMinSplitSizeIsTunable() {
+        // Raising the min-split-size to 5 GB tightens the bound: 30 GB / 5 GB = 6 whole tablets,
+        // so alignment is bounded to 6 nodes -> 6 tablets even though 100 nodes are available.
+        Config.tablet_reshard_min_split_size = 5L * DebugUtil.GIGABYTE;
+        Assertions.assertEquals(6, selectTabletCount(30L * DebugUtil.GIGABYTE, 100));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split rounds the byte-volume tablet estimate up to a whole
multiple of the active compute-node count and floors it at that node count, so that
tablets spread evenly across nodes (PR #75360). The floor is unconditional: on a
cluster with many compute nodes, a load whose data is small still gets split into one
tablet per node. For example a 1 GB load on a 12-node cluster is split into 12 tablets
of ~85 MB each, and a 5 GB load on a 100-node cluster into 100 tablets of ~50 MB each.
Lots of tiny tablets hurt compaction, metadata, and scan efficiency.

There was no lower bound on the resulting tablet size.

## What I'm doing:

Add a lower bound on the pre-split tablet **size** via a new FE config
`tablet_reshard_min_split_size` (default 2 GB, mutable). The compute-node count used for
the rounding/floor in `TabletPreSplitCoordinator.selectTabletCount` is now bounded by how
many min-split-size tablets the input can fill
(`totalBytes / tablet_reshard_min_split_size`):

```
effectiveMinSize    = min(tablet_reshard_min_split_size, tablet_reshard_target_size)
maxTabletsByMinSize = totalBytes / effectiveMinSize          // floor
alignmentNodeCount  = min(activeComputeNodeCount, max(1, maxTabletsByMinSize))
// round byteTarget up to a multiple of alignmentNodeCount, floor at alignmentNodeCount, clamp [2, max_split_count]
```

`effectiveMinSize` is clamped to `tablet_reshard_target_size` so the bound never forces
tablets larger than the byte-volume target already implies. Large loads keep full
per-node parallelism (when the data can fill at least one min-size tablet per node, the
bound is inert); only small-load-on-large-cluster over-splitting is reined in, and the
result stays a clean multiple of the (reduced) node count.

Effect with the 2 GB default (target_size = 10 GB):

| load / nodes | before | after |
|---|---|---|
| 1 GB / 12   | 12 (~85 MB each)  | 2           |
| 5 GB / 10   | 10 (~512 MB each) | 2 (~2.5 GB) |
| 30 GB / 100 | 100 (~300 MB each)| 15 (~2 GB)  |
| 100 GB / 12 | 12 (~8.3 GB each) | 12 (unchanged) |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5