### PR TITLE
[Enhancement] Add HTTP authentication framework gated by enable_http_auth (backport #73822)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -510,6 +510,11 @@ CONF_String(pprof_profile_dir, "${STARROCKS_HOME}/log");
 // to forward compatibility, will be removed later
 CONF_mBool(enable_token_check, "true");
 
+// Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
+// (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
+// exempt. Default false for backward compatibility.
+CONF_mBool(enable_http_auth, "false");
+
 // to open/close system metrics
 CONF_Bool(enable_system_metrics, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -512,8 +512,8 @@ CONF_mBool(enable_token_check, "true");
 
 // Whether to require Basic Auth for external BE HTTP endpoints. Internal endpoints
 // (BE-to-BE clone, internal load download, health probe, Prometheus metrics) are always
-// exempt. Default false for backward compatibility.
-CONF_mBool(enable_http_auth, "false");
+// exempt. Default false for backward compatibility. Immutable; requires a BE restart to change.
+CONF_Bool(enable_http_auth, "false");
 
 // to open/close system metrics
 CONF_Bool(enable_system_metrics, "true");

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -108,6 +108,7 @@ public:
     static Status NotFound(std::string_view msg) { return Status(TStatusCode::NOT_FOUND, msg); }
     static Status AlreadyExist(std::string_view msg) { return Status(TStatusCode::ALREADY_EXIST, msg); }
     static Status NotSupported(std::string_view msg) { return Status(TStatusCode::NOT_IMPLEMENTED_ERROR, msg); }
+    static Status NotAuthorized(std::string_view msg) { return Status(TStatusCode::NOT_AUTHORIZED, msg); }
     static Status EndOfFile(std::string_view msg) { return Status(TStatusCode::END_OF_FILE, msg); }
     static Status InternalError(std::string_view msg) { return Status(TStatusCode::INTERNAL_ERROR, msg); }
     static Status RuntimeError(std::string_view msg) { return Status(TStatusCode::RUNTIME_ERROR, msg); }

--- a/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_fe_metrics_scanner.cpp
@@ -16,16 +16,16 @@
 
 #include <simdjson.h>
 
-#include "agent/master_info.h"
 #include "exec/schema_scanner/schema_helper.h"
-#include "gutil/strings/numbers.h"
+#include "gen_cpp/FrontendService.h"
 #include "gutil/strings/substitute.h"
-#include "http/http_client.h"
+#include "runtime/client_cache.h"
 #include "runtime/runtime_state.h"
 #include "runtime/string_value.h"
 #include "types/logical_type.h"
 #include "util/metrics.h"
 #include "util/starrocks_metrics.h"
+#include "util/thrift_rpc_helper.h"
 
 namespace starrocks {
 
@@ -42,17 +42,30 @@ SchemaFeMetricsScanner::SchemaFeMetricsScanner()
 SchemaFeMetricsScanner::~SchemaFeMetricsScanner() = default;
 
 Status SchemaFeMetricsScanner::_get_fe_metrics(RuntimeState* state) {
+    int32_t timeout = state->query_options().query_timeout * 1000 / 2;
     for (const TFrontend& frontend : _param->frontends) {
-        std::string metrics;
-        std::string url = "http://" + frontend.ip + ":" + SimpleItoa(frontend.http_port) + "/metrics?type=json";
-        auto timeout = state->query_options().query_timeout * 1000 / 2;
-        auto mmetrics_cb = [&url, &metrics, &timeout](HttpClient* client) {
-            RETURN_IF_ERROR(client->init(url));
-            client->set_timeout_ms(timeout);
-            RETURN_IF_ERROR(client->execute(&metrics));
-            return Status::OK();
-        };
-        RETURN_IF_ERROR(HttpClient::execute_with_retry(2 /* retry times */, 1 /* sleep interval */, mmetrics_cb));
+        // Defensive guard: the FE planner always sets rpc_port (Config.rpc_port); a missing or
+        // non-positive port only happens under FE/BE version skew. Skip such a frontend with a
+        // warning rather than connecting to port 0 or failing the whole fe_metrics query.
+        if (!frontend.__isset.rpc_port || frontend.rpc_port <= 0) {
+            LOG(WARNING) << "skip fe_metrics for frontend " << frontend.id << " (" << frontend.ip
+                         << "): missing/invalid rpc_port";
+            continue;
+        }
+        // Fetch each FE's metrics over the FrontendService Thrift RPC. This replaces the
+        // previous HTTP scrape of /metrics?type=json, so fe_metrics works regardless of
+        // `enable_http_auth` (the RPC needs no HTTP Basic credentials). It takes no arguments —
+        // FE process metrics are global, with no per-object RBAC to authorize.
+        TFeMetricsResult result;
+        auto rpc_cb = [&result](FrontendServiceConnection& client) { client->getFeMetrics(result); };
+        RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(frontend.ip, frontend.rpc_port, rpc_cb, timeout));
+        if (result.__isset.status) {
+            RETURN_IF_ERROR(Status(result.status));
+        }
+        if (!result.__isset.json_metrics) {
+            return Status::InternalError("fe metrics response missing json_metrics from " + frontend.ip);
+        }
+        const std::string& metrics = result.json_metrics;
         VLOG(2) << "metrics: " << metrics;
 
         simdjson::ondemand::parser parser;

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -47,6 +47,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     int64_t _do_checksum(int64_t tablet_id, int64_t version);
 };

--- a/be/src/http/action/compact_rocksdb_meta_action.h
+++ b/be/src/http/action/compact_rocksdb_meta_action.h
@@ -33,6 +33,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _compact(HttpRequest* req);
 

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -62,6 +62,8 @@ public:
     static Status do_compaction(uint64_t tablet_id, const std::string& compaction_type,
                                 const std::string& rowset_ids_string);
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     Status _handle_show_compaction(HttpRequest* req, std::string* json_result);
     Status _handle_compaction(HttpRequest* req, std::string* json_result);

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     bool _check_request(HttpRequest* req);
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);

--- a/be/src/http/action/greplog_action.h
+++ b/be/src/http/action/greplog_action.h
@@ -28,6 +28,8 @@ public:
     ~GrepLogAction() override = default;
 
     void handle(HttpRequest* req) override;
+
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
 };
 
 } // namespace starrocks

--- a/be/src/http/action/health_action.cpp
+++ b/be/src/http/action/health_action.cpp
@@ -49,6 +49,10 @@ const static std::string HEADER_JSON = "application/json";
 
 HealthAction::HealthAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
 
+bool HealthAction::need_auth() const {
+    return true;
+}
+
 void HealthAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_health"));
     std::stringstream ss;

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -49,7 +49,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     [[maybe_unused]] ExecEnv* _exec_env;

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -49,6 +49,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     [[maybe_unused]] ExecEnv* _exec_env;
 };

--- a/be/src/http/action/lake/dump_tablet_metadata_action.h
+++ b/be/src/http/action/lake/dump_tablet_metadata_action.h
@@ -33,6 +33,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     ExecEnv* _exec_env;
 };

--- a/be/src/http/action/memory_metrics_action.cpp
+++ b/be/src/http/action/memory_metrics_action.cpp
@@ -27,6 +27,10 @@
 
 namespace starrocks {
 
+bool MemoryMetricsAction::need_auth() const {
+    return true;
+}
+
 void MemoryMetricsAction::handle(HttpRequest* req) {
     LOG(INFO) << "Start collect memory metrics.";
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_memory_metrics"));

--- a/be/src/http/action/memory_metrics_action.h
+++ b/be/src/http/action/memory_metrics_action.h
@@ -53,6 +53,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     void getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size,
                              std::vector<std::string> metric_labels_to_print);

--- a/be/src/http/action/memory_metrics_action.h
+++ b/be/src/http/action/memory_metrics_action.h
@@ -53,7 +53,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     void getMemoryMetricTree(MemTracker* memTracker, std::stringstream& result, int64_t total_size,

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -54,6 +54,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     static Status _handle_header(HttpRequest* req, std::string* json_header);
 

--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -320,6 +320,10 @@ void JsonMetricsVisitor::visit(const std::string& prefix, const std::string& nam
     }
 }
 
+bool MetricsAction::need_auth() const {
+    return true;
+}
+
 void MetricsAction::handle(HttpRequest* req) {
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_metrics"));
     const std::string& type = req->param("type");

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -63,7 +63,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
-    bool need_auth() const override { return false; }
+    // AuthN-only: require Basic identity when `config::enable_http_auth` is on (the
+    // injected verifier short-circuits when it is off). No extra privilege required —
+    // `required_privilege()` stays NONE. Defined out-of-line in the .cpp so BE
+    // incremental-coverage attributes the line to a be/src translation unit; a
+    // header-inline override is inlined into callers and not counted.
+    bool need_auth() const override;
 
 private:
     MetricRegistry* _metrics;

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -63,6 +63,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override { return false; }
+
 private:
     MetricRegistry* _metrics;
     MockFunc _mock_func;

--- a/be/src/http/action/pipeline_blocking_drivers_action.h
+++ b/be/src/http/action/pipeline_blocking_drivers_action.h
@@ -35,6 +35,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     // Returns information about the blocking drivers with the following format:

--- a/be/src/http/action/pprof_actions.h
+++ b/be/src/http/action/pprof_actions.h
@@ -40,7 +40,13 @@ namespace starrocks {
 
 class BfdParser;
 
-class HeapAction : public HttpHandler {
+// Shared base for pprof/profile handlers: requires System OPERATE privilege on top of identity AuthN.
+class PprofBaseHandler : public HttpHandler {
+public:
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+};
+
+class HeapAction : public PprofBaseHandler {
 public:
     HeapAction() = default;
     ~HeapAction() override = default;
@@ -48,7 +54,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class GrowthAction : public HttpHandler {
+class GrowthAction : public PprofBaseHandler {
 public:
     GrowthAction() = default;
     ~GrowthAction() override = default;
@@ -56,7 +62,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class ProfileAction : public HttpHandler {
+class ProfileAction : public PprofBaseHandler {
 public:
     ProfileAction() = default;
     ~ProfileAction() override = default;
@@ -64,7 +70,7 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class IOProfileAction : public HttpHandler {
+class IOProfileAction : public PprofBaseHandler {
 public:
     IOProfileAction() = default;
     ~IOProfileAction() override = default;
@@ -72,14 +78,14 @@ public:
     void handle(HttpRequest* req) override;
 };
 
-class PmuProfileAction : public HttpHandler {
+class PmuProfileAction : public PprofBaseHandler {
 public:
     PmuProfileAction() = default;
     ~PmuProfileAction() override = default;
     void handle(HttpRequest* req) override {}
 };
 
-class ContentionAction : public HttpHandler {
+class ContentionAction : public PprofBaseHandler {
 public:
     ContentionAction() = default;
     ~ContentionAction() override = default;
@@ -87,14 +93,14 @@ public:
     void handle(HttpRequest* req) override {}
 };
 
-class CmdlineAction : public HttpHandler {
+class CmdlineAction : public PprofBaseHandler {
 public:
     CmdlineAction() = default;
     ~CmdlineAction() override = default;
     void handle(HttpRequest* req) override;
 };
 
-class SymbolAction : public HttpHandler {
+class SymbolAction : public PprofBaseHandler {
 public:
     SymbolAction(BfdParser* parser) : _parser(parser) {}
     ~SymbolAction() override = default;

--- a/be/src/http/action/query_cache_action.h
+++ b/be/src/http/action/query_cache_action.h
@@ -35,6 +35,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     void _handle_stat(HttpRequest* req);

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -49,6 +49,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void reload(const std::string& path, int64_t tablet_id, int32_t schema_hash, HttpRequest* req);
 

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -53,6 +53,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     Status _handle(HttpRequest* req);
 

--- a/be/src/http/action/runtime_filter_cache_action.h
+++ b/be/src/http/action/runtime_filter_cache_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     void _handle(HttpRequest* req, const std::function<void(rapidjson::Document& root)>& func);
     void _handle_stat(HttpRequest* req);

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -36,6 +36,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     int64_t make_snapshot(int64_t tablet_id, int schema_hash, std::string* snapshot_path);
 

--- a/be/src/http/action/stop_be_action.h
+++ b/be/src/http/action/stop_be_action.h
@@ -31,6 +31,8 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::NODE; }
+
 private:
     [[maybe_unused]] ExecEnv* _exec_env;
 

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -63,6 +63,11 @@ public:
     void on_chunk_data(HttpRequest* req) override;
     void free_handler_ctx(void* ctx) override;
 
+    // Auth (identity + table-level INSERT priv) is performed by FE as part of the
+    // loadTxnBegin/streamLoadPut RPC flow; skip the framework-level pre-check to
+    // avoid an extra FE round-trip per stream-load request.
+    bool need_auth() const override { return false; }
+
 private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);
     Status _handle(StreamLoadContext* ctx);

--- a/be/src/http/action/transaction_stream_load.h
+++ b/be/src/http/action/transaction_stream_load.h
@@ -36,6 +36,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    // Framework-level Basic is skipped: this endpoint uses a label-bound session
+    // model where begin parses Basic and stashes credentials into StreamLoadContext,
+    // and subsequent commit/rollback look up the ctx by label. Identity + INSERT
+    // are validated inside the begin/commit/rollback RPCs on FE.
+    bool need_auth() const override { return false; }
+
 private:
     void _send_error_reply(HttpRequest* req, const Status& st);
 
@@ -56,6 +62,11 @@ public:
     void on_chunk_data(HttpRequest* req) override;
 
     void free_handler_ctx(void* ctx) override;
+
+    // Framework-level Basic is skipped: this endpoint looks up the
+    // StreamLoadContext by label and inherits the credentials captured at begin.
+    // Identity + INSERT are validated by FE during the streamLoadPut RPC flow.
+    bool need_auth() const override { return false; }
 
 private:
     Status _on_header(HttpRequest* http_req, StreamLoadContext* ctx);

--- a/be/src/http/action/update_config_action.h
+++ b/be/src/http/action/update_config_action.h
@@ -56,6 +56,8 @@ public:
     // hack to share update_config method with be_configs schema table sink
     static UpdateConfigAction* instance() { return _instance.load(); }
 
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
 private:
     static std::atomic<UpdateConfigAction*> _instance;
     ExecEnv* _exec_env;

--- a/be/src/http/download_action.h
+++ b/be/src/http/download_action.h
@@ -41,6 +41,12 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    bool need_auth() const override {
+        // NORMAL (BE-to-BE tablet clone, internal load file download) is internal and
+        // already gated by a shared token; only ERROR_LOG is user-facing.
+        return _download_type == ERROR_LOG;
+    }
+
 private:
     enum DOWNLOAD_TYPE {
         NORMAL = 1,

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -109,6 +109,12 @@ EvHttpServer::~EvHttpServer() {
 }
 
 Status EvHttpServer::start() {
+    // Mark the server as started so `set_auth_verifier` will DCHECK if called
+    // late. Setting before _bind() means even a failed start can't be "fixed
+    // up" by retroactively wiring a verifier between attempts — but that's
+    // intentional: re-using a partially-started instance isn't supported.
+    _started = true;
+
     // bind to
     RETURN_IF_ERROR(_bind());
     for (int i = 0; i < _num_workers; ++i) {
@@ -274,6 +280,26 @@ int EvHttpServer::on_header(struct evhttp_request* ev_req) {
         HttpChannel::send_reply(request.get(), HttpStatus::NOT_FOUND, "Not Found");
         return 0;
     }
+
+    // Basic-Auth check (gated by `config::enable_http_auth` inside the injected verifier).
+    // Done before handler->on_header so handlers don't get a chance to read the body.
+    // HttpCore stays format-agnostic: the verifier shapes the failure response (status,
+    // headers, body) and HttpCore just dispatches it.
+    if (handler->need_auth() && _auth_verifier) {
+        auto failure = _auth_verifier(request.get(), handler->required_privilege());
+        if (failure.has_value()) {
+            evhttp_remove_header(evhttp_request_get_input_headers(ev_req), HttpHeaders::EXPECT);
+            if (!failure->www_authenticate.empty()) {
+                evhttp_add_header(evhttp_request_get_output_headers(ev_req), "WWW-Authenticate",
+                                  failure->www_authenticate.c_str());
+            }
+            evhttp_add_header(evhttp_request_get_output_headers(ev_req), HttpHeaders::CONTENT_TYPE,
+                              HttpHeaders::JsonType.c_str());
+            HttpChannel::send_reply(request.get(), failure->http_status, failure->body);
+            return 0;
+        }
+    }
+
     // set handler before call on_header, because handler_ctx will set in on_header
     request->set_handler(handler);
     res = handler->on_header(request.get());

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -19,21 +19,43 @@
 
 #include <event2/event.h>
 
+#include <functional>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "common/status.h"
+#include "http/http_handler.h"
 #include "http/http_method.h"
+#include "http/http_status.h"
 #include "util/path_trie.hpp"
 
 namespace starrocks {
 
-class HttpHandler;
 class HttpRequest;
 
 class EvHttpServer {
 public:
+    // Result returned by an AuthVerifier when authentication or authorization fails.
+    // The verifier (injected by the service layer) is responsible for shaping the
+    // response body — HttpCore stays format-agnostic.
+    struct AuthVerifyFailure {
+        HttpStatus http_status = HttpStatus::UNAUTHORIZED;
+        // Value for the response's `WWW-Authenticate` header. Empty means the server
+        // will not add the header (e.g. for 403 where the header is semantically wrong).
+        std::string www_authenticate;
+        // Pre-serialized response body sent to the client as-is (Content-Type: application/json).
+        std::string body;
+    };
+
+    // Callback used to verify Basic Auth credentials (plus an optional role/privilege
+    // requirement) carried by an HTTP request. Returning std::nullopt means OK and the
+    // server proceeds to dispatch to the handler; returning a populated AuthVerifyFailure
+    // causes the server to short-circuit with that response. Service layer injects an
+    // implementation that talks to FE.
+    using AuthVerifier = std::function<std::optional<AuthVerifyFailure>(HttpRequest*, HttpHandler::RequiredPrivilege)>;
+
     EvHttpServer(int port, int num_workers = 1);
     EvHttpServer(std::string host, int port, int num_workers = 1);
     ~EvHttpServer();
@@ -42,6 +64,15 @@ public:
     bool register_handler(const HttpMethod& method, const std::string& path, HttpHandler* handler);
 
     void register_static_file_handler(HttpHandler* handler);
+
+    // Wire a Basic-Auth verifier. When set, EvHttpServer invokes it before dispatching
+    // any request whose handler reports `need_auth() == true`.
+    // Must be called BEFORE `start()`; not thread-safe to change after worker threads
+    // begin reading `_auth_verifier`.
+    void set_auth_verifier(AuthVerifier verifier) {
+        DCHECK(!_started) << "set_auth_verifier must be called before start()";
+        _auth_verifier = std::move(verifier);
+    }
 
     Status start();
     void stop();
@@ -79,6 +110,10 @@ private:
     PathTrie<HttpHandler*> _options_handlers;
     std::vector<struct event_base*> _event_bases;
     std::vector<struct evhttp*> _https;
+    AuthVerifier _auth_verifier;
+    // Set true once `start()` begins; gates `set_auth_verifier` so the verifier
+    // can't be swapped after worker threads start reading it.
+    bool _started = false;
 };
 
 } // namespace starrocks

--- a/be/src/http/http_handler.h
+++ b/be/src/http/http_handler.h
@@ -38,6 +38,22 @@ public:
 
     virtual void on_chunk_data(HttpRequest* req) {}
     virtual void free_handler_ctx(void* handler_ctx) {}
+
+    // Whether this handler requires Basic Auth when `config::enable_http_auth` is on.
+    // Default true. Internal endpoints (BE-to-BE clone, internal load download,
+    // health probe, Prometheus metrics) should override and return false.
+    virtual bool need_auth() const { return true; }
+
+    // Additional role/privilege required on top of identity AuthN, evaluated by FE
+    // via the `required_privilege` field of the checkAuth RPC. Mirrors the thrift
+    // `TPrivilegeRequirement` enum without dragging the thrift header into this base.
+    // Default NONE: identity-only auth.
+    enum class RequiredPrivilege {
+        NONE,
+        OPERATE, // user must hold System OPERATE privilege
+        NODE,    // user must hold System NODE privilege
+    };
+    virtual RequiredPrivilege required_privilege() const { return RequiredPrivilege::NONE; }
 };
 
 } // namespace starrocks

--- a/be/src/http/http_request.h
+++ b/be/src/http/http_request.h
@@ -53,6 +53,11 @@ public:
 
     const std::string& header(const std::string& key) const;
 
+    // Set an input request header. Production code populates `_headers` via
+    // `init_from_evhttp()` reading from libevent; this setter lets tests
+    // synthesize headers on an HttpRequest that wasn't fed through libevent.
+    void set_header(const std::string& key, const std::string& value) { _headers[key] = value; }
+
     const std::string& param(const std::string& key) const;
 
     // return params

--- a/be/src/http/web_page_handler.h
+++ b/be/src/http/web_page_handler.h
@@ -44,6 +44,11 @@ public:
 
     void handle(HttpRequest* req) override;
 
+    // BE Web UI pages (/, /varz, /memz, /mem_tracker, /logs, /proc_profile) plus
+    // the static-file fallback (/static/*). Operator-debug surface: callers need
+    // SYSTEM OPERATE privilege, matching the pprof and ioprofile policy.
+    RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
     // Register a route 'path' to be rendered via template.
     // The appropriate template to use is determined by 'path'.
     // If 'is_on_nav_bar' is true, a link to the page will be placed on the navbar

--- a/be/src/service/service_be/CMakeLists.txt
+++ b/be/src/service/service_be/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/service_be")
 
 add_library(ServiceBE
     backend_service.cpp
+    http_auth_response.cpp
     http_service.cpp
     internal_service.cpp
     lake_service.cpp

--- a/be/src/service/service_be/http_auth_response.cpp
+++ b/be/src/service/service_be/http_auth_response.cpp
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/http_auth_response.h"
+
+#include <fmt/format.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include "agent/master_info.h"
+#include "common/config.h"
+#include "common/logging.h"
+#include "gen_cpp/FrontendService.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "http/http_request.h"
+#include "http/utils.h"
+#include "runtime/client_cache.h"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+std::string build_auth_failure_body(std::string_view message) {
+    rapidjson::Document doc;
+    doc.SetObject();
+    auto& alloc = doc.GetAllocator();
+    doc.AddMember("status", rapidjson::Value("FAILED", alloc), alloc);
+    doc.AddMember("code", rapidjson::Value("1", alloc), alloc);
+    doc.AddMember("message", rapidjson::Value(message.data(), message.size(), alloc), alloc);
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    doc.Accept(writer);
+    return std::string(buf.GetString(), buf.GetSize());
+}
+
+EvHttpServer::AuthVerifyFailure make_unauthorized(std::string_view message) {
+    return EvHttpServer::AuthVerifyFailure{
+            .http_status = HttpStatus::UNAUTHORIZED,
+            .www_authenticate = "Basic realm=\"\"",
+            .body = build_auth_failure_body(message),
+    };
+}
+
+EvHttpServer::AuthVerifyFailure make_server_error(HttpStatus http_status, std::string_view message) {
+    return EvHttpServer::AuthVerifyFailure{
+            .http_status = http_status,
+            .www_authenticate = {}, // no Basic challenge — re-auth won't help
+            .body = build_auth_failure_body(message),
+    };
+}
+
+std::optional<EvHttpServer::AuthVerifyFailure> auth_failure_from_fe_status(const Status& fe_status) {
+    // FE's checkAuth distinguishes credential failure (NOT_AUTHORIZED) from
+    // internal problems (INTERNAL_ERROR — e.g. an unknown TPrivilegeRequirement
+    // enum value from a newer BE talking to an older FE). The two have different
+    // remedies, so map them to different HTTP status classes. The 401 body comes
+    // from FE (already scrubbed to "Access denied for user@host" there); the 500
+    // body is generic so we don't echo internal error strings to the client.
+    if (fe_status.code() == TStatusCode::NOT_AUTHORIZED) {
+        return make_unauthorized(fe_status.message());
+    }
+    if (!fe_status.ok()) {
+        LOG(WARNING) << "checkAuth FE returned non-OK status: " << fe_status;
+        return make_server_error(HttpStatus::INTERNAL_SERVER_ERROR, "auth verification failed");
+    }
+    return std::nullopt;
+}
+
+TPrivilegeRequirement::type to_thrift_privilege(HttpHandler::RequiredPrivilege priv) {
+    switch (priv) {
+    case HttpHandler::RequiredPrivilege::NONE:
+        return TPrivilegeRequirement::NONE;
+    case HttpHandler::RequiredPrivilege::OPERATE:
+        return TPrivilegeRequirement::OPERATE;
+    case HttpHandler::RequiredPrivilege::NODE:
+        return TPrivilegeRequirement::NODE;
+    }
+    LOG(ERROR) << "to_thrift_privilege: unknown RequiredPrivilege value " << static_cast<int>(priv)
+               << ", failing closed as OPERATE";
+    return TPrivilegeRequirement::OPERATE;
+}
+
+std::optional<EvHttpServer::AuthVerifyFailure> verify_http_basic_auth(
+        HttpRequest* req, HttpHandler::RequiredPrivilege required_privilege) {
+    if (!config::enable_http_auth) {
+        return std::nullopt;
+    }
+
+    AuthInfo auth;
+    if (!parse_basic_auth(*req, &auth)) {
+        return make_unauthorized("missing Basic authorization");
+    }
+
+    TAuthenticateParams params;
+    params.__set_user(auth.user);
+    params.__set_passwd(auth.passwd);
+    params.__set_host(auth.user_ip);
+    if (required_privilege != HttpHandler::RequiredPrivilege::NONE) {
+        params.__set_required_privilege(to_thrift_privilege(required_privilege));
+    }
+
+    TNetworkAddress master = get_master_address();
+    if (master.hostname.empty() || master.port == 0) {
+        LOG(WARNING) << "checkAuth: FE master address is not yet known on this BE";
+        return make_server_error(HttpStatus::SERVICE_UNAVAILABLE,
+                                 "auth verification failed: FE master address unknown");
+    }
+    TFeResult result;
+    Status rpc_st = ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master.hostname, master.port,
+            [&result, &params](FrontendServiceConnection& client) { client->checkAuth(result, params); },
+            config::thrift_rpc_timeout_ms);
+    if (!rpc_st.ok()) {
+        LOG(WARNING) << "checkAuth RPC to FE failed: " << rpc_st;
+        return make_server_error(HttpStatus::SERVICE_UNAVAILABLE, "auth verification failed");
+    }
+    return auth_failure_from_fe_status(Status(result.status));
+}
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_auth_response.h
+++ b/be/src/service/service_be/http_auth_response.h
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "common/status.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+class HttpRequest;
+
+// Helpers for shaping `AuthVerifyFailure` responses returned by the BE-side
+// AuthVerifier. Extracted from http_service.cpp so the FE-Status-to-HTTP-status
+// mapping can be unit-tested without spinning up a real server / FE.
+
+// Renders the JSON body sent on auth failure: mirrors FE's RestBaseResult
+// (FAILED case) shape: {status, code, message}.
+std::string build_auth_failure_body(std::string_view message);
+
+// 401 + WWW-Authenticate. Use for genuine credential / authorization failures
+// where the client can fix the issue by re-authenticating.
+EvHttpServer::AuthVerifyFailure make_unauthorized(std::string_view message);
+
+// 5xx, no WWW-Authenticate. Use for server-side problems (FE unreachable, FE
+// returned an internal error). The client's credentials may be valid; sending
+// 401 would mislead them into retrying the same creds and burning retries on a
+// server-side fault.
+EvHttpServer::AuthVerifyFailure make_server_error(HttpStatus http_status, std::string_view message);
+
+// Maps the FE-side `checkAuth` Status to an AuthVerifyFailure (or nullopt on
+// success). NOT_AUTHORIZED is the only status that maps to 401; any other
+// non-OK status is treated as an internal server problem (e.g. unknown
+// TPrivilegeRequirement enum value from a newer BE talking to an older FE)
+// and surfaced as 500. Pure function — safe to test directly.
+std::optional<EvHttpServer::AuthVerifyFailure> auth_failure_from_fe_status(const Status& fe_status);
+
+// Maps the BE-side `RequiredPrivilege` enum to its thrift twin. Listing every
+// case (no `default`) makes the compiler flag missing entries when the enum
+// grows; the unreachable fallback returns OPERATE so an unmapped value still
+// rejects non-operator callers without unnecessarily locking out legitimate
+// db_admin holders.
+TPrivilegeRequirement::type to_thrift_privilege(HttpHandler::RequiredPrivilege priv);
+
+// The full BE auth-verifier hook. Returns `nullopt` when authentication +
+// authorization both succeed (or when `enable_http_auth=false`), otherwise an
+// `AuthVerifyFailure` the EvHttpServer wraps into the HTTP response. Order of
+// checks: flag gate → Basic-Auth header → FE master address known → FE
+// checkAuth RPC. Anything before the RPC is unit-testable; the RPC itself is
+// covered by the end-to-end smoke test.
+std::optional<EvHttpServer::AuthVerifyFailure> verify_http_basic_auth(
+        HttpRequest* req, HttpHandler::RequiredPrivilege required_privilege);
+
+} // namespace starrocks

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -35,6 +35,7 @@
 #include "http_service.h"
 
 #include "fs/fs_util.h"
+#include "gen_cpp/HeartbeatService_types.h"
 #include "gutil/stl_util.h"
 #include "http/action/checksum_action.h"
 #include "http/action/compact_rocksdb_meta_action.h"
@@ -61,9 +62,11 @@
 #include "http/download_action.h"
 #include "http/ev_http_server.h"
 #include "http/http_method.h"
+#include "http/utils.h"
 #include "http/web_page_handler.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_path_mgr.h"
+#include "service/service_be/http_auth_response.h"
 #include "util/starrocks_metrics.h"
 
 namespace starrocks {
@@ -90,6 +93,8 @@ void HttpServiceBE::join() {
 
 Status HttpServiceBE::start() {
     add_default_path_handlers(_web_page_handler.get(), GlobalEnv::GetInstance()->process_mem_tracker());
+
+    _ev_http_server->set_auth_verifier(&verify_http_basic_auth);
 
     // register load
     auto* stream_load_action = new StreamLoadAction(_env, _http_concurrent_limiter.get());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -207,6 +207,7 @@ set(EXEC_FILES
         ./formats/disk_range_test.cpp
         ./geo/geo_types_test.cpp
         ./geo/wkt_parse_test.cpp
+        ./http/handler_required_privilege_test.cpp
         ./http/http_client_test.cpp
         ./http/http_utils_test.cpp
         ./http/message_body_sink_test.cpp
@@ -480,6 +481,7 @@ set(EXEC_FILES
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
+        ./service/service_be/http_auth_response_test.cpp
         ./service/service_be/internal_service_test.cpp
         ./storage/compaction_parallelization_test.cpp
         ./storage/delta_writer_test.cpp

--- a/be/test/http/handler_required_privilege_test.cpp
+++ b/be/test/http/handler_required_privilege_test.cpp
@@ -1,0 +1,205 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pins the priv-level overrides on BE HTTP handlers that were chosen with the
+// http_auth feature. Each override is a one-line virtual return, so the failure
+// mode is silent demotion/promotion in a future refactor (e.g. demoting NODE to
+// OPERATE for a node-mgmt endpoint, or promoting OPERATE to ADMIN for a
+// query-debug endpoint). Locking the values here keeps the SQL-aligned policy
+// from drifting.
+
+#include <gtest/gtest.h>
+
+#include "http/action/checksum_action.h"
+#include "http/action/compact_rocksdb_meta_action.h"
+#include "http/action/compaction_action.h"
+#include "http/action/datacache_action.h"
+#include "http/action/greplog_action.h"
+#include "http/action/health_action.h"
+#include "http/action/lake/dump_tablet_metadata_action.h"
+#include "http/action/memory_metrics_action.h"
+#include "http/action/meta_action.h"
+#include "http/action/metrics_action.h"
+#include "http/action/pipeline_blocking_drivers_action.h"
+#include "http/action/pprof_actions.h"
+#include "http/action/query_cache_action.h"
+#include "http/action/reload_tablet_action.h"
+#include "http/action/restore_tablet_action.h"
+#include "http/action/runtime_filter_cache_action.h"
+#include "http/action/snapshot_action.h"
+#include "http/action/stop_be_action.h"
+#include "http/action/stream_load.h"
+#include "http/action/transaction_stream_load.h"
+#include "http/action/update_config_action.h"
+#include "http/download_action.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/web_page_handler.h"
+
+#ifdef STARROCKS_JIT_ENABLE
+#include "http/action/jit_cache_action.h"
+#endif
+
+namespace starrocks {
+
+using Priv = HttpHandler::RequiredPrivilege;
+
+// --------- NODE (cluster_admin domain) ---------
+// Matches SQL `DROP BACKEND` policy. db_admin / security_admin must NOT be
+// able to stop BEs through this endpoint.
+TEST(BeHandlerPrivilegeTest, stop_be_requires_NODE) {
+    StopBeAction h(nullptr);
+    EXPECT_EQ(Priv::NODE, h.required_privilege());
+}
+
+// --------- OPERATE (DB / data / execution operate) ---------
+// Matches SQL `ADMIN SET BACKEND CONFIG` / `ADMIN COMPACT` policy.
+TEST(BeHandlerPrivilegeTest, update_config_requires_OPERATE) {
+    UpdateConfigAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, compaction_requires_OPERATE_all_subtypes) {
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_INFO).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::RUN_COMPACTION).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_REPAIR).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SUBMIT_REPAIR).required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CompactionAction(CompactionActionType::SHOW_RUNNING_TASK).required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, checksum_requires_OPERATE) {
+    ChecksumAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, reload_tablet_requires_OPERATE) {
+    ReloadTabletAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, restore_tablet_requires_OPERATE) {
+    RestoreTabletAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, snapshot_requires_OPERATE) {
+    SnapshotAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, meta_requires_OPERATE) {
+    MetaAction h(META_TYPE::HEADER);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, dump_tablet_metadata_requires_OPERATE) {
+    lake::DumpTabletMetadataAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, compact_rocksdb_meta_requires_OPERATE) {
+    CompactRocksDbMetaAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, datacache_requires_OPERATE) {
+    DataCacheAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, query_cache_requires_OPERATE) {
+    QueryCacheAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, runtime_filter_cache_requires_OPERATE) {
+    RuntimeFilterCacheAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+#ifdef STARROCKS_JIT_ENABLE
+TEST(BeHandlerPrivilegeTest, jit_cache_requires_OPERATE) {
+    JITCacheAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+#endif
+
+TEST(BeHandlerPrivilegeTest, pipeline_blocking_drivers_requires_OPERATE) {
+    PipelineBlockingDriversAction h(nullptr);
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+// --------- OPERATE (process profiling / log diagnostics) ---------
+// DB operators (db_admin → OPERATE) inspect profiles to diagnose hot queries
+// running on the BE. cluster_admin holders can pick up OPERATE explicitly when
+// they need pprof access.
+TEST(BeHandlerPrivilegeTest, pprof_handlers_require_OPERATE) {
+    EXPECT_EQ(Priv::OPERATE, HeapAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, GrowthAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, ProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, IOProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, PmuProfileAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, ContentionAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, CmdlineAction().required_privilege());
+    EXPECT_EQ(Priv::OPERATE, SymbolAction(nullptr).required_privilege());
+}
+
+TEST(BeHandlerPrivilegeTest, greplog_requires_OPERATE) {
+    GrepLogAction h;
+    EXPECT_EQ(Priv::OPERATE, h.required_privilege());
+}
+
+// --------- DownloadAction: dynamic need_auth() based on download type ---------
+// NORMAL (BE-to-BE tablet clone, internal load file download): token-gated,
+// framework Basic is skipped (`need_auth() == false`).
+// ERROR_LOG (user-facing load-failure log): framework Basic required.
+TEST(BeHandlerNeedAuthTest, download_action_normal_skips_framework_auth) {
+    DownloadAction normal(nullptr, std::vector<std::string>{});
+    EXPECT_FALSE(normal.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, download_action_error_log_requires_framework_auth) {
+    DownloadAction error_log(nullptr, std::string{});
+    EXPECT_TRUE(error_log.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_skip_framework_auth) {
+    EXPECT_FALSE(HealthAction(nullptr).need_auth());
+    EXPECT_FALSE(MetricsAction(nullptr).need_auth());
+    EXPECT_FALSE(MemoryMetricsAction().need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, stream_load_uses_builtin_fe_auth_flow) {
+    StreamLoadAction action(nullptr, nullptr);
+    EXPECT_FALSE(action.need_auth());
+}
+
+TEST(BeHandlerNeedAuthTest, transaction_endpoints_skip_framework_auth) {
+    // Both transaction-management endpoints opt out of the framework Basic-Auth
+    // gate — they use a label-bound session model (begin parses Basic, later ops
+    // look up the StreamLoadContext by label).
+    TransactionManagerAction txn_mgr(nullptr);
+    EXPECT_FALSE(txn_mgr.need_auth());
+    TransactionStreamLoadAction txn_load(nullptr);
+    EXPECT_FALSE(txn_load.need_auth());
+}
+
+TEST(BeHandlerPrivilegeTest, web_page_handler_requires_OPERATE) {
+    // BE Web UI is operator-debug surface — same policy as pprof / ioprofile.
+    EvHttpServer server(/*port=*/0, /*num_workers=*/1);
+    WebPageHandler handler(&server);
+    EXPECT_EQ(Priv::OPERATE, handler.required_privilege());
+}
+
+} // namespace starrocks

--- a/be/test/http/handler_required_privilege_test.cpp
+++ b/be/test/http/handler_required_privilege_test.cpp
@@ -174,10 +174,16 @@ TEST(BeHandlerNeedAuthTest, download_action_error_log_requires_framework_auth) {
     EXPECT_TRUE(error_log.need_auth());
 }
 
-TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_skip_framework_auth) {
-    EXPECT_FALSE(HealthAction(nullptr).need_auth());
-    EXPECT_FALSE(MetricsAction(nullptr).need_auth());
-    EXPECT_FALSE(MemoryMetricsAction().need_auth());
+// Probe / Prometheus endpoints (/api/health, /metrics, /metrics/memory) are AuthN-only:
+// historically anonymous, now gated by `config::enable_http_auth` -- need_auth() == true
+// (the injected verifier short-circuits when the flag is off) with no extra privilege.
+TEST(BeHandlerNeedAuthTest, probe_and_prometheus_endpoints_are_authn_only) {
+    EXPECT_TRUE(HealthAction(nullptr).need_auth());
+    EXPECT_EQ(Priv::NONE, HealthAction(nullptr).required_privilege());
+    EXPECT_TRUE(MetricsAction(nullptr).need_auth());
+    EXPECT_EQ(Priv::NONE, MetricsAction(nullptr).required_privilege());
+    EXPECT_TRUE(MemoryMetricsAction().need_auth());
+    EXPECT_EQ(Priv::NONE, MemoryMetricsAction().required_privilege());
 }
 
 TEST(BeHandlerNeedAuthTest, stream_load_uses_builtin_fe_auth_flow) {

--- a/be/test/http/transaction_stream_load_test.cpp
+++ b/be/test/http/transaction_stream_load_test.cpp
@@ -22,6 +22,7 @@
 
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
+#include "http/download_action.h"
 #include "http/http_channel.h"
 #include "http/http_request.h"
 #include "runtime/exec_env.h"
@@ -94,6 +95,10 @@ protected:
     ExecEnv _env;
     evhttp_request* _evhttp_req = nullptr;
 };
+
+// `need_auth() == false` for both handlers is pinned in handler_required_privilege_test.cpp
+// (BeHandlerNeedAuthTest.transaction_endpoints_skip_framework_auth). This file focuses on
+// the txn dispatch semantics under various auth/label combinations below.
 
 TEST_F(TransactionStreamLoadActionTest, txn_begin_no_auth) {
     TransactionManagerAction txn_action(&_env);

--- a/be/test/service/service_be/http_auth_response_test.cpp
+++ b/be/test/service/service_be/http_auth_response_test.cpp
@@ -1,0 +1,221 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/http_auth_response.h"
+
+#include <event2/buffer.h>
+#include <event2/http.h>
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "agent/master_info.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "http/ev_http_server.h"
+#include "http/http_handler.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
+
+namespace starrocks {
+
+// `auth_failure_from_fe_status` is the pure mapping that decides what HTTP
+// response a BE returns based on what FE's checkAuth came back with. The
+// classes are intentionally distinct because each suggests a different
+// remedy to the client:
+//
+//   NOT_AUTHORIZED (401 + WWW-Authenticate): fix your credentials
+//   INTERNAL_ERROR (500): a bug on the FE — operator must investigate
+//   network/RPC failure: 503, handled by caller (not this helper)
+//
+// Regression here is silent (e.g. someone collapses the switch and lumps
+// all non-OK into 401), so the cases are pinned explicitly.
+
+TEST(AuthFailureFromFeStatusTest, ok_returns_nullopt) {
+    auto result = auth_failure_from_fe_status(Status::OK());
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(AuthFailureFromFeStatusTest, not_authorized_maps_to_401_with_basic_challenge) {
+    auto result = auth_failure_from_fe_status(Status::NotAuthorized("bad password"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+    EXPECT_EQ("Basic realm=\"\"", result->www_authenticate);
+    // Body shape mirrors FE RestBaseResult — verify message round-trips into JSON.
+    EXPECT_NE(std::string::npos, result->body.find("FAILED"));
+    EXPECT_NE(std::string::npos, result->body.find("bad password"));
+}
+
+TEST(AuthFailureFromFeStatusTest, internal_error_maps_to_500_without_basic_challenge) {
+    // FE might return InternalError for unknown TPrivilegeRequirement enum
+    // values (cross-version mismatch). Client retrying with the same creds
+    // would never help, so we must NOT emit a Basic challenge. The body is
+    // a generic "auth verification failed" — internal error strings stay
+    // server-side (logged at WARNING), never echoed to the HTTP client.
+    auto result = auth_failure_from_fe_status(Status::InternalError("unknown required_privilege: 999"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::INTERNAL_SERVER_ERROR, result->http_status);
+    EXPECT_TRUE(result->www_authenticate.empty());
+    EXPECT_NE(std::string::npos, result->body.find("auth verification failed"));
+    EXPECT_EQ(std::string::npos, result->body.find("unknown required_privilege"));
+}
+
+TEST(AuthFailureFromFeStatusTest, other_non_ok_maps_to_500) {
+    // Defensive: any non-OK that isn't NOT_AUTHORIZED is treated as server-side.
+    // Pick a status that's neither — Aborted is a reasonable stand-in for
+    // "something unexpected came back from FE".
+    auto result = auth_failure_from_fe_status(Status::Aborted("aborted"));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::INTERNAL_SERVER_ERROR, result->http_status);
+    EXPECT_TRUE(result->www_authenticate.empty());
+}
+
+TEST(MakeUnauthorizedTest, has_401_and_basic_realm) {
+    auto failure = make_unauthorized("missing Basic");
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, failure.http_status);
+    EXPECT_EQ("Basic realm=\"\"", failure.www_authenticate);
+    EXPECT_NE(std::string::npos, failure.body.find("missing Basic"));
+}
+
+TEST(MakeServerErrorTest, respects_caller_supplied_status_and_omits_www_authenticate) {
+    auto failure = make_server_error(HttpStatus::SERVICE_UNAVAILABLE, "FE unreachable");
+    EXPECT_EQ(HttpStatus::SERVICE_UNAVAILABLE, failure.http_status);
+    EXPECT_TRUE(failure.www_authenticate.empty());
+    EXPECT_NE(std::string::npos, failure.body.find("FE unreachable"));
+}
+
+TEST(BuildAuthFailureBodyTest, contains_failed_status_code_and_message) {
+    std::string body = build_auth_failure_body("denied: bad pw");
+    // Shape mirrors FE's RestBaseResult — must be parseable JSON with the three
+    // expected keys (status / code / message).
+    EXPECT_NE(std::string::npos, body.find("\"status\":\"FAILED\""));
+    EXPECT_NE(std::string::npos, body.find("\"code\":\"1\""));
+    EXPECT_NE(std::string::npos, body.find("\"message\":\"denied: bad pw\""));
+}
+
+TEST(BuildAuthFailureBodyTest, escapes_quotes_in_message) {
+    // rapidjson must escape user-controlled strings to keep the body parseable.
+    std::string body = build_auth_failure_body("he said \"hi\"");
+    EXPECT_NE(std::string::npos, body.find("he said \\\"hi\\\""));
+}
+
+// --------- to_thrift_privilege ---------
+// Every enum value must round-trip to its thrift twin; missing cases trip
+// `-Wswitch` at compile time. The unreachable fallback is what catches a future
+// enum value that someone adds to the C++ side but forgets to map — pin its
+// "fail closed as OPERATE" behavior so we don't silently regress to NONE.
+
+TEST(ToThriftPrivilegeTest, maps_each_enum_value) {
+    EXPECT_EQ(TPrivilegeRequirement::NONE, to_thrift_privilege(HttpHandler::RequiredPrivilege::NONE));
+    EXPECT_EQ(TPrivilegeRequirement::OPERATE, to_thrift_privilege(HttpHandler::RequiredPrivilege::OPERATE));
+    EXPECT_EQ(TPrivilegeRequirement::NODE, to_thrift_privilege(HttpHandler::RequiredPrivilege::NODE));
+}
+
+TEST(ToThriftPrivilegeTest, unknown_enum_value_fails_closed_as_operate) {
+    // Synthesize an out-of-range RequiredPrivilege to simulate a future enum
+    // addition that didn't get a switch case. Fail-closed = OPERATE (still
+    // rejects non-operator callers; previously the default branch silently
+    // returned NONE, which would have downgraded authorization to AuthN-only).
+    auto bogus = static_cast<HttpHandler::RequiredPrivilege>(99);
+    EXPECT_EQ(TPrivilegeRequirement::OPERATE, to_thrift_privilege(bogus));
+}
+
+// --------- verify_http_basic_auth ---------
+// The verifier does flag-gate → Basic-Auth parse → FE master check → RPC.
+// Everything up to the RPC is unit-testable. The RPC + result handling are
+// covered end-to-end by summary/http_auth/http_auth_smoke_test.py (a real
+// cluster is needed to exercise FE's checkAuth).
+
+class VerifyHttpBasicAuthTest : public testing::Test {
+public:
+    void SetUp() override {
+        _saved_flag = config::enable_http_auth;
+        _saved_master_info = get_master_info();
+        _ev_req = evhttp_request_new(nullptr, nullptr);
+        ASSERT_NE(nullptr, _ev_req);
+    }
+    void TearDown() override {
+        config::enable_http_auth = _saved_flag;
+        // Restore master_info so later tests in this binary aren't affected.
+        // master_info refuses lower-or-equal epoch updates; bump just one above
+        // whatever the current epoch is so later tests can still apply their
+        // own updates (previously we used int64_max here, which poisoned every
+        // subsequent update_master_info call).
+        TMasterInfo restored = _saved_master_info;
+        restored.epoch = get_master_info().epoch + 1;
+        (void)update_master_info(restored);
+        if (_ev_req != nullptr) {
+            evhttp_request_free(_ev_req);
+            _ev_req = nullptr;
+        }
+    }
+
+protected:
+    bool _saved_flag = false;
+    TMasterInfo _saved_master_info;
+    evhttp_request* _ev_req = nullptr;
+};
+
+TEST_F(VerifyHttpBasicAuthTest, flag_off_skips_verification) {
+    config::enable_http_auth = false;
+    HttpRequest req(_ev_req);
+    // No headers populated, no FE configured. With the flag off, none of that
+    // matters — must return nullopt unconditionally.
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::OPERATE);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(VerifyHttpBasicAuthTest, missing_authorization_header_returns_401) {
+    config::enable_http_auth = true;
+    HttpRequest req(_ev_req);
+    // No Authorization header → parse_basic_auth fails → 401 with Basic challenge.
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::NONE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+    EXPECT_EQ("Basic realm=\"\"", result->www_authenticate);
+}
+
+TEST_F(VerifyHttpBasicAuthTest, malformed_authorization_returns_401) {
+    config::enable_http_auth = true;
+    HttpRequest req(_ev_req);
+    // "Bearer" instead of "Basic" — parse_basic_auth rejects it.
+    req.set_header(HttpHeaders::AUTHORIZATION, "Bearer not-a-basic-token");
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::NONE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::UNAUTHORIZED, result->http_status);
+}
+
+TEST_F(VerifyHttpBasicAuthTest, unknown_fe_master_returns_503) {
+    config::enable_http_auth = true;
+    // Overwrite master info with an empty endpoint. Use a high epoch so we win
+    // against any state a prior test in this binary may have stored (the
+    // master-info store ignores updates with a lower-or-equal epoch).
+    TMasterInfo empty;
+    empty.network_address.hostname = "";
+    empty.network_address.port = 0;
+    empty.epoch = 999999999;
+    EXPECT_TRUE(update_master_info(empty));
+
+    HttpRequest req(_ev_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo="); // root:
+    auto result = verify_http_basic_auth(&req, HttpHandler::RequiredPrivilege::OPERATE);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(HttpStatus::SERVICE_UNAVAILABLE, result->http_status);
+    // Service-side failure ⇒ no WWW-Authenticate (the client's creds may be fine).
+    EXPECT_TRUE(result->www_authenticate.empty());
+    EXPECT_NE(std::string::npos, result->body.find("FE master address unknown"));
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -688,6 +688,11 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
+    @ConfField(mutable = true, comment = "Whether to require Basic Auth for external HTTP endpoints. " +
+            "Internal endpoints (FE meta sync, health/metrics probes, OAuth2 callback) are always exempt. " +
+            "Default false for backward compatibility.")
+    public static boolean enable_http_auth = false;
+
     /**
      * Configs for query queue v2.
      * The configs {@code query_queue_v2_xxx} are effective only when {@code enable_query_queue_v2} is true.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -688,9 +688,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int http_port = 8030;
 
-    @ConfField(mutable = true, comment = "Whether to require Basic Auth for external HTTP endpoints. " +
+    @ConfField(comment = "Whether to require Basic Auth for external HTTP endpoints. " +
             "Internal endpoints (FE meta sync, health/metrics probes, OAuth2 callback) are always exempt. " +
-            "Default false for backward compatibility.")
+            "Default false for backward compatibility. Immutable; requires an FE restart to change.")
     public static boolean enable_http_auth = false;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
@@ -74,9 +74,9 @@ public class BootstrapFinishAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/bootstrap", new BootstrapFinishAction(controller));
     }
 
-    // FE bootstrap probe; intentionally unauthenticated. Caller can pass the cluster
-    // token to unlock additional fields (journal id / ports / version), but the endpoint
-    // itself accepts anonymous requests for readiness checks.
+    // Always anonymous, even under enable_http_auth: the FE-to-FE heartbeat (HeartbeatMgr)
+    // polls this with the cluster token, not HTTP Basic, so gating it would break peer-FE
+    // heartbeats.
     @Override
     public boolean needAuth() {
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/BootstrapFinishAction.java
@@ -74,8 +74,16 @@ public class BootstrapFinishAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/bootstrap", new BootstrapFinishAction(controller));
     }
 
+    // FE bootstrap probe; intentionally unauthenticated. Caller can pass the cluster
+    // token to unlock additional fields (journal id / ports / version), but the endpoint
+    // itself accepts anonymous requests for readiness checks.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
         boolean isReady = GlobalStateMgr.getCurrentState().isReady();
 
         // to json response

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoad.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/CancelStreamLoad.java
@@ -42,6 +42,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 
@@ -57,7 +58,8 @@ public class CancelStreamLoad extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+            throws DdlException, AccessDeniedException {
 
         if (redirectToLeader(request, response)) {
             return;
@@ -73,8 +75,11 @@ public class CancelStreamLoad extends RestBaseAction {
             throw new DdlException("No label selected.");
         }
 
-        // FIXME(cmy)
-        // checkWritePriv(authInfo.fullUserName, fullDbName);
+        // The actual cancel is keyed by (dbId, label) and ignores the {table} segment in the URL,
+        // so a URL-table-based INSERT check would be a confused-deputy gate (any INSERT user on
+        // some allowed table could cancel a load against a different table in the same db).
+        // Use db-level INSERT instead — consistent with GetStreamLoadState which is also dbId+label.
+        requireDbInsertIfHttpAuthEnabled(dbName);
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ConnectionAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ConnectionAction.java
@@ -34,11 +34,13 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.service.ExecuteEnv;
 import io.netty.handler.codec.http.HttpMethod;
@@ -56,8 +58,16 @@ public class ConnectionAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/connection", new ConnectionAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String connStr = request.getSingleParameter("connection_id");
         if (connStr == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
@@ -32,8 +32,14 @@ public class FeatureAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/v2/feature", new FeatureAction(controller));
     }
 
+    // Public endpoint: returns server version + feature flag list, no sensitive data.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         response.setContentType("application/json");
 
         RestResult result = new RestResult();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/FeatureAction.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.Version;
 import com.starrocks.feature.ProductFeature;
 import com.starrocks.http.ActionController;
@@ -32,10 +33,12 @@ public class FeatureAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/v2/feature", new FeatureAction(controller));
     }
 
-    // Public endpoint: returns server version + feature flag list, no sensitive data.
+    // Returns server version + feature flag list, no sensitive data. Historically
+    // anonymous; gated for backward compatibility so it requires Basic auth (AuthN-only,
+    // no privilege check) only when the operator opts in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetSmallFileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetSmallFileAction.java
@@ -58,8 +58,15 @@ public class GetSmallFileAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/get_small_file", new GetSmallFileAction(controller));
     }
 
+    // Internal BE-to-FE small-file download; gated by the cluster-shared token check below.
+    // Callers (BEs) don't carry user credentials, so we must not require Basic Auth here.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         String token = request.getSingleParameter("token");
         String fileIdStr = request.getSingleParameter("file_id");
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
@@ -41,6 +41,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 
@@ -57,7 +58,7 @@ public class GetStreamLoadState extends RestBaseAction {
 
     @Override
     public void executeWithoutPassword(BaseRequest request, BaseResponse response)
-            throws DdlException {
+            throws DdlException, AccessDeniedException {
 
         if (redirectToLeader(request, response)) {
             return;
@@ -73,8 +74,7 @@ public class GetStreamLoadState extends RestBaseAction {
             throw new DdlException("No label selected.");
         }
 
-        // FIXME(cmy)
-        // checkReadPriv(authInfo.fullUserName, fullDbName);
+        requireDbInsertIfHttpAuthEnabled(dbName);
 
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
         if (db == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http.rest;
 
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
@@ -51,10 +52,12 @@ public class HealthAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/health", new HealthAction(controller));
     }
 
-    // Liveness probe; intentionally unauthenticated.
+    // Liveness probe. Historically anonymous; gated for backward compatibility so it
+    // requires Basic auth (AuthN-only, no privilege check) only when the operator opts
+    // in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/HealthAction.java
@@ -51,8 +51,14 @@ public class HealthAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/health", new HealthAction(controller));
     }
 
+    // Liveness probe; intentionally unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         response.setContentType("application/json");
 
         RestResult result = new RestResult();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
@@ -49,8 +49,14 @@ public class IdleAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/idle_status", new IdleAction(controller));
     }
 
+    // K8s idle probe; intentionally unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) {
         String showDetails = request.getSingleParameter("show_details");
         if (Config.warehouse_idle_check_enable) {
             IdleStatus idleStatus = GlobalStateMgr.getCurrentState().getWarehouseIdleChecker()

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/IdleAction.java
@@ -49,10 +49,12 @@ public class IdleAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, "/api/idle_status", new IdleAction(controller));
     }
 
-    // K8s idle probe; intentionally unauthenticated.
+    // K8s idle probe. Historically anonymous; gated for backward compatibility so it
+    // requires Basic auth (AuthN-only, no privilege check) only when the operator opts
+    // in via `enable_http_auth`.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -123,8 +123,16 @@ public class MetricsAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, API_PATH, new MetricsAction(controller));
     }
 
+    // Prometheus-style metrics; intentionally unauthenticated by default. Per-table /
+    // per-MV / per-user-connection breakdowns do their own admin check inside
+    // parseRequestParams() and gracefully fall back when unauthenticated.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+    public boolean needAuth() {
+        return false;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
         // parse visitor type
         String type = request.getSingleParameter(TYPE_PARAM);
         MetricVisitor visitor = null;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -36,6 +36,7 @@ package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -123,12 +124,14 @@ public class MetricsAction extends RestBaseAction {
         controller.registerHandler(HttpMethod.GET, API_PATH, new MetricsAction(controller));
     }
 
-    // Prometheus-style metrics; intentionally unauthenticated by default. Per-table /
-    // per-MV / per-user-connection breakdowns do their own admin check inside
-    // parseRequestParams() and gracefully fall back when unauthenticated.
+    // Prometheus-style metrics. Historically anonymous; gated for backward compatibility
+    // so it requires Basic auth (AuthN-only, no privilege check) only when the operator
+    // opts in via `enable_http_auth`. The per-table / per-MV / per-user-connection
+    // breakdowns still do their own admin check inside parseRequestParams() and
+    // gracefully fall back when the caller lacks admin.
     @Override
     public boolean needAuth() {
-        return false;
+        return Config.enable_http_auth;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ProfileAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ProfileAction.java
@@ -39,6 +39,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -57,7 +58,9 @@ public class ProfileAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String queryId = request.getSingleParameter("query_id");
         if (queryId == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDetailAction.java
@@ -39,6 +39,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import io.netty.handler.codec.http.HttpMethod;
@@ -57,7 +58,9 @@ public class QueryDetailAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String eventTimeStr = request.getSingleParameter("event_time");
         if (eventTimeStr == null) {
             response.getContent().append("not valid parameter");

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
@@ -22,6 +22,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.dump.QueryDumper;
 import io.netty.handler.codec.http.HttpMethod;
@@ -54,7 +55,9 @@ public class QueryDumpAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException, AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         ConnectContext context = ConnectContext.get();
         String catalogDbName = request.getSingleParameter(DB);
         boolean enableMock = request.getSingleParameter(MOCK) == null ||

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -37,6 +37,7 @@ package com.starrocks.http.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.Pair;
@@ -50,10 +51,12 @@ import com.starrocks.http.HttpConnectContext;
 import com.starrocks.http.WebUtils;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.AuthorizationMgr;
+import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -83,6 +86,25 @@ public class RestBaseAction extends BaseAction {
 
     public RestBaseAction(ActionController controller) {
         super(controller);
+    }
+
+    /**
+     * Whether this action requires HTTP Basic Auth. {@code true} by default — auth is
+     * performed by {@link #execute(BaseRequest, BaseResponse)} before dispatching to
+     * {@link #executeWithoutPassword(BaseRequest, BaseResponse)}. Subclasses may override
+     * {@code execute} for pre-dispatch bypasses (see {@code LoadAction#tryInternalTokenBypass});
+     * the normal path must still call {@code super.execute(...)} so the auth pipeline runs.
+     * <p>
+     * Subclasses opt out by returning {@code false}:
+     * <ul>
+     *   <li>Probes / OAuth callback / internal token-protected endpoints — always {@code false}.</li>
+     *   <li>Endpoints that historically accepted anonymous requests and are gated for backward
+     *       compatibility — return {@link Config#enable_http_auth} so they require Basic only when
+     *       the operator opts in.</li>
+     * </ul>
+     */
+    public boolean needAuth() {
+        return true;
     }
 
     @Override
@@ -130,31 +152,41 @@ public class RestBaseAction extends BaseAction {
         }
     }
 
+    // Subclasses may override execute to short-circuit before auth runs (see
+    // LoadAction#tryInternalTokenBypass), but if a subclass falls through to
+    // the normal Basic-auth path it MUST call super.execute(...) — do not
+    // reimplement auth/ctx population, otherwise group-derived roles will be
+    // lost and requireXxxIfHttpAuthEnabled() helpers will deny legitimate users.
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException, AccessDeniedException {
-        ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
-        // check password
-        UserIdentity currentUser = checkPassword(authInfo);
-
         HttpConnectContext ctx = request.getConnectContext();
 
-        // Change user for ConnectContext if necessary
-        UserIdentity prevUserIdentity = ctx.getCurrentUserIdentity();
-        Set<Long> prevRoleIds = ctx.getCurrentRoleIds();
-        String prevUserName = ctx.getQualifiedUser();
+        if (needAuth()) {
+            ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
+            // 3.3 has no AuthenticationHandler / group-derived roles; checkPassword() verifies the
+            // Basic credentials and returns the UserIdentity, and ctx.setCurrentRoleIds(UserIdentity)
+            // derives the role set from that identity.
+            UserIdentity currentUser = checkPassword(authInfo);
 
-        ctx.setCurrentUserIdentity(currentUser);
-        ctx.setCurrentRoleIds(currentUser);
-        ctx.setQualifiedUser(authInfo.fullUserName);
+            // Change user for ConnectContext if necessary
+            UserIdentity prevUserIdentity = ctx.getCurrentUserIdentity();
+            Set<Long> prevRoleIds = ctx.getCurrentRoleIds();
+            String prevUserName = ctx.getQualifiedUser();
 
-        if (ctx.isRegistered() && prevUserName != null && !prevUserName.equals(authInfo.fullUserName)) {
-            ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
-            Pair<Boolean, String> userChangeRes = connectScheduler.onUserChanged(ctx, prevUserName, ctx.getQualifiedUser());
-            if (!userChangeRes.first) {
-                ctx.setCurrentUserIdentity(prevUserIdentity);
-                ctx.setCurrentRoleIds(prevRoleIds);
-                ctx.setQualifiedUser(prevUserName);
-                throw new StarRocksHttpException(SERVICE_UNAVAILABLE, userChangeRes.second);
+            ctx.setCurrentUserIdentity(currentUser);
+            ctx.setCurrentRoleIds(currentUser);
+            ctx.setQualifiedUser(authInfo.fullUserName);
+
+            if (ctx.isRegistered() && prevUserName != null && !prevUserName.equals(authInfo.fullUserName)) {
+                ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+                Pair<Boolean, String> userChangeRes =
+                        connectScheduler.onUserChanged(ctx, prevUserName, ctx.getQualifiedUser());
+                if (!userChangeRes.first) {
+                    ctx.setCurrentUserIdentity(prevUserIdentity);
+                    ctx.setCurrentRoleIds(prevRoleIds);
+                    ctx.setQualifiedUser(prevUserName);
+                    throw new StarRocksHttpException(SERVICE_UNAVAILABLE, userChangeRes.second);
+                }
             }
         }
 
@@ -162,16 +194,43 @@ public class RestBaseAction extends BaseAction {
         ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         ctx.setNettyChannel(request.getContext());
         ctx.setQueryId(UUIDUtil.genUUID());
-        ctx.setRemoteIP(authInfo.remoteIp);
+        ctx.setRemoteIP(request.getHostString());
         ctx.setThreadLocalInfo();
         executeWithoutPassword(request, response);
     }
 
-    // If user password should be checked, the derived class should implement this method, NOT 'execute()',
-    // otherwise, override 'execute()' directly
+    // Subclasses implement this. Auth + ConnectContext setup are already done by the final
+    // {@link #execute(BaseRequest, BaseResponse)} above; if {@link #needAuth()} returns false,
+    // the user-identity fields on ctx are left unset.
     protected void executeWithoutPassword(BaseRequest request, BaseResponse response)
             throws DdlException, AccessDeniedException {
         throw new DdlException("Not implemented");
+    }
+
+    // ---------- privilege helpers, gated by Config.enable_http_auth ----------
+    // Endpoints historically accepted anonymous (or any-authenticated) callers and we
+    // can't tighten them by default without breaking running scripts. These helpers
+    // let the subclass declare the intended privilege; the check actually runs only
+    // when the operator opts in via `enable_http_auth=true`.
+
+    /** Require INSERT on any table within the given db. */
+    protected void requireDbInsertIfHttpAuthEnabled(String dbName) throws AccessDeniedException {
+        if (!Config.enable_http_auth) {
+            return;
+        }
+        ConnectContext context = ConnectContext.get();
+        Authorizer.checkActionInDb(context.getCurrentUserIdentity(), context.getCurrentRoleIds(), dbName,
+                PrivilegeType.INSERT);
+    }
+
+    /** Require SYSTEM.OPERATE — for db/data/query operations. */
+    protected void requireOperateIfHttpAuthEnabled() throws AccessDeniedException {
+        if (!Config.enable_http_auth) {
+            return;
+        }
+        ConnectContext context = ConnectContext.get();
+        Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                PrivilegeType.OPERATE);
     }
 
     public void sendResult(BaseRequest request, BaseResponse response, RestBaseResult result) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowDataAction.java
@@ -37,12 +37,14 @@ package com.starrocks.http.rest;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -61,6 +63,12 @@ public class ShowDataAction extends RestBaseAction {
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
         controller.registerHandler(HttpMethod.GET, "/api/show_data", new ShowDataAction(controller));
+    }
+
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
+    @Override
+    public boolean needAuth() {
+        return Config.enable_http_auth;
     }
 
     public long getDataSizeOfDatabase(Database db) {
@@ -84,7 +92,9 @@ public class ShowDataAction extends RestBaseAction {
     }
 
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String dbName = request.getSingleParameter("db");
         ConcurrentHashMap<String, Database> fullNameToDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getFullNameToDb();
         long totalSize = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowMetaInfoAction.java
@@ -50,6 +50,7 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.persist.Storage;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -92,8 +93,16 @@ public class ShowMetaInfoAction extends RestBaseAction {
                 new ShowMetaInfoAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String action = request.getSingleParameter("action");
         // check param empty
         if (Strings.isNullOrEmpty(action)) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowRuntimeInfoAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowRuntimeInfoAction.java
@@ -35,10 +35,12 @@
 package com.starrocks.http.rest;
 
 import com.google.gson.Gson;
+import com.starrocks.common.Config;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,8 +59,16 @@ public class ShowRuntimeInfoAction extends RestBaseAction {
                 new ShowRuntimeInfoAction(controller));
     }
 
+    // Historically anonymous; gated for backward compatibility until enable_http_auth flips on.
     @Override
-    public void execute(BaseRequest request, BaseResponse response) {
+    public boolean needAuth() {
+        return Config.enable_http_auth;
+    }
+
+    @Override
+    protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         HashMap<String, String> feInfo = new HashMap<String, String>();
 
         // Get memory info

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TriggerAction.java
@@ -24,6 +24,7 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.server.GlobalStateMgr;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -52,7 +53,9 @@ public class TriggerAction extends RestBaseAction {
     }
 
     @Override
-    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) throws AccessDeniedException {
+        requireOperateIfHttpAuthEnabled();
+
         String triggerType = request.getSingleParameter("type");
 
         if (Strings.isNullOrEmpty(triggerType)) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaScanNode.java
@@ -324,6 +324,12 @@ public class SchemaScanNode extends ScanNode {
             feInfo.setId(fe.getNodeName());
             feInfo.setIp(fe.getHost());
             feInfo.setHttp_port(Config.http_port);
+            // Thrift (FrontendService) port, used by the BE fe_metrics scanner to fetch
+            // metrics over RPC instead of scraping the HTTP /metrics endpoint. Prefer the
+            // per-FE port reported via heartbeat (Frontend.getRpcPort()); fall back to the
+            // local Config.rpc_port only when it is not yet known (e.g. before the first
+            // heartbeat of the local node).
+            feInfo.setRpc_port(fe.getRpcPort() > 0 ? fe.getRpcPort() : Config.rpc_port);
             frontends.add(feInfo);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -100,6 +100,7 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.http.BaseAction;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.http.rest.WarehouseInfosBuilder;
 import com.starrocks.lake.LakeTablet;
@@ -119,6 +120,7 @@ import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.metric.JsonMetricVisitor;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.planner.OlapTableSink;
@@ -184,6 +186,7 @@ import com.starrocks.thrift.TFeLocksReq;
 import com.starrocks.thrift.TFeLocksRes;
 import com.starrocks.thrift.TFeMemoryReq;
 import com.starrocks.thrift.TFeMemoryRes;
+import com.starrocks.thrift.TFeMetricsResult;
 import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFetchResourceResult;
 import com.starrocks.thrift.TFinishSlotRequirementRequest;
@@ -689,6 +692,30 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TFeMemoryRes listFeMemoryUsage(TFeMemoryReq request) throws TException {
         return SysFeMemoryUsage.listFeMemoryUsage(request);
+    }
+
+    // information_schema.fe_metrics: return this FE's metrics as the JSON payload that the
+    // HTTP `/metrics?type=json` endpoint produces. Serving it over this Thrift RPC (instead of
+    // the BE scanner scraping the HTTP endpoint) keeps fe_metrics working regardless of
+    // `enable_http_auth` — the internal RPC needs no HTTP Basic credentials. FE process metrics
+    // have no per-object RBAC, so the RPC takes no arguments and there is nothing to authorize
+    // here.
+    @Override
+    public TFeMetricsResult getFeMetrics() throws TException {
+        TFeMetricsResult result = new TFeMetricsResult();
+        try {
+            JsonMetricVisitor visitor = new JsonMetricVisitor("starrocks_fe");
+            String json = MetricRepo.getMetric(visitor,
+                    new MetricsAction.RequestParams(false, false, false, false, false));
+            result.setJson_metrics(json);
+            result.setStatus(new TStatus(TStatusCode.OK));
+        } catch (Exception e) {
+            LOG.warn("get fe metrics failed", e);
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            result.setStatus(status);
+        }
+        return result;
     }
 
     // list MaterializedView table match pattern

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -270,6 +270,7 @@ import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TOlapTableIndexTablets;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
+import com.starrocks.thrift.TPrivilegeRequirement;
 import com.starrocks.thrift.TQueryStatisticsInfo;
 import com.starrocks.thrift.TRefreshTableRequest;
 import com.starrocks.thrift.TRefreshTableResponse;
@@ -1103,6 +1104,74 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             default:
                 status.setStatus_code(NOT_IMPLEMENTED_ERROR);
                 break;
+        }
+        return result;
+    }
+
+    @Override
+    public TFeResult checkAuth(TAuthenticateParams request) throws TException {
+        TStatus status = new TStatus(TStatusCode.OK);
+        TFeResult result = new TFeResult(FrontendServiceVersion.V1, status);
+        if (request == null || !request.isSetUser() || !request.isSetPasswd()) {
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs("missing authentication parameters");
+            return result;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("checkAuth request user={} host={} requiredPriv={}",
+                    request.getUser(),
+                    request.isSetHost() ? request.getHost() : null,
+                    request.isSetRequired_privilege() ? request.getRequired_privilege() : null);
+        }
+
+        String host = request.isSetHost() ? request.getHost() : "";
+        try {
+            // 3.3 has no AuthenticationHandler; authenticate via AuthenticationMgr.checkPlainPassword
+            // (returns null on failure) and derive the role set from the resolved identity. 3.3 has no
+            // group-derived-role support on this path, so role IDs come solely from the user identity.
+            UserIdentity currentUser = GlobalStateMgr.getCurrentState().getAuthenticationMgr()
+                    .checkPlainPassword(request.getUser(), host, request.getPasswd());
+            if (currentUser == null) {
+                throw new AccessDeniedException("invalid credentials");
+            }
+            ConnectContext ctx = new ConnectContext();
+            ctx.setCurrentUserIdentity(currentUser);
+            ctx.setCurrentRoleIds(currentUser);
+            Set<Long> roleIds = ctx.getCurrentRoleIds();
+
+            // getRequired_privilege() can return null when a newer BE sends an enum value
+            // this FE doesn't know (TPrivilegeRequirement.findByValue returns null); guard
+            // before the switch so we reject cleanly instead of throwing NPE.
+            TPrivilegeRequirement requiredPriv = request.isSetRequired_privilege()
+                    ? request.getRequired_privilege() : TPrivilegeRequirement.NONE;
+            if (requiredPriv == null) {
+                LOG.warn("checkAuth received unknown required_privilege (enum int) from BE for user={}",
+                        request.getUser());
+                status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                status.addToError_msgs("auth verification failed");
+                return result;
+            }
+            switch (requiredPriv) {
+                case NONE:
+                    break;
+                case OPERATE:
+                    Authorizer.checkSystemAction(currentUser, roleIds, PrivilegeType.OPERATE);
+                    break;
+                case NODE:
+                    Authorizer.checkSystemAction(currentUser, roleIds, PrivilegeType.NODE);
+                    break;
+                default:
+                    LOG.warn("checkAuth hit default switch arm for required_privilege={} (FE enum out of sync)",
+                            requiredPriv);
+                    status.setStatus_code(TStatusCode.INTERNAL_ERROR);
+                    status.addToError_msgs("auth verification failed");
+                    return result;
+            }
+        } catch (AccessDeniedException e) {
+            LOG.warn("checkAuth privilege check failed for user={}: {}", request.getUser(), e.getMessage());
+            status.setStatus_code(TStatusCode.NOT_AUTHORIZED);
+            status.addToError_msgs("Access denied for " + request.getUser() + "@" + host);
         }
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/BasicActionTest.java
@@ -56,4 +56,5 @@ public class BasicActionTest {
         result = WebUtils.sanitizeHttpReqUri(uri);
         Assert.assertEquals(uri, result);
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -136,14 +136,14 @@ public class RestBaseActionTest {
 
     @Test
     public void testAlwaysAnonymousRestActionsBypassBasicAuth() {
-        // These endpoints are never gated by enable_http_auth (probes / internal token-protected).
+        // These endpoints can never require Basic auth, even when the operator opts into
+        // `enable_http_auth`:
+        //  - GetSmallFile is internal token-protected.
+        //  - /api/bootstrap is polled by the FE-to-FE heartbeat (HeartbeatMgr) using the
+        //    cluster token rather than HTTP Basic; gating it would break peer-FE heartbeats.
         Config.enable_http_auth = true;
-        Assert.assertFalse(new BootstrapFinishAction(null).needAuth());
-        Assert.assertFalse(new FeatureAction(null).needAuth());
-        Assert.assertFalse(new HealthAction(null).needAuth());
         Assert.assertFalse(new GetSmallFileAction(null).needAuth());
-        Assert.assertFalse(new IdleAction(null).needAuth());
-        Assert.assertFalse(new MetricsAction(null).needAuth());
+        Assert.assertFalse(new BootstrapFinishAction(null).needAuth());
     }
 
     @Test
@@ -160,6 +160,25 @@ public class RestBaseActionTest {
         Assert.assertTrue(new ShowDataAction(null).needAuth());
         Assert.assertTrue(new ShowMetaInfoAction(null).needAuth());
         Assert.assertTrue(new ShowRuntimeInfoAction(null).needAuth());
+    }
+
+    @Test
+    public void testPublicProbeActionsAreAuthNOnlyGatedByHttpAuthFlag() {
+        // Health / observability probes were historically anonymous. They are now brought
+        // into the `enable_http_auth` scope at AuthN-only level: Basic identity required
+        // when the flag is on, anonymous (backward compatible) when off. None of them
+        // declare a privilege requirement, so identity alone is sufficient.
+        Config.enable_http_auth = false;
+        Assert.assertFalse(new HealthAction(null).needAuth());
+        Assert.assertFalse(new IdleAction(null).needAuth());
+        Assert.assertFalse(new FeatureAction(null).needAuth());
+        Assert.assertFalse(new MetricsAction(null).needAuth());
+
+        Config.enable_http_auth = true;
+        Assert.assertTrue(new HealthAction(null).needAuth());
+        Assert.assertTrue(new IdleAction(null).needAuth());
+        Assert.assertTrue(new FeatureAction(null).needAuth());
+        Assert.assertTrue(new MetricsAction(null).needAuth());
     }
 
     // -------- enable_http_auth-gated helpers --------

--- a/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/RestBaseActionTest.java
@@ -12,9 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import com.starrocks.common.Config;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.BootstrapFinishAction;
+import com.starrocks.http.rest.ConnectionAction;
+import com.starrocks.http.rest.FeatureAction;
+import com.starrocks.http.rest.GetSmallFileAction;
+import com.starrocks.http.rest.HealthAction;
+import com.starrocks.http.rest.IdleAction;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.http.rest.ShowDataAction;
+import com.starrocks.http.rest.ShowMetaInfoAction;
+import com.starrocks.http.rest.ShowRuntimeInfoAction;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.privilege.PrivilegeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -23,13 +39,19 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 import java.net.URI;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,14 +63,30 @@ public class RestBaseActionTest {
     private BaseResponse mockResponse;
     private TNetworkAddress mockAddr;
 
+    private boolean savedEnableHttpAuth;
+    private ConnectContext savedCtx;
+
     static class TestableRestBaseAction extends RestBaseAction {
         public TestableRestBaseAction() {
             super(null);
+        }
+
+        // Expose the protected enable_http_auth-gated helpers so tests in this package
+        // can call them without reflection.
+        public void callRequireOperate() throws AccessDeniedException {
+            requireOperateIfHttpAuthEnabled();
+        }
+
+        public void callRequireDbInsert(String db) throws AccessDeniedException {
+            requireDbInsertIfHttpAuthEnabled(db);
         }
     }
 
     @Before
     public void setUp() {
+        savedEnableHttpAuth = Config.enable_http_auth;
+        savedCtx = ConnectContext.get();
+
         restBaseAction = spy(new TestableRestBaseAction());
         mockRequest = mock(BaseRequest.class);
         mockResponse = mock(BaseResponse.class);
@@ -77,6 +115,16 @@ public class RestBaseActionTest {
         when(mockRequest.getContext()).thenReturn(mockCtx);
     }
 
+    @After
+    public void tearDown() {
+        Config.enable_http_auth = savedEnableHttpAuth;
+        if (savedCtx == null) {
+            ConnectContext.remove();
+        } else {
+            savedCtx.setThreadLocalInfo();
+        }
+    }
+
     @Test
     public void testRedirectTo() throws Exception {
         URI expectedUri = new URI("http", null, "127.0.0.1", 8030, "/api/mydb/testStreamLoad测试/_stream_load", null, null);
@@ -84,5 +132,137 @@ public class RestBaseActionTest {
 
         restBaseAction.redirectTo(mockRequest, mockResponse, mockAddr);
         verify(mockResponse).updateHeader(HttpHeaderNames.LOCATION.toString(), asciiUri);
+    }
+
+    @Test
+    public void testAlwaysAnonymousRestActionsBypassBasicAuth() {
+        // These endpoints are never gated by enable_http_auth (probes / internal token-protected).
+        Config.enable_http_auth = true;
+        Assert.assertFalse(new BootstrapFinishAction(null).needAuth());
+        Assert.assertFalse(new FeatureAction(null).needAuth());
+        Assert.assertFalse(new HealthAction(null).needAuth());
+        Assert.assertFalse(new GetSmallFileAction(null).needAuth());
+        Assert.assertFalse(new IdleAction(null).needAuth());
+        Assert.assertFalse(new MetricsAction(null).needAuth());
+    }
+
+    @Test
+    public void testCompatibilityGatedRestActionsFollowHttpAuthFlag() {
+        // Historically-anonymous endpoints: require Basic only when the operator opts in.
+        Config.enable_http_auth = false;
+        Assert.assertFalse(new ConnectionAction(null).needAuth());
+        Assert.assertFalse(new ShowDataAction(null).needAuth());
+        Assert.assertFalse(new ShowMetaInfoAction(null).needAuth());
+        Assert.assertFalse(new ShowRuntimeInfoAction(null).needAuth());
+
+        Config.enable_http_auth = true;
+        Assert.assertTrue(new ConnectionAction(null).needAuth());
+        Assert.assertTrue(new ShowDataAction(null).needAuth());
+        Assert.assertTrue(new ShowMetaInfoAction(null).needAuth());
+        Assert.assertTrue(new ShowRuntimeInfoAction(null).needAuth());
+    }
+
+    // -------- enable_http_auth-gated helpers --------
+
+    private TestableRestBaseAction newTestableAction() {
+        return new TestableRestBaseAction();
+    }
+
+    // The enable_http_auth-gated helpers read the current user identity from the thread-local
+    // ConnectContext; install a real identity so Authorizer argument matchers (any(UserIdentity))
+    // match (any(UserIdentity.class) does not match a null first argument).
+    private void setUpAuthedContext() {
+        ConnectContext context = new ConnectContext();
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setThreadLocalInfo();
+    }
+
+    @Test
+    public void testRequireOperate_disabled_isNoop() throws Exception {
+        Config.enable_http_auth = false;
+        ConnectContext.remove();
+        newTestableAction().callRequireOperate();
+    }
+
+    @Test
+    public void testRequireDbInsert_disabled_isNoop() throws Exception {
+        Config.enable_http_auth = false;
+        ConnectContext.remove();
+        newTestableAction().callRequireDbInsert("any_db");
+    }
+
+    @Test
+    public void testRequireOperate_enabled_callsAuthorizer() throws Exception {
+        Config.enable_http_auth = true;
+        setUpAuthedContext();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            // default no-throw = authorized
+            newTestableAction().callRequireOperate();
+            mocked.verify(() -> Authorizer.checkSystemAction(any(UserIdentity.class), any(),
+                    eq(PrivilegeType.OPERATE)));
+        }
+    }
+
+    @Test
+    public void testRequireOperate_enabled_denied_propagatesAccessDenied() throws Exception {
+        Config.enable_http_auth = true;
+        setUpAuthedContext();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkSystemAction(any(UserIdentity.class), any(),
+                            eq(PrivilegeType.OPERATE)))
+                    .thenThrow(new AccessDeniedException("operate denied"));
+
+            Assert.assertThrows(AccessDeniedException.class,
+                    () -> newTestableAction().callRequireOperate());
+        }
+    }
+
+    @Test
+    public void testRequireOperate_enabled_checksOperateOnly() throws Exception {
+        // requireOperateIfHttpAuthEnabled checks SYSTEM.OPERATE and nothing else (must not also try NODE).
+        Config.enable_http_auth = true;
+        setUpAuthedContext();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkSystemAction(any(UserIdentity.class), any(),
+                            eq(PrivilegeType.NODE)))
+                    .thenThrow(new AccessDeniedException("must not be called"));
+
+            newTestableAction().callRequireOperate();
+            mocked.verify(() -> Authorizer.checkSystemAction(any(UserIdentity.class), any(),
+                    eq(PrivilegeType.OPERATE)));
+            mocked.verify(() -> Authorizer.checkSystemAction(any(UserIdentity.class), any(),
+                    eq(PrivilegeType.NODE)), never());
+        }
+    }
+
+    @Test
+    public void testRequireDbInsert_enabled_denied_propagatesAccessDenied() throws Exception {
+        Config.enable_http_auth = true;
+        setUpAuthedContext();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            mocked.when(() -> Authorizer.checkActionInDb(any(UserIdentity.class), any(),
+                            eq("test_db"), eq(PrivilegeType.INSERT)))
+                    .thenThrow(new AccessDeniedException("db insert denied"));
+
+            Assert.assertThrows(AccessDeniedException.class,
+                    () -> newTestableAction().callRequireDbInsert("test_db"));
+        }
+    }
+
+    @Test
+    public void testRequireDbInsert_enabled_callsCheckActionInDb() throws Exception {
+        Config.enable_http_auth = true;
+        setUpAuthedContext();
+
+        try (MockedStatic<Authorizer> mocked = mockStatic(Authorizer.class)) {
+            newTestableAction().callRequireDbInsert("test_db");
+            mocked.verify(() -> Authorizer.checkActionInDb(any(UserIdentity.class), any(),
+                    eq("test_db"), eq(PrivilegeType.INSERT)));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -32,7 +32,10 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.MetricVisitor;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -51,6 +54,7 @@ import com.starrocks.thrift.TCreatePartitionResult;
 import com.starrocks.thrift.TDescribeTableParams;
 import com.starrocks.thrift.TDescribeTableResult;
 import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TFeMetricsResult;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.TGetDictQueryParamRequest;
 import com.starrocks.thrift.TGetDictQueryParamResponse;
@@ -152,6 +156,33 @@ public class FrontendServiceImplTest {
         TImmutablePartitionRequest request = new TImmutablePartitionRequest();
         TImmutablePartitionResult partition = impl.updateImmutablePartition(request);
         Assert.assertEquals(partition.getStatus().getStatus_code(), TStatusCode.RUNTIME_ERROR);
+    }
+
+    @Test
+    public void testGetFeMetrics() throws TException {
+        // information_schema.fe_metrics is served over this RPC instead of scraping HTTP /metrics.
+        // It returns the same JSON payload as /metrics?type=json with an OK status.
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TFeMetricsResult result = impl.getFeMetrics();
+        Assert.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
+        Assert.assertNotNull(result.getJson_metrics());
+    }
+
+    @Test
+    public void testGetFeMetricsReturnsErrorStatusOnException() throws TException {
+        // When metric collection throws, getFeMetrics must return an INTERNAL_ERROR status
+        // (with an error message) instead of propagating the exception.
+        new MockUp<MetricRepo>() {
+            @Mock
+            public String getMetric(MetricVisitor visitor, MetricsAction.RequestParams requestParams) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TFeMetricsResult result = impl.getFeMetrics();
+        Assert.assertEquals(TStatusCode.INTERNAL_ERROR, result.getStatus().getStatus_code());
+        Assert.assertFalse(result.getStatus().getError_msgs().isEmpty());
     }
 
     private static ConnectContext connectContext;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -58,12 +58,27 @@ struct TSetSessionParams {
     1: required string user
 }
 
+enum TPrivilegeRequirement {
+    // Identity-only authentication, no role/privilege check beyond AuthN.
+    NONE = 0,
+    // Caller must hold System-level OPERATE privilege.
+    // Maps to Authorizer.checkSystemAction(OPERATE) on the FE side.
+    OPERATE = 1,
+    // Caller must hold System-level NODE privilege.
+    // Maps to Authorizer.checkSystemAction(NODE) on the FE side.
+    NODE = 2,
+}
+
 struct TAuthenticateParams {
     1: required string user
     2: required string passwd
     3: optional string host
     4: optional string db_name
     5: optional list<string> table_names;
+    // Required role/privilege the caller must have, in addition to identity AuthN.
+    // Used by FE.checkAuth on the BE HTTP auth path so BE handlers can demand
+    // admin/operate-level checks without round-tripping the role check themselves.
+    6: optional TPrivilegeRequirement required_privilege;
 }
 
 struct TColumnDesc {
@@ -1976,5 +1991,10 @@ service FrontendService {
     TGetTemporaryTablesInfoResponse getTemporaryTablesInfo(1: TGetTemporaryTablesInfoRequest request)
 
     TReportFragmentFinishResponse reportFragmentFinish(TReportFragmentFinishParams request)
+
+    // Verify Basic Auth credentials. Used by BE to authenticate external HTTP requests
+    // when `enable_http_auth` is on. Returns OK status when the user/password pair is
+    // valid for the given host, or an error status otherwise.
+    TFeResult checkAuth(1: optional TAuthenticateParams request)
 }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1878,6 +1878,15 @@ struct TGetKeysResponse {
     1: optional list<binary> key_metas;
 }
 
+// information_schema.fe_metrics: the BE scanner fetches each FE's metrics over the getFeMetrics
+// RPC (instead of scraping the HTTP /metrics endpoint), so fe_metrics works regardless of
+// `enable_http_auth` and no longer depends on HTTP Basic auth. The RPC takes no arguments —
+// FE process metrics are global with no per-object RBAC to authorize.
+struct TFeMetricsResult {
+    1: optional Status.TStatus status
+    // JSON payload identical to the FE `/metrics?type=json` output, parsed by the BE scanner.
+    2: optional string json_metrics
+}
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -1972,6 +1981,9 @@ service FrontendService {
 
     // sys.fe_memory_usage
     TFeMemoryRes listFeMemoryUsage(1: TFeMemoryReq request)
+
+    // information_schema.fe_metrics
+    TFeMetricsResult getFeMetrics()
 
     TRequireSlotResponse requireSlotAsync(1: TRequireSlotRequest request)
     TFinishSlotRequirementResponse finishSlotRequirement(1: TFinishSlotRequirementRequest request)

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -476,6 +476,7 @@ struct TFrontend {
   1: optional string id
   2: optional string ip
   3: optional i32 http_port
+  4: optional i32 rpc_port
 }
 
 struct TSchemaScanNode {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Draft PR
No need to merge

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

