### PR TITLE
[BugFix] Track and bound memory in lake ADD INDEX fast path

### DIFF
--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -435,6 +435,14 @@ Status AddIndexSchemaChange::build_bitmap_for_column(Segment* segment, const Tab
         RETURN_IF_ERROR(feed_index_from_column(bitmap_writer.get(), *col, 0, n, type_size));
     }
 
+    // Final memory check: the loop-top check does not cover the last batch's
+    // growth, and finish() below materializes/serializes the whole accumulated
+    // index. Check once more here so the largest peak still fails cleanly
+    // instead of risking an OOM in finish().
+    if (auto* mem_tracker = CurrentThread::mem_tracker(); mem_tracker != nullptr) {
+        RETURN_IF_ERROR(mem_tracker->check_mem_limit("AddIndexSchemaChange"));
+    }
+
     // Write the bitmap blob to the shared target file and emit the
     // ColumnIndexMetaPB that describes its in-file layout. The file offset
     // used by the blob is determined by target_wfile's current append
@@ -592,6 +600,13 @@ Status AddIndexSchemaChange::build_bloom_for_column(Segment* segment, const Tabl
         // Emit exactly one bloom filter for this data page (mirrors
         // finish_current_page()), so read_bloom_filter(page) lines up 1:1.
         RETURN_IF_ERROR(bf_writer->flush());
+    }
+
+    // Final memory check: the per-page check does not cover the last page's
+    // growth, and finish() below serializes all accumulated per-page filters.
+    // Check once more here so a last-page overshoot still fails cleanly.
+    if (auto* mem_tracker = CurrentThread::mem_tracker(); mem_tracker != nullptr) {
+        RETURN_IF_ERROR(mem_tracker->check_mem_limit("AddIndexSchemaChange"));
     }
 
     RETURN_IF_ERROR(bf_writer->finish(target_wfile, out_meta));

--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -33,6 +33,7 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/substitute.h"
 #include "platform/key_cache.h"
+#include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/index_file_writer.h"
@@ -159,6 +160,19 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
         return Status::InternalError("AddIndexSchemaChange: base tablet metadata is null");
     }
 
+    // run() executes on the alter-worker thread, which has the per-alter
+    // SCHEMA_CHANGE_TASK mem tracker installed on TLS (see
+    // EngineAlterTabletTask::execute). The per-segment index build below,
+    // however, runs on lake_schema_change pool worker threads that do NOT
+    // inherit that TLS tracker — so without re-installing it, the build's
+    // allocations (esp. the whole-segment BITMAP index accumulated until
+    // finish()) would be charged to the process-root tracker and, with no
+    // check_mem_limit, could drive the process toward OOM instead of failing
+    // cleanly. Capture the tracker here and re-install it inside each pool
+    // task, mirroring the legacy inline DirectSchemaChange path. May be the
+    // process-root tracker (or null in bare unit tests); both are safe.
+    MemTracker* mem_tracker = CurrentThread::mem_tracker();
+
     for (const auto& rowset : base_metadata->rowsets()) {
         for (int seg_idx = 0; seg_idx < rowset.segment_metas_size(); ++seg_idx) {
             uint32_t rssid = get_rssid(rowset, seg_idx);
@@ -166,16 +180,21 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
             // reference would dangle if we captured by reference and the
             // metadata got mutated during the run (e.g. defensive).
             RowsetMetadataPB rowset_copy = rowset;
-            Status submit_st = runner.submit(
-                    [this, rowset_copy = std::move(rowset_copy), seg_idx, rssid, op_add_index]() -> Status {
-                        IndexDeltaGroupEntryPB entry;
-                        RETURN_IF_ERROR(build_idg_for_segment(rowset_copy, seg_idx, rssid, &entry));
-                        std::lock_guard<std::mutex> lg(_op_mtx);
-                        auto* se = op_add_index->add_segment_entries();
-                        se->set_segment_id(rssid);
-                        se->mutable_entry()->Swap(&entry);
-                        return Status::OK();
-                    });
+            Status submit_st = runner.submit([this, rowset_copy = std::move(rowset_copy), seg_idx, rssid, op_add_index,
+                                              mem_tracker]() -> Status {
+                // Re-install the alter's schema-change mem tracker on this
+                // pool worker thread so the index build is accounted for and
+                // subject to the same limit as the legacy path. RAII-restored
+                // on task exit, leaving the pool thread's TLS clean.
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
+                IndexDeltaGroupEntryPB entry;
+                RETURN_IF_ERROR(build_idg_for_segment(rowset_copy, seg_idx, rssid, &entry));
+                std::lock_guard<std::mutex> lg(_op_mtx);
+                auto* se = op_add_index->add_segment_entries();
+                se->set_segment_id(rssid);
+                se->mutable_entry()->Swap(&entry);
+                return Status::OK();
+            });
             if (!submit_st.ok()) {
                 // Submission failure short-circuits: wait for pending tasks
                 // to drain, then report the submit error (which takes
@@ -396,6 +415,16 @@ Status AddIndexSchemaChange::build_bitmap_for_column(Segment* segment, const Tab
     constexpr size_t kBatch = 4096;
     const size_t type_size = type_info->size();
     while (true) {
+        // Back-pressure: the bitmap writer accumulates the entire per-segment
+        // index (distinct-value dict + a roaring posting list per value) in
+        // memory until finish(), so check the schema-change mem limit each
+        // batch and abort cleanly rather than risk an OOM. The tracker was
+        // installed on this thread's TLS by run()'s task wrapper. Mirrors
+        // legacy DirectSchemaChange (schema_change.cpp). Null-guarded so bare
+        // unit tests (no TLS tracker) don't dereference null.
+        if (auto* mem_tracker = CurrentThread::mem_tracker(); mem_tracker != nullptr) {
+            RETURN_IF_ERROR(mem_tracker->check_mem_limit("AddIndexSchemaChange"));
+        }
         col->reset_column();
         size_t n = kBatch;
         Status st = col_iter->next_batch(&n, col.get());
@@ -530,6 +559,16 @@ Status AddIndexSchemaChange::build_bloom_for_column(Segment* segment, const Tabl
     auto col = ColumnHelper::create_column(TypeDescriptor(column.type()), column.is_nullable());
     const size_t type_size = type_info->size();
     for (int32_t page = 0; page < num_pages; ++page) {
+        // Back-pressure: the bloom writer keeps one finished filter per data
+        // page (plus the current page's distinct-value working set) in memory
+        // until finish(), so check the schema-change mem limit each page and
+        // abort cleanly rather than risk an OOM. The tracker was installed on
+        // this thread's TLS by run()'s task wrapper. Mirrors legacy
+        // DirectSchemaChange (schema_change.cpp). Null-guarded so bare unit
+        // tests (no TLS tracker) don't dereference null.
+        if (auto* mem_tracker = CurrentThread::mem_tracker(); mem_tracker != nullptr) {
+            RETURN_IF_ERROR(mem_tracker->check_mem_limit("AddIndexSchemaChange"));
+        }
         // [first_ordinal, last_ordinal] is the inclusive row range of data page
         // `page` — exactly what the read path will resolve for read_bloom_filter(page).
         auto [first_ordinal, last_ordinal] = col_reader->get_page_range(static_cast<size_t>(page));

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -29,6 +29,7 @@
 #include "column/nullable_column.h"
 #include "column/schema.h"
 #include "common/config_rowset_fwd.h"
+#include "common/thread/threadpool.h"
 #include "fs/fs.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
@@ -36,6 +37,8 @@
 #include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gen_cpp/types.pb.h"
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/fixed_location_provider.h"
@@ -991,6 +994,114 @@ TEST_F(AddIndexSchemaChangeTest, run_two_indexes_share_idx_file) {
     ASSERT_OK(sc.run(&op));
     ASSERT_EQ(1, op.segment_entries_size());
     EXPECT_EQ(2, op.segment_entries(0).entry().keys_size());
+}
+
+// The IDG fast path builds the whole per-segment index in memory (BITMAP
+// accumulates its dictionary + posting lists until finish()). It runs on
+// lake_schema_change pool workers that do NOT inherit the alter's schema-change
+// mem tracker, and historically had no check_mem_limit at all — so a large or
+// wide build could drive the CN past its mem limit toward OOM instead of
+// failing cleanly, unlike the legacy DirectSchemaChange path. These tests pin
+// the back-pressure: with the schema-change tracker already over its limit, the
+// build must abort with a clean MemoryLimitExceeded, not crash/OOM.
+//
+// Notes on the test harness:
+//  - The first two tests drive run() with the default (null) lake_schema_change
+//    pool, so the per-segment task executes INLINE on this thread; the tracker
+//    installed via SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER is the one run()
+//    captures and the build loop consults. The third test uses a REAL pool to
+//    cover the cross-thread re-install that is the actual cause of the OOM.
+//  - In BE_TEST builds the malloc hook does not charge MemTrackers, so we
+//    pre-consume the tracker past its limit to trigger the per-batch check
+//    deterministically rather than relying on the build's own allocations.
+TEST_F(AddIndexSchemaChangeTest, run_bitmap_trips_clean_mem_limit_exceeded) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/100);
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BITMAP, _c1_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    MemTracker sc_tracker(MemTrackerType::SCHEMA_CHANGE_TASK, /*byte_limit=*/1024, "sc_test", nullptr);
+    sc_tracker.consume(sc_tracker.limit() + 1); // push consumption past the limit
+
+    TxnLogPB_OpAddIndex op;
+    Status st;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(&sc_tracker);
+        st = sc.run(&op);
+    }
+    sc_tracker.release(sc_tracker.consumption()); // reset before dtor
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_mem_limit_exceeded()) << st.to_string();
+}
+
+// Same as above but exercises the check in build_bloom_for_column's batch loop.
+TEST_F(AddIndexSchemaChangeTest, run_bloom_trips_clean_mem_limit_exceeded) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/100);
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BLOOM_FILTER, _c1_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    MemTracker sc_tracker(MemTrackerType::SCHEMA_CHANGE_TASK, /*byte_limit=*/1024, "sc_test", nullptr);
+    sc_tracker.consume(sc_tracker.limit() + 1);
+
+    TxnLogPB_OpAddIndex op;
+    Status st;
+    {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(&sc_tracker);
+        st = sc.run(&op);
+    }
+    sc_tracker.release(sc_tracker.consumption());
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_mem_limit_exceeded()) << st.to_string();
+}
+
+// Regression guard for the tracker capture + re-install across the
+// lake_schema_change POOL-THREAD hop — the actual cause of the OOM (per-segment
+// builds run on pool workers that don't inherit the alter thread's tracker).
+// Here we drive run() with a REAL single-thread pool and install the over-limit
+// tracker ONLY on the parent thread. The build then runs on a pool worker whose
+// TLS tracker is NOT the over-limit one, so it can observe the limit ONLY if
+// run() captured the parent's tracker and the task wrapper re-installed it on
+// the worker. If that capture/re-install regressed, the check would consult the
+// (unlimited) process-root tracker and the build would wrongly succeed.
+TEST_F(AddIndexSchemaChangeTest, run_bitmap_pool_thread_inherits_mem_limit) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/100);
+
+    std::unique_ptr<ThreadPool> pool;
+    ASSERT_OK(ThreadPoolBuilder("idg_sc_test").set_min_threads(0).set_max_threads(1).build(&pool));
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BITMAP, _c1_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version, pool.get());
+
+    MemTracker sc_tracker(MemTrackerType::SCHEMA_CHANGE_TASK, /*byte_limit=*/1024, "sc_test", nullptr);
+    sc_tracker.consume(sc_tracker.limit() + 1);
+
+    TxnLogPB_OpAddIndex op;
+    Status st;
+    {
+        // Installed on the PARENT thread only; the pool worker does not inherit
+        // it via TLS — the fix must carry it across the hop.
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(&sc_tracker);
+        st = sc.run(&op);
+    }
+    sc_tracker.release(sc_tracker.consumption());
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_mem_limit_exceeded()) << st.to_string();
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

The lake `ADD INDEX` fast path (`AddIndexSchemaChange`, introduced by #71689) builds each
segment's `BITMAP` / `BLOOM` / `NGRAMBF` index on the shared `lake_schema_change` thread
pool. Those pool worker threads do **not** inherit the alter-worker thread's
`SCHEMA_CHANGE_TASK` mem tracker (installed on TLS by `EngineAlterTabletTask::execute`), and
the fast path had **no `check_mem_limit`** anywhere.

`BitmapIndexWriter` accumulates the entire per-segment index (distinct-value dictionary + a
roaring posting list per value) in memory until `finish()`. Because the pool threads run with
`tls_is_catched == false`, the malloc hook never aborts on a tracker-limit overrun — so a
large or wide `ADD INDEX` could drive the BE/CN toward an OS OOM-kill instead of failing
cleanly the way the legacy inline `DirectSchemaChange` path does (`schema_change.cpp` gates
each convert iteration on `check_mem_limit`). The build's memory was also charged to the
process-root tracker, making it invisible in schema-change memory metrics.

## What I'm doing:

Bring the fast path to parity with the legacy schema-change path:

1. `AddIndexSchemaChange::run()` (which executes synchronously on the alter-worker thread that
   already has the `SCHEMA_CHANGE_TASK` tracker on TLS) captures `CurrentThread::mem_tracker()`.
2. Each per-segment pool task re-installs that tracker on its worker thread via
   `SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER` (RAII-restored on task exit), so the whole
   `build_idg_for_segment` → `build_bitmap_for_column` / `build_bloom_for_column` call tree —
   and all its allocations — are attributed to and bounded by the schema-change tracker.
3. A per-batch, null-guarded `check_mem_limit("AddIndexSchemaChange")` is added at the top of
   both builder loops, so the build aborts with a clean `MemoryLimitExceeded` instead of
   risking an OOM.

The captured tracker is safe across the pool-thread hop: `run()` blocks in `runner.wait()`
(joining all tasks) before returning, and it is owned by the `EngineAlterTabletTask` that
outlives the call. `MemTracker` consume/check are atomic, so the shared tracker is a correct
aggregate cap across the fan-out.

Unit tests (`add_index_schema_change_test.cpp`) assert a clean `MemoryLimitExceeded` on both
the inline path (bitmap + bloom) and the real pool-thread path (`run_bitmap_pool_thread_inherits_mem_limit`,
which guards the cross-thread re-install). In `BE_TEST` the malloc hook does not charge
`MemTracker`s, so the tests pre-consume the tracker past its limit to trip the check
deterministically.

Fixes the OOM/observability gap; no correctness change to the produced index.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

> A large lake `ADD INDEX` that previously ran unbounded (untracked) can now legitimately fail
> with `Memory limit exceeded` once the aggregate build memory crosses the per-alter
> `memory_limitation_per_thread_for_schema_change` budget (shared across the concurrent
> per-segment builds). This is the intended back-pressure — the same failure mode the legacy
> `DirectSchemaChange` path already has — not a regression. No new config or metric is added.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
