### PR TITLE
[Enhancement] Skip privilege check for root in statistic SHOW statements

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -3505,10 +3505,13 @@ public class ShowExecutor {
         row.set(1, table.getName());
 
         // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
-        try {
-            Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-        } catch (AccessDeniedException e) {
-            return null;
+        // root always has every privilege, so skip the check for it.
+        if (!StatisticUtils.isRootUser(context)) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+            } catch (AccessDeniedException e) {
+                return null;
+            }
         }
 
         long totalCollectColumnsSize = StatisticUtils.getCollectibleColumns(table).size();
@@ -3550,10 +3553,13 @@ public class ShowExecutor {
         row.set(1, tableName);
 
         // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
-        try {
-            Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-        } catch (AccessDeniedException e) {
-            return null;
+        // root always has every privilege, so skip the check for it.
+        if (!StatisticUtils.isRootUser(context)) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+            } catch (AccessDeniedException e) {
+                return null;
+            }
         }
 
         long totalCollectColumnsSize = StatisticUtils.getCollectibleColumns(table).size();
@@ -3585,10 +3591,13 @@ public class ShowExecutor {
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }
-        try {
-            Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-        } catch (AccessDeniedException e) {
-            return null;
+        // root always has every privilege, so skip the check for it.
+        if (!StatisticUtils.isRootUser(context)) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+            } catch (AccessDeniedException e) {
+                return null;
+            }
         }
 
         row.set(1, table.getName());
@@ -3613,17 +3622,23 @@ public class ShowExecutor {
             throw new MetaNotFoundException("No found database: " + catalogName + "." + dbName);
         }
         row.set(0, catalogName + "." + dbName);
+
+        // getTable() also verifies the table still exists (throws below otherwise), so it must run
+        // unconditionally even for root - only the privilege check that follows can be skipped,
+        // since root is guaranteed to hold every privilege already.
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalogName, dbName, tableName);
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + catalogName + "." + dbName + "." + tableName);
         }
-        try {
-            Authorizer.checkAnyActionOnTable(context, new TableName(catalogName, db.getFullName(), table.getName()));
-        } catch (AccessDeniedException e) {
-            return null;
+        if (!StatisticUtils.isRootUser(context)) {
+            try {
+                Authorizer.checkAnyActionOnTable(context, new TableName(catalogName, db.getFullName(), table.getName()));
+            } catch (AccessDeniedException e) {
+                return null;
+            }
         }
 
-        row.set(1, table.getName());
+        row.set(1, tableName);
         row.set(2, histogramStatsMeta.getColumn());
         row.set(3, histogramStatsMeta.getType().name());
         row.set(4, histogramStatsMeta.getUpdateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
@@ -3647,10 +3662,13 @@ public class ShowExecutor {
         if (table == null) {
             throw new MetaNotFoundException("No found table: " + tableId);
         }
-        try {
-            Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-        } catch (AccessDeniedException e) {
-            return null;
+        // root always has every privilege, so skip the check for it.
+        if (!StatisticUtils.isRootUser(context)) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+            } catch (AccessDeniedException e) {
+                return null;
+            }
         }
 
         row.set(1, table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeJob;
+import com.starrocks.statistic.StatisticUtils;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -60,6 +61,11 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
 
             if (!analyzeJob.isAnalyzeAllTable()) {
                 String tableName = analyzeJob.getTableName();
+                row.set(3, tableName);
+
+                // getTable() also verifies the table still exists (throws below otherwise), so it
+                // must run unconditionally even for root - only the privilege check that follows can
+                // be skipped, since root is guaranteed to hold every privilege already.
                 Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
                         .getTable(context, analyzeJob.getCatalogName(), dbName, tableName);
 
@@ -67,15 +73,15 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
                     throw new MetaNotFoundException("No found table: " + tableName);
                 }
 
-                row.set(3, table.getName());
-
                 // In new privilege framework(RBAC), user needs any action on the table to show analysis job on it,
                 // for jobs on entire instance or entire db, we just show it directly because there isn't a specified
                 // table to check privilege on.
-                try {
-                    Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-                } catch (AccessDeniedException e) {
-                    return null;
+                if (!StatisticUtils.isRootUser(context)) {
+                    try {
+                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+                    } catch (AccessDeniedException e) {
+                        return null;
+                    }
                 }
 
                 if (null != columns && !columns.isEmpty()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -55,14 +55,18 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
         row.set(2, analyzeStatus.getTableName());
 
         Table table;
-        // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
+        // getTable() also verifies the table still exists (returns null / throws below otherwise),
+        // so it must run unconditionally even for root - only the privilege check that follows can
+        // be skipped, since root is guaranteed to hold every privilege already.
         try {
             table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
                     context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
             if (table == null) {
                 throw new SemanticException("Table %s is not found", analyzeStatus.getTableName());
             }
-            Authorizer.checkAnyActionOnTableLikeObject(context, analyzeStatus.getDbName(), table);
+            if (!StatisticUtils.isRootUser(context)) {
+                Authorizer.checkAnyActionOnTableLikeObject(context, analyzeStatus.getDbName(), table);
+            }
         } catch (Exception e) {
             LOG.warn("Failed to check privilege for show analyze status for table {}.", analyzeStatus.getTableName(), e);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -474,6 +474,14 @@ public class StatisticUtils {
         }
     }
 
+    // root always holds every privilege, so privilege checks on root are guaranteed to pass.
+    // Callers on hot paths (e.g. SHOW ANALYZE STATUS/JOB, SHOW STATS META) can use this to skip
+    // the privilege check itself, and where possible, the getTable() lookup that only exists to
+    // feed that check.
+    public static boolean isRootUser(ConnectContext context) {
+        return context.getCurrentUserIdentity().equals(UserIdentity.ROOT);
+    }
+
     // Get all the columns in the table that can be collected.
     // The list will only contain:
     // 1. non-aggregated column


### PR DESCRIPTION
## Why I'm doing:
`SHOW ANALYZE STATUS`, `SHOW ANALYZE JOB`, and `SHOW STATS META` / `SHOW HISTOGRAM STATS` / `SHOW MULTI COLUMN STATS META` all iterate over historical statistics metadata and, for each row, resolve the underlying table and then run an `Authorizer` privilege check before including that row in the output.

`root` always holds every privilege (it's granted the built-in `root_role`), so this check is guaranteed to pass. In BYOC deployments, ops backends poll these `SHOW` statements as `root`, so the check runs (and always succeeds) on every row of every poll — pure overhead in that case.

## What I'm doing:
- Added a small `StatisticUtils.isRootUser(context)` helper.
- Wrapped the `Authorizer.checkAnyActionOnTableLikeObject(...)` / `checkAnyActionOnTable(...)` call in all 7 affected methods (`ShowAnalyzeStatusStmt`, `ShowAnalyzeJobStmt`, and 5 methods in `ShowExecutor`) with `if (!StatisticUtils.isRootUser(context))`, so root skips just that check.

**Note on scope — table resolution itself is *not* skipped.** The initial version of this change also tried to skip the table lookup (`getTable()`) for root when possible, since for external catalogs (Hive/Iceberg) that call can be an expensive Glue/HMS RPC. That turned out to be unsafe:

```
getTable() serves two purposes bundled together:
  1. feed the privilege check          <- safe to skip for root (check always passes anyway)
  2. verify the table still exists     <- NOT safe to skip

If skipped for a table that was since dropped:
  root sees a stale row instead of it being filtered out,
  and any downstream field that assumes "table exists" can crash
  (caught by AnalyzeStmtTest.testShow: NPE on a null status
   field for a deliberately-nonexistent external table).
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
