### PR TITLE
[BugFix] Make experimental_lake_ignore_lost_segment skip lost segments without crashing

### DIFF
--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -20,6 +20,7 @@
 #include "base/status.h"
 #include "base/status_fmt.hpp"
 #include "base/statusor.h"
+#include "common/config_lake_fwd.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "exec/exec_env.h"
 #include "exec/olap_scan_node.h"
@@ -369,6 +370,19 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     }
 
     const auto* segment = segments[target_segment_idx].get();
+    // A GLM point-lookup must return exactly the rows at the requested locators: the consumer accumulates
+    // the fetched rows and materializes them by a permutation built over the full locator set. Yielding no
+    // row would leave the accumulated chunk shorter than the permutation (silent wrong rows, or a
+    // null-chunk deref when every locator is lost). So a null segment -- which, unlike a scan, this path
+    // cannot tolerate -- must fail cleanly here whether or not experimental_lake_ignore_lost_segment is on.
+    if (segment == nullptr) {
+        return Status::InternalError(fmt::format(
+                "null segment (index:{}) for lake rssid:{}{}", target_segment_idx, rssid,
+                config::experimental_lake_ignore_lost_segment
+                        ? " (a segment lost + tolerated by experimental_lake_ignore_lost_segment; a point lookup "
+                          "cannot locate rows in it)"
+                        : " (unexpected: experimental_lake_ignore_lost_segment is off)"));
+    }
     rs_opts.rowid_range_option->add(target.get(), segment, rowid_range, true);
 
     ASSIGN_OR_RETURN(auto iters, target->read(_read_schema, rs_opts));

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -243,6 +243,16 @@ Status ColumnModePartialUpdateHandler::_update_source_chunk_by_upt(const UptidTo
     // handle upt files one by one
     for (const auto& each : upt_id_to_rowid_pairs) {
         const uint32_t upt_id = each.first;
+        // A nullptr iterator is a lost update-file segment ignored via
+        // experimental_lake_ignore_lost_segment. A lost upt segment produces no rowid pairs, so this
+        // upt_id should not appear here; guard anyway so read_chunk_from_update_file never dereferences
+        // a null iterator (mirrors the close() guard below).
+        if (segment_iters[upt_id] == nullptr) {
+            LOG(WARNING) << "column-mode partial update skips a null update-file segment iterator, tablet: "
+                         << _rowset_ptr->tablet_id() << ", upt_id: " << upt_id
+                         << " (a lost segment via experimental_lake_ignore_lost_segment, or an unexpected empty slot)";
+            continue;
+        }
         // 1. get chunk from upt file
         ChunkUniquePtr upt_chunk = ChunkFactory::new_chunk(partial_schema, DEFAULT_CHUNK_SIZE);
         DeferOp iter_defer([&]() {

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -208,6 +208,14 @@ StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
                                    .fill_metadata_cache = false};
         ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts));
         for (auto& segment : segments) {
+            // A null placeholder slot means a segment produced no reader (e.g. a lost segment dropped by
+            // experimental_lake_ignore_lost_segment). This chunk-size estimate is position-agnostic, so
+            // just skip it whatever the cause.
+            if (segment == nullptr) {
+                LOG(WARNING) << "horizontal compaction chunk-size estimation skips a null (lost) segment, tablet: "
+                             << _tablet.id() << ", rowset: " << rowset->id();
+                continue;
+            }
             for (size_t i = 0; i < segment->num_columns(); ++i) {
                 auto uid = _tablet_schema->column(i).unique_id();
                 const auto* column_reader = segment->column_with_uid(uid);

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1294,7 +1294,10 @@ StatusOr<std::optional<OneRowsetScan>> build_one_rowset_scan(const RowsetPtr& ro
     }
     RETURN_IF_ERROR(res.status());
     out.iters = std::move(res).value();
-    CHECK(out.iters.size() == rowset->num_segments()) << "itrs.size != num_segments";
+    // Surface a wrong-sized iterator vector as a graceful error rather than aborting the BE: this is
+    // a recovery path (experimental_lake_ignore_lost_segment), and the sibling checks in
+    // LakePrimaryIndex / the local persistent-index loader already use RETURN_ERROR_IF_FALSE.
+    RETURN_ERROR_IF_FALSE(out.iters.size() == rowset->num_segments(), "itrs.size != num_segments");
 
     // One flat scan unit per non-null, non-skipped segment; the unit borrows the iterator owned by
     // out.iters.

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -124,4 +124,20 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     });
 }
 
+std::vector<uint32_t> LakePrimaryKeyCompactionConflictResolver::output_segment_num_rows() const {
+    // segment_metas order matches the positionally-aligned segment/iterator vectors produced by
+    // load_segments / get_each_segment_iterator, so index i here is the i-th resolved segment.
+    const auto& rowset_meta = _rowset->metadata();
+    std::vector<uint32_t> result;
+    result.reserve(rowset_meta.segment_metas_size());
+    for (int i = 0; i < rowset_meta.segment_metas_size(); i++) {
+        const auto& seg_meta = rowset_meta.segment_metas(i);
+        // num_rows is optional; report "unknown" for an old rowset that lacks it so the base resolver
+        // fails clearly instead of under-advancing the rows-mapper. Sibling readers guard it the same
+        // way (see lake_persistent_index.cpp / rowset.cpp).
+        result.push_back(seg_meta.has_num_rows() ? static_cast<uint32_t>(seg_meta.num_rows()) : kUnknownSegmentNumRows);
+    }
+    return result;
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.h
@@ -65,6 +65,11 @@ public:
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler)
             override;
 
+protected:
+    // Per-output-segment row counts from the output rowset metadata, so the base resolver can advance
+    // the rows-mapper past a lost segment (experimental_lake_ignore_lost_segment) without the segment.
+    std::vector<uint32_t> output_segment_num_rows() const override;
+
 private:
     // input
     const TabletMetadata* _metadata = nullptr;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -182,6 +182,21 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
     for (size_t i = 0; i < metadata().next_compaction_offset(); ++i) {
         auto* segment_meta = output_rowset->add_segment_metas();
         segment_meta->CopyFrom(metadata().segment_metas(i));
+        if (already_compacted_segments[i].segment == nullptr) {
+            // A null slot here is only expected when a physically-lost segment was tolerated by
+            // experimental_lake_ignore_lost_segment; with the flag off it is an unexpected bug, so fail
+            // loudly instead of silently mis-accounting.
+            RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                                  fmt::format("unexpected null segment when collecting compacted segment info, "
+                                              "tablet:{} rowset:{} segidx:{}",
+                                              _tablet_id, metadata().id(), i));
+            // Its file size is unknown, so drop the file-size info (like the get_data_size failure branch).
+            // Still account its metadata row count so the output rowset's num_rows stays consistent with
+            // the sum of the segment_metas we copied above.
+            clear_file_size_info = true;
+            uncompacted_num_rows += metadata().segment_metas(i).num_rows();
+            continue;
+        }
         StatusOr<int64_t> size_or = already_compacted_segments[i].segment->get_data_size();
         int64_t file_size = 0;
         if (size_or.ok()) {
@@ -217,6 +232,21 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
          i < metadata().segment_metas_size(); ++i, ++idx) {
         auto* segment_meta = output_rowset->add_segment_metas();
         segment_meta->CopyFrom(metadata().segment_metas(i));
+        if (uncompacted_segments[idx].segment == nullptr) {
+            // A null slot here is only expected when a physically-lost segment was tolerated by
+            // experimental_lake_ignore_lost_segment; with the flag off it is an unexpected bug, so fail
+            // loudly instead of silently mis-accounting.
+            RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                                  fmt::format("unexpected null segment when collecting uncompacted segment info, "
+                                              "tablet:{} rowset:{} segidx:{}",
+                                              _tablet_id, metadata().id(), i));
+            // Its file size is unknown, so drop the file-size info (like the get_data_size failure branch).
+            // Still account its metadata row count so the output rowset's num_rows stays consistent with
+            // the sum of the segment_metas we copied above.
+            clear_file_size_info = true;
+            uncompacted_num_rows += metadata().segment_metas(i).num_rows();
+            continue;
+        }
         StatusOr<int64_t> size_or = uncompacted_segments[idx].segment->get_data_size();
         int64_t file_size = 0;
         if (size_or.ok()) {
@@ -431,6 +461,12 @@ StatusOr<size_t> Rowset::get_read_iterator_num() {
 
     size_t segment_num = 0;
     for (auto& seg_ptr : segments) {
+        // This count is position-agnostic, so a null placeholder slot (e.g. a lost segment dropped by
+        // experimental_lake_ignore_lost_segment) simply contributes no read iterator -- skip it whatever
+        // its cause.
+        if (seg_ptr == nullptr) {
+            continue;
+        }
         if (seg_ptr->num_rows() == 0) {
             continue;
         }
@@ -449,8 +485,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     TRACE_COUNTER_SCOPE_LATENCY_US("get_each_segment_us");
     std::vector<LoadedSegment> segments;
     RETURN_IF_ERROR(load_segments(&segments, file_data_cache));
-    std::vector<ChunkIteratorPtr> seg_iterators;
-    seg_iterators.reserve(segments.size());
+    // Size the result up front and write each iterator to its segment's position, so the returned
+    // vector stays positionally aligned with `segments` (and its size always equals num_segments).
+    // Callers index it by position and assert on the size; a segment that produces no iterator -- a
+    // lost segment (experimental_lake_ignore_lost_segment) or an EndOfFile segment -- is left as the
+    // default null in its own slot. Mirrors get_each_segment_iterator_with_delvec.
+    std::vector<ChunkIteratorPtr> seg_iterators(segments.size());
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
     SegmentReadOptions seg_options;
     ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
@@ -477,6 +517,16 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
 
     for (int i = 0; i < segments.size(); i++) {
         auto& seg_ptr = segments[i].segment;
+        if (seg_ptr == nullptr) {
+            // This vector must stay positionally aligned, so a null segment can only be tolerated (its
+            // slot left as the default null placeholder) when experimental_lake_ignore_lost_segment
+            // dropped a physically-lost segment. With the flag off it is an unexpected bug -- fail loudly.
+            RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                                  fmt::format("unexpected null segment in get_each_segment_iterator, "
+                                              "tablet:{} rowset:{} segidx:{}",
+                                              tablet_id(), metadata().id(), i));
+            continue;
+        }
         seg_options.tablet_range = std::nullopt;
         const int32_t meta_pos = segments[i].segment_meta_pos;
         if (meta_pos < _metadata->segment_metas_size() && _metadata->segment_metas(meta_pos).shared() &&
@@ -485,12 +535,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
         }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
+            // Leave seg_iterators[i] as the default null placeholder, preserving alignment.
             continue;
         }
         if (!res.ok()) {
             return res.status();
         }
-        seg_iterators.push_back(std::move(res).value());
+        seg_iterators[i] = std::move(res).value();
     }
     return seg_iterators;
 }
@@ -530,6 +581,17 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
 
     for (int i = 0; i < segments.size(); i++) {
         auto& seg_ptr = segments[i].segment;
+        if (seg_ptr == nullptr) {
+            // This vector must stay positionally aligned (callers derive the rssid from a segment's
+            // position), so a null segment can only be tolerated -- leaving seg_iterators[i] as the
+            // default null placeholder, same as the EOF case -- when experimental_lake_ignore_lost_segment
+            // dropped a physically-lost segment. With the flag off it is an unexpected bug -- fail loudly.
+            RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                                  fmt::format("unexpected null segment in get_each_segment_iterator_with_delvec, "
+                                              "tablet:{} rowset:{} segidx:{}",
+                                              tablet_id(), metadata().id(), i));
+            continue;
+        }
         // Give the i-th iterator its own stats when requested, so concurrent scans don't race on a
         // shared stats object; otherwise all segments share `stats`.
         if (per_segment_stats != nullptr && i < static_cast<int>(per_segment_stats->size())) {
@@ -678,6 +740,15 @@ Status Rowset::load_segments(std::vector<LoadedSegment>* segments, SegmentReadOp
             }
         } else if (segment_or.status().is_not_found() && ignore_lost_segment) {
             LOG(WARNING) << "Ignored lost segment " << seg_name;
+            // Keep the segment vector positionally aligned with metadata: leave a nullptr placeholder
+            // for the lost segment instead of dropping it (mirrors the metadata-filter skip above).
+            // Callers index the result by segment position (to derive rssid) and assert
+            // size == num_segments; a dropped entry would misalign every later segment and trip those
+            // checks. In index-mapping mode the slot is already nullptr from the earlier resize(), so
+            // only the sequential path needs to push the placeholder.
+            if (!use_index_mapping) {
+                segments->emplace_back(LoadedSegment{nullptr, meta_pos});
+            }
         } else {
             return segment_or.status().clone_and_prepend(fmt::format(
                     "load_segments failed tablet:{} rowset:{} segid:{}", _tablet_id, metadata().id(), seg_id));

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -151,10 +151,14 @@ public:
 
     [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments(const LakeIOOptions& lake_io_opts);
 
-    // Pairs a loaded segment with its position in _metadata->segment_metas(). load_segments() packs
-    // its result densely (segment-range start, partial-compaction trim, lost segments), so an
-    // element's index there is NOT its metadata position; consult per-segment metadata (e.g. shared())
-    // via `segment_meta_pos` -- the segment_metas() array position, not Segment::id()/segment_idx.
+    // Pairs a loaded segment with its position in _metadata->segment_metas(). load_segments() does not
+    // keep its result index-aligned with segment_metas -- segment-range start and partial-compaction
+    // trim shift/drop entries -- so an element's index there is NOT its metadata position; consult
+    // per-segment metadata (e.g. shared()) via `segment_meta_pos`, the segment_metas() array position,
+    // not Segment::id()/segment_idx. A lost segment (experimental_lake_ignore_lost_segment) is the
+    // exception: it is kept in place as a nullptr placeholder to preserve alignment. As a result the
+    // `segment` here -- and the SegmentPtr entries from segments()/get_segments() -- can be null, so
+    // every consumer must treat a null segment as "skip this one".
     struct LoadedSegment {
         SegmentPtr segment;           // nullptr if the segment was skipped, filtered out, or lost
         int32_t segment_meta_pos = 0; // position in _metadata->segment_metas()

--- a/be/src/storage/lake/segment_pk_iterator.cpp
+++ b/be/src/storage/lake/segment_pk_iterator.cpp
@@ -136,7 +136,12 @@ StatusOr<MutableColumnPtr> SegmentPKIterator::encoded_pk_column(const Chunk* chu
 }
 
 void SegmentPKIterator::close() {
-    _iter->close();
+    // _iter is null when this wraps a lost segment ignored via experimental_lake_ignore_lost_segment
+    // (get_each_segment_iterator returns a nullptr placeholder for that slot). _load() already tolerates
+    // a null _iter; guard close() too so PK publish/partial-update paths don't crash on the empty slot.
+    if (_iter != nullptr) {
+        _iter->close();
+    }
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -239,9 +239,10 @@ Status TabletReader::init_compaction_column_paths(const TabletReaderParams& read
 
     DCHECK(is_compaction(read_params.reader_type) && read_params.column_access_paths != nullptr &&
            read_params.column_access_paths->empty());
+    // get_non_null_segments() drops lost-segment placeholders (experimental_lake_ignore_lost_segment).
     int num_readers = 0;
     for (const auto& rowset : _rowsets) {
-        auto segments = rowset->get_segments();
+        auto segments = rowset->get_non_null_segments();
         std::for_each(segments.begin(), segments.end(),
                       [&](const auto& segment) { num_readers += segment->num_rows() > 0 ? 1 : 0; });
     }
@@ -255,7 +256,7 @@ Status TabletReader::init_compaction_column_paths(const TabletReaderParams& read
         }
         readers.clear();
         for (const auto& rowset : _rowsets) {
-            for (const auto& segment : rowset->get_segments()) {
+            for (const auto& segment : rowset->get_non_null_segments()) {
                 if (segment->num_rows() == 0) {
                     continue;
                 }

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -17,6 +17,7 @@
 #include "base/debug/trace.h"
 #include "column/chunk_factory.h"
 #include "common/config_exec_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
@@ -80,9 +81,6 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     auto chunk = chunk_shared_ptr.get();
 
     auto itr = _segment_iters[segment_id].get();
-    if (itr == nullptr) {
-        return Status::OK();
-    }
     auto& dest = pk_cols[segment_id];
     auto col = pk_column->clone();
     if (itr != nullptr) {
@@ -99,6 +97,16 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
             }
         }
         itr->close();
+    } else {
+        // A null iterator only appears for a physically-lost segment that get_each_segment_iterator
+        // dropped under experimental_lake_ignore_lost_segment; with the flag off it is an unexpected bug,
+        // so fail loudly. When tolerated, leave the encoded PK column empty (it contributes no rows to the
+        // index) instead of leaving pk_cols[segment_id] null, which the compaction-publish caller
+        // dereferences (pk_col->size() / index.try_replace(*pk_col, ...)).
+        RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                              strings::Substitute("unexpected null segment iterator at position $0 during "
+                                                  "compaction state collection",
+                                                  segment_id));
     }
     dest = std::move(col);
     _memory_usage += dest->memory_usage();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1967,14 +1967,25 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
     } else {
         RETURN_IF_ERROR(resolver->execute());
     }
+    // A lost output segment (experimental_lake_ignore_lost_segment) has no data and its SST must not be
+    // ingested, otherwise the PK index would reference an rssid that scans skip. The resolver reports
+    // those positions; skip both the delvec and the SST ingest for them so the index stays consistent
+    // (the segment_metas are still kept in the output rowset -- its data is simply gone).
+    const auto& lost_segments = resolver->lost_segment_positions();
     // 3. add delvec to builder
-    for (auto&& each : delvecs) {
-        builder->append_delvec(each.second, each.first);
+    for (size_t i = 0; i < delvecs.size(); i++) {
+        if (lost_segments.count(static_cast<uint32_t>(i)) > 0) {
+            continue;
+        }
+        builder->append_delvec(delvecs[i].second, delvecs[i].first);
     }
     // 4. ingest ssts to index
     DCHECK(op_compaction.ssts_size() == 0 || delvecs.size() == op_compaction.ssts_size())
             << "delvecs.size(): " << delvecs.size() << ", op_compaction.ssts_size(): " << op_compaction.ssts_size();
     for (int i = 0; i < op_compaction.ssts_size() && use_cloud_native_pk_index(*metadata); i++) {
+        if (lost_segments.count(static_cast<uint32_t>(i)) > 0) {
+            continue;
+        }
         uint32_t rssid = metadata->next_rowset_id() + get_segment_idx(op_compaction.output_rowset(), i);
         DelvecPagePB delvec_page_pb = builder->delvec_page(rssid);
         delvec_page_pb.set_version(metadata->version());

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -161,6 +161,14 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
                                    .fill_metadata_cache = true};
         ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts));
         for (auto& segment : segments) {
+            // A null placeholder slot means a segment produced no reader (e.g. a lost segment dropped by
+            // experimental_lake_ignore_lost_segment). This chunk-size estimate is position-agnostic, so
+            // just skip it whatever the cause.
+            if (segment == nullptr) {
+                LOG(WARNING) << "vertical compaction chunk-size estimation skips a null (lost) segment, tablet: "
+                             << _tablet.id() << ", rowset: " << rowset->id();
+                continue;
+            }
             for (auto column_index : column_group) {
                 auto uid = _tablet_schema->column(column_index).unique_id();
                 const auto* column_reader = segment->column_with_uid(uid);

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -143,6 +143,13 @@ Status LakeMetaReader::_init_seg_meta_collecters(const lake::VersionedTablet& ta
     RETURN_IF_ERROR(_get_segments(tablet, &segments, &options_list));
     for (int i = 0; i < segments.size(); ++i) {
         auto& segment = segments[i];
+        // A null placeholder slot means a segment was dropped (e.g. a lost segment via
+        // experimental_lake_ignore_lost_segment); skip it whatever the cause. segments and options_list
+        // are built index-aligned in _get_segments(), so skipping the pair keeps every other segment at
+        // its correct position.
+        if (segment == nullptr) {
+            continue;
+        }
         auto& options = options_list[i];
         auto seg_collecter = std::make_unique<SegmentMetaCollecter>(segment);
 

--- a/be/src/storage/lake_meta_reader.h
+++ b/be/src/storage/lake_meta_reader.h
@@ -64,6 +64,9 @@ public:
                              std::vector<SegmentMetaCollectOptions>* options_list) {
         return _get_segments(tablet, segments, options_list);
     }
+    Status TEST_init_seg_meta_collecters(const lake::VersionedTablet& tablet, const LakeMetaReaderParams& params) {
+        return _init_seg_meta_collecters(tablet, params);
+    }
 #endif
 
 private:

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -14,11 +14,14 @@
 
 #include "storage/primary_key_compaction_conflict_resolver.h"
 
+#include <fmt/format.h>
+
 #include "base/debug/trace.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "common/config_exec_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
@@ -56,6 +59,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 // a per-chunk threshold of 1, reverting to pre-patch behaviour.
                 const size_t batch_rows_threshold =
                         static_cast<size_t>(std::max<int32_t>(1, config::primary_key_compaction_replace_batch_rows));
+                // Metadata row counts, used only to advance the mapper past a lost segment (see below).
+                const auto seg_num_rows = output_segment_num_rows();
                 for (size_t segment_id = 0; segment_id < segment_iters.size(); segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // only hold pkey, so can use larger chunk size
@@ -152,6 +157,47 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                             dv->init(params.new_version, tmp_deletes.data(), tmp_deletes.size());
                         }
                         handle_delvec_result_func(params.rowset_id + segment_id, dv, tmp_deletes.size());
+                    } else {
+                        // itr == nullptr: get_each_segment_iterator only leaves a null slot for a
+                        // physically-lost segment tolerated by experimental_lake_ignore_lost_segment, so
+                        // with the flag off this is an unexpected bug -- fail loudly rather than silently
+                        // leaving stale index entries.
+                        RETURN_ERROR_IF_FALSE(config::experimental_lake_ignore_lost_segment,
+                                              fmt::format("unexpected null segment iterator at position {} (rssid {})",
+                                                          segment_id, params.rowset_id + segment_id));
+                        RETURN_ERROR_IF_FALSE(
+                                segment_id < seg_num_rows.size(),
+                                fmt::format("lost segment at position {} (rssid {}) has no metadata row count; cannot "
+                                            "advance the rows-mapper past it",
+                                            segment_id, params.rowset_id + segment_id));
+                        // Lost segment: its data is gone, so we cannot read its PKs to update the primary
+                        // index -- those keys are left pointing at the input rowsets that apply_opcompaction
+                        // then deletes (stale until an index rebuild; same class as a lost input segment). We
+                        // must still advance the rows-mapper by this segment's row count so the following
+                        // segments stay aligned (otherwise they would read this segment's mapper values and
+                        // produce wrong delvecs). The lost segment is skipped on read, so it needs no delvec.
+                        const uint32_t lost_rows = seg_num_rows[segment_id];
+                        if (lost_rows == kUnknownSegmentNumRows) {
+                            return Status::InternalError(
+                                    fmt::format("output rowset segment {} has no num_rows in metadata; cannot advance "
+                                                "rows-mapper past a lost segment (rssid: {})",
+                                                segment_id, params.rowset_id + segment_id));
+                        }
+                        LOG(WARNING) << "ignore lost segment in compaction conflict resolution, tablet: "
+                                     << params.tablet_id << ", rssid: " << (params.rowset_id + segment_id) << ", left "
+                                     << lost_rows << " PK index entries stale (skipped)";
+                        // Advance the mapper in vector_chunk_size batches, reusing one buffer, to bound
+                        // transient memory (the running CRC accumulates across next_values calls, so a
+                        // chunked read is byte-identical to one big read).
+                        uint32_t remaining = lost_rows;
+                        std::vector<uint64_t> skipped;
+                        while (remaining > 0) {
+                            const uint32_t n =
+                                    std::min<uint32_t>(remaining, static_cast<uint32_t>(config::vector_chunk_size));
+                            skipped.clear();
+                            RETURN_IF_ERROR(mapper_iter.next_values(n, &skipped));
+                            remaining -= n;
+                        }
                     }
                 }
                 return Status::OK();
@@ -179,10 +225,32 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
                 // up to K parallel per-segment reads (each on its own RAF) and
                 // pipeline our processing of segment N against the still-pending
                 // downloads for segments N+1..N+K-1.
+                // This path only needs each segment's row count (never its data), so a null slot -- a
+                // physically-lost segment tolerated by experimental_lake_ignore_lost_segment -- falls back
+                // to the metadata row count. That keeps the rows-mapper aligned and the delvec (built purely
+                // from the mapper values) is still generated correctly.
+                const auto seg_num_rows = output_segment_num_rows();
                 std::vector<size_t> per_segment_rows;
                 per_segment_rows.reserve(segments.size());
-                for (const auto& seg : segments) {
-                    per_segment_rows.push_back(seg->num_rows());
+                for (size_t i = 0; i < segments.size(); i++) {
+                    if (segments[i] != nullptr) {
+                        per_segment_rows.push_back(segments[i]->num_rows());
+                        continue;
+                    }
+                    // A null segment only comes from a physically-lost segment tolerated by the flag; with
+                    // the flag off it is an unexpected bug -- fail loudly.
+                    RETURN_ERROR_IF_FALSE(
+                            config::experimental_lake_ignore_lost_segment,
+                            fmt::format("unexpected null segment at position {} during compaction conflict resolution",
+                                        i));
+                    if (i < seg_num_rows.size() && seg_num_rows[i] != kUnknownSegmentNumRows) {
+                        per_segment_rows.push_back(seg_num_rows[i]);
+                    } else {
+                        return Status::InternalError(fmt::format(
+                                "cannot determine row count for a lost segment (index {}) during compaction "
+                                "conflict resolution",
+                                i));
+                    }
                 }
                 RETURN_IF_ERROR(mapper_iter.prepare_segments(per_segment_rows));
 
@@ -194,10 +262,23 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
                     std::vector<uint64_t> rssid_rowids;
                     {
                         const int64_t t0 = MonotonicMicros();
-                        RETURN_IF_ERROR(mapper_iter.next_values(segments[segment_id]->num_rows(), &rssid_rowids));
+                        RETURN_IF_ERROR(mapper_iter.next_values(per_segment_rows[segment_id], &rssid_rowids));
                         mapper_read_us_accum += MonotonicMicros() - t0;
                     }
-                    DCHECK(segments[segment_id]->num_rows() == rssid_rowids.size());
+                    DCHECK(per_segment_rows[segment_id] == rssid_rowids.size());
+                    if (segments[segment_id] == nullptr) {
+                        // Lost segment (experimental_lake_ignore_lost_segment). We already advanced the
+                        // rows-mapper above so the following segments stay aligned. Record its position
+                        // and emit an empty delvec placeholder (keeps delvecs 1:1 with ssts); the caller
+                        // then skips both the SST ingest and the delvec for this position, so the PK
+                        // index never references the lost rssid -- consistent with the read path, where a
+                        // lost segment contributes neither data nor index entries.
+                        _lost_segment_positions.insert(static_cast<uint32_t>(segment_id));
+                        DelVectorPtr dv = std::make_shared<DelVector>();
+                        dv->init(params.new_version, nullptr, 0);
+                        handle_delvec_result_func(params.rowset_id + segment_id, dv, 0);
+                        continue;
+                    }
                     for (int i = 0; i < rssid_rowids.size(); i++) {
                         const uint32_t rssid = rssid_rowids[i] >> 32;
                         const uint32_t rowid = rssid_rowids[i] & 0xffffffff;

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <set>
 #include <string>
 
 #include "common/status.h"
@@ -28,6 +30,12 @@ class DelvecLoader;
 class Schema;
 class PrimaryIndex;
 class Segment;
+
+// Sentinel returned by output_segment_num_rows() for a segment whose row count is unavailable (e.g. an
+// old cross-version rowset whose metadata has no num_rows). Lets the resolver fail with a clear error
+// if it ever needs that count to advance the rows-mapper past a lost segment, instead of silently
+// under-advancing and failing later with a confusing row-count mismatch.
+inline constexpr uint32_t kUnknownSegmentNumRows = UINT32_MAX;
 
 struct CompactConflictResolveParams {
     int64_t tablet_id = 0;
@@ -63,6 +71,23 @@ public:
     Status execute();
 
     Status execute_without_update_index();
+
+    // Output segment positions that were skipped because their segment file was lost
+    // (experimental_lake_ignore_lost_segment). Populated by execute_without_update_index(); the caller
+    // must skip the SST ingest and delvec for these positions so the PK index does not reference a
+    // lost rssid. Positions index the output rowset's segments/ssts (which are 1:1).
+    const std::set<uint32_t>& lost_segment_positions() const { return _lost_segment_positions; }
+
+protected:
+    // Per-output-segment row counts, in segment_metas order. Used to advance the rows-mapper past a
+    // lost segment (a nullptr placeholder produced when experimental_lake_ignore_lost_segment drops a
+    // missing segment) so the mapper stays aligned for the remaining segments -- the segment object
+    // itself is only needed for its row count here. The default empty vector means "no lost segment is
+    // possible" (local engine, whose segments are never null); only the lake resolver overrides it.
+    virtual std::vector<uint32_t> output_segment_num_rows() const { return {}; }
+
+    // Output segment positions skipped due to a lost segment; see lost_segment_positions().
+    std::set<uint32_t> _lost_segment_positions;
 };
 
 } // namespace starrocks

--- a/be/src/storage/query/split_morsel_queue.cpp
+++ b/be/src/storage/query/split_morsel_queue.cpp
@@ -643,7 +643,9 @@ BaseRowset* LogicalSplitMorselQueue::_find_largest_rowset(const std::vector<Base
 }
 
 SegmentSharedPtr LogicalSplitMorselQueue::_find_largest_segment(BaseRowset* rowset) const {
-    const auto& segments = rowset->get_segments();
+    // get_non_null_segments() drops any lost-segment placeholders (experimental_lake_ignore_lost_segment).
+    // Logical split does not need positional alignment, so this compacted view is fine.
+    const auto segments = rowset->get_non_null_segments();
     if (segments.empty()) {
         return nullptr;
     }
@@ -661,9 +663,13 @@ SegmentSharedPtr LogicalSplitMorselQueue::_find_largest_segment(BaseRowset* rows
 StatusOr<SegmentGroupPtr> LogicalSplitMorselQueue::_create_segment_group(BaseRowset* rowset) {
     std::vector<SegmentSharedPtr> segments;
     if (rowset->is_overlapped()) {
-        segments.emplace_back(_find_largest_segment(rowset));
+        // _find_largest_segment returns nullptr only if the whole rowset was lost
+        // (experimental_lake_ignore_lost_segment) -- then there is no segment to add.
+        if (auto largest = _find_largest_segment(rowset); largest != nullptr) {
+            segments.emplace_back(std::move(largest));
+        }
     } else {
-        segments = rowset->get_segments();
+        segments = rowset->get_non_null_segments();
     }
 
     for (const auto& segment : segments) {

--- a/be/src/storage/rowset/base_rowset.h
+++ b/be/src/storage/rowset/base_rowset.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -35,6 +36,19 @@ public:
     virtual bool is_overlapped() const = 0;
     //virtual StatusOr<std::vector<SegmentSharedPtr>> get_segments() = 0;
     virtual std::vector<SegmentSharedPtr> get_segments() = 0;
+
+    // get_segments() with the nullptr placeholders removed. A null entry appears only for a lake rowset
+    // when experimental_lake_ignore_lost_segment dropped a physically-missing segment (local rowsets
+    // never produce nulls). Use this from consumers that just iterate the segments and do NOT need
+    // positional alignment with the segment metadata (e.g. scan-split planning, compaction sizing);
+    // consumers that derive an rssid from a segment's position must use get_segments() instead and
+    // handle the null slots themselves.
+    std::vector<SegmentSharedPtr> get_non_null_segments() {
+        std::vector<SegmentSharedPtr> segments = get_segments();
+        segments.erase(std::remove(segments.begin(), segments.end(), nullptr), segments.end());
+        return segments;
+    }
+
     virtual Status load() { return Status::OK(); };
 
     virtual bool has_data_files() const = 0;

--- a/be/test/storage/lake/lake_meta_reader_test.cpp
+++ b/be/test/storage/lake/lake_meta_reader_test.cpp
@@ -18,11 +18,14 @@
 
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "column/vectorized_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/logging.h"
+#include "fs/fs.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
@@ -222,6 +225,29 @@ TEST_F(LakeMetaReaderTest, test_get_segments_rowset_ids) {
     // Verify rowset ids are different for different rowsets
     EXPECT_NE(options_list[0].pk_rowsetid, options_list[1].pk_rowsetid)
             << "Expected different rowset ids for different rowsets";
+}
+
+// experimental_lake_ignore_lost_segment: _init_seg_meta_collecters must skip a lost segment (the
+// nullptr placeholder from load_segments) instead of building a SegmentMetaCollecter for it, so a
+// metadata scan over a tablet with a physically-missing segment file does not crash.
+TEST_F(LakeMetaReaderTest, test_init_seg_meta_collecters_ignore_lost_segment) {
+    ASSIGN_OR_ABORT(auto tablet_id, create_tablet_with_data(PRIMARY_KEYS, 1, 1));
+
+    ASSIGN_OR_ABORT(auto meta, _tablet_mgr->get_tablet_metadata(tablet_id, 2));
+    ASSERT_GT(meta->rowsets_size(), 0);
+    ASSERT_GT(meta->rowsets(0).segment_metas_size(), 0);
+    auto seg_name = meta->rowsets(0).segment_metas(0).filename();
+    _tablet_mgr->metacache()->prune();
+    ASSERT_OK(FileSystem::Default()->delete_file(_tablet_mgr->segment_location(tablet_id, seg_name)));
+
+    config::experimental_lake_ignore_lost_segment = true;
+    DeferOp reset([] { config::experimental_lake_ignore_lost_segment = false; });
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_id, 2));
+    LakeMetaReader reader;
+    LakeMetaReaderParams params;
+    // The sole segment is lost, so the collector loop must skip the null slot without crashing.
+    ASSERT_OK(reader.TEST_init_seg_meta_collecters(tablet, params));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -33,6 +33,7 @@
 #include "common/config_rowset_fwd.h"
 #include "common/logging.h"
 #include "fs/bundle_file.h"
+#include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
@@ -2169,6 +2170,86 @@ TEST_P(LakePrimaryKeyPublishTest, test_parallel_upsert_with_multiple_memtables) 
     config::pk_index_parallel_execution_min_rows = old_pk_index_parallel_execution_min_rows;
     config::l0_max_mem_usage = old_l0_max_mem_usage;
     config::pk_index_memtable_max_count = old_pk_index_memtable_max_count;
+}
+
+// experimental_lake_ignore_lost_segment: a PK compaction whose output segment file is lost before the
+// compaction txn is published must not crash and must not fail the publish. This covers all three
+// publish shapes with an error-injected (physically deleted) lost output segment:
+//   1. light publish, NO loss    -> normal SST ingest + conflict resolver
+//   2. light publish, lost seg   -> conflict-resolver lost branch + SST-ingest skip
+//   3. non-light publish, lost   -> CompactionState empty PK column
+// and runs under both LOCAL (resolver execute()) and CLOUD_NATIVE (resolver execute_without_update_index
+// + SST ingest) persistent index via the param list.
+TEST_P(LakePrimaryKeyPublishTest, test_compaction_publish_tolerates_lost_output_segment) {
+    auto tablet_id = _tablet_metadata->id();
+    int64_t version = 1;
+    int shift = 0;
+
+    auto write_rowsets = [&](int n) {
+        for (int i = 0; i < n; i++) {
+            auto [chunk, indexes] = gen_data_and_index(kChunkSize, shift++, false, true);
+            int64_t txn_id = next_id();
+            ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                             .set_tablet_manager(_tablet_mgr.get())
+                                             .set_tablet_id(tablet_id)
+                                             .set_txn_id(txn_id)
+                                             .set_partition_id(_partition_id)
+                                             .set_mem_tracker(_mem_tracker.get())
+                                             .set_schema_id(_tablet_schema->id())
+                                             .set_slot_descriptors(&_slot_pointers)
+                                             .set_profile(&_dummy_runtime_profile)
+                                             .build());
+            CHECK_OK(dw->open());
+            CHECK_OK(dw->write(*chunk, indexes.data(), indexes.size()));
+            CHECK_OK(dw->finish_with_txnlog());
+            dw->close();
+            CHECK_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+            version++;
+        }
+    };
+
+    // Compact, optionally delete an output segment (error injection), then publish.
+    auto compact_and_publish = [&](bool lose_output_segment) -> Status {
+        int64_t txn_id = next_id();
+        auto old_min = config::lake_pk_compaction_min_input_segments;
+        config::lake_pk_compaction_min_input_segments = 1;
+        DeferOp reset_min([&] { config::lake_pk_compaction_min_input_segments = old_min; });
+        auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+        RETURN_IF_ERROR(task->execute(CompactionTask::kNoCancelFn));
+        if (lose_output_segment) {
+            ASSIGN_OR_ABORT(auto txnlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+            const auto& out = txnlog->op_compaction().output_rowset();
+            if (out.segment_metas_size() > 0) {
+                _tablet_mgr->metacache()->prune();
+                RETURN_IF_ERROR(FileSystem::Default()->delete_file(
+                        _tablet_mgr->segment_location(tablet_id, out.segment_metas(0).filename())));
+            }
+        }
+        auto st = publish_single_version(tablet_id, version + 1, txn_id).status();
+        version++;
+        return st;
+    };
+
+    // 1. Light publish (default enable_light_pk_compaction_publish=true), no loss: normal ingest path.
+    write_rowsets(3);
+    ASSERT_OK(compact_and_publish(/*lose_output_segment=*/false));
+
+    // 2. Light publish, lost output segment: resolver lost branch + SST-ingest skip.
+    config::experimental_lake_ignore_lost_segment = true;
+    DeferOp reset_flag([] { config::experimental_lake_ignore_lost_segment = false; });
+    write_rowsets(3);
+    ASSERT_OK(compact_and_publish(/*lose_output_segment=*/true));
+
+    // 3. Non-light publish, lost output segment: CompactionState empty PK column path.
+    config::enable_light_pk_compaction_publish = false;
+    DeferOp reset_light([] { config::enable_light_pk_compaction_publish = true; });
+    write_rowsets(3);
+    ASSERT_OK(compact_and_publish(/*lose_output_segment=*/true));
+
+    // The tablet stays readable afterwards (a lost segment's rows are simply gone).
+    ASSIGN_OR_ABORT(auto chunk, read(tablet_id, version));
+    (void)chunk;
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -30,10 +30,12 @@
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/logging.h"
+#include "fs/fs.h"
 #include "fs/fs_factory.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/metacache.h"
+#include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/transactions.h"
@@ -44,6 +46,7 @@
 #include "storage/tablet_schema.h"
 #include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/predicate_tree/predicate_tree.hpp"
+#include "storage_primitive/primary_key_encoding_types.h"
 #include "test_util.h"
 #include "types/type_descriptor.h"
 
@@ -238,6 +241,167 @@ TEST_F(LakeRowsetTest, test_load_segments) {
         auto segment = cache->lookup_segment(seg->file_name());
         ASSERT_TRUE(segment != nullptr);
     }
+}
+
+// experimental_lake_ignore_lost_segment: when a segment file is physically missing, load_segments
+// must (a) fail hard when the flag is off, and (b) when the flag is on, skip the lost segment while
+// keeping the result positionally aligned -- a null placeholder in the lost slot, size unchanged --
+// so the PK-index callers' `size == num_segments` checks and rssid derivation keep working instead
+// of hitting the CHECK/RETURN_ERROR_IF_FALSE that used to crash/fail the rebuild.
+TEST_F(LakeRowsetTest, test_load_segments_ignore_lost_segment) {
+    create_rowsets_for_testing();
+
+    // Physically remove the middle segment file to simulate a lost segment.
+    auto lost_seg_name = _tablet_metadata->rowsets(0).segment_metas(1).filename();
+    auto lost_seg_path = _tablet_mgr->segment_location(_tablet_metadata->id(), lost_seg_name);
+    // Drop any cached copy so the loader actually re-reads from the (now missing) file.
+    _tablet_mgr->metacache()->prune();
+    ASSERT_OK(FileSystem::Default()->delete_file(lost_seg_path));
+
+    auto rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+    ASSERT_EQ(rowset->num_segments(), 3);
+
+    // Flag off: a missing segment is a hard error.
+    {
+        config::experimental_lake_ignore_lost_segment = false;
+        std::vector<SegmentPtr> segments;
+        auto st = rowset->load_segments(&segments, false);
+        ASSERT_FALSE(st.ok());
+    }
+
+    // Flag on: the lost segment is skipped, but its slot is preserved as a null placeholder so the
+    // vector stays aligned with the segment metadata.
+    {
+        config::experimental_lake_ignore_lost_segment = true;
+        DeferOp reset([] { config::experimental_lake_ignore_lost_segment = false; });
+
+        std::vector<SegmentPtr> segments;
+        ASSERT_OK(rowset->load_segments(&segments, false));
+        ASSERT_EQ(segments.size(), static_cast<size_t>(rowset->num_segments()));
+        EXPECT_NE(segments[0], nullptr);
+        EXPECT_EQ(segments[1], nullptr);
+        EXPECT_NE(segments[2], nullptr);
+
+        // The delvec iterator builder (the PK rebuild path) must not crash on the null slot and must
+        // keep the same positional alignment: the lost segment yields a null iterator in its own slot.
+        OlapReaderStatistics stats;
+        auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0});
+        ASSIGN_OR_ABORT(auto seg_iters,
+                        rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
+        ASSERT_EQ(seg_iters.size(), static_cast<size_t>(rowset->num_segments()));
+        EXPECT_NE(seg_iters[0], nullptr);
+        EXPECT_EQ(seg_iters[1], nullptr);
+        EXPECT_NE(seg_iters[2], nullptr);
+
+        // The non-delvec builder must keep the same alignment: the lost segment is a null placeholder.
+        ASSIGN_OR_ABORT(auto plain_iters, rowset->get_each_segment_iterator(input_schema, false, &stats));
+        ASSERT_EQ(plain_iters.size(), static_cast<size_t>(rowset->num_segments()));
+        EXPECT_NE(plain_iters[0], nullptr);
+        EXPECT_EQ(plain_iters[1], nullptr);
+        EXPECT_NE(plain_iters[2], nullptr);
+        for (auto& it : plain_iters) {
+            if (it != nullptr) {
+                it->close();
+            }
+        }
+
+        // get_read_iterator_num must skip the null slot (2 live segments; overlapped, so no union).
+        ASSIGN_OR_ABORT(auto iter_num, rowset->get_read_iterator_num());
+        EXPECT_EQ(iter_num, 2);
+
+        // get_non_null_segments() returns only the live segments (the lost slot is dropped), so
+        // position-agnostic consumers (logical-split scan, compaction sizing) never see a null.
+        auto non_null = rowset->get_non_null_segments();
+        EXPECT_EQ(non_null.size(), 2);
+        for (const auto& s : non_null) {
+            EXPECT_NE(s, nullptr);
+        }
+    }
+}
+
+// The PK publish / partial-update paths wrap every slot returned by get_each_segment_iterator in a
+// SegmentPKIterator, including the nullptr placeholder produced for a lost segment. SegmentPKIterator
+// must tolerate a null underlying iterator: yield no rows and, crucially, not crash in close() (which
+// used to call _iter->close() unconditionally).
+TEST_F(LakeRowsetTest, test_segment_pk_iterator_tolerates_null_slot) {
+    SegmentPKIterator it;
+    ASSERT_OK(it.init(nullptr, *_schema, /*lazy_load=*/true, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1,
+                      /*defer_data_load=*/true));
+    EXPECT_TRUE(it.done()); // an empty slot yields no rows
+    it.close();             // must not crash on the null underlying iterator
+}
+
+// Covers add_partial_compaction_segments_info's null guards: a lost segment in either the
+// already-compacted range or the uncompacted range must be skipped (file-size info dropped) rather
+// than crashing on the null placeholder. With next_compaction_offset=1 and compaction_segment_limit=1
+// over a 3-segment rowset, segment 0 is in the already-compacted range and segment 2 in the
+// uncompacted range, so losing both exercises both guards.
+TEST_F(LakeRowsetTest, test_ignore_lost_segment_partial_compaction) {
+    create_rowsets_for_testing();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+    // A writer providing the "new compacted" segment for section 2 of add_partial_compaction.
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    {
+        std::vector<int> k{100, 101, 102};
+        std::vector<int> v{1, 2, 3};
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(k.data(), k.size() * sizeof(int));
+        c1->append_numbers(v.data(), v.size() * sizeof(int));
+        Chunk chunk({std::move(c0), std::move(c1)}, _schema);
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+    }
+
+    // Lose segment 0 (already-compacted range) and segment 2 (uncompacted range).
+    for (int idx : {0, 2}) {
+        auto name = _tablet_metadata->rowsets(0).segment_metas(idx).filename();
+        ASSERT_OK(FileSystem::Default()->delete_file(_tablet_mgr->segment_location(_tablet_metadata->id(), name)));
+    }
+    _tablet_mgr->metacache()->prune();
+
+    config::experimental_lake_ignore_lost_segment = true;
+    DeferOp reset([] { config::experimental_lake_ignore_lost_segment = false; });
+
+    auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 1 /* compaction_segment_limit */);
+    ASSERT_TRUE(rs->partial_segments_compaction());
+
+    TxnLogPB txn_log;
+    auto op_compaction = txn_log.mutable_op_compaction();
+    CompactionTaskContext context(txn_id, _tablet_metadata->id(), 456, false, false, nullptr);
+    VersionedTablet vt(nullptr, _tablet_metadata);
+    VerticalCompactionTask task(vt, {rs}, &context, _tablet_schema);
+    // Must not crash on the lost (null) segments in the already-compacted / uncompacted ranges.
+    ASSERT_OK(task.fill_compaction_segment_info(op_compaction, writer.get()));
+    writer->close();
+}
+
+// Covers the null-segment skip in VerticalCompactionTask::calculate_chunk_size_for_column_group: a
+// lost segment must be skipped instead of dereferencing null in column_with_uid. Uses
+// compaction_segment_limit=0 so the rowset is not in partial-compaction mode (which would early-return
+// before the segment loop).
+TEST_F(LakeRowsetTest, test_ignore_lost_segment_vertical_chunk_size) {
+    create_rowsets_for_testing();
+
+    auto name = _tablet_metadata->rowsets(0).segment_metas(1).filename();
+    ASSERT_OK(FileSystem::Default()->delete_file(_tablet_mgr->segment_location(_tablet_metadata->id(), name)));
+    _tablet_mgr->metacache()->prune();
+
+    config::experimental_lake_ignore_lost_segment = true;
+    DeferOp reset([] { config::experimental_lake_ignore_lost_segment = false; });
+
+    auto rs = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0 /* compaction_segment_limit */);
+    CompactionTaskContext context(next_id(), _tablet_metadata->id(), 456, false, false, nullptr);
+    VersionedTablet vt(nullptr, _tablet_metadata);
+    VerticalCompactionTask task(vt, {rs}, &context, _tablet_schema);
+    // Must skip the lost (null) segment instead of crashing on segment->column_with_uid.
+    ASSIGN_OR_ABORT(auto chunk_size, task.calculate_chunk_size_for_column_group({0}));
+    EXPECT_GT(chunk_size, 0);
 }
 
 TEST_F(LakeRowsetTest, test_segment_update_cache_size) {


### PR DESCRIPTION
## Why I'm doing:

`experimental_lake_ignore_lost_segment=true` is supposed to let a lake tablet
skip a segment whose file is physically missing (a break-glass recovery switch),
but in practice it still crashed / errored:

- `Rowset::load_segments` swallowed the `not_found`, but the sequential path
  **dropped** the segment instead of leaving a placeholder. That broke the two
  invariants the lake PK-index paths rely on:
  1. **Positional alignment** — callers derive `rssid = rowset id + segment idx`
     from the segment's *position*, so a dropped entry shifts every later segment.
  2. **Size equality** — the index build/rebuild/load paths assert
     `size == num_segments`.
- As a result a lost segment tripped the `CHECK` in `LakePersistentIndex` rebuild
  (hard crash) and the `RETURN_ERROR_IF_FALSE` checks in `LakePrimaryIndex` and
  the local persistent-index loader.

## What I'm doing:

Follow the design already used for EOF / zonemap-pruned segments: leave a
`nullptr` placeholder for a lost segment so the vector stays aligned and
`size == num_segments` still holds, then make every deref site null-safe.

- `rowset.cpp`: emplace a `LoadedSegment{nullptr, meta_pos}` placeholder in the
  ignore branch; null-guard `get_each_segment_iterator`,
  `get_each_segment_iterator_with_delvec`, `get_read_iterator_num` and
  `add_partial_compaction_segments_info`.
- Compaction chunk-size sizing (`horizontal_/vertical_compaction_task.cpp`) and
  the flat-JSON compaction reader (`tablet_reader.cpp`): skip null segments.
- `primary_key_compaction_conflict_resolver.cpp`: this path reads the
  rows-mapper in lockstep with each segment's row count and cannot produce a
  correct delvec with a missing segment, so it now returns a clear error instead
  of crashing on the null deref.

The PK consumers that index by position (LakePrimaryIndex, persistent-index
loader/rebuild, RowsetUpdateState via SegmentPKIterator, CompactionState,
column-mode partial update, primary-key recover) already skip null entries, so
they work unchanged.

Added a regression UT (`LakeRowsetTest.test_load_segments_ignore_lost_segment`)
that physically deletes a segment and verifies: flag-off → hard error; flag-on →
`load_segments` returns an aligned null placeholder in the lost slot; and the
delvec iterator builder stays aligned without crashing.

This only affects behavior when the experimental flag is enabled; the default
(`false`) path is unchanged.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
