### PR TITLE
[Doc] Clarify support for Partition Evolution statistics in Iceberg

### DIFF
--- a/docs/en/using_starrocks/Cost_based_optimizer.md
+++ b/docs/en/using_starrocks/Cost_based_optimizer.md
@@ -684,7 +684,7 @@ The following limits apply when you collect statistics for external tables:
   - Currently, only Leader FE node can trigger ANALYZE tasks.
   - The system only supports checking for partition changes on Hive and Iceberg tables, and only collects statistics on the partitions where the data has changed. For the Delta Lake/Hudi tables, the system collects statistics of the entire table.
   - If Partition Transforms are applied to Iceberg tables, the collection of statistics is supported only for `identity`, `year`, `month`, `day`, `hour` type Transforms.
-  - Collecting statistics for Partition Evolution for Iceberg tables is not supported.
+  - Collecting statistics for Partition Evolution for Iceberg tables is supported in version 4.0 and above.
 
 The following examples happen in a database under the Hive external catalog. If you want to collect statistics of a Hive table from the `default_catalog`, reference the table in the `[catalog_name.][database_name.]<table_name>` format.
 

--- a/docs/ja/using_starrocks/Cost_based_optimizer.md
+++ b/docs/ja/using_starrocks/Cost_based_optimizer.md
@@ -685,7 +685,7 @@ partition_name:
   - 現在、Leader FE ノードのみが ANALYZE タスクをトリガーできます。
   - システムは Hive および Iceberg テーブルのパーティション変更のみをチェックし、データが変更されたパーティションの統計情報のみを収集します。Delta Lake/Hudi テーブルの場合、システムはテーブル全体の統計情報を収集します。
   - Iceberg テーブルに Partition Transforms が適用されている場合、`identity`、`year`、`month`、`day`、`hour` タイプの Transforms のみ統計情報の収集がサポートされています。
-  - Iceberg テーブルの Partition Evolution の統計情報の収集はサポートされていません。
+  - Iceberg テーブルの Partition Evolution に関する統計情報の収集は、バージョン 4.0 以降でサポートされています。
 
 以下の例は、Hive 外部カタログのデータベースで発生します。`default_catalog` から Hive テーブルの統計情報を収集したい場合は、テーブルを `[catalog_name.][database_name.]<table_name>` 形式で参照してください。
 

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -673,8 +673,6 @@ partition_name:
   - 目前只有 Leader FE 节点可以触发收集任务。
   - 仅支持检查 Hive、Iceberg 外表的分区变动，只收集数据发生变动分区的统计信息。对于 Delta Lake/Hudi 外表，系统会收集整表的统计信息。
   - 如果 Iceberg 表启用 Partition Transform，仅支持对于 `identity`、`year`、`month`、`day`、`hour` 类型 Transform 收集统计信息。
-  - 不支持针对 Iceberg 表的 Partition Evolution 收集统计信息。
-
   - Iceberg 表 Partition Evolution 统计信息的收集功能在 4.0 及更高版本中已启用。
 
 以下示例默认在 External Catalog 指定数据库下采集表的统计信息。如果是在 `default_catalog` 下采集 External Catalog 下表的统计信息，引用表名时可以使用 `[catalog_name.][database_name.]<table_name>` 格式。

--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -675,6 +675,8 @@ partition_name:
   - 如果 Iceberg 表启用 Partition Transform，仅支持对于 `identity`、`year`、`month`、`day`、`hour` 类型 Transform 收集统计信息。
   - 不支持针对 Iceberg 表的 Partition Evolution 收集统计信息。
 
+  - Iceberg 表 Partition Evolution 统计信息的收集功能在 4.0 及更高版本中已启用。
+
 以下示例默认在 External Catalog 指定数据库下采集表的统计信息。如果是在 `default_catalog` 下采集 External Catalog 下表的统计信息，引用表名时可以使用 `[catalog_name.][database_name.]<table_name>` 格式。
 
 ### 查询触发采集


### PR DESCRIPTION
Updated the documentation to reflect that collecting statistics for Partition Evolution for Iceberg tables is supported in version 4.0 and above.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5