### PR TITLE
[BugFix] Keep shared vector-index .vi files alive during lake vacuum

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -156,13 +156,31 @@ int64_t calculate_retry_delay(int64_t last_delay, int64_t base, int64_t max_retr
 
 namespace {
 
+static bool is_shared_segment(const RowsetMetadataPB& rowset, int index) {
+    if (index >= rowset.segment_metas_size()) {
+        return false;
+    }
+    const auto& segment_meta = rowset.segment_metas(index);
+    return segment_meta.has_bundle_file_offset() || segment_meta.shared();
+}
+
 // Delete .vi files for segments in a rowset using segment_metas metadata.
-static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, const std::string& base_dir, int64_t tablet_id,
-                                     const RowsetMetadataPB& rowset) {
-    for (const auto& segment_meta : rowset.segment_metas()) {
+// A .vi is a per-segment sidecar whose lifetime follows its owning segment. When the
+// segment is shared across split siblings, its .vi must be routed through the
+// refcounting shared-file deleter so it is not deleted while a sibling still references
+// the segment (mirrors the segment routing in collect_garbage_files).
+static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, AsyncSharedFileDeleter* shared_file_deleter,
+                                     const std::string& base_dir, int64_t tablet_id, const RowsetMetadataPB& rowset) {
+    for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+        const auto& segment_meta = rowset.segment_metas(i);
+        const bool shared_file = is_shared_segment(rowset, i);
         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_name = gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id);
-            RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, vi_name)));
+            auto vi_path = join_path(base_dir, gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id));
+            if (shared_file && shared_file_deleter != nullptr) {
+                RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
+            } else {
+                RETURN_IF_ERROR(deleter->delete_file(vi_path));
+            }
         }
     }
     return Status::OK();
@@ -300,14 +318,6 @@ void run_clear_task_async(std::function<void()> task) {
     LOG_IF(ERROR, !st.ok()) << st;
 }
 
-static bool is_shared_segment(const RowsetMetadataPB& rowset, int index) {
-    if (index >= rowset.segment_metas_size()) {
-        return false;
-    }
-    const auto& segment_meta = rowset.segment_metas(index);
-    return segment_meta.has_bundle_file_offset() || segment_meta.shared();
-}
-
 static Status collect_garbage_files(const TabletMetadataPB& metadata, const std::string& base_dir,
                                     AsyncFileDeleter* deleter, AsyncSharedFileDeleter* shared_file_deleter,
                                     int64_t* garbage_data_size, const TabletRetainInfo& retain_info) {
@@ -325,8 +335,9 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
                 RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, rowset.segment_metas(i).filename())));
             }
         }
-        // Delete associated .vi files using per-segment vector index metadata
-        RETURN_IF_ERROR(delete_rowset_vi_files(deleter, base_dir, metadata.id(), rowset));
+        // Delete associated .vi files using per-segment vector index metadata. A shared
+        // segment's .vi follows the segment, so route it through the shared-file deleter.
+        RETURN_IF_ERROR(delete_rowset_vi_files(deleter, shared_file_deleter, base_dir, metadata.id(), rowset));
 
         for (const auto& del_file : rowset.del_files()) {
             if (del_file.shared() && shared_file_deleter != nullptr) {
@@ -370,7 +381,13 @@ static Status collect_alive_shared_files(TabletManager* tablet_mgr, const std::v
             for (const auto& rowset : metadata->rowsets()) {
                 for (int i = 0; i < rowset.segment_metas_size(); ++i) {
                     if (is_shared_segment(rowset, i)) {
-                        RETURN_IF_ERROR(deleter->delay_delete(join_path(data_dir, rowset.segment_metas(i).filename())));
+                        const auto& segment_meta = rowset.segment_metas(i);
+                        RETURN_IF_ERROR(deleter->delay_delete(join_path(data_dir, segment_meta.filename())));
+                        // A shared segment's per-segment .vi sidecars are shared too.
+                        for (int64_t vi_id : segment_meta.vector_index_ids()) {
+                            RETURN_IF_ERROR(deleter->delay_delete(join_path(
+                                    data_dir, gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id))));
+                        }
                     }
                 }
                 for (const auto& del_file : rowset.del_files()) {
@@ -1177,8 +1194,16 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 for (const auto& rowset : latest_metadata->rowsets()) {
                     for (int i = 0; i < rowset.segment_metas_size(); ++i) {
                         if (!is_shared_segment(rowset, i) || allow_delete_shared_files) {
-                            RETURN_IF_ERROR(
-                                    deleter.delete_file(join_path(data_dir, rowset.segment_metas(i).filename())));
+                            const auto& segment_meta = rowset.segment_metas(i);
+                            RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment_meta.filename())));
+                            // Delete the segment's per-segment .vi sidecars under the same shared
+                            // guard, so a shared segment's .vi is not removed while a sibling tablet
+                            // still references the segment.
+                            for (int64_t vi_id : segment_meta.vector_index_ids()) {
+                                RETURN_IF_ERROR(deleter.delete_file(
+                                        join_path(data_dir, gen_vector_index_filename(segment_meta.filename(),
+                                                                                      latest_metadata->id(), vi_id))));
+                            }
                         }
                     }
                     for (const auto& del_file : rowset.del_files()) {
@@ -1186,8 +1211,6 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
                         }
                     }
-                    // Delete associated .vi files using per-segment vector index metadata
-                    RETURN_IF_ERROR(delete_rowset_vi_files(&deleter, data_dir, latest_metadata->id(), rowset));
                 }
                 if (latest_metadata->has_delvec_meta()) {
                     for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, RANGE-distribution tablet split shares physical segment files across child tablets without rewriting them. A vector-index `.vi` file is a per-segment sidecar (`<segment>_<index_id>.vi`, derived from the segment filename, with no independent `shared` bit). Vacuum protects shared *segments* via the refcounting `AsyncSharedFileDeleter`, but deleted `.vi` files without honoring the owning segment's `shared` bit.

As a result, a split sibling's regular vacuum (`collect_garbage_files`) — or a tablet drop (`delete_tablets_impl`) — could delete a shared segment's `.vi` while another sibling still referenced that segment, silently degrading vector search on the surviving sibling. The `vector_index_built_version` watermark is carried forward, so the lost index is not automatically rebuilt.

## What I'm doing:

Make `.vi` deletion follow the owning segment's shared semantics, symmetric with how segments are already handled in vacuum:

- `delete_rowset_vi_files` (used by `collect_garbage_files`) routes a shared segment's `.vi` through the refcounting `AsyncSharedFileDeleter` instead of deleting it outright via the plain deleter.
- `collect_alive_shared_files` delay-deletes a shared segment's `.vi`, so it survives while any sibling still references the segment.
- The tablet-drop path (`delete_tablets_impl`) deletes `.vi` inline under the same `!is_shared_segment(...) || allow_delete_shared_files` guard as the segment itself.

No protobuf, split, or merge changes. The orphan scan already protects metadata-referenced `.vi`, and the async vector-index build path is tablet-id-agnostic, so no companion changes are needed.

Tests (`be/test/storage/lake/vacuum_test.cpp`): added `test_vacuum_shared_file_cleanup_keep_referenced_vector_index` (shared `.vi` kept while a sibling references the segment), `test_vacuum_shared_file_cleanup_unreferenced_vector_index` (reclaimed when unreferenced), and `test_delete_tablets_shared_metadata_files_vector_index` (drop path). Focused run: 21/21 LakeVacuumTest cases pass (the three new tests plus the pre-existing `.vi`/shared-metadata regressions).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5