### PR TITLE
[BugFix] Skip sync histogram load during statistics collection to avoid FE deadlock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -544,6 +544,19 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
     public Map<String, Histogram> getHistogramStatistics(Table table, List<String> columns) {
         Preconditions.checkState(table != null);
 
+        // Skip loading histogram statistics when we are inside a statistics-collect connection
+        // (recursion guard) or when the target is a statistics-internal table, or when the
+        // statistics tables are not in a healthy state. Without this guard a histogram-collect
+        // INSERT that holds the histogram_statistics READ lock would synchronously load the
+        // histogram of its own source table, and that loader re-acquires the histogram_statistics
+        // READ lock -> self-deadlock. This mirrors the guard already present in getColumnStatistics.
+        if (StatisticUtils.statisticTableBlackListCheck(table.getId())) {
+            return Maps.newHashMap();
+        }
+        if (!StatisticUtils.checkStatisticTableStateNormal()) {
+            return Maps.newHashMap();
+        }
+
         List<String> columnHasHistogram = new ArrayList<>();
         for (String columnName : columns) {
             if (GlobalStateMgr.getCurrentState().getAnalyzeMgr().getHistogramStatsMetaMap()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorageTest.java
@@ -139,11 +139,9 @@ public class CachedStatisticStorageTest {
 
                 cachedStatisticStorage.getColumnStatistic(table, "v2");
                 result = ColumnStatistic.builder().setDistinctValuesCount(999).build();
-                minTimes = 0;
 
                 cachedStatisticStorage.getColumnStatistic(table, "v3");
                 result = ColumnStatistic.builder().setDistinctValuesCount(666).build();
-                minTimes = 0;
             }
         };
         ColumnStatistic columnStatistic1 =
@@ -442,6 +440,66 @@ public class CachedStatisticStorageTest {
         Map<String, Histogram> histogramMap =
                 cachedStatisticStorage.getConnectorHistogramStatistics(table, ImmutableList.of("c1"));
         Assertions.assertEquals(0, histogramMap.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testGetHistogramStatisticsSkipInStatisticsConnection(
+            @Mocked AsyncLoadingCache<ColumnStatsCacheKey, Optional<Histogram>> histogramCache) {
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "t0");
+
+        // A histogram-collect INSERT holds the histogram_statistics READ lock while its plan is
+        // optimized; estimating the source scan then calls getHistogramStatistics on the source
+        // table. If that synchronously loads the histogram, the loader re-acquires the
+        // histogram_statistics READ lock and (behind a queued publish WRITE) self-deadlocks.
+        // The guard must short-circuit for statistics-collect connections BEFORE touching the
+        // cache, so the loader is never dispatched. Assert getAll is never called.
+        new Expectations() {
+            {
+                histogramCache.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
+                times = 0;
+            }
+        };
+
+        CachedStatisticStorage cachedStatisticStorage = new CachedStatisticStorage();
+
+        connectContext.setThreadLocalInfo();
+        boolean prev = connectContext.isStatisticsConnection();
+        connectContext.setStatisticsConnection(true);
+        try {
+            Map<String, Histogram> result =
+                    cachedStatisticStorage.getHistogramStatistics(table, ImmutableList.of("v1"));
+            Assertions.assertTrue(result.isEmpty());
+        } finally {
+            connectContext.setStatisticsConnection(prev);
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testGetHistogramStatisticsSkipForStatisticsInternalTable(
+            @Mocked AsyncLoadingCache<ColumnStatsCacheKey, Optional<Histogram>> histogramCache) {
+        Database statsDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(StatsConstants.STATISTICS_DB_NAME);
+        Table statsTable = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(statsDb.getFullName(), "table_statistic_v1");
+        Assertions.assertNotNull(statsTable);
+
+        // The other guard branch: statistics-internal tables (in the collect blacklist DB) must also
+        // skip the load, independent of the connection type, so the cache is never touched.
+        new Expectations() {
+            {
+                histogramCache.getAll((Iterable<? extends ColumnStatsCacheKey>) any);
+                times = 0;
+            }
+        };
+
+        CachedStatisticStorage cachedStatisticStorage = new CachedStatisticStorage();
+        ConnectContext.remove();
+        Map<String, Histogram> result =
+                cachedStatisticStorage.getHistogramStatistics(statsTable, ImmutableList.of("column_name"));
+        Assertions.assertTrue(result.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
The result is a permanent cycle:

```
collect INSERT → (future.get) loader → (READ behind queued WRITE)
publish → (WRITE behind READ) collect INSERT
```

It is invisible to the lock-manager deadlock checker because one edge is a `CompletableFuture` wait, not a lock edge. As more daemons queue on the same table, the whole FE freezes.

| Thread | On `histogram_statistics` (rid=10053) | State | Origin |
  |---|---|---|---|
  | ① pool-1 (hold) | Holds READ, blocked in `future.get()` (not waiting on a lock) | WAITING (parking) | Collect INSERT optimization phase, `getHistogramStatistics` |
  | ② pool-0 (writer) | Waiting for WRITE (queued right behind ①'s READ) | TIMED_WAITING | Transaction commit, `commitTransactionUnderDatabaseWLock` |
  | ③ refresher-4 (loader) | Waiting for READ (queued behind ②'s WRITE) | WAITING (monitor) | Loading histogram, `SELECT FROM histogram_statistics` |
  
  **Cycle:** ① holds READ and parks in `future.get()` waiting for the loader (③) → ③ needs READ but, under FIFO writer-priority, is stuck behind ②'s WRITE → ② needs WRITE but is blocked by ①'s READ. The two READs (① and ③) are
  compatible in isolation, but the WRITE (②) wedged between them prevents ③ from being granted. The lock-manager deadlock checker misses it because the ①→③ edge is a `CompletableFuture` wait, not a lock edge.

```
"analyze-task-concurrency-pool-1" #172 daemon prio=5 os_prio=0 cpu=3650.77ms elapsed=261.80s tid=0x0000073e48015e40 nid=0xad20 waiting on condition  [0x0000073e2a5f2000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.19/Native Method)
	- parking to wait for  <0x00000006a84a3f60> (a java.util.concurrent.CompletableFuture$Signaller)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.19/LockSupport.java:211)
	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@17.0.19/CompletableFuture.java:1864)
	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.19/ForkJoinPool.java:3465)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.19/ForkJoinPool.java:3436)
	at java.util.concurrent.CompletableFuture.waitingGet(java.base@17.0.19/CompletableFuture.java:1898)
	at java.util.concurrent.CompletableFuture.get(java.base@17.0.19/CompletableFuture.java:2072)
	at com.starrocks.sql.optimizer.statistics.CachedStatisticStorage.getHistogramStatistics(CachedStatisticStorage.java:579)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.estimateScanColumns(StatisticsCalcUtils.java:75)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeOlapScanNode(StatisticsCalculator.java:395)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:352)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:197)
	at com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator.accept(LogicalOlapScanOperator.java:194)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:251)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:900)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.Utils.calculateStatistics(Utils.java:889)
	at com.starrocks.sql.optimizer.QueryOptimizer.logicalJoinReorder(QueryOptimizer.java:907)
	at com.starrocks.sql.optimizer.QueryOptimizer.pushDownAggregation(QueryOptimizer.java:857)
	at com.starrocks.sql.optimizer.QueryOptimizer.logicalRuleRewrite(QueryOptimizer.java:697)
	at com.starrocks.sql.optimizer.QueryOptimizer.rewriteAndValidatePlan(QueryOptimizer.java:829)
	at com.starrocks.sql.optimizer.QueryOptimizer.optimizeByCost(QueryOptimizer.java:260)
	at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:216)
	at com.starrocks.sql.InsertPlanner.buildExecPlan(InsertPlanner.java:586)
	at com.starrocks.sql.InsertPlanner.plan(InsertPlanner.java:354)
	at com.starrocks.sql.StatementPlanner.planInsertStmt(StatementPlanner.java:302)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:166)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:111)
	at com.starrocks.qe.StmtExecutor.generateExecPlan(StmtExecutor.java:861)
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:1031)
	at com.starrocks.statistic.StatisticsCollectJob.collectStatisticSync(StatisticsCollectJob.java:263)
	at com.starrocks.statistic.HistogramStatisticsCollectJob.collect(HistogramStatisticsCollectJob.java:138)
	at com.starrocks.statistic.StatisticExecutor.collectStatistics(StatisticExecutor.java:577)
	at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:2369)
	at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:2320)
	at com.starrocks.qe.StmtExecutor.lambda$handleAnalyzeStmt$2(StmtExecutor.java:2249)
	at com.starrocks.qe.StmtExecutor$$Lambda$1579/0x0000073ea4b2bd40.run(Unknown Source)
	at com.starrocks.statistic.CancelableAnalyzeTask.run(CancelableAnalyzeTask.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.19/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.19/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.19/Thread.java:840)
```
```
"analyze-task-concurrency-pool-0" #165 daemon prio=5 os_prio=0 cpu=7108.55ms elapsed=265.15s tid=0x0000073e4800eb20 nid=0xad19 in Object.wait()  [0x0000073e2acf2000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.19/Native Method)
	- waiting on <no object reference available>
	at com.starrocks.common.util.concurrent.lock.LockManager.lockAcquireSlowPath(LockManager.java:191)
	- locked <0x00000006a8949bd8> (a com.starrocks.common.util.concurrent.lock.Locker)
	at com.starrocks.common.util.concurrent.lock.LockManager.lock(LockManager.java:157)
	at com.starrocks.common.util.concurrent.lock.Locker.lock(Locker.java:90)
	at com.starrocks.common.util.concurrent.lock.Locker.tryLockTablesWithIntensiveDbLock(Locker.java:281)
	at com.starrocks.transaction.GlobalTransactionMgr.commitTransactionUnderDatabaseWLock(GlobalTransactionMgr.java:515)
	at com.starrocks.transaction.GlobalTransactionMgr.retryCommitOnRateLimitExceeded(GlobalTransactionMgr.java:477)
	at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:3700)
	at com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:3238)
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:1187)
	at com.starrocks.statistic.StatisticsCollectJob.collectStatisticSync(StatisticsCollectJob.java:263)
	at com.starrocks.statistic.HistogramStatisticsCollectJob.collect(HistogramStatisticsCollectJob.java:138)
	at com.starrocks.statistic.StatisticExecutor.collectStatistics(StatisticExecutor.java:577)
	at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:2369)
	at com.starrocks.qe.StmtExecutor.executeAnalyze(StmtExecutor.java:2320)
	at com.starrocks.qe.StmtExecutor.lambda$handleAnalyzeStmt$2(StmtExecutor.java:2249)
	at com.starrocks.qe.StmtExecutor$$Lambda$1579/0x0000073ea4b2bd40.run(Unknown Source)
	at com.starrocks.statistic.CancelableAnalyzeTask.run(CancelableAnalyzeTask.java:57)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.19/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.19/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.19/Thread.java:840)
```
```
"stats-cache-refresher-4" #68 daemon prio=5 os_prio=0 cpu=2901.73ms elapsed=269.49s tid=0x0000073e700565e0 nid=0xaca7 in Object.wait()  [0x0000073e9cd80000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.19/Native Method)
	- waiting on <no object reference available>
	at com.starrocks.common.util.concurrent.lock.LockManager.lockAcquireSlowPath(LockManager.java:189)
	- locked <0x00000006a3c3d810> (a com.starrocks.common.util.concurrent.lock.Locker)
	at com.starrocks.common.util.concurrent.lock.LockManager.lock(LockManager.java:157)
	at com.starrocks.common.util.concurrent.lock.Locker.lock(Locker.java:90)
	at com.starrocks.common.util.concurrent.lock.Locker.lockTablesWithIntensiveDbLock(Locker.java:214)
	at com.starrocks.sql.analyzer.PlannerMetaLocker.lock(PlannerMetaLocker.java:154)
	at com.starrocks.sql.StatementPlanner.lock(StatementPlanner.java:503)
	at com.starrocks.sql.StatementPlanner.lambda$analyzeStatement$0(StatementPlanner.java:227)
	at com.starrocks.sql.StatementPlanner$$Lambda$556/0x0000073ea4684330.run(Unknown Source)
	at com.starrocks.sql.StatementPlanner.analyzeStatement(StatementPlanner.java:289)
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:135)
	at com.starrocks.statistic.StatisticExecutor.executeDQL(StatisticExecutor.java:767)
	at com.starrocks.statistic.StatisticExecutor.executeStatisticDQL(StatisticExecutor.java:723)
	at com.starrocks.statistic.StatisticExecutor.queryHistogram(StatisticExecutor.java:309)
	at com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader.queryHistogramStatistics(ColumnHistogramStatsCacheLoader.java:120)
	at com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader.lambda$asyncLoadAll$1(ColumnHistogramStatsCacheLoader.java:93)
	at com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader$$Lambda$494/0x0000073ea465d018.get(Unknown Source)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(java.base@17.0.19/CompletableFuture.java:1768)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.19/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.19/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.19/Thread.java:840)
```

## What I'm doing

Add the same guard to `getHistogramStatistics()` so a statistics-collect connection (recursion guard via `isStatisticsConnection`) and statistics-internal tables skip the synchronous histogram load. During collection the optimizer simply falls back to default estimates instead of loading a histogram of the very table it is collecting, so the loader is never dispatched and the cycle cannot form. Histogram collection itself (the INSERT and commit) is unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
