### PR TITLE
[BugFix] LIKE single-char wildcard '_' returns wrong results on GIN inverted index (backport #75551)

### DIFF
--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -20,6 +20,18 @@
 
 namespace starrocks {
 
+std::optional<InvertedIndexQueryType> choose_inverted_index_query_type(bool valid_like, std::string_view pattern) {
+    // TODO: push LIKE patterns containing '_' down to the inverted index. For now we
+    // fall back to the canonical LIKE engine (correct, just not accelerated): the
+    // builtin index could match '_' with a custom matcher, but CLucene WildcardQuery
+    // has no escape and can't faithfully handle a literal '?'/'*'.
+    if (valid_like && pattern.find('_') != std::string_view::npos) {
+        return std::nullopt;
+    }
+    bool has_wildcard = pattern.find('*') != std::string_view::npos || pattern.find('%') != std::string_view::npos;
+    return has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY : InvertedIndexQueryType::EQUAL_QUERY;
+}
+
 ColumnExprPredicate::ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state,
                                          const SlotDescriptor* slot_desc)
         : ColumnPredicate(std::move(type_info), column_id), _state(state), _slot_desc(slot_desc), _monotonic(true) {
@@ -335,12 +347,15 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
         return Status::OK();
     }
     std::string str_v = padded_value.to_string();
-    InvertedIndexQueryType query_type = InvertedIndexQueryType::UNKNOWN_QUERY;
-    if (str_v.find('*') == std::string::npos && str_v.find('%') == std::string::npos) {
-        query_type = InvertedIndexQueryType::EQUAL_QUERY;
-    } else {
-        query_type = InvertedIndexQueryType::MATCH_WILDCARD_QUERY;
+
+    auto query_type_opt = choose_inverted_index_query_type(vaild_like, str_v);
+    if (!query_type_opt) {
+        // A LIKE pattern containing '_' is not pushed down (see
+        // choose_inverted_index_query_type); fall back to the canonical LIKE engine.
+        return Status::NotSupported("LIKE pattern is not pushed down to the inverted index");
     }
+    InvertedIndexQueryType query_type = *query_type_opt;
+
     roaring::Roaring roaring;
     RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
     if (with_not) {

--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -1,8 +1,11 @@
+#include <optional>
+#include <string_view>
 #include <utility>
 
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "storage/column_predicate.h"
+#include "storage/index/inverted/inverted_index_common.h"
 #include "storage/olap_common.h"
 #include "storage/types.h"
 
@@ -85,6 +88,8 @@ private:
     bool _monotonic;
     mutable std::vector<uint8_t> _tmp_select;
 };
+
+std::optional<InvertedIndexQueryType> choose_inverted_index_query_type(bool valid_like, std::string_view pattern);
 
 class ColumnTruePredicate final : public ColumnPredicate {
 public:

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -369,6 +369,7 @@ set(EXEC_FILES
         ./storage/size_tiered_compaction_policy_test.cpp
         ./storage/aggregate_iterator_test.cpp
         ./storage/chunk_aggregator_test.cpp
+        ./storage/choose_inverted_index_query_type_test.cpp
         ./storage/chunk_helper_test.cpp
         ./storage/column_aggregator_test.cpp
         ./storage/column_predicate_test.cpp

--- a/be/test/storage/choose_inverted_index_query_type_test.cpp
+++ b/be/test/storage/choose_inverted_index_query_type_test.cpp
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "storage/column_expr_predicate.h"
+
+namespace starrocks {
+
+// Unit-tests the extracted query-type decision used by inverted-index pushdown,
+// including the new fallback (std::nullopt) for LIKE patterns containing '_'.
+TEST(ChooseInvertedIndexQueryTypeTest, all_branches) {
+    using QT = InvertedIndexQueryType;
+
+    // LIKE patterns containing '_' are not pushed down (the fix); they fall back to the LIKE engine.
+    EXPECT_FALSE(choose_inverted_index_query_type(true, "foo_bar").has_value());
+    EXPECT_FALSE(choose_inverted_index_query_type(true, "中_文").has_value());
+    EXPECT_FALSE(choose_inverted_index_query_type(true, "a_b%c").has_value());
+
+    // A '%' or '*' (with no '_') still pushes down as a wildcard query on this branch.
+    EXPECT_EQ(QT::MATCH_WILDCARD_QUERY, choose_inverted_index_query_type(true, "foo%bar").value());
+    EXPECT_EQ(QT::MATCH_WILDCARD_QUERY, choose_inverted_index_query_type(false, "foo*bar").value());
+    // No wildcard and no '_' is an exact-match query.
+    EXPECT_EQ(QT::EQUAL_QUERY, choose_inverted_index_query_type(true, "foobar").value());
+}
+
+} // namespace starrocks

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1689,3 +1689,75 @@ SELECT sleep(10);
 DROP TABLE t_vertical_compaction;
 -- result:
 -- !result
+-- name: test_gin_like_underscore_wildcard @native
+set low_cardinality_optimize_v2 = false;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+CREATE TABLE `t_gin_like_underscore` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "enable_persistent_index" = "true",
+            "replicated_storage" = "false", "compression" = "LZ4");
+-- result:
+-- !result
+INSERT INTO t_gin_like_underscore VALUES
+(1, "abc"),
+(2, "aXc"),
+(3, "ac"),
+(4, "abbc"),
+(5, "a_c"),
+(6, "中a文"),
+(7, NULL);
+-- result:
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a_c" ORDER BY id1;
+-- result:
+1
+2
+5
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a_%" ORDER BY id1;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab_" ORDER BY id1;
+-- result:
+1
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "中_文" ORDER BY id1;
+-- result:
+6
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a\_c" ORDER BY id1;
+-- result:
+5
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column NOT LIKE "a_c" ORDER BY id1;
+-- result:
+3
+4
+6
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab%" ORDER BY id1;
+-- result:
+1
+4
+-- !result
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
+-- result:
+1
+-- !result
+DROP TABLE t_gin_like_underscore;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -930,3 +930,38 @@ ALTER TABLE t_vertical_compaction BASE COMPACT;
 SELECT sleep(10);
 
 DROP TABLE t_vertical_compaction;
+
+-- name: test_gin_like_underscore_wildcard @native
+set low_cardinality_optimize_v2 = false;
+set cbo_enable_low_cardinality_optimize = false;
+CREATE TABLE `t_gin_like_underscore` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `text_column` varchar(255) NULL COMMENT "",
+  INDEX gin_none (`text_column`) USING GIN ("parser" = "none") COMMENT 'whole line index'
+) ENGINE=OLAP
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "enable_persistent_index" = "true",
+            "replicated_storage" = "false", "compression" = "LZ4");
+
+INSERT INTO t_gin_like_underscore VALUES
+(1, "abc"),
+(2, "aXc"),
+(3, "ac"),
+(4, "abbc"),
+(5, "a_c"),
+(6, "中a文"),
+(7, NULL);
+
+-- LIKE patterns containing '_' : the fix routes these to the canonical LIKE fallback
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a_c" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a_%" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab_" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "中_文" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "a\_c" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column NOT LIKE "a_c" ORDER BY id1;
+-- patterns without '_' still push down to the index unchanged
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "ab%" ORDER BY id1;
+SELECT id1 FROM t_gin_like_underscore WHERE text_column LIKE "abc" ORDER BY id1;
+
+DROP TABLE t_gin_like_underscore;


### PR DESCRIPTION
## Why I'm doing:
A `LIKE` pattern containing the single-char wildcard `_` (with or without `%`) is mis-handled by
the GIN inverted index: it is classified as an exact-match query, so the index returns the wrong
row bitmap and matching rows are silently dropped. Adding the index changes query results, which
violates index result-transparency. Both the CLucene and builtin GIN implementations are affected.

## What I'm doing:
Stop pushing a `_`-bearing `LIKE` pattern down to the GIN inverted index: it now
returns `Status::NotSupported` and falls back to the canonical row-by-row LIKE engine,
which evaluates `_` correctly (the `%`-only, exact-match, and `MATCH` paths are
unchanged). The query-type decision is extracted into a small unit-tested helper
`choose_inverted_index_query_type(...)`, which also fulfills the pre-existing TODO there.

Fixes #75550 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


