### PR TITLE
[Enhancement] Make gradle parquet version the same as maven (1.16.0)

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -72,7 +72,7 @@ subprojects {
         set("nimbusds.version", "9.37.2")
         set("odps.version", "0.48.7-public")
         set("paimon.version", "1.3.1")
-        set("parquet.version", "1.15.2")
+        set("parquet.version", "1.16.0")
         set("orc.version", "1.9.1")
         set("protobuf-java.version", "3.25.5")
         set("puppycrawl.version", "10.21.1")


### PR DESCRIPTION
## Why I'm doing:

gradle and maven are out of sync as maven already uses 1.16.0

## What I'm doing:

bump gradle to 1.16.0

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
