### PR TITLE
[Enhancement] Negative-cache range-colocate placement-convergence queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -59,8 +59,10 @@ import java.util.stream.Collectors;
  * peer GroupId stable once aligned.
  *
  * <h3>Architecture</h3>
- * Stateless component owned by {@link TabletReshardJobMgr} and invoked from that manager's
- * existing scheduler tick. Every {@link #runOneCycle} call walks
+ * Owned by {@link TabletReshardJobMgr} and invoked from that manager's existing scheduler tick.
+ * Holds one piece of state — a {@link ColocateConvergenceCache} that throttles repeated StarOS
+ * placement-convergence queries; every other decision is recomputed each tick. Every
+ * {@link #runOneCycle} call walks
  * {@link ColocateTableIndex#getUnstableGroupIds} and either does work or fast-returns when the
  * unstable set is empty (the steady-state). Shares the manager's
  * {@code tablet_reshard_job_scheduler_interval_ms} cadence; no separate thread, timer, or
@@ -88,6 +90,9 @@ import java.util.stream.Collectors;
 public class ColocateChecker {
     private static final Logger LOG = LogManager.getLogger(ColocateChecker.class);
 
+    // Throttles per-tick queryShardGroupStable load; all its semantics live in the cache class.
+    private final ColocateConvergenceCache convergenceCache = new ColocateConvergenceCache();
+
     /**
      * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
      * Fast-returns when there's no work to do; otherwise iterates unstable range-colocate
@@ -100,6 +105,9 @@ public class ColocateChecker {
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         // Steady-state fast-path: no unstable groups → cheap read-lock empty-check, no allocation.
         if (!colocateTableIndex.hasUnstableGroups()) {
+            // Nothing left to converge: drop any lingering negative-cache entries so the cache is
+            // bounded to the duration of active migrations (and reclaimed after a leader gap).
+            convergenceCache.clear();
             return;
         }
         Set<Long> processedColocateGroupIds = new HashSet<>();
@@ -188,12 +196,21 @@ public class ColocateChecker {
      *
      * @return {@code true} iff every PACK shard group reports placement-converged.
      */
-    private boolean isPlacementConverged(ColocateTableIndex colocateTableIndex,
-                                         List<ColocateTableIndex.GroupId> peers,
-                                         List<ColocateRange> expectedRanges, long colocateGroupId) {
+    boolean isPlacementConverged(ColocateTableIndex colocateTableIndex,
+                                 List<ColocateTableIndex.GroupId> peers,
+                                 List<ColocateRange> expectedRanges, long colocateGroupId) {
         List<Long> packGroupIds = expectedRanges.stream()
                 .map(ColocateRange::getShardGroupId)
                 .collect(Collectors.toList());
+        // Negative-cache fast path, before worker-group resolution / any RPC: if any PACK group was
+        // recently reported not-converged, the whole colocate group cannot be converged yet (it needs
+        // every PACK group converged), so skip the StarOS round-trip this tick. The cache is
+        // negative-only, so a flip still rides a fresh all-true read — see ColocateConvergenceCache.
+        if (convergenceCache.shouldSkipQuery(packGroupIds)) {
+            LOG.debug("colocate group {} skipped placement-convergence query; a PACK group was reported "
+                    + "not-converged within the cache TTL", colocateGroupId);
+            return false;
+        }
         // Both expected failures on this path fail closed (group stays unstable, retried next tick):
         // resolving the worker group can throw ErrorReportException (warehouse has no available compute
         // nodes) and the StarOS query can throw StarClientException. Anything unexpected propagates to
@@ -209,11 +226,17 @@ public class ColocateChecker {
                         Math.min(batchStart + batchSize, packGroupIds.size()));
                 List<Boolean> stable = starOSAgent.queryShardGroupStable(batch, workerGroupId);
                 // A size mismatch would let allMatch pass on a subset and flip the group stable while a
-                // group is still migrating — fail closed so placement convergence is never faked.
+                // group is still migrating — fail closed so placement convergence is never faked. An
+                // incomplete response is an error, not cached: retried promptly next tick.
                 if (stable.size() != batch.size()) {
                     LOG.warn("placement-convergence query returned {} results for {} PACK groups in colocate "
                             + "group {}; staying unstable", stable.size(), batch.size(), colocateGroupId);
                     return false;
+                }
+                // Feed each fresh per-group result to the negative cache (caches not-converged, drops
+                // converged) so a still-migrating group is not re-queried every tick.
+                for (int i = 0; i < batch.size(); i++) {
+                    convergenceCache.record(batch.get(i), Boolean.TRUE.equals(stable.get(i)));
                 }
                 if (!stable.stream().allMatch(Boolean.TRUE::equals)) {
                     LOG.debug("colocate group {} not yet placement-converged on StarOS; staying unstable",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateConvergenceCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateConvergenceCache.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.common.Config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Negative cache of PACK shard groups StarOS recently reported NOT placement-converged. It exists only
+ * to throttle {@link ColocateChecker}'s per-tick {@code queryShardGroupStable} load while a
+ * range-colocate group is still migrating.
+ *
+ * <h3>Negative-only</h3>
+ * Only not-converged observations are stored — never converged. The stable flip is terminal (the
+ * checker never revisits a group once stable) and StarOS's stability predicate is best-effort /
+ * eventually-consistent, so caching a "converged" could flip a group stable on stale data; a cached
+ * "not converged" only delays the flip by up to the TTL (a missed-optimization delay, never a wrong
+ * flip). An entry is dropped as soon as its group is observed converged, and {@link #clear()} empties
+ * the cache when nothing is migrating, so the map stays bounded to the groups actively migrating during
+ * a reshard. Entries are timestamped, so any that linger across a same-process leader
+ * demotion/re-promotion are treated as expired (re-query) — never a premature flip.
+ *
+ * <h3>Lifecycle</h3>
+ * The TTL is the runtime-mutable {@link Config#tablet_reshard_colocate_checker_convergence_cache_ttl_ms}
+ * (values {@code <= 0} disable the cache entirely: no reads, no writes, no growth). Per-leader,
+ * in-memory, non-journaled, and accessed only from the single reshard scheduler thread
+ * (TabletReshardJobMgr is a FrontendDaemon), so it needs no synchronization.
+ */
+class ColocateConvergenceCache {
+    // packShardGroupId -> wall-clock ms of the last StarOS "not converged" observation.
+    private final Map<Long, Long> notConvergedSinceMs = new HashMap<>();
+
+    /**
+     * @return {@code true} iff some group in {@code packGroupIds} was reported not-converged within the
+     *         TTL window — the whole colocate group cannot be converged yet, so the StarOS query can be
+     *         skipped this tick. Always {@code false} when the cache is disabled (TTL {@code <= 0}).
+     */
+    boolean shouldSkipQuery(List<Long> packGroupIds) {
+        long ttlMs = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        if (ttlMs <= 0) {
+            return false;
+        }
+        long now = currentTimeMillis();
+        for (long packGroupId : packGroupIds) {
+            Long since = notConvergedSinceMs.get(packGroupId);
+            // A stale/backward wall clock (elapsed < 0) is treated as expired (re-query) — fail-safe.
+            if (since != null && now - since >= 0 && now - since < ttlMs) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Records one PACK group's freshly-queried stability: caches a not-converged result so it is not
+     * re-queried within the TTL, or drops the entry once the group is converged (converged is never
+     * cached — the flip must ride a fresh read). No-op when the cache is disabled.
+     */
+    void record(long packShardGroupId, boolean converged) {
+        if (Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms <= 0) {
+            return;
+        }
+        if (converged) {
+            notConvergedSinceMs.remove(packShardGroupId);
+        } else {
+            notConvergedSinceMs.put(packShardGroupId, currentTimeMillis());
+        }
+    }
+
+    /** Drops every entry; a no-op if already empty. Called when no group is migrating. */
+    void clear() {
+        if (!notConvergedSinceMs.isEmpty()) {
+            notConvergedSinceMs.clear();
+        }
+    }
+
+    // package-private seam so tests can control the time source via JMockit MockUp.
+    long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -55,7 +55,8 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
     // Original tablet id -> resharding tablet info
     protected final Map<Long, ReshardingTabletInfo> reshardingTabletInfos = Maps.newConcurrentMap();
 
-    // Colocate checker: stateless, invoked from this manager's tick. Owns no
+    // Colocate checker: invoked from this manager's tick. Holds only a small per-leader,
+    // in-memory placement-convergence negative cache (non-journaled). Owns no
     // thread of its own — shares this manager's scheduler cadence
     // ({@code tablet_reshard_job_scheduler_interval_ms}) and self-gates on shared-data-mode,
     // leader status, and empty unstable-groups before doing any real work.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4605,6 +4605,14 @@ public class Config extends ConfigBase {
             + "Should be no larger than tablet_reshard_target_size.")
     public static long tablet_reshard_min_split_size = 2L * 1024L * 1024L * 1024L;
 
+    @ConfField(mutable = true, comment = "TTL in milliseconds for the range-colocate checker's "
+            + "placement-convergence negative cache. Within this window a PACK shard group last "
+            + "reported not-yet-converged by StarOS is not re-queried, throttling the per-tick "
+            + "queryShardGroupStable load while a group is still migrating. Only not-converged "
+            + "results are cached, so a stale entry only delays the group's stable flip by up to "
+            + "this window (never a premature flip); values <= 0 disable the cache.")
+    public static long tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 1000;
+
     @ConfField(mutable = true, comment = "Whether to enable tablet merge in tablet reshard. " +
             "Only takes effect for tables in clusters with run_mode=shared_data.")
     public static boolean tablet_reshard_enable_tablet_merge = false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -621,6 +621,294 @@ public class ColocateCheckerTest {
         colocateTableIndex.markGroupUnstable(groupId, /* needEditLog */ false);
     }
 
+    @Test
+    public void testConvergenceNegativeCacheSkipsQueryWithinTtl() {
+        // Build inputs from the real (stable) group; do NOT mark it unstable so the shared
+        // background daemon stays idle and the query count is deterministic.
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            Assertions.assertFalse(
+                    checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId));
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // Advance the clock but stay within the TTL window: the cached not-converged entry
+            // must short-circuit the second call with no additional RPC.
+            clock[0] = 2000L;
+            Assertions.assertFalse(
+                    checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId));
+            Assertions.assertEquals(1, queryCount[0],
+                    "second call within TTL must be served from the negative cache");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergenceCacheEntryExpiresAndReQueries() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // Advance past the TTL: the stale entry must be ignored and the group re-queried.
+            clock[0] = 1000L + 5000L + 1L;
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(2, queryCount[0], "an expired cache entry must be re-queried");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergenceCacheTtlIsRuntimeMutable() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // Clock advances to within the original 5000ms TTL (would be a cache hit)...
+            clock[0] = 3000L;
+            // ...but shrinking the TTL at runtime makes the 2000ms-old entry expired -> re-query.
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 1000;
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(2, queryCount[0],
+                    "shrinking the TTL config at runtime must expire the cached entry and re-query");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergedResultIsNotCached() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.TRUE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            Assertions.assertTrue(
+                    checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId));
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // Same instant, no clock advance: a converged (true) result must NOT be cached, so the
+            // second call queries again -> the stable flip always rides a fresh read.
+            Assertions.assertTrue(
+                    checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId));
+            Assertions.assertEquals(2, queryCount[0], "a converged result must never be served from cache");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergenceCacheDisabledWhenTtlNonPositive() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            // Seed a fresh negative entry while the cache is enabled.
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // TTL 0 disables the cache: the seeded entry must not be consulted -> re-query.
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 0;
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(2, queryCount[0], "TTL 0 must disable the cache and re-query");
+
+            // A negative TTL disables it too.
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = -1;
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(3, queryCount[0], "a negative TTL must disable the cache and re-query");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergenceCacheTreatsBackwardClockAsExpired() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS");
+
+            // Wall clock jumps backward (e.g. NTP correction): negative elapsed must be treated as
+            // expired and re-queried, never as an indefinitely fresh entry.
+            clock[0] = 500L;
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(2, queryCount[0], "a backward clock must be treated as expired and re-query");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
+    @Test
+    public void testConvergenceCacheClearedWhenNoUnstableGroups() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        List<ColocateTableIndex.GroupId> peers =
+                colocateTableIndex.getAllGroupIdsWithSameColocateGroupId(groupId.grpId);
+
+        long previousTtl = Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms;
+        Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = 5000;
+        long[] clock = {1000L};
+        int[] queryCount = {0};
+        new MockUp<ColocateConvergenceCache>() {
+            @Mock
+            long currentTimeMillis() {
+                return clock[0];
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Boolean> queryShardGroupStable(List<Long> shardGroupIds, long workerGroupId) {
+                queryCount[0]++;
+                return Collections.nCopies(shardGroupIds.size(), Boolean.FALSE);
+            }
+        };
+        try {
+            ColocateChecker checker = new ColocateChecker();
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(1, queryCount[0], "first call must query StarOS and seed the cache");
+
+            // The group is stable (never marked unstable), so a cycle finds no unstable groups and
+            // must clear the negative cache. The next call within TTL then re-queries (cache miss).
+            Assertions.assertFalse(colocateTableIndex.hasUnstableGroups(),
+                    "precondition: no unstable groups so runOneCycle takes the cache-clearing fast path");
+            checker.runOneCycle();
+            checker.isPlacementConverged(colocateTableIndex, peers, expectedRanges, groupId.grpId);
+            Assertions.assertEquals(2, queryCount[0],
+                    "runOneCycle with no unstable groups must clear the cache, forcing a re-query");
+        } finally {
+            Config.tablet_reshard_colocate_checker_convergence_cache_ttl_ms = previousTtl;
+        }
+    }
+
     // ---- Misplaced-PACK-group detection (pure, no cluster) ----
     //
     // These exercise the read-only detection logic that reassignShardGroups consumes. They build


### PR DESCRIPTION
## Why I'm doing:

While a range-colocate group is range-aligned and PACK-membership-settled but not yet
placement-converged, `ColocateChecker.isPlacementConverged` fires `StarOSAgent.queryShardGroupStable`
for every PACK shard group on every scheduler tick (`tablet_reshard_job_scheduler_interval_ms`,
default 10ms) until the group converges — roughly 100 queries/s per group. Each group's stability is
computed server-side, so re-polling the same not-yet-converged groups that often is wasteful. The
per-RPC latency is already bounded by `tablet_reshard_colocate_checker_convergence_batch_size`; this
addresses the remaining per-tick *frequency*. It is the follow-up cache optimization deferred from the
review of #75290 (the placement-convergence gate).

## What I'm doing:

Add a short-TTL, **negative-only** cache to `isPlacementConverged`, keyed by PACK `shardGroupId`,
recording when a group was last reported *not converged*. Within the TTL window that group is not
re-queried, throttling the common "still migrating" polling.

**Only not-converged results are cached — never converged.** The stable flip is terminal (the checker
never revisits a group once it is marked stable) and StarOS's stability predicate is best-effort /
eventually-consistent (a single `true` is explicitly not durable). Caching a `true` could let the flip
ride on a `≤TTL`-stale `true` → a premature stable flip → exactly the transient host-non-local
execution the convergence gate exists to prevent. A negative cache only throttles polling; when the
group does flip, it flips on a **fresh** all-`true` read. A cached negative can only *delay* the flip by
up to the TTL — never cause a wrong flip. (@kevincai — this answers your "whether a negative cache?
think about it again" note on #75290; happy to adjust if you see a case for caching converged results.)

Details:
- Fast path before any RPC: if any PACK group has a fresh negative entry, return `false` (the whole
  group cannot be converged) without querying StarOS.
- A group's entry is dropped once it is observed converged, and the whole cache is cleared on any tick
  that finds no unstable groups — bounding it to active-migration windows. Per-leader, in-memory,
  non-journaled; entries are timestamped, so any lingering across a leader gap are treated as expired.
- A backward/stale wall clock is treated as expired (re-query) — fail-safe.
- The TTL is a runtime-mutable config `tablet_reshard_colocate_checker_convergence_cache_ttl_ms`
  (default 1000ms); values `<= 0` disable the cache.
- All existing fail-closed behavior (worker-group resolution failure, size-mismatch, query exception)
  is preserved and never cached.

The new config follows the existing `tablet_reshard_*` convention — documented via its `@ConfField`
comment; this family is not listed in `FE_configuration.md`, matching the sibling knobs added in #75290.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
