### PR TITLE
[Enhancement] Route VARCHAR sort keys through meta-tier tablet pre-split

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -30,6 +30,7 @@ import org.apache.orc.DecimalColumnStatistics;
 import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
+import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.StripeInformation;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TimestampColumnStatistics;
@@ -65,10 +66,15 @@ import java.util.Objects;
  *       a pre-1970 sub-second — and packs the calendar date through the same proleptic conversion as
  *       the boundary parse). TIMESTAMP_INSTANT is deferred (the load applies a session-tz offset this
  *       reader cannot reproduce).</li>
+ *   <li>ORC STRING/VARCHAR -> StarRocks VARCHAR, using the stripe min/max when ORC
+ *       kept them exact (getMinimum()/getMaximum() non-null); a truncated bound (value
+ *       > 1024 bytes -> getMinimum()/getMaximum() null) marks the stripe truncated -> data
+ *       tier. StarRocks CHAR (the BE pads/truncates it to a fixed width before routing) and the
+ *       ORC CHAR source category (space-padded) are both deferred -> data tier.</li>
  * </ul>
- * Everything else — STRING/CHAR/VARCHAR (data-tier fallback anyway), BOOLEAN,
- * FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this reader cannot reproduce),
- * non-matching-precision/scale DECIMAL, and any complex type — makes the reader throw
+ * Everything else -- BOOLEAN, FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this
+ * reader cannot reproduce), non-matching-precision/scale DECIMAL, ORC CHAR, and any complex type --
+ * makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier. That is
  * NOT a load failure. Pure I/O failures surface as {@link StarRocksException}.
  * Note: a legacy ORC file lacking modern UTC stats (pre-1.5-era footer) decodes through the JVM
@@ -153,10 +159,10 @@ public final class OrcStripeStatisticsReader {
      * Reject ORC/StarRocks type pairings outside meta tier's supported window
      * eagerly, before iterating stripes. Anything outside the window means "fall
      * back to data tier", not "fail the load". The supported window is the unannotated
-     * integer categories, ORC DATE → StarRocks DATE, ORC DECIMAL → a same-precision/scale
-     * StarRocks DECIMAL, and ORC TIMESTAMP → StarRocks DATETIME. String, boolean,
-     * floating-point, TIMESTAMP_INSTANT, non-matching DECIMAL, and complex types are deferred
-     * (fall back to data tier).
+     * integer categories, ORC DATE -> StarRocks DATE, ORC DECIMAL -> a same-precision/scale
+     * StarRocks DECIMAL, ORC TIMESTAMP -> StarRocks DATETIME, and ORC STRING/VARCHAR ->
+     * StarRocks VARCHAR. Boolean, floating-point, TIMESTAMP_INSTANT, non-matching DECIMAL,
+     * a CHAR target, and complex types are deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             TypeDescription fieldType, Column sortKeyColumn) throws MetaTierUnavailableException {
@@ -172,6 +178,12 @@ public final class OrcStripeStatisticsReader {
             // Plain ORC TIMESTAMP is local (no timezone); the BE load stores its UTC wall clock
             // verbatim (no session-tz offset, unlike TIMESTAMP_INSTANT) → StarRocks DATETIME.
             case TIMESTAMP -> starRocksPrimitive == PrimitiveType.DATETIME;
+            // ORC STRING/VARCHAR categories are unpadded; their stripe min/max are
+            // unsigned-byte-ordered (Text/WritableComparator), matching BE VARCHAR routing.
+            // Target CHAR is excluded (the BE pads/truncates CHAR to its fixed width before
+            // routing, so raw stripe stats would not match the routed key), as is the ORC CHAR
+            // source category (space-padded) -> data tier.
+            case STRING, VARCHAR -> starRocksPrimitive == PrimitiveType.VARCHAR;
             default -> false;
         };
         if (!compatible) {
@@ -218,6 +230,10 @@ public final class OrcStripeStatisticsReader {
         if (sortKeyStatistics instanceof TimestampColumnStatistics timestampStatistics
                 && timestampStatistics.getNumberOfValues() > 0) {
             return convertTimestampStripe(timestampStatistics, rowCount, location);
+        }
+        if (sortKeyStatistics instanceof StringColumnStatistics stringStatistics
+                && stringStatistics.getNumberOfValues() > 0) {
+            return convertStringStripe(stringStatistics, rowCount, location);
         }
         // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
         // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
@@ -295,6 +311,32 @@ public final class OrcStripeStatisticsReader {
         } catch (RuntimeException conversionFailure) {
             throw new MetaTierUnavailableException(String.format(
                     "ORC decimal stats value not representable for sort-key column \"%s\": %s",
+                    location.starRocksColumn.getName(), conversionFailure.getMessage()));
+        }
+        return new RowGroupStatistics(
+                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+    }
+
+    private static RowGroupStatistics convertStringStripe(
+            StringColumnStatistics stringStatistics, long rowCount, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        // ORC returns null minimum/maximum exactly when the value was truncated (only a
+        // lower/upper BOUND is retained, for strings longer than 1024 bytes). A truncated
+        // bound is a widened endpoint, unsafe for boundary placement -- mark truncated so
+        // the pipeline falls back to data tier.
+        String min = stringStatistics.getMinimum();
+        String max = stringStatistics.getMaximum();
+        if (min == null || max == null) {
+            return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ true);
+        }
+        Variant minVariant;
+        Variant maxVariant;
+        try {
+            minVariant = Variant.of(location.starRocksColumn.getType(), min);
+            maxVariant = Variant.of(location.starRocksColumn.getType(), max);
+        } catch (RuntimeException conversionFailure) {
+            throw new MetaTierUnavailableException(String.format(
+                    "ORC string stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
         return new RowGroupStatistics(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -72,8 +72,11 @@ import java.util.Objects;
  *   <li>Parquet INT64 with TIMESTAMP annotation, {@code isAdjustedToUTC=false}
  *       (MILLIS/MICROS/NANOS) → StarRocks DATETIME. UTC-adjusted timestamps are
  *       deferred (the load applies a session-tz offset this reader cannot reproduce).</li>
- *   <li>Parquet BINARY with UTF8 (string) annotation → StarRocks CHAR/VARCHAR
- *       (always marked truncated → forces data-tier fallback for string sort keys)</li>
+ *   <li>Parquet BINARY with UTF8 (string) annotation -> StarRocks VARCHAR
+ *       (footer min/max are decoded as UTF-8 and used directly; FE compares them in the
+ *       same unsigned-byte order the BE uses to route rows). CHAR is deferred -> data tier:
+ *       the BE pads/truncates a CHAR value to its fixed width before routing, so raw footer
+ *       stats would not match the routed key.</li>
  *   <li>Parquet INT32/INT64 with DECIMAL annotation → StarRocks DECIMAL of the SAME
  *       precision and scale (the unscaled integer's signed order equals the decimal order).</li>
  *   <li>Parquet FIXED_LEN_BYTE_ARRAY/BINARY with DECIMAL annotation → StarRocks DECIMAL of the
@@ -238,7 +241,11 @@ public final class ParquetRowGroupStatisticsReader {
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> {
                 if (logicalAnnotation instanceof StringLogicalTypeAnnotation) {
-                    yield starRocksPrimitive == PrimitiveType.CHAR || starRocksPrimitive == PrimitiveType.VARCHAR;
+                    // VARCHAR only. A CHAR(N) load pads/truncates every value to the fixed width
+                    // before the BE routes the row (pad_char_values, be/src/exec/data_sinks/tablet_sink.cpp),
+                    // so the raw footer min/max would not match the routed key and could yield a
+                    // skewed split. CHAR falls back to the data tier, which samples the post-cast rows.
+                    yield starRocksPrimitive == PrimitiveType.VARCHAR;
                 }
                 yield isSignedByteArrayDecimal(logicalAnnotation, sortKeyColumn, typeDefinedColumnOrder);
             }
@@ -284,23 +291,21 @@ public final class ParquetRowGroupStatisticsReader {
                     "Parquet stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        // Parquet writers commonly truncate BINARY/string min/max (parquet-mr defaults
-        // to 64 bytes). Truncation does not just inflate spurious overlap — it can also
-        // hide real overlap when adjacent row groups share a long common prefix, which
-        // the downstream overlap detector cannot recover. Mark binary stats as
-        // truncated unconditionally so the pipeline falls back to data tier for string
-        // sort keys until column-index exactness flags are read explicitly. Numeric
-        // and boolean stats are always exact and stay false.
-        // Only string-annotated BINARY is truncation-prone (parquet-mr truncates long binary
-        // min/max at 64 bytes). Numeric stats — including BINARY-backed and FLBA-backed DECIMAL —
-        // are exact; marking a decimal truncated would force a needless data-tier fallback.
-        boolean truncated = location.parquetTypeName == PrimitiveTypeName.BINARY
-                && location.logicalAnnotation instanceof StringLogicalTypeAnnotation;
+        // String (BINARY+UTF8) chunk min/max are exact in practice: parquet-cpp and
+        // parquet-mr do not truncate chunk-level Statistics (parquet-mr's
+        // parquet.statistics.truncate.length defaults to Integer.MAX_VALUE; parquet-cpp
+        // drops stats past max_statistics_size, which the isEmpty() guard above already
+        // routes to data tier). Pre-split is a pure planning optimization: the BE routes
+        // every loaded row to a tablet by its true value, independent of these stats. So
+        // even under a hypothetical custom-truncating writer, a widened min/max can only
+        // skew split boundaries or trigger a conservative overlap fallback -- it can never
+        // misroute or drop data. All numeric/temporal stats are exact too, so this reader
+        // never marks a Parquet row group truncated.
         return new RowGroupStatistics(
                 new Tuple(List.of(minVariant)),
                 new Tuple(List.of(maxVariant)),
                 rowCount,
-                truncated);
+                /*truncated=*/ false);
     }
 
     private static Variant toVariant(Object parquetValue, SortKeyLocation location)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
@@ -38,6 +38,7 @@ import com.starrocks.catalog.Table;
 
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.Arrays;
 
 public class StringUtils {
     private static final String CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -83,35 +84,16 @@ public class StringUtils {
     }
 
     /*
-     * Compare string with utf-8 byte array, same with DM,BE,StorageEngine
+     * Compare two strings by their UTF-8 bytes in UNSIGNED byte order, matching how BE
+     * orders VARCHAR (memcmp on the raw bytes; see be/src/base/string/memcmp.h) and
+     * therefore how BE routes rows into range-distributed tablets. Bytes are masked to
+     * 0..255 (Java byte is signed); on a common prefix the shorter string is smaller (no
+     * trailing-NUL special case). A CHAR value that embeds a NUL is a separate, out-of-scope
+     * edge: the BE CHAR load strips at the first NUL (be/src/column/datum_convert.cpp), which
+     * this raw-byte compare does not model.
      */
     public static int compareStringWithUTF8ByteArray(String s1, String s2) {
-        byte[] s1Bytes = s1.getBytes(StandardCharsets.UTF_8);
-        byte[] s2Bytes = s2.getBytes(StandardCharsets.UTF_8);
-
-        int minLength = Math.min(s1Bytes.length, s2Bytes.length);
-        int i;
-        for (i = 0; i < minLength; i++) {
-            if (s1Bytes[i] < s2Bytes[i]) {
-                return -1;
-            } else if (s1Bytes[i] > s2Bytes[i]) {
-                return 1;
-            }
-        }
-        if (s1Bytes.length > s2Bytes.length) {
-            if (s1Bytes[i] == 0x00) {
-                return 0;
-            } else {
-                return 1;
-            }
-        } else if (s1Bytes.length < s2Bytes.length) {
-            if (s2Bytes[i] == 0x00) {
-                return 0;
-            } else {
-                return -1;
-            }
-        } else {
-            return 0;
-        }
+        return Arrays.compareUnsigned(
+                s1.getBytes(StandardCharsets.UTF_8), s2.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -117,18 +117,67 @@ class OrcStripeStatisticsReaderTest {
     }
 
     @Test
-    void stringColumnFallsBackToDataTier() throws Exception {
-        // ORC string stats would always need data-tier fallback; v1 rejects the
-        // type eagerly rather than wiring a string-stats path.
+    void readsStringStatistics() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<tenant:string>",
+                /*rowCount=*/ 8,
+                (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
+                        .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
+
+        List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+
+        Assertions.assertFalse(stripeStatistics.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics stripe : stripeStatistics) {
+            Assertions.assertFalse(stripe.isTruncated());
+            String minValue = stripe.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = stripe.getMaxTuple().getValues().get(0).getStringValue();
+            Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("tenant-00", globalMin);
+        Assertions.assertEquals("tenant-07", globalMax);
+    }
+
+    @Test
+    void truncatedStringStatsFallBackToDataTier() throws Exception {
+        // ORC keeps exact string min/max only up to 1024 bytes; beyond that it records
+        // a truncated bound and getMinimum()/getMaximum() return null -> mark truncated.
+        String longPrefix = "z".repeat(2000);
         Path orcPath = writeOrc(
                 "struct<tenant:string>",
                 /*rowCount=*/ 4,
                 (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
-                        .setVal(batchRow, ("tenant-" + rowIndex).getBytes(StandardCharsets.UTF_8)));
+                        .setVal(batchRow, (longPrefix + rowIndex).getBytes(StandardCharsets.UTF_8)));
+
+        List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+
+        Assertions.assertFalse(stripeStatistics.isEmpty());
+        for (RowGroupStatistics stripe : stripeStatistics) {
+            Assertions.assertTrue(stripe.isTruncated());
+            Assertions.assertNull(stripe.getMinTuple());
+            Assertions.assertNull(stripe.getMaxTuple());
+        }
+    }
+
+    @Test
+    void charSortKeyFallsBackToDataTier() throws Exception {
+        // A CHAR(N) sort key is padded/truncated to its fixed width by the BE before routing,
+        // so the raw stripe min/max cannot be trusted for a meta-tier split -- reject eagerly.
+        Path orcPath = writeOrc(
+                "struct<tenant:string>",
+                /*rowCount=*/ 4,
+                (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
+                        .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("tenant", TypeFactory.createCharType(16))));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -94,9 +94,9 @@ class ParquetRowGroupStatisticsReaderTest {
         String globalMin = null;
         String globalMax = null;
         for (RowGroupStatistics rowGroup : rowGroupStatistics) {
-            // Binary stats are conservatively marked truncated so string sort keys
-            // route through data tier — see the class javadoc for rationale.
-            Assertions.assertTrue(rowGroup.isTruncated());
+            // String chunk stats are exact in practice (parquet-cpp/parquet-mr do not
+            // truncate chunk-level Statistics); trust them for a meta-tier split.
+            Assertions.assertFalse(rowGroup.isTruncated());
             String minValue = rowGroup.getMinTuple().getValues().get(0).getStringValue();
             String maxValue = rowGroup.getMaxTuple().getValues().get(0).getStringValue();
             Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
@@ -105,6 +105,21 @@ class ParquetRowGroupStatisticsReaderTest {
         }
         Assertions.assertEquals("tenant-00", globalMin);
         Assertions.assertEquals("tenant-15", globalMax);
+    }
+
+    @Test
+    void charSortKeyFallsBackToDataTier() throws Exception {
+        // A CHAR(N) sort key is padded/truncated to its fixed width by the BE before routing,
+        // so the raw UTF8 footer min/max cannot be trusted for a meta-tier split -- reject eagerly.
+        Path parquetPath = writeParquet(
+                "message schema { required binary tenant (UTF8); }",
+                /*rowCount=*/ 4,
+                (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("tenant", TypeFactory.createCharType(16))));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -275,8 +275,25 @@ public class VariantTest {
         StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "abc\0");
         StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "abc");
 
-        // When one string has null byte at the end, they should be equal
-        Assertions.assertEquals(0, v1.compareTo(v2));
+        // A trailing NUL is a real extra byte: BE memcompare (be/src/base/string/memcmp.h)
+        // has no NUL special case, so the longer string sorts after the shorter one.
+        Assertions.assertTrue(v1.compareTo(v2) > 0);
+        Assertions.assertTrue(v2.compareTo(v1) < 0);
+    }
+
+    @Test
+    public void testStringVariantNonAsciiUnsignedOrder() {
+        // FE StringVariant ordering must equal BE unsigned-byte order.
+        StringVariant z = new StringVariant(VarcharType.VARCHAR, "z");
+        StringVariant e = new StringVariant(VarcharType.VARCHAR, "é"); // é, 0xC3 0xA9
+        Assertions.assertTrue(z.compareTo(e) < 0);
+        Assertions.assertTrue(e.compareTo(z) > 0);
+        StringVariant a = new StringVariant(VarcharType.VARCHAR, "a");
+        StringVariant cjk = new StringVariant(VarcharType.VARCHAR, "中"); // 中, 0xE4 0xB8 0xAD
+        Assertions.assertTrue(a.compareTo(cjk) < 0);
+        StringVariant abc = new StringVariant(VarcharType.VARCHAR, "abc");
+        StringVariant abcd = new StringVariant(VarcharType.VARCHAR, "abcd");
+        Assertions.assertTrue(abc.compareTo(abcd) < 0);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/StringUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/StringUtilsTest.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StringUtilsTest {
+
+    @Test
+    public void asciiOrderingUnchanged() {
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abc", "abd") < 0);
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abd", "abc") > 0);
+        Assertions.assertEquals(0, StringUtils.compareStringWithUTF8ByteArray("abc", "abc"));
+    }
+
+    @Test
+    public void shorterPrefixIsSmaller() {
+        // "abc" < "abcd" (common prefix, shorter first) -- matches BE length tie-break.
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abc", "abcd") < 0);
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abcd", "abc") > 0);
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("", "a") < 0);
+        Assertions.assertEquals(0, StringUtils.compareStringWithUTF8ByteArray("", ""));
+    }
+
+    @Test
+    public void nonAsciiComparesUnsigned() {
+        // 'z' = 0x7A, 'é' = U+00E9 = UTF-8 0xC3 0xA9. Unsigned: 0x7A < 0xC3, so "z" < "é".
+        // (Signed-byte compare would treat 0xC3 as -61 and wrongly rank "é" first.)
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("z", "é") < 0);
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("é", "z") > 0);
+        // Multi-byte CJK '中' = 0xE4 0xB8 0xAD, still greater than ASCII 'a'.
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("a", "中") < 0);
+        // Two non-ASCII: 'é'(0xC3..) < '中'(0xE4..).
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("é", "中") < 0);
+    }
+
+    @Test
+    public void trailingNulByteHasNoSpecialCase() {
+        // "abc\0" is longer than "abc"; with no NUL special case, longer is larger.
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abc", "abc\0") < 0);
+        Assertions.assertTrue(StringUtils.compareStringWithUTF8ByteArray("abc\0", "abc") > 0);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
@@ -522,6 +522,34 @@ public class RangeDistributionPrunerTest {
         });
     }
 
+    @Test
+    public void testSingleColumnNonAsciiEqualityPrune() {
+        Column k = new Column("k", VarcharType.VARCHAR, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        // Unsigned byte order: a < b < c < d < m < é (é's first UTF-8 byte 0xC3 > ASCII 'm' 0x6D).
+        // Tablet 3 spans an ASCII lower bound to a non-ASCII upper bound; [m, é] is a valid
+        // ascending range ONLY under unsigned bytes. The old signed compare ranks é below every
+        // ASCII byte, inverting that range so RangeDistributionPruner's TreeMap lookup drops it.
+        tablets.add(createTablet(1L, "a", "b", k));
+        tablets.add(createTablet(2L, "c", "d", k));
+        tablets.add(createTablet(3L, "m", "é", k));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("é"), true);
+        filter.setUpperBound(new StringLiteral("é"), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k), filters);
+
+        // "é" lies in tablet 3's [m, é] under unsigned bytes, so only tablet 3 matches. The old
+        // signed-byte compare inverts that range and orders every tablet above the query, so the
+        // pruner returns empty (misses tablet 3) -- this assertion is the RED/GREEN guard.
+        Assertions.assertEquals(Collections.singleton(3L), new HashSet<>(pruner.prune()));
+    }
+
     private Tablet createTablet(long id, String lower, String upper, Column column) {
         LocalTablet tablet = new LocalTablet(id);
         List<Variant> lowerValues = Lists.newArrayList(Variant.of(column.getType(), lower));


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split's meta tier (the footer-statistics path) could not handle VARCHAR sort keys — string columns always fell back to the more expensive data-tier sample. Extending the meta tier to strings also surfaced a pre-existing correctness bug: the FE string comparator (`StringUtils.compareStringWithUTF8ByteArray`) compared UTF-8 bytes as **signed** Java bytes and carried a trailing-NUL "equal" special case, so its ordering diverged from the BE, which routes range-distributed rows by an **unsigned** `memcmp` (`be/src/base/string/memcmp.h`). For a non-ASCII VARCHAR range-distribution key this could make `RangeDistributionPruner` prune a tablet the BE had actually filled, dropping rows from query results. Meta-tier string boundaries are only safe once FE ordering matches BE ordering.

## What I'm doing:

1. **Fix the FE string comparator to match BE (query-correctness bug fix).** `StringUtils.compareStringWithUTF8ByteArray` now delegates to `Arrays.compareUnsigned` — unsigned UTF-8 byte order, shorter-prefix-is-smaller tie-break, no trailing-NUL special case — which is byte-identical to BE `memcompare`. Its sole caller is `StringVariant.compareToImpl`, so this aligns every consumer of `Variant`/`Tuple` ordering (pre-split boundaries, query-time `RangeDistributionPruner`, range-colocate dispatch) with how the BE routes rows, for both VARCHAR and CHAR keys.

2. **Parquet meta-tier VARCHAR.** `ParquetRowGroupStatisticsReader` no longer marks BINARY+UTF8 (string) chunk statistics truncated. parquet-cpp / parquet-mr do not truncate chunk-level `Statistics` (parquet-mr's `parquet.statistics.truncate.length` defaults to `Integer.MAX_VALUE`; parquet-cpp drops oversized stats entirely, which the existing `isEmpty()` guard already routes to the data tier). Pre-split is a pure planning optimization — the BE routes every row by its true value — so a VARCHAR sort key now flows through the meta tier.

3. **ORC meta-tier VARCHAR.** `OrcStripeStatisticsReader` accepts the ORC STRING/VARCHAR categories (unpadded, unsigned-byte-ordered stripe stats) for a VARCHAR sort key and decodes the stripe min/max. ORC returns `null` from `getMinimum()`/`getMaximum()` exactly when a value exceeded 1024 bytes and only a truncated bound was retained; that stripe is marked truncated and falls back to the data tier.

**CHAR is intentionally deferred to the data tier** (both readers): the BE pads/truncates a `CHAR(N)` value to its fixed width before it routes the row (`pad_char_values`, `be/src/exec/data_sinks/tablet_sink.cpp`), so raw footer/stripe stats would not match the routed key and could produce a skewed split. The data tier samples the post-cast rows and is unaffected. This also matches the existing deferral of the ORC CHAR source category.

Tests: new `StringUtilsTest`; `VariantTest` gains a non-ASCII ordering case and updates the trailing-NUL case to BE parity; `RangeDistributionPrunerTest` gains a non-ASCII pruning regression; the Parquet/ORC reader tests assert meta-tier VARCHAR reads, ORC's >1024-byte truncation fallback, and CHAR-sort-key data-tier fallback.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5