### PR TITLE
[Enhancement] Add scalar PFOR codec for builtin GIN BM25 block posting

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -358,6 +358,7 @@ set(STORAGE_FILES
     index/inverted/builtin/builtin_inverted_reader.cpp
     index/inverted/builtin/builtin_inverted_index_iterator.cpp
     index/inverted/builtin/builtin_simple_analyzer.cpp
+    index/inverted/builtin/gin_pfor.cpp
     manual_compaction.cpp
     rowset/unique_rowset_id_generator.cpp
     rowset/rowset.cpp

--- a/be/src/storage/index/inverted/builtin/gin_pfor.cpp
+++ b/be/src/storage/index/inverted/builtin/gin_pfor.cpp
@@ -24,6 +24,11 @@ namespace starrocks::gin_pfor {
 
 namespace {
 
+// Maximum number of values a single encode()/decode() call may handle: the exception position and
+// the exception count are both u8 in the frozen format, so a stream cannot represent more than this
+// many values. The GIN block size (128) is well under this bound.
+constexpr size_t kMaxValues = 255;
+
 // Mask of the low `b` bits. b is always in [0, 32] here.
 inline uint32_t low_mask(int b) {
     return b >= 32 ? 0xFFFFFFFFu : ((1u << b) - 1u);
@@ -105,7 +110,7 @@ int choose_bit_width(const uint32_t* vals, size_t n) {
 } // namespace
 
 void encode(const uint32_t* vals, size_t n, faststring* out) {
-    DCHECK_LE(n, 255u); // pos and num_exceptions are u8; GIN block size is 128
+    CHECK_LE(n, kMaxValues); // enforce in all builds: pos/num_exceptions are u8 (GIN block size is 128)
 
     const int b = choose_bit_width(vals, n);
 
@@ -148,7 +153,8 @@ void encode(const uint32_t* vals, size_t n, faststring* out) {
 }
 
 size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out) {
-    if (len < 2) return 0; // need at least the 2-byte header
+    if (len < 2) return 0;        // need at least the 2-byte header
+    if (n > kMaxValues) return 0; // more values than the u8 exception pos/count header can represent
     const uint8_t* p = data;
     const uint8_t* const limit = data + len;
 

--- a/be/src/storage/index/inverted/builtin/gin_pfor.cpp
+++ b/be/src/storage/index/inverted/builtin/gin_pfor.cpp
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/gin_pfor.h"
+
+#include <glog/logging.h>
+
+#include <cstring>
+
+#include "base/string/faststring.h"
+
+namespace starrocks::gin_pfor {
+
+namespace {
+
+// Mask of the low `b` bits. b is always in [0, 32] here.
+inline uint32_t low_mask(int b) {
+    return b >= 32 ? 0xFFFFFFFFu : ((1u << b) - 1u);
+}
+
+// Bit-length of v: number of bits needed to represent it (0 for v == 0).
+inline int bit_length(uint32_t v) {
+    return v == 0 ? 0 : (32 - __builtin_clz(v));
+}
+
+// Append `v` to `out` as LEB128 (identical bytes to the codebase's encode_varint32, kept inline so
+// the codec depends only on faststring and stays a self-contained frozen format).
+inline void put_varint(faststring* out, uint32_t v) {
+    while (v >= 0x80) {
+        out->push_back(static_cast<char>(v | 0x80));
+        v >>= 7;
+    }
+    out->push_back(static_cast<char>(v));
+}
+
+// Read one LEB128 value from [p, limit). Returns the pointer past it, or nullptr if truncated or if
+// the encoding is longer than a uint32 can hold (malformed input).
+inline const uint8_t* get_varint(const uint8_t* p, const uint8_t* limit, uint32_t* out) {
+    uint32_t result = 0;
+    int shift = 0;
+    while (p < limit) {
+        uint8_t byte = *p++;
+        result |= static_cast<uint32_t>(byte & 0x7F) << shift;
+        if ((byte & 0x80) == 0) {
+            *out = result;
+            return p;
+        }
+        shift += 7;
+        if (shift > 28) return nullptr; // a uint32 LEB128 is at most 5 bytes
+    }
+    return nullptr;
+}
+
+// Pick the low-bit width that minimizes the encoded size, using the bit-length histogram method
+// (same family as Lucene PForUtil's freqs[] and Doris/TurboPFor's _p4bits): the encoded size depends
+// only on the distribution of value bit-lengths, not on the values themselves. So summarize that
+// distribution once in O(n), then evaluate every candidate width against the histogram instead of
+// rescanning all values per width. Produces the exact same width (hence the same bytes) as a brute
+// per-width rescan, in O(n + W^2) instead of O(n*W), W = 33.
+//
+// This is a writer-side heuristic only; it is NOT part of the on-disk format and can be retuned
+// freely without breaking old segments.
+int choose_bit_width(const uint32_t* vals, size_t n) {
+    // hist[k] = number of values whose bit-length is exactly k (k in 0..32).
+    int hist[33] = {0};
+    int maxbits = 0;
+    for (size_t i = 0; i < n; ++i) {
+        int bl = bit_length(vals[i]);
+        ++hist[bl];
+        if (bl > maxbits) maxbits = bl;
+    }
+
+    int best_b = 0;
+    size_t best_cost = static_cast<size_t>(-1);
+    for (int b = 0; b <= maxbits; ++b) {
+        // A value with bit-length k > b overflows b low bits and becomes an exception costing
+        // 1 (pos) + varint_len(high) bytes; high has (k - b) bits so varint_len = ceil((k-b)/7).
+        size_t exc_bytes = 0;
+        for (int k = b + 1; k <= maxbits; ++k) {
+            if (hist[k] != 0) {
+                exc_bytes += static_cast<size_t>(hist[k]) * (1 + ((k - b) + 6) / 7);
+            }
+        }
+        size_t stream_bytes = (n * static_cast<size_t>(b) + 7) / 8;
+        size_t cost = 2 /*header*/ + exc_bytes + stream_bytes;
+        if (cost < best_cost) {
+            best_cost = cost;
+            best_b = b;
+        }
+    }
+    return best_b;
+}
+
+} // namespace
+
+void encode(const uint32_t* vals, size_t n, faststring* out) {
+    DCHECK_LE(n, 255u); // pos and num_exceptions are u8; GIN block size is 128
+
+    const int b = choose_bit_width(vals, n);
+
+    uint8_t num_exc = 0;
+    for (size_t i = 0; i < n; ++i) {
+        uint32_t high = (b >= 32) ? 0u : (vals[i] >> b);
+        if (high != 0) ++num_exc;
+    }
+
+    out->push_back(static_cast<char>(b));
+    out->push_back(static_cast<char>(num_exc));
+
+    // exception table: {pos:u8, high:varint} in increasing position order
+    for (size_t i = 0; i < n; ++i) {
+        uint32_t high = (b >= 32) ? 0u : (vals[i] >> b);
+        if (high != 0) {
+            out->push_back(static_cast<char>(i));
+            put_varint(out, high);
+        }
+    }
+
+    // low stream: n values, b bits each, LSB-first
+    const size_t stream_bytes = (n * static_cast<size_t>(b) + 7) / 8;
+    if (stream_bytes > 0) {
+        const size_t start = out->size();
+        out->resize(start + stream_bytes);
+        uint8_t* p = out->data() + start;
+        std::memset(p, 0, stream_bytes);
+        const uint32_t mask = low_mask(b);
+        for (size_t i = 0; i < n; ++i) {
+            uint32_t v = vals[i] & mask;
+            size_t bitpos = i * static_cast<size_t>(b);
+            for (int j = 0; j < b; ++j) {
+                if ((v >> j) & 1u) {
+                    p[(bitpos + j) >> 3] |= static_cast<uint8_t>(1u << ((bitpos + j) & 7));
+                }
+            }
+        }
+    }
+}
+
+size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out) {
+    if (len < 2) return 0; // need at least the 2-byte header
+    const uint8_t* p = data;
+    const uint8_t* const limit = data + len;
+
+    const int b = *p++;
+    const uint8_t num_exc = *p++;
+    if (b > 32) return 0; // malformed bit width
+
+    uint8_t exc_pos[256];
+    uint32_t exc_high[256];
+    for (int e = 0; e < num_exc; ++e) {
+        if (p >= limit) return 0;
+        exc_pos[e] = *p++;
+        const uint8_t* np = get_varint(p, limit, &exc_high[e]);
+        if (np == nullptr) return 0;
+        p = np;
+    }
+
+    const size_t stream_bytes = (n * static_cast<size_t>(b) + 7) / 8;
+    if (static_cast<size_t>(limit - p) < stream_bytes) return 0;
+    const uint8_t* s = p;
+    for (size_t i = 0; i < n; ++i) {
+        uint32_t v = 0;
+        size_t bitpos = i * static_cast<size_t>(b);
+        for (int j = 0; j < b; ++j) {
+            if ((s[(bitpos + j) >> 3] >> ((bitpos + j) & 7)) & 1u) {
+                v |= (1u << j);
+            }
+        }
+        out[i] = v;
+    }
+    p += stream_bytes;
+
+    // apply patches; b < 32 is guaranteed whenever num_exc > 0, so (high << b) never overflows.
+    for (int e = 0; e < num_exc; ++e) {
+        out[exc_pos[e]] |= (exc_high[e] << b);
+    }
+
+    return static_cast<size_t>(p - data);
+}
+
+} // namespace starrocks::gin_pfor

--- a/be/src/storage/index/inverted/builtin/gin_pfor.cpp
+++ b/be/src/storage/index/inverted/builtin/gin_pfor.cpp
@@ -155,12 +155,19 @@ size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out) {
     const int b = *p++;
     const uint8_t num_exc = *p++;
     if (b > 32) return 0; // malformed bit width
+    // b == 32 means every value already fits in 32 low bits, so a well-formed block has no
+    // exceptions. Reject b == 32 with exceptions from corrupt input so the patch step below never
+    // evaluates (high << 32), a shift by the full type width (undefined behavior).
+    if (b == 32 && num_exc > 0) return 0;
 
     uint8_t exc_pos[256];
     uint32_t exc_high[256];
     for (int e = 0; e < num_exc; ++e) {
         if (p >= limit) return 0;
         exc_pos[e] = *p++;
+        // Reject an out-of-range exception position from corrupt persisted bytes before it is used
+        // to index out[0..n) in the patch step below (otherwise an out-of-bounds write).
+        if (exc_pos[e] >= n) return 0;
         const uint8_t* np = get_varint(p, limit, &exc_high[e]);
         if (np == nullptr) return 0;
         p = np;
@@ -181,7 +188,8 @@ size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out) {
     }
     p += stream_bytes;
 
-    // apply patches; b < 32 is guaranteed whenever num_exc > 0, so (high << b) never overflows.
+    // apply patches; the checks above guarantee b < 32 whenever num_exc > 0 (so (high << b) is
+    // well-defined) and every exc_pos < n (so the index stays in bounds).
     for (int e = 0; e < num_exc; ++e) {
         out[exc_pos[e]] |= (exc_high[e] << b);
     }

--- a/be/src/storage/index/inverted/builtin/gin_pfor.h
+++ b/be/src/storage/index/inverted/builtin/gin_pfor.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace starrocks {
+class faststring;
+
+// Architecture-neutral scalar PFOR (Patched Frame-Of-Reference) codec used by the builtin
+// GIN BM25 block posting to encode a block's docid gaps and term frequencies.
+//
+// It is deliberately a hand-written, fixed byte layout: NO TurboPFor, NO SIMD-tagged format.
+// Shared-data segments live on object storage and are read by arbitrary x86/ARM compute nodes,
+// so the encoding must decode identically everywhere. x86 and ARM are both little-endian and the
+// packing below is pure byte/shift work, so the bytes are reproducible across architectures.
+//
+// On-disk format for one uint32 stream of `n` values (the frozen format, see
+// docs/design/builtin-gin-bm25-pr1-storage-plan.md §3.1):
+//
+//   [bit_width      : u8]                              low-bit width b in [0, 32]
+//   [num_exceptions : u8]                              count of values whose (val >> b) != 0
+//   [exceptions     : num_exceptions x {pos:u8, high:varint}]   pos in [0, n), high = val >> b
+//   [low_stream     : n values x b bits, LSB-first bit-packed, ceil(n*b/8) bytes]
+//
+// Decode reconstructs each value as low_bits, then for every exception ORs in (high << b).
+// `n` must be <= 255 so that `pos` and `num_exceptions` fit in u8; the GIN block size is 128.
+namespace gin_pfor {
+
+// Append the PFOR encoding of vals[0..n) to *out. n may be 0 (emits a 2-byte empty header).
+void encode(const uint32_t* vals, size_t n, faststring* out);
+
+// Decode exactly `n` values from data[0..len) into out[0..n).
+// Returns the number of bytes consumed, or 0 on malformed / truncated input.
+size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out);
+
+} // namespace gin_pfor
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/gin_pfor.h
+++ b/be/src/storage/index/inverted/builtin/gin_pfor.h
@@ -40,11 +40,12 @@ class faststring;
 // `n` must be <= 255 so that `pos` and `num_exceptions` fit in u8; the GIN block size is 128.
 namespace gin_pfor {
 
-// Append the PFOR encoding of vals[0..n) to *out. n may be 0 (emits a 2-byte empty header).
+// Append the PFOR encoding of vals[0..n) to *out. n may be 0 (emits a 2-byte empty header) and must
+// be <= 255 (checked): the frozen format stores exception positions and count as u8.
 void encode(const uint32_t* vals, size_t n, faststring* out);
 
 // Decode exactly `n` values from data[0..len) into out[0..n).
-// Returns the number of bytes consumed, or 0 on malformed / truncated input.
+// Returns the number of bytes consumed, or 0 on malformed / truncated input or unsupported n > 255.
 size_t decode(const uint8_t* data, size_t len, size_t n, uint32_t* out);
 
 } // namespace gin_pfor

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -412,6 +412,7 @@ SET(DW_TEST_FILES
     ./storage/index/vector_search_test.cpp
     ./storage/index/vector/vector_index_cache_test.cpp
     ./storage/index/builtin_inverted_index_test.cpp
+    ./storage/index/gin_pfor_test.cpp
     ./storage/kv_store_test.cpp
     ./storage/lake/alter_tablet_meta_test.cpp
     ./storage/lake/async_delta_writer_test.cpp

--- a/be/test/storage/index/gin_pfor_test.cpp
+++ b/be/test/storage/index/gin_pfor_test.cpp
@@ -1,0 +1,163 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/gin_pfor.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "base/string/faststring.h"
+
+namespace starrocks {
+
+class GinPforTest : public testing::Test {
+protected:
+    // encode `in`, decode it back, and assert the round-trip is lossless and that decode()
+    // reports it consumed exactly the encoded length.
+    static void check_roundtrip(const std::vector<uint32_t>& in) {
+        faststring buf;
+        gin_pfor::encode(in.data(), in.size(), &buf);
+        std::vector<uint32_t> out(in.size(), 0xDEADBEEF);
+        size_t consumed = gin_pfor::decode(buf.data(), buf.size(), in.size(), out.data());
+        EXPECT_EQ(consumed, buf.size()) << "decode must consume the whole encoded buffer";
+        EXPECT_EQ(out, in);
+    }
+};
+
+// Pins the frozen byte layout for a simple no-exception stream: values {3,1,2}, max=3 -> bit_width=2,
+// no exceptions, low stream = 3 values * 2 bits = 6 bits -> 1 byte.
+// LSB-first packing: v0=3(0b11)@bits0-1, v1=1(0b01)@bits2-3, v2=2(0b10)@bits4-5 => 0b00100111 = 0x27.
+TEST_F(GinPforTest, encode_exact_bytes_no_exception) {
+    std::vector<uint32_t> in = {3, 1, 2};
+    faststring buf;
+    gin_pfor::encode(in.data(), in.size(), &buf);
+    ASSERT_EQ(buf.size(), 3u);
+    EXPECT_EQ(buf.data()[0], 0x02); // bit_width
+    EXPECT_EQ(buf.data()[1], 0x00); // num_exceptions
+    EXPECT_EQ(buf.data()[2], 0x27); // packed low stream
+}
+
+// Pins the frozen byte layout for the exception path: {2,1,3,2,1000,2,1,3}, max=1000 -> the
+// size-optimal width is 2 with one exception (1000). Header {bit_width=2, num_exceptions=1},
+// exception {pos=4, high=1000>>2=250 -> varint 0xFA 0x01}, then the 8 low-2-bit values packed
+// LSB-first into 2 bytes (0xB6, 0xD8). This characterizes the chosen width + exception encoding so a
+// refactor of the width-selection heuristic cannot silently change the output.
+TEST_F(GinPforTest, encode_exact_bytes_with_exception) {
+    std::vector<uint32_t> in = {2, 1, 3, 2, 1000, 2, 1, 3};
+    faststring buf;
+    gin_pfor::encode(in.data(), in.size(), &buf);
+    ASSERT_EQ(buf.size(), 7u);
+    const uint8_t expected[] = {0x02, 0x01, 0x04, 0xFA, 0x01, 0xB6, 0xD8};
+    for (size_t i = 0; i < sizeof(expected); ++i) {
+        EXPECT_EQ(buf.data()[i], expected[i]) << "byte " << i;
+    }
+}
+
+TEST_F(GinPforTest, roundtrip_basic) {
+    check_roundtrip({2, 1, 3, 2, 1, 2, 1, 3});
+}
+
+// One large outlier among small values: PFOR must patch it rather than corrupt the round-trip.
+TEST_F(GinPforTest, roundtrip_single_outlier) {
+    check_roundtrip({2, 1, 3, 2, 1000, 2, 1, 3});
+}
+
+TEST_F(GinPforTest, roundtrip_empty) {
+    std::vector<uint32_t> in = {};
+    faststring buf;
+    gin_pfor::encode(in.data(), in.size(), &buf);
+    // empty stream still emits the 2-byte header (bit_width=0, num_exceptions=0).
+    ASSERT_EQ(buf.size(), 2u);
+    EXPECT_EQ(buf.data()[0], 0x00);
+    EXPECT_EQ(buf.data()[1], 0x00);
+    size_t consumed = gin_pfor::decode(buf.data(), buf.size(), 0, nullptr);
+    EXPECT_EQ(consumed, 2u);
+}
+
+TEST_F(GinPforTest, roundtrip_single_value) {
+    check_roundtrip({5});
+}
+
+TEST_F(GinPforTest, roundtrip_all_zeros) {
+    check_roundtrip({0, 0, 0, 0});
+}
+
+TEST_F(GinPforTest, roundtrip_all_equal) {
+    check_roundtrip({7, 7, 7});
+}
+
+TEST_F(GinPforTest, roundtrip_max_u32) {
+    check_roundtrip({UINT32_MAX, 0, UINT32_MAX, 1});
+}
+
+// Several outliers of differing magnitude mixed with small values.
+TEST_F(GinPforTest, roundtrip_mixed_outliers) {
+    check_roundtrip({1, 2, 100000, 3, 1, 70000, 2, 1, 4, 999999});
+}
+
+// Two streams concatenated into one buffer (as a block stores gaps then tfs): decoding the first
+// must report the exact byte offset where the second begins.
+TEST_F(GinPforTest, decode_framing_two_streams) {
+    std::vector<uint32_t> a = {2, 1, 3, 2};       // gaps-like
+    std::vector<uint32_t> b = {1, 2, 1, 1, 5000}; // tfs-like with an outlier
+    faststring buf;
+    gin_pfor::encode(a.data(), a.size(), &buf);
+    size_t size_a = buf.size();
+    gin_pfor::encode(b.data(), b.size(), &buf);
+
+    std::vector<uint32_t> out_a(a.size(), 0);
+    size_t consumed_a = gin_pfor::decode(buf.data(), buf.size(), a.size(), out_a.data());
+    EXPECT_EQ(consumed_a, size_a);
+    EXPECT_EQ(out_a, a);
+
+    std::vector<uint32_t> out_b(b.size(), 0);
+    size_t consumed_b = gin_pfor::decode(buf.data() + consumed_a, buf.size() - consumed_a, b.size(), out_b.data());
+    EXPECT_EQ(consumed_a + consumed_b, buf.size());
+    EXPECT_EQ(out_b, b);
+}
+
+// Deterministic fuzz: many random stream sizes/values (with occasional large outliers) round-trip.
+TEST_F(GinPforTest, fuzz_roundtrip) {
+    std::mt19937 rng(12345);
+    for (int iter = 0; iter < 1000; ++iter) {
+        size_t n = rng() % 129; // 0..128 (GIN block size)
+        std::vector<uint32_t> in(n);
+        for (size_t i = 0; i < n; ++i) {
+            uint32_t r = rng();
+            if (r % 16 == 0) {
+                in[i] = r; // ~6% large outliers
+            } else {
+                in[i] = r % 8; // mostly small, like real gaps/tfs
+            }
+        }
+        check_roundtrip(in);
+    }
+}
+
+// Truncated input must be rejected (return 0), never read out of bounds.
+TEST_F(GinPforTest, decode_truncated_returns_zero) {
+    std::vector<uint32_t> in = {2, 1, 1000, 3};
+    faststring buf;
+    gin_pfor::encode(in.data(), in.size(), &buf);
+    std::vector<uint32_t> out(in.size(), 0);
+    // Drop the last byte -> truncated low stream.
+    EXPECT_EQ(gin_pfor::decode(buf.data(), buf.size() - 1, in.size(), out.data()), 0u);
+    // A 1-byte buffer is too short even for the header.
+    EXPECT_EQ(gin_pfor::decode(buf.data(), 1, in.size(), out.data()), 0u);
+}
+
+} // namespace starrocks

--- a/be/test/storage/index/gin_pfor_test.cpp
+++ b/be/test/storage/index/gin_pfor_test.cpp
@@ -116,6 +116,17 @@ TEST_F(GinPforTest, roundtrip_outlier_at_last_position) {
     check_roundtrip({1, 2, 3, 1, 2, 3, 1, 999999});
 }
 
+// n == 255 is the largest value count the u8 exception-position/count header can represent; it must
+// round-trip (with exceptions). Guards the n > 255 rejection against an off-by-one and exercises
+// encode()'s size check at the boundary.
+TEST_F(GinPforTest, roundtrip_max_block_size) {
+    std::vector<uint32_t> in(255);
+    for (size_t i = 0; i < in.size(); ++i) {
+        in[i] = (i % 16 == 0) ? (100000u + static_cast<uint32_t>(i)) : (i % 7); // a few outliers
+    }
+    check_roundtrip(in);
+}
+
 // Two streams concatenated into one buffer (as a block stores gaps then tfs): decoding the first
 // must report the exact byte offset where the second begins.
 TEST_F(GinPforTest, decode_framing_two_streams) {
@@ -186,6 +197,16 @@ TEST_F(GinPforTest, decode_rejects_bit_width_32_with_exceptions) {
     const uint8_t corrupt[] = {0x20, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00};
     std::vector<uint32_t> out(1, 0);
     EXPECT_EQ(gin_pfor::decode(corrupt, sizeof(corrupt), 1, out.data()), 0u);
+}
+
+// The u8 exception-position/count header cannot represent more than 255 values, so decode() must
+// reject n > 255 (return 0) rather than silently produce meaningless output. {bit_width=0,
+// num_exceptions=0} is an otherwise-valid 2-byte stream that would "succeed" for any n without the
+// guard; out is oversized so the check is on the return value, not on a would-be overflow.
+TEST_F(GinPforTest, decode_rejects_n_over_255) {
+    const uint8_t buf[] = {0x00, 0x00};
+    std::vector<uint32_t> out(256, 0);
+    EXPECT_EQ(gin_pfor::decode(buf, sizeof(buf), 256, out.data()), 0u);
 }
 
 } // namespace starrocks

--- a/be/test/storage/index/gin_pfor_test.cpp
+++ b/be/test/storage/index/gin_pfor_test.cpp
@@ -109,6 +109,13 @@ TEST_F(GinPforTest, roundtrip_mixed_outliers) {
     check_roundtrip({1, 2, 100000, 3, 1, 70000, 2, 1, 4, 999999});
 }
 
+// An outlier at the very last position (pos == n-1) is a valid exception and must survive the
+// round-trip. This guards the decode-side exception-position bounds check against an off-by-one
+// (rejecting the last legal position would corrupt real data).
+TEST_F(GinPforTest, roundtrip_outlier_at_last_position) {
+    check_roundtrip({1, 2, 3, 1, 2, 3, 1, 999999});
+}
+
 // Two streams concatenated into one buffer (as a block stores gaps then tfs): decoding the first
 // must report the exact byte offset where the second begins.
 TEST_F(GinPforTest, decode_framing_two_streams) {
@@ -158,6 +165,27 @@ TEST_F(GinPforTest, decode_truncated_returns_zero) {
     EXPECT_EQ(gin_pfor::decode(buf.data(), buf.size() - 1, in.size(), out.data()), 0u);
     // A 1-byte buffer is too short even for the header.
     EXPECT_EQ(gin_pfor::decode(buf.data(), 1, in.size(), out.data()), 0u);
+}
+
+// A corrupt block whose exception position is >= n must be rejected, not applied. These bytes are
+// read from persisted segments on shared storage, so an out-of-range pos must return 0 rather than
+// write past the caller's out[0..n) buffer (heap overflow). Hand-crafted block: bit_width=2,
+// num_exceptions=1, exception {pos=10, high=1}, then 1 low-stream byte for n=4 values.
+TEST_F(GinPforTest, decode_rejects_out_of_range_exception_pos) {
+    const uint8_t corrupt[] = {0x02, 0x01, 0x0A, 0x01, 0x00};
+    std::vector<uint32_t> out(4, 0);
+    EXPECT_EQ(gin_pfor::decode(corrupt, sizeof(corrupt), 4, out.data()), 0u);
+}
+
+// bit_width=32 means every value already fits in 32 low bits, so a well-formed block can have no
+// exceptions. A corrupt block with bit_width=32 AND an exception is malformed and must be rejected;
+// otherwise applying the patch would evaluate (high << 32), a shift by the full type width (UB).
+// Hand-crafted block: bit_width=32, num_exceptions=1, exception {pos=0, high=1}, 4 low-stream bytes
+// for n=1 value.
+TEST_F(GinPforTest, decode_rejects_bit_width_32_with_exceptions) {
+    const uint8_t corrupt[] = {0x20, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00};
+    std::vector<uint32_t> out(1, 0);
+    EXPECT_EQ(gin_pfor::decode(corrupt, sizeof(corrupt), 1, out.data()), 0u);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

A follow-up feature adds BM25 relevance scoring on top of the builtin GIN inverted index. Its block posting stores, per term, the docid gaps and term frequencies, which must be compact yet decode identically on any compute node. In shared-data, segments live on object storage and can be read by arbitrary x86/ARM compute nodes, so a SIMD-tagged layout (e.g. TurboPFor's AVX2/NEON variants, which are not mutually readable across architectures) cannot be used.

This PR lands the codec building block first, on its own, so the storage and scoring layers can later build on a frozen, architecture-neutral on-disk format.

## What I'm doing:

Add `gin_pfor`, a scalar PFOR (Patched Frame-Of-Reference) codec with a fixed byte layout (`[bit_width][num_exceptions][exceptions...][LSB-first bit-packed low stream]`). It is deliberately SIMD-free and TurboPFor-free, depends only on `faststring`, and the byte format is reproducible on any little-endian architecture. There is no caller yet; this is the leaf used by the upcoming BM25 block posting.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5