### PR TITLE
[Enhancement] Support bitmap_agg (exact distinct count) in IVM aggregate MVs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -128,6 +128,9 @@ public class IVMAnalyzer {
                     // approx_count_distinct / ndv: HLL state union is well-defined.
                     .put(FunctionSet.APPROX_COUNT_DISTINCT,  args -> args.length == 1)
                     .put(FunctionSet.NDV,                    args -> args.length == 1)
+                    // bitmap_agg: exact distinct count. bitmap_union(to_bitmap(col)) normalizes to this;
+                    // BITMAP state unions associatively, so the delta merge is well-defined.
+                    .put(FunctionSet.BITMAP_AGG,             args -> args.length == 1)
                     .build();
 
     private static boolean isFixedOrFloat(Type t) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -96,6 +96,30 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * bitmap_union(to_bitmap(col)) is the exact-distinct-count pattern. The analyzer normalizes it to
+     * bitmap_agg(col) (raw INT arg, BITMAP intermediate state), which IVM must accept and maintain via
+     * the already-registered bitmap_agg combinators.
+     */
+    @Test
+    public void testBitmapUnionAggregateYieldsIvmRewrite() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_bitmap "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, bitmap_union(to_bitmap(c1)) FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+
+        assertTrue(result.isPresent(), "bitmap_union aggregate MV must produce an IVM rewrite result");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy());
+    }
+
+    /**
      * GROUP BY without aggregates (a DISTINCT-on-keys MV) must yield QUERY_COMPUTED, not
      * AUTO_INCREMENT — otherwise the MV row-id type disagrees with the refresh plan.
      */

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
@@ -119,7 +119,7 @@ AS SELECT k, dt, HLL_UNION(HLL_HASH(s_short)) AS h
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: hll_union. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv].')
+E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: hll_union. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv, bitmap_agg].')
 -- !result
 CREATE MATERIALIZED VIEW mv_bmp PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -128,7 +128,12 @@ AS SELECT k, dt, BITMAP_UNION(TO_BITMAP(k)) AS b
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: bitmap_agg. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv].')
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_bmp WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b) AS dc FROM mv_bmp ORDER BY k, dt;
+-- result:
+1	2023-12-01	1
+2	2023-12-02	1
 -- !result
 drop database db_${uuid0} force;
 -- result:

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
@@ -4,8 +4,8 @@
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
 --   * MIN/MAX(DECIMAL) — state is the value itself; no AVG-style (sum, count) plumbing
 --   * ARRAY_AGG(arg)   — single-arg accepted; ORDER BY variant rejected
--- HLL_UNION / BITMAP_UNION remain rejected (Column.type singleton mutation bug
--- in the underlying combinator path; deferred to a separate PR).
+--   * BITMAP_UNION(to_bitmap(...)) — now accepted: normalizes to bitmap_agg.
+-- HLL_UNION remains rejected (hll_union is not yet whitelisted; a separate change).
 
 create external catalog mv_iceberg_${uuid0}
 properties
@@ -107,8 +107,7 @@ AS SELECT k, dt, HLL_UNION(HLL_HASH(s_short)) AS h
    GROUP BY k, dt;
 
 -- ============================================================
--- NEGATIVE: BITMAP_UNION not in whitelist
--- expected: SemanticException "IVMAnalyzer does not support aggregate function: bitmap_union"
+-- POSITIVE: BITMAP_UNION(TO_BITMAP(...)) IVM MV — now accepted (normalizes to bitmap_agg)
 -- ============================================================
 CREATE MATERIALIZED VIEW mv_bmp PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -116,6 +115,8 @@ PROPERTIES ("refresh_mode" = "incremental")
 AS SELECT k, dt, BITMAP_UNION(TO_BITMAP(k)) AS b
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
+[UC]REFRESH MATERIALIZED VIEW mv_bmp WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b) AS dc FROM mv_bmp ORDER BY k, dt;
 
 -- cleanup
 drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

Incremental materialized views could not maintain an exact distinct-count aggregate. The common way users express it — `bitmap_union(to_bitmap(col))` — is normalized by the optimizer to `bitmap_agg(col)`, which was not in the IVM aggregate whitelist, so such an MV was rejected at CREATE time. Exact incremental distinct count (e.g. daily UV) is one of the most common materialized-view needs.

## What I'm doing:

Add `bitmap_agg` to `IVMAnalyzer.IVM_SUPPORTED_AGG_FUNCTIONS`. `bitmap_agg`'s argument is a raw integer, so it never hits the metric-type combinator gate in `AggStateUtils.isSupportedAggStateFunction`, and its combinators (`_combine` / `_state_union` / `_state_merge`) are already registered. The BITMAP intermediate state unions associatively, so the incremental delta merge is well-defined — the existing IVM combinator and delta-aggregate machinery maintains it with no other code change.

Tests: an `IVMAnalyzer` unit test, and flipping the `BITMAP_UNION` negative case in `test_ivm_whitelist_widening` to a positive (it normalizes to `bitmap_agg`). `HLL_UNION` stays rejected (hll_union is not yet whitelisted; a separate change).

Fixes #issue: N/A — IVM aggregate-whitelist extension, no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
