### PR TITLE
[BugFix] Replicate lake IDG (.idx) indexes in cross-cluster replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -658,6 +658,21 @@ Status LakeReplicationTxnManager::build_existed_filename_uuids_map(
         }
     }
 
+    // Collect UUIDs from idg (.idx) files so a repeated full-snapshot replication reuses the
+    // already-replicated .idx (and its encryption meta) instead of re-copying it.
+    if (target_data_version_tablet_meta->has_idg_meta()) {
+        const auto& idg_meta = target_data_version_tablet_meta->idg_meta();
+        for (const auto& [_, idg_ver_pb] : idg_meta.idgs()) {
+            for (const auto& entry : idg_ver_pb.entries()) {
+                if (!entry.has_index_file() || entry.index_file().empty()) {
+                    continue;
+                }
+                existed_filename_uuids.emplace(extract_uuid_from(entry.index_file()),
+                                               std::make_pair(entry.index_file(), entry.encryption_meta()));
+            }
+        }
+    }
+
     return Status::OK();
 }
 
@@ -685,6 +700,13 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
     new_metadata->mutable_dcg_meta()->mutable_dcgs()->clear();
     new_metadata->mutable_sstable_meta()->Clear();
     new_metadata->mutable_delvec_meta()->Clear();
+    // Drop the target's pre-replication idg_meta. Without this the target's stale
+    // per-segment IDG (.idx) entries would be carried into the replicated metadata:
+    // their rssids no longer match the freshly replicated rowsets (dangling entries),
+    // their .idx files leak (never orphaned/vacuumed since a retained entry still
+    // "references" them), and the source's own indexes would be missing. The source's
+    // idg_meta is rebuilt below, mirroring rowsets/dcg/sstable/delvec.
+    new_metadata->mutable_idg_meta()->Clear();
 
     // deal with segments and dels
     for (const auto& src_rowset_meta : src_tablet_meta->rowsets()) {
@@ -864,6 +886,53 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
                             } else {
                                 dcg_ver_pb.add_encryption_metas(existing_encryption_meta);
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // deal with idg_meta (per-segment Index Delta Group / .idx sidecar index files,
+    // produced by the lake ADD INDEX fast path: BITMAP / NGRAMBF / bloom_filter_columns).
+    // Mirror the sstable/dcg handling: copy the source IDG metadata, then rewrite each
+    // .idx filename (and encryption meta) and register the file for copy via
+    // determine_final_filename, so the source's fast-path indexes are actually replicated
+    // to the target. The IDG map is keyed by rssid; rowset ids and next_rowset_id are
+    // adopted verbatim from the source above (set_rowset_uid only mints a fresh 128-bit
+    // uid, not the numeric rowset id), so the source's rssid keys stay valid against the
+    // copied rowsets and need no remap. The target's own stale idg_meta was cleared above;
+    // the publish-time applier orphans its now-unreferenced .idx via collect_idg_orphan_files.
+    if (src_tablet_meta->has_idg_meta()) {
+        IndexDeltaGroupMetadataPB* dest_meta = new_metadata->mutable_idg_meta();
+        dest_meta->CopyFrom(src_tablet_meta->idg_meta());
+        for (auto& [rssid, idg_ver] : *dest_meta->mutable_idgs()) {
+            for (auto& entry : *idg_ver.mutable_entries()) {
+                if (!entry.has_index_file() || entry.index_file().empty()) {
+                    continue;
+                }
+                const auto src_idx_filename = entry.index_file();
+                std::string final_idx_filename;
+                ASSIGN_OR_RETURN(
+                        auto is_existed,
+                        determine_final_filename(src_idx_filename, txn_id, existed_filename_uuids, final_idx_filename,
+                                                 target_tablet_id, src_data_dir, file_locations, filename_map));
+                entry.set_index_file(final_idx_filename);
+                // The source's encryption meta belongs to the source cluster; drop it and
+                // re-derive against the target (matching the segment handling above).
+                entry.clear_encryption_meta();
+
+                if (config::enable_transparent_data_encryption) {
+                    if (!is_existed) {
+                        // .idx file doesn't exist on target, use the newly generated encryption metadata
+                        std::pair<std::string, FileEncryptionPair> pair = filename_map[src_idx_filename];
+                        entry.set_encryption_meta(pair.second.encryption_meta);
+                    } else {
+                        // .idx file already replicated in a previous txn, reuse its existing encryption metadata
+                        auto uuid = extract_uuid_from(src_idx_filename);
+                        auto it = existed_filename_uuids.find(uuid);
+                        if (it != existed_filename_uuids.end()) {
+                            entry.set_encryption_meta(it->second.second);
                         }
                     }
                 }

--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -903,7 +903,33 @@ StatusOr<std::shared_ptr<TabletMetadataPB>> LakeReplicationTxnManager::convert_a
     // uid, not the numeric rowset id), so the source's rssid keys stay valid against the
     // copied rowsets and need no remap. The target's own stale idg_meta was cleared above;
     // the publish-time applier orphans its now-unreferenced .idx via collect_idg_orphan_files.
-    if (src_tablet_meta->has_idg_meta()) {
+    //
+    // Fast-schema-change caveat: when the source and target tablets assign different column
+    // unique ids to the same logical column, replication remaps the ids embedded in
+    // segment/.cols footers via build_file_converters + column_unique_id_map. The IDG entry
+    // keys (IndexKey.col_unique_id / dropped_keys) AND the col_unique_ids embedded inside the
+    // .idx payload footer -- which IndexFileReader::find(col_unique_id, index_type) and the
+    // scan probe (ScalarColumnIterator matches k.col_unique_id == opts.col_unique_id) look up
+    // by the TARGET id -- are NOT converted here (build_file_converters only rewrites
+    // is_segment()/is_cols() footers). Copying idg_meta + .idx verbatim under a divergent id
+    // space would make the replica either silently ignore the index (target id misses the
+    // source-keyed entry) or, on a unique-id collision, apply an index built for a different
+    // column and prune rows wrongly. Until the .idx footer + IDG-key remap is implemented,
+    // skip IDG replication whenever the id spaces diverge: leave idg_meta cleared (index
+    // absent on the replica, to be rebuilt on the target) rather than publishing a
+    // mismappable index. The common identical-schema CCR path (empty map) is unaffected.
+    std::unordered_map<uint32_t, uint32_t> idg_column_unique_id_map;
+    if (target_tablet_meta->has_schema()) {
+        ReplicationUtils::calc_column_unique_id_map(src_tablet_meta->schema().column(),
+                                                    target_tablet_meta->schema().column(), &idg_column_unique_id_map);
+    }
+    if (src_tablet_meta->has_idg_meta() && !idg_column_unique_id_map.empty()) {
+        LOG(WARNING) << "Lake replicate storage task, skipping IDG (.idx) index replication because source/target "
+                        "column unique ids diverge (fast schema change); the fast-path index will be absent on the "
+                        "replica and must be rebuilt on the target. target_tablet_id: "
+                     << target_tablet_id << ", txn_id: " << txn_id
+                     << ", unique_id_map size: " << idg_column_unique_id_map.size();
+    } else if (src_tablet_meta->has_idg_meta()) {
         IndexDeltaGroupMetadataPB* dest_meta = new_metadata->mutable_idg_meta();
         dest_meta->CopyFrom(src_tablet_meta->idg_meta());
         for (auto& [rssid, idg_ver] : *dest_meta->mutable_idgs()) {

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -865,14 +865,19 @@ protected:
         schema->set_id(next_id());
         schema->set_num_short_key_columns(1);
         schema->set_num_rows_per_row_block(65535);
+        // Fixed, tablet-independent column unique ids: cross-cluster replication of the SAME
+        // logical table normally shares the column unique-id space between source and target,
+        // so calc_column_unique_id_map() is empty and the IDG (.idx) fast-path indexes replicate
+        // verbatim. (A per-tablet next_id() here would fabricate a divergent id space that does
+        // not model real same-table CCR and would trip the divergent-id skip guard.)
         auto c0 = schema->add_column();
-        c0->set_unique_id(next_id());
+        c0->set_unique_id(1);
         c0->set_name("c0");
         c0->set_type("INT");
         c0->set_is_key(true);
         c0->set_is_nullable(false);
         auto c1 = schema->add_column();
-        c1->set_unique_id(next_id());
+        c1->set_unique_id(2);
         c1->set_name("c1");
         c1->set_type("INT");
         c1->set_is_key(false);
@@ -1509,6 +1514,79 @@ TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_replicated_and_stale_drop
     EXPECT_EQ(1, built_entry.keys(0).col_unique_id());
     EXPECT_EQ(NGRAMBF, built_entry.keys(0).index_type());
     EXPECT_EQ(2, built_entry.version());
+}
+
+// Regression: when the source and target tablets assign DIFFERENT column unique ids to the same
+// logical column (fast-schema-change divergence, calc_column_unique_id_map non-empty), replication
+// must NOT copy the source idg_meta / .idx verbatim. The IDG entry keys and the col_unique_ids
+// embedded in the .idx payload footer are keyed by the SOURCE id, while the scan probe and
+// IndexFileReader::find() look up by the TARGET id, so a verbatim copy would be silently ignored or
+// (on a unique-id collision) mis-applied to a different column and prune rows wrongly. Until the
+// .idx-footer + IDG-key remap is implemented, the fast path is skipped and idg_meta stays empty on
+// the replica (index absent, to be rebuilt on the target) -- never a mismappable index.
+TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_skipped_on_divergent_column_ids) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Source tablet metadata (version 2) with one rowset + segment and a source IDG entry.
+    const std::string src_idx = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-0000000000aa.idx";
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    // Diverge the source's column unique-id space from the target's (target c1 uid == 2). This makes
+    // calc_column_unique_id_map() non-empty and must trigger the IDG replication skip.
+    src_meta_v2->mutable_schema()->mutable_column(1)->set_unique_id(9999);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segment_metas()->set_filename("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    src_meta_v2->set_next_rowset_id(2);
+    {
+        auto& src_ver = (*src_meta_v2->mutable_idg_meta()->mutable_idgs())[1];
+        auto* src_entry = src_ver.add_entries();
+        auto* k = src_entry->add_keys();
+        k->set_col_unique_id(2); // source-space id for column c1
+        k->set_index_type(NGRAMBF);
+        src_entry->set_index_file(src_idx);
+        src_entry->set_version(2);
+    }
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 1024; });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 512; });
+
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 0; // sequential path
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+    ASSERT_OK(status);
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    ASSERT_TRUE(txn_log->has_op_replication());
+    ASSERT_TRUE(txn_log->op_replication().has_tablet_metadata());
+    const auto& built_meta = txn_log->op_replication().tablet_metadata();
+
+    // The rowset/segment still replicates; only the IDG fast-path index is skipped.
+    ASSERT_EQ(1, built_meta.rowsets_size());
+    // idg_meta must be empty: neither the source's entry nor any target stale entry survives.
+    EXPECT_TRUE(built_meta.idg_meta().idgs().empty());
 }
 
 // Regression companion: with transparent data encryption ON, the replicated source IDG entry must

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -50,6 +50,7 @@
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/join.h"
+#include "platform/key_cache.h"
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
@@ -1376,6 +1377,220 @@ TEST_F(LakeReplicationRemoteStorageTest, test_parallel_copy_error_handling) {
     // Parallel copy should fail because download_lake_file_with_converter fails with mock FS
     EXPECT_FALSE(status.ok());
     pool->shutdown();
+}
+
+// Regression: lake-to-lake replication must replicate the source's IDG (.idx) fast-path
+// indexes and must NOT carry the target's pre-replication idg_meta.
+// Before the fix, convert_and_build_new_tablet_meta cleared rowsets/dcg/sstable/delvec but
+// left idg_meta untouched and never rebuilt it from the source, so the built (copied) tablet
+// metadata carried the target's STALE idg_meta and never picked up the source's — silently
+// losing the index on the replica and leaking the target's stale .idx files. This drives the
+// full replicate path and inspects the produced replication txn log (whose tablet_metadata is
+// exactly what the publish-time applier commits).
+TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_replicated_and_stale_dropped) {
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    // Give the TARGET tablet (data_version 1) a pre-existing (stale) idg_meta entry keyed by an
+    // rssid the replicated rowsets won't use, referencing a distinct .idx file. It must not survive.
+    const std::string stale_idx = "00000000000000ff_ffffffff-ffff-ffff-ffff-0000000000ff.idx";
+    {
+        auto target_v1 = std::make_shared<TabletMetadata>(*_target_tablet_metadata);
+        auto& stale_ver = (*target_v1->mutable_idg_meta()->mutable_idgs())[999];
+        auto* stale_entry = stale_ver.add_entries();
+        auto* sk = stale_entry->add_keys();
+        sk->set_col_unique_id(42);
+        sk->set_index_type(BITMAP);
+        stale_entry->set_index_file(stale_idx);
+        stale_entry->set_version(1);
+        // A stale entry with an empty index_file exercises the empty-index_file skip in
+        // build_existed_filename_uuids_map (the file is not registered for dedup); it must
+        // still be dropped along with the rest of the target's stale idg_meta.
+        auto* stale_empty = stale_ver.add_entries();
+        stale_empty->add_keys()->set_col_unique_id(43);
+        stale_empty->set_version(1); // index_file intentionally unset
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*target_v1));
+    }
+
+    // Source tablet metadata (version 2) with one rowset + segment and a source IDG entry
+    // (rssid=1) referencing a source .idx file.
+    const std::string src_idx = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-0000000000aa.idx";
+    const std::string src_uuid = "aaaaaaaa-bbbb-cccc-dddd-0000000000aa";
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segment_metas()->set_filename("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    src_meta_v2->set_next_rowset_id(2);
+    {
+        auto& src_ver = (*src_meta_v2->mutable_idg_meta()->mutable_idgs())[1];
+        auto* src_entry = src_ver.add_entries();
+        auto* k = src_entry->add_keys();
+        k->set_col_unique_id(1);
+        k->set_index_type(NGRAMBF); // non-default (BITMAP==0) so carry-through is discriminating
+        src_entry->set_index_file(src_idx);
+        src_entry->set_version(2);
+    }
+    {
+        // A source entry with no index_file exercises the empty-index_file skip in the rebuild
+        // loop: it must be carried through verbatim (no filename rewrite, no copy registration).
+        auto& src_ver2 = (*src_meta_v2->mutable_idg_meta()->mutable_idgs())[2];
+        auto* e = src_ver2.add_entries();
+        e->add_keys()->set_col_unique_id(7);
+        e->set_version(2); // index_file intentionally unset
+    }
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 1024; });
+    // The .idx file goes through the non-segment copy path (use_converter=false); mock it.
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 512; });
+
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 0; // sequential path
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+    ASSERT_OK(status);
+
+    // Inspect the produced replication txn log; its tablet_metadata is what publish will apply.
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    ASSERT_TRUE(txn_log->has_op_replication());
+    ASSERT_TRUE(txn_log->op_replication().has_tablet_metadata());
+    const auto& built_meta = txn_log->op_replication().tablet_metadata();
+
+    // The source's IDG entries (rssid=1 with a .idx, rssid=2 with none) survive; the target's
+    // stale entries (rssid=999) are gone.
+    const auto& idgs = built_meta.idg_meta().idgs();
+    ASSERT_EQ(2u, idgs.size());
+    ASSERT_TRUE(idgs.find(999) == idgs.end());
+    auto it1 = idgs.find(1);
+    ASSERT_TRUE(it1 != idgs.end());
+
+    // The empty-index_file source entry (rssid=2) is carried through verbatim: still present,
+    // still has no index_file (the rebuild loop skipped it without rewriting/registering a file).
+    auto it2 = idgs.find(2);
+    ASSERT_TRUE(it2 != idgs.end());
+    ASSERT_EQ(1, it2->second.entries_size());
+    EXPECT_FALSE(it2->second.entries(0).has_index_file());
+
+    const auto& built_ver = it1->second;
+    ASSERT_EQ(1, built_ver.entries_size());
+    const auto& built_entry = built_ver.entries(0);
+    ASSERT_TRUE(built_entry.has_index_file());
+    // The .idx filename is rewritten to the target's txn-scoped name (source UUID preserved),
+    // so it differs from both the raw source name and the target's stale name.
+    EXPECT_NE(src_idx, built_entry.index_file());
+    EXPECT_NE(stale_idx, built_entry.index_file());
+    EXPECT_NE(std::string::npos, built_entry.index_file().find(".idx"));
+    EXPECT_NE(std::string::npos, built_entry.index_file().find(src_uuid)); // UUID carried across rename
+    EXPECT_EQ(extract_uuid_from(src_idx), extract_uuid_from(built_entry.index_file()));
+    // The stale .idx filename must never appear in the built metadata.
+    EXPECT_EQ(std::string::npos, built_entry.index_file().find("0000000000ff"));
+    // Key metadata is carried through.
+    ASSERT_EQ(1, built_entry.keys_size());
+    EXPECT_EQ(1, built_entry.keys(0).col_unique_id());
+    EXPECT_EQ(NGRAMBF, built_entry.keys(0).index_type());
+    EXPECT_EQ(2, built_entry.version());
+}
+
+// Regression companion: with transparent data encryption ON, the replicated source IDG entry must
+// carry a freshly-derived (target-side) encryption_meta for its .idx file, mirroring the segment/
+// sstable/dcg handling. Covers the enable_transparent_data_encryption branch of the idg rebuild.
+TEST_F(LakeReplicationRemoteStorageTest, test_idg_meta_replicated_encrypted) {
+    // Seed a master key so create_encryption_meta_pair_using_current_kek() succeeds.
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    ASSERT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+    BoolConfigGuard enc_guard(&config::enable_transparent_data_encryption);
+    config::enable_transparent_data_encryption = true;
+
+    auto mock_fs = std::make_shared<MockStarletFileSystemForReplication>();
+    SyncPoint::GetInstance()->SetCallBack("new_fs_starlet::get_shard_filesystem", [&](void* arg) {
+        auto* fs_st = static_cast<absl::StatusOr<std::shared_ptr<staros::starlet::fslib::FileSystem>>*>(arg);
+        *fs_st = mock_fs;
+    });
+
+    const std::string src_idx = "0000000000000001_aaaaaaaa-bbbb-cccc-dddd-0000000000aa.idx";
+    auto src_meta_v2 = std::make_shared<TabletMetadata>(*_src_tablet_metadata);
+    src_meta_v2->set_version(2);
+    auto* rowset = src_meta_v2->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(4096);
+    rowset->add_segment_metas()->set_filename("0000000000000001_aaaaaaaa-bbbb-cccc-dddd-000000000001.dat");
+    src_meta_v2->set_next_rowset_id(2);
+    {
+        auto& src_ver = (*src_meta_v2->mutable_idg_meta()->mutable_idgs())[1];
+        auto* src_entry = src_ver.add_entries();
+        src_entry->add_keys()->set_col_unique_id(1);
+        src_entry->set_index_file(src_idx);
+        src_entry->set_version(2);
+    }
+
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::build_source_tablet_meta::inject",
+                                          [&](void* arg) {
+                                              auto* meta_ptr = static_cast<TabletMetadataPtr*>(arg);
+                                              *meta_ptr = src_meta_v2;
+                                          });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::download_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 1024; });
+    SyncPoint::GetInstance()->SetCallBack("LakeReplicationTxnManager::replicate_task::copy_non_segment",
+                                          [&](void* arg) { *static_cast<size_t*>(arg) = 512; });
+
+    Int32ConfigGuard min_file_guard(&config::lake_replication_parallel_copy_min_file_count);
+    config::lake_replication_parallel_copy_min_file_count = 0; // sequential path
+
+    auto original_master_info = get_master_info();
+    TMasterInfo info = original_master_info;
+    info.__set_min_active_txn_id(0);
+    ASSERT_TRUE(update_master_info(info));
+
+    auto request = build_request(false /* with_full_path */);
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request, nullptr);
+    (void)update_master_info(original_master_info);
+    ASSERT_OK(status);
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(_target_tablet_id, _transaction_id));
+    ASSERT_TRUE(txn_log->has_op_replication());
+    ASSERT_TRUE(txn_log->op_replication().has_tablet_metadata());
+    const auto& built_meta = txn_log->op_replication().tablet_metadata();
+
+    const auto& idgs = built_meta.idg_meta().idgs();
+    auto it1 = idgs.find(1);
+    ASSERT_TRUE(it1 != idgs.end());
+    ASSERT_EQ(1, it1->second.entries_size());
+    const auto& built_entry = it1->second.entries(0);
+    // The .idx entry carries a freshly-derived, non-empty target encryption_meta.
+    EXPECT_TRUE(built_entry.has_encryption_meta());
+    EXPECT_FALSE(built_entry.encryption_meta().empty());
 }
 #endif // USE_STAROS
 


### PR DESCRIPTION
## Why I'm doing:

Shared-data (lake) cross-cluster replication silently drops the source table's Index
Delta Group (IDG / `.idx` sidecar) fast-path indexes on the replica, and leaks the
target's pre-existing `.idx` files.

The lake ADD INDEX fast path (`CREATE/ALTER ... ADD INDEX USING BITMAP|NGRAMBF`, or
`ALTER TABLE ... SET("bloom_filter_columns"=...)`) does not rewrite segment data; it
writes per-segment `.idx` sidecar files and records them in
`TabletMetadataPB.idg_meta` (keyed by rssid).

`LakeReplicationTxnManager::convert_and_build_new_tablet_meta` builds the replicated
tablet metadata by starting from the **target** metadata, then `Clear()`-ing and
rebuilding `rowsets` / `dcg_meta` / `sstable_meta` / `delvec_meta` from the **source** —
but it never touched `idg_meta`. As a result the built metadata (which is packed into
`op_replication.tablet_metadata` and committed verbatim at publish time) carried the
**target's stale** `idg_meta` and never the source's. Concretely:

- The source's `.idx` indexes are never fetched/registered → the index silently
  disappears on the replica; a query that relied on bloom/ngram/bitmap pruning
  full-scans, with no user-visible signal (`SHOW CREATE TABLE` may still list the index).
- The target's old `idg_meta` survives; its rssids no longer match the freshly
  replicated rowsets (dangling entries), and because a retained entry still "references"
  those `.idx` files, the publish-time `collect_idg_orphan_files` never orphans them →
  the stale `.idx` files leak forever (vacuum never reclaims them).

The compaction / drop-index / replication-log appliers in `txn_log_applier.cpp` already
handle the IDG lifecycle (clear → rebuild from source → `collect_idg_orphan_files`); the
applier faithfully propagates whatever `convert_and_build_new_tablet_meta` produces, so
the missing piece was purely the metadata builder.

## What I'm doing:

In `LakeReplicationTxnManager::convert_and_build_new_tablet_meta`:

1. `Clear()` the target's `idg_meta` alongside `rowsets`/`dcg_meta`/`sstable_meta`/`delvec_meta`.
2. Rebuild `idg_meta` from the source, mirroring the existing sstable/dcg handling:
   `CopyFrom` the source IDG metadata, then for each entry rewrite the `.idx` filename via
   `determine_final_filename` (which registers the file for physical copy) and re-derive
   the encryption meta against the target. The IDG map is keyed by rssid; rowset numeric
   ids and `next_rowset_id` are adopted verbatim from the source (`set_rowset_uid` only
   mints a fresh 128-bit `uid`, not the numeric id), so the source's rssid keys stay valid
   against the copied rowsets and need no remap.

Because the target's stale `idg_meta` is now cleared, its `.idx` files become unreferenced
and are correctly orphaned/vacuumed by the existing publish-time `collect_idg_orphan_files`
path.

I also add IDG `.idx` files to `build_existed_filename_uuids_map` so a repeated
full-snapshot replication reuses the already-replicated `.idx` (and its encryption meta)
instead of re-copying it, matching the existing segment/sstable/dcg behavior.

Only single-file `.idx` payloads exist here — GIN/VECTOR are `NotSupported` by the lake
ADD INDEX fast path — so there is no directory-copy hazard. No proto changes.

Added a regression test (`LakeReplicationRemoteStorageTest.test_idg_meta_replicated_and_stale_dropped`)
that seeds the target with a stale IDG entry, injects a source metadata carrying an IDG
entry, drives the full replicate path, and asserts the produced replication txn log's
`tablet_metadata.idg_meta` contains exactly the source's entry (with a rewritten `.idx`
filename preserving the source UUID) and none of the target's stale entry.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

A lake table with fast-path (`.idx`) indexes now keeps those indexes after cross-cluster
replication (previously the replica lost them). No metadata format change; a source/target
without `idg_meta` behaves exactly as before, and a replication txn log produced by this
build remains safe for an older applier (it simply won't copy the extra `idg_meta`, i.e.
the pre-fix behavior — no corruption).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
