### PR TITLE
[BugFix] Fix three FE leader-demotion bugs (seal NPE, closed-txn commit, routine-load slot leak)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -374,13 +374,21 @@ public class JournalWriter {
                     : new DrainResult(DrainResult.Status.BARRIER_REACHED, lastCommittedJournalId);
         }
 
+        // Capture the barrier task into a local: the journal-writer thread can complete and null
+        // out activeDrainBarrierTask very quickly (an empty/fast drain finishes in ~ms), so
+        // re-reading the field below would race to null -> NPE in waitForDrainResult -> the
+        // sealJournalWriter demotion stage fails and the node exits. Hold our own reference.
+        JournalTask barrierTask;
         if (activeDrainBarrierTask == null) {
             writerState.compareAndSet(WriterState.RUNNING, WriterState.SEALING);
-            activeDrainBarrierTask = JournalTask.createBarrierTask();
-            journalQueue.put(activeDrainBarrierTask);
+            barrierTask = JournalTask.createBarrierTask();
+            activeDrainBarrierTask = barrierTask;
+            journalQueue.put(barrierTask);
+        } else {
+            barrierTask = activeDrainBarrierTask;
         }
 
-        return waitForDrainResult(activeDrainBarrierTask, timeoutMs);
+        return waitForDrainResult(barrierTask, timeoutMs);
     }
 
     private boolean needForceRollJournal() {

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJEJournal.java
@@ -413,7 +413,16 @@ public class BDBJEJournal implements Journal {
                         currentTransaction.commit();
                     }
                     return;
-                } catch (DatabaseException e) {
+                } catch (DatabaseException | IllegalStateException e) {
+                    // IllegalStateException: the JE transaction was invalidated/closed before commit() ran
+                    // (e.g. it timed out during a long stall, or leadership was lost). JE's
+                    // Transaction.checkOpen() throws a plain java.lang.IllegalStateException ("Transaction
+                    // has been closed"), which is NOT a DatabaseException. If it escaped, it would bypass
+                    // JournalWriter.writeOneBatch's JournalException handler, the in-flight batch's tasks
+                    // would never be aborted, their waiting callers would block forever, and the leader WAL
+                    // apply in-flight fence would leak -> demotion's awaitLeaderWalAppliesDrained then times
+                    // out (leader_demotion_drain_timeout_sec) and System.exit(-1)s. Treat it as a commit
+                    // failure so the normal retry/abort path runs.
                     String errMsg = String.format("failed to commit journal after retried %d times! txn[%s] db[%s]",
                             i + 1, currentTransaction, currentJournalDB);
                     LOG.error(errMsg, e);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -218,6 +218,30 @@ public class RoutineLoadMgr implements Writable, MemoryTrackable {
         }
     }
 
+    /**
+     * Release every BE task slot this leader session reserved. Called from
+     * {@link RoutineLoadTaskScheduler#onStopped()} on leader demotion: the routine-load tasks the
+     * counts accounted for are abandoned once the leader session ends, so the per-backend usage must
+     * return to zero. Without this, every leader -> follower -> leader cycle leaks slots
+     * (takeBeTaskSlot only increments, demotion never releases, and updateBeTaskSlot does not reset
+     * already-present alive backends), eventually exhausting max_routine_load_task_num_per_be so
+     * takeBeTaskSlot returns -1 and no routine-load task can be scheduled again. Keeps the backend
+     * entries (capacity structure) intact; only zeroes usage.
+     */
+    public void clearBeTaskSlot() {
+        slotLock.lock();
+        try {
+            for (Map<Long, Integer> nodeMap : warehouseNodeTasksNum.values()) {
+                nodeMap.replaceAll((nodeId, count) -> 0);
+            }
+            for (Map<Long, Set<Long>> nodeToJobs : warehouseNodeToJobs.values()) {
+                nodeToJobs.values().forEach(Set::clear);
+            }
+        } finally {
+            slotLock.unlock();
+        }
+    }
+
     public void updateBeTaskSlot() {
         slotLock.lock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -157,6 +157,12 @@ public class RoutineLoadTaskScheduler extends LeaderDaemon {
         // The slot watermark is reset so the next leader re-queries BE slot capacity.
         needScheduleTasksQueue.clear();
         lastBackendSlotUpdateTime = -1;
+        // Release this leader session's BE task-slot reservations: the tasks they accounted for are
+        // abandoned on demotion. Without this the per-backend slot counts only grow across
+        // leader -> follower -> leader cycles (takeBeTaskSlot increments, demotion never releases,
+        // and updateBeTaskSlot does not reset already-present alive backends), eventually exhausting
+        // max_routine_load_task_num_per_be so the next leader can never dispatch a task.
+        routineLoadManager.clearBeTaskSlot();
     }
 
     private static void awaitTermination(String name, java.util.concurrent.ExecutorService pool, long deadlineMs) {

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
@@ -362,6 +362,67 @@ public class BDBJEJournalTest {
         journal.batchWriteCommit();
     }
 
+    @Test
+    public void testBatchWriteCommitConvertsTransactionClosedToJournalException(
+            @Mocked CloseSafeDatabase database,
+            @Mocked BDBEnvironment environment,
+            @Mocked Database rawDatabase,
+            @Mocked Environment rawEnvironment,
+            @Mocked Transaction txn) throws Exception {
+        // Regression: when a journal commit's BDBJE transaction was invalidated/closed before commit()
+        // ran (e.g. it timed out during a long stall while leadership was being handed off),
+        // Transaction.commit() throws a plain java.lang.IllegalStateException ("Transaction ... has been
+        // closed") -- NOT a DatabaseException. batchWriteCommit must convert it into a JournalException;
+        // otherwise the unchecked exception escapes JournalWriter.writeOneBatch's JournalException handler,
+        // the in-flight batch's tasks are never aborted, their waiting callers block forever, the leader
+        // WAL-apply fence leaks, and demotion's awaitLeaderWalAppliesDrained times out -> System.exit(-1).
+        BDBJEJournal journal = new BDBJEJournal(environment, database);
+        DataOutputBuffer buffer = new DataOutputBuffer();
+        Text.writeString(buffer, "petals on a wet black bough");
+
+        new Expectations(database) {
+            {
+                database.getDb();
+                minTimes = 0;
+                result = rawDatabase;
+                database.put((Transaction) any, (DatabaseEntry) any, (DatabaseEntry) any);
+                minTimes = 0;
+                result = OperationStatus.SUCCESS;
+            }
+        };
+        new Expectations(rawDatabase) {
+            {
+                rawDatabase.getEnvironment();
+                minTimes = 0;
+                result = rawEnvironment;
+                rawDatabase.getDatabaseName();
+                minTimes = 0;
+                result = "fakeDb";
+            }
+        };
+        new Expectations(rawEnvironment) {
+            {
+                rawEnvironment.beginTransaction(null, (TransactionConfig) any);
+                minTimes = 0;
+                result = txn;
+            }
+        };
+        new Expectations(txn) {
+            {
+                txn.commit();
+                result = new IllegalStateException("Transaction Id -1 has been closed");
+            }
+        };
+
+        journal.batchWriteBegin();
+        journal.batchWriteAppend(1, buffer);
+        // shouldRetry=false simulates a sealing/demoting writer (fail fast, no retry): the commit failure
+        // must surface as a JournalException, not let the unchecked IllegalStateException escape.
+        JournalException e = assertThrows(JournalException.class, () -> journal.batchWriteCommit(() -> false));
+        Assertions.assertTrue(e.getCause() instanceof IllegalStateException,
+                "the JE 'Transaction has been closed' ISE must be wrapped as the JournalException cause");
+    }
+
     // retry 1: commit fails
     // retry 2: begin txn with exception
     // retry 3: put return error

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSlotResetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadSlotResetTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.routineload;
+
+import com.starrocks.server.WarehouseManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RoutineLoadSlotResetTest {
+
+    @Test
+    public void testOnStoppedReleasesBeTaskSlotsOnDemotion() {
+        // Regression: per-backend routine-load task-slot counts are leader-session state. On
+        // demotion the tasks they account for are abandoned, so RoutineLoadTaskScheduler#onStopped()
+        // must release them. Without this, every leader->follower->leader cycle leaks slots
+        // (takeBeTaskSlot only ever increments, demotion never releases, and updateBeTaskSlot does
+        // not reset already-present alive backends), eventually exhausting
+        // max_routine_load_task_num_per_be so takeBeTaskSlot returns -1 and no routine-load task
+        // can be scheduled again.
+        RoutineLoadMgr mgr = new RoutineLoadMgr();
+        long nodeId = 10001L;
+        mgr.getNodeTasksNum().put(nodeId, 0);
+        int idleWhenEmpty = mgr.getClusterIdleSlotNum();
+        Assertions.assertTrue(idleWhenEmpty > 0, "precondition: backend has idle slots");
+
+        mgr.takeBeTaskSlot(WarehouseManager.DEFAULT_WAREHOUSE_ID, 1L);
+        mgr.takeBeTaskSlot(WarehouseManager.DEFAULT_WAREHOUSE_ID, 2L);
+        Assertions.assertTrue(mgr.getClusterIdleSlotNum() < idleWhenEmpty,
+                "precondition: slots should be taken");
+
+        RoutineLoadTaskScheduler scheduler = new RoutineLoadTaskScheduler(mgr);
+        scheduler.onStopped();
+
+        Assertions.assertEquals(idleWhenEmpty, mgr.getClusterIdleSlotNum(),
+                "onStopped() must release this leader session's BE task slots");
+        Assertions.assertEquals(0, (int) mgr.getNodeTasksNum().get(nodeId));
+        Assertions.assertTrue(
+                mgr.getNodeToJobs(WarehouseManager.DEFAULT_WAREHOUSE_ID).get(nodeId).isEmpty(),
+                "node->jobs mapping must be cleared on demotion");
+    }
+}


### PR DESCRIPTION
## Why / what

Three independent FE bugs in the leader-demotion / journal path that already exist on `main` (and released branches), split out of #75125 so they can be reviewed and backported on their own.

1. **`JournalWriter.sealAndGetCommittedWatermark` NPE** — after queueing the drain barrier it re-read the volatile `activeDrainBarrierTask` field for `waitForDrainResult()`; the journal-writer thread can complete the barrier and null the field within a few ms (empty/fast drain), so the re-read races to null → NPE → the `sealJournalWriter` demotion stage fails → `System.exit`, degrading a graceful leader transfer into a hard exit. Fixed by holding the task in a local. (This bug is present on `main` today — `JournalWriter.java` re-reads the field.)
2. **`BDBJEJournal.batchWriteCommit` closed-transaction `IllegalStateException`** — a commit racing a journal seal throws a closed-txn ISE that escaped the batch-abort path; treat it as a commit failure (alongside `DatabaseException`) so callers unblock instead of leaking the WAL-apply fence.
3. **`RoutineLoadTaskScheduler` BE task-slot leak on demotion** — BE task-slot counts were not released when the scheduler stopped on leader demotion, leaking slots across transfers (`no available be slot`). Release them in `RoutineLoadMgr.clearBeTaskSlot()` on stop.

## Tests

- `JournalWriter` NPE: validated on a real 5FE+3BE cluster — heavy in-flight ALTER + repeated transfers, 0 seal-NPE in any FE log (reproduced the NPE before the fix).
- `BDBJEJournalTest`, `RoutineLoadSlotResetTest` unit tests added.

## Backport

These bugs affect released versions — please backport to the active release branches (3.5 / 4.0 / 4.1).

Split from #75125 (leader-daemon graceful-demotion adaptation). Draft pending review.