### PR TITLE
[Enhancement] Support HLL_UNION/PERCENTILE_UNION/BITMAP_UNION in IVM aggregate MVs (backport #75610)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/combinator/AggStateUtils.java
@@ -60,6 +60,14 @@ public class AggStateUtils {
                     .add(FunctionSet.SUM)
                     .add(FunctionSet.AVG)
                     .build();
+    // bitmap_union/hll_union/percentile_union take a metric-typed argument whose combinator state
+    // is that same type, so they are exempt from the metric-type argument rejection below.
+    public static final Set<String> METRIC_STATE_UNION_FUNCTIONS =
+            new ImmutableSortedSet.Builder<>(String.CASE_INSENSITIVE_ORDER)
+                    .add(FunctionSet.BITMAP_UNION)
+                    .add(FunctionSet.HLL_UNION)
+                    .add(FunctionSet.PERCENTILE_UNION)
+                    .build();
 
     /**
      * TODO: Refactor this function to unify the same check policy with FunctionAnalyzer#analyze
@@ -77,12 +85,14 @@ public class AggStateUtils {
                 FunctionSet.onlyAnalyticUsedFunctions.contains(aggFunc.functionName())) {
             return false;
         }
+        String fnName = aggFunc.functionName();
+        boolean isMetricStateUnion = METRIC_STATE_UNION_FUNCTIONS.contains(fnName);
         // unsupported argument types
         if (Stream.of(aggFunc.getArgs()).anyMatch(t -> t.isUnknown() || t.isTime() ||
-                t.isBitmapType() || t.isHllType() || t.isPercentile() || t.isNull() || t.isDecimalV2())) {
+                (!isMetricStateUnion && (t.isBitmapType() || t.isHllType() || t.isPercentile())) ||
+                t.isNull() || t.isDecimalV2())) {
             return false;
         }
-        String fnName = aggFunc.functionName();
         if (ONLY_NUMERIC_ARGUMENT_FUNCTIONS_L1.contains(fnName) &&
                 Stream.of(aggFunc.getArgs()).anyMatch(t -> !t.canApplyToNumeric())) {
             return false;
@@ -145,6 +155,15 @@ public class AggStateUtils {
         } else {
             return fnName;
         }
+    }
+
+    /**
+     * Base aggregate name from a resolved function, keyed on TYPE not name: a genuine combinator
+     * (avg_union) is stripped to its base (avg), but a plain aggregate whose name merely ends in
+     * "_union" (bitmap_union/hll_union/percentile_union) is kept whole, not mis-stripped to "bitmap".
+     */
+    public static String getBaseAggFuncName(Function fn) {
+        return isAggStateCombinator(fn) ? getAggFuncNameOfCombinator(fn.functionName()) : fn.functionName();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer.mv;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
@@ -131,6 +132,12 @@ public class IVMAnalyzer {
                     // bitmap_agg: exact distinct count. bitmap_union(to_bitmap(col)) normalizes to this;
                     // BITMAP state unions associatively, so the delta merge is well-defined.
                     .put(FunctionSet.BITMAP_AGG,             args -> args.length == 1)
+                    // bitmap_union/hll_union/percentile_union: the argument is already a metric sketch
+                    // (from bitmap_hash/hll_hash/percentile_hash, or a metric column), unioned
+                    // associatively like bitmap_agg.
+                    .put(FunctionSet.BITMAP_UNION,           args -> args.length == 1 && args[0].isBitmapType())
+                    .put(FunctionSet.HLL_UNION,              args -> args.length == 1 && args[0].isHllType())
+                    .put(FunctionSet.PERCENTILE_UNION,       args -> args.length == 1 && args[0].isPercentile())
                     .build();
 
     private static boolean isFixedOrFloat(Type t) {
@@ -537,7 +544,10 @@ public class IVMAnalyzer {
     }
 
     private Expr buildStateMergeFuncExpr(IVMAggFunctionInfo aggFunctionInfo) throws AnalysisException {
-        String aggFuncName = AggStateUtils.getAggFuncNameOfCombinator(aggFunctionInfo.aggFuncName);
+        Function origFn = aggFunctionInfo.aggFunc.getFn();
+        String aggFuncName = origFn != null
+                ? AggStateUtils.getBaseAggFuncName(origFn)
+                : AggStateUtils.getAggFuncNameOfCombinator(aggFunctionInfo.aggFuncName);
         String stateMergeFuncName = AggStateUtils.stateMergeFunctionName(aggFuncName);
         SlotRef slotRef = new SlotRef(null, aggFunctionInfo.newAggFuncName);
         // <func>_state_merge(<slotRef>)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -314,6 +314,11 @@ public class AggStateCombinatorTest extends MVTestBase {
                 break;
             }
             List<Type> argTypes = Stream.of(aggFunc.getArgs()).map(this::mockType).collect(Collectors.toList());
+            // BITMAP/HLL/PERCENTILE need an aggregate table, so they cannot be raw t1 columns.
+            // bitmap_union/hll_union/percentile_union now take such an arg.
+            if (argTypes.stream().anyMatch(t -> t.isBitmapType() || t.isHllType() || t.isPercentile())) {
+                continue;
+            }
             List<String> argTypeStr = argTypes.stream().map(this::mockType).map(Type::toSql).collect(Collectors.toList());
             aggArgTypes.add(argTypeStr);
             for (String argType : argTypeStr) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -119,6 +119,44 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
         assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy());
     }
 
+    @Test
+    public void testHllUnionAggregateYieldsIvmRewrite() throws Exception {
+        assertMetricUnionYieldsIvmRewrite("hll_union(hll_hash(c1))");
+    }
+
+    @Test
+    public void testPercentileUnionAggregateYieldsIvmRewrite() throws Exception {
+        assertMetricUnionYieldsIvmRewrite("percentile_union(percentile_hash(c1))");
+    }
+
+    @Test
+    public void testBitmapUnionHashAggregateYieldsIvmRewrite() throws Exception {
+        assertMetricUnionYieldsIvmRewrite("bitmap_union(bitmap_hash(c1))");
+    }
+
+    /**
+     * The metric-state unions roll up an already-built sketch (bitmap_hash/hll_hash/percentile_hash
+     * here). Unlike bitmap_union(to_bitmap(...)), they are not normalized away, so IVM must accept
+     * each union directly and maintain it via its agg-state combinators.
+     */
+    private void assertMetricUnionYieldsIvmRewrite(String aggExpr) throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_metric_union "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, " + aggExpr + " FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+
+        CreateMaterializedViewStatement stmt = parseMvDdl(ddl);
+        QueryStatement qs = stmt.getQueryStatement();
+        Analyzer.analyze(qs, connectContext);
+
+        IVMAnalyzer analyzer = new IVMAnalyzer(connectContext, stmt, qs);
+        Optional<IVMAnalyzer.IVMAnalyzeResult> result =
+                analyzer.rewrite(MaterializedView.RefreshMode.INCREMENTAL);
+
+        assertTrue(result.isPresent(), aggExpr + " MV must produce an IVM rewrite result");
+        assertEquals(RowIdStrategy.QUERY_COMPUTED, result.get().rowIdStrategy());
+    }
+
     /**
      * GROUP BY without aggregates (a DISTINCT-on-keys MV) must yield QUERY_COMPUTED, not
      * AUTO_INCREMENT — otherwise the MV row-id type disagrees with the refresh plan.

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_whitelist_widening
@@ -4,8 +4,8 @@
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
 --   * MIN/MAX(DECIMAL) — state is the value itself; no AVG-style (sum, count) plumbing
 --   * ARRAY_AGG(arg)   — single-arg accepted; ORDER BY variant rejected
--- HLL_UNION / BITMAP_UNION remain rejected (Column.type singleton mutation bug
--- in the underlying combinator path; deferred to a separate PR).
+--   * BITMAP_UNION(to_bitmap(...)) — accepted: normalizes to bitmap_agg
+--   * HLL_UNION / BITMAP_UNION over a metric sketch (hll_hash / bitmap_hash) — accepted directly
 create external catalog mv_iceberg_${uuid0}
 properties
 (
@@ -119,7 +119,12 @@ AS SELECT k, dt, HLL_UNION(HLL_HASH(s_short)) AS h
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: IVMAnalyzer does not support aggregate function: hll_union. Supported functions: [count, sum, avg, min, max, array_agg, bool_or, approx_count_distinct, ndv, bitmap_agg].')
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_hll WITH SYNC MODE;
+SELECT k, dt, hll_cardinality(h) AS ndv FROM mv_hll ORDER BY k, dt;
+-- result:
+1	2023-12-01	2
+2	2023-12-02	2
 -- !result
 CREATE MATERIALIZED VIEW mv_bmp PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -134,6 +139,34 @@ SELECT k, dt, bitmap_count(b) AS dc FROM mv_bmp ORDER BY k, dt;
 -- result:
 1	2023-12-01	1
 2	2023-12-02	1
+-- !result
+CREATE MATERIALIZED VIEW mv_bmp_hash PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, BITMAP_UNION(BITMAP_HASH(s_short)) AS b2
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_bmp_hash WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b2) AS dc FROM mv_bmp_hash ORDER BY k, dt;
+-- result:
+1	2023-12-01	2
+2	2023-12-02	2
+-- !result
+CREATE MATERIALIZED VIEW mv_pct PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, PERCENTILE_UNION(PERCENTILE_HASH(d_dec)) AS p
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_pct WITH SYNC MODE;
+SELECT k, dt, percentile_approx_raw(p, 0.5) AS p50 FROM mv_pct ORDER BY k, dt;
+-- result:
+1	2023-12-01	15.625
+2	2023-12-02	35.125
 -- !result
 drop database db_${uuid0} force;
 -- result:

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_whitelist_widening
@@ -4,8 +4,8 @@
 --   * AVG(DECIMAL)     — enabled by #73012 (preserve AggStateDesc on state_union)
 --   * MIN/MAX(DECIMAL) — state is the value itself; no AVG-style (sum, count) plumbing
 --   * ARRAY_AGG(arg)   — single-arg accepted; ORDER BY variant rejected
---   * BITMAP_UNION(to_bitmap(...)) — now accepted: normalizes to bitmap_agg.
--- HLL_UNION remains rejected (hll_union is not yet whitelisted; a separate change).
+--   * BITMAP_UNION(to_bitmap(...)) — accepted: normalizes to bitmap_agg
+--   * HLL_UNION / BITMAP_UNION over a metric sketch (hll_hash / bitmap_hash) — accepted directly
 
 create external catalog mv_iceberg_${uuid0}
 properties
@@ -96,8 +96,7 @@ AS SELECT k, dt, ARRAY_AGG(s_short ORDER BY k) AS arr_s
    GROUP BY k, dt;
 
 -- ============================================================
--- NEGATIVE: HLL_UNION not in whitelist
--- expected: SemanticException "IVMAnalyzer does not support aggregate function: hll_union"
+-- POSITIVE: HLL_UNION(HLL_HASH(...)) IVM MV — now whitelisted (HLL state unions associatively)
 -- ============================================================
 CREATE MATERIALIZED VIEW mv_hll PARTITION BY dt
 REFRESH DEFERRED MANUAL
@@ -105,6 +104,8 @@ PROPERTIES ("refresh_mode" = "incremental")
 AS SELECT k, dt, HLL_UNION(HLL_HASH(s_short)) AS h
    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
    GROUP BY k, dt;
+[UC]REFRESH MATERIALIZED VIEW mv_hll WITH SYNC MODE;
+SELECT k, dt, hll_cardinality(h) AS ndv FROM mv_hll ORDER BY k, dt;
 
 -- ============================================================
 -- POSITIVE: BITMAP_UNION(TO_BITMAP(...)) IVM MV — now accepted (normalizes to bitmap_agg)
@@ -117,6 +118,30 @@ AS SELECT k, dt, BITMAP_UNION(TO_BITMAP(k)) AS b
    GROUP BY k, dt;
 [UC]REFRESH MATERIALIZED VIEW mv_bmp WITH SYNC MODE;
 SELECT k, dt, bitmap_count(b) AS dc FROM mv_bmp ORDER BY k, dt;
+
+-- ============================================================
+-- POSITIVE: BITMAP_UNION(BITMAP_HASH(...)) IVM MV — direct bitmap_union, no to_bitmap normalization
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_bmp_hash PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, BITMAP_UNION(BITMAP_HASH(s_short)) AS b2
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+[UC]REFRESH MATERIALIZED VIEW mv_bmp_hash WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b2) AS dc FROM mv_bmp_hash ORDER BY k, dt;
+
+-- ============================================================
+-- POSITIVE: PERCENTILE_UNION(PERCENTILE_HASH(...)) IVM MV — direct percentile_union
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_pct PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, PERCENTILE_UNION(PERCENTILE_HASH(d_dec)) AS p
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+[UC]REFRESH MATERIALIZED VIEW mv_pct WITH SYNC MODE;
+SELECT k, dt, percentile_approx_raw(p, 0.5) AS p50 FROM mv_pct ORDER BY k, dt;
 
 -- cleanup
 drop database db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

An incremental MV (`refresh_mode = incremental`) can already roll up the exact-distinct sketch `bitmap_agg`, but not the other metric-sketch aggregates. `hll_union` / `percentile_union` / `bitmap_union` over a sketch column (e.g. `hll_union(hll_hash(col))`) were rejected by the IVM analyzer, even though each unions associatively and is well-defined under delta maintenance.

## What I'm doing:

Backport of #75610 to `branch-4.1`. Mergify's automatic backport (#75646) landed a commit with unresolved `<<<<<<<`/`=======`/`>>>>>>>` conflict markers left in `AggStateCombinatorTest.java` and was auto-closed as conflicting; GitHub then refuses to reopen a PR whose head branch was force-pushed while closed, so this is a fresh PR from the same `mergify/bp/branch-4.1/pr-75610` branch with the conflict actually resolved.

The conflict was between two independent additions at the same call site in `AggStateCombinatorTest.buildTableT1`:
- an existing skip for VARIANT-typed agg args (VARIANT can no longer be an OLAP column) — not present on `branch-4.1`, because that removal hasn't been backported here, so `branch-4.1`'s `t1` fixture still carries a raw VARIANT column and needs no such skip;
- the new skip added by #75610 for BITMAP/HLL/PERCENTILE-typed agg args, which *is* needed on every branch that whitelists `bitmap_union`/`hll_union`/`percentile_union` over a sketch column, since those types cannot be raw base-table columns either.

Resolution keeps only the second (BITMAP/HLL/PERCENTILE) skip; the rest of the cherry-picked commit is unchanged from #75610.

Fixes #issue: N/A — conflict-resolution redo of an auto-backport; no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Supersedes #75646 (closed, could not be reopened after the branch was force-pushed).

