### PR TITLE
[BugFix] Fix tvr delta lineage inconsistent on Iceberg MV IVM refresh when tail snapshots are consecutive REPLACEs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -841,7 +841,6 @@ public class IcebergMetadata implements ConnectorMetadata {
             // Skip REPLACE (compaction) snapshots - they rewrite files without changing logical data,
             // consistent with Iceberg's IncrementalAppendScan and IncrementalChangelogScan behavior.
             if (DataOperations.REPLACE.equals(snapshot.operation())) {
-                lastSnapshotId = snapshot.snapshotId();
                 continue;
             }
             long currentSnapshotId = snapshot.snapshotId();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -292,11 +292,11 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
             throw e;
         }
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
-            logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
-                    baseTableInfo.getDbName());
-            throw new SemanticException(formatPartitionShapeChangeError(
-                    String.format("no tvr delta traits found for base table %s.%s",
-                            baseTableInfo.getDbName(), baseTableInfo.getTableName())));
+            logger.info("No logical-change snapshot in ({}, {}] for base table {}.{} "
+                            + "(range spans only compaction/REPLACE); treating as a no-op refresh",
+                    maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot(),
+                    baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            return TvrTableDelta.of(maxTvrDelta.to, maxTvrDelta.to);
         }
         // check whether the last delta trait is equal to the max delta
         TvrTableDeltaTrait lastTvrDeltaTrait = tableDeltaTraits.get(tableDeltaTraits.size() - 1);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4025,11 +4025,14 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertTrue(traits.get(0).isAppendOnly());
         Assertions.assertTrue(traits.get(1).isAppendOnly());
 
-        // Verify contiguous delta boundaries: snap2→snap3, snap4→snap4
-        // (snap3 is the REPLACE snapshot ID — used as boundary but not emitted as a trait)
+        // Verify contiguous delta boundaries after skipping REPLACE:
+        //   traits[0] = (snap2, snap4]   ← spans over snap3 (REPLACE, no logical change)
+        //   traits[1] = (snap4, snap4]   ← degenerate self-delta of the newest APPEND
+        // Skipping REPLACE does NOT advance the running `lastSnapshotId`, so the previous
+        // APPEND's `to` is anchored to the next real (non-REPLACE) snapshot below it.
         TvrTableDelta delta0 = traits.get(0).getTvrDelta();
         Assertions.assertEquals(snap2.snapshotId(), delta0.start().get());
-        Assertions.assertEquals(snap3.snapshotId(), delta0.end().get());
+        Assertions.assertEquals(snap4.snapshotId(), delta0.end().get());
 
         TvrTableDelta delta1 = traits.get(1).getTvrDelta();
         Assertions.assertEquals(snap4.snapshotId(), delta1.start().get());
@@ -4118,5 +4121,64 @@ public class IcebergMetadataTest extends TableTestBase {
         assertTrue(exception.getMessage().contains("Starting snapshot (exclusive)"));
         assertTrue(exception.getMessage().contains(String.valueOf(snap1.snapshotId())));
         assertTrue(exception.getMessage().contains(String.valueOf(snap3.snapshotId())));
+    }
+
+    @Test
+    public void testListTableDeltaTraitsConsecutiveReplacesOnTailReturnsEmpty() {
+        // snap1: APPEND (mv's last-refreshed base version — used as exclusive start)
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("append", snap1.operation());
+
+        // snap2: REPLACE (first compaction after the last mv refresh)
+        mockedNativeTableA.newRewrite().deleteFile(FILE_A).addFile(FILE_A_1).commit();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("replace", snap2.operation());
+
+        // snap3: REPLACE (second compaction — currentSnapshot, becomes toSnapshotInclusive)
+        mockedNativeTableA.newRewrite().deleteFile(FILE_A_1).addFile(FILE_A_2).commit();
+        Snapshot snap3 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("replace", snap3.operation());
+
+        IcebergTable icebergTable = new IcebergTable(1, "testTbl", CATALOG_NAME, CATALOG_NAME,
+                "db", "testTbl", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TvrTableSnapshot from = TvrTableSnapshot.of(Optional.of(snap1.snapshotId()));
+        TvrTableSnapshot to = TvrTableSnapshot.of(Optional.of(snap3.snapshotId()));
+
+        List<TvrTableDeltaTrait> traits = metadata.listTableDeltaTraits("db", icebergTable, from, to);
+        // Range spans only REPLACE snapshots — no logical data change → empty trait list.
+        // Prior to the fix this returned a non-empty list whose newest trait ended at snap2
+        // (the intermediate REPLACE id), triggering the "tvr delta lineage inconsistent" error.
+        Assertions.assertTrue(traits.isEmpty(),
+                "consecutive REPLACE-only tail must not emit a trait pointing at an intermediate REPLACE id");
+    }
+
+    @Test
+    public void testListTableDeltaTraitsSingleReplaceAsToSnapshotReturnsEmpty() {
+        // snap1: APPEND (mv's last-refreshed base version)
+        mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+
+        // snap2: REPLACE (only new commit since last refresh — a bare compaction)
+        mockedNativeTableA.newRewrite().deleteFile(FILE_A).addFile(FILE_A_1).commit();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+        Assertions.assertEquals("replace", snap2.operation());
+
+        IcebergTable icebergTable = new IcebergTable(1, "testTbl", CATALOG_NAME, CATALOG_NAME,
+                "db", "testTbl", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+
+        TvrTableSnapshot from = TvrTableSnapshot.of(Optional.of(snap1.snapshotId()));
+        TvrTableSnapshot to = TvrTableSnapshot.of(Optional.of(snap2.snapshotId()));
+
+        List<TvrTableDeltaTrait> traits = metadata.listTableDeltaTraits("db", icebergTable, from, to);
+        Assertions.assertTrue(traits.isEmpty(),
+                "REPLACE-only tail must return empty traits (no logical data change)");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -1627,12 +1627,9 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         advanceTableVersionTo(1);
         mockListTableDeltaTraits(ImmutableList.of());
 
-        Throwable thrown = Assertions.assertThrows(Throwable.class, () -> getIVMRefreshedExecPlan(mv));
-        String chain = collectMessages(thrown);
-        Assertions.assertTrue(chain.contains("no tvr delta traits"),
-                "expected 'no tvr delta traits' in chain, got: " + chain);
-        Assertions.assertTrue(chain.contains("Drop and recreate"),
-                "expected drop-and-recreate guidance in chain, got: " + chain);
+        ExecPlan execPlan = getIVMRefreshedExecPlan(mv);
+        Assertions.assertNull(execPlan,
+                "empty trait list with a non-empty maxTvrDelta must be treated as a no-op refresh");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Users running INCREMENTAL materialized views on Iceberg base tables saw the following refresh error every time the base table's tail contained two or more consecutive REPLACE (compaction) snapshots:


```
Refresh mv xxx failed after 1 times, try lock failed: 0,
error-msg : com.starrocks.sql.analyzer.SemanticException: Getting analyzing error.
Detail message: Cannot incrementally refresh materialized view xxx:
tvr delta lineage inconsistent for base table xxx.xxxx
(last delta snapshot Snapshot@(1325037422170829543) != max delta snapshot Snapshot@(4976694107355655243)).
INCREMENTAL materialized views do not support partition-shape changes
(DELETE / OVERWRITE / DROP PARTITION / snapshot expiration / table replacement).
Drop and recreate the materialized view to recover..
    at com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor
        .getBaseTableChangedVersionRange(MVIVMRefreshProcessor.java:257)
    at com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor
        .getProcessExecPlan(MVIVMRefreshProcessor.java:113)
    ...
```

The base table had only undergone compaction (Iceberg RewriteFiles) — no logical data change, no partition-shape change — yet the MV was forced into "drop & recreate".
The current snapshot's summary shows a typical bin-pack rewrite (added-records == deleted-records, only files were rewritten):

```

{
  "operation": "replace",
  "added-data-files":     "13",
  "deleted-data-files":   "1385",
  "added-records":     "8564791",
  "deleted-records":   "8564791",
  "added-files-size": "3691281215",
  "removed-files-size":"3766603048",
  "changed-partition-count": "12",
  "engine-name": "flink",
  "iceberg-version": "Apache Iceberg 1.20.1"
}
```

### Root cause

IcebergMetadata.listTableDeltaTraits walks ancestors of toSnapshotInclusive in reverse (newest → oldest) and skips REPLACE snapshots so compaction is invisible to IVM (consistent with Iceberg's IncrementalAppendScan/IncrementalChangelogScan). Each emitted delta uses the running lastSnapshotId as its to boundary.
Before this PR the REPLACE-skip branch also advanced lastSnapshotId onto the REPLACE it just skipped:

```java
if (DataOperations.REPLACE.equals(snapshot.operation())) {
    lastSnapshotId = snapshot.snapshotId();   // ← the culprit
    continue;
}
```
That extra assignment is wrong: since the REPLACE contributes no data, the next non-REPLACE ancestor's delta should still be anchored at the original to boundary (either toSnapshotInclusive, or the previously-emitted APPEND's from).

### Trace for the reported chain

Base table snapshot chain (mv had last refreshed to `snapX`):

```
                                        mv baseline (fromExclusive)
                                                   │
                                                   ▼
   ...  APPEND(snapX)  →  REPLACE(snap2=1325...)  →  REPLACE(snap3=4976...=currentSnapshot)
                          first compaction            second compaction (toSnapshotInclusive)
```

Iteration inside `listTableDeltaTraits` (initial `lastSnapshotId = 4976...`):

| iter | snapshot            | op      | branch     | lastSnapshotId after         | emitted delta          |
|------|---------------------|---------|------------|------------------------------|------------------------|
| 1    | `snap3` = 4976...   | REPLACE | continue   | **1325... (BUG)** was `4976...` | —                      |
| 2    | `snap2` = 1325...   | REPLACE | continue   | still `1325...`              | —                      |
| 3    | `snapX`             | APPEND  | else       | `snapX`                      | `(snapX, 1325...]`     |

After `Collections.reverse`, the newest trait's `to` is `1325...`.

Upstream `MVIVMRefreshProcessor.getBaseTableChangedVersionRange` then compares:

```java
lastTvrDeltaSnapshot = tableDeltaTraits.get(size-1).getTvrDelta().toSnapshot(); // 1325...
if (!lastTvrDeltaSnapshot.equals(maxTvrDelta.toSnapshot())) {                   // 4976...
    throw new SemanticException(formatPartitionShapeChangeError(
        "tvr delta lineage inconsistent for base table %s.%s "
        + "(last delta snapshot %s != max delta snapshot %s)", ...));
}
```

`1325... != 4976...` → the false-positive "partition-shape change" is raised, and the user is told to drop and recreate the MV.

The two long IDs in the exception message — `1325037422170829543` and `4976694107355655243` — are exactly `snap2` and `snap3` in this trace.

## What I'm doing:

Drop the erroneous `lastSnapshotId = snapshot.snapshotId();` inside the REPLACE branch. Skipping a REPLACE now is truly transparent — it never alters the boundary state of surrounding deltas.

### Behavior matrix (before → after)

| Chain (fromExcl → … → toIncl)                                     | Before                                                                 | After                                          |
|-------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------|
| `APPEND(sX) → REPLACE(s2) → REPLACE(s3=to)` **(reported bug)**    | `[(sX, s2]]` → upstream throws `tvr delta lineage inconsistent` ❌     | `[]` — no logical change, empty trait list ✅ |
| `APPEND(s1) → REPLACE(s2=to)` (single compaction)                 | `[]`                                                                   | `[]` (unchanged)                               |
| `APPEND(s1) → APPEND(s2) → REPLACE(s3) → APPEND(s4=to)`           | `[(s2, s3], (s4, s4]]` — a delta pointed at a REPLACE id               | `[(s2, s4], (s4, s4]]` — REPLACE id absent ✅ |
| `APPEND(s1) → REPLACE(s2) → APPEND(s3=to)`                        | `[(s3, s3]]`                                                           | `[(s3, s3]]` (unchanged)                       |

Post-fix invariant: **no returned delta's `to` is ever a REPLACE snapshot id**. The upstream lineage check therefore can no longer misfire on compaction-only tails.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
