### PR TITLE
[BugFix] Keep automated cluster snapshots restorable across tablet split/merge

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -91,6 +91,7 @@ public class MergeTabletJob extends TabletReshardJob {
         return dbId;
     }
 
+    @Override
     public long getTableId() {
         return tableId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -103,6 +103,7 @@ public class SplitTabletJob extends TabletReshardJob {
         return dbId;
     }
 
+    @Override
     public long getTableId() {
         return tableId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -117,6 +117,10 @@ public abstract class TabletReshardJob implements Writable {
         return jobState.isFinalState();
     }
 
+    public boolean isAborted() {
+        return jobState == JobState.ABORTED;
+    }
+
     protected boolean abort(String reason) {
         if (!canAbort()) {
             LOG.warn("Tablet reshard job cannot abort. {}", this);
@@ -206,6 +210,8 @@ public abstract class TabletReshardJob implements Writable {
     }
 
     public abstract long getParallelTablets();
+
+    public abstract long getTableId();
 
     /*
      * Admission-time reservation. Reserve the table for this job before it is queued in

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -329,8 +329,11 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
                 continue;
             }
 
-            // Job is done, remove expired job
-            if (job.isExpired()) {
+            // Job is done, remove expired job once no automated cluster snapshot still covers the
+            // pre-reshard state it retains (the parent/source tablets). Keeping the job keeps
+            // isTableSafeToDeleteTablet() reporting the table's tablets as unsafe to reclaim.
+            if (job.isExpired() && GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
+                    .isDeletionSafeToExecute(job.getFinishedTimeMs())) {
                 GlobalStateMgr.getCurrentState().getEditLog().logRemoveTabletReshardJob(job.getJobId(), wal -> {
                     iterator.remove();
                 });

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -17,6 +17,7 @@ package com.starrocks.lake.snapshot;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksException;
@@ -44,6 +45,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -364,17 +366,34 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
             return true;
         }
 
-        boolean safe = true;
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
+        long safeDeletionTimeMs = getSafeDeletionTimeMs();
+
+        Map<Long, AlterJobV2> alterJobs =
+                new HashMap<>(GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2());
         alterJobs.putAll(GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2());
-        for (Map.Entry<Long, AlterJobV2> entry : alterJobs.entrySet()) {
-            AlterJobV2 alterJob = entry.getValue();
+        for (AlterJobV2 alterJob : alterJobs.values()) {
             if (alterJob.getTableId() == tableId) {
-                safe = (alterJob.getFinishedTimeMs() < getSafeDeletionTimeMs());
+                if (alterJob.getFinishedTimeMs() >= safeDeletionTimeMs) {
+                    return false;
+                }
                 break;
             }
         }
-        return safe;
+
+        // A tablet reshard (split/merge) replaces a table's tablets and leaves the pre-reshard
+        // parent/source tablets referenced only by an already-captured snapshot. Keep the table's
+        // tablets until every covering automated snapshot has expired, mirroring the ALTER-job
+        // handling above. An aborted reshard removes no tablets (an abort can only happen before the
+        // old tablets are dropped), so it is not snapshot-relevant and must not pin the table.
+        for (TabletReshardJob reshardJob :
+                GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJobs().values()) {
+            if (reshardJob.getTableId() == tableId && !reshardJob.isAborted()
+                    && (!reshardJob.isDone() || reshardJob.getFinishedTimeMs() >= safeDeletionTimeMs)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public boolean isDeletionSafeToExecute(long deletionCreatedTimeMs) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -37,8 +38,24 @@ import org.junit.jupiter.api.Test;
 public class TabletReshardJobMgrTest {
     public static class TestNormalTabletReshardJob extends TabletReshardJob {
 
+        private long tableId = 0;
+
         public TestNormalTabletReshardJob(long jobId, TabletReshardJob.JobType jobType) {
             super(jobId, jobType);
+        }
+
+        public void setTableId(long tableId) {
+            this.tableId = tableId;
+        }
+
+        public void markFinished(long finishedTimeMs) {
+            this.jobState = JobState.FINISHED;
+            this.finishedTimeMs = finishedTimeMs;
+        }
+
+        @Override
+        public long getTableId() {
+            return tableId;
         }
 
         @Override
@@ -262,6 +279,100 @@ public class TabletReshardJobMgrTest {
         jobMgr.addTabletReshardJob(job2);
 
         Assertions.assertEquals(2, jobMgr.getAllJobsInfo().getItems().size());
+    }
+
+    @Test
+    public void testIsTableSafeToDeleteTabletWithReshardJob() {
+        long tableId = 918273L;
+
+        // Use a local mgr injected via GlobalStateMgr so the shared singleton's background daemon
+        // does not reap the job under test.
+        TabletReshardJobMgr localMgr = new TabletReshardJobMgr();
+        TestNormalTabletReshardJob job = new TestNormalTabletReshardJob(1, TabletReshardJob.JobType.SPLIT_TABLET);
+        job.setTableId(tableId);
+        job.jobState = TabletReshardJob.JobState.FINISHED;
+        job.finishedTimeMs = 1000L;
+        localMgr.tabletReshardJobs.put(job.getJobId(), job);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public TabletReshardJobMgr getTabletReshardJobMgr() {
+                return localMgr;
+            }
+        };
+
+        final boolean[] automatedOn = {false};
+        final long[] boundary = {0L};
+        new MockUp<ClusterSnapshotMgr>() {
+            @Mock
+            public boolean isAutomatedSnapshotOn() {
+                return automatedOn[0];
+            }
+
+            @Mock
+            public long getSafeDeletionTimeMs() {
+                return boundary[0];
+            }
+        };
+
+        ClusterSnapshotMgr csMgr = GlobalStateMgr.getCurrentState().getClusterSnapshotMgr();
+
+        // Automated snapshot off: no behavior change, always safe.
+        automatedOn[0] = false;
+        Assertions.assertTrue(csMgr.isTableSafeToDeleteTablet(tableId));
+
+        // Automated on, reshard finished at/after the safe-deletion boundary (a snapshot covers the
+        // pre-reshard state): the table's tablets must not be reclaimed.
+        automatedOn[0] = true;
+        boundary[0] = 1000L;
+        Assertions.assertFalse(csMgr.isTableSafeToDeleteTablet(tableId));
+        // A different table with no reshard job is unaffected.
+        Assertions.assertTrue(csMgr.isTableSafeToDeleteTablet(tableId + 1));
+
+        // Automated on, reshard finished before the boundary (every covering snapshot expired): safe.
+        boundary[0] = 2000L;
+        Assertions.assertTrue(csMgr.isTableSafeToDeleteTablet(tableId));
+
+        // A still-running reshard job keeps the table unsafe while automated snapshot is on.
+        job.jobState = TabletReshardJob.JobState.RUNNING;
+        Assertions.assertFalse(csMgr.isTableSafeToDeleteTablet(tableId));
+
+        // An ABORTED reshard removed no tablets, so it must NOT pin the table even when it finished
+        // at/after the safe-deletion boundary (its partial orphan shards stay reclaimable).
+        job.jobState = TabletReshardJob.JobState.ABORTED;
+        boundary[0] = 1000L; // == job.finishedTimeMs, so only the aborted-state guard prevents pinning
+        Assertions.assertTrue(csMgr.isTableSafeToDeleteTablet(tableId));
+    }
+
+    @Test
+    public void testExpiredReshardJobRetainedUntilSnapshotSafe() {
+        TabletReshardJobMgr jobMgr = new TabletReshardJobMgr();
+
+        TestNormalTabletReshardJob job = new TestNormalTabletReshardJob(1, TabletReshardJob.JobType.SPLIT_TABLET);
+        job.setTableId(100L);
+        job.jobState = TabletReshardJob.JobState.FINISHED;
+        job.finishedTimeMs = 1000L; // deep in the past -> isExpired() is true
+        jobMgr.tabletReshardJobs.put(job.getJobId(), job);
+        Assertions.assertTrue(job.isExpired());
+
+        final long[] boundary = {0L};
+        new MockUp<ClusterSnapshotMgr>() {
+            @Mock
+            public long getSafeDeletionTimeMs() {
+                return boundary[0];
+            }
+        };
+
+        // A covering snapshot (safe-deletion boundary <= finishedTimeMs): the expired job is retained
+        // so isTableSafeToDeleteTablet() keeps the pre-reshard tablets alive.
+        boundary[0] = 500L;
+        jobMgr.runAfterCatalogReady();
+        Assertions.assertEquals(1, jobMgr.getTabletReshardJobs().size());
+
+        // No covering snapshot (boundary > finishedTimeMs): the expired job is reaped (no leak).
+        boundary[0] = 2000L;
+        jobMgr.runAfterCatalogReady();
+        Assertions.assertTrue(jobMgr.getTabletReshardJobs().isEmpty());
     }
 
     private void mockLeaderAdmissionOpen() {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -27,6 +27,9 @@ import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.alter.SchemaChangeJobV2;
+import com.starrocks.alter.reshard.TabletReshardJob;
+import com.starrocks.alter.reshard.TabletReshardJobMgr;
+import com.starrocks.alter.reshard.TabletReshardJobMgrTest;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
@@ -125,6 +128,7 @@ public class StarMgrMetaSyncerTest {
     private EditLog editLog;
 
     private ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+    private TabletReshardJobMgr tabletReshardJobMgr = new TabletReshardJobMgr();
     private StorageVolumeMgr storageVolumeMgr = new SharedDataStorageVolumeMgr();
 
     // PACK shard group ids surfaced by ColocateRangeMgr. Tests mutate this to register
@@ -268,6 +272,15 @@ public class StarMgrMetaSyncerTest {
                         "p1", baseIndex, distributionInfo));
             }
         };
+        // Stub getTabletReshardJobMgr() via MockUp rather than Expectations: TabletReshardJobMgr is a
+        // FrontendDaemon (a Thread), which jmockit cannot cascade-mock inside an Expectations block.
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public TabletReshardJobMgr getTabletReshardJobMgr() {
+                return tabletReshardJobMgr;
+            }
+        };
+
         UtFrameUtils.mockInitWarehouseEnv();
 
         // skip all the initialization in MetricRepo
@@ -963,6 +976,93 @@ public class StarMgrMetaSyncerTest {
         Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
         Assertions.assertFalse(deletedGroups.contains(packGroupId));
         Assertions.assertEquals(1, shardGroupInfos.size());
+
+        Config.meta_sync_force_delete_shard_meta = oldForceDelete;
+        Config.shard_group_clean_threshold_sec = oldCleanThreshold;
+    }
+
+    // A reshard leaves the pre-split parent shard group orphaned in StarOS. While an unexpired
+    // automated snapshot covers the pre-reshard state, deleteUnusedShardAndShardGroup must not reap
+    // it; once every covering snapshot expires it is reaped normally.
+    @Test
+    public void testReshardParentShardGroupRetainedByClusterSnapshot() {
+        boolean oldForceDelete = Config.meta_sync_force_delete_shard_meta;
+        long oldCleanThreshold = Config.shard_group_clean_threshold_sec;
+        Config.meta_sync_force_delete_shard_meta = false;
+        Config.shard_group_clean_threshold_sec = 0;
+
+        long reshardTableId = 6L;
+        long orphanGroupId = shardGroupId + 100; // not part of the FE-known shard group set
+
+        TabletReshardJobMgrTest.TestNormalTabletReshardJob reshardJob =
+                new TabletReshardJobMgrTest.TestNormalTabletReshardJob(1, TabletReshardJob.JobType.SPLIT_TABLET);
+        reshardJob.setTableId(reshardTableId);
+        reshardJob.markFinished(1000L);
+        tabletReshardJobMgr.getTabletReshardJobs().put(reshardJob.getJobId(), reshardJob);
+
+        List<ShardGroupInfo> shardGroupInfos = new ArrayList<>();
+        shardGroupInfos.add(ShardGroupInfo.newBuilder()
+                .setGroupId(orphanGroupId)
+                .putLabels("tableId", String.valueOf(reshardTableId))
+                .putLabels("dbId", String.valueOf(66L))
+                .putLabels("partitionId", String.valueOf(666L))
+                .putLabels("indexId", String.valueOf(6666L))
+                .putProperties("createTime", String.valueOf(System.currentTimeMillis() - 86400 * 1000))
+                .build());
+        List<Long> deletedGroups = new ArrayList<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public StarOSAgent.ListShardGroupResult listShardGroup(long startGroupId) {
+                return new StarOSAgent.ListShardGroupResult(shardGroupInfos, 0L);
+            }
+
+            @Mock
+            public List<Long> listShard(long groupId) {
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public void deleteShardGroup(List<Long> groupIds) {
+                deletedGroups.addAll(groupIds);
+            }
+        };
+
+        MaterializedViewHandler rollupHandler = new MaterializedViewHandler();
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public MaterializedViewHandler getRollupHandler() {
+                return rollupHandler;
+            }
+
+            @Mock
+            public SchemaChangeHandler getSchemaChangeHandler() {
+                return schemaChangeHandler;
+            }
+        };
+
+        final long[] boundary = {0L};
+        new MockUp<ClusterSnapshotMgr>() {
+            @Mock
+            public boolean isAutomatedSnapshotOn() {
+                return true;
+            }
+
+            @Mock
+            public long getSafeDeletionTimeMs() {
+                return boundary[0];
+            }
+        };
+
+        // Covered by an unexpired automated snapshot (reshard finished at/after the boundary): retained.
+        boundary[0] = 1000L;
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        Assertions.assertFalse(deletedGroups.contains(orphanGroupId));
+
+        // Every covering snapshot expired (reshard finished before the boundary): reaped.
+        boundary[0] = 2000L;
+        Deencapsulation.invoke(starMgrMetaSyncer, "deleteUnusedShardAndShardGroup");
+        Assertions.assertTrue(deletedGroups.contains(orphanGroupId));
 
         Config.meta_sync_force_delete_shard_meta = oldForceDelete;
         Config.shard_group_clean_threshold_sec = oldCleanThreshold;


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, a range-distribution tablet split/merge is metadata-only: child/merged tablets share the pre-reshard parent/source tablets' physical files, and the reshard job's `CLEANING` phase removes the parent/source tablets from the catalog and `TabletInvertedIndex`. `StarMgrMetaSyncer` then reaps the now-orphaned parent StarMgr shard and its `.meta`, gated only by `ClusterSnapshotMgr.isTableSafeToDeleteTablet()` — which consulted **ALTER jobs only**, not reshard jobs.

As a result, an in-place **automated** cluster snapshot taken at a partition version *before* a later split/merge lost the pre-reshard parent tablet metadata: restoring the FE + StarMgr image back to that version could no longer find the parent tablet, so the snapshot was not restorable.

## What I'm doing:

Wire reshard jobs into the existing **time-based** automated-snapshot protection, mirroring exactly how ALTER jobs are already handled (`AlterHandler.clearExpireFinishedOrCancelledAlterJobsV2` + `isTableSafeToDeleteTablet`):

- `ClusterSnapshotMgr.isTableSafeToDeleteTablet()` now also reports a table as **unsafe to reclaim tablets** while it has a not-yet-done reshard job, or one whose `finishedTimeMs >= getSafeDeletionTimeMs()` (i.e. a covering automated snapshot is still unexpired). This blocks `StarMgrMetaSyncer` from reaping the parent/source shard + `.meta`. While editing the method I also copy the rollup-handler job map before `putAll` (the old code mutated the live map) and cache `getSafeDeletionTimeMs()` once.
- `TabletReshardJobMgr.runTabletReshardJobs()` retains an expired done job until `isDeletionSafeToExecute(finishedTimeMs)`, so the protection signal survives until every covering snapshot expires; then the parent is reclaimed normally (no permanent leak). Editlog replay of removal stays unconditional (mirrors `AlterHandler.replayRemoveAlterJobV2`) so leaders and followers stay consistent.
- `TabletReshardJob` gains an abstract `getTableId()` (already implemented by `SplitTabletJob`/`MergeTabletJob`).

The pre-reshard parent **data files** are already protected for automated snapshots: `AutovacuumDaemon` clamps the vacuum grace timestamp to `getSafeDeletionTimeMs()`, and the BE regular vacuum only collects garbage from versions committed before that grace — so the shared parent-era segments are never reclaimed while a covering snapshot exists. No BE change is needed. Both **split** and **merge** are covered.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

This corrects a metadata-reclamation bug (an unexpired automated snapshot's parent tablet was wrongly reaped); it does not change SQL syntax, configuration, or any external interface. It only retains reshard-parent metadata slightly longer, bounded by the automated-snapshot retention window.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5