### PR TITLE
[Refactor] Move query cache metrics to ComputeEnv

### DIFF
--- a/be/src/compute_env/CMakeLists.txt
+++ b/be/src/compute_env/CMakeLists.txt
@@ -64,6 +64,7 @@ set(COMPUTE_ENV_SPILL_FILES
 set(COMPUTE_ENV_QUERY_CACHE_FILES
     query_cache/cache_manager.cpp
     query_cache/lane_arbiter.cpp
+    query_cache/query_cache_metrics.cpp
 )
 
 set(COMPUTE_ENV_QUERY_FILES

--- a/be/src/compute_env/compute_env.cpp
+++ b/be/src/compute_env/compute_env.cpp
@@ -102,7 +102,7 @@ Status ComputeEnv::init(const ComputeEnvOptions& options) {
     const size_t query_cache_capacity = options.query_cache_capacity == 0
                                                 ? std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024)
                                                 : options.query_cache_capacity;
-    status = _init_query_cache(query_cache_capacity);
+    status = _init_query_cache(query_cache_capacity, options.metrics);
     if (!status.ok()) {
         destroy();
         return status;
@@ -194,8 +194,9 @@ Status ComputeEnv::_init_spill(const std::vector<std::string>& store_paths, Metr
     return Status::OK();
 }
 
-Status ComputeEnv::_init_query_cache(size_t capacity) {
+Status ComputeEnv::_init_query_cache(size_t capacity, MetricRegistry* metrics) {
     _cache_mgr = std::make_unique<query_cache::CacheManager>(capacity);
+    RETURN_IF_ERROR(_cache_mgr->install_metrics(metrics));
     return Status::OK();
 }
 

--- a/be/src/compute_env/compute_env.h
+++ b/be/src/compute_env/compute_env.h
@@ -96,7 +96,7 @@ private:
     Status _init_workgroup(const ComputeEnvOptions& options, int64_t max_executor_threads);
     Status _init_load_path(std::vector<std::string> store_paths, bool use_dummy_load_path_mgr);
     Status _init_spill(const std::vector<std::string>& store_paths, MetricRegistry* metrics);
-    Status _init_query_cache(size_t capacity);
+    Status _init_query_cache(size_t capacity, MetricRegistry* metrics);
     Status _start_result_mgr();
     void _stop_stream_load_pipes();
     void _stop_workgroup();

--- a/be/src/compute_env/query_cache/cache_manager.cpp
+++ b/be/src/compute_env/query_cache/cache_manager.cpp
@@ -14,13 +14,51 @@
 
 #include "compute_env/query_cache/cache_manager.h"
 
+#include "base/metrics.h"
 #include "base/utility/defer_op.h"
+#include "compute_env/query_cache/query_cache_metrics.h"
+
 namespace starrocks::query_cache {
 
+namespace {
+const char* const kQueryCacheMetricsHookName = "query_cache_metrics";
+} // namespace
+
 CacheManager::CacheManager(size_t capacity) : _cache(capacity) {}
+
+CacheManager::~CacheManager() {
+    if (_metrics_registry != nullptr) {
+        _metrics_registry->deregister_hook(kQueryCacheMetricsHookName);
+    }
+}
+
 static void delete_cache_entry(const CacheKey& key, void* value) {
     auto* cache_value = (CacheValue*)value;
     delete cache_value;
+}
+
+Status CacheManager::install_metrics(MetricRegistry* registry) {
+    if (registry == nullptr) {
+        return Status::OK();
+    }
+    if (_metrics_registry != nullptr) {
+        DCHECK_EQ(_metrics_registry, registry);
+        return Status::OK();
+    }
+
+    auto metrics = std::make_unique<QueryCacheMetrics>();
+    if (!metrics->install(registry)) {
+        return Status::InternalError("register query cache metrics failed");
+    }
+    if (!registry->register_hook(kQueryCacheMetricsHookName, [this] { _update_metrics(); })) {
+        metrics->hide();
+        return Status::InternalError("register query cache metrics hook failed");
+    }
+
+    _metrics = std::move(metrics);
+    _metrics_registry = registry;
+    _update_metrics();
+    return Status::OK();
 }
 
 void CacheManager::populate(const std::string& key, const CacheValue& value) {
@@ -61,6 +99,12 @@ void CacheManager::invalidate_all() {
     // set capacity of cache to zero, the cache shall prune all cache entries.
     _cache.set_capacity(0);
     _cache.set_capacity(old_capacity);
+}
+
+void CacheManager::_update_metrics() {
+    if (_metrics != nullptr) {
+        _metrics->update(capacity(), memory_usage(), lookup_count(), hit_count());
+    }
 }
 
 } // namespace starrocks::query_cache

--- a/be/src/compute_env/query_cache/cache_manager.h
+++ b/be/src/compute_env/query_cache/cache_manager.h
@@ -24,8 +24,12 @@
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
 
-namespace starrocks::query_cache {
+namespace starrocks {
+class MetricRegistry;
+
+namespace query_cache {
 class CacheManager;
+class QueryCacheMetrics;
 using CacheManagerRawPtr = CacheManager*;
 using CacheManagerPtr = std::shared_ptr<CacheManager>;
 
@@ -63,7 +67,8 @@ struct CacheValue {
 class CacheManager {
 public:
     explicit CacheManager(size_t capacity);
-    ~CacheManager() = default;
+    ~CacheManager();
+    Status install_metrics(MetricRegistry* registry);
     void populate(const std::string& key, const CacheValue& value);
     StatusOr<CacheValue> probe(const std::string& key);
     size_t memory_usage();
@@ -74,6 +79,11 @@ public:
     void invalidate_all();
 
 private:
+    void _update_metrics();
+
     ShardedLRUCache _cache;
+    std::unique_ptr<QueryCacheMetrics> _metrics;
+    MetricRegistry* _metrics_registry = nullptr;
 };
-} // namespace starrocks::query_cache
+} // namespace query_cache
+} // namespace starrocks

--- a/be/src/compute_env/query_cache/query_cache_metrics.cpp
+++ b/be/src/compute_env/query_cache/query_cache_metrics.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "compute_env/query_cache/query_cache_metrics.h"
+
+namespace starrocks::query_cache {
+
+bool QueryCacheMetrics::install(MetricRegistry* registry) {
+    DCHECK(registry != nullptr);
+    if (!registry->register_metric("query_cache_capacity", &query_cache_capacity) ||
+        !registry->register_metric("query_cache_usage", &query_cache_usage) ||
+        !registry->register_metric("query_cache_usage_ratio", &query_cache_usage_ratio) ||
+        !registry->register_metric("query_cache_lookup_count", &query_cache_lookup_count) ||
+        !registry->register_metric("query_cache_hit_count", &query_cache_hit_count) ||
+        !registry->register_metric("query_cache_hit_ratio", &query_cache_hit_ratio)) {
+        hide();
+        return false;
+    }
+    return true;
+}
+
+void QueryCacheMetrics::hide() {
+    query_cache_capacity.hide();
+    query_cache_usage.hide();
+    query_cache_usage_ratio.hide();
+    query_cache_lookup_count.hide();
+    query_cache_hit_count.hide();
+    query_cache_hit_ratio.hide();
+}
+
+void QueryCacheMetrics::update(size_t capacity, size_t usage, size_t lookup_count, size_t hit_count) {
+    const double usage_ratio = (capacity == 0) ? 0.0 : static_cast<double>(usage) / static_cast<double>(capacity);
+    const double hit_ratio =
+            (lookup_count == 0) ? 0.0 : static_cast<double>(hit_count) / static_cast<double>(lookup_count);
+
+    query_cache_capacity.set_value(static_cast<int64_t>(capacity));
+    query_cache_usage.set_value(static_cast<int64_t>(usage));
+    query_cache_usage_ratio.set_value(usage_ratio);
+    query_cache_lookup_count.set_value(static_cast<int64_t>(lookup_count));
+    query_cache_hit_count.set_value(static_cast<int64_t>(hit_count));
+    query_cache_hit_ratio.set_value(hit_ratio);
+}
+
+} // namespace starrocks::query_cache

--- a/be/src/compute_env/query_cache/query_cache_metrics.h
+++ b/be/src/compute_env/query_cache/query_cache_metrics.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+
+#include "base/metrics.h"
+
+namespace starrocks::query_cache {
+
+class QueryCacheMetrics {
+public:
+    bool install(MetricRegistry* registry);
+    void hide();
+    void update(size_t capacity, size_t usage, size_t lookup_count, size_t hit_count);
+
+    METRIC_DEFINE_INT_GAUGE(query_cache_capacity, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(query_cache_usage, MetricUnit::BYTES);
+    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_usage_ratio, MetricUnit::PERCENT);
+    METRIC_DEFINE_INT_GAUGE(query_cache_lookup_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(query_cache_hit_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_hit_ratio, MetricUnit::PERCENT);
+};
+
+} // namespace starrocks::query_cache

--- a/be/src/service/backend_metrics_initializer.cpp
+++ b/be/src/service/backend_metrics_initializer.cpp
@@ -46,6 +46,7 @@
 #include "platform/platform_metrics.h"
 #include "runtime/runtime_metrics.h"
 #include "service/service_metrics.h"
+#include "storage/index/vector/vector_index_cache_metrics.h"
 #include "storage/storage_metrics.h"
 #ifndef __APPLE__
 #include "util/jvm_metrics.h"
@@ -276,6 +277,7 @@ void BackendMetricsInitializer::initialize(ProcessMetricsRegistry* process_metri
     CatalogScanMetrics::instance()->install(registry);
     SpillMetrics::instance()->install(registry);
     DataCacheMetrics::instance()->install(registry);
+    VectorIndexCacheMetrics::instance()->install(registry);
     StorageMetrics::instance()->install(registry);
     KeyCache::instance().install_metrics(registry);
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -342,6 +342,7 @@ set(STORAGE_FILES
     index/inverted/clucene/match_operator.cpp
     index/vector/empty_index_reader.cpp
     index/vector/vector_index_cache.cpp
+    index/vector/vector_index_cache_metrics.cpp
     index/vector/vector_index_builder_factory.cpp
     index/vector/vector_index_writer.cpp
     index/vector/vector_index_builder.cpp

--- a/be/src/storage/index/vector/vector_index_cache.cpp
+++ b/be/src/storage/index/vector/vector_index_cache.cpp
@@ -18,10 +18,12 @@
 
 #include "common/logging.h"
 #include "runtime/mem_tracker.h"
+#include "storage/index/vector/vector_index_cache_metrics.h"
 
 namespace starrocks {
 
-VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cache(capacity) {
+VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker, VectorIndexCacheMetrics* metrics)
+        : _cache(capacity), _metrics(metrics == nullptr ? VectorIndexCacheMetrics::instance() : metrics) {
     // The HNSW/tenann index lives in the normal heap, so the global allocator hook
     // already charges its bytes to the process tracker once during load. Accounting
     // them additively on the vector_index tracker (a child of process) would count
@@ -29,6 +31,7 @@ VectorIndexCache::VectorIndexCache(size_t capacity, MemTracker* tracker) : _cach
     // mem_limit. Use the excluding-root variant so the vector_index tracker labels
     // the usage without re-adding it to process.
     _cache.set_mem_tracker_excluding_root(tracker);
+    _update_metrics();
 }
 
 // Drain IndexRefs outside _cache._lock before ~DynamicCache acquires it.
@@ -66,6 +69,11 @@ bool VectorIndexCache::Lookup(const tenann::CacheKey& key, tenann::IndexCacheHan
     return true;
 }
 
+void VectorIndexCache::SetCapacity(size_t new_capacity) {
+    _cache.set_capacity(new_capacity);
+    _update_metrics();
+}
+
 void VectorIndexCache::Insert(const tenann::CacheKey& key, tenann::IndexRef ref, tenann::IndexCacheHandle* handle) {
     Entry* entry = _cache.get_or_create(key.to_string());
     {
@@ -73,6 +81,7 @@ void VectorIndexCache::Insert(const tenann::CacheKey& key, tenann::IndexRef ref,
         entry->value().set_ref(ref);
         _cache.update_object_size(entry, entry->value().memory_usage());
     }
+    _update_metrics();
     *handle = _wrap(entry, std::move(ref));
 }
 
@@ -93,12 +102,14 @@ bool VectorIndexCache::GetOrCreate(const tenann::CacheKey& key, const IndexLoade
             } catch (const std::exception& e) {
                 g.unlock();
                 _cache.remove(entry);
+                _update_metrics();
                 LOG(ERROR) << "VectorIndexCache loader threw for key " << key.to_string() << ": " << e.what();
                 return false;
             }
             if (loaded == nullptr) {
                 g.unlock();
                 _cache.remove(entry);
+                _update_metrics();
                 LOG(ERROR) << "VectorIndexCache loader returned null IndexRef for key " << key.to_string();
                 return false;
             }
@@ -110,6 +121,7 @@ bool VectorIndexCache::GetOrCreate(const tenann::CacheKey& key, const IndexLoade
     if (warm_hit) {
         _hit_count.fetch_add(1, std::memory_order_relaxed);
     }
+    _update_metrics();
     *handle = _wrap(entry, std::move(ref));
     return true;
 }
@@ -120,6 +132,13 @@ tenann::IndexCacheHandle VectorIndexCache::_wrap(Entry* entry, tenann::IndexRef 
     Cache* cache = &_cache;
     return tenann::IndexCacheHandle(
             std::move(ref), std::shared_ptr<void>(entry, [cache](void* p) { cache->release(static_cast<Entry*>(p)); }));
+}
+
+void VectorIndexCache::_update_metrics() const {
+    if (_metrics == nullptr) {
+        return;
+    }
+    _metrics->update(capacity(), memory_usage(), lookup_count(), hit_count());
 }
 
 } // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_cache.h
+++ b/be/src/storage/index/vector/vector_index_cache.h
@@ -19,7 +19,8 @@
 
 namespace starrocks {
 class MemTracker;
-}
+class VectorIndexCacheMetrics;
+} // namespace starrocks
 
 #ifdef WITH_TENANN
 
@@ -59,7 +60,7 @@ public:
     using Cache = DynamicCache<std::string, VectorIndexCacheEntry>;
     using Entry = Cache::Entry;
 
-    VectorIndexCache(size_t capacity, MemTracker* tracker);
+    VectorIndexCache(size_t capacity, MemTracker* tracker, VectorIndexCacheMetrics* metrics = nullptr);
     ~VectorIndexCache() override;
 
     VectorIndexCache(const VectorIndexCache&) = delete;
@@ -72,7 +73,7 @@ public:
     [[nodiscard]] bool GetOrCreate(const tenann::CacheKey& key, const IndexLoader& loader,
                                    tenann::IndexCacheHandle* handle) override;
 
-    void SetCapacity(size_t new_capacity) { _cache.set_capacity(new_capacity); }
+    void SetCapacity(size_t new_capacity);
     size_t capacity() const { return _cache.capacity(); }
     size_t memory_usage() const { return _cache.size(); }
 
@@ -81,8 +82,10 @@ public:
 
 private:
     tenann::IndexCacheHandle _wrap(Entry* entry, tenann::IndexRef ref);
+    void _update_metrics() const;
 
     Cache _cache;
+    VectorIndexCacheMetrics* _metrics = nullptr;
     std::atomic<uint64_t> _lookup_count{0};
     std::atomic<uint64_t> _hit_count{0};
 };
@@ -97,7 +100,7 @@ namespace starrocks {
 // reference accessors without their own WITH_TENANN guards.
 class VectorIndexCache {
 public:
-    VectorIndexCache(size_t, MemTracker*) {}
+    VectorIndexCache(size_t, MemTracker*, VectorIndexCacheMetrics* = nullptr) {}
     void SetCapacity(size_t) {}
     size_t capacity() const { return 0; }
     size_t memory_usage() const { return 0; }

--- a/be/src/storage/index/vector/vector_index_cache_metrics.cpp
+++ b/be/src/storage/index/vector/vector_index_cache_metrics.cpp
@@ -29,6 +29,10 @@ VectorIndexCacheMetrics* VectorIndexCacheMetrics::instance() {
     return instance;
 }
 
+VectorIndexCacheMetrics::~VectorIndexCacheMetrics() {
+    hide();
+}
+
 bool VectorIndexCacheMetrics::install(MetricRegistry* registry) {
     DCHECK(registry != nullptr);
     if (_registry != nullptr) {

--- a/be/src/storage/index/vector/vector_index_cache_metrics.cpp
+++ b/be/src/storage/index/vector/vector_index_cache_metrics.cpp
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/vector/vector_index_cache_metrics.h"
+
+namespace starrocks {
+
+namespace {
+
+const char* const kVectorIndexCacheMetricsHookName = "vector_index_cache_metrics";
+
+} // namespace
+
+VectorIndexCacheMetrics* VectorIndexCacheMetrics::instance() {
+    // Process-lifetime singleton: registered Metric objects keep back-pointers
+    // to MetricRegistry, so avoid exit-time destruction after registry teardown.
+    static auto* instance = new VectorIndexCacheMetrics();
+    return instance;
+}
+
+bool VectorIndexCacheMetrics::install(MetricRegistry* registry) {
+    DCHECK(registry != nullptr);
+    if (_registry != nullptr) {
+        DCHECK_EQ(_registry, registry);
+        return _registry == registry;
+    }
+
+    if (!registry->register_metric("vector_index_cache_capacity", &vector_index_cache_capacity) ||
+        !registry->register_metric("vector_index_cache_usage", &vector_index_cache_usage) ||
+        !registry->register_metric("vector_index_cache_usage_ratio", &vector_index_cache_usage_ratio) ||
+        !registry->register_metric("vector_index_cache_lookup_count", &vector_index_cache_lookup_count) ||
+        !registry->register_metric("vector_index_cache_hit_count", &vector_index_cache_hit_count) ||
+        !registry->register_metric("vector_index_cache_hit_ratio", &vector_index_cache_hit_ratio) ||
+        !registry->register_metric("vector_index_cache_dynamic_lookup_count",
+                                   &vector_index_cache_dynamic_lookup_count) ||
+        !registry->register_metric("vector_index_cache_dynamic_hit_count", &vector_index_cache_dynamic_hit_count) ||
+        !registry->register_metric("vector_index_cache_dynamic_hit_ratio", &vector_index_cache_dynamic_hit_ratio) ||
+        !registry->register_hook(kVectorIndexCacheMetricsHookName, [this] { refresh(); })) {
+        hide();
+        return false;
+    }
+
+    _registry = registry;
+    return true;
+}
+
+void VectorIndexCacheMetrics::hide() {
+    if (_registry != nullptr) {
+        _registry->deregister_hook(kVectorIndexCacheMetricsHookName);
+        _registry = nullptr;
+    }
+    vector_index_cache_capacity.hide();
+    vector_index_cache_usage.hide();
+    vector_index_cache_usage_ratio.hide();
+    vector_index_cache_lookup_count.hide();
+    vector_index_cache_hit_count.hide();
+    vector_index_cache_hit_ratio.hide();
+    vector_index_cache_dynamic_lookup_count.hide();
+    vector_index_cache_dynamic_hit_count.hide();
+    vector_index_cache_dynamic_hit_ratio.hide();
+}
+
+void VectorIndexCacheMetrics::update(size_t capacity, size_t usage, uint64_t lookup_count, uint64_t hit_count) {
+    _capacity.store(capacity, std::memory_order_relaxed);
+    _usage.store(usage, std::memory_order_relaxed);
+    _lookup_count.store(lookup_count, std::memory_order_relaxed);
+    _hit_count.store(hit_count, std::memory_order_relaxed);
+}
+
+void VectorIndexCacheMetrics::refresh() {
+    std::lock_guard lock(_refresh_mutex);
+
+    const auto capacity = _capacity.load(std::memory_order_relaxed);
+    const auto usage = _usage.load(std::memory_order_relaxed);
+    const auto lookup_count = _lookup_count.load(std::memory_order_relaxed);
+    const auto hit_count = _hit_count.load(std::memory_order_relaxed);
+    const auto dynamic_lookup_count = _delta_since_last_refresh(lookup_count, _previous_lookup_count);
+    const auto dynamic_hit_count = _delta_since_last_refresh(hit_count, _previous_hit_count);
+    const auto usage_ratio = (capacity == 0) ? 0.0 : static_cast<double>(usage) / static_cast<double>(capacity);
+    const auto hit_ratio =
+            (lookup_count == 0) ? 0.0 : static_cast<double>(hit_count) / static_cast<double>(lookup_count);
+    const auto dynamic_hit_ratio = (dynamic_lookup_count == 0) ? 0.0
+                                                               : static_cast<double>(dynamic_hit_count) /
+                                                                         static_cast<double>(dynamic_lookup_count);
+
+    vector_index_cache_capacity.set_value(static_cast<int64_t>(capacity));
+    vector_index_cache_usage.set_value(static_cast<int64_t>(usage));
+    vector_index_cache_usage_ratio.set_value(usage_ratio);
+    vector_index_cache_lookup_count.set_value(static_cast<int64_t>(lookup_count));
+    vector_index_cache_hit_count.set_value(static_cast<int64_t>(hit_count));
+    vector_index_cache_hit_ratio.set_value(hit_ratio);
+    vector_index_cache_dynamic_lookup_count.set_value(static_cast<int64_t>(dynamic_lookup_count));
+    vector_index_cache_dynamic_hit_count.set_value(static_cast<int64_t>(dynamic_hit_count));
+    vector_index_cache_dynamic_hit_ratio.set_value(dynamic_hit_ratio);
+
+    _previous_lookup_count = lookup_count;
+    _previous_hit_count = hit_count;
+}
+
+uint64_t VectorIndexCacheMetrics::_delta_since_last_refresh(uint64_t current, uint64_t previous) {
+    return current >= previous ? current - previous : current;
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_cache_metrics.h
+++ b/be/src/storage/index/vector/vector_index_cache_metrics.h
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+#include "base/metrics.h"
+
+namespace starrocks {
+
+class VectorIndexCacheMetrics {
+public:
+    VectorIndexCacheMetrics() = default;
+    explicit VectorIndexCacheMetrics(MetricRegistry* registry) { install(registry); }
+    ~VectorIndexCacheMetrics() = default;
+
+    static VectorIndexCacheMetrics* instance();
+
+    bool install(MetricRegistry* registry);
+    void hide();
+    void update(size_t capacity, size_t usage, uint64_t lookup_count, uint64_t hit_count);
+    void refresh();
+
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_capacity, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_usage, MetricUnit::BYTES);
+    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_usage_ratio, MetricUnit::PERCENT);
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_lookup_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_hit_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_hit_ratio, MetricUnit::PERCENT);
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_dynamic_lookup_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(vector_index_cache_dynamic_hit_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_dynamic_hit_ratio, MetricUnit::PERCENT);
+
+private:
+    static uint64_t _delta_since_last_refresh(uint64_t current, uint64_t previous);
+
+    MetricRegistry* _registry = nullptr;
+    std::atomic<size_t> _capacity{0};
+    std::atomic<size_t> _usage{0};
+    std::atomic<uint64_t> _lookup_count{0};
+    std::atomic<uint64_t> _hit_count{0};
+
+    std::mutex _refresh_mutex;
+    uint64_t _previous_lookup_count = 0;
+    uint64_t _previous_hit_count = 0;
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/vector/vector_index_cache_metrics.h
+++ b/be/src/storage/index/vector/vector_index_cache_metrics.h
@@ -27,7 +27,7 @@ class VectorIndexCacheMetrics {
 public:
     VectorIndexCacheMetrics() = default;
     explicit VectorIndexCacheMetrics(MetricRegistry* registry) { install(registry); }
-    ~VectorIndexCacheMetrics() = default;
+    ~VectorIndexCacheMetrics();
 
     static VectorIndexCacheMetrics* instance();
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -14,33 +14,22 @@
 
 #include "util/system_metrics.h"
 
-#include <exec/exec_env.h>
 #include <runtime/mem_tracker.h>
 
 #include "cache/datacache.h"
-#include "storage/index/vector/vector_index_cache.h"
-#include "storage/storage_env.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
 #endif
 #include "cache/mem_cache/page_cache.h"
 #include "common/config_cache_fwd.h"
-#include "compute_env/query_cache/cache_manager.h"
 #include "jemalloc/jemalloc.h"
+#include "runtime/runtime_env.h"
+#include "storage/index/vector/vector_index_cache.h"
+#include "storage/storage_env.h"
 
 namespace starrocks {
 
 const char* const SystemMetrics::_s_hook_name = "system_metrics";
-
-class QueryCacheMetrics {
-public:
-    METRIC_DEFINE_INT_GAUGE(query_cache_capacity, MetricUnit::BYTES);
-    METRIC_DEFINE_INT_GAUGE(query_cache_usage, MetricUnit::BYTES);
-    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_usage_ratio, MetricUnit::PERCENT);
-    METRIC_DEFINE_INT_GAUGE(query_cache_lookup_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(query_cache_hit_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_DOUBLE_GAUGE(query_cache_hit_ratio, MetricUnit::PERCENT);
-};
 
 class VectorIndexCacheMetrics {
     friend class SystemMetrics;
@@ -87,7 +76,6 @@ void SystemMetrics::install(MetricRegistry* registry) {
         return;
     }
     _install_memory_metrics(registry);
-    _install_query_cache_metrics(registry);
     _install_vector_index_cache_metrics(registry);
     _registry = registry;
 }
@@ -101,7 +89,6 @@ void SystemMetrics::update() {
     }
 
     update_memory_metrics();
-    _update_query_cache_metrics();
     _update_vector_index_cache_metrics();
 }
 
@@ -240,35 +227,6 @@ void SystemMetrics::update_memory_metrics() {
     SET_MEM_METRIC_VALUE(replication_mem_tracker, replication_mem_bytes)
     SET_MEM_METRIC_VALUE(vector_index_mem_tracker, vector_index_mem_bytes)
 #undef SET_MEM_METRIC_VALUE
-}
-
-void SystemMetrics::_update_query_cache_metrics() {
-    auto* cache_mgr = ExecEnv::GetInstance()->cache_mgr();
-    if (UNLIKELY(cache_mgr == nullptr)) {
-        return;
-    }
-    auto capacity = cache_mgr->capacity();
-    auto usage = cache_mgr->memory_usage();
-    auto lookup_count = cache_mgr->lookup_count();
-    auto hit_count = cache_mgr->hit_count();
-    auto usage_ratio = (capacity == 0L) ? 0.0 : double(usage) / double(capacity);
-    auto hit_ratio = (lookup_count == 0L) ? 0.0 : double(hit_count) / double(lookup_count);
-    _query_cache_metrics->query_cache_capacity.set_value(capacity);
-    _query_cache_metrics->query_cache_usage.set_value(usage);
-    _query_cache_metrics->query_cache_usage_ratio.set_value(usage_ratio);
-    _query_cache_metrics->query_cache_lookup_count.set_value(lookup_count);
-    _query_cache_metrics->query_cache_hit_count.set_value(hit_count);
-    _query_cache_metrics->query_cache_hit_ratio.set_value(hit_ratio);
-}
-
-void SystemMetrics::_install_query_cache_metrics(MetricRegistry* registry) {
-    _query_cache_metrics = std::make_unique<QueryCacheMetrics>();
-    registry->register_metric("query_cache_capacity", &_query_cache_metrics->query_cache_capacity);
-    registry->register_metric("query_cache_usage", &_query_cache_metrics->query_cache_usage);
-    registry->register_metric("query_cache_usage_ratio", &_query_cache_metrics->query_cache_usage_ratio);
-    registry->register_metric("query_cache_lookup_count", &_query_cache_metrics->query_cache_lookup_count);
-    registry->register_metric("query_cache_hit_count", &_query_cache_metrics->query_cache_hit_count);
-    registry->register_metric("query_cache_hit_ratio", &_query_cache_metrics->query_cache_hit_ratio);
 }
 
 void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry) {

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -24,31 +24,10 @@
 #include "common/config_cache_fwd.h"
 #include "jemalloc/jemalloc.h"
 #include "runtime/runtime_env.h"
-#include "storage/index/vector/vector_index_cache.h"
-#include "storage/storage_env.h"
 
 namespace starrocks {
 
 const char* const SystemMetrics::_s_hook_name = "system_metrics";
-
-class VectorIndexCacheMetrics {
-    friend class SystemMetrics;
-
-public:
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_capacity, MetricUnit::BYTES);
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_usage, MetricUnit::BYTES);
-    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_usage_ratio, MetricUnit::PERCENT);
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_lookup_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_hit_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_hit_ratio, MetricUnit::PERCENT);
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_dynamic_lookup_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(vector_index_cache_dynamic_hit_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_DOUBLE_GAUGE(vector_index_cache_dynamic_hit_ratio, MetricUnit::PERCENT);
-
-private:
-    uint64_t _previous_lookup_count = 0;
-    uint64_t _previous_hit_count = 0;
-};
 
 SystemMetrics::SystemMetrics() = default;
 
@@ -76,7 +55,6 @@ void SystemMetrics::install(MetricRegistry* registry) {
         return;
     }
     _install_memory_metrics(registry);
-    _install_vector_index_cache_metrics(registry);
     _registry = registry;
 }
 
@@ -89,7 +67,6 @@ void SystemMetrics::update() {
     }
 
     update_memory_metrics();
-    _update_vector_index_cache_metrics();
 }
 
 void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
@@ -227,55 +204,6 @@ void SystemMetrics::update_memory_metrics() {
     SET_MEM_METRIC_VALUE(replication_mem_tracker, replication_mem_bytes)
     SET_MEM_METRIC_VALUE(vector_index_mem_tracker, vector_index_mem_bytes)
 #undef SET_MEM_METRIC_VALUE
-}
-
-void SystemMetrics::_install_vector_index_cache_metrics(MetricRegistry* registry) {
-    _vector_index_cache_metrics = std::make_unique<VectorIndexCacheMetrics>();
-    registry->register_metric("vector_index_cache_capacity", &_vector_index_cache_metrics->vector_index_cache_capacity);
-    registry->register_metric("vector_index_cache_usage", &_vector_index_cache_metrics->vector_index_cache_usage);
-    registry->register_metric("vector_index_cache_usage_ratio",
-                              &_vector_index_cache_metrics->vector_index_cache_usage_ratio);
-    registry->register_metric("vector_index_cache_lookup_count",
-                              &_vector_index_cache_metrics->vector_index_cache_lookup_count);
-    registry->register_metric("vector_index_cache_hit_count",
-                              &_vector_index_cache_metrics->vector_index_cache_hit_count);
-    registry->register_metric("vector_index_cache_hit_ratio",
-                              &_vector_index_cache_metrics->vector_index_cache_hit_ratio);
-    registry->register_metric("vector_index_cache_dynamic_lookup_count",
-                              &_vector_index_cache_metrics->vector_index_cache_dynamic_lookup_count);
-    registry->register_metric("vector_index_cache_dynamic_hit_count",
-                              &_vector_index_cache_metrics->vector_index_cache_dynamic_hit_count);
-    registry->register_metric("vector_index_cache_dynamic_hit_ratio",
-                              &_vector_index_cache_metrics->vector_index_cache_dynamic_hit_ratio);
-}
-
-void SystemMetrics::_update_vector_index_cache_metrics() {
-    auto* index_cache = StorageEnv::GetInstance()->vector_index_cache();
-    if (UNLIKELY(index_cache == nullptr)) {
-        return;
-    }
-    auto capacity = index_cache->capacity();
-    auto usage = index_cache->memory_usage();
-    auto lookup_count = index_cache->lookup_count();
-    auto hit_count = index_cache->hit_count();
-    auto usage_ratio = (capacity == 0L) ? 0.0 : double(usage) / double(capacity);
-    auto hit_ratio = (lookup_count == 0L) ? 0.0 : double(hit_count) / double(lookup_count);
-    auto dynamic_lookup_count = lookup_count - _vector_index_cache_metrics->_previous_lookup_count;
-    auto dynamic_hit_count = hit_count - _vector_index_cache_metrics->_previous_hit_count;
-    auto dynamic_hit_ratio =
-            (dynamic_lookup_count == 0) ? 0.0 : double(dynamic_hit_count) / double(dynamic_lookup_count);
-    _vector_index_cache_metrics->vector_index_cache_capacity.set_value(capacity);
-    _vector_index_cache_metrics->vector_index_cache_usage.set_value(usage);
-    _vector_index_cache_metrics->vector_index_cache_usage_ratio.set_value(usage_ratio);
-    _vector_index_cache_metrics->vector_index_cache_lookup_count.set_value(lookup_count);
-    _vector_index_cache_metrics->vector_index_cache_hit_count.set_value(hit_count);
-    _vector_index_cache_metrics->vector_index_cache_hit_ratio.set_value(hit_ratio);
-    _vector_index_cache_metrics->vector_index_cache_dynamic_lookup_count.set_value(dynamic_lookup_count);
-    _vector_index_cache_metrics->vector_index_cache_dynamic_hit_count.set_value(dynamic_hit_count);
-    _vector_index_cache_metrics->vector_index_cache_dynamic_hit_ratio.set_value(dynamic_hit_ratio);
-
-    _vector_index_cache_metrics->_previous_lookup_count = lookup_count;
-    _vector_index_cache_metrics->_previous_hit_count = hit_count;
 }
 
 } // namespace starrocks

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -24,7 +24,6 @@
 
 namespace starrocks {
 
-class QueryCacheMetrics;
 class VectorIndexCacheMetrics;
 
 class MemoryMetrics {
@@ -89,10 +88,6 @@ public:
 private:
     void _install_memory_metrics(MetricRegistry* registry);
 
-    void _install_query_cache_metrics(MetricRegistry* registry);
-
-    void _update_query_cache_metrics();
-
     void _install_vector_index_cache_metrics(MetricRegistry* registry);
 
     void _update_vector_index_cache_metrics();
@@ -104,7 +99,6 @@ private:
     static const char* const _s_hook_name;
 
     std::unique_ptr<MemoryMetrics> _memory_metrics;
-    std::unique_ptr<QueryCacheMetrics> _query_cache_metrics;
     std::unique_ptr<VectorIndexCacheMetrics> _vector_index_cache_metrics;
 
     std::mutex _update_mutex;

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -24,8 +24,6 @@
 
 namespace starrocks {
 
-class VectorIndexCacheMetrics;
-
 class MemoryMetrics {
 public:
     METRIC_DEFINE_INT_GAUGE(jemalloc_allocated_bytes, MetricUnit::BYTES);
@@ -88,10 +86,6 @@ public:
 private:
     void _install_memory_metrics(MetricRegistry* registry);
 
-    void _install_vector_index_cache_metrics(MetricRegistry* registry);
-
-    void _update_vector_index_cache_metrics();
-
     void _update_datacache_mem_tracker();
     void _update_pagecache_mem_tracker();
 
@@ -99,7 +93,6 @@ private:
     static const char* const _s_hook_name;
 
     std::unique_ptr<MemoryMetrics> _memory_metrics;
-    std::unique_ptr<VectorIndexCacheMetrics> _vector_index_cache_metrics;
 
     std::mutex _update_mutex;
     MetricRegistry* _registry = nullptr;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -402,6 +402,7 @@ SET(DW_TEST_FILES
     ./storage/index/vector_index_test.cpp
     ./storage/index/vector_search_test.cpp
     ./storage/index/vector/vector_index_cache_test.cpp
+    ./storage/index/vector/vector_index_cache_metrics_test.cpp
     ./storage/index/builtin_inverted_index_test.cpp
     ./storage/kv_store_test.cpp
     ./storage/lake/alter_tablet_meta_test.cpp

--- a/be/test/compute_env/compute_env_test.cpp
+++ b/be/test/compute_env/compute_env_test.cpp
@@ -208,6 +208,20 @@ TEST(ComputeEnvTest, ComputeEnvInstallsDriverLimiterMetric) {
     env.destroy();
 }
 
+TEST(ComputeEnvTest, ComputeEnvInstallsQueryCacheMetrics) {
+    init_compute_env_test_context();
+    MetricRegistry registry("test_registry");
+    ComputeEnv env;
+
+    ASSERT_OK(env.init(make_compute_env_options(&registry)));
+    registry.trigger_hook();
+    assert_metric_value(&registry, "query_cache_capacity", "4194304");
+    assert_metric_value(&registry, "query_cache_lookup_count", "0");
+
+    env.destroy();
+    ASSERT_EQ(nullptr, registry.get_metric("query_cache_capacity"));
+}
+
 TEST(ComputeEnvTest, LoadPathLifecycle) {
     init_compute_env_test_context();
     ComputeEnv env;

--- a/be/test/compute_env/query_cache_test.cpp
+++ b/be/test/compute_env/query_cache_test.cpp
@@ -14,11 +14,36 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
+#include "base/metrics.h"
 #include "column/fixed_length_column.h"
 #include "compute_env/query_cache/cache_manager.h"
 #include "compute_env/query_cache/lane_arbiter.h"
 
 namespace starrocks {
+
+namespace {
+
+void assert_metric_value(MetricRegistry* registry, const std::string& name, const std::string& value) {
+    auto* metric = registry->get_metric(name);
+    ASSERT_NE(nullptr, metric);
+    ASSERT_EQ(value, metric->to_string());
+}
+
+double metric_double_value(MetricRegistry* registry, const std::string& name) {
+    auto* metric = registry->get_metric(name);
+    EXPECT_NE(nullptr, metric);
+    return metric == nullptr ? 0.0 : std::stod(metric->to_string());
+}
+
+int64_t metric_int_value(MetricRegistry* registry, const std::string& name) {
+    auto* metric = registry->get_metric(name);
+    EXPECT_NE(nullptr, metric);
+    return metric == nullptr ? 0 : std::stoll(metric->to_string());
+}
+
+} // namespace
 
 TEST(ComputeEnvQueryCacheTest, cache_manager_populates_probes_and_invalidates) {
     query_cache::CacheManager cache_mgr(1024 * 1024);
@@ -60,6 +85,46 @@ TEST(ComputeEnvQueryCacheTest, lane_arbiter_assigns_releases_and_skips_processed
     lane_arbiter.enable_passthrough_mode();
     EXPECT_TRUE(lane_arbiter.in_passthrough_mode());
     EXPECT_EQ(query_cache::AR_IO, lane_arbiter.try_acquire_lane(40));
+}
+
+TEST(ComputeEnvQueryCacheTest, cache_manager_installs_updates_and_removes_metrics) {
+    MetricRegistry registry("query_cache_metrics_test");
+
+    {
+        query_cache::CacheManager cache_mgr(1024 * 1024);
+        ASSERT_TRUE(cache_mgr.install_metrics(&registry).ok());
+
+        assert_metric_value(&registry, "query_cache_capacity", "1048576");
+        assert_metric_value(&registry, "query_cache_usage", "0");
+        assert_metric_value(&registry, "query_cache_usage_ratio", "0.000000");
+        assert_metric_value(&registry, "query_cache_lookup_count", "0");
+        assert_metric_value(&registry, "query_cache_hit_count", "0");
+        assert_metric_value(&registry, "query_cache_hit_ratio", "0.000000");
+
+        auto chunk = std::make_shared<Chunk>();
+        auto column = Int8Column::create();
+        column->append(1);
+        chunk->append_column(std::move(column), 1);
+
+        query_cache::CacheValue value(100, 7, {chunk});
+        cache_mgr.populate("cache-key", value);
+        ASSERT_TRUE(cache_mgr.probe("cache-key").ok());
+
+        registry.trigger_hook();
+        EXPECT_GT(metric_int_value(&registry, "query_cache_usage"), 0);
+        EXPECT_GT(metric_double_value(&registry, "query_cache_usage_ratio"), 0.0);
+        assert_metric_value(&registry, "query_cache_lookup_count", "1");
+        assert_metric_value(&registry, "query_cache_hit_count", "1");
+        assert_metric_value(&registry, "query_cache_hit_ratio", "1.000000");
+    }
+
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_capacity"));
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_usage"));
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_usage_ratio"));
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_lookup_count"));
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_hit_count"));
+    EXPECT_EQ(nullptr, registry.get_metric("query_cache_hit_ratio"));
+    registry.trigger_hook();
 }
 
 } // namespace starrocks

--- a/be/test/storage/index/vector/vector_index_cache_metrics_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_metrics_test.cpp
@@ -43,6 +43,25 @@ TEST(VectorIndexCacheMetricsTest, InstallRegistersMetrics) {
     assert_metric_registered(&registry, "vector_index_cache_dynamic_hit_ratio");
 }
 
+TEST(VectorIndexCacheMetricsTest, DestructorDeregistersHook) {
+    MetricRegistry registry("test_registry");
+    {
+        VectorIndexCacheMetrics metrics(&registry);
+        metrics.update(/*capacity=*/100, /*usage=*/25, /*lookup_count=*/4, /*hit_count=*/3);
+        registry.trigger_hook();
+    }
+
+    VectorIndexCacheMetrics metrics;
+    ASSERT_TRUE(metrics.install(&registry));
+    metrics.update(/*capacity=*/200, /*usage=*/50, /*lookup_count=*/8, /*hit_count=*/4);
+    registry.trigger_hook();
+
+    EXPECT_EQ(200, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(50, metrics.vector_index_cache_usage.value());
+    EXPECT_EQ(8, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(4, metrics.vector_index_cache_hit_count.value());
+}
+
 TEST(VectorIndexCacheMetricsTest, RefreshPublishesSnapshotAndDynamicDeltas) {
     MetricRegistry registry("test_registry");
     VectorIndexCacheMetrics metrics(&registry);

--- a/be/test/storage/index/vector/vector_index_cache_metrics_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_metrics_test.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/vector/vector_index_cache_metrics.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+namespace {
+
+void assert_metric_registered(MetricRegistry* registry, const std::string& name) {
+    ASSERT_NE(nullptr, registry->get_metric(name));
+}
+
+} // namespace
+
+TEST(VectorIndexCacheMetricsTest, InstallRegistersMetrics) {
+    MetricRegistry registry("test_registry");
+    VectorIndexCacheMetrics metrics;
+
+    ASSERT_TRUE(metrics.install(&registry));
+
+    assert_metric_registered(&registry, "vector_index_cache_capacity");
+    assert_metric_registered(&registry, "vector_index_cache_usage");
+    assert_metric_registered(&registry, "vector_index_cache_usage_ratio");
+    assert_metric_registered(&registry, "vector_index_cache_lookup_count");
+    assert_metric_registered(&registry, "vector_index_cache_hit_count");
+    assert_metric_registered(&registry, "vector_index_cache_hit_ratio");
+    assert_metric_registered(&registry, "vector_index_cache_dynamic_lookup_count");
+    assert_metric_registered(&registry, "vector_index_cache_dynamic_hit_count");
+    assert_metric_registered(&registry, "vector_index_cache_dynamic_hit_ratio");
+}
+
+TEST(VectorIndexCacheMetricsTest, RefreshPublishesSnapshotAndDynamicDeltas) {
+    MetricRegistry registry("test_registry");
+    VectorIndexCacheMetrics metrics(&registry);
+
+    metrics.update(/*capacity=*/100, /*usage=*/25, /*lookup_count=*/4, /*hit_count=*/3);
+    registry.trigger_hook();
+
+    EXPECT_EQ(100, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(25, metrics.vector_index_cache_usage.value());
+    EXPECT_DOUBLE_EQ(0.25, metrics.vector_index_cache_usage_ratio.value());
+    EXPECT_EQ(4, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(3, metrics.vector_index_cache_hit_count.value());
+    EXPECT_DOUBLE_EQ(0.75, metrics.vector_index_cache_hit_ratio.value());
+    EXPECT_EQ(4, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(3, metrics.vector_index_cache_dynamic_hit_count.value());
+    EXPECT_DOUBLE_EQ(0.75, metrics.vector_index_cache_dynamic_hit_ratio.value());
+
+    metrics.update(/*capacity=*/200, /*usage=*/100, /*lookup_count=*/7, /*hit_count=*/5);
+    registry.trigger_hook();
+
+    EXPECT_EQ(200, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(100, metrics.vector_index_cache_usage.value());
+    EXPECT_DOUBLE_EQ(0.5, metrics.vector_index_cache_usage_ratio.value());
+    EXPECT_EQ(7, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(5, metrics.vector_index_cache_hit_count.value());
+    EXPECT_DOUBLE_EQ(5.0 / 7.0, metrics.vector_index_cache_hit_ratio.value());
+    EXPECT_EQ(3, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(2, metrics.vector_index_cache_dynamic_hit_count.value());
+    EXPECT_DOUBLE_EQ(2.0 / 3.0, metrics.vector_index_cache_dynamic_hit_ratio.value());
+}
+
+TEST(VectorIndexCacheMetricsTest, RefreshHandlesCounterResetWithoutUnsignedUnderflow) {
+    MetricRegistry registry("test_registry");
+    VectorIndexCacheMetrics metrics(&registry);
+
+    metrics.update(/*capacity=*/100, /*usage=*/10, /*lookup_count=*/10, /*hit_count=*/8);
+    registry.trigger_hook();
+
+    metrics.update(/*capacity=*/100, /*usage=*/0, /*lookup_count=*/1, /*hit_count=*/1);
+    registry.trigger_hook();
+
+    EXPECT_EQ(1, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_hit_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_dynamic_hit_count.value());
+    EXPECT_DOUBLE_EQ(1.0, metrics.vector_index_cache_dynamic_hit_ratio.value());
+}
+
+} // namespace starrocks

--- a/be/test/storage/index/vector/vector_index_cache_test.cpp
+++ b/be/test/storage/index/vector/vector_index_cache_test.cpp
@@ -35,6 +35,7 @@
 #include "storage/index/vector/empty_index_reader.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/tenann_index_reader.h"
+#include "storage/index/vector/vector_index_cache_metrics.h"
 #include "storage/index/vector/vector_index_file_reader.h"
 #include "tenann/common/error.h"
 #include "tenann/index/index.h"
@@ -176,6 +177,56 @@ TEST_F(VectorIndexCacheTest, LookupAndHitCounters_TrackedAcrossPaths) {
     EXPECT_FALSE(cache_->Lookup(tenann::CacheKey("/missing.vi"), &h));
     EXPECT_EQ(2u, cache_->lookup_count());
     EXPECT_EQ(1u, cache_->hit_count());
+}
+
+TEST_F(VectorIndexCacheTest, Metrics_UpdatedFromCacheOperations) {
+    MetricRegistry registry("test_registry");
+    VectorIndexCacheMetrics metrics(&registry);
+    auto cache = std::make_unique<VectorIndexCache>(/*capacity=*/16 * 1024, tracker_.get(), &metrics);
+    registry.trigger_hook();
+
+    EXPECT_EQ(16 * 1024, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_usage.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_hit_count.value());
+
+    auto loader = [&]() -> tenann::IndexRef { return make_dummy_ref(2048); };
+    tenann::IndexCacheHandle h;
+    EXPECT_TRUE(cache->GetOrCreate(tenann::CacheKey("/metrics.vi"), loader, &h));
+    registry.trigger_hook();
+
+    EXPECT_EQ(16 * 1024, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(2048, metrics.vector_index_cache_usage.value());
+    EXPECT_DOUBLE_EQ(2048.0 / (16 * 1024), metrics.vector_index_cache_usage_ratio.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_hit_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_dynamic_hit_count.value());
+
+    EXPECT_TRUE(cache->GetOrCreate(tenann::CacheKey("/metrics.vi"), loader, &h));
+    registry.trigger_hook();
+
+    EXPECT_EQ(2, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_hit_count.value());
+    EXPECT_DOUBLE_EQ(0.5, metrics.vector_index_cache_hit_ratio.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_dynamic_hit_count.value());
+    EXPECT_DOUBLE_EQ(1.0, metrics.vector_index_cache_dynamic_hit_ratio.value());
+
+    EXPECT_TRUE(cache->Lookup(tenann::CacheKey("/metrics.vi"), &h));
+    registry.trigger_hook();
+
+    EXPECT_EQ(2, metrics.vector_index_cache_lookup_count.value());
+    EXPECT_EQ(1, metrics.vector_index_cache_hit_count.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_dynamic_lookup_count.value());
+    EXPECT_EQ(0, metrics.vector_index_cache_dynamic_hit_count.value());
+
+    cache->SetCapacity(8 * 1024);
+    registry.trigger_hook();
+
+    EXPECT_EQ(8 * 1024, metrics.vector_index_cache_capacity.value());
+    EXPECT_EQ(2048, metrics.vector_index_cache_usage.value());
+    EXPECT_DOUBLE_EQ(0.25, metrics.vector_index_cache_usage_ratio.value());
 }
 
 TEST_F(VectorIndexCacheTest, GetOrCreate_ConcurrentCallers_SingleFlight) {

--- a/be/test/util/starrocks_metrics_test.cpp
+++ b/be/test/util/starrocks_metrics_test.cpp
@@ -52,6 +52,7 @@
 #include "runtime/runtime_metrics.h"
 #include "service/backend_metrics_initializer.h"
 #include "service/service_metrics.h"
+#include "storage/index/vector/vector_index_cache_metrics.h"
 #include "storage/storage_metrics.h"
 
 namespace starrocks {
@@ -161,6 +162,7 @@ TEST_F(BackendMetricsTest, Normal) {
     auto runtime_metrics = RuntimeMetrics::instance();
     auto service_metrics = ServiceMetrics::instance();
     auto storage_metrics = StorageMetrics::instance();
+    auto vector_index_cache_metrics = VectorIndexCacheMetrics::instance();
     auto metrics = backend_metrics_registry_for_test();
     metrics->collect(&visitor);
     // check metric
@@ -217,6 +219,13 @@ TEST_F(BackendMetricsTest, Normal) {
         auto metric = metrics->get_metric("push_requests_total", MetricLabels().add("status", "SUCCESS"));
         ASSERT_TRUE(metric != nullptr);
         ASSERT_STREQ("106", metric->to_string().c_str());
+    }
+    {
+        vector_index_cache_metrics->update(/*capacity=*/1024, /*usage=*/256, /*lookup_count=*/2, /*hit_count=*/1);
+        metrics->trigger_hook();
+        auto metric = metrics->get_metric("vector_index_cache_capacity");
+        ASSERT_TRUE(metric != nullptr);
+        ASSERT_STREQ("1024", metric->to_string().c_str());
     }
     {
         storage_metrics->push_requests_fail_total.increment(107);

--- a/build-support/exec_env_singleton_allowlist.txt
+++ b/build-support/exec_env_singleton_allowlist.txt
@@ -12,4 +12,3 @@ src/service/service_be/lake_service.cpp
 src/service/service_be/starrocks_be.cpp
 src/data_workflows/load/push_broker_reader.cpp
 src/udf/java/utils.cpp
-src/util/system_metrics.cpp


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
