### PR TITLE
[Tool] Drop vestigial -liberty from BE system link libs

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -857,7 +857,7 @@ if (APPLE)
         list(APPEND STARROCKS_SYSTEM_LINK_LIBS ${MIMALLOC_LIB})
     endif()
 else()
-    set(STARROCKS_SYSTEM_LINK_LIBS -lresolv -liberty -lc -lm -ldl -rdynamic -pthread)
+    set(STARROCKS_SYSTEM_LINK_LIBS -lresolv -lc -lm -ldl -rdynamic -pthread)
 endif()
 
 set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}

--- a/be/src/starrocks_format/CMakeLists.txt
+++ b/be/src/starrocks_format/CMakeLists.txt
@@ -54,7 +54,7 @@ SET(STARROCKS_FORMAT_LIBS
     ${STARROCKS_LIBS}
     ${STARROCKS_DEPENDENCIES}
     -static-libstdc++ -static-libgcc
-    -lresolv -liberty -lc -lm -ldl -rdynamic -pthread -Wl,-wrap=__cxa_throw
+    -lresolv -lc -lm -ldl -rdynamic -pthread -Wl,-wrap=__cxa_throw
     hdfs_so
 )
 message(STATUS "STARROCKS_FORMAT_LIBS is ${STARROCKS_FORMAT_LIBS}")


### PR DESCRIPTION
## Why I'm doing:

The BE link paths hard-code `-liberty` on non-Apple builds. Historically it was
paired with `-lbfd` (libiberty is bfd's companion library); `-lbfd` was later
removed but `-liberty` was left behind. No BE code references any libiberty
symbol (`cplus_demangle`, `bfd`, etc.), so the flag is vestigial.

It only stays linkable as long as the toolchain/build image happens to ship
`libiberty.a`. On an image that does not, the GNU gold linker (used on the
CentOS + GCC toolchain) fails at the final link:

```
/usr/bin/ld.gold: error: cannot find -liberty
collect2: error: ld returned 1 exit status
make[2]: *** [.../starrocks_be] Error 1
```

Ubuntu CI uses lld and its image ships libiberty, so this only surfaces on the
CentOS + gold build path.

## What I'm doing:

Drop the orphaned `-liberty` from both link paths that hard-code it, so linking no
longer depends on `libiberty.a` being present in the toolchain image:

- `STARROCKS_SYSTEM_LINK_LIBS` in `be/CMakeLists.txt` (the `starrocks_be` binary)
- `STARROCKS_FORMAT_LIBS` in `be/src/starrocks_format/CMakeLists.txt` (the
  `--format-lib` build, `libstarrocks_format.so`)

```cmake
-    ... -lresolv -liberty -lc -lm -ldl -rdynamic -pthread ...
+    ... -lresolv -lc -lm -ldl -rdynamic -pthread ...
```

No BE source references libiberty symbols, so nothing else needs it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
