### PR TITLE
[BugFix] Skip stale IDG index for DCG-overlaid columns after column-mode partial update

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1643,6 +1643,19 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
         // create delta column iterator
         // TODO io_coalesce
         _column_iterators[cid] = std::move(col_iter);
+        // The column is served from a Delta Column Group (.cols) for this query
+        // version (column-mode partial update overlay). A fast-path IDG index
+        // (.idx sidecar) is keyed by the BASE segment id and was built over the
+        // BASE column values; it does NOT describe the overlaid DCG values and
+        // is not rebuilt on a column-mode update. Probing it here would let the
+        // DCG column iterator surface the STALE base index via
+        // has_{original,ngram}_bloom_filter_index(), and the pruning gate would
+        // filter rows against values the column no longer holds -> silently
+        // wrong results. Drop the IDG context so the DCG column falls back to an
+        // unindexed (correct) scan, matching footer-index behavior (a footer
+        // index lives on the base ColumnReader, which the DCG reader does not
+        // inherit, so it is never consulted for DCG-overlaid columns).
+        iter_opts.idg_loader = nullptr;
         opts.encryption_info = dcg_encryption_info;
         ASSIGN_OR_RETURN(auto dcg_file, _opts.fs->new_random_access_file(opts, dcg_filename));
         iter_opts.read_file = dcg_file.get();
@@ -3928,6 +3941,9 @@ Status SegmentIterator::_apply_bitmap_index() {
             const ColumnUID ucid = cid_2_ucid[cid];
             // the column's index in this segment file
             ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid));
+            // Non-null => the column is served from a Delta Column Group (.cols)
+            // for this query version (column-mode partial update overlay).
+            const bool served_from_dcg = (segment_ptr != nullptr);
             if (segment_ptr == nullptr) {
                 // find segment from delta column group failed, using main segment
                 segment_ptr = _segment;
@@ -3943,7 +3959,20 @@ Status SegmentIterator::_apply_bitmap_index() {
             // ColumnReader::new_bitmap_index_iterator is unreachable and
             // fast-path built bitmap indexes stored in .idx sidecar files
             // would be invisible to the pruning gate.
-            opts.idg_loader = _opts.idg_loader;
+            //
+            // But the fast-path IDG .idx is keyed by the BASE segment id and was
+            // built over the BASE column values. A column-mode partial update
+            // overlays new values into a DCG (.cols) WITHOUT rebuilding the
+            // index. Attaching the base .idx to a DCG-overlaid column would
+            // prune rows against values the column no longer holds -> silently
+            // wrong results. So only wire the IDG loader when the column is
+            // served from the base segment; for a DCG-overlaid column leave it
+            // unset so new_bitmap_index_iterator falls back to the (absent)
+            // footer bitmap index -> correct unindexed scan, matching the footer
+            // index behavior.
+            if (!served_from_dcg) {
+                opts.idg_loader = _opts.idg_loader;
+            }
             opts.tablet_id = _opts.tablet_id;
             opts.segment_id = _opts.rowset_id + segment_id();
             opts.query_version = _opts.version;

--- a/test/sql/test_schema_change/R/test_lake_add_index_pk_column_partial_update
+++ b/test/sql/test_schema_change/R/test_lake_add_index_pk_column_partial_update
@@ -1,0 +1,121 @@
+-- name: test_lake_add_index_pk_column_partial_update @cloud
+create database lake_idx_pu_${uuid0};
+-- result:
+-- !result
+use lake_idx_pu_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_noidx (
+    k1 int,
+    v1 int
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE t_fast (
+    k1 int,
+    v1 int
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_noidx values (1,10),(2,20),(3,30),(4,20),(5,20);
+-- result:
+-- !result
+insert into t_fast  values (1,10),(2,20),(3,30),(4,20),(5,20);
+-- result:
+-- !result
+ALTER TABLE t_fast ADD INDEX idx_v1(v1) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+update t_noidx set v1 = 777 where k1 <= 2;
+-- result:
+-- !result
+update t_fast  set v1 = 777 where k1 <= 2;
+-- result:
+-- !result
+select count(*) from t_noidx where v1 = 777;
+-- result:
+2
+-- !result
+select count(*) from t_fast  where v1 = 777;
+-- result:
+2
+-- !result
+select count(*) from t_noidx where v1 = 20;
+-- result:
+2
+-- !result
+select count(*) from t_fast  where v1 = 20;
+-- result:
+2
+-- !result
+select count(*) from t_noidx where v1 = 10;
+-- result:
+0
+-- !result
+select count(*) from t_fast  where v1 = 10;
+-- result:
+0
+-- !result
+select * from t_fast order by k1;
+-- result:
+1	777
+2	777
+3	30
+4	20
+5	20
+-- !result
+CREATE TABLE t_bf (
+    k1 int,
+    s1 varchar(32)
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_bf values (1,'aa'),(2,'bb'),(3,'cc'),(4,'bb'),(5,'bb');
+-- result:
+-- !result
+ALTER TABLE t_bf SET ("bloom_filter_columns" = "s1");
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+update t_bf set s1 = 'zz' where k1 <= 2;
+-- result:
+-- !result
+select count(*) from t_bf where s1 = 'zz';
+-- result:
+2
+-- !result
+select count(*) from t_bf where s1 = 'bb';
+-- result:
+2
+-- !result
+select count(*) from t_bf where s1 = 'cc';
+-- result:
+1
+-- !result
+select * from t_bf order by k1;
+-- result:
+1	zz
+2	zz
+3	cc
+4	bb
+5	bb
+-- !result
+drop database lake_idx_pu_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_schema_change/T/test_lake_add_index_pk_column_partial_update
+++ b/test/sql/test_schema_change/T/test_lake_add_index_pk_column_partial_update
@@ -1,0 +1,80 @@
+-- name: test_lake_add_index_pk_column_partial_update @cloud
+create database lake_idx_pu_${uuid0};
+use lake_idx_pu_${uuid0};
+
+-- Regression for: column-mode partial update of a column carrying a fast-path
+-- (IDG) index returned WRONG query results. The column-mode update writes new
+-- values into a Delta Column Group (.cols) without rebuilding the index; the
+-- read path still probed the stale base-segment .idx for the DCG-overlaid
+-- column and pruned rows against values the column no longer held.
+--
+-- Two flavors are covered, matching the two read sites of the fix:
+--   * BITMAP  -> _apply_bitmap_index                (bitmap-index pruning gate)
+--   * BLOOM   -> _init_column_iterator_by_cid       (scalar bloom/ngram probe)
+-- t_noidx (no index) is the correctness baseline; the indexed tables must
+-- return identical results after a column-mode update.
+
+-- ============ BITMAP: fast-path ADD INDEX ============
+CREATE TABLE t_noidx (
+    k1 int,
+    v1 int
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE t_fast (
+    k1 int,
+    v1 int
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+insert into t_noidx values (1,10),(2,20),(3,30),(4,20),(5,20);
+insert into t_fast  values (1,10),(2,20),(3,30),(4,20),(5,20);
+
+-- fast-path ADD INDEX: builds the IDG .idx bitmap over the pre-update values
+ALTER TABLE t_fast ADD INDEX idx_v1(v1) USING BITMAP;
+function: wait_alter_table_finish()
+
+-- column-mode partial update v1 -> 777, a value the index never saw, for k1<=2
+SET partial_update_mode = 'column';
+update t_noidx set v1 = 777 where k1 <= 2;
+update t_fast  set v1 = 777 where k1 <= 2;
+
+-- After update: v1=777 -> 2 rows (k1=1,2); v1=20 -> 2 rows (k1=4,5); v1=10 -> 0.
+-- Before the fix, t_fast returned v1=777 -> 0 (stale bitmap prunes the new value)
+-- and v1=20 -> 3 (stale bitmap still maps k1=2 to its old value 20).
+select count(*) from t_noidx where v1 = 777;
+select count(*) from t_fast  where v1 = 777;
+select count(*) from t_noidx where v1 = 20;
+select count(*) from t_fast  where v1 = 20;
+select count(*) from t_noidx where v1 = 10;
+select count(*) from t_fast  where v1 = 10;
+select * from t_fast order by k1;
+
+-- ============ BLOOM: fast-path bloom_filter_columns ============
+CREATE TABLE t_bf (
+    k1 int,
+    s1 varchar(32)
+) PRIMARY KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+insert into t_bf values (1,'aa'),(2,'bb'),(3,'cc'),(4,'bb'),(5,'bb');
+
+-- fast-path bloom filter: builds the IDG .idx bloom over the pre-update values
+ALTER TABLE t_bf SET ("bloom_filter_columns" = "s1");
+function: wait_alter_table_finish()
+
+-- column-mode partial update s1 -> 'zz', a value the bloom never saw, for k1<=2
+update t_bf set s1 = 'zz' where k1 <= 2;
+
+-- After update: s1='zz' -> 2 (k1=1,2); s1='bb' -> 2 (k1=4,5); s1='cc' -> 1.
+-- Before the fix, t_bf returned s1='zz' -> 0: the stale bloom (built over
+-- {aa,bb,cc}) reports 'zz' as definitely-absent and prunes the updated rows.
+select count(*) from t_bf where s1 = 'zz';
+select count(*) from t_bf where s1 = 'bb';
+select count(*) from t_bf where s1 = 'cc';
+select * from t_bf order by k1;
+
+drop database lake_idx_pu_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

On a shared-data (lake) **PRIMARY KEY** table, a **column-mode partial update**
(`partial_update_mode = column`) of a column that carries a **fast-path IDG index**
(`ALTER TABLE ... ADD INDEX ... USING BITMAP`, or `bloom_filter_columns` / NGRAMBF added via the
fast path) returned **silently wrong query results** — no error, no crash.

Reproduction (lake PK table, `v1` values seen by the index, then column-mode update `v1 → 777`
for a subset):

| table | index on the updated column | `count(*) WHERE v1=777` | correct? |
|---|---|---|---|
| no index | none | 2 | ✅ |
| `CREATE TABLE ... INDEX ... USING BITMAP` (footer) | footer | 2 | ✅ |
| `ALTER TABLE ... ADD INDEX ... USING BITMAP` (fast-path IDG) | IDG `.idx` | **0** | ❌ **WRONG** |

The updated rows were **missing** from equality queries on the new value, and still counted under
their old value, until the tablet's next compaction healed it.

**Root cause:** a column-mode partial update writes the updated column into a Delta Column Group
(`.cols`) and does **not** rebuild the column's index. At read time the DCG-overlaid column is
served by a DCG column iterator over `.cols` (the new values), but the read path still probed the
fast-path IDG index using the **base** segment id (`rowset_id + segment_id()`) and surfaced that
**stale** `.idx` (built over the pre-update base values) to the pruning gates
(`_apply_bitmap_index` for BITMAP; `has_{original,ngram}_bloom_filter_index()` set from the IDG
probe in `ScalarColumnIterator::init` for bloom/ngram). The IDG entry's version is the ADD-INDEX
version (`<= query_version`), so a later column-mode update does not filter it out, and the gate
pruned rows against values the column no longer holds.

A traditional footer index is unaffected: it lives on the base segment's `ColumnReader`, which the
DCG iterator's `.cols` reader does not inherit, so `has_bitmap_index()` is false there and the DCG
column falls back to a correct unindexed scan. Only the IDG path re-attached the base index to the
DCG column.

## What I'm doing:

When a column is served from a Delta Column Group for the query version, do **not** wire the IDG
loader for that column — matching the (correct) footer-index behavior. `idg_loader == nullptr` is
already the documented signal that keeps a reader on the footer-only path, so the DCG-overlaid
column falls back to a correct unindexed scan; base (non-overlay) columns are untouched and keep
the fast-path IDG index. Two read sites:

- `_init_column_iterator_by_cid` (covers bloom / ngram bloom): in the DCG branch, clear
  `iter_opts.idg_loader` before initializing the DCG column iterator, so the IDG probe in
  `ScalarColumnIterator::init` does not set `_has_idg_{original,ngram}_bf`.
- `_apply_bitmap_index` (covers BITMAP): only pass `opts.idg_loader` when the column is served from
  the base segment (`_get_dcg_segment(ucid) == nullptr`); for a DCG-overlaid column leave it unset
  so `new_bitmap_index_iterator` stays on the footer path.

The fast path for pure-base columns is fully preserved (no regression to the ADD INDEX fast-path
read capability). This covers all three IDG fast-path flavors (BITMAP, plain BLOOM_FILTER,
NGRAMBF). GIN inverted indexes are a separate index family and are not part of the IDG fast path,
so they are untouched here.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
