### PR TITLE
[BugFix] Acquire TabletInvertedIndex write lock once in markTabletsForceDelete

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -211,11 +211,30 @@ public class TabletInvertedIndex implements MemoryTrackable {
     }
 
     /**
-     * Batch mark tablets for force delete.
+     * Batch mark tablets for force delete with a single write lock acquisition,
+     * reducing lock contention compared to calling markTabletForceDelete() in a loop.
      */
     public void markTabletsForceDelete(Collection<Tablet> tablets) {
-        for (Tablet tablet : tablets) {
-            markTabletForceDelete(tablet);
+        if (tablets.isEmpty()) {
+            return;
+        }
+        // LakeTablet is managed by StarOS, no need to do this mark and clean up. A cluster does
+        // not mix LocalTablet and LakeTablet, so inspecting one tablet is enough to decide; bail
+        // out before taking the write lock when the batch belongs to a lake table.
+        if (tablets.iterator().next() instanceof LakeTablet) {
+            return;
+        }
+        writeLock();
+        try {
+            for (Tablet tablet : tablets) {
+                Set<Long> backendIds = tablet.getBackendIds();
+                if (backendIds.isEmpty()) {
+                    continue;
+                }
+                forceDeleteTablets.put(tablet.getId(), backendIds);
+            }
+        } finally {
+            writeUnlock();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletInvertedIndexTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.starrocks.authorization.IdGenerator;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -195,6 +197,86 @@ public class TabletInvertedIndexTest {
         Assertions.assertEquals(
                 batchIndex.getTabletIdsByBackendId(2001L),
                 singleIndex.getTabletIdsByBackendId(2001L));
+    }
+
+    @Test
+    public void testMarkTabletsForceDeleteBatch() {
+        // Given: two tablets with replicas on distinct backends, plus a tablet with no replicas
+        long tabletId1 = 5001L;
+        long tabletId2 = 5002L;
+        long emptyTabletId = 5003L;
+
+        Replica r1 = new Replica(300L, 3000L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica r2 = new Replica(301L, 3001L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+
+        LocalTablet tablet1 = new LocalTablet(tabletId1, Arrays.asList(r1));
+        LocalTablet tablet2 = new LocalTablet(tabletId2, Arrays.asList(r2));
+        // Empty backend set -> should be skipped by the batch mark
+        LocalTablet emptyTablet = new LocalTablet(emptyTabletId);
+
+        // When: batch mark all of them for force delete
+        tabletInvertedIndex.markTabletsForceDelete(Arrays.asList(tablet1, tablet2, emptyTablet));
+
+        // Then: tablets with backends are marked, the empty one is skipped
+        Assertions.assertTrue(tabletInvertedIndex.tabletForceDelete(tabletId1, 3000L));
+        Assertions.assertTrue(tabletInvertedIndex.tabletForceDelete(tabletId2, 3001L));
+        Assertions.assertFalse(tabletInvertedIndex.tabletForceDelete(emptyTabletId, 0L));
+        Assertions.assertEquals(2, tabletInvertedIndex.getForceDeleteTablets().size());
+    }
+
+    @Test
+    public void testMarkTabletsForceDeleteConsistentWithSingleMark() {
+        // Verify batch mark produces the same result as marking each tablet individually
+        long tabletId1 = 6001L;
+        long tabletId2 = 6002L;
+
+        TabletInvertedIndex batchIndex = new TabletInvertedIndex();
+        TabletInvertedIndex singleIndex = new TabletInvertedIndex();
+
+        Replica r1 = new Replica(400L, 4000L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+        Replica r2 = new Replica(401L, 4001L, 1L, 123, 0L, 0L,
+                Replica.ReplicaState.NORMAL, -1L, 1L);
+
+        LocalTablet tablet1 = new LocalTablet(tabletId1, Arrays.asList(r1));
+        LocalTablet tablet2 = new LocalTablet(tabletId2, Arrays.asList(r2));
+
+        // Batch mark
+        batchIndex.markTabletsForceDelete(Arrays.asList(tablet1, tablet2));
+
+        // Sequential single mark
+        singleIndex.markTabletForceDelete(tablet1);
+        singleIndex.markTabletForceDelete(tablet2);
+
+        // Both should mark the same (tabletId, backendId) pairs
+        for (long tabletId : new long[] {tabletId1, tabletId2}) {
+            Set<Long> batchBackends = batchIndex.getForceDeleteTablets().get(tabletId);
+            Set<Long> singleBackends = singleIndex.getForceDeleteTablets().get(tabletId);
+            Assertions.assertEquals(singleBackends, batchBackends);
+        }
+        Assertions.assertEquals(
+                singleIndex.getForceDeleteTablets().size(),
+                batchIndex.getForceDeleteTablets().size());
+    }
+
+    @Test
+    public void testMarkTabletsForceDeleteSkipsLakeTablets() {
+        // LakeTablet is managed by StarOS; a lake-table batch must be a no-op (no marking, no lock work)
+        LakeTablet lakeTablet1 = new LakeTablet(7001L);
+        LakeTablet lakeTablet2 = new LakeTablet(7002L);
+
+        tabletInvertedIndex.markTabletsForceDelete(Arrays.asList(lakeTablet1, lakeTablet2));
+
+        Assertions.assertTrue(tabletInvertedIndex.getForceDeleteTablets().isEmpty());
+        Assertions.assertFalse(tabletInvertedIndex.tabletForceDelete(7001L, 0L));
+    }
+
+    @Test
+    public void testMarkTabletsForceDeleteEmptyCollection() {
+        tabletInvertedIndex.markTabletsForceDelete(Collections.emptyList());
+        Assertions.assertTrue(tabletInvertedIndex.getForceDeleteTablets().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
markTabletsForceDelete() looped over the tablets and dispatched to the single-tablet markTabletForceDelete(), which acquires the write lock on every iteration. On this branch the global read/write lock is still in effect (the lock-removal refactor #66288 was not backported), so a batch of N tablets incurred N writeLock()/writeUnlock() cycles. That defeats the purpose of the batch interface added by #70052 to reduce write lock contention.

Acquire the write lock once for the whole batch and write all entries under it. A cluster never mixes LocalTablet and LakeTablet, so when the batch belongs to a lake table we return early (before taking the lock) instead of testing instanceof on every iteration. Empty-backend tablets are still skipped. Add unit tests covering the batch mark, equivalence to sequential single marks, the lake-table no-op, and the empty batch.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5

