### PR TITLE
[BugFix] Flag bundled segments as shared when orphaning them for vacuum

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -253,9 +253,10 @@ void MetaFileBuilder::apply_column_mode_partial_update(const TxnLogPB_OpWrite& o
     for (const auto& segment_meta : op_write.rowset().segment_metas()) {
         FileMetaPB file_meta;
         file_meta.set_name(segment_meta.filename());
-        if (segment_meta.has_shared()) {
-            file_meta.set_shared(segment_meta.shared());
-        }
+        // Mirror is_shared_segment(): a bundled segment (bundle_file_offset set) is shared with
+        // sibling tablets. The orphan FileMetaPB only carries `shared`, so encode bundling into it
+        // too, otherwise vacuum deletes the shared bundle file while a sibling still references it.
+        file_meta.set_shared(segment_meta.shared() || segment_meta.has_bundle_file_offset());
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }
@@ -817,9 +818,10 @@ void MetaFileBuilder::apply_opcompaction_with_conflict(const TxnLogPB_OpCompacti
     for (const auto& segment_meta : rowset_metadata.segment_metas()) {
         FileMetaPB file_meta;
         file_meta.set_name(segment_meta.filename());
-        if (segment_meta.has_shared()) {
-            file_meta.set_shared(segment_meta.shared());
-        }
+        // Mirror is_shared_segment(): a bundled compaction-output segment is shared with sibling
+        // tablets. Encode bundling into the orphan's `shared` flag so vacuum's alive-check protects
+        // it instead of deleting a bundle file a sibling still references.
+        file_meta.set_shared(segment_meta.shared() || segment_meta.has_bundle_file_offset());
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -579,9 +579,13 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         // after rename, add old segment to orphan files, for gc later.
         FileMetaPB file_meta;
         file_meta.set_name(src_seg_meta.filename());
-        if (src_seg_meta.has_shared()) {
-            file_meta.set_shared(src_seg_meta.shared());
-        }
+        // A bundled segment is physically shared with sibling tablets, but its shared-ness is
+        // encoded by bundle_file_offset rather than the `shared` flag. The orphan FileMetaPB only
+        // carries `shared`, so mirror is_shared_segment() here (shared || has_bundle_file_offset).
+        // Otherwise vacuum's collect_garbage_files sees file.shared()==false, routes the orphan to
+        // the plain deleter, and deletes the physical bundle file even while a sibling tablet still
+        // references it in a live rowset -- wedging that sibling's publish.
+        file_meta.set_shared(src_seg_meta.shared() || src_seg_meta.has_bundle_file_offset());
         orphan_files->push_back(std::move(file_meta));
         // A sync .vi built for the replaced src segment is keyed on the src segment name and
         // unreachable after the replace (the dest segment has its own copy); orphan it too. In

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -282,6 +282,108 @@ TEST_P(LakePartialUpdateTest, test_write) {
     }
 }
 
+// Regression test: when a partial update orphans a bundled segment, the orphan_files entry must be
+// flagged shared so vacuum's cross-tablet alive-check protects it.
+//
+// Under file bundling one physical .dat holds the segments of several sibling tablets, and a
+// segment's shared-ness is encoded by bundle_file_offset (not the `shared` flag). The orphan
+// FileMetaPB only carries `shared`, so the orphan-producing paths must set it to
+// is_shared_segment() = shared || has_bundle_file_offset(). Otherwise collect_garbage_files sees
+// file.shared()==false, routes the orphan to the plain deleter, and deletes the physical bundle
+// file even while a sibling tablet still references it in a live rowset -- wedging that publish.
+//
+// This test stamps a bundle_file_offset onto a row-mode partial update segment (as a bundled load
+// records it), publishes so rewrite_segment orphans the raw segment, and asserts the orphaned
+// segment is flagged shared.
+TEST_P(LakePartialUpdateTest, test_bundled_orphan_segment_marked_shared) {
+    // Column mode orphans the partial-column update segment via a different path; this test targets
+    // the row-mode rewrite orphan path.
+    if (GetParam().partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        return;
+    }
+
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+
+    // 1. Normal full write so the partial update has base rows to rewrite against.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // 2. Row-mode partial update write (num_rows > 0 so rewrite_segment rewrites + orphans the raw
+    //    segment); do not publish yet.
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(GetParam().partial_update_mode)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+    }
+
+    // 3. Simulate file bundling: stamp bundle_file_offset onto the written segment(s). Offset 0 keeps
+    //    the standalone segment file readable; num_rows is left intact so the rewrite runs normally.
+    std::set<std::string> bundled_segments;
+    {
+        ASSIGN_OR_ABORT(auto original_txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        auto new_txn_log = std::make_shared<TxnLogPB>(*original_txn_log);
+        auto* rowset = new_txn_log->mutable_op_write()->mutable_rowset();
+        ASSERT_GT(rowset->segment_metas_size(), 0);
+        for (int i = 0; i < rowset->segment_metas_size(); i++) {
+            auto* seg = rowset->mutable_segment_metas(i);
+            bundled_segments.insert(seg->filename());
+            seg->set_bundle_file_offset(0);
+        }
+        ASSERT_OK(_tablet_mgr->put_txn_log(new_txn_log));
+    }
+
+    // 4. Publish. rewrite_segment rewrites the bundled segment and orphans the raw one.
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    version++;
+
+    // 5. The orphaned raw bundle segment must be flagged shared for vacuum's alive-check.
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    int checked = 0;
+    for (const auto& file : metadata->orphan_files()) {
+        if (bundled_segments.count(file.name()) > 0) {
+            checked++;
+            EXPECT_TRUE(file.shared()) << "orphaned bundle segment must be flagged shared: " << file.name();
+        }
+    }
+    EXPECT_EQ(checked, static_cast<int>(bundled_segments.size()))
+            << "every bundled segment should have been orphaned by the rewrite";
+}
+
 // This test case covers the following logic:
 // - with_default branch in get_column_values() (default values and column_to_expr_value override)
 // - Column mode generates DCG then switches to row mode, triggering need_dcg_check and DCG loading paths


### PR DESCRIPTION
## Why I'm doing:

When file bundling is enabled (`enable_file_bundling = true`, the default for shared-data tables since 4.0), one physical `.dat` holds the segments of several sibling tablets of a partition, and a segment's shared-ness is encoded by `bundle_file_offset` — so vacuum's `is_shared_segment()` is `shared() || has_bundle_file_offset()`.

Consider a 3-tablet bundled primary-key table and one load where tablet A upserts a row while tablets B and C only delete rows. B and C get a **0-row bundled segment** (their slice of the shared `.dat`), which `rewrite_segment` leaves as a live rowset segment (it skips empty rowsets). Tablet A rewrites its own slice during publish and **orphans the raw bundle segment**.

`orphan_files` entries are `FileMetaPB`, which carries only `name` / `size` / `shared` / `encryption_meta` — **not** `bundle_file_offset`. The orphan-producing paths (`RowsetUpdateState::rewrite_segment`, `MetaFileBuilder::apply_column_mode_partial_update`, `MetaFileBuilder::apply_opcompaction_with_conflict`) copied only `segment.shared()`, so tablet A's orphan landed with `shared=false`. `collect_garbage_files` then routes it through the **plain deleter** and deletes the physical bundle file — while B and C still reference it in a live rowset. Their next publish fails at `prepare_primary_index -> Rowset::load_segments`:

```
Not found: load_segments failed ... Object s3://.../<txn>_<uuid>.dat does not exist
```

which wedges the whole table's publish queue. `collect_garbage_files` cannot recover the bundle info from an orphan `FileMetaPB` (no offset, no rowset/index to feed `is_shared_segment`), so the `shared` flag is the only signal on the orphan path — it must be set correctly when the orphan is produced.

## What I'm doing:

Set the orphan `FileMetaPB.shared` to `is_shared_segment()`'s definition (`shared() || has_bundle_file_offset()`) in all three orphan-producing paths. `collect_garbage_files`'s existing `file.shared()` check then routes bundled orphans through the alive-checked shared-file deleter, so `collect_alive_shared_files` vetoes deletion while any sibling still references the bundle file. The bundle file is GC'd only once no tablet references it (e.g. after the empty slices are compacted away). Add a regression test.

Reproduced end-to-end on a 3-tablet file-bundled PK table (1 tablet upsert + 2 tablets delete-only, then accelerated vacuum): before the fix the delete-only tablets wedge publish with "segment does not exist"; after the fix publish succeeds.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
