### PR TITLE
[Enhancement] Keep the MERGE duplicate check on the join distribution

### DIFF
--- a/be/src/exec/enforce_unique_row_locator_node.cpp
+++ b/be/src/exec/enforce_unique_row_locator_node.cpp
@@ -18,12 +18,6 @@
 #include "exec/pipeline/exec_node_pipeline_adapter.h"
 #include "exec/pipeline/limit_operator.h"
 #include "exec/pipeline/pipeline_builder.h"
-#include "exec/pipeline/pipeline_builder_operators.h"
-#include "exprs/column_ref.h"
-#include "exprs/expr_context.h"
-#include "gen_cpp/PlanNodes_types.h"
-#include "runtime/descriptors.h"
-#include "runtime/runtime_state.h"
 
 namespace starrocks {
 
@@ -54,30 +48,6 @@ StatusOr<pipeline::OpFactories> EnforceUniqueRowLocatorNode::decompose_to_pipeli
     using namespace pipeline;
 
     ASSIGN_OR_RETURN(auto ops, _children[0]->decompose_to_pipeline(context));
-
-    // Self-sufficient within-BE check: locally shuffle by the (_file, _pos) row-locator
-    // key so all matches of one target row reach the same operator instance, regardless of
-    // how the child pipeline distributes chunks across drivers (e.g. a post-probe
-    // passthrough the join adds when hash_join_interpolate_passthrough is on). Cross-BE
-    // co-location is still provided by the FE-pinned shuffle merge join. maybe_interpolate
-    // is a no-op / cheap when the input is already locally key-partitioned. NULL-key rows
-    // (NOT-MATCHED inserts) are exempt from the check and may land on any driver.
-    // ExprContexts are left unprepared: the PartitionExchanger prepares/opens/closes them.
-    // Use context->runtime_state(): this PipelineNode's prepare() never runs, so
-    // ExecNode::runtime_state() is null.
-    RuntimeState* state = context->runtime_state();
-    std::vector<ExprContext*> partition_ctxs;
-    partition_ctxs.reserve(_unique_key_slot_ids.size());
-    for (SlotId slot_id : _unique_key_slot_ids) {
-        SlotDescriptor* slot_desc = state->desc_tbl().get_slot_descriptor(slot_id);
-        if (slot_desc == nullptr) {
-            return Status::InternalError("EnforceUniqueRowLocatorNode: row-locator slot " + std::to_string(slot_id) +
-                                         " not found in the descriptor table");
-        }
-        auto* col_ref = _pool->add(new ColumnRef(slot_desc));
-        partition_ctxs.push_back(_pool->add(new ExprContext(col_ref)));
-    }
-    ops = pipeline::builder::maybe_interpolate_local_shuffle_exchange(context, state, id(), ops, partition_ctxs);
 
     auto factory = std::make_shared<EnforceUniqueRowLocatorOperatorFactory>(context->next_operator_id(), id(),
                                                                             _unique_key_slot_ids);

--- a/be/src/exec/pipeline/enforce_unique_row_locator_operator.cpp
+++ b/be/src/exec/pipeline/enforce_unique_row_locator_operator.cpp
@@ -127,6 +127,8 @@ Status EnforceUniqueRowLocatorOperator::push_chunk(RuntimeState* state, const Ch
     const auto* file_path_data = down_cast<const BinaryColumn*>(file_path_inner);
     const auto* row_pos_data = row_pos_typed->get_data().data();
 
+    _seen.reserve(_seen.size() + num_rows);
+
     for (size_t i = 0; i < num_rows; ++i) {
         // Skip rows where any key column is null
         if (file_path_nullable != nullptr && file_path_nullable->is_null(i)) {

--- a/be/test/exec/pipeline/enforce_unique_row_locator_operator_test.cpp
+++ b/be/test/exec/pipeline/enforce_unique_row_locator_operator_test.cpp
@@ -28,7 +28,6 @@
 #include "common/config_exec_fwd.h"
 #include "exec/enforce_unique_row_locator_node.h"
 #include "exec/pipeline/empty_set_operator.h"
-#include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_builder.h"
 #include "gen_cpp/PlanNodes_types.h"
@@ -348,14 +347,13 @@ protected:
         TTupleDescriptor t_tuple_desc;
         t_tuple_desc.id = 1;
         t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
-        // _file (slot 10, VARCHAR) and _pos (slot 11, BIGINT): decompose_to_pipeline
-        // resolves these by slot id to build the row-locator local-shuffle partition exprs.
+        // _file (slot 10, VARCHAR) and _pos (slot 11, BIGINT): the node stores these
+        // slot ids and the operator resolves them from each chunk's slot-id map.
         addSlot(t_desc_table, /*slot_id=*/10, /*parent_tuple=*/1, TPrimitiveType::VARCHAR);
         addSlot(t_desc_table, /*slot_id=*/11, /*parent_tuple=*/1, TPrimitiveType::BIGINT);
         ASSERT_OK(DescriptorTbl::create(&_state, &_pool, t_desc_table, &_desc_tbl, config::vector_chunk_size));
         _fragment_ctx = std::make_shared<pipeline::FragmentContext>();
-        // decompose_to_pipeline resolves row-locator slots via context->runtime_state(),
-        // i.e. the fragment's runtime state, so it must carry the descriptor table.
+        // The fragment context mirrors the real pipeline-builder setup.
         auto fragment_state = std::make_shared<RuntimeState>();
         fragment_state->set_desc_tbl(_desc_tbl);
         _fragment_ctx->set_runtime_state(std::move(fragment_state));
@@ -453,19 +451,18 @@ TEST_F(EnforceUniqueRowLocatorNodeTest, DecomposeWithLimitAppendsLimitOperator) 
     node.close(&_state);
 }
 
-// With DOP > 1 and a child source not partitioned by the row-locator key, decompose
-// must interpolate a local shuffle by (_file, _pos) below the check; the interpolated
-// local-exchange source becomes the pipeline head feeding the enforce operator.
-TEST_F(EnforceUniqueRowLocatorNodeTest, DecomposeInterpolatesRowLocatorShuffleUnderParallelism) {
+// MERGE correctness depends on the merge join preserving local key distribution.
+// EnforceUniqueRowLocatorNode itself must not add a row-locator local shuffle:
+// NOT-MATCHED insert rows have NULL row-locator keys and should not be funneled by
+// a duplicate-check partition key they never use.
+TEST_F(EnforceUniqueRowLocatorNodeTest, DecomposeDoesNotInterpolateRowLocatorShuffleUnderParallelism) {
     EnforceUniqueRowLocatorNode node = make_node({10, 11});
     node._children.push_back(make_child());
 
     auto context = make_context(/*dop=*/4);
     ASSIGN_OR_ABORT(auto ops, node.decompose_to_pipeline(&context));
-    ASSERT_GE(ops.size(), 2);
-    // The child's plain source was not locally partitioned by (_file, _pos), so a local
-    // shuffle exchange must be interpolated: its source operator heads the pipeline.
-    EXPECT_NE(dynamic_cast<LocalExchangeSourceOperatorFactory*>(ops.front().get()), nullptr);
+    ASSERT_EQ(ops.size(), 2);
+    EXPECT_NE(dynamic_cast<EmptySetOperatorFactory*>(ops.front().get()), nullptr);
     EXPECT_NE(dynamic_cast<EnforceUniqueRowLocatorOperatorFactory*>(ops.back().get()), nullptr);
     node.close(&_state);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -4970,6 +4970,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableOptimizerSkewJoinByBroadCastSkewValues = !enableOptimizerSkewJoinByQueryRewrite;
     }
 
+    // Disable both skew-join rewrites at once. setEnableOptimizerSkewJoinOptimizeV1/V2 each turn the
+    // other on, so callers that need both off (e.g. MERGE INTO, whose per-driver duplicate check must
+    // not have its join key salted by V1 or broadcast by V2) must use this.
+    public void disableSkewJoinOptimize() {
+        this.enableOptimizerSkewJoinByBroadCastSkewValues = false;
+        this.enableOptimizerSkewJoinByQueryRewrite = false;
+    }
+
     public boolean isEnableColumnExprPredicate() {
         return enableColumnExprPredicate;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/MergeIntoPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/MergeIntoPlanner.java
@@ -148,8 +148,16 @@ public class MergeIntoPlanner {
                                      List<ColumnRefOperator> outputColumns, List<String> colNames,
                                      IcebergTable icebergTable, PhysicalPropertySet requiredProperty) {
         boolean prevIsEnableLocalShuffleAgg = session.getSessionVariable().isEnableLocalShuffleAgg();
+        boolean prevSkewJoinOptimizeV1 = session.getSessionVariable().isEnableOptimizerSkewJoinOptimizeV1();
+        boolean prevSkewJoinOptimizeV2 = session.getSessionVariable().isEnableOptimizerSkewJoinOptimizeV2();
         try {
             session.getSessionVariable().setEnableLocalShuffleAgg(false);
+            // Disable BOTH skew-join rewrites for the MERGE plan. The broadcast rewrite (V2) replicates
+            // the target side, and the query-rewrite rewrite (V1) salts skewed keys with a random value;
+            // either one scatters the source rows matching one target row across drivers and breaks the
+            // per-driver co-location EnforceUniqueRowLocatorNode relies on. The single-flag setters each
+            // flip the other on, so disable both explicitly here.
+            session.getSessionVariable().disableSkewJoinOptimize();
 
             // Optimize
             OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
@@ -163,16 +171,23 @@ public class MergeIntoPlanner {
 
             // Setup Iceberg sink and configure pipeline. plan() already rejected
             // non-pipeline sessions, so the sink always runs on the pipeline engine.
-            setupIcebergMergeSink(execPlan, colNames, icebergTable, session);
+            setupIcebergMergeSink(execPlan, mergeIntoStmt, colNames, icebergTable, session);
             IcebergPlannerUtils.configureIcebergSinkPipeline(execPlan, session, true);
 
             return execPlan;
         } finally {
             session.getSessionVariable().setEnableLocalShuffleAgg(prevIsEnableLocalShuffleAgg);
+            // Restore the previous skew mode; the single-flag setters flip the other off, so picking
+            // by the previous mode is enough to recover the normal states (V2 default / V1 / both off).
+            if (prevSkewJoinOptimizeV2) {
+                session.getSessionVariable().setEnableOptimizerSkewJoinOptimizeV2(true);
+            } else if (prevSkewJoinOptimizeV1) {
+                session.getSessionVariable().setEnableOptimizerSkewJoinOptimizeV1(true);
+            }
         }
     }
 
-    private void setupIcebergMergeSink(ExecPlan execPlan, List<String> colNames,
+    private void setupIcebergMergeSink(ExecPlan execPlan, MergeIntoStmt mergeIntoStmt, List<String> colNames,
                                        IcebergTable icebergTable, ConnectContext session) {
         DescriptorTable descriptorTable = execPlan.getDescTbl();
         TupleDescriptor rowDeltaTuple = descriptorTable.createTupleDescriptor();
@@ -201,6 +216,10 @@ public class MergeIntoPlanner {
         // Keep the target scan and merge join bound together so sink validation and
         // duplicate checking never fall back to scans/joins from the source subtree.
         MergeTargetContext mergeTargetContext = findMergeTargetContext(execPlan, icebergTable);
+        if (mergeTargetContext != null) {
+            // Reject join shapes the BE cannot execute (there is no MERGE_JOIN_NODE executor).
+            validateMergeJoinIsExecutableByBackend(mergeTargetContext.mergeJoin);
+        }
         Expression filterExpr = mergeTargetContext == null
                 ? null
                 : buildTargetIcebergFilterExpr(mergeTargetContext.targetScan);
@@ -235,6 +254,8 @@ public class MergeIntoPlanner {
      *   <li>within a BE: the hash join's probe side is locally shuffled by join key
      *       across drivers, so all matches of one target row land on one driver.</li>
      * </ul>
+     * The MERGE join disables post-join passthrough so this local key distribution is
+     * still intact when rows reach the check.
      * Everything above the check (e.g. the partition-column shuffle for partitioned
      * targets) is free to redistribute rows arbitrarily.
      */
@@ -247,8 +268,12 @@ public class MergeIntoPlanner {
             // the USING subquery.
             return;
         }
-        PlanNode joinNode = mergeTargetContext.mergeJoin;
+        JoinNode joinNode = mergeTargetContext.mergeJoin;
         validateMergeJoinKeepsTargetUnreplicated(joinNode);
+        // Keep the join's local key distribution intact for the duplicate check.
+        // This gate only suppresses the post-join passthrough exchange; the join
+        // input-side local shuffle is still controlled by the BE hash-join builder.
+        joinNode.setCanLocalShuffle(false);
 
         PlanFragment joinFragment = joinNode.getFragment();
         PlanNode currentRoot = joinFragment.getPlanRoot();
@@ -361,6 +386,9 @@ public class MergeIntoPlanner {
      * where it is exact; a scanned source is always rejected.
      */
     private static void validateMergeJoinKeepsTargetUnreplicated(PlanNode joinNode) {
+        // Reject join shapes the BE cannot execute (also enforced unconditionally in
+        // setupIcebergMergeSink; redundant here but keeps this method self-contained).
+        validateMergeJoinIsExecutableByBackend(joinNode);
         if (joinNode instanceof HashJoinNode) {
             JoinNode.DistributionMode mode = ((HashJoinNode) joinNode).getDistrMode();
             Preconditions.checkState(mode == JoinNode.DistributionMode.PARTITIONED
@@ -370,15 +398,33 @@ public class MergeIntoPlanner {
                             + "prevented this), got distribution mode %s", mode);
             return;
         }
-        if (joinNode instanceof NestLoopJoinNode) {
-            PlanNode source = joinNode.getChild(0);
-            long sourceCardinality = source.getCardinality();
-            if (!subtreeHasScanNode(source) && sourceCardinality >= 0 && sourceCardinality <= 1) {
-                return;
-            }
+        // NestLoopJoinNode: executability is already validated above. A constant single-row source
+        // (no scans, cardinality <= 1) cannot match any target row twice, so the per-driver dedup
+        // stays sound even though the broadcast target is replicated. A multi-row probe is rejected.
+        PlanNode source = joinNode.getChild(0);
+        long sourceCardinality = source.getCardinality();
+        if (!subtreeHasScanNode(source) && sourceCardinality >= 0 && sourceCardinality <= 1) {
+            return;
         }
-        throw new SemanticException("MERGE INTO requires at least one equality predicate between the "
-                + "target and the source in the ON clause");
+        throw new SemanticException(
+                "MERGE INTO requires the target-source join to run as a shuffle hash join (built from an "
+                        + "equality predicate in the ON clause); got an unsupported join shape: "
+                        + joinNode.getClass().getSimpleName());
+    }
+
+    /**
+     * Reject join shapes the BE cannot execute. {@code exec_factory.cpp} builds an operator only for
+     * HASH_JOIN_NODE and CROSS_JOIN_NODE/NESTLOOP_JOIN_NODE — there is no MERGE_JOIN_NODE executor, so a
+     * sort-merge join (e.g. {@code join_implementation_mode=merge}) must fail fast at the FE. This is a
+     * backend-capability invariant independent of the duplicate check, so it holds even when elided.
+     */
+    private static void validateMergeJoinIsExecutableByBackend(PlanNode joinNode) {
+        if (!(joinNode instanceof HashJoinNode) && !(joinNode instanceof NestLoopJoinNode)) {
+            throw new SemanticException(
+                    "MERGE INTO requires the target-source join to run as a shuffle hash join (built from an "
+                            + "equality predicate in the ON clause); got an unsupported join shape: "
+                            + joinNode.getClass().getSimpleName());
+        }
     }
 
     private static boolean subtreeHasScanNode(PlanNode root) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeIntoAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeIntoAnalyzerIcebergTest.java
@@ -16,7 +16,10 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.HintNode;
+import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.MergeIntoStmt;
+import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.parser.SqlParser;
@@ -58,6 +61,13 @@ public class MergeIntoAnalyzerIcebergTest {
     private static MergeIntoStmt parseMerge(String sql) {
         return (MergeIntoStmt) SqlParser.parse(
                 sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+    }
+
+    private static JoinRelation analyzeAndGetSyntheticJoin(String sql) {
+        MergeIntoStmt stmt = parseMerge(sql);
+        MergeIntoAnalyzer.analyze(stmt, connectContext);
+        SelectRelation selectRelation = (SelectRelation) stmt.getQueryStatement().getQueryRelation();
+        return (JoinRelation) selectRelation.getRelation();
     }
 
     // ---- Error cases ----
@@ -558,6 +568,35 @@ public class MergeIntoAnalyzerIcebergTest {
         assertTrue(stmt.getTable() instanceof IcebergTable);
         assertNotNull(stmt.getQueryStatement());
         assertNotNull(stmt.getOutputColumnNames());
+    }
+
+    @Test
+    public void testUnpartitionedMergeForcesShuffleJoinHint() {
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT 1 AS id, 'new' AS data, '2024-01-01' AS date) AS s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN UPDATE SET data = s.data";
+
+        JoinRelation joinRelation = analyzeAndGetSyntheticJoin(sql);
+
+        assertEquals(HintNode.HINT_JOIN_SHUFFLE, joinRelation.getJoinHint(),
+                "Unpartitioned Iceberg MERGE must not broadcast the target side");
+    }
+
+    @Test
+    public void testPartitionedMergePinsShuffleJoin() {
+        String sql = "MERGE INTO iceberg0.partitioned_db.t1_v2 AS t " +
+                "USING (SELECT 1 AS id, 'new' AS data, '2024-01-01' AS date) AS s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN UPDATE SET data = s.data";
+
+        JoinRelation joinRelation = analyzeAndGetSyntheticJoin(sql);
+
+        // The duplicate-match check sits above this join and is correct only when the target
+        // side is never broadcast/replicated. That holds for partitioned targets too, so the
+        // shuffle hint is pinned unconditionally (not only for the unpartitioned case).
+        assertEquals(HintNode.HINT_JOIN_SHUFFLE, joinRelation.getJoinHint(),
+                "Partitioned Iceberg MERGE must also keep the target side shuffle-distributed");
     }
 
     // ---- Positional INSERT VALUES tests ----

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeIntoPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeIntoPlanTest.java
@@ -35,6 +35,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.MergeIntoPlanner;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.JoinOperator;
@@ -42,11 +43,14 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TPlan;
+import com.starrocks.thrift.TPlanNode;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
@@ -57,6 +61,7 @@ import java.util.List;
 import java.util.Queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -86,6 +91,13 @@ public class MergeIntoPlanTest extends PlanTestBase {
         ExecPlan execPlan = getMergeExecPlan(sql);
         return execPlan.getExplainString(TExplainLevel.NORMAL);
     }
+
+    private static boolean containsEnforceUnique(ExecPlan execPlan) {
+        // The EnforceUniqueRowLocatorNode sits in the merge join's fragment, which is
+        // not necessarily the sink fragment, so search across all fragments.
+        return findNode(execPlan, EnforceUniqueRowLocatorNode.class) != null;
+    }
+
 
     @Test
     public void testMergePlanContainsEnforceUnique() throws Exception {
@@ -159,6 +171,27 @@ public class MergeIntoPlanTest extends PlanTestBase {
                 "Partitioned MERGE should contain ENFORCE UNIQUE node");
         assertTrue(explainString.contains("ICEBERG ROW DELTA SINK"),
                 "Partitioned MERGE should produce ICEBERG ROW DELTA SINK");
+    }
+
+    @Test
+    public void testMergeRejectsMergeJoinImplementation() {
+        // join_implementation_mode=merge makes the optimizer pick a sort-merge join (MergeJoinNode),
+        // which the BE cannot execute (exec_factory.cpp has no MERGE_JOIN_NODE branch). MERGE planning
+        // must fail fast at the FE with a clear error instead of emitting an unexecutable plan.
+        String prevJoinImplementationMode = connectContext.getSessionVariable().getJoinImplementationMode();
+        try {
+            connectContext.getSessionVariable().setJoinImplementationMode("merge");
+            String sql = "MERGE INTO iceberg0.partitioned_db.t1_v2 AS t " +
+                    "USING (SELECT id, data, date FROM iceberg0.partitioned_db.t1_v2) AS s " +
+                    "ON t.id = s.id AND t.data = s.data AND t.date = s.date " +
+                    "WHEN MATCHED THEN UPDATE SET data = s.data";
+            Exception e = assertThrows(Exception.class, () -> getMergeExecPlan(sql));
+            assertTrue(e.getMessage() != null && e.getMessage().toLowerCase().contains("unsupported join shape"),
+                    "MERGE under join_implementation_mode=merge must be rejected with a clear error; got: "
+                            + e.getMessage());
+        } finally {
+            connectContext.getSessionVariable().setJoinImplementationMode(prevJoinImplementationMode);
+        }
     }
 
     @Test
@@ -374,6 +407,35 @@ public class MergeIntoPlanTest extends PlanTestBase {
     }
 
     @Test
+    public void testMergeHashJoinDisablesPostJoinPassthrough() throws Exception {
+        boolean previous = setHashJoinInterpolatePassthrough(true);
+        try {
+            String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                    "USING (" +
+                    "  SELECT 1 AS id, 'a' AS data, '2024-01-01' AS date " +
+                    "  UNION ALL SELECT 2 AS id, 'b' AS data, '2024-01-01' AS date " +
+                    ") AS s " +
+                    "ON t.id = s.id " +
+                    "WHEN MATCHED THEN UPDATE SET data = s.data " +
+                    "WHEN NOT MATCHED THEN INSERT (id, data, date) VALUES (s.id, s.data, s.date)";
+            ExecPlan execPlan = getMergeExecPlan(sql);
+            HashJoinNode joinNode = findNode(execPlan, HashJoinNode.class);
+            assertNotNull(joinNode, "Plan must contain the merge HashJoinNode");
+            assertFalse(joinNode.getCanLocalShuffle(),
+                    "MERGE planner must suppress post-join passthrough on the target join");
+
+            TPlanNode thriftJoin = findThriftNode(joinNode.treeToThrift(), joinNode.getId().asInt());
+            assertNotNull(thriftJoin, "Join node must be serialized to thrift");
+            assertFalse(thriftJoin.hash_join_node.isSetInterpolate_passthrough()
+                            && thriftJoin.hash_join_node.isInterpolate_passthrough(),
+                    "MERGE duplicate checking relies on the join's local key distribution; "
+                            + "post-join passthrough must be disabled");
+        } finally {
+            setHashJoinInterpolatePassthrough(previous);
+        }
+    }
+
+    @Test
     public void testDuplicateConstantSourceMergeContainsEnforceUnique() throws Exception {
         int previousPipelineDop = connectContext.getSessionVariable().getPipelineDop();
         int previousPipelineSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
@@ -483,6 +545,8 @@ public class MergeIntoPlanTest extends PlanTestBase {
         NestLoopJoinNode nestLoopJoin = findNode(execPlan, NestLoopJoinNode.class);
         assertNotNull(nestLoopJoin,
                 "Constant-source MERGE is expected to fold the ON equality and plan a nestloop join");
+        assertFalse(nestLoopJoin.getCanLocalShuffle(),
+                "MERGE planner must suppress post-join passthrough on the target join");
         EnforceUniqueRowLocatorNode enforceNode = findNode(execPlan, EnforceUniqueRowLocatorNode.class);
         assertNotNull(enforceNode, "Plan must contain an EnforceUniqueRowLocatorNode");
         assertEquals(enforceNode.getFragment(), nestLoopJoin.getFragment(),
@@ -620,6 +684,22 @@ public class MergeIntoPlanTest extends PlanTestBase {
             queue.addAll(node.getChildren());
         }
         return matches;
+    }
+
+    private static TPlanNode findThriftNode(TPlan plan, int nodeId) {
+        return plan.getNodes().stream()
+                .filter(node -> node.node_id == nodeId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean setHashJoinInterpolatePassthrough(boolean value) throws Exception {
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        Field field = SessionVariable.class.getDeclaredField("hashJoinInterpolatePassthrough");
+        field.setAccessible(true);
+        boolean previous = field.getBoolean(sessionVariable);
+        field.setBoolean(sessionVariable, value);
+        return previous;
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_merge_into
+++ b/test/sql/test_iceberg/R/test_iceberg_merge_into
@@ -175,6 +175,35 @@ set pipeline_dop = 0;
 set pipeline_sink_dop = 0;
 -- result:
 -- !result
+set pipeline_dop = 4;
+-- result:
+-- !result
+set pipeline_sink_dop = 4;
+-- result:
+-- !result
+set hash_join_interpolate_passthrough = true;
+-- result:
+-- !result
+MERGE INTO iceberg_merge_unp_${uuid0}.iceberg_merge_db_${uuid0}.t_merge AS t
+USING (
+    SELECT 1 AS id, 'dup1' AS name, 26 AS age, 55000 AS salary
+    UNION ALL
+    SELECT 1 AS id, 'dup2' AS name, 27 AS age, 56000 AS salary
+) AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET name = s.name;
+-- result:
+[REGEX]E: \(5609.*matched by more than one source row.*
+-- !result
+set hash_join_interpolate_passthrough = false;
+-- result:
+-- !result
+set pipeline_dop = 0;
+-- result:
+-- !result
+set pipeline_sink_dop = 0;
+-- result:
+-- !result
 create table iceberg_merge_unp_${uuid0}.iceberg_merge_db_${uuid0}.t_v1 (
     id INT, name STRING
 ) PROPERTIES ("format-version" = "1");

--- a/test/sql/test_iceberg/T/test_iceberg_merge_into
+++ b/test/sql/test_iceberg/T/test_iceberg_merge_into
@@ -147,6 +147,30 @@ set pipeline_dop = 0;
 set pipeline_sink_dop = 0;
 
 -- ================================================
+-- Test 10: Duplicate-match detection with high DOP and
+-- hash_join_interpolate_passthrough enabled. The post-probe passthrough this
+-- session var requests would round-robin chunks after the merge join and break
+-- the per-driver seen-set co-location; the MERGE planner suppresses it on the
+-- merge join, so the duplicate is still caught.
+-- ================================================
+set pipeline_dop = 4;
+set pipeline_sink_dop = 4;
+set hash_join_interpolate_passthrough = true;
+
+MERGE INTO iceberg_merge_unp_${uuid0}.iceberg_merge_db_${uuid0}.t_merge AS t
+USING (
+    SELECT 1 AS id, 'dup1' AS name, 26 AS age, 55000 AS salary
+    UNION ALL
+    SELECT 1 AS id, 'dup2' AS name, 27 AS age, 56000 AS salary
+) AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET name = s.name;
+
+set hash_join_interpolate_passthrough = false;
+set pipeline_dop = 0;
+set pipeline_sink_dop = 0;
+
+-- ================================================
 -- Error tests
 -- ================================================
 


### PR DESCRIPTION
## Why I'm doing:

The base MERGE INTO pipeline (#74725) relies on a BE-side local shuffle of the row-locator (`_file`, `_pos`) key so that the per-driver `EnforceUniqueRowLocatorNode` sees all source rows matching one target row on the same driver. That duplicate-match check's correctness is really a property of the source–target join distribution, which the FE controls; re-doing it in the BE is redundant and, more importantly, does not defend against optimizer rewrites (skew join) that scatter matching rows across drivers.

## What I'm doing:

Keep the MERGE duplicate check correct on the join distribution:

- **Rely on the FE-pinned shuffle join for co-location.** The MERGE join is a shuffle hash join (hint pinned by `MergeIntoAnalyzer`), so every target row is owned by one instance and all matching source rows already meet on one driver. Drop the now-redundant BE row-locator local-shuffle interpolation.
- **Place the check on the join and fail loud on bad shapes.** Put `EnforceUniqueRowLocatorNode` directly above the merge join, disable post-join passthrough (`setCanLocalShuffle(false)`), and reject join shapes the BE cannot execute — there is no `MERGE_JOIN_NODE` executor in `exec_factory`, so `join_implementation_mode=merge` for MERGE is rejected at the FE instead of emitting an unexecutable plan.
- **Disable both skew-join rewrites during MERGE planning.** The broadcast rewrite (V2) replicates the target side and the query-rewrite rewrite (V1) salts skewed keys with a random value; either one scatters the source rows matching one target row across drivers and bypasses the per-driver check. The single-flag setters each turn the other on, so a new `SessionVariable.disableSkewJoinOptimize()` turns both off, and the previous mode is restored after planning.

Tested with targeted cases in `MergeIntoPlanTest` / `MergeIntoAnalyzerIcebergTest`, BE `enforce_unique_row_locator_operator_test`, and the `test_iceberg_merge_into` SQL-tester case.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
