### PR TITLE
[BugFix] Initialize StringSearch::_pattern and fix split_debug_symbol log

### DIFF
--- a/be/src/base/string/string_search.hpp
+++ b/be/src/base/string/string_search.hpp
@@ -159,7 +159,7 @@ private:
 
     bool bloom_query(char c) const { return _mask & (1UL << (c & (BLOOM_WIDTH - 1))); }
 
-    const Slice* _pattern;
+    const Slice* _pattern = nullptr;
     int64_t _mask{0};
     int64_t _skip = 0;
 };

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -338,7 +338,7 @@ export STARROCKS_TEST_BINARY_DIR=${STARROCKS_TEST_BINARY_BASE_DIR}/test
 split_debug_symbol() {
     local bin="$1"
     local symbol="${bin}.debuginfo"
-    echo -n "[INFO] Split $(basename "$bin") debug symbol to $(basename "$symbol") ..."
+    echo "[INFO] Split $(basename "$bin") debug symbol to $(basename "$symbol") ..."
     objcopy --only-keep-debug "$bin" "$symbol"
     strip --strip-debug "$bin"
     objcopy --add-gnu-debuglink="$symbol" "$bin"


### PR DESCRIPTION
Initialize StringSearch::_pattern to nullptr so a default-constructed StringSearch::search() safely returns -1 instead of dereferencing an uninitialized pointer.

Also use echo instead of echo -n in run-be-ut.sh split_debug_symbol so the per-binary log line is flushed on its own line.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
