### PR TITLE
[Enhancement] Surface external table collection metadata via SHOW ANALYZE STATUS Properties column

### DIFF
--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
@@ -32,7 +32,7 @@ This statement returns the following columns.
 | Status        | The status of the task.                                      |
 | StartTime     | The time when the task starts executing.                     |
 | EndTime       | The time when the task execution ends.                       |
-| Properties    | Custom parameters.                                           |
+| Properties    | Custom parameters. For external table (for example, Iceberg, Hive, or Paimon) collection tasks, this also includes collection metadata such as `table_format`, `partition_count`, `column_count`, and, for Iceberg tables, `snapshot_id`, `total_files`, and `total_rows`. |
 | Reason        | The reason why the task failed. NULL is returned if the execution was successful. |
 
 ## References

--- a/docs/ja/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
+++ b/docs/ja/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
@@ -34,7 +34,7 @@ SHOW ANALYZE STATUS [WHERE]
 | Status        | タスクのステータス。                                         |
 | StartTime     | タスクが実行を開始した時間。                                 |
 | EndTime       | タスクの実行が終了した時間。                                 |
-| Properties    | カスタムパラメータ。                                         |
+| Properties    | カスタムパラメータ。外部テーブル（Iceberg、Hive、Paimon など）の収集タスクの場合、`table_format`、`partition_count`、`column_count`、および Iceberg テーブル固有の `snapshot_id`、`total_files`、`total_rows` などの収集メタデータも含まれます。 |
 | Reason        | タスクが失敗した理由。実行が成功した場合は NULL が返されます。 |
 
 ## 参考文献

--- a/docs/zh/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
+++ b/docs/zh/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_STATUS.md
@@ -30,7 +30,7 @@ SHOW ANALYZE STATUS [LIKE | WHERE predicate]
 | Status     | 任务状态，包括 RUNNING（正在执行）、SUCCESS（执行成功）和 FAILED（执行失败）。 |
 | StartTime  | 任务开始执行的时间。                                         |
 | EndTime    | 任务结束执行的时间。                                         |
-| Properties | 自定义参数信息。                                             |
+| Properties | 自定义参数信息。对于外部表（如 Iceberg、Hive、Paimon）的采集任务，还会包含本次采集的元信息，例如 `table_format`、`partition_count`、`column_count`，以及 Iceberg 表特有的 `snapshot_id`、`total_files`、`total_rows`。 |
 | Reason     | 任务失败的原因。如果执行成功则为 NULL。                      |
 
 ## 相关文档

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -86,6 +86,8 @@ import org.apache.thrift.TSerializer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -408,19 +410,20 @@ public class IcebergTable extends Table {
     }
 
     @Override
-    public String getStatsCollectSummary() {
+    public Map<String, String> getStatsCollectMetadata() {
         org.apache.iceberg.Snapshot snapshot = getNativeTable().currentSnapshot();
         if (snapshot == null) {
-            return "";
+            return Collections.emptyMap();
         }
-        java.util.Map<String, String> summary = snapshot.summary();
+        Map<String, String> summary = snapshot.summary();
         if (summary == null) {
-            summary = java.util.Collections.emptyMap();
+            summary = Collections.emptyMap();
         }
-        return String.format("snapshotId=%d totalFiles=%s totalRows=%s",
-                snapshot.snapshotId(),
-                summary.getOrDefault("total-data-files", "0"),
-                summary.getOrDefault("total-records", "0"));
+        Map<String, String> result = new LinkedHashMap<>();
+        result.put("snapshot_id", String.valueOf(snapshot.snapshotId()));
+        result.put("total_files", summary.getOrDefault("total-data-files", "0"));
+        result.put("total_rows", summary.getOrDefault("total-records", "0"));
+        return result;
     }
 
     public org.apache.iceberg.Table getNativeTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -413,10 +413,11 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return type == TableType.ICEBERG;
     }
 
-    // Returns a one-line summary string for stats-collection logging.
-    // Subclasses can override to include connector-specific metadata (e.g. snapshot info).
-    public String getStatsCollectSummary() {
-        return "";
+    // Returns structured metadata about this table for stats-collection observability
+    // (e.g. snapshot_id/total_files/total_rows). Subclasses can override to include
+    // connector-specific metadata. Empty by default.
+    public Map<String, String> getStatsCollectMetadata() {
+        return Collections.emptyMap();
     }
 
     public boolean isDeltalakeTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
@@ -60,6 +60,8 @@ public interface AnalyzeStatus {
 
     Map<String, String> getProperties();
 
+    void setProperties(Map<String, String> properties);
+
     LocalDateTime getStartTime();
 
     LocalDateTime getEndTime();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
@@ -136,6 +136,10 @@ public class ExternalAnalyzeStatus implements AnalyzeStatus, Writable {
         return properties;
     }
 
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
     @Override
     public LocalDateTime getStartTime() {
         return startTime;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
@@ -136,6 +136,7 @@ public class ExternalAnalyzeStatus implements AnalyzeStatus, Writable {
         return properties;
     }
 
+    @Override
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -65,6 +65,7 @@ import org.apache.velocity.VelocityContext;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,11 +127,23 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                 jobId, catalogName, db.getOriginName(), table.getName(),
                 partitionNames.size(), columnNames.size());
 
-        String tableSummary = table.getStatsCollectSummary();
-        if (!tableSummary.isEmpty()) {
-            LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
-                    jobId, catalogName, db.getOriginName(), table.getName(), tableSummary);
+        Map<String, String> extendedInfo = new LinkedHashMap<>();
+        extendedInfo.put("table_format", table.getType().name());
+        extendedInfo.put("partition_count", String.valueOf(partitionNames.size()));
+        extendedInfo.put("column_count", String.valueOf(columnNames.size()));
+        extendedInfo.putAll(table.getStatsCollectMetadata());
+        if (analyzeStatus instanceof ExternalAnalyzeStatus) {
+            // Merge into the existing properties map so it surfaces via the Properties column of
+            // SHOW ANALYZE STATUS without introducing new columns.
+            Map<String, String> mergedProperties = new LinkedHashMap<>();
+            if (analyzeStatus.getProperties() != null) {
+                mergedProperties.putAll(analyzeStatus.getProperties());
+            }
+            mergedProperties.putAll(extendedInfo);
+            ((ExternalAnalyzeStatus) analyzeStatus).setProperties(mergedProperties);
         }
+        LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
+                jobId, catalogName, db.getOriginName(), table.getName(), extendedInfo);
 
         String status = "SUCCESS";
         String failureReason = "";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -67,6 +67,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -128,20 +129,20 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                 partitionNames.size(), columnNames.size());
 
         Map<String, String> extendedInfo = new LinkedHashMap<>();
-        extendedInfo.put("table_format", table.getType().name());
+        extendedInfo.put("table_format", table.getType().name().toLowerCase(Locale.ROOT));
         extendedInfo.put("partition_count", String.valueOf(partitionNames.size()));
         extendedInfo.put("column_count", String.valueOf(columnNames.size()));
         extendedInfo.putAll(table.getStatsCollectMetadata());
-        if (analyzeStatus instanceof ExternalAnalyzeStatus) {
-            // Merge into the existing properties map so it surfaces via the Properties column of
-            // SHOW ANALYZE STATUS without introducing new columns.
-            Map<String, String> mergedProperties = new LinkedHashMap<>();
-            if (analyzeStatus.getProperties() != null) {
-                mergedProperties.putAll(analyzeStatus.getProperties());
-            }
-            mergedProperties.putAll(extendedInfo);
-            ((ExternalAnalyzeStatus) analyzeStatus).setProperties(mergedProperties);
+
+        // Merge into the existing properties map so it surfaces via the Properties column of
+        // SHOW ANALYZE STATUS without introducing new columns.
+        Map<String, String> mergedProperties = new LinkedHashMap<>();
+        if (analyzeStatus.getProperties() != null) {
+            mergedProperties.putAll(analyzeStatus.getProperties());
         }
+        mergedProperties.putAll(extendedInfo);
+        analyzeStatus.setProperties(mergedProperties);
+
         LOG.info("[ExternalStats] table info | jobId={} catalog={} db={} table={} {}",
                 jobId, catalogName, db.getOriginName(), table.getName(), extendedInfo);
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/NativeAnalyzeStatus.java
@@ -156,6 +156,11 @@ public class NativeAnalyzeStatus implements AnalyzeStatus, Writable {
     }
 
     @Override
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    @Override
     public LocalDateTime getStartTime() {
         return startTime;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -423,4 +423,35 @@ public class IcebergTableTest extends TableTestBase {
         LightWeightIcebergTable light = new LightWeightIcebergTable(base);
         Assertions.assertThrows(UnsupportedOperationException.class, light::getNativeTable);
     }
+
+    @Test
+    public void testGetStatsCollectMetadata() {
+        org.apache.iceberg.BaseTable nativeTable = Mockito.mock(org.apache.iceberg.BaseTable.class);
+        org.apache.iceberg.Snapshot snapshot = Mockito.mock(org.apache.iceberg.Snapshot.class);
+        Mockito.when(nativeTable.currentSnapshot()).thenReturn(snapshot);
+        Mockito.when(snapshot.snapshotId()).thenReturn(123456789L);
+        Mockito.when(snapshot.summary()).thenReturn(ImmutableMap.of(
+                "total-data-files", "5",
+                "total-records", "1000"));
+
+        IcebergTable table = IcebergTable.builder()
+                .setId(1)
+                .setSrTableName("t")
+                .setCatalogName("cat")
+                .setCatalogDBName("db")
+                .setCatalogTableName("tbl")
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(nativeTable)
+                .setIcebergProperties(new HashMap<>())
+                .build();
+
+        Map<String, String> metadata = table.getStatsCollectMetadata();
+        Assertions.assertEquals("123456789", metadata.get("snapshot_id"));
+        Assertions.assertEquals("5", metadata.get("total_files"));
+        Assertions.assertEquals("1000", metadata.get("total_rows"));
+
+        // No current snapshot (e.g. empty table) -> empty metadata, not an error.
+        Mockito.when(nativeTable.currentSnapshot()).thenReturn(null);
+        Assertions.assertTrue(table.getStatsCollectMetadata().isEmpty());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1182,7 +1182,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         Map<String, String> properties = analyzeStatus.getProperties();
         Assertions.assertEquals("custom_value", properties.get("custom_key"));
-        Assertions.assertEquals("HIVE", properties.get("table_format"));
+        Assertions.assertEquals("hive", properties.get("table_format"));
         Assertions.assertEquals("1", properties.get("partition_count"));
         Assertions.assertEquals("3", properties.get("column_count"));
 
@@ -1199,7 +1199,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                 table.getUUID(), Lists.newArrayList("r_regionkey", "r_name", "r_comment"), StatsConstants.AnalyzeType.FULL,
                 StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
         Assertions.assertThrows(Exception.class, () -> collectJob.collect(connectContext, failedStatus));
-        Assertions.assertEquals("HIVE", failedStatus.getProperties().get("table_format"));
+        Assertions.assertEquals("hive", failedStatus.getProperties().get("table_format"));
         Assertions.assertEquals("3", failedStatus.getProperties().get("column_count"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1152,6 +1152,58 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
     }
 
     @Test
+    public void testExternalFullStatisticsCollectJobExtendedInfo() throws Exception {
+        Database database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
+        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "tpch", "region");
+
+        ExternalFullStatisticsCollectJob collectJob = (ExternalFullStatisticsCollectJob)
+                StatisticsCollectJobFactory.buildExternalStatisticsCollectJob("hive0",
+                        database,
+                        table, null,
+                        Lists.newArrayList("r_regionkey", "r_name", "r_comment"),
+                        StatsConstants.AnalyzeType.FULL,
+                        StatsConstants.ScheduleType.ONCE,
+                        Maps.newHashMap());
+
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus) {
+                // Skip the actual query execution, only exercise collect()'s bookkeeping logic.
+            }
+        };
+
+        // Existing (user-supplied) properties must be preserved alongside the merged-in collection metadata.
+        Map<String, String> initialProperties = Maps.newHashMap();
+        initialProperties.put("custom_key", "custom_value");
+        ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "hive0", "tpch", "region",
+                table.getUUID(), Lists.newArrayList("r_regionkey", "r_name", "r_comment"), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, initialProperties, LocalDateTime.now());
+        collectJob.collect(connectContext, analyzeStatus);
+
+        Map<String, String> properties = analyzeStatus.getProperties();
+        Assertions.assertEquals("custom_value", properties.get("custom_key"));
+        Assertions.assertEquals("HIVE", properties.get("table_format"));
+        Assertions.assertEquals("1", properties.get("partition_count"));
+        Assertions.assertEquals("3", properties.get("column_count"));
+
+        // The merge happens before the collection try-block runs, so the properties must still be
+        // populated on the AnalyzeStatus even when the collection itself fails.
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            public void collectStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus)
+                    throws Exception {
+                throw new DdlException("mock collect failure");
+            }
+        };
+        ExternalAnalyzeStatus failedStatus = new ExternalAnalyzeStatus(2, "hive0", "tpch", "region",
+                table.getUUID(), Lists.newArrayList("r_regionkey", "r_name", "r_comment"), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        Assertions.assertThrows(Exception.class, () -> collectJob.collect(connectContext, failedStatus));
+        Assertions.assertEquals("HIVE", failedStatus.getProperties().get("table_format"));
+        Assertions.assertEquals("3", failedStatus.getProperties().get("column_count"));
+    }
+
+    @Test
     public void testIcebergPartitionTransformFullStatisticsBuildCollectSQLList() {
         // test partition column type is timestamp without time zone
         Database database =


### PR DESCRIPTION
## Why I'm doing:
For external tables (Iceberg/Hive/Paimon), a single `SHOW ANALYZE STATUS` row represents one collection run over N partitions × M columns, but today there's no way to tell how big that run actually was — how many partitions/columns were touched, or (for Iceberg) which snapshot and how many files/rows the table had at collection time. This makes it hard to judge collection cost or diagnose slow/failed runs without grepping `fe.log` for the `[ExternalStats]` structured logs added in earlier PRs (#75335, #75529).

We initially considered adding a dedicated history table for this, but that was dropped as too heavyweight. This PR takes the lightest approach instead: reuse the `Properties` column that `SHOW ANALYZE STATUS` already exposes, rather than introducing new columns/schema.

Incarnation of this pr https://github.com/StarRocks/starrocks/pull/75342

## What I'm doing:
- Added a `Table.getStatsCollectMetadata()` hook (replacing the log-only `getStatsCollectSummary()` string) that returns structured key/value metadata instead of a pre-formatted string. `IcebergTable` overrides it to report `snapshot_id` / `total_files` / `total_rows` from the current snapshot; other table types return empty.
- In `ExternalFullStatisticsCollectJob.collect()`, build an `extendedInfo` map (`table_format`, `partition_count`, `column_count`, plus whatever `getStatsCollectMetadata()` returns) and merge it into the job's existing `AnalyzeStatus.properties` map — no new columns, so it just shows up in the `Properties` field of `SHOW ANALYZE STATUS` for external table rows.
- This merge happens *before* the collection try-block runs, so the info is captured even when the collection itself fails:

  ```
  collect()
    ├─ compute extendedInfo (table_format/partition_count/column_count/snapshot_id/...)
    ├─ merge into analyzeStatus.properties   <-- always runs
    └─ try { ...actual SQL scan/insert... }  <-- may throw, properties already set
  ```

- Kept the `[ExternalStats] table info` log line, now logging the structured map instead of a fixed-format string (still grep-able, more machine-parseable).
- Docs (`en`/`zh`/`ja`) updated to note that `Properties` now also carries this collection metadata for external table jobs.
- Added unit tests: `IcebergTableTest#testGetStatsCollectMetadata` and `StatisticsCollectJobTest#testExternalFullStatisticsCollectJobExtendedInfo` (covers both the success path and that properties are still populated when collection fails).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5