### PR TITLE
[Tool] fix sonarcloud FE analysis: use SONAR_TOKEN secret + branch analysis

### DIFF
--- a/.github/workflows/ci-merged-sonarcloud-fe.yml
+++ b/.github/workflows/ci-merged-sonarcloud-fe.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Analyze FE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: f0fb4d25c03bae90c2e994c45c29c49dc86fc169
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           thrift --version
           whereis thrift
@@ -71,5 +71,5 @@ jobs:
           export SONAR_SCANNER_OPTS="-Xms3072m -Xmx12288m"
           export MAVEN_OPTS="-Xms3072m -Xmx12288m"
           mvn -B -DskipTests verify org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar \
-            -Dsonar.projectKey=StarRocks_starrocks -Dsonar.pullrequest.key=${{ github.event.number }} \
-            -Dsonar.pullrequest.base=${{ github.base_ref }} -Dsonar.pullrequest.branch=${{ github.head_ref }}
+            -Dsonar.projectKey=StarRocks_starrocks -Dsonar.organization=starrocks \
+            -Dsonar.branch.name=${{ github.ref_name }}

--- a/.github/workflows/sonarcloud-be-build.yml
+++ b/.github/workflows/sonarcloud-be-build.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.changes.outputs.be == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: f0fb4d25c03bae90c2e994c45c29c49dc86fc169
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           sonar-scanner -Dsonar.organization=starrocks -Dsonar.projectKey=Starrocks_be -Dsonar.cfamily.build-wrapper-output="be/build-wrapper" -Dsonar.host.url="https://sonarcloud.io" -Dsonar.sources="be/src" -Dsonar.pullrequest.key=${{ github.event.number }} -Dsonar.pullrequest.base=${{ github.base_ref }} -Dsonar.pullrequest.branch=${{ github.head_ref }} -Dsonar.projectBaseDir=. -Dsonar.pullrequest.github.repository=StarRocks/starrocks
 


### PR DESCRIPTION
## Why I'm doing:
The `MERGE SONARCLOUD FE` workflow (`ci-merged-sonarcloud-fe.yml`) has failed on **every** push to main with `Not authorized or project not found`, and the BE workflow carries the same exposed token. This is a credential + config problem, not a reason to drop SonarCloud (alternative to #75170 which removes it).

## What I'm doing:
Two root causes, both fixed without removing the workflows:

1. **Token leaked → auto-revoked.** `SONAR_TOKEN` was hardcoded in plaintext (`f0fb4d25...`) in these public workflows. Leaked SonarCloud tokens are auto-revoked by secret scanning, so the token was dead → every analysis failed auth. Both FE and BE now read `${{ secrets.SONAR_TOKEN }}` (the secret has been configured on the repo).

2. **Wrong analysis mode on FE.** The FE job is `push: branches:[main]` (post-merge), but passed PR-mode params (`sonar.pullrequest.key/base/branch` = `github.event.number/base_ref/head_ref`), all **empty** on a push event. Switched to branch analysis (`-Dsonar.branch.name=${{ github.ref_name }}`) and added the missing `-Dsonar.organization=starrocks`.

Verified against SonarCloud with a valid org token: project `StarRocks_starrocks` (starrocks-fe) exists and is reachable; last successful analysis was 2026-01-26 (when the token died).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Note on BE
`sonarcloud-be-build.yml` uses project key `Starrocks_be`, which does **not** exist in the SonarCloud `starrocks` org (only `StarRocks_starrocks` exists). BE analysis still needs that project created on SonarCloud to actually pass; BE is gated behind the `be-build` label and is not the source of the recurring main failures, so only its hardcoded token is fixed here.