### PR TITLE
[Enhancement] Hash partition_name in external table statistics to avoid primary key size overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -79,6 +79,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -114,7 +115,7 @@ public class PartitionSelector {
             "WHERE DB_NAME ='%s' and TABLE_NAME='%s' AND %s;";
     private static final String EXTERNAL_TABLE_PARTITION_META_TEMPLATE = "SELECT PARTITION_NAME, SUM(ROW_COUNT) as ROW_COUNT," +
             "CAST(SUM(DATA_SIZE) AS BIGINT) as DATA_SIZE FROM _statistics_.external_column_statistics " +
-            "WHERE TABLE_UUID = '%s' AND PARTITION_NAME in ('%s') GROUP BY PARTITION_NAME;";
+            "WHERE TABLE_UUID = '%s' AND PARTITION_NAME in (%s) GROUP BY PARTITION_NAME;";
     // NOTE: `json` to `datetime` is not supported yet, so we use `string` here.
     private static final String JSON_QUERY_TEMPLATE = "CAST(CAST(JSON_QUERY(%s, '$[0].[%d]') AS STRING) AS %s)";
 
@@ -808,17 +809,28 @@ public class PartitionSelector {
     /**
      * Use `_statistics_.external_column_statistics` to get partition statistics for an external table
      * such as Iceberg/Hudi by its table UUID.
+     * <p>
+     * partition_name is stored hashed (see {@link com.starrocks.statistic.StatisticUtils#hashExternalPartitionName})
+     * so the IN-list is built from hashes; results are translated back to the real partition names the caller
+     * passed in via {@code needPartitionNames} before being returned.
      */
     public static Map<String, Pair<Long, Long>> getExternalTablePartitionStats(Table table, Set<String> needPartitionNames) {
-        String sql = String.format(EXTERNAL_TABLE_PARTITION_META_TEMPLATE, table.getUUID(),
-                String.join(",", needPartitionNames));
+        if (needPartitionNames.isEmpty()) {
+            return Maps.newHashMap();
+        }
+        Map<String, String> hashToPartitionName = needPartitionNames.stream()
+                .collect(Collectors.toMap(StatisticUtils::hashExternalPartitionName, Function.identity(), (a, b) -> a));
+        String inClause = hashToPartitionName.keySet().stream()
+                .map(hash -> "'" + hash + "'")
+                .collect(Collectors.joining(","));
+        String sql = String.format(EXTERNAL_TABLE_PARTITION_META_TEMPLATE, table.getUUID(), inClause);
         LOG.info("Get external table partition stats by sql: {}", sql);
         List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);
-        return deserializeExternalStatisticsResult(batch);
+        return deserializeExternalStatisticsResult(batch, hashToPartitionName);
     }
 
     private static Map<String, Pair<Long, Long>> deserializeExternalStatisticsResult(
-            List<TResultBatch> batches) {
+            List<TResultBatch> batches, Map<String, String> hashToPartitionName) {
         Map<String, Pair<Long, Long>> result = new HashMap<>();
         for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
             for (ByteBuffer buffer : batch.getRows()) {
@@ -827,7 +839,7 @@ public class PartitionSelector {
                 List<String> data = MetaFunctions.LookupRecord.fromJson(jsonString).data;
 
                 if (data != null && data.size() >= 3) {
-                    String partitionName = data.get(0);
+                    String partitionName = hashToPartitionName.getOrDefault(data.get(0), data.get(0));
                     long rowCount = Long.parseLong(data.get(1));
                     long dataSize = Long.parseLong(data.get(2));
                     result.put(partitionName, Pair.create(rowCount, dataSize));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -348,8 +348,14 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
 
+            // Store a fixed-length hash instead of the raw partition name: external partition names (e.g.
+            // Iceberg partition-evolution values like "tenant_id=hash-xxx") can be long enough that
+            // (table_uuid, partition_name, column_name) exceeds the BE primary_key_limit_size. partition_name is
+            // an opaque key here (never shown to users, never substring-matched), so hashing it is safe.
+            String hashedPartitionName = StatisticUtils.hashExternalPartitionName(data.getPartitionName());
+
             params.add("'" + table.getUUID() + "'");
-            params.add("'" + StringEscapeUtils.escapeSql(data.getPartitionName()) + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(hashedPartitionName) + "'");
             params.add("'" + StringEscapeUtils.escapeSql(data.getColumnName()) + "'");
             params.add("'" + catalogName + "'");
             params.add("'" + db.getOriginName() + "'");
@@ -363,7 +369,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             params.add("now()");
             // int
             row.add(new StringLiteral(table.getUUID())); // table id, wait to byte
-            row.add(new StringLiteral(data.getPartitionName()));
+            row.add(new StringLiteral(hashedPartitionName));
             row.add(new StringLiteral(data.getColumnName())); // column name, 20 byte
             row.add(new StringLiteral(catalogName));
             row.add(new StringLiteral(db.getOriginName()));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME;
+import static com.starrocks.statistic.StatsConstants.EXTERNAL_PARTITION_NAME_HASH_PREFIX;
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.MULTI_COLUMN_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
@@ -211,9 +212,14 @@ public class StatisticSQLBuilder {
         nameGroups.forEach((type, names) -> {
             VelocityContext context = new VelocityContext();
             context.put("type", type);
+            // Only consider rows whose partition_name has been hashed (see StatisticUtils#hashExternalPartitionName).
+            // Rows written before that change still carry the raw (unhashed) partition name under the same
+            // table_uuid/column_name, and this query aggregates across all partitions, so including both would
+            // double count row_count/data_size/ndv for the same logical partition.
             context.put("predicate",
                     "table_uuid = \"" + tableUUID + "\"" + " and column_name in (" +
-                            names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")");
+                            names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")" +
+                            " and partition_name like \"" + EXTERNAL_PARTITION_NAME_HASH_PREFIX + "%\"");
             querySQL.add(build(context, QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE));
         });
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -284,6 +284,19 @@ public class StatisticUtils {
         return instant.toEpochMilli();
     }
 
+    /**
+     * Hash a real (external table) partition name into a short, fixed-length form suitable for storing as the
+     * partition_name column of {@link StatsConstants#EXTERNAL_FULL_STATISTICS_TABLE_NAME}. Iceberg partition
+     * names produced by partition evolution (e.g. "tenant_id=hash-xxx") can be arbitrarily long and, combined
+     * with table_uuid and column_name, exceed the BE primary_key_limit_size. partition_name is never displayed
+     * to users nor substring-matched, so replacing it with a hash is safe; the fixed prefix marks the value as
+     * hashed so readers can distinguish it from any raw partition name written before this change.
+     */
+    public static String hashExternalPartitionName(String partitionName) {
+        long hash = Hashing.murmur3_128().hashUnencodedChars(partitionName).asLong();
+        return StatsConstants.EXTERNAL_PARTITION_NAME_HASH_PREFIX + String.format("%016x", hash);
+    }
+
     public static Set<String> getUpdatedPartitionNames(Table table, LocalDateTime checkTime) {
         // get updated partitions
         Set<String> updatedPartitions = null;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -71,6 +71,13 @@ public class StatsConstants {
     public static final String EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME = "external_histogram_statistics";
     public static final String MULTI_COLUMN_STATISTICS_TABLE_NAME = "multi_column_statistics";
 
+    // Prefix tagging hashed partition_name values written to EXTERNAL_FULL_STATISTICS_TABLE_NAME.
+    // Iceberg partition-evolution names (e.g. "tenant_id=hash-xxx") can exceed the BE primary_key_limit_size
+    // (128 bytes) once combined with table_uuid + column_name, so the raw partition name is replaced with a
+    // fixed-length hash before insert. The prefix lets reads filter out pre-migration rows that still carry the
+    // raw (unhashed) partition name, without needing to migrate or delete them.
+    public static final String EXTERNAL_PARTITION_NAME_HASH_PREFIX = "v2h-";
+
 
     public static final String INFORMATION_SCHEMA = "information_schema";
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class StatisticSQLBuilderTest {
+
+    @Test
+    void buildQueryExternalFullStatisticsSQLFiltersHashedPartitionsOnly() {
+        String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL(
+                "d6cfa1ed-0000-0000-0000-000000000000",
+                List.of("col1"),
+                List.<Type>of(IntegerType.INT));
+
+        // Only rows whose partition_name has been migrated to the hashed format should be aggregated,
+        // otherwise pre-migration raw-partition-name rows for the same table_uuid/column_name would be
+        // double counted alongside their re-collected, hash-keyed counterparts.
+        Assertions.assertTrue(sql.contains("partition_name like \"" + StatsConstants.EXTERNAL_PARTITION_NAME_HASH_PREFIX + "%\""),
+                "expected predicate to filter partition_name by the hash prefix, got: " + sql);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
@@ -113,4 +113,21 @@ class StatisticUtilsTest extends PlanTestBase {
             globalDefault.setBigQueryProfileThreshold(savedBigQueryThresholdMs + "ms");
         }
     }
+
+    @Test
+    void hashExternalPartitionName() {
+        String longPartitionName = "tenant_id=hash-2c933fdc";
+        String hashed = StatisticUtils.hashExternalPartitionName(longPartitionName);
+
+        Assertions.assertTrue(hashed.startsWith(StatsConstants.EXTERNAL_PARTITION_NAME_HASH_PREFIX));
+        // prefix + 16 fixed hex chars, regardless of input length
+        Assertions.assertEquals(StatsConstants.EXTERNAL_PARTITION_NAME_HASH_PREFIX.length() + 16, hashed.length());
+        // deterministic
+        Assertions.assertEquals(hashed, StatisticUtils.hashExternalPartitionName(longPartitionName));
+        // different input -> different hash
+        Assertions.assertNotEquals(hashed, StatisticUtils.hashExternalPartitionName("tenant_id=hash-deadbeef"));
+        // fixed length even for a very long, arbitrarily-formatted partition path
+        String veryLongPartitionName = "tenant_id=" + "a".repeat(200);
+        Assertions.assertEquals(hashed.length(), StatisticUtils.hashExternalPartitionName(veryLongPartitionName).length());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Background collection of column statistics for external tables (Iceberg/Hive/Paimon) writes one row per (table, partition, column) into the internal `_statistics_.external_column_statistics` table, whose primary key is `(table_uuid, partition_name, column_name)`.

For tables that use partition evolution (e.g. a hashed/bucketed partition column), the resulting `partition_name` string can be long. Combined with `table_uuid` and `column_name`, the encoded primary key can exceed the BE's `primary_key_limit_size` (128 bytes by default), and the write fails with `primary key size exceed the limit`. Because the failed partition's stats never get persisted, the very next query re-triggers collection for the same partition, and it fails again — the table gets stuck in a permanent collection-failure loop and never accumulates usable statistics.

`partition_name` is only ever used internally as an opaque dedup/lookup key — it's never shown to users and no code path does substring/prefix matching on it. So there's no need to preserve the original value; replacing it with a fixed-length hash removes the size cap concern entirely, independent of how long or deeply nested the underlying partition scheme is.

## What I'm doing:
- Add `StatisticUtils.hashExternalPartitionName()`, which hashes a partition name into a fixed-length, prefixed string (`v2h-<16 hex chars>`). Applied at the single place `external_column_statistics.partition_name` is actually written (`ExternalFullStatisticsCollectJob`, shared by both full and sample collection), so the stored key length is now bounded regardless of the source partition name.
- Update the one read path that filters by `partition_name` (`PartitionSelector.getExternalTablePartitionStats`, used for materialized-view refresh partition selection) to hash its lookup keys and translate the results back to the caller's original partition names.
- The main CBO statistics-loading query never filtered or grouped by `partition_name`, so it's unaffected by the format change — except for one migration concern:

  ```
  Before migration                         After migration
  +---------------------------------+      +---------------------------------+
  | partition_name = "tenant_id=    |      | partition_name =                |
  |   hash-2c933fdc" (raw, long)    |      |   "v2h-a1b2c3d4e5f60789" (hashed)|
  +---------------------------------+      +---------------------------------+
        same logical partition, but a different primary key now -> both rows
        coexist, so a naive SUM(row_count) across all rows for the table would
        double count this partition
  ```

  Since a primary-key table can't overwrite the old raw-format row with the new hash-keyed one (different key), the aggregate query now adds a `partition_name LIKE 'v2h-%'` filter so only hashed rows are counted. This avoids any destructive migration (no TRUNCATE/DELETE): pre-existing raw-format rows simply stop being read and are naturally superseded as tables get re-collected.
- While touching the IN-clause construction in `PartitionSelector`, also fixed a latent bug: multiple partition names were joined into one comma-separated string and wrapped in a single pair of quotes (`IN ('a,b,c')`), which only ever matched a single-partition lookup.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
