### PR TITLE
[Enhancement] Push down range partition predicates to Hive Metastore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -145,6 +145,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
+    public List<String> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        return normal.listPartitionNamesByFilter(databaseName, tableName, filter);
+    }
+
+    @Override
     public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(tblName);
         if (metadata == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -123,6 +123,13 @@ public interface ConnectorMetadata {
     }
 
     /**
+     * List partition names by HMS filter expression, e.g. {@code dt >= '20260601' AND dt <= '20260607'}.
+     */
+    default List<String> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        return Lists.newArrayList();
+    }
+
+    /**
      * Get Table descriptor for the table specific by `dbName`.`tblName`
      *
      * @param dbName  - the string represents the database name

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -84,6 +84,9 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     // eg: HivePartitionValue -> List("year=2022/month=10", "year=2022/month=11")
     protected LoadingCache<HivePartitionValue, List<String>> partitionKeysCache;
 
+    // eg: HivePartitionFilter -> List("dt=20260601/hour=01/app=xxx", ...)
+    protected LoadingCache<HivePartitionFilter, List<String>> partitionKeysByFilterCache;
+
     // eg: "year=2022/month=10" -> Partition
     protected LoadingCache<HivePartitionName, Partition> partitionCache;
     protected LoadingCache<DatabaseTableName, HivePartitionStats> tableStatsCache;
@@ -159,9 +162,13 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         if (enableListNamesCache) {
             partitionKeysCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
                     .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
+            partitionKeysByFilterCache = newCacheBuilder(expireAfterWriteSec, refreshIntervalSec, maxSize)
+                    .build(asyncReloading(CacheLoader.from(this::loadPartitionKeysByFilter), executor));
         } else {
             partitionKeysCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
                     .build(asyncReloading(CacheLoader.from(this::loadPartitionKeys), executor));
+            partitionKeysByFilterCache = newCacheBuilder(NEVER_CACHE, NEVER_CACHE, NEVER_CACHE)
+                    .build(asyncReloading(CacheLoader.from(this::loadPartitionKeysByFilter), executor));
         }
 
         hmsExternalTableCache = newCacheBuilder(expireAfterWriteSec, NEVER_REFRESH, maxSize).build();
@@ -300,13 +307,41 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     }
 
     @Override
+    public List<String> getPartitionKeysByFilter(String dbName, String tableName, String filter) {
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        lastAccessTimeMap.put(databaseTableName, System.currentTimeMillis());
+        HivePartitionFilter hivePartitionFilter = HivePartitionFilter.of(databaseTableName, filter);
+        List<String> partitionNames = get(partitionKeysByFilterCache, hivePartitionFilter);
+        LOG.info("listPartitionsByFilter on {}.{} returned {} partitions, filter: {}", dbName, tableName,
+                partitionNames.size(), filter);
+        return partitionNames;
+    }
+
+    private List<String> loadPartitionKeysByFilter(HivePartitionFilter hivePartitionFilter) {
+        DatabaseTableName databaseTableName = hivePartitionFilter.getHiveTableName();
+        String dbName = databaseTableName.getDatabaseName();
+        String tableName = databaseTableName.getTableName();
+        String filter = hivePartitionFilter.getFilter();
+        LOG.info("Loading partitions by filter from metastore on {}.{}, filter: {}", dbName, tableName, filter);
+        return metastore.getPartitionKeysByFilter(dbName, tableName, filter);
+    }
+
+    @Override
     public boolean partitionExists(Table table, List<String> partitionValues) {
         return metastore.partitionExists(table, partitionValues);
     }
 
     private List<String> loadPartitionKeys(HivePartitionValue hivePartitionValue) {
-        return metastore.getPartitionKeysByValue(hivePartitionValue.getHiveTableName().getDatabaseName(),
-                hivePartitionValue.getHiveTableName().getTableName(), hivePartitionValue.getPartitionValues());
+        String dbName = hivePartitionValue.getHiveTableName().getDatabaseName();
+        String tableName = hivePartitionValue.getHiveTableName().getTableName();
+        List<Optional<String>> partitionValues = hivePartitionValue.getPartitionValues();
+        if (partitionValues.isEmpty()) {
+            LOG.debug("Loading all partition names from metastore on {}.{}", dbName, tableName);
+            return metastore.getPartitionKeys(dbName, tableName);
+        }
+        LOG.debug("Loading partition names by value from metastore on {}.{}, values: {}", dbName, tableName,
+                partitionValues);
+        return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
     public Database getDb(String dbName) {
@@ -725,6 +760,7 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         databaseNamesCache.invalidateAll();
         tableNamesCache.invalidateAll();
         partitionKeysCache.invalidateAll();
+        partitionKeysByFilterCache.invalidateAll();
         databaseCache.invalidateAll();
         tableCache.invalidateAll();
         partitionCache.invalidateAll();
@@ -752,6 +788,9 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     private void invalidateTablePartitionInfo(String dbName, String tableName, DatabaseTableName databaseTableName) {
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
                 equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
+        partitionKeysByFilterCache.asMap().keySet().stream().filter(hivePartitionFilter ->
+                hivePartitionFilter.getHiveTableName().equals(databaseTableName))
+                .forEach(partitionKeysByFilterCache::invalidate);
         List<HivePartitionName> presentPartitions = getPresentPartitionNames(partitionCache, dbName, tableName);
         partitionCache.invalidateAll(presentPartitions);
         List<HivePartitionName> presentPartitionStats = getPresentPartitionNames(partitionStatsCache, dbName, tableName);
@@ -762,6 +801,9 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
         DatabaseTableName databaseTableName = DatabaseTableName.of(partitionName.getDatabaseName(), partitionName.getTableName());
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
                 equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
+        partitionKeysByFilterCache.asMap().keySet().stream().filter(hivePartitionFilter ->
+                hivePartitionFilter.getHiveTableName().equals(databaseTableName))
+                .forEach(partitionKeysByFilterCache::invalidate);
         partitionCache.invalidate(partitionName);
         partitionStatsCache.synchronous().invalidate(partitionName);
     }
@@ -807,6 +849,9 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
                 databaseTableName = DatabaseTableName.of(hivePartitionName.getDatabaseName(), hivePartitionName.getTableName());
         partitionKeysCache.asMap().keySet().stream().filter(hivePartitionValue -> hivePartitionValue.getHiveTableName().
                 equals(databaseTableName)).forEach(partitionKeysCache::invalidate);
+        partitionKeysByFilterCache.asMap().keySet().stream().filter(hivePartitionFilter ->
+                hivePartitionFilter.getHiveTableName().equals(databaseTableName))
+                .forEach(partitionKeysByFilterCache::invalidate);
         partitionCache.put(hivePartitionName, partition);
         partitionStatsCache.put(hivePartitionName, CompletableFuture.completedFuture(updatedPartitionStats));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -258,6 +258,15 @@ public class HiveMetaClient {
         }
     }
 
+    public List<Partition> getPartitionsByFilter(String dbName, String tableName, String filter) {
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.listPartitionsByFilter")) {
+            Class<?>[] argClasses = {String.class, String.class, String.class, short.class};
+            return callRPC("listPartitionsByFilter",
+                    String.format("Failed to listPartitionsByFilter on [%s.%s]", dbName, tableName),
+                    argClasses, dbName, tableName, filter, (short) -1);
+        }
+    }
+
     public Database getDb(String dbName) {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.getDatabase")) {
             return callRPC("getDatabase", String.format("Failed to get database %s", dbName), dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -342,6 +342,11 @@ public class HiveMetadata implements ConnectorMetadata {
         return hmsOps.getPartitionKeysByValue(dbName, tblName, partitionValues);
     }
 
+    @Override
+    public List<String> listPartitionNamesByFilter(String dbName, String tblName, String filter) {
+        return hmsOps.getPartitionKeysByFilter(dbName, tblName, filter);
+    }
+
     private List<Partition> buildGetRemoteFilesPartitions(Table table, GetRemoteFilesParams params) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         if (table.isUnPartitioned()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
@@ -55,7 +56,7 @@ import static com.starrocks.connector.hive.Partition.TRANSIENT_LAST_DDL_TIME;
 
 public class HiveMetastore implements IHiveMetastore {
 
-    private static final Logger LOG = LogManager.getLogger(CachingHiveMetastore.class);
+    private static final Logger LOG = LogManager.getLogger(HiveMetastore.class);
     private final HiveMetaClient client;
     private final String catalogName;
     private final MetastoreType metastoreType;
@@ -155,6 +156,43 @@ public class HiveMetastore implements IHiveMetastore {
                     .map(v -> v.orElse("")).collect(Collectors.toList());
             return client.getPartitionKeysByValue(dbName, tableName, partitionValuesStr);
         }
+    }
+
+    @Override
+    public List<String> getPartitionKeysByFilter(String dbName, String tableName, String filter) {
+        LOG.info("Calling HMS listPartitionsByFilter on {}.{}, filter: {}", dbName, tableName, filter);
+        org.apache.hadoop.hive.metastore.api.Table table = client.getTable(dbName, tableName);
+        List<String> partitionColumnNames = table.getPartitionKeys().stream()
+                .map(FieldSchema::getName)
+                .collect(Collectors.toList());
+        if (partitionColumnNames.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions =
+                client.getPartitionsByFilter(dbName, tableName, filter);
+
+        if (partitions == null || partitions.isEmpty()) {
+            LOG.info("HMS listPartitionsByFilter returned 0 partitions on {}.{}, filter: {}", dbName, tableName, filter);
+            return Lists.newArrayList();
+        }
+        List<String> partitionNames = Lists.newArrayListWithCapacity(partitions.size());
+        for (org.apache.hadoop.hive.metastore.api.Partition partition : partitions) {
+            if (partition == null || partition.getValues() == null) {
+                LOG.warn("Skip null partition returned by listPartitionsByFilter on {}.{}", dbName, tableName);
+                continue;
+            }
+            if (partition.getValues().size() != partitionColumnNames.size()) {
+                throw new StarRocksConnectorException(
+                        "Partition values size %s does not match partition column size %s on %s.%s, values: %s",
+                        partition.getValues().size(), partitionColumnNames.size(), dbName, tableName,
+                        partition.getValues());
+            }
+            partitionNames.add(toHivePartitionName(partitionColumnNames, partition.getValues()));
+        }
+        LOG.info("HMS listPartitionsByFilter returned {} partitions on {}.{}, filter: {}", partitionNames.size(),
+                dbName, tableName, filter);
+        return partitionNames;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -283,6 +283,19 @@ public class HiveMetastoreOperations {
         return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
+    public List<String> getPartitionKeysByFilter(String dbName, String tableName, String filter) {
+        Table table = getTable(dbName, tableName);
+        if (table instanceof HiveTable) {
+            HiveTable hiveTable = (HiveTable) table;
+            if (partitionProjectionService.isEnabled(table)) {
+                LOG.info("Partition projection enabled on {}.{}, skip HMS filter pushdown and use partial list API",
+                        dbName, tableName);
+                return getPartitionKeysByValue(dbName, tableName, HivePartitionValue.ALL_PARTITION_VALUES);
+            }
+        }
+        return metastore.getPartitionKeysByFilter(dbName, tableName, filter);
+    }
+
     public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
         return metastore.getPartition(dbName, tableName, partitionValues);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionFilter.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.base.Objects;
+import com.starrocks.connector.DatabaseTableName;
+
+public class HivePartitionFilter {
+    private final DatabaseTableName tableName;
+    private final String filter;
+
+    public HivePartitionFilter(DatabaseTableName tableName, String filter) {
+        this.tableName = tableName;
+        this.filter = filter;
+    }
+
+    public static HivePartitionFilter of(DatabaseTableName tableName, String filter) {
+        return new HivePartitionFilter(tableName, filter);
+    }
+
+    public DatabaseTableName getHiveTableName() {
+        return tableName;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HivePartitionFilter)) {
+            return false;
+        }
+        HivePartitionFilter that = (HivePartitionFilter) o;
+        return Objects.equal(tableName, that.tableName) && Objects.equal(filter, that.filter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tableName, filter);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -42,6 +42,10 @@ public interface IHiveMetastore extends IMetastore {
 
     List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues);
 
+    default List<String> getPartitionKeysByFilter(String dbName, String tableName, String filter) {
+        return Lists.newArrayList();
+    }
+
     default Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionNames) {
         return Maps.newHashMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -113,6 +113,11 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<String> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        return hmsOps.getPartitionKeysByFilter(databaseName, tableName, filter);
+    }
+
+    @Override
     public Database getDb(ConnectContext context, String dbName) {
         Database database;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -195,6 +195,12 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     }
 
     @Override
+    public List<String> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        ConnectorMetadata metadata = metadataOfTable(databaseName, tableName);
+        return metadata.listPartitionNamesByFilter(databaseName, tableName, filter);
+    }
+
+    @Override
     public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(dbName, tblName);
         return metadata.getTable(context, dbName, tblName);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -709,6 +709,27 @@ public class MetadataMgr {
         return ImmutableList.copyOf(partitionNames.build());
     }
 
+    public List<String> listPartitionNamesByFilter(String catalogName, String dbName, String tableName, String filter) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        ImmutableSet.Builder<String> partitionNames = ImmutableSet.builder();
+        if (connectorMetadata.isPresent()) {
+            try {
+                LOG.info("listPartitionNamesByFilter on {}.{}.{}, filter: {}", catalogName, dbName, tableName, filter);
+                connectorMetadata.get().listPartitionNamesByFilter(dbName, tableName, filter).
+                        forEach(partitionNames::add);
+                List<String> result = ImmutableList.copyOf(partitionNames.build());
+                LOG.info("listPartitionNamesByFilter on {}.{}.{} returned {} partitions, filter: {}",
+                        catalogName, dbName, tableName, result.size(), filter);
+                return result;
+            } catch (Exception e) {
+                LOG.error("Failed to listPartitionNamesByFilter on [{}.{}.{}], filter: {}", catalogName, dbName,
+                        tableName, filter, e);
+                throw e;
+            }
+        }
+        return ImmutableList.copyOf(partitionNames.build());
+    }
+
     public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator, Column> columns) {
         Statistics.Builder statistics = Statistics.builder();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -64,6 +64,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -81,6 +82,35 @@ import static com.starrocks.connector.paimon.PaimonMetadata.getRowCount;
 
 public class OptExternalPartitionPruner {
     private static final Logger LOG = LogManager.getLogger(OptExternalPartitionPruner.class);
+
+    /**
+     * HMS partition filter for metadata pruning: either equality values or a range filter string.
+     */
+    public static class PartitionPruneFilter {
+        private final List<Optional<String>> eqPartitionValues;
+        private final Optional<String> hmsFilter;
+
+        public PartitionPruneFilter(List<Optional<String>> eqPartitionValues, Optional<String> hmsFilter) {
+            this.eqPartitionValues = eqPartitionValues;
+            this.hmsFilter = hmsFilter;
+        }
+
+        public List<Optional<String>> getEqPartitionValues() {
+            return eqPartitionValues;
+        }
+
+        public Optional<String> getHmsFilter() {
+            return hmsFilter;
+        }
+
+        public boolean useEqFilter() {
+            return eqPartitionValues.stream().anyMatch(Optional::isPresent) && hmsFilter.isEmpty();
+        }
+
+        public boolean useRangeFilter() {
+            return hmsFilter.isPresent();
+        }
+    }
 
     public static LogicalScanOperator prunePartitions(OptimizerContext context,
                                                       LogicalScanOperator logicalScanOperator) {
@@ -269,6 +299,155 @@ public class OptExternalPartitionPruner {
         return effectivePartitionPredicate;
     }
 
+    /**
+     * Build partition metadata filter for HMS. Supports equality pushdown via listPartitionNamesByValue,
+     * and range pushdown via listPartitionsByFilter for partition columns that have range predicates.
+     */
+    public static PartitionPruneFilter getPartitionPruneFilter(LogicalScanOperator operator,
+                                                               List<Column> partitionColumns,
+                                                               ScalarOperator predicate) {
+        if (partitionColumns.isEmpty()) {
+            return new PartitionPruneFilter(Lists.newArrayList(), Optional.empty());
+        }
+        List<Optional<ScalarOperator>> effectiveEqPredicates =
+                getEffectivePartitionPredicate(operator, partitionColumns, predicate);
+        if (effectiveEqPredicates.stream().anyMatch(Optional::isPresent)) {
+            return new PartitionPruneFilter(getPartitionValue(effectiveEqPredicates), Optional.empty());
+        }
+        Optional<String> hmsFilter = buildHmsRangeFilter(operator, partitionColumns, predicate);
+        if (hmsFilter.isPresent()) {
+            return new PartitionPruneFilter(
+                    Lists.newArrayList(Optional.empty()), hmsFilter);
+        }
+        return new PartitionPruneFilter(
+                partitionColumns.stream().map(c -> Optional.<String>empty()).collect(Collectors.toList()),
+                Optional.empty());
+    }
+
+    private static BinaryType flipBinaryType(BinaryType type) {
+        switch (type) {
+            case GE:
+                return BinaryType.LE;
+            case GT:
+                return BinaryType.LT;
+            case LE:
+                return BinaryType.GE;
+            case LT:
+                return BinaryType.GT;
+            default:
+                return type;
+        }
+    }
+
+    private static boolean isHmsFilterSupportedPartitionType(Column partitionColumn) {
+        return partitionColumn.getType().isStringType()
+                || partitionColumn.getType().isIntegerType()
+                || partitionColumn.getType().isNumericType();
+    }
+
+    private static Optional<String> buildHmsRangeFilter(LogicalScanOperator operator, List<Column> partitionColumns,
+                                                          ScalarOperator predicate) {
+        if (predicate == null) {
+            return Optional.empty();
+        }
+        List<String> filters = Lists.newArrayList();
+        boolean hasRange = false;
+        for (Column partitionColumn : partitionColumns) {
+            if (!isHmsFilterSupportedPartitionType(partitionColumn)) {
+                continue;
+            }
+            ColumnRefOperator columnRef = operator.getColumnReference(partitionColumn);
+            for (ScalarOperator conjunct : Utils.extractConjuncts(predicate)) {
+                Optional<String> filter = toHmsColumnFilter(conjunct, columnRef, partitionColumn.getName());
+                if (filter.isPresent()) {
+                    filters.add(filter.get());
+                    if (filter.get().contains(">") || filter.get().contains("<")) {
+                        hasRange = true;
+                    }
+                }
+            }
+        }
+        if (!hasRange || filters.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(String.join(" AND ", filters));
+    }
+
+    private static Optional<String> toHmsColumnFilter(ScalarOperator conjunct, ColumnRefOperator columnRef,
+                                                      String columnName) {
+        if (!(conjunct instanceof BinaryPredicateOperator)) {
+            return Optional.empty();
+        }
+        BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
+        BinaryType binaryType = binary.getBinaryType();
+        if (!binaryType.isEqual() && !binaryType.isRange()) {
+            return Optional.empty();
+        }
+        ScalarOperator left = binary.getChild(0);
+        ScalarOperator right = binary.getChild(1);
+        if (left.isColumnRef() && columnRef.equals(left) && right.isConstantRef()) {
+            return Optional.of(formatHmsFilter(columnName, binaryType, (ConstantOperator) right));
+        }
+        if (right.isColumnRef() && columnRef.equals(right) && left.isConstantRef()) {
+            return Optional.of(formatHmsFilter(columnName, flipBinaryType(binaryType), (ConstantOperator) left));
+        }
+        return Optional.empty();
+    }
+
+    private static String formatHmsFilter(String columnName, BinaryType binaryType, ConstantOperator constant) {
+        String op;
+        switch (binaryType) {
+            case EQ:
+                op = "=";
+                break;
+            case GE:
+                op = ">=";
+                break;
+            case GT:
+                op = ">";
+                break;
+            case LE:
+                op = "<=";
+                break;
+            case LT:
+                op = "<";
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported binary type: " + binaryType);
+        }
+        String value = getConstantStringValue(constant);
+        if (needsQuoteForHmsFilter(constant)) {
+            return columnName + " " + op + " '" + escapeHmsFilterValue(value) + "'";
+        }
+        return columnName + " " + op + " " + value;
+    }
+
+    private static boolean needsQuoteForHmsFilter(ConstantOperator constant) {
+        return constant.getType().isStringType()
+                || constant.getType().isDate()
+                || constant.getType().isDatetime();
+    }
+
+    private static String getConstantStringValue(ConstantOperator constant) {
+        if (constant.getType().isStringType()) {
+            return constant.getVarchar();
+        }
+        if (constant.getType().isDate()) {
+            LocalDateTime dateTime = constant.getDate();
+            return String.format("%04d-%02d-%02d", dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth());
+        }
+        if (constant.getType().isDatetime()) {
+            LocalDateTime dateTime = constant.getDatetime();
+            return String.format("%04d-%02d-%02d %02d:%02d:%02d", dateTime.getYear(), dateTime.getMonthValue(),
+                    dateTime.getDayOfMonth(), dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond());
+        }
+        return constant.toString();
+    }
+
+    private static String escapeHmsFilterValue(String value) {
+        return value.replace("'", "''");
+    }
+
     private static List<Optional<String>> getPartitionValue(List<Optional<ScalarOperator>> predicates) {
         List<Optional<String>> partitionValues = Lists.newArrayList();
         for (Optional<ScalarOperator> predicate : predicates) {
@@ -322,18 +501,35 @@ public class OptExternalPartitionPruner {
 
                 // get partition names
                 List<String> partitionNames;
-                // check if the partition predicate could be used for filter partition names
-                List<Optional<ScalarOperator>> effectivePartitionPredicate =
-                        getEffectivePartitionPredicate(operator, partitionColumns, operator.getPredicate());
-                if (effectivePartitionPredicate.stream().anyMatch(Optional::isPresent)) {
-                    List<Optional<String>> partitionValues = getPartitionValue(effectivePartitionPredicate);
+                PartitionPruneFilter partitionPruneFilter = getPartitionPruneFilter(operator, partitionColumns,
+                        operator.getPredicate());
+                String catalogName = table.getCatalogName();
+                String dbName = table.getCatalogDBName();
+                String tableName = table.getCatalogTableName();
+                if (partitionPruneFilter.useEqFilter()) {
+                    LOG.info("Hive partition prune using eq filter, table: {}.{}.{}, values: {}",
+                            catalogName, dbName, tableName, partitionPruneFilter.getEqPartitionValues());
                     partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .listPartitionNamesByValue(table.getCatalogName(), table.getCatalogDBName(),
-                                    table.getCatalogTableName(), partitionValues);
+                            .listPartitionNamesByValue(catalogName, dbName, tableName,
+                                    partitionPruneFilter.getEqPartitionValues());
+                    LOG.info("Hive partition prune eq filter returned {} partitions, table: {}.{}.{}",
+                            partitionNames.size(), catalogName, dbName, tableName);
+                } else if (partitionPruneFilter.useRangeFilter()) {
+                    String hmsFilter = partitionPruneFilter.getHmsFilter().get();
+                    LOG.info("Hive partition prune using range filter, table: {}.{}.{}, hmsFilter: {}",
+                            catalogName, dbName, tableName, hmsFilter);
+                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .listPartitionNamesByFilter(catalogName, dbName, tableName, hmsFilter);
+                    LOG.info("Hive partition prune range filter returned {} partitions, table: {}.{}.{}, hmsFilter: {}",
+                            partitionNames.size(), catalogName, dbName, tableName, hmsFilter);
                 } else {
+                    LOG.info("Hive partition prune using full partition list, table: {}.{}.{}", catalogName, dbName,
+                            tableName);
                     partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .listPartitionNames(table.getCatalogName(), table.getCatalogDBName(),
-                                    table.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT);
+                            .listPartitionNames(catalogName, dbName, tableName,
+                                    ConnectorMetadataRequestContext.DEFAULT);
+                    LOG.info("Hive partition prune full list returned {} partitions, table: {}.{}.{}",
+                            partitionNames.size(), catalogName, dbName, tableName);
                 }
 
                 List<PartitionKey> keys = new ArrayList<>();

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1262,39 +1262,43 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     @Override
     public int getNumPartitionsByFilter(String dbName, String tableName, String filter)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return getNumPartitionsByFilter(null, dbName, tableName, filter);
     }
 
     @Override
     public int getNumPartitionsByFilter(String catName, String dbName, String tableName, String filter)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return client.get_num_partitions_by_filter(
+                MetaStoreUtils.prependCatalogToDbName(catName, dbName, conf), tableName, filter);
     }
 
     @Override
     public List<Partition> listPartitionsByFilter(String db_name, String tbl_name, String filter, short max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return listPartitionsByFilter(null, db_name, tbl_name, filter, max_parts);
     }
 
     @Override
     public List<Partition> listPartitionsByFilter(String catName, String db_name, String tbl_name, String filter,
                                                   int max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return client.get_partitions_by_filter(
+                MetaStoreUtils.prependCatalogToDbName(catName, db_name, conf), tbl_name, filter,
+                shrinkMaxtoShort(max_parts));
     }
 
     @Override
     public PartitionSpecProxy listPartitionSpecsByFilter(String db_name, String tbl_name, String filter, int max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return listPartitionSpecsByFilter(null, db_name, tbl_name, filter, max_parts);
     }
 
     @Override
     public PartitionSpecProxy listPartitionSpecsByFilter(String catName, String db_name, String tbl_name, String filter,
                                                          int max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return PartitionSpecProxy.Factory.get(client.get_part_specs_by_filter(
+                MetaStoreUtils.prependCatalogToDbName(catName, db_name, conf), tbl_name, filter, max_parts));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -462,6 +462,19 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testGetPartitionKeysByFilter() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        List<String> partitionNames = cachingHiveMetastore.getPartitionKeysByFilter("db1", "tbl1",
+                "col1 >= '20260601' AND col1 <= '20260606'");
+        Assertions.assertEquals(Lists.newArrayList("col1=20260601"), partitionNames);
+        // second call should hit filter cache, not full partition list cache
+        Assertions.assertEquals(partitionNames, cachingHiveMetastore.getPartitionKeysByFilter("db1", "tbl1",
+                "col1 >= '20260601' AND col1 <= '20260606'"));
+    }
+
+    @Test
     public void testGetPartitionKeys() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, executor,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.hive;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.ExceptionChecker;
 import mockit.Mock;
 import mockit.MockUp;
@@ -21,12 +22,17 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TSocket;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 public class HiveMetastoreClientTest {
     @Test
@@ -51,5 +57,64 @@ public class HiveMetastoreClientTest {
         ExceptionChecker.expectThrowsWithMsg(NoSuchObjectException.class,
                 "Table not found",
                 () -> metaStoreClient.getTable("db", "table"));
+    }
+
+    @Test
+    public void testListPartitionsByFilter(@Mocked ThriftHiveMetastore.Iface client) throws TException {
+        new MockUp<TSocket>() {
+            @Mock
+            public boolean isOpen() {
+                return true;
+            }
+        };
+
+        Partition partition = new Partition();
+        partition.setValues(Lists.newArrayList("20260601"));
+
+        new MockUp<ThriftHiveMetastore.Client>() {
+            @Mock
+            List<Partition> get_partitions_by_filter(String dbName, String tblName, String filter, short maxParts)
+                    throws MetaException, NoSuchObjectException, TException {
+                Assertions.assertEquals("db", dbName);
+                Assertions.assertEquals("tbl", tblName);
+                Assertions.assertEquals("dt >= '20260601' AND dt <= '20260606'", filter);
+                Assertions.assertEquals((short) -1, maxParts);
+                return Lists.newArrayList(partition);
+            }
+        };
+
+        Configuration configuration = new HiveConf();
+        configuration.set("metastore.thrift.uris", "thrift://127.0.0.1:1234");
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(configuration);
+        List<Partition> partitions = metaStoreClient.listPartitionsByFilter(
+                "db", "tbl", "dt >= '20260601' AND dt <= '20260606'", (short) -1);
+        Assertions.assertEquals(1, partitions.size());
+        Assertions.assertEquals("20260601", partitions.get(0).getValues().get(0));
+    }
+
+    @Test
+    public void testListPartitionsByFilterPropagatesNoSuchObject(@Mocked ThriftHiveMetastore.Iface client)
+            throws TException {
+        new MockUp<TSocket>() {
+            @Mock
+            public boolean isOpen() {
+                return true;
+            }
+        };
+
+        new MockUp<ThriftHiveMetastore.Client>() {
+            @Mock
+            List<Partition> get_partitions_by_filter(String dbName, String tblName, String filter, short maxParts)
+                    throws MetaException, NoSuchObjectException, TException {
+                throw new NoSuchObjectException("Table not found");
+            }
+        };
+
+        Configuration configuration = new HiveConf();
+        configuration.set("metastore.thrift.uris", "thrift://127.0.0.1:1234");
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(configuration);
+        ExceptionChecker.expectThrowsWithMsg(NoSuchObjectException.class,
+                "Table not found",
+                () -> metaStoreClient.listPartitionsByFilter("db", "missing_tbl", "dt = '20260601'", (short) -1));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -104,6 +105,33 @@ public class HiveMetastoreTest {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
         Assertions.assertTrue(metastore.tableExists("db1", "tbl1"));
+    }
+
+    @Test
+    public void testGetPartitionKeysByFilter() {
+        HiveMetaClient client = new MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        List<String> partitionNames = metastore.getPartitionKeysByFilter("db1", "tbl1",
+                "col1 >= '20260601' AND col1 <= '20260606'");
+        Assertions.assertEquals(Lists.newArrayList("col1=20260601"), partitionNames);
+    }
+
+    @Test
+    public void testGetPartitionKeysByFilterEmptyResult() {
+        HiveMetaClient client = new MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        List<String> partitionNames = metastore.getPartitionKeysByFilter("db1", "tbl1",
+                "col1 >= '20990101'");
+        Assertions.assertEquals(Lists.newArrayList(), partitionNames);
+    }
+
+    @Test
+    public void testGetPartitionKeysByFilterMultiColumn() {
+        HiveMetaClient client = new MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        List<String> partitionNames = metastore.getPartitionKeysByFilter("db1", "multi_part_tbl",
+                "dt >= '20260601' AND dt <= '20260606'");
+        Assertions.assertEquals(Lists.newArrayList("dt=20260601/hour=01/app=test"), partitionNames);
     }
 
     @Test
@@ -330,7 +358,15 @@ public class HiveMetastoreTest {
                     return getTransactionalTable(dbName, tblName, false);
                 }
             }
-            List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "INT", ""));
+            List<FieldSchema> partKeys;
+            if (tblName.equals("multi_part_tbl")) {
+                partKeys = Lists.newArrayList(
+                        new FieldSchema("dt", "STRING", ""),
+                        new FieldSchema("hour", "STRING", ""),
+                        new FieldSchema("app", "STRING", ""));
+            } else {
+                partKeys = Lists.newArrayList(new FieldSchema("col1", "INT", ""));
+            }
             List<FieldSchema> unPartKeys;
             if (tblName.equals("spark_table")) {
                 unPartKeys = Lists.newArrayList(
@@ -480,7 +516,30 @@ public class HiveMetastoreTest {
         }
 
         public List<String> getPartitionKeysByValue(String dbName, String tableName, List<String> partitionValues) {
+            if ("multi_part_tbl".equals(tableName) && !partitionValues.isEmpty()) {
+                String dt = partitionValues.get(0);
+                if ("20260601".equals(dt)) {
+                    return Lists.newArrayList("dt=20260601/hour=01/app=test", "dt=20260601/hour=02/app=test");
+                } else if ("20260602".equals(dt)) {
+                    return Lists.newArrayList("dt=20260602/hour=01/app=test");
+                }
+                return Lists.newArrayList();
+            }
             return Lists.newArrayList("col1");
+        }
+
+        public List<Partition> getPartitionsByFilter(String dbName, String tableName, String filter) {
+            if (filter != null && filter.contains("20990101")) {
+                return Lists.newArrayList();
+            }
+            if ("multi_part_tbl".equals(tableName)) {
+                Partition partition = new Partition();
+                partition.setValues(Lists.newArrayList("20260601", "01", "test"));
+                return Lists.newArrayList(partition);
+            }
+            Partition partition = new Partition();
+            partition.setValues(Lists.newArrayList("20260601"));
+            return Lists.newArrayList(partition);
         }
 
         public void addPartitions(String dbName, String tableName, List<Partition> partitions) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -716,6 +716,250 @@ public class ListPartitionPrunerTest {
     }
 
     @Test
+    public void testGetPartitionPruneFilterWithUserReportedSql() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        Column hourCol = new Column("hour", StringType.STRING);
+        Column appCol = new Column("app", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(32, StringType.STRING, "dt", true);
+        ColumnRefOperator hourColumnRef = new ColumnRefOperator(33, StringType.STRING, "hour", true);
+        ColumnRefOperator appColumnRef = new ColumnRefOperator(34, StringType.STRING, "app", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+        columnMetaToColRefMap.put(hourCol, hourColumnRef);
+        columnMetaToColRefMap.put(appCol, appColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt", "hour", "app"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef, ConstantOperator.createVarchar("20260601")),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef, ConstantOperator.createVarchar("20260606")));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator,
+                        ImmutableList.of(dtCol, hourCol, appCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertTrue(filter.useRangeFilter());
+        Assertions.assertEquals("dt >= '20260601' AND dt <= '20260606'", filter.getHmsFilter().get());
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithStringRange() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(10, StringType.STRING, "dt", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef, ConstantOperator.createVarchar("20260601")),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef, ConstantOperator.createVarchar("20260607")));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator, ImmutableList.of(dtCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertTrue(filter.useRangeFilter());
+        Assertions.assertEquals("dt >= '20260601' AND dt <= '20260607'", filter.getHmsFilter().get());
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithEqPredicate() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(12, StringType.STRING, "dt", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, dtColumnRef,
+                ConstantOperator.createVarchar("20260601"));
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator, ImmutableList.of(dtCol), predicate);
+        Assertions.assertTrue(filter.useEqFilter());
+        Assertions.assertFalse(filter.useRangeFilter());
+        Assertions.assertEquals(Optional.of("20260601"), filter.getEqPartitionValues().get(0));
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithoutPushdown() {
+        Column dtCol = new Column("dt", DateType.DATE);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(13, DateType.DATE, "dt", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef,
+                        ConstantOperator.createDate(LocalDateTime.of(2026, 6, 1, 0, 0, 0))),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef,
+                        ConstantOperator.createDate(LocalDateTime.of(2026, 6, 7, 0, 0, 0))));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator, ImmutableList.of(dtCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertFalse(filter.useRangeFilter());
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithMultiColumnDtRangeOnly() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        Column hourCol = new Column("hour", StringType.STRING);
+        Column appCol = new Column("app", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(20, StringType.STRING, "dt", true);
+        ColumnRefOperator hourColumnRef = new ColumnRefOperator(21, StringType.STRING, "hour", true);
+        ColumnRefOperator appColumnRef = new ColumnRefOperator(22, StringType.STRING, "app", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+        columnMetaToColRefMap.put(hourCol, hourColumnRef);
+        columnMetaToColRefMap.put(appCol, appColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt", "hour", "app"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef, ConstantOperator.createVarchar("20260601")),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef, ConstantOperator.createVarchar("20260607")));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator,
+                        ImmutableList.of(dtCol, hourCol, appCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertTrue(filter.useRangeFilter());
+        Assertions.assertEquals("dt >= '20260601' AND dt <= '20260607'", filter.getHmsFilter().get());
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithMultiColumnDtEqOnly() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        Column hourCol = new Column("hour", StringType.STRING);
+        Column appCol = new Column("app", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(23, StringType.STRING, "dt", true);
+        ColumnRefOperator hourColumnRef = new ColumnRefOperator(24, StringType.STRING, "hour", true);
+        ColumnRefOperator appColumnRef = new ColumnRefOperator(25, StringType.STRING, "app", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+        columnMetaToColRefMap.put(hourCol, hourColumnRef);
+        columnMetaToColRefMap.put(appCol, appColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt", "hour", "app"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, dtColumnRef,
+                ConstantOperator.createVarchar("20260601"));
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator,
+                        ImmutableList.of(dtCol, hourCol, appCol), predicate);
+        Assertions.assertTrue(filter.useEqFilter());
+        Assertions.assertFalse(filter.useRangeFilter());
+        Assertions.assertEquals(Optional.of("20260601"), filter.getEqPartitionValues().get(0));
+        Assertions.assertEquals(Optional.empty(), filter.getEqPartitionValues().get(1));
+        Assertions.assertEquals(Optional.empty(), filter.getEqPartitionValues().get(2));
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithMultiColumnDtAndHourRange() {
+        Column dtCol = new Column("dt", StringType.STRING);
+        Column hourCol = new Column("hour", IntegerType.INT);
+        Column appCol = new Column("app", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(26, StringType.STRING, "dt", true);
+        ColumnRefOperator hourColumnRef = new ColumnRefOperator(27, IntegerType.INT, "hour", true);
+        ColumnRefOperator appColumnRef = new ColumnRefOperator(28, StringType.STRING, "app", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+        columnMetaToColRefMap.put(hourCol, hourColumnRef);
+        columnMetaToColRefMap.put(appCol, appColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt", "hour", "app"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef, ConstantOperator.createVarchar("20260601")),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef, ConstantOperator.createVarchar("20260607")),
+                new BinaryPredicateOperator(BinaryType.GE, hourColumnRef, ConstantOperator.createInt(10)),
+                new BinaryPredicateOperator(BinaryType.LE, hourColumnRef, ConstantOperator.createInt(12)));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator,
+                        ImmutableList.of(dtCol, hourCol, appCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertTrue(filter.useRangeFilter());
+        Assertions.assertEquals("dt >= '20260601' AND dt <= '20260607' AND hour >= 10 AND hour <= 12",
+                filter.getHmsFilter().get());
+    }
+
+    @Test
+    public void testGetPartitionPruneFilterWithMultiColumnNoPushdown() {
+        Column dtCol = new Column("dt", DateType.DATE);
+        Column hourCol = new Column("hour", StringType.STRING);
+        Column appCol = new Column("app", StringType.STRING);
+        ColumnRefOperator dtColumnRef = new ColumnRefOperator(29, DateType.DATE, "dt", true);
+        ColumnRefOperator hourColumnRef = new ColumnRefOperator(30, StringType.STRING, "hour", true);
+        ColumnRefOperator appColumnRef = new ColumnRefOperator(31, StringType.STRING, "app", true);
+
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        columnMetaToColRefMap.put(dtCol, dtColumnRef);
+        columnMetaToColRefMap.put(hourCol, hourColumnRef);
+        columnMetaToColRefMap.put(appCol, appColumnRef);
+
+        HiveTable hiveTable = HiveTable.builder()
+                .setPartitionColumnNames(ImmutableList.of("dt", "hour", "app"))
+                .build();
+        LogicalHiveScanOperator scanOperator = new LogicalHiveScanOperator(hiveTable, Maps.newHashMap(),
+                columnMetaToColRefMap, Operator.DEFAULT_LIMIT, null);
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.GE, dtColumnRef,
+                        ConstantOperator.createDate(LocalDateTime.of(2026, 6, 1, 0, 0, 0))),
+                new BinaryPredicateOperator(BinaryType.LE, dtColumnRef,
+                        ConstantOperator.createDate(LocalDateTime.of(2026, 6, 7, 0, 0, 0))));
+        ScalarOperator predicate = Utils.compoundAnd(conjuncts);
+
+        OptExternalPartitionPruner.PartitionPruneFilter filter =
+                OptExternalPartitionPruner.getPartitionPruneFilter(scanOperator,
+                        ImmutableList.of(dtCol, hourCol, appCol), predicate);
+        Assertions.assertFalse(filter.useEqFilter());
+        Assertions.assertFalse(filter.useRangeFilter());
+    }
+
+    @Test
     public void testCastTypePredicate() throws AnalysisException {
         // date_col = "2021-01-01"
         conjuncts.clear();


### PR DESCRIPTION
## Why I'm doing:
﻿
For Hive/Hudi external tables, StarRocks currently pushes equality partition
predicates to HMS via `listPartitionNamesByValue`, but range predicates still
trigger a full partition list fetch from HMS. FE then prunes locally, which is
inefficient for tables with a large number of partitions and increases HMS
metadata pressure.
﻿
This PR pushes range partition predicates to HMS via `listPartitionsByFilter`,
so only matching partitions are returned.
﻿


## What I'm doing:
### Optimizer
- Extend `OptExternalPartitionPruner` with `PartitionPruneFilter` and
 `getPartitionPruneFilter()`
- Build HMS filter strings from range predicates (`>=`, `>`, `<=`, `<`) on
 partition columns
- Support string, integer, and numeric partition column types
- Route to `MetadataMgr.listPartitionNamesByFilter()` when a range filter is
 available; keep existing equality and full-list fallback paths unchanged
﻿
### Connector
- Add `HiveMetaClient.getPartitionsByFilter()` wrapping HMS
 `listPartitionsByFilter`
- Add `HiveMetastore.getPartitionKeysByFilter()` with partition name conversion
- Add `HivePartitionFilter` and cache filter-based lookups in
 `CachingHiveMetastore`
- Extend `ConnectorMetadata` / `MetadataMgr` with `listPartitionNamesByFilter()`
- Propagate through `HiveMetadata`, `HudiMetadata`, and `UnifiedMetadata`
﻿
### Tests
- `ListPartitionPrunerTest`: HMS filter string generation for equality, range,
 multi-column, and non-pushable scenarios
- `HiveMetastoreTest`: `getPartitionKeysByFilter()` for single/multi-column
- `HiveMetastoreClientTest`: `listPartitionsByFilter` RPC
- `CachingHiveMetastoreTest`: filter-based partition cache
﻿
## What type of PR is this:
﻿
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool
﻿
Does this PR entail a change in behavior?
﻿
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.
﻿
If yes, please specify the type of change:
﻿
- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.
﻿
**Behavior change detail:** Queries with range predicates on Hive/Hudi partition
columns (e.g. `dt >= '20260601' AND dt <= '20260607'`) will now push filters to
HMS via `listPartitionsByFilter` instead of fetching all partitions. Queries
with only equality predicates or no pushable predicates retain existing behavior.
﻿
## Checklist:
﻿
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
﻿
## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
 - [ ] 4.1
 - [ ] 4.0
 - [ ] 3.5