### PR TITLE
[BugFix][Refactor] Make global dictionary maps rehash-stable and fixing race conditions for looking them up

### DIFF
--- a/be/src/column/global_dict/decoder.cpp
+++ b/be/src/column/global_dict/decoder.cpp
@@ -38,14 +38,14 @@ public:
     using StringColumnType = RunTimeColumnType<TYPE_VARCHAR>;
     using StringCppType = RunTimeCppType<TYPE_VARCHAR>;
 
-    GlobalDictDecoderBase(Dict dict) : _dict(std::move(dict)) {}
+    GlobalDictDecoderBase(const Dict& dict) : _dict(&dict) {}
 
     Status decode_string(const Column* in, Column* out) override;
 
     Status decode_array(const Column* in, Column* out) override;
 
 private:
-    Dict _dict;
+    const Dict* _dict;
 };
 
 template <typename Dict>
@@ -109,8 +109,8 @@ Status GlobalDictDecoderBase<Dict>::decode_string(const Column* in, Column* out)
     // handle const columns
     if (in->is_constant()) {
         auto id = in->get(0).get<DictCppType>();
-        auto iter = _dict.find(id);
-        if (iter == _dict.end()) {
+        auto iter = _dict->find(id);
+        if (iter == _dict->end()) {
             return Status::InternalError(fmt::format("Dict Decode failed, Dict can't take cover all key :{}", id));
         }
         out->append_datum(Datum(iter->second));
@@ -127,8 +127,8 @@ Status GlobalDictDecoderBase<Dict>::decode_string(const Column* in, Column* out)
         std::vector<StringCppType> res_slices(num_rows);
         for (size_t i = 0; i < num_rows; i++) {
             DictCppType key = dict_data[i];
-            auto iter = _dict.find(key);
-            if (iter == _dict.end()) {
+            auto iter = _dict->find(key);
+            if (iter == _dict->end()) {
                 return Status::InternalError(fmt::format("Dict Decode failed, Dict can't take cover all key :{}", key));
             }
             res_slices[i] = iter->second;
@@ -151,8 +151,8 @@ Status GlobalDictDecoderBase<Dict>::decode_string(const Column* in, Column* out)
     for (size_t i = 0; i < num_rows; i++) {
         if (column->null_column_data()[i] == 0) {
             DictCppType key = dict_data[i];
-            auto iter = _dict.find(key);
-            if (iter == _dict.end()) {
+            auto iter = _dict->find(key);
+            if (iter == _dict->end()) {
                 return Status::InternalError(fmt::format("Dict Decode failed, Dict can't take cover all key :{}", key));
             }
             res_slices[i] = iter->second;

--- a/be/src/column/global_dict/types_fwd_decl.h
+++ b/be/src/column/global_dict/types_fwd_decl.h
@@ -29,8 +29,9 @@ using GlobalDictMap = phmap::flat_hash_map<Slice, DictId, SliceHashWithSeed<Phma
 using RGlobalDictMap = phmap::flat_hash_map<DictId, Slice>;
 
 using GlobalDictMapEntity = std::pair<GlobalDictMap, RGlobalDictMap>;
-// column-id -> GlobalDictMap
-using GlobalDictMaps = phmap::flat_hash_map<uint32_t, GlobalDictMapEntity>;
+// column-id -> GlobalDictMap. node_hash_map, not flat: callers hold pointers to entries across lazy
+// inserts, so entries must stay put on rehash.
+using GlobalDictMaps = phmap::node_hash_map<uint32_t, GlobalDictMapEntity>;
 
 // column-name -> GlobalDictMap
 // template to avoid incomplete type problems
@@ -44,6 +45,6 @@ using GlobalDictByNameMaps = phmap::flat_hash_map<std::string, GlobalDictsWithVe
 
 using DictColumnsValidMap = phmap::flat_hash_map<std::string, bool, SliceHashWithSeed<PhmapSeed1>, SliceEqual>;
 
-using ColumnIdToGlobalDictMap = phmap::flat_hash_map<uint32_t, GlobalDictMap*>;
+using ColumnIdToGlobalDictMap = phmap::flat_hash_map<uint32_t, const GlobalDictMap*>;
 
 } // namespace starrocks

--- a/be/src/compute_env/global_dict/fragment_dict_state.cpp
+++ b/be/src/compute_env/global_dict/fragment_dict_state.cpp
@@ -23,7 +23,9 @@
 
 namespace starrocks {
 
-FragmentDictState::FragmentDictState() : _dict_optimize_parser(std::make_unique<DictOptimizeParser>()) {}
+FragmentDictState::FragmentDictState() : _dict_optimize_parser(std::make_unique<DictOptimizeParser>()) {
+    _dict_optimize_parser->set_mutable_dict_maps(&_query_global_dicts);
+}
 
 FragmentDictState::~FragmentDictState() = default;
 

--- a/be/src/compute_env/global_dict/fragment_dict_state.h
+++ b/be/src/compute_env/global_dict/fragment_dict_state.h
@@ -36,13 +36,13 @@ public:
     FragmentDictState();
     ~FragmentDictState();
 
-    const GlobalDictMaps& query_global_dicts() const { return _query_global_dicts; }
     GlobalDictMaps* mutable_query_global_dicts() { return &_query_global_dicts; }
 
     const GlobalDictMaps& load_global_dicts() const { return _load_global_dicts; }
     const phmap::flat_hash_map<uint32_t, int64_t>& load_dict_versions() const { return _load_dict_versions; }
 
     DictOptimizeParser* mutable_dict_optimize_parser();
+    const DictOptimizeParser* dict_optimize_parser() const { return _dict_optimize_parser.get(); }
 
     Status init_query_global_dict(RuntimeState* runtime_state, const GlobalDictLists& global_dict_list);
     Status init_query_global_dict_exprs(RuntimeState* runtime_state, const std::map<int, TExpr>& exprs);

--- a/be/src/compute_env/global_dict/parser.cpp
+++ b/be/src/compute_env/global_dict/parser.cpp
@@ -441,6 +441,25 @@ Status DictOptimizeParser::eval_dict_expr(RuntimeState* runtime_state, SlotId id
     return eval_expression(runtime_state, _dict_exprs[id], &doc, id);
 }
 
+const GlobalDictMap* DictOptimizeParser::get_dict_map(SlotId slot_id) const {
+    std::lock_guard<std::recursive_mutex> guard(_dict_maps_mutex);
+    auto it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    return it == _mutable_dict_maps->end() ? nullptr : &it->second.first;
+}
+
+StatusOr<const RGlobalDictMap*> DictOptimizeParser::get_or_build_rdict(RuntimeState* runtime_state, SlotId slot_id) {
+    std::lock_guard<std::recursive_mutex> guard(_dict_maps_mutex);
+    auto it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    if (it == _mutable_dict_maps->end()) {
+        RETURN_IF_ERROR(eval_dict_expr(runtime_state, slot_id));
+        it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    }
+    if (it == _mutable_dict_maps->end()) {
+        return Status::InternalError(fmt::format("global dictionary not found for slot {}", slot_id));
+    }
+    return &it->second.second;
+}
+
 void DictOptimizeParser::set_output_slot_id(std::vector<ExprContext*>* pexpr_ctxs,
                                             const std::vector<SlotId>& slot_ids) {
     auto& expr_ctxs = *pexpr_ctxs;
@@ -522,11 +541,10 @@ void DictOptimizeParser::rewrite_descriptor(RuntimeState* runtime_state, const s
     if (fragment_dict_state == nullptr) {
         return;
     }
-    const auto& global_dict = fragment_dict_state->query_global_dicts();
-    if (global_dict.empty()) return;
+    const auto* parser = fragment_dict_state->dict_optimize_parser();
 
     for (auto& slot_desc : *slot_descs) {
-        if (global_dict.count(slot_desc->id()) && slot_desc->type().type == LowCardDictType) {
+        if (slot_desc->type().type == LowCardDictType && parser->get_dict_map(slot_desc->id()) != nullptr) {
             SlotDescriptor* newSlot = runtime_state->global_obj_pool()->add(new SlotDescriptor(*slot_desc));
             newSlot->type().type = TYPE_VARCHAR;
             slot_desc = newSlot;

--- a/be/src/compute_env/global_dict/parser.h
+++ b/be/src/compute_env/global_dict/parser.h
@@ -65,6 +65,12 @@ public:
 
     Status eval_dict_expr(RuntimeState* runtime_state, SlotId id);
 
+    // Forward dict for `slot_id`, or nullptr if not present.
+    const GlobalDictMap* get_dict_map(SlotId slot_id) const;
+
+    // Reverse dict for `slot_id`, built lazily if needed.
+    StatusOr<const RGlobalDictMap*> get_or_build_rdict(RuntimeState* runtime_state, SlotId slot_id);
+
     void close(RuntimeState* runtime_state) noexcept;
 
     void check_could_apply_dict_optimize(ExprContext* expr_ctx, DictOptimizeContext* dict_opt_ctx);
@@ -98,7 +104,7 @@ private:
     ObjectPool _free_pool;
     std::unordered_map<SlotId, ExprContext*> _dict_exprs;
     // Mutex to protect concurrent access to _mutable_dict_maps in parallel prepare
-    std::recursive_mutex _dict_maps_mutex;
+    mutable std::recursive_mutex _dict_maps_mutex;
 };
 
 } // namespace starrocks

--- a/be/src/compute_env/query/scan_conjuncts_manager.cpp
+++ b/be/src/compute_env/query/scan_conjuncts_manager.cpp
@@ -26,6 +26,7 @@
 #include "common/config_scan_io_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
 #include "compute_env/runtime_range_pruner.h"
 #include "compute_env/runtime_range_pruner.hpp"
 #include "exprs/binary_predicate.h"
@@ -79,10 +80,10 @@ static Expr* get_root_expr(ExprContext* ctx) {
     return get_root_expr(ctx->root());
 }
 
-static const GlobalDictMaps& get_query_global_dicts(const RuntimeState* runtime_state) {
+static const GlobalDictMap* get_global_dict(const RuntimeState* runtime_state, SlotId slot_id) {
     const auto* fragment_dict_state = runtime_state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    return fragment_dict_state->query_global_dicts();
+    return fragment_dict_state->dict_optimize_parser()->get_dict_map(slot_id);
 }
 
 template <typename ValueType>
@@ -446,7 +447,7 @@ Status ChunkPredicateBuilder<E, Type>::_build_bitset_in_predicates(PredicateComp
         // Low-cardinality dictionary columns can only use VARCHAR-type predicates during the index application phase.
         // Therefore, if the runtime bitset filter corresponds to a global low-cardinality dictionary column,
         // it cannot be pushed down to the storage layer for index application.
-        if (const auto& dict_map = get_query_global_dicts(_opts.runtime_state); dict_map.contains(slot_id)) {
+        if (get_global_dict(_opts.runtime_state, slot_id) != nullptr) {
             continue;
         }
 
@@ -508,14 +509,14 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
         const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range) {
     // clang-format on
 
-    const auto& global_dicts = get_query_global_dicts(_opts.runtime_state);
-    const auto global_dict_iter = SlotType == TYPE_VARCHAR ? global_dicts.find(slot.id()) : global_dicts.end();
+    const GlobalDictMap* global_dict =
+            SlotType == TYPE_VARCHAR ? get_global_dict(_opts.runtime_state, slot.id()) : nullptr;
 
     auto is_in_values_dict_encoded = [&](const Expr* root_expr) -> bool {
         if constexpr (SlotType != TYPE_VARCHAR) {
             return false;
         }
-        return global_dict_iter != global_dicts.end() && root_expr->get_num_children() > 0 &&
+        return global_dict != nullptr && root_expr->get_num_children() > 0 &&
                root_expr->get_child(0)->type().type == LowCardDictType;
     };
 
@@ -588,7 +589,7 @@ requires(!lt_is_date<SlotType>) Status ChunkPredicateBuilder<E, Type>::normalize
             if constexpr (SlotType == TYPE_VARCHAR) {
                 if (is_in_values_dict_encoded(root_expr)) {
                     RETURN_IF_ERROR((normalize_in_pred.template operator()<LowCardDictType, GlobalDictCodeDecoder>(
-                            i, root_expr, &global_dict_iter->second.first)));
+                            i, root_expr, global_dict)));
                     continue;
                 }
             }
@@ -808,8 +809,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
     }
     DCHECK(!Negative);
 
-    const auto& global_dicts = get_query_global_dicts(_opts.runtime_state);
-    const auto global_dict_iter = SlotType == TYPE_VARCHAR ? global_dicts.find(slot.id()) : global_dicts.end();
+    const GlobalDictMap* global_dict =
+            SlotType == TYPE_VARCHAR ? get_global_dict(_opts.runtime_state, slot.id()) : nullptr;
 
     auto process = [&]<LogicalType MappingType, template <typename> typename Decoder, typename... Args>(Args &&
                                                                                                         ... args)
@@ -924,8 +925,8 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
     };
 
     if constexpr (SlotType == TYPE_VARCHAR) {
-        if (global_dict_iter != global_dicts.end()) {
-            return process.template operator()<LowCardDictType, GlobalDictCodeDecoder>(&global_dict_iter->second.first);
+        if (global_dict != nullptr) {
+            return process.template operator()<LowCardDictType, GlobalDictCodeDecoder>(global_dict);
         }
     }
     return process.template operator()<SlotType, DummyDecoder>(nullptr);
@@ -940,14 +941,14 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
 
     using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
 
-    const auto& global_dicts = get_query_global_dicts(_opts.runtime_state);
-    const auto global_dict_iter = SlotType == TYPE_VARCHAR ? global_dicts.find(slot.id()) : global_dicts.end();
+    const GlobalDictMap* global_dict =
+            SlotType == TYPE_VARCHAR ? get_global_dict(_opts.runtime_state, slot.id()) : nullptr;
 
     auto is_in_values_dict_encoded = [&](const Expr* root_expr) -> bool {
         if constexpr (SlotType != TYPE_VARCHAR) {
             return false;
         }
-        return global_dict_iter != global_dicts.end() && root_expr->get_num_children() > 0 &&
+        return global_dict != nullptr && root_expr->get_num_children() > 0 &&
                root_expr->get_child(0)->type().type == LowCardDictType;
     };
 
@@ -1028,7 +1029,7 @@ Status ChunkPredicateBuilder<E, Type>::normalize_not_in_or_not_equal_predicate(
             if constexpr (SlotType == TYPE_VARCHAR) {
                 if (is_in_values_dict_encoded(root_expr)) {
                     RETURN_IF_ERROR((normalize_in_pred.template operator()<LowCardDictType, GlobalDictCodeDecoder>(
-                            i, root_expr, &global_dict_iter->second.first)));
+                            i, root_expr, global_dict)));
                     continue;
                 }
             }
@@ -1311,7 +1312,7 @@ Status ChunkPredicateBuilder<E, Type>::_get_column_predicates(PredicateParser* p
 
             // When a pushed-down runtime filter is applied, VARCHAR columns use local dict IDs instead of global dict IDs.
             // Therefore, global low-cardinality dict columns cannot be pushed down.
-            if (const auto& dict_map = get_query_global_dicts(_opts.runtime_state); dict_map.contains(slot_id)) {
+            if (get_global_dict(_opts.runtime_state, slot_id) != nullptr) {
                 continue;
             }
 
@@ -1529,7 +1530,7 @@ StatusOr<RuntimeFilterPredicates> ScanConjunctsManager::get_runtime_filter_predi
         }
         // When a pushed-down runtime filter is applied, VARCHAR columns use local dict IDs instead of global dict IDs.
         // Therefore, global low-cardinality dict columns cannot be pushed down.
-        if (const auto& dict_map = get_query_global_dicts(_opts.runtime_state); dict_map.contains(slot_id)) {
+        if (get_global_dict(_opts.runtime_state, slot_id) != nullptr) {
             continue;
         }
         auto column_id = parser->column_id(*slot_desc);

--- a/be/src/connector/hive/hive_connector.cpp
+++ b/be/src/connector/hive/hive_connector.cpp
@@ -748,7 +748,7 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerContext* ctx) {
     const THdfsScanNode& hdfs_scan_node = _provider->_hdfs_scan_node;
     const auto* fragment_dict_state = _runtime_state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict_map = fragment_dict_state->query_global_dicts();
+    const auto* dict_optimize_parser = fragment_dict_state->dict_optimize_parser();
     auto global_dict = _pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     TupleDescriptor* tuple_desc = _runtime_state->desc_tbl().get_tuple_descriptor(hdfs_scan_node.tuple_id);
@@ -757,14 +757,13 @@ Status HiveDataSource::_init_global_dicts(HdfsScannerContext* ctx) {
         if (!slot->is_materialized()) {
             continue;
         }
-        auto iter = global_dict_map.find(slot->id());
-        if (iter != global_dict_map.end()) {
-            auto& dict_map = iter->second.first;
-            global_dict->emplace(slot->id(), const_cast<GlobalDictMap*>(&dict_map));
+        const GlobalDictMap* dict_map = dict_optimize_parser->get_dict_map(slot->id());
+        if (dict_map != nullptr) {
+            global_dict->emplace(slot->id(), dict_map);
 #ifdef DEBUG
             std::stringstream ss;
             ss << "slot_id: " << slot->id() << " global dict: ";
-            for (const auto& kv : dict_map) {
+            for (const auto& kv : *dict_map) {
                 ss << "<" << kv.first << " " << kv.second << ">"
                    << ", ";
             }

--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -259,7 +259,7 @@ Status LakeDataSource::init_global_dicts(TabletReaderParams* params) {
     const TLakeScanNode& thrift_lake_scan_node = _provider->_t_lake_scan_node;
     const auto* fragment_dict_state = _runtime_state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict_map = fragment_dict_state->query_global_dicts();
+    const auto* dict_optimize_parser = fragment_dict_state->dict_optimize_parser();
     auto global_dict = _obj_pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     const TupleDescriptor* tuple_desc = _runtime_state->desc_tbl().get_tuple_descriptor(thrift_lake_scan_node.tuple_id);
@@ -267,12 +267,11 @@ Status LakeDataSource::init_global_dicts(TabletReaderParams* params) {
         if (!slot->is_materialized()) {
             continue;
         }
-        auto iter = global_dict_map.find(slot->id());
-        if (iter != global_dict_map.end()) {
-            auto& dict_map = iter->second.first;
+        const GlobalDictMap* dict_map = dict_optimize_parser->get_dict_map(slot->id());
+        if (dict_map != nullptr) {
             int32_t index = _tablet_schema->field_index(slot->col_name());
             DCHECK(index >= 0);
-            global_dict->emplace(index, const_cast<GlobalDictMap*>(&dict_map));
+            global_dict->emplace(index, dict_map);
         }
     }
     params->global_dictmaps = global_dict;

--- a/be/src/exec/pipeline/dict_decode_operator.cpp
+++ b/be/src/exec/pipeline/dict_decode_operator.cpp
@@ -16,8 +16,11 @@
 
 #include "column/column_helper.h"
 #include "column/global_dict/decoder.h"
+#include "column/global_dict/types.h"
 #include "common/logging.h"
+#include "common/statusor.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
 #include "exprs/expr_executor.h"
 #include "runtime/runtime_state.h"
 
@@ -98,13 +101,10 @@ Status DictDecodeOperatorFactory::prepare(RuntimeState* state) {
 
     auto* fragment_dict_state = state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict = fragment_dict_state->query_global_dicts();
     auto* dict_optimize_parser = fragment_dict_state->mutable_dict_optimize_parser();
 
     for (auto& [slot_id, v] : _string_functions) {
-        auto dict_iter = global_dict.find(slot_id);
-        auto dict_not_contains_cid = dict_iter == global_dict.end();
-        if (dict_not_contains_cid) {
+        if (dict_optimize_parser->get_dict_map(slot_id) == nullptr) {
             auto& [expr_ctx, dict_ctx] = v;
             dict_optimize_parser->check_could_apply_dict_optimize(expr_ctx, &dict_ctx);
             if (!dict_ctx.could_apply_dict_optimize) {
@@ -113,9 +113,7 @@ Status DictDecodeOperatorFactory::prepare(RuntimeState* state) {
             }
 
             RETURN_IF_ERROR(dict_optimize_parser->eval_expression(state, expr_ctx, &dict_ctx, slot_id));
-            auto dict_iter = global_dict.find(slot_id);
-            DCHECK(dict_iter != global_dict.end());
-            if (dict_iter == global_dict.end()) {
+            if (dict_optimize_parser->get_dict_map(slot_id) == nullptr) {
                 return Status::InternalError(fmt::format("Eval Expr Error for cid:{}", slot_id));
             }
         }
@@ -125,23 +123,8 @@ Status DictDecodeOperatorFactory::prepare(RuntimeState* state) {
     int need_decode_size = _decode_column_cids.size();
     for (int i = 0; i < need_decode_size; ++i) {
         int need_encode_cid = _encode_column_cids[i];
-        auto dict_iter = global_dict.find(need_encode_cid);
-        auto dict_not_contains_cid = dict_iter == global_dict.end();
-
-        if (dict_not_contains_cid) {
-            if (dict_optimize_parser->eval_dict_expr(state, need_encode_cid).ok()) {
-                dict_iter = global_dict.find(need_encode_cid);
-                dict_not_contains_cid = dict_iter == global_dict.end();
-            }
-        }
-
-        if (dict_not_contains_cid) {
-            return Status::InternalError(fmt::format("Not found dict for cid:{}", need_encode_cid));
-        }
-        // TODO : avoid copy dict
-        GlobalDictDecoderPtr decoder = create_global_dict_decoder(dict_iter->second.second);
-
-        _decoders.emplace_back(std::move(decoder));
+        ASSIGN_OR_RETURN(const RGlobalDictMap* rdict, dict_optimize_parser->get_or_build_rdict(state, need_encode_cid));
+        _decoders.emplace_back(create_global_dict_decoder(*rdict));
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -22,6 +22,7 @@
 #include "base/statusor.h"
 #include "common/config_lake_fwd.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
 #include "connector/lake/lake_global_late_materialization_context.h"
 #include "exec/exec_env.h"
 #include "exec/olap_scan_node.h"
@@ -68,7 +69,7 @@ Status init_global_dicts_for_scan_node(RuntimeState* state, ObjectPool* pool, co
                                        ColumnIdToGlobalDictMap** global_dicts) {
     const auto* fragment_dict_state = state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict_map = fragment_dict_state->query_global_dicts();
+    const auto* dict_optimize_parser = fragment_dict_state->dict_optimize_parser();
 
     auto dicts = pool->add(new ColumnIdToGlobalDictMap());
     for (auto* slot : slots) {
@@ -76,10 +77,8 @@ Status init_global_dicts_for_scan_node(RuntimeState* state, ObjectPool* pool, co
         if (index < 0) {
             return Status::InternalError(fmt::format("invalid field name: {}", slot->col_name()));
         }
-        auto iter = global_dict_map.find(slot->id());
-        if (iter != global_dict_map.end()) {
-            auto& dict_map = iter->second.first;
-            dicts->emplace(index, const_cast<GlobalDictMap*>(&dict_map));
+        if (const GlobalDictMap* dict_map = dict_optimize_parser->get_dict_map(slot->id()); dict_map != nullptr) {
+            dicts->emplace(index, dict_map);
         }
     }
     *global_dicts = dicts;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -31,6 +31,7 @@
 #include "common/statusor.h"
 #include "common/util/table_metrics.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
 #include "compute_env/query/query_runtime_state.h"
 #include "compute_env/query/query_scan_metrics.h"
 #include "compute_env/runtime_range_pruner.hpp"
@@ -661,7 +662,7 @@ Status OlapChunkSource::_init_global_dicts(TabletReaderParams* params) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     const auto* fragment_dict_state = _runtime_state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict_map = fragment_dict_state->query_global_dicts();
+    const auto* dict_optimize_parser = fragment_dict_state->dict_optimize_parser();
     auto global_dict = _obj_pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     const TupleDescriptor* tuple_desc = _runtime_state->desc_tbl().get_tuple_descriptor(thrift_olap_scan_node.tuple_id);
@@ -669,9 +670,8 @@ Status OlapChunkSource::_init_global_dicts(TabletReaderParams* params) {
         if (!slot->is_materialized()) {
             continue;
         }
-        auto iter = global_dict_map.find(slot->id());
-        if (iter != global_dict_map.end()) {
-            auto& dict_map = iter->second.first;
+        const GlobalDictMap* dict_map = dict_optimize_parser->get_dict_map(slot->id());
+        if (dict_map != nullptr) {
             int32_t index;
             if (_use_vector_index && !_refine_distance && slot->id() == _vector_slot_id) {
                 index = _tablet_schema->num_columns();
@@ -679,7 +679,7 @@ Status OlapChunkSource::_init_global_dicts(TabletReaderParams* params) {
                 index = _tablet_schema->field_index(slot->col_name());
             }
             DCHECK(index >= 0);
-            global_dict->emplace(index, const_cast<GlobalDictMap*>(&dict_map));
+            global_dict->emplace(index, dict_map);
         }
     }
     params->global_dictmaps = global_dict;

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -22,6 +22,7 @@
 #include "common/status.h"
 #include "common/system/backend_options.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/global_dict/parser.h"
 #include "compute_env/query/query_scan_metrics.h"
 #include "exec/olap_scan_node.h"
 #include "exprs/chunk_predicate_evaluator.h"
@@ -261,19 +262,18 @@ Status TabletScanner::_init_unused_output_columns(const std::vector<std::string>
 Status TabletScanner::_init_global_dicts() {
     const auto* fragment_dict_state = _runtime_state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
-    const auto& global_dict_map = fragment_dict_state->query_global_dicts();
+    const auto* dict_optimize_parser = fragment_dict_state->dict_optimize_parser();
     auto global_dict = _pool.add(new ColumnIdToGlobalDictMap());
     // mapping column id to storage column ids
     for (auto slot : _parent->_tuple_desc->slots()) {
         if (!slot->is_materialized()) {
             continue;
         }
-        auto iter = global_dict_map.find(slot->id());
-        if (iter != global_dict_map.end()) {
-            auto& dict_map = iter->second.first;
+        const GlobalDictMap* dict_map = dict_optimize_parser->get_dict_map(slot->id());
+        if (dict_map != nullptr) {
             int32_t index = _tablet_schema->field_index(slot->col_name());
             DCHECK(index >= 0);
-            global_dict->emplace(index, const_cast<GlobalDictMap*>(&dict_map));
+            global_dict->emplace(index, dict_map);
         }
     }
     _params.global_dictmaps = global_dict;

--- a/be/src/storage/rowset/column_decoder.h
+++ b/be/src/storage/rowset/column_decoder.h
@@ -42,7 +42,7 @@ public:
     }
 
     void set_all_page_dict_encoded(bool all_page_dict_encoded) { _all_page_dict_encoded = all_page_dict_encoded; }
-    void set_global_dict(GlobalDictMap* global_dict) { _global_dict = global_dict; }
+    void set_global_dict(const GlobalDictMap* global_dict) { _global_dict = global_dict; }
     // check global dict is superset of local dict
     void check_global_dict();
 
@@ -67,7 +67,7 @@ private:
 private:
     std::optional<std::vector<int16_t>> _code_convert_map;
     ColumnIterator* _iter = nullptr;
-    GlobalDictMap* _global_dict = nullptr;
+    const GlobalDictMap* _global_dict = nullptr;
     bool _all_page_dict_encoded = false;
 };
 

--- a/be/src/storage/rowset/dictcode_column_iterator.cpp
+++ b/be/src/storage/rowset/dictcode_column_iterator.cpp
@@ -95,7 +95,7 @@ Status GlobalDictCodeColumnIterator::decode_string_dict_codes(const Column& code
 }
 
 Status GlobalDictCodeColumnIterator::build_code_convert_map(ColumnIterator* file_column_iter,
-                                                            GlobalDictMap* global_dict,
+                                                            const GlobalDictMap* global_dict,
                                                             std::vector<int16_t>* code_convert_map) {
     DCHECK(file_column_iter->all_page_dict_encoded());
 

--- a/be/src/storage/rowset/dictcode_column_iterator.h
+++ b/be/src/storage/rowset/dictcode_column_iterator.h
@@ -100,7 +100,7 @@ public:
         return Status::NotSupported("unsupport decode_dict_codes in GlobalDictCodeColumnIterator");
     }
 
-    static Status build_code_convert_map(ColumnIterator* file_column_iter, GlobalDictMap* global_dict,
+    static Status build_code_convert_map(ColumnIterator* file_column_iter, const GlobalDictMap* global_dict,
                                          std::vector<int16_t>* code_convert_map);
 
     std::string name() const override { return "GlobalDictCodeColumnIterator"; }

--- a/be/test/compute_env/fragment_dict_state_test.cpp
+++ b/be/test/compute_env/fragment_dict_state_test.cpp
@@ -51,10 +51,10 @@ TEST(FragmentDictStateTest, InitQueryAndLoadGlobalDicts) {
             fragment_dict_state.init_query_global_dict(&state, {make_global_dict(3, 11, {0, 1}, {"", "query-value"})}));
     ASSERT_OK(fragment_dict_state.init_load_global_dict(&state, {make_global_dict(5, 17, {0, 2}, {"", "load-value"})}));
 
-    const auto& query_dicts = fragment_dict_state.query_global_dicts();
-    ASSERT_EQ(1, query_dicts.size());
-    ASSERT_NE(query_dicts.find(3), query_dicts.end());
-    EXPECT_EQ("query-value", query_dicts.find(3)->second.second.find(1)->second.to_string());
+    const auto* query_dicts = fragment_dict_state.mutable_query_global_dicts();
+    ASSERT_EQ(1, query_dicts->size());
+    ASSERT_NE(query_dicts->find(3), query_dicts->end());
+    EXPECT_EQ("query-value", query_dicts->find(3)->second.second.find(1)->second.to_string());
 
     const auto& load_dicts = fragment_dict_state.load_global_dicts();
     ASSERT_EQ(1, load_dicts.size());

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -54,6 +54,7 @@ void OlapScanOperatorTest::SetUp() {
     _thrift_tbl.tupleDescriptors.emplace_back(t_tuple_desc);
 
     _tnode.row_tuples.emplace_back(1);
+    _tnode.olap_scan_node.tuple_id = 1;
 
     Status st = DescriptorTbl::create(&_runtime_state, &_object_pool, _thrift_tbl, &_tbl, _chunk_size);
     ASSERT_TRUE(st.ok());


### PR DESCRIPTION
## Why I'm doing:
The fragment-shared `GlobalDictMaps` (`_query_global_dicts`) is a `phmap::flat_hash_map`, and it keeps receiving **lazy derived-dict inserts during execution** — `eval_dict_expr`, and `OlapScanContext::parse_conjuncts` once runtime filters arrive from join build sides. Meanwhile:

- `OlapChunkSource::_init_global_dicts` captures a raw `GlobalDictMap*` (`&entity.first`) into `params->global_dictmaps` and dereferences it **per segment / per chunk** for the whole scan.
- `DictDecodeOperator` resolves `&entity.second` and copies it into each decoder.

A fragment instance runs with pipeline parallelism (DOP drivers on many threads) all sharing this one map. So:

1. **Dangling pointer:** a `flat_hash_map` rehash on any insert relocates every entry, dangling pointers captured earlier — reachable even single-threaded (capture, then a later insert).
2. **Race Conditions:** the scan's capturing `find` runs unsynchronized against the inserts, which hold `_dict_maps_mutex`. A `find` overlapping an `emplace` tears the map's control/slot arrays.

## What I'm doing:
1. **`node_hash_map` for the outer `GlobalDictMaps`** (`types_fwd_decl.h`) — entries are pointer-stable across rehash, so captured `GlobalDictMap*`/`RGlobalDictMap*` survive later inserts. Inner `GlobalDictMap`/`RGlobalDictMap` stay `flat_hash_map` (hot per-row lookups). Drop-in: `node_hash_map` has the same API.
2. **Locked accessors on `DictOptimizeParser`** — `get_dict_map()` and `get_or_build_rdict()` do the `find` (and lazy build) under `_dict_maps_mutex` and return a stable **`const`** pointer. The scan capture (`_init_global_dicts`) and both `DictDecodeOperator` loops now go through these instead of the raw unsynchronized `find`.
3. **Remove the per-operator reverse-dict copy** (`create_global_dict_decoder` / `GlobalDictDecoderBase`) — the decoder now holds a `const RGlobalDictMap*` into the node-stable, immutable entry instead of copying (`// TODO : avoid copy dict`). 
4. **Const-correctness** — Making all dictionaries const, ensuring that consumers won't change them, also removing const casts from the code.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
