### PR TITLE
[BugFix] Preserve column default when modifying column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -96,6 +96,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.ColumnDefAnalyzer;
 import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.analyzer.IndexAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -274,6 +275,22 @@ public class SchemaChangeHandler extends AlterHandler {
             return ColumnBuilder.buildGeneratedColumn(table, columnDef);
         }
         return ColumnBuilder.buildColumn(columnDef);
+    }
+
+    private void inheritDefaultValueForModify(Column modColumn, Column oriColumn, OlapTable olapTable)
+            throws DdlException {
+        ColumnDef.DefaultValueDef inheritedDefaultValue = oriColumn.toColumnDef(olapTable).getDefaultValueDef();
+        inheritedDefaultValue.expr = inheritedDefaultValue.expr.clone();
+        if (inheritedDefaultValue.isSet) {
+            try {
+                inheritedDefaultValue.expr =
+                        ColumnDefAnalyzer.validateDefaultValue(modColumn.getType(), inheritedDefaultValue.expr);
+            } catch (AnalysisException e) {
+                throw new DdlException(
+                        String.format("Invalid default value for '%s': %s", modColumn.getName(), e.getMessage()));
+            }
+        }
+        modColumn.setDefaultValueDef(inheritedDefaultValue);
     }
 
     /**
@@ -870,6 +887,9 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         Column oriColumn = schemaForFinding.get(modColIndex);
+        if (!alterClause.getColumnDef().getDefaultValueDef().isSet) {
+            inheritDefaultValueForModify(modColumn, oriColumn, olapTable);
+        }
 
         for (Index index : olapTable.getIndexes()) {
             if (index.getIndexType() == IndexDef.IndexType.GIN) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -250,6 +250,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         this.isAggregationTypeImplicit = false;
         this.isKey = isKey;
         this.isAllowNull = isAllowNull;
+        setDefaultValueDef(defaultValueDef);
+        this.isAutoIncrement = false;
+        this.comment = comment;
+        this.generatedColumnExpr = null;
+        this.uniqueId = columnUniqId;
+        this.physicalName = physicalName;
+        this.createdTime = System.currentTimeMillis();
+    }
+
+    public void setDefaultValueDef(ColumnDef.DefaultValueDef defaultValueDef) {
+        this.defaultValue = null;
+        this.defaultExpr = null;
         if (defaultValueDef != null) {
             if (defaultValueDef.expr instanceof StringLiteral) {
                 String value = ((StringLiteral) defaultValueDef.expr).getValue();
@@ -276,12 +288,6 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                 }
             }
         }
-        this.isAutoIncrement = false;
-        this.comment = comment;
-        this.generatedColumnExpr = null;
-        this.uniqueId = columnUniqId;
-        this.physicalName = physicalName;
-        this.createdTime = System.currentTimeMillis();
     }
 
     public Column(Column column) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -192,6 +192,27 @@ public class AlterJobV2Test extends StarRocksTestBase {
     }
 
     @Test
+    public void testModifyColumnInheritsDefaultValueWhenOmitted() throws Exception {
+        try {
+            starRocksAssert.withTable("CREATE TABLE modify_column_keep_default(" +
+                        "k1 int, v1 varchar(8) NOT NULL DEFAULT 'abc') ENGINE = OLAP " +
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) properties('replication_num' = '1');");
+
+            String alterStmtStr = "alter table test.modify_column_keep_default modify column v1 varchar(16) not null";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr,
+                        connectContext);
+            DDLStmtExecutor.execute(alterTableStmt, connectContext);
+
+            waitForSchemaChangeAlterJobFinish();
+            OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getDb("test").getTable("modify_column_keep_default");
+            Assertions.assertEquals("abc", table.getBaseColumn("v1").getDefaultValue());
+        } finally {
+            starRocksAssert.dropTable("modify_column_keep_default");
+        }
+    }
+
+    @Test
     public void testModifyRelatedColumnWithStr2DatePartitionTable() {
         try {
             // modify column which define in mv


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... MODIFY COLUMN` rebuilds the target column from the clause definition. When the clause omits `DEFAULT`, the parsed column definition uses `NOT_SET`, so columns with an existing default value can be treated as if the default is being removed and schema change rejects the operation.

## What I'm doing:

- Preserve the existing column default value when `MODIFY COLUMN` omits `DEFAULT`.
- Revalidate the inherited default value against the modified column type before applying it.
- Add a regression test for modifying a column with an omitted default value.

Fixes #

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
