### PR TITLE
[Enhancement] Name shared-data vector index files by the segment's owning tablet id

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -81,6 +81,11 @@ struct FileInfo {
     // rewrite), so the apply path can persist them into SegmentMetadataPB::vector_index_ids and
     // keep async builds / vacuum / reads in sync. Empty for files with no vector index.
     std::vector<int64_t> vector_index_ids;
+    // Tablet id under which this segment's .vi files were written; embedded in the .vi filename so
+    // it stays stable and reader-agnostic across tablet split (see the field comment on
+    // SegmentMetadataPB::vector_index_tablet_id). -1 when no vector index; otherwise set together
+    // with vector_index_ids and persisted into SegmentMetadataPB::vector_index_tablet_id.
+    int64_t vector_index_tablet_id = -1;
 
     // Cache key uniquely identifying this FileInfo as a *slice* of a physical file. Caches keyed
     // on file identity (e.g. lake metacache for Segments) must use this rather than `path` so two

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -81,11 +81,6 @@ struct FileInfo {
     // rewrite), so the apply path can persist them into SegmentMetadataPB::vector_index_ids and
     // keep async builds / vacuum / reads in sync. Empty for files with no vector index.
     std::vector<int64_t> vector_index_ids;
-    // Tablet id under which this segment's .vi files were written; embedded in the .vi filename so
-    // it stays stable and reader-agnostic across tablet split (see the field comment on
-    // SegmentMetadataPB::vector_index_tablet_id). -1 when no vector index; otherwise set together
-    // with vector_index_ids and persisted into SegmentMetadataPB::vector_index_tablet_id.
-    int64_t vector_index_tablet_id = -1;
 
     // Cache key uniquely identifying this FileInfo as a *slice* of a physical file. Caches keyed
     // on file identity (e.g. lake metacache for Segments) must use this rather than `path` so two

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -76,16 +76,6 @@ struct FileInfo {
     std::shared_ptr<FileSystem> fs;
     // It is used to store the file offset of the bundle file.
     std::optional<int64_t> bundle_file_offset;
-    // IDs of vector indexes whose .vi file belongs to this segment. Populated when a segment is
-    // produced outside the normal tablet-writer flush path (e.g. the partial-update segment
-    // rewrite), so the apply path can persist them into SegmentMetadataPB::vector_index_ids and
-    // keep async builds / vacuum / reads in sync. Empty for files with no vector index.
-    std::vector<int64_t> vector_index_ids;
-    // Tablet id under which this segment's .vi files were written; embedded in the .vi filename so
-    // it stays stable and reader-agnostic across tablet split (see the field comment on
-    // SegmentMetadataPB::vector_index_tablet_id). -1 when no vector index; otherwise set together
-    // with vector_index_ids and persisted into SegmentMetadataPB::vector_index_tablet_id.
-    int64_t vector_index_tablet_id = -1;
 
     // Cache key uniquely identifying this FileInfo as a *slice* of a physical file. Caches keyed
     // on file identity (e.g. lake metacache for Segments) must use this rather than `path` so two

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -103,33 +103,37 @@ inline std::string gen_segment_filename(int64_t txn_id) {
     return fmt::format("{:016x}_{}.dat", txn_id, generate_uuid_string());
 }
 
-// Generate vector index filename from segment filename. The tablet_id disambiguates
-// segments that share a physical file across tablets (file bundling), where the recorded
-// segment filename is the shared bundle name and the offset alone is not on the read path;
-// without it those tablets would collide on the same .vi path and overwrite each other.
-// Non-bundled segments carry it too (redundant but keeps naming uniform, no special-casing).
-// e.g. "0123_abcd.dat" + tablet 9 + index 123 -> "0123_abcd_9_123.vi"
-inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t tablet_id, int64_t index_id) {
+// Generate vector index filename from segment filename. |owner_tablet_id| disambiguates segments
+// that share a physical file across tablets (file bundling), where the recorded segment filename is
+// the shared bundle name; without it those tablets would collide on the same .vi path and overwrite
+// each other. It must be the tablet that WROTE the segment (recorded in
+// SegmentMetadataPB::vector_index_tablet_id), NOT the tablet reading it, so a segment shared across
+// tablets after a tablet split resolves to the same .vi from every reader. Non-bundled segments
+// carry it too (redundant but keeps naming uniform, no special-casing).
+// e.g. "0123_abcd.dat" + owner 9 + index 123 -> "0123_abcd_9_123.vi"
+inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t owner_tablet_id,
+                                             int64_t index_id) {
     if (segment_filename.ends_with(".dat")) {
-        return fmt::format("{}_{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), tablet_id, index_id);
+        return fmt::format("{}_{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), owner_tablet_id,
+                           index_id);
     }
-    return fmt::format("{}_{}_{}.vi", segment_filename, tablet_id, index_id);
+    return fmt::format("{}_{}_{}.vi", segment_filename, owner_tablet_id, index_id);
 }
 
 // Compute the vector-index file path that sits next to a segment file in shared-data
 // layout: split |segment_path| into directory + basename, compute the .vi filename
 // from the basename, then re-join under the original directory.
 //
-//   "data/000_abcd.dat"  + tablet 9 + 0  -> "data/000_abcd_9_0.vi"
-//   "/foo/bar/seg.dat"   + tablet 9 + 5  -> "/foo/bar/seg_9_5.vi"
-//   "seg.dat"            + tablet 9 + 7  -> "seg_9_7.vi"            (no directory part)
-//   "/seg.dat"           + tablet 9 + 1  -> "seg_9_1.vi"            (root-only directory)
-inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t tablet_id,
+//   "data/000_abcd.dat"  + owner 9 + 0  -> "data/000_abcd_9_0.vi"
+//   "/foo/bar/seg.dat"   + owner 9 + 5  -> "/foo/bar/seg_9_5.vi"
+//   "seg.dat"            + owner 9 + 7  -> "seg_9_7.vi"            (no directory part)
+//   "/seg.dat"           + owner 9 + 1  -> "seg_9_1.vi"            (root-only directory)
+inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t owner_tablet_id,
                                                            int64_t index_id) {
     const size_t last_slash = segment_path.find_last_of('/');
     std::string_view basename =
             (last_slash == std::string_view::npos) ? segment_path : segment_path.substr(last_slash + 1);
-    std::string vi_filename = gen_vector_index_filename(basename, tablet_id, index_id);
+    std::string vi_filename = gen_vector_index_filename(basename, owner_tablet_id, index_id);
     if (last_slash == std::string_view::npos) {
         return vi_filename;
     }

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -141,20 +141,21 @@ inline std::string gen_vector_index_path_from_segment_path(std::string_view segm
     return fmt::format("{}/{}", dir, vi_filename);
 }
 
-// The tablet id embedded in a persisted segment's .vi filenames: the recorded owner
-// (vector_index_tablet_id, the tablet that WROTE the segment), carried verbatim across tablet
-// split so every reader resolves the same .vi. Every segment that records vector_index_ids also
-// records this owner (stamped at write time by the tablet writers / segment rewrite), so callers
-// must only ask for it on a vector-indexed segment; the DCHECK guards that invariant.
-inline int64_t vector_index_owner_tablet_id(const SegmentMetadataPB& segment_meta) {
-    DCHECK(segment_meta.has_vector_index_tablet_id())
-            << "vector-indexed segment missing its recorded owner tablet id: " << segment_meta.filename();
-    return segment_meta.vector_index_tablet_id();
+// The per-segment unique id embedded in a persisted segment's .vi filenames
+// (segment_vector_index_uid): its value is the id of the tablet that WROTE the segment, used purely
+// as a unique key and carried verbatim across tablet split so every reader resolves the same .vi.
+// Every segment that records vector_index_ids also records this uid (stamped at write time by the
+// tablet writers / segment rewrite), so callers must only ask for it on a vector-indexed segment;
+// the DCHECK guards that invariant.
+inline int64_t resolve_segment_vector_index_uid(const SegmentMetadataPB& segment_meta) {
+    DCHECK(segment_meta.has_segment_vector_index_uid())
+            << "vector-indexed segment missing its recorded vector index uid: " << segment_meta.filename();
+    return segment_meta.segment_vector_index_uid();
 }
 
-// .vi filename for one index of a persisted (vector-indexed) segment, named by its recorded owner.
+// .vi filename for one index of a persisted (vector-indexed) segment, named by its recorded uid.
 inline std::string gen_vector_index_filename_for_segment(const SegmentMetadataPB& segment_meta, int64_t index_id) {
-    return gen_vector_index_filename(segment_meta.filename(), vector_index_owner_tablet_id(segment_meta), index_id);
+    return gen_vector_index_filename(segment_meta.filename(), resolve_segment_vector_index_uid(segment_meta), index_id);
 }
 
 // Helper function to extract uuid from filename, which is used in shared-data cross cluster migration

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -104,37 +104,33 @@ inline std::string gen_segment_filename(int64_t txn_id) {
     return fmt::format("{:016x}_{}.dat", txn_id, generate_uuid_string());
 }
 
-// Generate vector index filename from segment filename. |owner_tablet_id| disambiguates segments
-// that share a physical file across tablets (file bundling), where the recorded segment filename is
-// the shared bundle name; without it those tablets would collide on the same .vi path and overwrite
-// each other. It must be the tablet that WROTE the segment (recorded in
-// SegmentMetadataPB::vector_index_tablet_id), NOT the tablet reading it, so a segment shared across
-// tablets after a tablet split resolves to the same .vi from every reader. Non-bundled segments
-// carry it too (redundant but keeps naming uniform, no special-casing).
-// e.g. "0123_abcd.dat" + owner 9 + index 123 -> "0123_abcd_9_123.vi"
-inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t owner_tablet_id,
-                                             int64_t index_id) {
+// Generate vector index filename from segment filename. The tablet_id disambiguates
+// segments that share a physical file across tablets (file bundling), where the recorded
+// segment filename is the shared bundle name and the offset alone is not on the read path;
+// without it those tablets would collide on the same .vi path and overwrite each other.
+// Non-bundled segments carry it too (redundant but keeps naming uniform, no special-casing).
+// e.g. "0123_abcd.dat" + tablet 9 + index 123 -> "0123_abcd_9_123.vi"
+inline std::string gen_vector_index_filename(std::string_view segment_filename, int64_t tablet_id, int64_t index_id) {
     if (segment_filename.ends_with(".dat")) {
-        return fmt::format("{}_{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), owner_tablet_id,
-                           index_id);
+        return fmt::format("{}_{}_{}.vi", segment_filename.substr(0, segment_filename.size() - 4), tablet_id, index_id);
     }
-    return fmt::format("{}_{}_{}.vi", segment_filename, owner_tablet_id, index_id);
+    return fmt::format("{}_{}_{}.vi", segment_filename, tablet_id, index_id);
 }
 
 // Compute the vector-index file path that sits next to a segment file in shared-data
 // layout: split |segment_path| into directory + basename, compute the .vi filename
 // from the basename, then re-join under the original directory.
 //
-//   "data/000_abcd.dat"  + owner 9 + 0  -> "data/000_abcd_9_0.vi"
-//   "/foo/bar/seg.dat"   + owner 9 + 5  -> "/foo/bar/seg_9_5.vi"
-//   "seg.dat"            + owner 9 + 7  -> "seg_9_7.vi"            (no directory part)
-//   "/seg.dat"           + owner 9 + 1  -> "seg_9_1.vi"            (root-only directory)
-inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t owner_tablet_id,
+//   "data/000_abcd.dat"  + tablet 9 + 0  -> "data/000_abcd_9_0.vi"
+//   "/foo/bar/seg.dat"   + tablet 9 + 5  -> "/foo/bar/seg_9_5.vi"
+//   "seg.dat"            + tablet 9 + 7  -> "seg_9_7.vi"            (no directory part)
+//   "/seg.dat"           + tablet 9 + 1  -> "seg_9_1.vi"            (root-only directory)
+inline std::string gen_vector_index_path_from_segment_path(std::string_view segment_path, int64_t tablet_id,
                                                            int64_t index_id) {
     const size_t last_slash = segment_path.find_last_of('/');
     std::string_view basename =
             (last_slash == std::string_view::npos) ? segment_path : segment_path.substr(last_slash + 1);
-    std::string vi_filename = gen_vector_index_filename(basename, owner_tablet_id, index_id);
+    std::string vi_filename = gen_vector_index_filename(basename, tablet_id, index_id);
     if (last_slash == std::string_view::npos) {
         return vi_filename;
     }

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -22,6 +22,7 @@
 #include "base/string/string_parser.hpp"
 #include "base/uid_util.h"
 #include "gen_cpp/Types_types.h" // for PUniqueId
+#include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/util.h"
 #include "storage/primitive/lake_file_name.h"
 
@@ -142,6 +143,24 @@ inline std::string gen_vector_index_path_from_segment_path(std::string_view segm
         return vi_filename;
     }
     return fmt::format("{}/{}", dir, vi_filename);
+}
+
+// Resolve the tablet id embedded in a persisted segment's .vi filenames: the recorded owner
+// (vector_index_tablet_id, the tablet that WROTE the segment) when present, otherwise
+// |fallback_tablet_id| — for segments persisted before the field existed, where the current
+// tablet is correct unless the segment was later shared across tablets by a tablet split.
+// Always resolve through here instead of re-implementing the ternary at call sites, so the
+// fallback rule lives in exactly one place.
+inline int64_t resolve_vector_index_owner_tablet_id(const SegmentMetadataPB& segment_meta, int64_t fallback_tablet_id) {
+    return segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : fallback_tablet_id;
+}
+
+// .vi filename for one index of a persisted segment, named by the segment's recorded owner
+// (see resolve_vector_index_owner_tablet_id for the fallback rule).
+inline std::string gen_vector_index_filename_for_segment(const SegmentMetadataPB& segment_meta,
+                                                         int64_t fallback_tablet_id, int64_t index_id) {
+    return gen_vector_index_filename(segment_meta.filename(),
+                                     resolve_vector_index_owner_tablet_id(segment_meta, fallback_tablet_id), index_id);
 }
 
 // Helper function to extract uuid from filename, which is used in shared-data cross cluster migration

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -141,22 +141,20 @@ inline std::string gen_vector_index_path_from_segment_path(std::string_view segm
     return fmt::format("{}/{}", dir, vi_filename);
 }
 
-// Resolve the tablet id embedded in a persisted segment's .vi filenames: the recorded owner
-// (vector_index_tablet_id, the tablet that WROTE the segment) when present, otherwise
-// |fallback_tablet_id| — for segments persisted before the field existed, where the current
-// tablet is correct unless the segment was later shared across tablets by a tablet split.
-// Always resolve through here instead of re-implementing the ternary at call sites, so the
-// fallback rule lives in exactly one place.
-inline int64_t resolve_vector_index_owner_tablet_id(const SegmentMetadataPB& segment_meta, int64_t fallback_tablet_id) {
-    return segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : fallback_tablet_id;
+// The tablet id embedded in a persisted segment's .vi filenames: the recorded owner
+// (vector_index_tablet_id, the tablet that WROTE the segment), carried verbatim across tablet
+// split so every reader resolves the same .vi. Every segment that records vector_index_ids also
+// records this owner (stamped at write time by the tablet writers / segment rewrite), so callers
+// must only ask for it on a vector-indexed segment; the DCHECK guards that invariant.
+inline int64_t vector_index_owner_tablet_id(const SegmentMetadataPB& segment_meta) {
+    DCHECK(segment_meta.has_vector_index_tablet_id())
+            << "vector-indexed segment missing its recorded owner tablet id: " << segment_meta.filename();
+    return segment_meta.vector_index_tablet_id();
 }
 
-// .vi filename for one index of a persisted segment, named by the segment's recorded owner
-// (see resolve_vector_index_owner_tablet_id for the fallback rule).
-inline std::string gen_vector_index_filename_for_segment(const SegmentMetadataPB& segment_meta,
-                                                         int64_t fallback_tablet_id, int64_t index_id) {
-    return gen_vector_index_filename(segment_meta.filename(),
-                                     resolve_vector_index_owner_tablet_id(segment_meta, fallback_tablet_id), index_id);
+// .vi filename for one index of a persisted (vector-indexed) segment, named by its recorded owner.
+inline std::string gen_vector_index_filename_for_segment(const SegmentMetadataPB& segment_meta, int64_t index_id) {
+    return gen_vector_index_filename(segment_meta.filename(), vector_index_owner_tablet_id(segment_meta), index_id);
 }
 
 // Helper function to extract uuid from filename, which is used in shared-data cross cluster migration

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -503,6 +503,14 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
                 }
             }
         }
+        // Record the owning tablet id for .vi naming, mirroring
+        // HorizontalGeneralTabletWriter::record_segment_vector_index_ids: the .vi filename embeds it
+        // (fill_vector_index_file_paths above uses _tablet_id), and readers must use this recorded id
+        // rather than their own so a segment shared across tablets after a split still resolves to the
+        // same .vi (see SegmentMetadataPB.vector_index_tablet_id).
+        if (!segment_file_info.vector_index_ids.empty()) {
+            segment_file_info.vector_index_tablet_id = _tablet_id;
+        }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());
         _stats.segment_count++;

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -321,12 +321,6 @@ void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileI
     for (const auto& [index_id, _] : seg_writer->vector_index_file_paths()) {
         segment_file_info.vector_index_ids.push_back(index_id);
     }
-    // Record the tablet id that produced these .vi files. The .vi filename embeds it, and readers
-    // must use this recorded id (not their own) so a segment shared across tablets after a split
-    // still resolves to the same .vi (see SegmentMetadataPB.vector_index_tablet_id).
-    if (!segment_file_info.vector_index_ids.empty()) {
-        segment_file_info.vector_index_tablet_id = _tablet_id;
-    }
 }
 
 Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
@@ -502,14 +496,6 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
                     segment_file_info.vector_index_ids.push_back(index_id);
                 }
             }
-        }
-        // Record the owning tablet id for .vi naming, mirroring
-        // HorizontalGeneralTabletWriter::record_segment_vector_index_ids: the .vi filename embeds it
-        // (fill_vector_index_file_paths above uses _tablet_id), and readers must use this recorded id
-        // rather than their own so a segment shared across tablets after a split still resolves to the
-        // same .vi (see SegmentMetadataPB.vector_index_tablet_id).
-        if (!segment_file_info.vector_index_ids.empty()) {
-            segment_file_info.vector_index_tablet_id = _tablet_id;
         }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -321,6 +321,12 @@ void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileI
     for (const auto& [index_id, _] : seg_writer->vector_index_file_paths()) {
         segment_file_info.vector_index_ids.push_back(index_id);
     }
+    // Record the tablet id that produced these .vi files. The .vi filename embeds it, and readers
+    // must use this recorded id (not their own) so a segment shared across tablets after a split
+    // still resolves to the same .vi (see SegmentMetadataPB.vector_index_tablet_id).
+    if (!segment_file_info.vector_index_ids.empty()) {
+        segment_file_info.vector_index_tablet_id = _tablet_id;
+    }
 }
 
 Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -321,6 +321,12 @@ void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileI
     for (const auto& [index_id, _] : seg_writer->vector_index_file_paths()) {
         segment_file_info.vector_index_ids.push_back(index_id);
     }
+    // Record the tablet id that produced these .vi files (fill_vector_index_file_paths embeds it
+    // in the filename); readers must use this recorded id, not their own, so a segment shared
+    // across tablets after a split resolves the same .vi.
+    if (!segment_file_info.vector_index_ids.empty()) {
+        segment_file_info.vector_index_tablet_id = _tablet_id;
+    }
 }
 
 Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
@@ -496,6 +502,10 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
                     segment_file_info.vector_index_ids.push_back(index_id);
                 }
             }
+        }
+        // Record the owning tablet id for .vi naming, mirroring record_segment_vector_index_ids.
+        if (!segment_file_info.vector_index_ids.empty()) {
+            segment_file_info.vector_index_tablet_id = _tablet_id;
         }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -325,7 +325,7 @@ void HorizontalGeneralTabletWriter::record_segment_vector_index_ids(SegmentFileI
     // in the filename); readers must use this recorded id, not their own, so a segment shared
     // across tablets after a split resolves the same .vi.
     if (!segment_file_info.vector_index_ids.empty()) {
-        segment_file_info.vector_index_tablet_id = _tablet_id;
+        segment_file_info.segment_vector_index_uid = _tablet_id;
     }
 }
 
@@ -505,7 +505,7 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         }
         // Record the owning tablet id for .vi naming, mirroring record_segment_vector_index_ids.
         if (!segment_file_info.vector_index_ids.empty()) {
-            segment_file_info.vector_index_tablet_id = _tablet_id;
+            segment_file_info.segment_vector_index_uid = _tablet_id;
         }
         _data_size += segment_size;
         collect_writer_stats(_stats, segment_writer.get());

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -218,6 +218,8 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         // children.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
+    // Must run after the replace block above, which rebuilds ids/owner wholesale.
+    fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());
@@ -746,6 +748,8 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
         // 2. We need del files to rebuild cloud native PK index.
         auto rowset = _tablet_meta->add_rowsets();
         rowset->CopyFrom(op_compaction.output_rowset());
+        // Compaction outputs are written by this tablet; backstop the .vi owner id.
+        fill_missing_vector_index_owner(rowset, _tablet_meta->id());
         rowset->set_id(_tablet_meta->next_rowset_id());
         rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
         rowset->set_version(_tablet_meta->version());
@@ -1209,6 +1213,18 @@ bool is_primary_key(const TabletMetadata& metadata) {
     return metadata.schema().keys_type() == KeysType::PRIMARY_KEYS;
 }
 
+void fill_missing_vector_index_owner(RowsetMetadataPB* rowset, int64_t tablet_id) {
+    for (auto& segment_meta : *rowset->mutable_segment_metas()) {
+        // shared() means the segment reached this tablet via a tablet-split cross-publish and was
+        // written by another tablet; the local id is never a correct owner there (see the
+        // declaration comment in meta_file.h).
+        if (segment_meta.vector_index_ids_size() > 0 && !segment_meta.has_vector_index_tablet_id() &&
+            !segment_meta.shared()) {
+            segment_meta.set_vector_index_tablet_id(tablet_id);
+        }
+    }
+}
+
 void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
                                  const std::vector<FileMetaPB>& orphan_files, const std::vector<FileMetaPB>& dels) {
     // If this is the first call, copy rowset_pb directly
@@ -1302,6 +1318,8 @@ Status MetaFileBuilder::set_final_rowset() {
         // tablet and must not alias a sibling: mint a fresh uid.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
+    // Must run after the replace block above, which rebuilds ids/owner wholesale.
+    fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -192,12 +192,9 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
         }
-        // Persist the owning tablet id used to name these .vi files (see the field comment on
-        // SegmentMetadataPB::vector_index_tablet_id); refresh it wholesale like vector_index_ids.
+        // The dest segment is a brand-new file written by this tablet: drop any stale owner copied
+        // from the partial segment; fill_missing_vector_index_owner below stamps the publisher.
         segment_meta->clear_vector_index_tablet_id();
-        if (replace_seg.second.vector_index_tablet_id >= 0) {
-            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
-        }
         // The rewrite file is a brand-new file private to this tablet, not shared with
         // sibling split tablets. If the original segment was marked shared during a
         // cross-publish, clear the flag so GC routes the rewrite file through the normal
@@ -218,7 +215,8 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         // children.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
-    // Must run after the replace block above, which rebuilds ids/owner wholesale.
+    // Sole producer of the owner id; must run after the replace block above, which rebuilds
+    // vector_index_ids and clears stale owners.
     fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());
@@ -748,7 +746,7 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
         // 2. We need del files to rebuild cloud native PK index.
         auto rowset = _tablet_meta->add_rowsets();
         rowset->CopyFrom(op_compaction.output_rowset());
-        // Compaction outputs are written by this tablet; backstop the .vi owner id.
+        // Compaction outputs are written by this tablet; stamp the .vi owner id.
         fill_missing_vector_index_owner(rowset, _tablet_meta->id());
         rowset->set_id(_tablet_meta->next_rowset_id());
         rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
@@ -1295,12 +1293,9 @@ Status MetaFileBuilder::set_final_rowset() {
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
         }
-        // See apply_opwrite: refresh the owning tablet id used to name these .vi files
-        // (SegmentMetadataPB::vector_index_tablet_id) wholesale like vector_index_ids.
+        // See apply_opwrite: drop any stale owner from the replaced segment;
+        // fill_missing_vector_index_owner below stamps the publisher.
         segment_meta->clear_vector_index_tablet_id();
-        if (replace_seg.second.vector_index_tablet_id >= 0) {
-            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
-        }
         // See apply_opwrite: clear the shared flag for the rewrite file, which is
         // private to this tablet and must not be GC'd through the shared-file path.
         if (segment_meta->has_shared()) {
@@ -1318,7 +1313,8 @@ Status MetaFileBuilder::set_final_rowset() {
         // tablet and must not alias a sibling: mint a fresh uid.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
-    // Must run after the replace block above, which rebuilds ids/owner wholesale.
+    // Sole producer of the owner id; must run after the replace block above, which rebuilds
+    // vector_index_ids and clears stale owners.
     fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -195,9 +195,9 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
         }
         // Refresh the owning tablet id wholesale like vector_index_ids: the replace FileInfo
         // carries the authoritative owner for the rewritten segment.
-        segment_meta->clear_vector_index_tablet_id();
-        if (replace_seg.second.vector_index_tablet_id >= 0) {
-            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
+        segment_meta->clear_segment_vector_index_uid();
+        if (replace_seg.second.segment_vector_index_uid >= 0) {
+            segment_meta->set_segment_vector_index_uid(replace_seg.second.segment_vector_index_uid);
         }
         // The rewrite file is a brand-new file private to this tablet, not shared with
         // sibling split tablets. If the original segment was marked shared during a
@@ -1282,9 +1282,9 @@ Status MetaFileBuilder::set_final_rowset() {
             segment_meta->add_vector_index_ids(vi_id);
         }
         // See apply_opwrite: refresh the owner from the replace FileInfo.
-        segment_meta->clear_vector_index_tablet_id();
-        if (replace_seg.second.vector_index_tablet_id >= 0) {
-            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
+        segment_meta->clear_segment_vector_index_uid();
+        if (replace_seg.second.segment_vector_index_uid >= 0) {
+            segment_meta->set_segment_vector_index_uid(replace_seg.second.segment_vector_index_uid);
         }
         // See apply_opwrite: clear the shared flag for the rewrite file, which is
         // private to this tablet and must not be GC'd through the shared-file path.

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -192,9 +192,12 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
         }
-        // The dest segment is a brand-new file written by this tablet: drop any stale owner copied
-        // from the partial segment; fill_missing_vector_index_owner below stamps the publisher.
+        // Refresh the owning tablet id wholesale like vector_index_ids: the replace FileInfo
+        // carries the authoritative owner for the rewritten segment.
         segment_meta->clear_vector_index_tablet_id();
+        if (replace_seg.second.vector_index_tablet_id >= 0) {
+            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
+        }
         // The rewrite file is a brand-new file private to this tablet, not shared with
         // sibling split tablets. If the original segment was marked shared during a
         // cross-publish, clear the flag so GC routes the rewrite file through the normal
@@ -215,9 +218,6 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         // children.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
-    // Sole producer of the owner id; must run after the replace block above, which rebuilds
-    // vector_index_ids and clears stale owners.
-    fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());
@@ -746,8 +746,6 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
         // 2. We need del files to rebuild cloud native PK index.
         auto rowset = _tablet_meta->add_rowsets();
         rowset->CopyFrom(op_compaction.output_rowset());
-        // Compaction outputs are written by this tablet; stamp the .vi owner id.
-        fill_missing_vector_index_owner(rowset, _tablet_meta->id());
         rowset->set_id(_tablet_meta->next_rowset_id());
         rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
         rowset->set_version(_tablet_meta->version());
@@ -1211,18 +1209,6 @@ bool is_primary_key(const TabletMetadata& metadata) {
     return metadata.schema().keys_type() == KeysType::PRIMARY_KEYS;
 }
 
-void fill_missing_vector_index_owner(RowsetMetadataPB* rowset, int64_t tablet_id) {
-    for (auto& segment_meta : *rowset->mutable_segment_metas()) {
-        // shared() means the segment reached this tablet via a tablet-split cross-publish and was
-        // written by another tablet; the local id is never a correct owner there (see the
-        // declaration comment in meta_file.h).
-        if (segment_meta.vector_index_ids_size() > 0 && !segment_meta.has_vector_index_tablet_id() &&
-            !segment_meta.shared()) {
-            segment_meta.set_vector_index_tablet_id(tablet_id);
-        }
-    }
-}
-
 void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
                                  const std::vector<FileMetaPB>& orphan_files, const std::vector<FileMetaPB>& dels) {
     // If this is the first call, copy rowset_pb directly
@@ -1293,9 +1279,11 @@ Status MetaFileBuilder::set_final_rowset() {
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
         }
-        // See apply_opwrite: drop any stale owner from the replaced segment;
-        // fill_missing_vector_index_owner below stamps the publisher.
+        // See apply_opwrite: refresh the owner from the replace FileInfo.
         segment_meta->clear_vector_index_tablet_id();
+        if (replace_seg.second.vector_index_tablet_id >= 0) {
+            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
+        }
         // See apply_opwrite: clear the shared flag for the rewrite file, which is
         // private to this tablet and must not be GC'd through the shared-file path.
         if (segment_meta->has_shared()) {
@@ -1313,9 +1301,6 @@ Status MetaFileBuilder::set_final_rowset() {
         // tablet and must not alias a sibling: mint a fresh uid.
         tablet_reshard_helper::set_rowset_uid(rowset);
     }
-    // Sole producer of the owner id; must run after the replace block above, which rebuilds
-    // vector_index_ids and clears stale owners.
-    fill_missing_vector_index_owner(rowset, _tablet_meta->id());
 
     rowset->set_id(_tablet_meta->next_rowset_id());
     rowset->set_version(_tablet_meta->version());

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -170,7 +170,7 @@ void MetaFileBuilder::append_dcg(uint32_t rssid,
     (*_tablet_meta->mutable_dcg_meta()->mutable_dcgs())[rssid] = new_dcg_ver;
 }
 
-void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
+void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, SegmentFileInfo>& replace_segments,
                                     const std::vector<FileMetaPB>& orphan_files) {
     auto rowset = _tablet_meta->add_rowsets();
     rowset->CopyFrom(op_write.rowset());
@@ -1209,7 +1209,7 @@ bool is_primary_key(const TabletMetadata& metadata) {
     return metadata.schema().keys_type() == KeysType::PRIMARY_KEYS;
 }
 
-void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
+void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, SegmentFileInfo>& replace_segments,
                                  const std::vector<FileMetaPB>& orphan_files, const std::vector<FileMetaPB>& dels) {
     // If this is the first call, copy rowset_pb directly
     if (_pending_rowset_data.rowset_pb.segment_metas_size() == 0) {
@@ -1345,7 +1345,7 @@ Status MetaFileBuilder::set_final_rowset() {
 }
 
 void MetaFileBuilder::batch_apply_opwrite(const TxnLogPB_OpWrite& op_write,
-                                          const std::map<int, FileInfo>& replace_segments,
+                                          const std::map<int, SegmentFileInfo>& replace_segments,
                                           const std::vector<FileMetaPB>& orphan_files) {
     // Each del already carries name + shared + encryption_meta together in its FileMetaPB.
     std::vector<FileMetaPB> dels;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -170,7 +170,8 @@ void MetaFileBuilder::append_dcg(uint32_t rssid,
     (*_tablet_meta->mutable_dcg_meta()->mutable_dcgs())[rssid] = new_dcg_ver;
 }
 
-void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, SegmentFileInfo>& replace_segments,
+void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
+                                    const std::map<int, SegmentFileInfo>& replace_segments,
                                     const std::vector<FileMetaPB>& orphan_files) {
     auto rowset = _tablet_meta->add_rowsets();
     rowset->CopyFrom(op_write.rowset());
@@ -1209,7 +1210,8 @@ bool is_primary_key(const TabletMetadata& metadata) {
     return metadata.schema().keys_type() == KeysType::PRIMARY_KEYS;
 }
 
-void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, SegmentFileInfo>& replace_segments,
+void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb,
+                                 const std::map<int, SegmentFileInfo>& replace_segments,
                                  const std::vector<FileMetaPB>& orphan_files, const std::vector<FileMetaPB>& dels) {
     // If this is the first call, copy rowset_pb directly
     if (_pending_rowset_data.rowset_pb.segment_metas_size() == 0) {

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -192,6 +192,12 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
         }
+        // Persist the owning tablet id used to name these .vi files (see the field comment on
+        // SegmentMetadataPB::vector_index_tablet_id); refresh it wholesale like vector_index_ids.
+        segment_meta->clear_vector_index_tablet_id();
+        if (replace_seg.second.vector_index_tablet_id >= 0) {
+            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
+        }
         // The rewrite file is a brand-new file private to this tablet, not shared with
         // sibling split tablets. If the original segment was marked shared during a
         // cross-publish, clear the flag so GC routes the rewrite file through the normal
@@ -1272,6 +1278,12 @@ Status MetaFileBuilder::set_final_rowset() {
         segment_meta->clear_vector_index_ids();
         for (int64_t vi_id : replace_seg.second.vector_index_ids) {
             segment_meta->add_vector_index_ids(vi_id);
+        }
+        // See apply_opwrite: refresh the owning tablet id used to name these .vi files
+        // (SegmentMetadataPB::vector_index_tablet_id) wholesale like vector_index_ids.
+        segment_meta->clear_vector_index_tablet_id();
+        if (replace_seg.second.vector_index_tablet_id >= 0) {
+            segment_meta->set_vector_index_tablet_id(replace_seg.second.vector_index_tablet_id);
         }
         // See apply_opwrite: clear the shared flag for the rewrite file, which is
         // private to this tablet and must not be GC'd through the shared-file path.

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -24,6 +24,7 @@
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/segment_file_info.h"
 
 namespace starrocks {
 
@@ -56,7 +57,7 @@ public:
                     const std::vector<std::vector<ColumnUID>>& unique_column_id_list,
                     const std::vector<int64_t>& file_sizes);
     // handle txn log
-    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
+    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, SegmentFileInfo>& replace_segments,
                        const std::vector<FileMetaPB>& orphan_files);
     void apply_column_mode_partial_update(const TxnLogPB_OpWrite& op_write);
     Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction, uint32_t max_compact_input_rowset_id,
@@ -80,9 +81,9 @@ public:
     void apply_drop_index(const TxnLogPB_OpDropIndex& op);
 
     // batch processing functions for merging multiple opwrites into one rowset
-    void batch_apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
+    void batch_apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, SegmentFileInfo>& replace_segments,
                              const std::vector<FileMetaPB>& orphan_files);
-    void add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
+    void add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, SegmentFileInfo>& replace_segments,
                     const std::vector<FileMetaPB>& orphan_files, const std::vector<FileMetaPB>& dels);
     Status set_final_rowset();
 
@@ -137,7 +138,7 @@ private:
 private:
     struct PendingRowsetData {
         RowsetMetadataPB rowset_pb;
-        std::map<int, FileInfo> replace_segments;
+        std::map<int, SegmentFileInfo> replace_segments;
         std::vector<FileMetaPB> orphan_files;
         // Per-del metadata: name + shared + encryption_meta carried together so the
         // parallel-array invariant between filename / shared / encryption can't drift.

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -192,17 +192,19 @@ void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& m
                                                const TxnLogPB_OpCompaction& op_compaction,
                                                RowsetMetadataPB& last_input_rowset);
 
-// Backstop for SegmentMetadataPB::vector_index_tablet_id: called at every publish funnel that adds
-// a rowset WRITTEN BY |tablet_id| to that tablet's metadata (op_write / compaction output / schema
-// change), it stamps the owner on any segment that recorded vector_index_ids without it, so a
-// writer path that forgot the stamp still persists a correct owner. Segments marked shared() are
-// skipped: those arrive via a tablet-split cross-publish and were written by another tablet — their
-// recorded owner (or its absence) must be carried verbatim, never overwritten with the local id.
+// SOLE producer of SegmentMetadataPB::vector_index_tablet_id. Writers never set the field; instead,
+// every publish funnel that adds a rowset WRITTEN BY |tablet_id| to that tablet's metadata
+// (op_write / compaction output / schema change) calls this to stamp the owner on each segment that
+// records vector_index_ids. At those funnels the publishing tablet IS the writing tablet, which is
+// also the id embedded in the .vi filenames on disk, so the stamped value always matches the files.
+// Segments marked shared() are skipped: those arrive via a tablet-split cross-publish and were
+// written by another tablet — their recorded owner (or its absence) must be carried verbatim, never
+// overwritten with the local id.
 // Replication: the non-PK applier's apply_replication_log adds rowsets directly and is deliberately
-// not backstopped. PK replication reuses the op_write funnels, so a replicated segment lacking an
-// owner gets stamped with the destination tablet id — harmless, because .vi files are not
-// replicated: any owner value resolves to a nonexistent file, the same degraded behavior such
-// segments had before this field existed.
+// not stamped. PK replication reuses the op_write funnels, so a replicated segment lacking an owner
+// gets stamped with the destination tablet id — harmless, because .vi files are not replicated: any
+// owner value resolves to a nonexistent file, the same degraded behavior such segments had before
+// this field existed.
 void fill_missing_vector_index_owner(RowsetMetadataPB* rowset, int64_t tablet_id);
 
 } // namespace lake

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -192,20 +192,5 @@ void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& m
                                                const TxnLogPB_OpCompaction& op_compaction,
                                                RowsetMetadataPB& last_input_rowset);
 
-// SOLE producer of SegmentMetadataPB::vector_index_tablet_id. Writers never set the field; instead,
-// every publish funnel that adds a rowset WRITTEN BY |tablet_id| to that tablet's metadata
-// (op_write / compaction output / schema change) calls this to stamp the owner on each segment that
-// records vector_index_ids. At those funnels the publishing tablet IS the writing tablet, which is
-// also the id embedded in the .vi filenames on disk, so the stamped value always matches the files.
-// Segments marked shared() are skipped: those arrive via a tablet-split cross-publish and were
-// written by another tablet — their recorded owner (or its absence) must be carried verbatim, never
-// overwritten with the local id.
-// Replication: the non-PK applier's apply_replication_log adds rowsets directly and is deliberately
-// not stamped. PK replication reuses the op_write funnels, so a replicated segment lacking an owner
-// gets stamped with the destination tablet id — harmless, because .vi files are not replicated: any
-// owner value resolves to a nonexistent file, the same degraded behavior such segments had before
-// this field existed.
-void fill_missing_vector_index_owner(RowsetMetadataPB* rowset, int64_t tablet_id);
-
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -192,5 +192,18 @@ void trim_partial_compaction_last_input_rowset(const MutableTabletMetadataPtr& m
                                                const TxnLogPB_OpCompaction& op_compaction,
                                                RowsetMetadataPB& last_input_rowset);
 
+// Backstop for SegmentMetadataPB::vector_index_tablet_id: called at every publish funnel that adds
+// a rowset WRITTEN BY |tablet_id| to that tablet's metadata (op_write / compaction output / schema
+// change), it stamps the owner on any segment that recorded vector_index_ids without it, so a
+// writer path that forgot the stamp still persists a correct owner. Segments marked shared() are
+// skipped: those arrive via a tablet-split cross-publish and were written by another tablet — their
+// recorded owner (or its absence) must be carried verbatim, never overwritten with the local id.
+// Replication: the non-PK applier's apply_replication_log adds rowsets directly and is deliberately
+// not backstopped. PK replication reuses the op_write funnels, so a replicated segment lacking an
+// owner gets stamped with the destination tablet id — harmless, because .vi files are not
+// replicated: any owner value resolves to a nonexistent file, the same degraded behavior such
+// segments had before this field existed.
+void fill_missing_vector_index_owner(RowsetMetadataPB* rowset, int64_t tablet_id);
+
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -379,6 +379,14 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
+        // Owner tablet id for .vi naming: use the recorded id so a segment shared across tablets
+        // after a split resolves the same .vi; fall back to this tablet for segments written
+        // before vector_index_tablet_id existed (those are never shared yet).
+        seg_options.vector_index_tablet_id = tablet_id();
+        if (meta_pos < _metadata->segment_metas_size() &&
+            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
+            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
+        }
 
         if (options.rowid_range_option != nullptr) { // physical split.
             auto [rowid_range, is_first_split_of_segment] =
@@ -474,6 +482,11 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
+        seg_options.vector_index_tablet_id = tablet_id();
+        if (meta_pos < _metadata->segment_metas_size() &&
+            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
+            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
+        }
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             continue;
@@ -531,6 +544,11 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
         if (meta_pos < _metadata->segment_metas_size() && _metadata->segment_metas(meta_pos).shared() &&
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
+        }
+        seg_options.vector_index_tablet_id = tablet_id();
+        if (meta_pos < _metadata->segment_metas_size() &&
+            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
+            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
         }
         // Apply per-segment rowid range if provided
         if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -381,12 +381,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             seg_options.tablet_range = *shared_segment_range;
         }
         // Owner tablet id for .vi naming: a segment shared across tablets after a split must
-        // resolve the same .vi from every reader (see vector_index_owner_tablet_id). Set only for
+        // resolve the same .vi from every reader (see resolve_segment_vector_index_uid). Set only for
         // vector-indexed segments; read() is the sole entry point that sets belonged_to_cloud_native,
         // so only its iterators reach the ANN-reader path that consumes this.
         if (meta_pos < _metadata->segment_metas_size() &&
             _metadata->segment_metas(meta_pos).vector_index_ids_size() > 0) {
-            seg_options.vector_index_tablet_id = vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos));
+            seg_options.segment_vector_index_uid = resolve_segment_vector_index_uid(_metadata->segment_metas(meta_pos));
         }
 
         if (options.rowid_range_option != nullptr) { // physical split.

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -29,6 +29,7 @@
 #include "runtime/runtime_env.h"
 #include "storage/delete_predicates.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/index_delta_group_loader.h"
 #include "storage/lake/lake_delvec_loader.h"
 #include "storage/lake/meta_file.h"
@@ -379,14 +380,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
-        // Owner tablet id for .vi naming: use the recorded id so a segment shared across tablets
-        // after a split resolves the same .vi; fall back to this tablet for segments written
-        // before vector_index_tablet_id existed (those are never shared yet).
-        seg_options.vector_index_tablet_id = tablet_id();
-        if (meta_pos < _metadata->segment_metas_size() &&
-            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
-            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
-        }
+        // Owner tablet id for .vi naming: a segment shared across tablets after a split must
+        // resolve the same .vi from every reader (see resolve_vector_index_owner_tablet_id).
+        seg_options.vector_index_tablet_id =
+                meta_pos < _metadata->segment_metas_size()
+                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
+                        : tablet_id();
 
         if (options.rowid_range_option != nullptr) { // physical split.
             auto [rowid_range, is_first_split_of_segment] =
@@ -482,11 +481,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
-        seg_options.vector_index_tablet_id = tablet_id();
-        if (meta_pos < _metadata->segment_metas_size() &&
-            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
-            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
-        }
+        seg_options.vector_index_tablet_id =
+                meta_pos < _metadata->segment_metas_size()
+                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
+                        : tablet_id();
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             continue;
@@ -545,11 +543,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
-        seg_options.vector_index_tablet_id = tablet_id();
-        if (meta_pos < _metadata->segment_metas_size() &&
-            _metadata->segment_metas(meta_pos).has_vector_index_tablet_id()) {
-            seg_options.vector_index_tablet_id = _metadata->segment_metas(meta_pos).vector_index_tablet_id();
-        }
+        seg_options.vector_index_tablet_id =
+                meta_pos < _metadata->segment_metas_size()
+                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
+                        : tablet_id();
         // Apply per-segment rowid range if provided
         if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
             seg_options.rowid_range_option = (*rowid_range_per_segment)[i];

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -382,6 +382,8 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
         }
         // Owner tablet id for .vi naming: a segment shared across tablets after a split must
         // resolve the same .vi from every reader (see resolve_vector_index_owner_tablet_id).
+        // Filled only here: read() is the sole entry point that sets belonged_to_cloud_native,
+        // so only its iterators can reach the ANN-reader path that consumes this.
         seg_options.vector_index_tablet_id =
                 meta_pos < _metadata->segment_metas_size()
                         ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
@@ -481,10 +483,6 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
-        seg_options.vector_index_tablet_id =
-                meta_pos < _metadata->segment_metas_size()
-                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
-                        : tablet_id();
         auto res = seg_ptr->new_iterator(schema, seg_options);
         if (res.status().is_end_of_file()) {
             continue;
@@ -543,10 +541,6 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
             shared_segment_range.has_value()) {
             seg_options.tablet_range = *shared_segment_range;
         }
-        seg_options.vector_index_tablet_id =
-                meta_pos < _metadata->segment_metas_size()
-                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
-                        : tablet_id();
         // Apply per-segment rowid range if provided
         if (rowid_range_per_segment != nullptr && i < rowid_range_per_segment->size()) {
             seg_options.rowid_range_option = (*rowid_range_per_segment)[i];

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -381,13 +381,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             seg_options.tablet_range = *shared_segment_range;
         }
         // Owner tablet id for .vi naming: a segment shared across tablets after a split must
-        // resolve the same .vi from every reader (see resolve_vector_index_owner_tablet_id).
-        // Filled only here: read() is the sole entry point that sets belonged_to_cloud_native,
-        // so only its iterators can reach the ANN-reader path that consumes this.
-        seg_options.vector_index_tablet_id =
-                meta_pos < _metadata->segment_metas_size()
-                        ? resolve_vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos), tablet_id())
-                        : tablet_id();
+        // resolve the same .vi from every reader (see vector_index_owner_tablet_id). Set only for
+        // vector-indexed segments; read() is the sole entry point that sets belonged_to_cloud_native,
+        // so only its iterators reach the ANN-reader path that consumes this.
+        if (meta_pos < _metadata->segment_metas_size() &&
+            _metadata->segment_metas(meta_pos).vector_index_ids_size() > 0) {
+            seg_options.vector_index_tablet_id = vector_index_owner_tablet_id(_metadata->segment_metas(meta_pos));
+        }
 
         if (options.rowid_range_option != nullptr) { // physical split.
             auto [rowid_range, is_first_split_of_segment] =

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -286,8 +286,7 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
                                                const std::string& dest_path, FileInfo* file_info) {
     // The src .vi was named by the src segment's owner tablet id; the dest is a brand-new segment
     // written by this tablet, so its .vi is named by (and recorded as owned by) this tablet.
-    const int64_t src_vi_tablet_id =
-            src_seg_meta.has_vector_index_tablet_id() ? src_seg_meta.vector_index_tablet_id() : params.tablet->id();
+    const int64_t src_vi_tablet_id = resolve_vector_index_owner_tablet_id(src_seg_meta, params.tablet->id());
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
         auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
         auto dest_vi =
@@ -618,12 +617,9 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         // async mode the src ids only marked a scheduled build — no .vi file ever existed.
         if (!defer_vector_index_build) {
             // The replaced src .vi was named by the src segment's owner tablet id.
-            const int64_t src_vi_tablet_id = src_seg_meta.has_vector_index_tablet_id()
-                                                     ? src_seg_meta.vector_index_tablet_id()
-                                                     : params.tablet->id();
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 FileMetaPB vi_meta;
-                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), src_vi_tablet_id, index_id));
+                vi_meta.set_name(gen_vector_index_filename_for_segment(src_seg_meta, params.tablet->id(), index_id));
                 orphan_files->push_back(std::move(vi_meta));
             }
         }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -284,8 +284,9 @@ static StatusOr<RewriteVectorIndexOptions> resolve_rewrite_vector_index_options(
 static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& params,
                                                const SegmentMetadataPB& src_seg_meta, const std::string& src_path,
                                                const std::string& dest_path, FileInfo* file_info) {
-    // The src .vi was named by the src segment's owner tablet id; the dest is a brand-new segment
-    // written by this tablet, so its .vi is named by (and recorded as owned by) this tablet.
+    // The src .vi is named by the src segment's recorded owner; the dest is a brand-new segment
+    // written by this tablet, so its .vi is named by this tablet (owner recorded by the caller
+    // via stamp_rewrite_vector_index_owner).
     const int64_t src_vi_tablet_id = resolve_vector_index_owner_tablet_id(src_seg_meta, params.tablet->id());
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
         auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
@@ -294,9 +295,16 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
         file_info->vector_index_ids.push_back(index_id);
     }
-    // The dest segment's owner (SegmentMetadataPB.vector_index_tablet_id) is stamped at publish
-    // time by fill_missing_vector_index_owner, like every other freshly written segment.
     return Status::OK();
+}
+
+// The dest segment of a rewrite is a brand-new file written by this tablet, so whatever
+// vector_index_ids the rewrite recorded (built inline, scheduled async, or carried from the src)
+// have their .vi named under params.tablet->id(); record it as the owner for every rewrite path.
+static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, FileInfo* file_info) {
+    if (!file_info->vector_index_ids.empty()) {
+        file_info->vector_index_tablet_id = params.tablet->id();
+    }
 }
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
@@ -545,6 +553,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
                 has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
                 params.tablet, std::move(vector_index_opts)));
         file_info.path = dest_path;
+        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
@@ -566,12 +575,12 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         if (!defer_vector_index_build) {
             RETURN_IF_ERROR(carry_src_segment_vector_indexes(params, src_seg_meta, src_path, dest_path, &file_info));
         } else if (unmodified_column_ids.empty()) {
-            // Copy-only async fast path: the rewrite never sees a SegmentWriter, so carry the src's
-            // scheduled ids (async has no .vi file to copy) lest the metadata refresh wipe them.
+            // Copy-only async fast path (see the block comment above).
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 file_info.vector_index_ids.push_back(index_id);
             }
         }
+        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else {
         need_rename = false;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -289,8 +289,7 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
     const int64_t src_vi_tablet_id =
             src_seg_meta.has_vector_index_tablet_id() ? src_seg_meta.vector_index_tablet_id() : params.tablet->id();
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
-        auto src_vi =
-                params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
+        auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
         auto dest_vi =
                 params.tablet->segment_location(gen_vector_index_filename(dest_path, params.tablet->id(), index_id));
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -289,7 +289,7 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
     // via stamp_rewrite_vector_index_owner).
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
         auto src_vi = params.tablet->segment_location(
-                gen_vector_index_filename(src_path, vector_index_owner_tablet_id(src_seg_meta), index_id));
+                gen_vector_index_filename(src_path, resolve_segment_vector_index_uid(src_seg_meta), index_id));
         auto dest_vi =
                 params.tablet->segment_location(gen_vector_index_filename(dest_path, params.tablet->id(), index_id));
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
@@ -303,7 +303,7 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
 // have their .vi named under params.tablet->id(); record it as the owner for every rewrite path.
 static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, SegmentFileInfo* file_info) {
     if (!file_info->vector_index_ids.empty()) {
-        file_info->vector_index_tablet_id = params.tablet->id();
+        file_info->segment_vector_index_uid = params.tablet->id();
     }
 }
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -283,7 +283,7 @@ static StatusOr<RewriteVectorIndexOptions> resolve_rewrite_vector_index_options(
 // mode has no src .vi to carry: the dest ids recorded by the rewrite already cover all indexes.
 static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& params,
                                                const SegmentMetadataPB& src_seg_meta, const std::string& src_path,
-                                               const std::string& dest_path, FileInfo* file_info) {
+                                               const std::string& dest_path, SegmentFileInfo* file_info) {
     // The src .vi is named by the src segment's recorded owner; the dest is a brand-new segment
     // written by this tablet, so its .vi is named by this tablet (owner recorded by the caller
     // via stamp_rewrite_vector_index_owner).
@@ -301,7 +301,7 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
 // The dest segment of a rewrite is a brand-new file written by this tablet, so whatever
 // vector_index_ids the rewrite recorded (built inline, scheduled async, or carried from the src)
 // have their .vi named under params.tablet->id(); record it as the owner for every rewrite path.
-static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, FileInfo* file_info) {
+static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, SegmentFileInfo* file_info) {
     if (!file_info->vector_index_ids.empty()) {
         file_info->vector_index_tablet_id = params.tablet->id();
     }
@@ -481,7 +481,7 @@ StatusOr<bool> RowsetUpdateState::file_exist(const std::string& full_path) {
 }
 
 Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
-                                          std::map<int, FileInfo>* replace_segments,
+                                          std::map<int, SegmentFileInfo>* replace_segments,
                                           std::vector<FileMetaPB>* orphan_files) {
     CHECK_MEM_LIMIT("RowsetUpdateState::rewrite_segment");
     TRACE_COUNTER_SCOPE_LATENCY_US("rewrite_segment_latency_us");
@@ -546,23 +546,25 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
     int64_t t_rewrite_start = MonotonicMillis();
     if (has_auto_increment_partial_update_state(params) &&
         !_auto_increment_partial_update_states[segment_id].skip_rewrite) {
-        FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
+        SegmentFileInfo file_info;
+        file_info.path = params.tablet->segment_location(dest_path);
         RETURN_IF_ERROR(SegmentRewriter::rewrite_auto_increment_lake(
                 src, &file_info, params.tablet_schema, _auto_increment_partial_update_states[segment_id],
                 unmodified_column_ids,
                 has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
-                params.tablet, std::move(vector_index_opts)));
+                params.tablet, std::move(vector_index_opts), &file_info.vector_index_ids));
         file_info.path = dest_path;
         stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
-        FileInfo file_info{.path = params.tablet->segment_location(dest_path)};
+        SegmentFileInfo file_info;
+        file_info.path = params.tablet->segment_location(dest_path);
 
         RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
                 src, &file_info, params.tablet_schema, unmodified_column_ids,
                 _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer,
-                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts)));
+                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts), &file_info.vector_index_ids));
         file_info.path = dest_path;
 
         // Sync indexes on the *updated* columns are not rebuilt by the rewrite (their data is

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -564,7 +564,8 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         RETURN_IF_ERROR(SegmentRewriter::rewrite_partial_update(
                 src, &file_info, params.tablet_schema, unmodified_column_ids,
                 _partial_update_states[segment_id].write_columns, segment_id, partial_rowset_footer,
-                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts), &file_info.vector_index_ids));
+                {root_path, std::to_string(rowset_meta.id())}, std::move(vector_index_opts),
+                &file_info.vector_index_ids));
         file_info.path = dest_path;
 
         // Sync indexes on the *updated* columns are not rebuilt by the rewrite (their data is

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -284,13 +284,20 @@ static StatusOr<RewriteVectorIndexOptions> resolve_rewrite_vector_index_options(
 static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& params,
                                                const SegmentMetadataPB& src_seg_meta, const std::string& src_path,
                                                const std::string& dest_path, FileInfo* file_info) {
+    // The src .vi was named by the src segment's owner tablet id; the dest is a brand-new segment
+    // written by this tablet, so its .vi is named by (and recorded as owned by) this tablet.
+    const int64_t src_vi_tablet_id =
+            src_seg_meta.has_vector_index_tablet_id() ? src_seg_meta.vector_index_tablet_id() : params.tablet->id();
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
         auto src_vi =
-                params.tablet->segment_location(gen_vector_index_filename(src_path, params.tablet->id(), index_id));
+                params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
         auto dest_vi =
                 params.tablet->segment_location(gen_vector_index_filename(dest_path, params.tablet->id(), index_id));
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
         file_info->vector_index_ids.push_back(index_id);
+    }
+    if (!file_info->vector_index_ids.empty()) {
+        file_info->vector_index_tablet_id = params.tablet->id();
     }
     return Status::OK();
 }
@@ -565,6 +572,10 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 file_info.vector_index_ids.push_back(index_id);
             }
+            // The deferred build names the dest .vi by this tablet (the dest owner); record it.
+            if (!file_info.vector_index_ids.empty()) {
+                file_info.vector_index_tablet_id = params.tablet->id();
+            }
         }
         (*replace_segments)[segment_id] = file_info;
     } else {
@@ -593,9 +604,13 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         // unreachable after the replace (the dest segment has its own copy); orphan it too. In
         // async mode the src ids only marked a scheduled build — no .vi file ever existed.
         if (!defer_vector_index_build) {
+            // The replaced src .vi was named by the src segment's owner tablet id.
+            const int64_t src_vi_tablet_id = src_seg_meta.has_vector_index_tablet_id()
+                                                     ? src_seg_meta.vector_index_tablet_id()
+                                                     : params.tablet->id();
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 FileMetaPB vi_meta;
-                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), params.tablet->id(), index_id));
+                vi_meta.set_name(gen_vector_index_filename(src_seg_meta.filename(), src_vi_tablet_id, index_id));
                 orphan_files->push_back(std::move(vi_meta));
             }
         }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -295,10 +295,22 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
         file_info->vector_index_ids.push_back(index_id);
     }
+    // The dest .vi owner is stamped by the caller via stamp_rewrite_vector_index_owner, uniformly
+    // across every rewrite path.
+    return Status::OK();
+}
+
+// The dest segment is a brand-new file written by this tablet, so whatever vector_index_ids the
+// rewrite recorded (inline build, scheduled async build, or carried src ids) have their .vi named
+// under params.tablet->id(). Record that as the owner (SegmentMetadataPB.vector_index_tablet_id) for
+// EVERY rewrite path, not just the copy-only async one: SegmentRewriter can also leave ids on
+// auto-increment rewrites and on partial updates with vector-indexed unmodified columns, and
+// MetaFileBuilder persists ids while clearing the owner unless we set it here. Stamping the writer id
+// keeps the .vi name reader-agnostic if the segment is later shared by a tablet split.
+static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, FileInfo* file_info) {
     if (!file_info->vector_index_ids.empty()) {
         file_info->vector_index_tablet_id = params.tablet->id();
     }
-    return Status::OK();
 }
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
@@ -547,6 +559,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
                 has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
                 params.tablet, std::move(vector_index_opts)));
         file_info.path = dest_path;
+        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
@@ -568,14 +581,15 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         if (!defer_vector_index_build) {
             RETURN_IF_ERROR(carry_src_segment_vector_indexes(params, src_seg_meta, src_path, dest_path, &file_info));
         } else if (unmodified_column_ids.empty()) {
+            // Copy-only async fast path: the rewrite never sees a SegmentWriter, so carry the src's
+            // scheduled ids (async has no .vi file to copy) lest the metadata refresh wipe them.
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 file_info.vector_index_ids.push_back(index_id);
             }
-            // The deferred build names the dest .vi by this tablet (the dest owner); record it.
-            if (!file_info.vector_index_ids.empty()) {
-                file_info.vector_index_tablet_id = params.tablet->id();
-            }
         }
+        // Stamp the dest owner for every partial-update rewrite path (including async rewrites that
+        // left ids for vector-indexed unmodified columns), not just the branches above.
+        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else {
         need_rename = false;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -294,22 +294,9 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
         file_info->vector_index_ids.push_back(index_id);
     }
-    // The dest .vi owner is stamped by the caller via stamp_rewrite_vector_index_owner, uniformly
-    // across every rewrite path.
+    // The dest segment's owner (SegmentMetadataPB.vector_index_tablet_id) is stamped at publish
+    // time by fill_missing_vector_index_owner, like every other freshly written segment.
     return Status::OK();
-}
-
-// The dest segment is a brand-new file written by this tablet, so whatever vector_index_ids the
-// rewrite recorded (inline build, scheduled async build, or carried src ids) have their .vi named
-// under params.tablet->id(). Record that as the owner (SegmentMetadataPB.vector_index_tablet_id) for
-// EVERY rewrite path, not just the copy-only async one: SegmentRewriter can also leave ids on
-// auto-increment rewrites and on partial updates with vector-indexed unmodified columns, and
-// MetaFileBuilder persists ids while clearing the owner unless we set it here. Stamping the writer id
-// keeps the .vi name reader-agnostic if the segment is later shared by a tablet split.
-static void stamp_rewrite_vector_index_owner(const RowsetUpdateStateParams& params, FileInfo* file_info) {
-    if (!file_info->vector_index_ids.empty()) {
-        file_info->vector_index_tablet_id = params.tablet->id();
-    }
 }
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(uint32_t segment_id,
@@ -558,7 +545,6 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
                 has_partial_update_state(params) ? &_partial_update_states[segment_id].write_columns : nullptr,
                 params.tablet, std::move(vector_index_opts)));
         file_info.path = dest_path;
-        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else if (has_partial_update_state(params)) {
         const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
@@ -586,9 +572,6 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
                 file_info.vector_index_ids.push_back(index_id);
             }
         }
-        // Stamp the dest owner for every partial-update rewrite path (including async rewrites that
-        // left ids for vector-indexed unmodified columns), not just the branches above.
-        stamp_rewrite_vector_index_owner(params, &file_info);
         (*replace_segments)[segment_id] = file_info;
     } else {
         need_rename = false;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -608,10 +608,15 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
         // unreachable after the replace (the dest segment has its own copy); orphan it too. In
         // async mode the src ids only marked a scheduled build — no .vi file ever existed.
         if (!defer_vector_index_build) {
-            // The replaced src .vi was named by the src segment's owner tablet id.
+            // The replaced src .vi was named by the src segment's owner tablet id. Carry the src's
+            // shared flag (like the segment orphan above) so a split-shared .vi still referenced by
+            // sibling tablets is routed through the shared-file deleter and delayed, not deleted.
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 FileMetaPB vi_meta;
                 vi_meta.set_name(gen_vector_index_filename_for_segment(src_seg_meta, params.tablet->id(), index_id));
+                if (src_seg_meta.has_shared()) {
+                    vi_meta.set_shared(src_seg_meta.shared());
+                }
                 orphan_files->push_back(std::move(vi_meta));
             }
         }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -287,9 +287,9 @@ static Status carry_src_segment_vector_indexes(const RowsetUpdateStateParams& pa
     // The src .vi is named by the src segment's recorded owner; the dest is a brand-new segment
     // written by this tablet, so its .vi is named by this tablet (owner recorded by the caller
     // via stamp_rewrite_vector_index_owner).
-    const int64_t src_vi_tablet_id = resolve_vector_index_owner_tablet_id(src_seg_meta, params.tablet->id());
     for (int64_t index_id : src_seg_meta.vector_index_ids()) {
-        auto src_vi = params.tablet->segment_location(gen_vector_index_filename(src_path, src_vi_tablet_id, index_id));
+        auto src_vi = params.tablet->segment_location(
+                gen_vector_index_filename(src_path, vector_index_owner_tablet_id(src_seg_meta), index_id));
         auto dest_vi =
                 params.tablet->segment_location(gen_vector_index_filename(dest_path, params.tablet->id(), index_id));
         RETURN_IF_ERROR(fs::copy_file(src_vi, dest_vi).status());
@@ -613,7 +613,7 @@ Status RowsetUpdateState::rewrite_segment(uint32_t segment_id, int64_t txn_id, c
             // sibling tablets is routed through the shared-file deleter and delayed, not deleted.
             for (int64_t index_id : src_seg_meta.vector_index_ids()) {
                 FileMetaPB vi_meta;
-                vi_meta.set_name(gen_vector_index_filename_for_segment(src_seg_meta, params.tablet->id(), index_id));
+                vi_meta.set_name(gen_vector_index_filename_for_segment(src_seg_meta, index_id));
                 if (src_seg_meta.has_shared()) {
                     vi_meta.set_shared(src_seg_meta.shared());
                 }

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -24,6 +24,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/primitive/primary_key_encoding_types.h"
+#include "storage/rowset/segment_file_info.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
@@ -124,7 +125,7 @@ public:
     // Thread-safe for concurrent calls with DIFFERENT segment_id values,
     // provided each call uses its own replace_segments/orphan_files containers.
     Status rewrite_segment(uint32_t segment_id, int64_t txn_id, const RowsetUpdateStateParams& params,
-                           std::map<int, FileInfo>* replace_segments, std::vector<FileMetaPB>* orphan_files);
+                           std::map<int, SegmentFileInfo>* replace_segments, std::vector<FileMetaPB>* orphan_files);
 
     // Release `segment_id`-th segment file's state (upserts + partial state).
     void release_segment(uint32_t segment_id);

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -768,12 +768,8 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
     // Helper to collect .vi files tracked in a rowset's segment_metas
     auto collect_vi_files = [&](const RowsetMetadataPB& rowset) {
         for (const auto& segment_meta : rowset.segment_metas()) {
-            // Name .vi files by the segment's recorded owner tablet id (matches how they were written);
-            // fall back to this txn's tablet for segments written before vector_index_tablet_id existed.
-            const int64_t vi_tablet_id =
-                    segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : tablet_id;
             for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }
@@ -799,11 +795,8 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
             const auto& segment_name = segment_metas[idx].filename();
             files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segment_name));
             // Delete .vi files for this new segment, named by its recorded owner tablet id.
-            const int64_t vi_tablet_id = segment_metas[idx].has_vector_index_tablet_id()
-                                                 ? segment_metas[idx].vector_index_tablet_id()
-                                                 : tablet_id;
             for (int64_t vi_id : segment_metas[idx].vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_name, vi_tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename_for_segment(segment_metas[idx], tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -769,7 +769,7 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
     auto collect_vi_files = [&](const RowsetMetadataPB& rowset) {
         for (const auto& segment_meta : rowset.segment_metas()) {
             for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename_for_segment(segment_meta, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }
@@ -796,7 +796,7 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
             files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segment_name));
             // Delete .vi files for this new segment, named by its recorded owner tablet id.
             for (int64_t vi_id : segment_metas[idx].vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename_for_segment(segment_metas[idx], tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename_for_segment(segment_metas[idx], vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -768,8 +768,12 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
     // Helper to collect .vi files tracked in a rowset's segment_metas
     auto collect_vi_files = [&](const RowsetMetadataPB& rowset) {
         for (const auto& segment_meta : rowset.segment_metas()) {
+            // Name .vi files by the segment's recorded owner tablet id (matches how they were written);
+            // fall back to this txn's tablet for segments written before vector_index_tablet_id existed.
+            const int64_t vi_tablet_id =
+                    segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : tablet_id;
             for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }
@@ -794,9 +798,12 @@ void collect_files_in_log(TabletManager* tablet_mgr, const TxnLog& txn_log, std:
              ++idx, ++cnt) {
             const auto& segment_name = segment_metas[idx].filename();
             files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, segment_name));
-            // Delete .vi files for this new segment
+            // Delete .vi files for this new segment, named by its recorded owner tablet id.
+            const int64_t vi_tablet_id = segment_metas[idx].has_vector_index_tablet_id()
+                                                 ? segment_metas[idx].vector_index_tablet_id()
+                                                 : tablet_id;
             for (int64_t vi_id : segment_metas[idx].vector_index_ids()) {
-                auto vi_name = gen_vector_index_filename(segment_name, tablet_id, vi_id);
+                auto vi_name = gen_vector_index_filename(segment_name, vi_tablet_id, vi_id);
                 files_to_delete->emplace_back(tablet_mgr->segment_location(tablet_id, vi_name));
             }
         }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -662,6 +662,9 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
+            // Schema-change conversion segments were written by this (shadow) tablet; backstop
+            // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
+            fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }
         if (op_schema_change.has_delvec_meta()) {
             DCHECK(op_schema_change.linked_segment());
@@ -1073,6 +1076,8 @@ private:
         if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
+            // These segments were written by this tablet; backstop the .vi owner id.
+            fill_missing_vector_index_owner(rowset, _metadata->id());
             rowset->set_id(_metadata->next_rowset_id());
             rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(_metadata->next_rowset_id() + get_rowset_id_step(*rowset));
@@ -1185,6 +1190,8 @@ private:
             // Replace the first input rowset with output rowset
             auto output_rowset = _metadata->mutable_rowsets(first_idx);
             output_rowset->CopyFrom(op_compaction.output_rowset());
+            // Compaction outputs are written by this tablet; backstop the .vi owner id.
+            fill_missing_vector_index_owner(output_rowset, _metadata->id());
             output_rowset->set_id(_metadata->next_rowset_id());
             output_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(_metadata->next_rowset_id() + get_rowset_id_step(*output_rowset));
@@ -1266,6 +1273,9 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
+            // Schema-change conversion segments were written by this (shadow) tablet; backstop
+            // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
+            fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }
         DCHECK(!op_schema_change.has_delvec_meta());
         return Status::OK();

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -662,7 +662,7 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
-            // Schema-change conversion segments were written by this (shadow) tablet; backstop
+            // Schema-change conversion segments were written by this (shadow) tablet; stamp
             // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
             fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }
@@ -1076,7 +1076,7 @@ private:
         if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
-            // These segments were written by this tablet; backstop the .vi owner id.
+            // These segments were written by this tablet; stamp the .vi owner id.
             fill_missing_vector_index_owner(rowset, _metadata->id());
             rowset->set_id(_metadata->next_rowset_id());
             rowset->set_version(_new_version);
@@ -1190,7 +1190,7 @@ private:
             // Replace the first input rowset with output rowset
             auto output_rowset = _metadata->mutable_rowsets(first_idx);
             output_rowset->CopyFrom(op_compaction.output_rowset());
-            // Compaction outputs are written by this tablet; backstop the .vi owner id.
+            // Compaction outputs are written by this tablet; stamp the .vi owner id.
             fill_missing_vector_index_owner(output_rowset, _metadata->id());
             output_rowset->set_id(_metadata->next_rowset_id());
             output_rowset->set_version(_new_version);
@@ -1273,7 +1273,7 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
-            // Schema-change conversion segments were written by this (shadow) tablet; backstop
+            // Schema-change conversion segments were written by this (shadow) tablet; stamp
             // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
             fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -662,9 +662,6 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
-            // Schema-change conversion segments were written by this (shadow) tablet; stamp
-            // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
-            fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }
         if (op_schema_change.has_delvec_meta()) {
             DCHECK(op_schema_change.linked_segment());
@@ -1076,8 +1073,6 @@ private:
         if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
-            // These segments were written by this tablet; stamp the .vi owner id.
-            fill_missing_vector_index_owner(rowset, _metadata->id());
             rowset->set_id(_metadata->next_rowset_id());
             rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(_metadata->next_rowset_id() + get_rowset_id_step(*rowset));
@@ -1190,8 +1185,6 @@ private:
             // Replace the first input rowset with output rowset
             auto output_rowset = _metadata->mutable_rowsets(first_idx);
             output_rowset->CopyFrom(op_compaction.output_rowset());
-            // Compaction outputs are written by this tablet; stamp the .vi owner id.
-            fill_missing_vector_index_owner(output_rowset, _metadata->id());
             output_rowset->set_id(_metadata->next_rowset_id());
             output_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(_metadata->next_rowset_id() + get_rowset_id_step(*output_rowset));
@@ -1273,9 +1266,6 @@ private:
             new_rowset->CopyFrom(rowset);
             new_rowset->set_version(_new_version);
             _metadata->set_next_rowset_id(new_rowset->id() + get_rowset_id_step(*new_rowset));
-            // Schema-change conversion segments were written by this (shadow) tablet; stamp
-            // the .vi owner id. ADD VECTOR INDEX rewrites flow through here.
-            fill_missing_vector_index_owner(new_rowset, _metadata->id());
         }
         DCHECK(!op_schema_change.has_delvec_meta());
         return Status::OK();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -143,7 +143,7 @@ void RssidFileInfoContainer::add_rssid_to_file(const TabletMetadata& metadata) {
 }
 
 void RssidFileInfoContainer::add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_idx,
-                                               const std::map<int, FileInfo>& replace_segments) {
+                                               const std::map<int, SegmentFileInfo>& replace_segments) {
     DCHECK(segment_idx < meta.segment_metas_size());
     uint32_t local_segment_id = get_segment_idx(meta, static_cast<int32_t>(segment_idx));
     if (replace_segments.count(segment_idx) > 0) {
@@ -322,7 +322,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     const int64_t io_count_remote_before = state.stats().io_count_remote;
 
     std::vector<FileMetaPB> orphan_files;
-    std::map<int, FileInfo> replace_segments;
+    std::map<int, SegmentFileInfo> replace_segments;
     RssidFileInfoContainer rssid_fileinfo_container;
     rssid_fileinfo_container.add_rssid_to_file(*metadata);
     // Init update state.
@@ -390,7 +390,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         if (use_parallel_partial_update && batch_end - batch_start > 1) {
             TRACE_COUNTER_SCOPE_LATENCY_US("parallel_load_rewrite_seg_latency_us");
             uint32_t batch_count = batch_end - batch_start;
-            std::vector<std::map<int, FileInfo>> per_seg_replace(batch_count);
+            std::vector<std::map<int, SegmentFileInfo>> per_seg_replace(batch_count);
             std::vector<std::vector<FileMetaPB>> per_seg_orphans(batch_count);
 
             std::mutex status_mutex;

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -63,7 +63,7 @@ class RssidFileInfoContainer {
 public:
     void add_rssid_to_file(const TabletMetadata& metadata);
     void add_rssid_to_file(const RowsetMetadataPB& meta, uint32_t rowset_id, uint32_t segment_idx,
-                           const std::map<int, FileInfo>& replace_segments);
+                           const std::map<int, SegmentFileInfo>& replace_segments);
 
     const std::unordered_map<uint32_t, FileInfo>& rssid_to_file() const { return _rssid_to_file_info; }
     const std::unordered_map<uint32_t, uint32_t>& rssid_to_rowid() const { return _rssid_to_rowid; }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -174,12 +174,8 @@ static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, AsyncSharedFileD
     for (int i = 0; i < rowset.segment_metas_size(); ++i) {
         const auto& segment_meta = rowset.segment_metas(i);
         const bool shared_file = is_shared_segment(rowset, i);
-        // Use the segment's recorded owner tablet id (matches how the .vi was named at write time);
-        // fall back to this tablet for segments written before vector_index_tablet_id existed.
-        const int64_t vi_tablet_id =
-                segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : tablet_id;
         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_path = join_path(base_dir, gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id));
+            auto vi_path = join_path(base_dir, gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id));
             if (shared_file && shared_file_deleter != nullptr) {
                 RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
             } else {
@@ -1479,16 +1475,12 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
                 data_files.erase(segment);
                 data_files_in_metadatas.emplace(segment);
             }
-            // Protect associated .vi files using per-segment vector index metadata. Name them by the
+            // Protect associated .vi files using per-segment vector index metadata. Named by the
             // segment's recorded owner tablet id (not check_meta->id()) so a segment shared across
-            // tablets after a split is protected under the same .vi name every referencing tablet uses;
-            // fall back to check_meta->id() for segments written before vector_index_tablet_id existed.
+            // tablets after a split is protected under the same .vi name every referencing tablet uses.
             for (const auto& segment_meta : rowset.segment_metas()) {
-                const int64_t vi_tablet_id = segment_meta.has_vector_index_tablet_id()
-                                                     ? segment_meta.vector_index_tablet_id()
-                                                     : check_meta->id();
                 for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                    auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id);
+                    auto vi_name = gen_vector_index_filename_for_segment(segment_meta, check_meta->id(), vi_id);
                     data_files.erase(vi_name);
                     data_files_in_metadatas.emplace(vi_name);
                 }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -389,6 +389,15 @@ static Status collect_alive_shared_files(TabletManager* tablet_mgr, const std::v
                                     data_dir, gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id))));
                         }
                     }
+                    // A split-shared segment's .vi is referenced by every sibling under the same
+                    // owner-based name, so delay-delete it too (bundle-only .vi is per-tablet).
+                    const auto& segment_meta = rowset.segment_metas(i);
+                    if (segment_meta.shared()) {
+                        for (int64_t vi_id : segment_meta.vector_index_ids()) {
+                            RETURN_IF_ERROR(deleter->delay_delete(join_path(
+                                    data_dir, gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id))));
+                        }
+                    }
                 }
                 for (const auto& del_file : rowset.del_files()) {
                     if (del_file.shared()) {
@@ -1211,6 +1220,11 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
                         }
                     }
+                    // Delete associated .vi files; a shared segment's .vi follows its segment —
+                    // retained via the shared-file deleter unless shared deletion is allowed here.
+                    RETURN_IF_ERROR(delete_rowset_vi_files(
+                            &deleter, allow_delete_shared_files ? nullptr : &dummy_shared_file_deleter, data_dir,
+                            latest_metadata->id(), rowset));
                 }
                 if (latest_metadata->has_delvec_meta()) {
                     for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -174,8 +174,12 @@ static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, AsyncSharedFileD
     for (int i = 0; i < rowset.segment_metas_size(); ++i) {
         const auto& segment_meta = rowset.segment_metas(i);
         const bool shared_file = is_shared_segment(rowset, i);
+        // Use the segment's recorded owner tablet id (matches how the .vi was named at write time);
+        // fall back to this tablet for segments written before vector_index_tablet_id existed.
+        const int64_t vi_tablet_id =
+                segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : tablet_id;
         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_path = join_path(base_dir, gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id));
+            auto vi_path = join_path(base_dir, gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id));
             if (shared_file && shared_file_deleter != nullptr) {
                 RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
             } else {
@@ -1475,10 +1479,16 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
                 data_files.erase(segment);
                 data_files_in_metadatas.emplace(segment);
             }
-            // Protect associated .vi files using per-segment vector index metadata
+            // Protect associated .vi files using per-segment vector index metadata. Name them by the
+            // segment's recorded owner tablet id (not check_meta->id()) so a segment shared across
+            // tablets after a split is protected under the same .vi name every referencing tablet uses;
+            // fall back to check_meta->id() for segments written before vector_index_tablet_id existed.
             for (const auto& segment_meta : rowset.segment_metas()) {
+                const int64_t vi_tablet_id = segment_meta.has_vector_index_tablet_id()
+                                                     ? segment_meta.vector_index_tablet_id()
+                                                     : check_meta->id();
                 for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                    auto vi_name = gen_vector_index_filename(segment_meta.filename(), check_meta->id(), vi_id);
+                    auto vi_name = gen_vector_index_filename(segment_meta.filename(), vi_tablet_id, vi_id);
                     data_files.erase(vi_name);
                     data_files_in_metadatas.emplace(vi_name);
                 }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -175,7 +175,7 @@ static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, AsyncSharedFileD
         const auto& segment_meta = rowset.segment_metas(i);
         const bool shared_file = is_shared_segment(rowset, i);
         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_path = join_path(base_dir, gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id));
+            auto vi_path = join_path(base_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id));
             if (shared_file && shared_file_deleter != nullptr) {
                 RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
             } else {
@@ -394,8 +394,8 @@ static Status collect_alive_shared_files(TabletManager* tablet_mgr, const std::v
                     const auto& segment_meta = rowset.segment_metas(i);
                     if (segment_meta.shared()) {
                         for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                            RETURN_IF_ERROR(deleter->delay_delete(join_path(
-                                    data_dir, gen_vector_index_filename_for_segment(segment_meta, tablet_id, vi_id))));
+                            RETURN_IF_ERROR(deleter->delay_delete(
+                                    join_path(data_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id))));
                         }
                     }
                 }
@@ -1493,7 +1493,7 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
             // check_meta->id(): split-shared segments must be protected under the writer's name).
             for (const auto& segment_meta : rowset.segment_metas()) {
                 for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                    auto vi_name = gen_vector_index_filename_for_segment(segment_meta, check_meta->id(), vi_id);
+                    auto vi_name = gen_vector_index_filename_for_segment(segment_meta, vi_id);
                     data_files.erase(vi_name);
                     data_files_in_metadatas.emplace(vi_name);
                 }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1475,9 +1475,8 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
                 data_files.erase(segment);
                 data_files_in_metadatas.emplace(segment);
             }
-            // Protect associated .vi files using per-segment vector index metadata. Named by the
-            // segment's recorded owner tablet id (not check_meta->id()) so a segment shared across
-            // tablets after a split is protected under the same .vi name every referencing tablet uses.
+            // Protect associated .vi files, named by the segment's recorded owner (not
+            // check_meta->id(): split-shared segments must be protected under the writer's name).
             for (const auto& segment_meta : rowset.segment_metas()) {
                 for (int64_t vi_id : segment_meta.vector_index_ids()) {
                     auto vi_name = gen_vector_index_filename_for_segment(segment_meta, check_meta->id(), vi_id);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1202,8 +1202,8 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                             // (skipped while a sibling may still reference a shared segment), named by
                             // the segment's recorded owner so the right file is removed after a split.
                             for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                                RETURN_IF_ERROR(deleter.delete_file(
-                                        join_path(data_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id))));
+                                RETURN_IF_ERROR(deleter.delete_file(join_path(
+                                        data_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id))));
                             }
                         }
                     }

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -383,16 +383,9 @@ static Status collect_alive_shared_files(TabletManager* tablet_mgr, const std::v
                     if (is_shared_segment(rowset, i)) {
                         const auto& segment_meta = rowset.segment_metas(i);
                         RETURN_IF_ERROR(deleter->delay_delete(join_path(data_dir, segment_meta.filename())));
-                        // A shared segment's per-segment .vi sidecars are shared too.
-                        for (int64_t vi_id : segment_meta.vector_index_ids()) {
-                            RETURN_IF_ERROR(deleter->delay_delete(join_path(
-                                    data_dir, gen_vector_index_filename(segment_meta.filename(), tablet_id, vi_id))));
-                        }
-                    }
-                    // A split-shared segment's .vi is referenced by every sibling under the same
-                    // owner-based name, so delay-delete it too (bundle-only .vi is per-tablet).
-                    const auto& segment_meta = rowset.segment_metas(i);
-                    if (segment_meta.shared()) {
+                        // The segment's per-segment .vi sidecars follow the segment; they are named by
+                        // its recorded owner, so delay-delete them under that owner-based name (covers
+                        // both split-shared and bundled segments, matching is_shared_segment above).
                         for (int64_t vi_id : segment_meta.vector_index_ids()) {
                             RETURN_IF_ERROR(deleter->delay_delete(
                                     join_path(data_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id))));
@@ -1205,13 +1198,12 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                         if (!is_shared_segment(rowset, i) || allow_delete_shared_files) {
                             const auto& segment_meta = rowset.segment_metas(i);
                             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, segment_meta.filename())));
-                            // Delete the segment's per-segment .vi sidecars under the same shared
-                            // guard, so a shared segment's .vi is not removed while a sibling tablet
-                            // still references the segment.
+                            // Delete the segment's per-segment .vi sidecars under the same shared guard
+                            // (skipped while a sibling may still reference a shared segment), named by
+                            // the segment's recorded owner so the right file is removed after a split.
                             for (int64_t vi_id : segment_meta.vector_index_ids()) {
                                 RETURN_IF_ERROR(deleter.delete_file(
-                                        join_path(data_dir, gen_vector_index_filename(segment_meta.filename(),
-                                                                                      latest_metadata->id(), vi_id))));
+                                        join_path(data_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id))));
                             }
                         }
                     }
@@ -1220,11 +1212,6 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                             RETURN_IF_ERROR(deleter.delete_file(join_path(data_dir, del_file.name())));
                         }
                     }
-                    // Delete associated .vi files; a shared segment's .vi follows its segment —
-                    // retained via the shared-file deleter unless shared deletion is allowed here.
-                    RETURN_IF_ERROR(delete_rowset_vi_files(
-                            &deleter, allow_delete_shared_files ? nullptr : &dummy_shared_file_deleter, data_dir,
-                            latest_metadata->id(), rowset));
                 }
                 if (latest_metadata->has_delvec_meta()) {
                     for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -112,7 +112,7 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
             const auto& seg_name = segment_meta.filename();
             // Name .vi files by the segment's recorded owner tablet id so a segment shared across
             // tablets after a split builds/reads the same .vi.
-            const int64_t vi_tablet_id = vector_index_owner_tablet_id(segment_meta);
+            const int64_t vi_tablet_id = resolve_segment_vector_index_uid(segment_meta);
             std::vector<int64_t> index_ids;
             for (int64_t idx_id : segment_meta.vector_index_ids()) {
                 // Skip indexes whose .vi file already exists (partial retry recovery).
@@ -144,7 +144,7 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
                 segment_file_info.encryption_meta = segment_meta.encryption_meta();
             }
             // index_ids is non-empty here; pair the owner with it (see FileInfo's field comment).
-            segment_file_info.vector_index_tablet_id = vi_tablet_id;
+            segment_file_info.segment_vector_index_uid = vi_tablet_id;
 
             _work_items.push_back({cand.version, std::move(segment_file_info), std::move(index_ids)});
         }
@@ -297,7 +297,7 @@ Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const SegmentFileI
             seg_basename = seg_basename.substr(pos + 1);
         }
         std::string vi_name =
-                gen_vector_index_filename(seg_basename, segment_file_info.vector_index_tablet_id, index_id);
+                gen_vector_index_filename(seg_basename, segment_file_info.segment_vector_index_uid, index_id);
         std::string vi_path = _tablet_mgr->segment_location(tablet_id, vi_name);
 
         ASSIGN_OR_RETURN(auto builder_type,

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -110,12 +110,17 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
             }
 
             const auto& seg_name = segment_meta.filename();
+            // Name .vi files by the segment's recorded owner tablet id so a segment shared across
+            // tablets after a split builds/reads the same .vi; fall back to this task's tablet for
+            // segments written before vector_index_tablet_id existed.
+            const int64_t vi_tablet_id =
+                    segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : _tablet_id;
             std::vector<int64_t> index_ids;
             for (int64_t idx_id : segment_meta.vector_index_ids()) {
                 // Skip indexes whose .vi file already exists (partial retry recovery).
                 // This only runs for segments in the current batch (bounded by
                 // max_rowsets_per_batch), so S3 HEAD cost is minimal.
-                std::string vi_name = gen_vector_index_filename(seg_name, _tablet_id, idx_id);
+                std::string vi_name = gen_vector_index_filename(seg_name, vi_tablet_id, idx_id);
                 std::string vi_path = _tablet_mgr->segment_location(_tablet_id, vi_name);
                 if (fs::path_exist(vi_path)) {
                     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id
@@ -140,7 +145,7 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
                 segment_file_info.encryption_meta = segment_meta.encryption_meta();
             }
 
-            _work_items.push_back({cand.version, std::move(segment_file_info), std::move(index_ids)});
+            _work_items.push_back({cand.version, std::move(segment_file_info), std::move(index_ids), vi_tablet_id});
         }
 
         // Mark this version as processed in _rowset_versions.
@@ -164,7 +169,9 @@ Status VectorIndexBuildTask::build_one_segment(size_t work_index) {
     const auto& work = _work_items[work_index];
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " building segment=" << work.segment_file_info.path
               << " version=" << work.rowset_version << " index_ids_count=" << work.index_ids.size();
-    RETURN_IF_ERROR(build_segment(_tablet_id, work.segment_file_info, work.index_ids, _tablet_schema));
+    RETURN_IF_ERROR(
+            build_segment(_tablet_id, work.vector_index_tablet_id, work.segment_file_info, work.index_ids,
+                          _tablet_schema));
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " built segment=" << work.segment_file_info.path
               << " successfully";
     return Status::OK();
@@ -227,7 +234,7 @@ Status VectorIndexBuildTask::execute(const BuildVectorIndexRequest& request, Bui
     return Status::OK();
 }
 
-Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& segment_file_info,
+Status VectorIndexBuildTask::build_segment(int64_t tablet_id, int64_t vi_tablet_id, const FileInfo& segment_file_info,
                                            const std::vector<int64_t>& index_ids,
                                            const TabletSchemaCSPtr& tablet_schema) {
     // Open the segment file (FileInfo carries size/encryption for proper access)
@@ -290,7 +297,7 @@ Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& se
         if (auto pos = seg_basename.rfind('/'); pos != std::string_view::npos) {
             seg_basename = seg_basename.substr(pos + 1);
         }
-        std::string vi_name = gen_vector_index_filename(seg_basename, _tablet_id, index_id);
+        std::string vi_name = gen_vector_index_filename(seg_basename, vi_tablet_id, index_id);
         std::string vi_path = _tablet_mgr->segment_location(tablet_id, vi_name);
 
         ASSIGN_OR_RETURN(auto builder_type,

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -111,10 +111,8 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
 
             const auto& seg_name = segment_meta.filename();
             // Name .vi files by the segment's recorded owner tablet id so a segment shared across
-            // tablets after a split builds/reads the same .vi; fall back to this task's tablet for
-            // segments written before vector_index_tablet_id existed.
-            const int64_t vi_tablet_id =
-                    segment_meta.has_vector_index_tablet_id() ? segment_meta.vector_index_tablet_id() : _tablet_id;
+            // tablets after a split builds/reads the same .vi.
+            const int64_t vi_tablet_id = resolve_vector_index_owner_tablet_id(segment_meta, _tablet_id);
             std::vector<int64_t> index_ids;
             for (int64_t idx_id : segment_meta.vector_index_ids()) {
                 // Skip indexes whose .vi file already exists (partial retry recovery).

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -132,7 +132,8 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
             }
 
             std::string seg_path = _tablet_mgr->segment_location(_tablet_id, seg_name);
-            FileInfo segment_file_info{.path = seg_path};
+            SegmentFileInfo segment_file_info;
+            segment_file_info.path = seg_path;
             if (segment_meta.has_size()) {
                 segment_file_info.size = segment_meta.size();
             }
@@ -232,7 +233,7 @@ Status VectorIndexBuildTask::execute(const BuildVectorIndexRequest& request, Bui
     return Status::OK();
 }
 
-Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& segment_file_info,
+Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const SegmentFileInfo& segment_file_info,
                                            const std::vector<int64_t>& index_ids,
                                            const TabletSchemaCSPtr& tablet_schema) {
     // Open the segment file (FileInfo carries size/encryption for proper access)

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -112,7 +112,7 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
             const auto& seg_name = segment_meta.filename();
             // Name .vi files by the segment's recorded owner tablet id so a segment shared across
             // tablets after a split builds/reads the same .vi.
-            const int64_t vi_tablet_id = resolve_vector_index_owner_tablet_id(segment_meta, _tablet_id);
+            const int64_t vi_tablet_id = vector_index_owner_tablet_id(segment_meta);
             std::vector<int64_t> index_ids;
             for (int64_t idx_id : segment_meta.vector_index_ids()) {
                 // Skip indexes whose .vi file already exists (partial retry recovery).

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -142,8 +142,10 @@ Status VectorIndexBuildTask::prepare(const BuildVectorIndexRequest& request) {
             if (segment_meta.has_encryption_meta()) {
                 segment_file_info.encryption_meta = segment_meta.encryption_meta();
             }
+            // index_ids is non-empty here; pair the owner with it (see FileInfo's field comment).
+            segment_file_info.vector_index_tablet_id = vi_tablet_id;
 
-            _work_items.push_back({cand.version, std::move(segment_file_info), std::move(index_ids), vi_tablet_id});
+            _work_items.push_back({cand.version, std::move(segment_file_info), std::move(index_ids)});
         }
 
         // Mark this version as processed in _rowset_versions.
@@ -167,8 +169,7 @@ Status VectorIndexBuildTask::build_one_segment(size_t work_index) {
     const auto& work = _work_items[work_index];
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " building segment=" << work.segment_file_info.path
               << " version=" << work.rowset_version << " index_ids_count=" << work.index_ids.size();
-    RETURN_IF_ERROR(build_segment(_tablet_id, work.vector_index_tablet_id, work.segment_file_info, work.index_ids,
-                                  _tablet_schema));
+    RETURN_IF_ERROR(build_segment(_tablet_id, work.segment_file_info, work.index_ids, _tablet_schema));
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " built segment=" << work.segment_file_info.path
               << " successfully";
     return Status::OK();
@@ -231,7 +232,7 @@ Status VectorIndexBuildTask::execute(const BuildVectorIndexRequest& request, Bui
     return Status::OK();
 }
 
-Status VectorIndexBuildTask::build_segment(int64_t tablet_id, int64_t vi_tablet_id, const FileInfo& segment_file_info,
+Status VectorIndexBuildTask::build_segment(int64_t tablet_id, const FileInfo& segment_file_info,
                                            const std::vector<int64_t>& index_ids,
                                            const TabletSchemaCSPtr& tablet_schema) {
     // Open the segment file (FileInfo carries size/encryption for proper access)
@@ -294,7 +295,8 @@ Status VectorIndexBuildTask::build_segment(int64_t tablet_id, int64_t vi_tablet_
         if (auto pos = seg_basename.rfind('/'); pos != std::string_view::npos) {
             seg_basename = seg_basename.substr(pos + 1);
         }
-        std::string vi_name = gen_vector_index_filename(seg_basename, vi_tablet_id, index_id);
+        std::string vi_name =
+                gen_vector_index_filename(seg_basename, segment_file_info.vector_index_tablet_id, index_id);
         std::string vi_path = _tablet_mgr->segment_location(tablet_id, vi_name);
 
         ASSIGN_OR_RETURN(auto builder_type,

--- a/be/src/storage/lake/vector_index_build_task.cpp
+++ b/be/src/storage/lake/vector_index_build_task.cpp
@@ -169,9 +169,8 @@ Status VectorIndexBuildTask::build_one_segment(size_t work_index) {
     const auto& work = _work_items[work_index];
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " building segment=" << work.segment_file_info.path
               << " version=" << work.rowset_version << " index_ids_count=" << work.index_ids.size();
-    RETURN_IF_ERROR(
-            build_segment(_tablet_id, work.vector_index_tablet_id, work.segment_file_info, work.index_ids,
-                          _tablet_schema));
+    RETURN_IF_ERROR(build_segment(_tablet_id, work.vector_index_tablet_id, work.segment_file_info, work.index_ids,
+                                  _tablet_schema));
     LOG(INFO) << "VectorIndexBuildTask: tablet=" << _tablet_id << " built segment=" << work.segment_file_info.path
               << " successfully";
     return Status::OK();

--- a/be/src/storage/lake/vector_index_build_task.h
+++ b/be/src/storage/lake/vector_index_build_task.h
@@ -39,7 +39,7 @@ class VectorIndexBuildTask {
 public:
     struct SegmentWork {
         int64_t rowset_version;
-        // Carries the owner tablet id for this segment's .vi filenames in vector_index_tablet_id
+        // Carries this segment's vector index uid for its .vi filenames (segment_vector_index_uid)
         // (resolved from the segment meta in prepare()).
         SegmentFileInfo segment_file_info;
         std::vector<int64_t> index_ids;

--- a/be/src/storage/lake/vector_index_build_task.h
+++ b/be/src/storage/lake/vector_index_build_task.h
@@ -38,12 +38,10 @@ class VectorIndexBuildTask {
 public:
     struct SegmentWork {
         int64_t rowset_version;
+        // Carries the owner tablet id for this segment's .vi filenames in vector_index_tablet_id
+        // (resolved from the segment meta in prepare()).
         FileInfo segment_file_info;
         std::vector<int64_t> index_ids;
-        // Tablet id to embed in the .vi filename: the segment's recorded owner
-        // (SegmentMetadataPB.vector_index_tablet_id) so a segment shared across tablets after a
-        // split builds/reads the same .vi; falls back to this task's tablet id when unset.
-        int64_t vector_index_tablet_id = -1;
     };
 
     explicit VectorIndexBuildTask(TabletManager* tablet_mgr);
@@ -72,8 +70,8 @@ public:
     Status execute(const BuildVectorIndexRequest& request, BuildVectorIndexResponse* response);
 
 private:
-    Status build_segment(int64_t tablet_id, int64_t vi_tablet_id, const FileInfo& segment_file_info,
-                         const std::vector<int64_t>& index_ids, const TabletSchemaCSPtr& tablet_schema);
+    Status build_segment(int64_t tablet_id, const FileInfo& segment_file_info, const std::vector<int64_t>& index_ids,
+                         const TabletSchemaCSPtr& tablet_schema);
 
     TabletManager* _tablet_mgr;
     int64_t _tablet_id = 0;

--- a/be/src/storage/lake/vector_index_build_task.h
+++ b/be/src/storage/lake/vector_index_build_task.h
@@ -21,6 +21,7 @@
 #include "common/status.h"
 #include "fs/fs.h"
 #include "gen_cpp/lake_service.pb.h"
+#include "storage/rowset/segment_file_info.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
@@ -40,7 +41,7 @@ public:
         int64_t rowset_version;
         // Carries the owner tablet id for this segment's .vi filenames in vector_index_tablet_id
         // (resolved from the segment meta in prepare()).
-        FileInfo segment_file_info;
+        SegmentFileInfo segment_file_info;
         std::vector<int64_t> index_ids;
     };
 
@@ -70,7 +71,7 @@ public:
     Status execute(const BuildVectorIndexRequest& request, BuildVectorIndexResponse* response);
 
 private:
-    Status build_segment(int64_t tablet_id, const FileInfo& segment_file_info, const std::vector<int64_t>& index_ids,
+    Status build_segment(int64_t tablet_id, const SegmentFileInfo& segment_file_info, const std::vector<int64_t>& index_ids,
                          const TabletSchemaCSPtr& tablet_schema);
 
     TabletManager* _tablet_mgr;

--- a/be/src/storage/lake/vector_index_build_task.h
+++ b/be/src/storage/lake/vector_index_build_task.h
@@ -71,8 +71,8 @@ public:
     Status execute(const BuildVectorIndexRequest& request, BuildVectorIndexResponse* response);
 
 private:
-    Status build_segment(int64_t tablet_id, const SegmentFileInfo& segment_file_info, const std::vector<int64_t>& index_ids,
-                         const TabletSchemaCSPtr& tablet_schema);
+    Status build_segment(int64_t tablet_id, const SegmentFileInfo& segment_file_info,
+                         const std::vector<int64_t>& index_ids, const TabletSchemaCSPtr& tablet_schema);
 
     TabletManager* _tablet_mgr;
     int64_t _tablet_id = 0;

--- a/be/src/storage/lake/vector_index_build_task.h
+++ b/be/src/storage/lake/vector_index_build_task.h
@@ -40,6 +40,10 @@ public:
         int64_t rowset_version;
         FileInfo segment_file_info;
         std::vector<int64_t> index_ids;
+        // Tablet id to embed in the .vi filename: the segment's recorded owner
+        // (SegmentMetadataPB.vector_index_tablet_id) so a segment shared across tablets after a
+        // split builds/reads the same .vi; falls back to this task's tablet id when unset.
+        int64_t vector_index_tablet_id = -1;
     };
 
     explicit VectorIndexBuildTask(TabletManager* tablet_mgr);
@@ -68,8 +72,8 @@ public:
     Status execute(const BuildVectorIndexRequest& request, BuildVectorIndexResponse* response);
 
 private:
-    Status build_segment(int64_t tablet_id, const FileInfo& segment_file_info, const std::vector<int64_t>& index_ids,
-                         const TabletSchemaCSPtr& tablet_schema);
+    Status build_segment(int64_t tablet_id, int64_t vi_tablet_id, const FileInfo& segment_file_info,
+                         const std::vector<int64_t>& index_ids, const TabletSchemaCSPtr& tablet_schema);
 
     TabletManager* _tablet_mgr;
     int64_t _tablet_id = 0;

--- a/be/src/storage/rowset/segment_file_info.cpp
+++ b/be/src/storage/rowset/segment_file_info.cpp
@@ -55,6 +55,11 @@ void SegmentFileInfo::to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_
     for (int64_t vi_id : vector_index_ids) {
         segment_meta->add_vector_index_ids(vi_id);
     }
+    // Record the owning tablet id for .vi naming (see SegmentMetadataPB.vector_index_tablet_id).
+    // Paired with vector_index_ids: only meaningful when this segment has vector indexes.
+    if (vector_index_tablet_id >= 0) {
+        segment_meta->set_vector_index_tablet_id(vector_index_tablet_id);
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_file_info.cpp
+++ b/be/src/storage/rowset/segment_file_info.cpp
@@ -55,11 +55,6 @@ void SegmentFileInfo::to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_
     for (int64_t vi_id : vector_index_ids) {
         segment_meta->add_vector_index_ids(vi_id);
     }
-    // Record the owning tablet id for .vi naming (see SegmentMetadataPB.vector_index_tablet_id).
-    // Paired with vector_index_ids: only meaningful when this segment has vector indexes.
-    if (vector_index_tablet_id >= 0) {
-        segment_meta->set_vector_index_tablet_id(vector_index_tablet_id);
-    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_file_info.cpp
+++ b/be/src/storage/rowset/segment_file_info.cpp
@@ -55,10 +55,10 @@ void SegmentFileInfo::to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_
     for (int64_t vi_id : vector_index_ids) {
         segment_meta->add_vector_index_ids(vi_id);
     }
-    // Record the owning tablet id for .vi naming (see SegmentMetadataPB.vector_index_tablet_id).
+    // Record the segment's vector index uid for .vi naming (see SegmentMetadataPB.segment_vector_index_uid).
     // Paired with vector_index_ids: only meaningful when this segment has vector indexes.
-    if (vector_index_tablet_id >= 0) {
-        segment_meta->set_vector_index_tablet_id(vector_index_tablet_id);
+    if (segment_vector_index_uid >= 0) {
+        segment_meta->set_segment_vector_index_uid(segment_vector_index_uid);
     }
 }
 

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -45,9 +45,9 @@ struct SegmentFileInfo : public FileInfo {
 
     // Serialize this segment's full per-segment metadata into |segment_meta|: the file attributes
     // (filename, size, encryption_meta, bundle_file_offset), the sort-key fields, num_rows,
-    // vector_index_ids, and segment_idx. |segment_idx| is a required input (placed first so callers
-    // cannot forget it): a contiguous positional index at write time, or a sparse one after
-    // compaction/merge.
+    // vector_index_ids, vector_index_tablet_id, and segment_idx. |segment_idx| is a required input
+    // (placed first so callers cannot forget it): a contiguous positional index at write time, or a
+    // sparse one after compaction/merge.
     void to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_meta) const;
 };
 

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -40,8 +40,11 @@ struct SegmentFileInfo : public FileInfo {
     std::vector<VariantTuple> sort_key_samples;
     int64_t sort_key_sample_row_interval = 0;
     int64_t num_rows = 0;
-    // IDs of vector indexes configured for this segment (one .vi file per id).
+    // IDs of vector indexes whose .vi file belongs to this segment (one .vi file per id).
     std::vector<int64_t> vector_index_ids;
+    // Owner tablet id embedded in this segment's .vi filenames; stable across tablet split
+    // (see SegmentMetadataPB::vector_index_tablet_id). -1 when no vector index.
+    int64_t vector_index_tablet_id = -1;
 
     // Serialize this segment's full per-segment metadata into |segment_meta|: the file attributes
     // (filename, size, encryption_meta, bundle_file_offset), the sort-key fields, num_rows,

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -42,13 +42,13 @@ struct SegmentFileInfo : public FileInfo {
     int64_t num_rows = 0;
     // IDs of vector indexes whose .vi file belongs to this segment (one .vi file per id).
     std::vector<int64_t> vector_index_ids;
-    // Owner tablet id embedded in this segment's .vi filenames; stable across tablet split
-    // (see SegmentMetadataPB::vector_index_tablet_id). -1 when no vector index.
-    int64_t vector_index_tablet_id = -1;
+    // Per-segment vector index uid embedded in this segment's .vi filenames (value = writer tablet id),
+    // (see SegmentMetadataPB::segment_vector_index_uid). -1 when no vector index.
+    int64_t segment_vector_index_uid = -1;
 
     // Serialize this segment's full per-segment metadata into |segment_meta|: the file attributes
     // (filename, size, encryption_meta, bundle_file_offset), the sort-key fields, num_rows,
-    // vector_index_ids, vector_index_tablet_id, and segment_idx. |segment_idx| is a required input
+    // vector_index_ids, segment_vector_index_uid, and segment_idx. |segment_idx| is a required input
     // (placed first so callers cannot forget it): a contiguous positional index at write time, or a
     // sparse one after compaction/merge.
     void to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_meta) const;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1110,9 +1110,9 @@ Status SegmentIterator::_init_ann_reader() {
 #ifdef WITH_TENANN
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
-            // Use the segment's recorded owner tablet id (set from SegmentMetadataPB by Rowset) so a
-            // segment shared across tablets after a split resolves the same .vi; fall back to the
-            // reading tablet for segments written before vector_index_tablet_id existed.
+            // Owner tablet id for the .vi name, resolved from SegmentMetadataPB by lake
+            // Rowset::read() (today the only producer of belonged_to_cloud_native); the tablet_id
+            // arm only guards callers that never fill the option.
             const int64_t vi_tablet_id = _opts.vector_index_tablet_id >= 0 ? _opts.vector_index_tablet_id
                                                                            : static_cast<int64_t>(_opts.tablet_id);
             index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(), vi_tablet_id,

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1112,10 +1112,10 @@ Status SegmentIterator::_init_ann_reader() {
         if (_opts.belonged_to_cloud_native) {
             // Owner tablet id for the .vi name, filled from SegmentMetadataPB by lake Rowset::read()
             // (the only producer of belonged_to_cloud_native) for every vector-indexed segment.
-            DCHECK_GE(_opts.vector_index_tablet_id, 0)
+            DCHECK_GE(_opts.segment_vector_index_uid, 0)
                     << "cloud-native ANN read without a resolved .vi owner tablet id";
             index_path = lake::gen_vector_index_path_from_segment_path(
-                    _segment->file_name(), _opts.vector_index_tablet_id, tablet_index_meta->index_id());
+                    _segment->file_name(), _opts.segment_vector_index_uid, tablet_index_meta->index_id());
         } else {
             index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                                  segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1110,7 +1110,12 @@ Status SegmentIterator::_init_ann_reader() {
 #ifdef WITH_TENANN
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
-            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(), _opts.tablet_id,
+            // Use the segment's recorded owner tablet id (set from SegmentMetadataPB by Rowset) so a
+            // segment shared across tablets after a split resolves the same .vi; fall back to the
+            // reading tablet for segments written before vector_index_tablet_id existed.
+            const int64_t vi_tablet_id = _opts.vector_index_tablet_id >= 0 ? _opts.vector_index_tablet_id
+                                                                           : static_cast<int64_t>(_opts.tablet_id);
+            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(), vi_tablet_id,
                                                                        tablet_index_meta->index_id());
         } else {
             index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1110,13 +1110,12 @@ Status SegmentIterator::_init_ann_reader() {
 #ifdef WITH_TENANN
         std::string index_path;
         if (_opts.belonged_to_cloud_native) {
-            // Owner tablet id for the .vi name, resolved from SegmentMetadataPB by lake
-            // Rowset::read() (today the only producer of belonged_to_cloud_native); the tablet_id
-            // arm only guards callers that never fill the option.
-            const int64_t vi_tablet_id = _opts.vector_index_tablet_id >= 0 ? _opts.vector_index_tablet_id
-                                                                           : static_cast<int64_t>(_opts.tablet_id);
-            index_path = lake::gen_vector_index_path_from_segment_path(_segment->file_name(), vi_tablet_id,
-                                                                       tablet_index_meta->index_id());
+            // Owner tablet id for the .vi name, filled from SegmentMetadataPB by lake Rowset::read()
+            // (the only producer of belonged_to_cloud_native) for every vector-indexed segment.
+            DCHECK_GE(_opts.vector_index_tablet_id, 0)
+                    << "cloud-native ANN read without a resolved .vi owner tablet id";
+            index_path = lake::gen_vector_index_path_from_segment_path(
+                    _segment->file_name(), _opts.vector_index_tablet_id, tablet_index_meta->index_id());
         } else {
             index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                                  segment_id(), tablet_index_meta->index_id());

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -69,6 +69,10 @@ public:
     std::shared_ptr<DelvecLoader> delvec_loader;
     bool is_primary_keys = false;
     uint64_t tablet_id = 0;
+    // Tablet id to use when deriving this segment's vector index (.vi) path. For cloud-native
+    // reads this is the recorded owner (SegmentMetadataPB.vector_index_tablet_id) so a segment
+    // shared across tablets after a split resolves the same .vi; defaults to tablet_id.
+    int64_t vector_index_tablet_id = -1;
     // rowset base segment id
     uint32_t rowset_id = 0;
     uint32_t dynamic_rss_id_base = 0;

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -69,9 +69,8 @@ public:
     std::shared_ptr<DelvecLoader> delvec_loader;
     bool is_primary_keys = false;
     uint64_t tablet_id = 0;
-    // Tablet id to use when deriving this segment's vector index (.vi) path. For cloud-native
-    // reads this is the recorded owner (SegmentMetadataPB.vector_index_tablet_id) so a segment
-    // shared across tablets after a split resolves the same .vi; defaults to tablet_id.
+    // Owner tablet id for this segment's .vi path (see SegmentMetadataPB.vector_index_tablet_id);
+    // filled by lake Rowset::read(). -1 = unset, consumers fall back to tablet_id.
     int64_t vector_index_tablet_id = -1;
     // rowset base segment id
     uint32_t rowset_id = 0;

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -70,7 +70,8 @@ public:
     bool is_primary_keys = false;
     uint64_t tablet_id = 0;
     // Owner tablet id for this segment's .vi path (see SegmentMetadataPB.vector_index_tablet_id);
-    // filled by lake Rowset::read(). -1 = unset, consumers fall back to tablet_id.
+    // filled by lake Rowset::read() for vector-indexed segments. -1 = unset (non-lake or no vector
+    // index); the cloud-native ANN read path requires it set.
     int64_t vector_index_tablet_id = -1;
     // rowset base segment id
     uint32_t rowset_id = 0;

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -69,10 +69,10 @@ public:
     std::shared_ptr<DelvecLoader> delvec_loader;
     bool is_primary_keys = false;
     uint64_t tablet_id = 0;
-    // Owner tablet id for this segment's .vi path (see SegmentMetadataPB.vector_index_tablet_id);
+    // Per-segment vector index uid for this segment's .vi path (see SegmentMetadataPB.segment_vector_index_uid);
     // filled by lake Rowset::read() for vector-indexed segments. -1 = unset (non-lake or no vector
     // index); the cloud-native ANN read path requires it set.
-    int64_t vector_index_tablet_id = -1;
+    int64_t segment_vector_index_uid = -1;
     // rowset base segment id
     uint32_t rowset_id = 0;
     uint32_t dynamic_rss_id_base = 0;

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -24,12 +24,12 @@ namespace starrocks {
 
 SegmentRewriter::SegmentRewriter() = default;
 
-// Mirror of HorizontalGeneralTabletWriter::record_segment_vector_index_ids for the rewrite path:
-// persist on the dest FileInfo the ids of vector indexes whose .vi the dest segment will have —
-// built inline by this writer (sync) or produced later by the FE-scheduled build task (async,
-// above the deferred-build threshold; a dest rewrite file is never a bundle). The ids come from
-// the caller-resolved path map, so shared-nothing callers (empty map) record nothing.
-static void record_rewrite_vector_index_ids(const SegmentWriter& writer, FileInfo* dest) {
+// Append to |out_ids| the ids of vector indexes whose .vi the dest segment will have. Shared-nothing
+// callers pass out_ids == nullptr (empty path map), so nothing is recorded.
+static void record_rewrite_vector_index_ids(const SegmentWriter& writer, std::vector<int64_t>* out_ids) {
+    if (out_ids == nullptr) {
+        return;
+    }
     if (writer.defer_vector_index_build()) {
         if (writer.num_rows() < writer.vector_index_build_threshold()) {
             return;
@@ -38,7 +38,7 @@ static void record_rewrite_vector_index_ids(const SegmentWriter& writer, FileInf
         return;
     }
     for (const auto& [index_id, _] : writer.vector_index_file_paths()) {
-        dest->vector_index_ids.push_back(index_id);
+        out_ids->push_back(index_id);
     }
 }
 
@@ -47,7 +47,8 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
                                                std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                                uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
                                                SegmentFileMark segment_file_mark,
-                                               RewriteVectorIndexOptions vector_index_opts) {
+                                               RewriteVectorIndexOptions vector_index_opts,
+                                               std::vector<int64_t>* out_vector_index_ids) {
     constexpr size_t kBufferSize = 1024 * 1024; // 1 MB
     if (UNLIKELY(column_ids.empty())) {
         // In shared-nothing mode, this size can be null, and we don't need it so it's ok to return zero;
@@ -112,7 +113,7 @@ Status SegmentRewriter::rewrite_partial_update(const FileInfo& src, FileInfo* de
     TEST_ERROR_POINT("SegmentRewriter::rewrite1");
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    record_rewrite_vector_index_ids(writer, dest);
+    record_rewrite_vector_index_ids(writer, out_vector_index_ids);
     dest->size = segment_file_size;
     return Status::OK();
 }
@@ -217,7 +218,8 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
         const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
         starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
         const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
-        const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts) {
+        const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts,
+        std::vector<int64_t>* out_vector_index_ids) {
     if (unmodified_column_ids.size() == 0) {
         DCHECK_EQ(unmodified_column_data, nullptr);
     }
@@ -313,7 +315,7 @@ Status SegmentRewriter::rewrite_auto_increment_lake(
     TEST_ERROR_POINT("SegmentRewriter::rewrite3");
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    record_rewrite_vector_index_ids(writer, dest);
+    record_rewrite_vector_index_ids(writer, out_vector_index_ids);
     dest->size = segment_file_size;
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -24,9 +24,10 @@ class Column;
 // callers fill the location-provider-resolved .vi paths (keyed on the dest segment name) plus the
 // schema's index_build_mode/threshold; the rewrite then mirrors the normal lake writer: sync
 // indexes are built inline at the reader-visible path, async builds are deferred to the
-// FE-scheduled VectorIndexBuildTask, and the actually-produced/scheduled index ids are recorded
-// on the dest FileInfo. Shared-nothing callers leave the defaults (empty paths, sync, threshold
-// 0): the SegmentWriter then uses its IndexDescriptor fallback paths and no ids are recorded.
+// FE-scheduled VectorIndexBuildTask, and the actually-produced/scheduled index ids are returned
+// through the caller's out_vector_index_ids. Shared-nothing callers leave the defaults (empty paths,
+// sync, threshold 0) and pass no out param: the SegmentWriter uses its IndexDescriptor fallback
+// paths and no ids are recorded.
 struct RewriteVectorIndexOptions {
     std::map<int64_t, std::string> file_paths;
     bool defer_build = false;
@@ -47,7 +48,8 @@ public:
                                          std::vector<uint32_t>& column_ids, MutableColumns& columns,
                                          uint32_t segment_id, const FooterPointerPB& partial_rowset_footer,
                                          SegmentFileMark segment_file_mark = {},
-                                         RewriteVectorIndexOptions vector_index_opts = {});
+                                         RewriteVectorIndexOptions vector_index_opts = {},
+                                         std::vector<int64_t>* out_vector_index_ids = nullptr);
     static Status rewrite_auto_increment(const std::string& src_path, const std::string& dest_path,
                                          const TabletSchemaCSPtr& tschema,
                                          AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
@@ -57,7 +59,8 @@ public:
             const FileInfo& src, FileInfo* dest, const TabletSchemaCSPtr& tschema,
             starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
             const std::vector<uint32_t>& unmodified_column_ids, MutableColumns* unmodified_column_data,
-            const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts = {});
+            const starrocks::lake::Tablet* tablet, RewriteVectorIndexOptions vector_index_opts = {},
+            std::vector<int64_t>* out_vector_index_ids = nullptr);
 };
 
 } // namespace starrocks

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -6210,6 +6210,8 @@ protected:
             auto* segment_meta = rowset->add_segment_metas();
             segment_meta->set_filename(seg_name);
             segment_meta->add_vector_index_ids(kIndexId);
+            // Record the .vi owner as the write path does; it names the built .vi file.
+            segment_meta->set_vector_index_tablet_id(kTabletId);
         }
 
         CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -6211,7 +6211,7 @@ protected:
             segment_meta->set_filename(seg_name);
             segment_meta->add_vector_index_ids(kIndexId);
             // Record the .vi owner as the write path does; it names the built .vi file.
-            segment_meta->set_vector_index_tablet_id(kTabletId);
+            segment_meta->set_segment_vector_index_uid(kTabletId);
         }
 
         CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -868,11 +868,11 @@ TEST_F(MetaFileTest, test_apply_opwrite_del_op_offset_uses_max_segment_id) {
     EXPECT_EQ(118, metadata->next_rowset_id());
 }
 
-// The publish funnel backstops SegmentMetadataPB::vector_index_tablet_id: a writer path that
-// records vector_index_ids but forgets to stamp the owner still persists a correct owner
-// (= the publishing tablet, which wrote the segment). Segments arriving from a tablet-split
-// cross-publish (shared=true) were written by ANOTHER tablet and must be carried verbatim.
-TEST_F(MetaFileTest, test_apply_opwrite_backstops_vector_index_owner) {
+// The publish funnel is the SOLE producer of SegmentMetadataPB::vector_index_tablet_id: writers
+// never set it; apply stamps the publishing tablet (= the tablet that wrote the segment) on every
+// segment recording vector_index_ids. Segments arriving from a tablet-split cross-publish
+// (shared=true) were written by ANOTHER tablet and must be carried verbatim.
+TEST_F(MetaFileTest, test_apply_opwrite_stamps_vector_index_owner) {
     const int64_t tablet_id = 31003;
     auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
     auto metadata = std::make_shared<TabletMetadata>();
@@ -884,16 +884,16 @@ TEST_F(MetaFileTest, test_apply_opwrite_backstops_vector_index_owner) {
     TxnLogPB_OpWrite op_write;
     auto* rowset = op_write.mutable_rowset();
     {
-        // ids recorded, owner forgotten, not shared: the backstop fills the publishing tablet.
-        auto* forgot_owner = rowset->add_segment_metas();
-        forgot_owner->set_filename("forgot_owner.dat");
-        forgot_owner->add_vector_index_ids(100);
-        // ids + explicit owner: preserved, never overwritten.
+        // ids recorded, no owner (the normal writer output): apply stamps the publishing tablet.
+        auto* plain = rowset->add_segment_metas();
+        plain->set_filename("plain.dat");
+        plain->add_vector_index_ids(100);
+        // pre-set owner (e.g. carried metadata): preserved, never overwritten.
         auto* has_owner = rowset->add_segment_metas();
         has_owner->set_filename("has_owner.dat");
         has_owner->add_vector_index_ids(100);
         has_owner->set_vector_index_tablet_id(9999);
-        // ids, owner forgotten, but shared (split cross-publish): written by another tablet,
+        // ids without owner but shared (split cross-publish): written by another tablet,
         // stamping the local id would be wrong — must stay absent.
         auto* shared_seg = rowset->add_segment_metas();
         shared_seg->set_filename("shared.dat");

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -375,7 +375,7 @@ TEST_F(MetaFileTest, test_dcg) {
         RowsetMetadataPB rowset_metadata;
         rowset_metadata.add_segment_metas()->set_filename("aaa.dat");
         TxnLogPB_OpWrite op_write;
-        std::map<int, FileInfo> replace_segments;
+        std::map<int, SegmentFileInfo> replace_segments;
         std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
@@ -565,7 +565,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         RowsetMetadataPB rowset_metadata;
         rowset_metadata.add_segment_metas()->set_filename("aaa.dat");
         TxnLogPB_OpWrite op_write;
-        std::map<int, FileInfo> replace_segments;
+        std::map<int, SegmentFileInfo> replace_segments;
         std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
@@ -585,7 +585,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         delfile.set_name("bbb2.del");
         rowset_metadata.add_del_files()->CopyFrom(delfile);
         TxnLogPB_OpWrite op_write;
-        std::map<int, FileInfo> replace_segments;
+        std::map<int, SegmentFileInfo> replace_segments;
         std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
@@ -627,7 +627,7 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
         RowsetMetadataPB rowset_metadata;
         rowset_metadata.add_segment_metas()->set_filename("ddd.dat");
         TxnLogPB_OpWrite op_write;
-        std::map<int, FileInfo> replace_segments;
+        std::map<int, SegmentFileInfo> replace_segments;
         std::vector<FileMetaPB> orphan_files;
         op_write.mutable_rowset()->CopyFrom(rowset_metadata);
         builder.apply_opwrite(op_write, replace_segments, orphan_files);
@@ -899,12 +899,16 @@ TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
         untouched->set_vector_index_tablet_id(9999);
     }
 
-    std::map<int, FileInfo> replace_segments;
-    FileInfo rewrite0{.path = "rewrite0.dat", .size = 1024};
+    std::map<int, SegmentFileInfo> replace_segments;
+    SegmentFileInfo rewrite0;
+    rewrite0.path = "rewrite0.dat";
+    rewrite0.size = 1024;
     rewrite0.vector_index_ids.push_back(100);
     rewrite0.vector_index_tablet_id = tablet_id;
     replace_segments[0] = rewrite0;
-    FileInfo rewrite1{.path = "rewrite1.dat", .size = 2048}; // no ids, no owner
+    SegmentFileInfo rewrite1; // no ids, no owner
+    rewrite1.path = "rewrite1.dat";
+    rewrite1.size = 2048;
     replace_segments[1] = rewrite1;
 
     builder.apply_opwrite(op_write, replace_segments, {});
@@ -1916,8 +1920,8 @@ TEST_F(MetaFileTest, test_apply_opwrite_clears_shared_segments_for_rewrite) {
     }
 
     // Partial update: segment 0 is rewritten into a new private file.
-    std::map<int, FileInfo> replace_segments;
-    FileInfo rewrite_info;
+    std::map<int, SegmentFileInfo> replace_segments;
+    SegmentFileInfo rewrite_info;
     rewrite_info.path = "rewrite0.dat";
     rewrite_info.size = 1500;
     replace_segments[0] = rewrite_info;
@@ -1959,8 +1963,8 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_clears_shared_segments_for_rewrite
         sm1->set_shared(true);
     }
 
-    std::map<int, FileInfo> replace_segments;
-    FileInfo rewrite_info;
+    std::map<int, SegmentFileInfo> replace_segments;
+    SegmentFileInfo rewrite_info;
     rewrite_info.path = "rewrite0.dat";
     rewrite_info.size = 1500;
     replace_segments[0] = rewrite_info;

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -868,7 +868,7 @@ TEST_F(MetaFileTest, test_apply_opwrite_del_op_offset_uses_max_segment_id) {
     EXPECT_EQ(118, metadata->next_rowset_id());
 }
 
-// The partial-update replace path refreshes vector_index_tablet_id wholesale from the replace
+// The partial-update replace path refreshes segment_vector_index_uid wholesale from the replace
 // FileInfo (apply_replace_segment): a recorded owner overwrites whatever the replaced segment
 // carried, and an unset owner (-1) clears a stale one. Non-replaced segments are carried verbatim.
 TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
@@ -891,12 +891,12 @@ TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
         auto* stale_owner = rowset->add_segment_metas();
         stale_owner->set_filename("partial1.dat");
         stale_owner->add_vector_index_ids(100);
-        stale_owner->set_vector_index_tablet_id(7777);
+        stale_owner->set_segment_vector_index_uid(7777);
         // Not replaced: carried verbatim.
         auto* untouched = rowset->add_segment_metas();
         untouched->set_filename("untouched.dat");
         untouched->add_vector_index_ids(100);
-        untouched->set_vector_index_tablet_id(9999);
+        untouched->set_segment_vector_index_uid(9999);
     }
 
     std::map<int, SegmentFileInfo> replace_segments;
@@ -904,7 +904,7 @@ TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
     rewrite0.path = "rewrite0.dat";
     rewrite0.size = 1024;
     rewrite0.vector_index_ids.push_back(100);
-    rewrite0.vector_index_tablet_id = tablet_id;
+    rewrite0.segment_vector_index_uid = tablet_id;
     replace_segments[0] = rewrite0;
     SegmentFileInfo rewrite1; // no ids, no owner
     rewrite1.path = "rewrite1.dat";
@@ -917,13 +917,13 @@ TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
     const auto& written = metadata->rowsets(0);
     ASSERT_EQ(3, written.segment_metas_size());
     EXPECT_EQ("rewrite0.dat", written.segment_metas(0).filename());
-    ASSERT_TRUE(written.segment_metas(0).has_vector_index_tablet_id());
-    EXPECT_EQ(tablet_id, written.segment_metas(0).vector_index_tablet_id());
+    ASSERT_TRUE(written.segment_metas(0).has_segment_vector_index_uid());
+    EXPECT_EQ(tablet_id, written.segment_metas(0).segment_vector_index_uid());
     EXPECT_EQ("rewrite1.dat", written.segment_metas(1).filename());
     EXPECT_EQ(0, written.segment_metas(1).vector_index_ids_size());
-    EXPECT_FALSE(written.segment_metas(1).has_vector_index_tablet_id());
-    ASSERT_TRUE(written.segment_metas(2).has_vector_index_tablet_id());
-    EXPECT_EQ(9999, written.segment_metas(2).vector_index_tablet_id());
+    EXPECT_FALSE(written.segment_metas(1).has_segment_vector_index_uid());
+    ASSERT_TRUE(written.segment_metas(2).has_segment_vector_index_uid());
+    EXPECT_EQ(9999, written.segment_metas(2).segment_vector_index_uid());
 }
 
 TEST_F(MetaFileTest, test_apply_opcompaction_delete_delvec_with_segment_id) {

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -868,6 +868,55 @@ TEST_F(MetaFileTest, test_apply_opwrite_del_op_offset_uses_max_segment_id) {
     EXPECT_EQ(118, metadata->next_rowset_id());
 }
 
+// The publish funnel backstops SegmentMetadataPB::vector_index_tablet_id: a writer path that
+// records vector_index_ids but forgets to stamp the owner still persists a correct owner
+// (= the publishing tablet, which wrote the segment). Segments arriving from a tablet-split
+// cross-publish (shared=true) were written by ANOTHER tablet and must be carried verbatim.
+TEST_F(MetaFileTest, test_apply_opwrite_backstops_vector_index_owner) {
+    const int64_t tablet_id = 31003;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(110);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    TxnLogPB_OpWrite op_write;
+    auto* rowset = op_write.mutable_rowset();
+    {
+        // ids recorded, owner forgotten, not shared: the backstop fills the publishing tablet.
+        auto* forgot_owner = rowset->add_segment_metas();
+        forgot_owner->set_filename("forgot_owner.dat");
+        forgot_owner->add_vector_index_ids(100);
+        // ids + explicit owner: preserved, never overwritten.
+        auto* has_owner = rowset->add_segment_metas();
+        has_owner->set_filename("has_owner.dat");
+        has_owner->add_vector_index_ids(100);
+        has_owner->set_vector_index_tablet_id(9999);
+        // ids, owner forgotten, but shared (split cross-publish): written by another tablet,
+        // stamping the local id would be wrong — must stay absent.
+        auto* shared_seg = rowset->add_segment_metas();
+        shared_seg->set_filename("shared.dat");
+        shared_seg->add_vector_index_ids(100);
+        shared_seg->set_shared(true);
+        // no vector indexes: no owner field at all.
+        auto* no_vi = rowset->add_segment_metas();
+        no_vi->set_filename("no_vi.dat");
+    }
+
+    builder.apply_opwrite(op_write, {}, {});
+
+    ASSERT_EQ(1, metadata->rowsets_size());
+    const auto& written = metadata->rowsets(0);
+    ASSERT_EQ(4, written.segment_metas_size());
+    ASSERT_TRUE(written.segment_metas(0).has_vector_index_tablet_id());
+    EXPECT_EQ(tablet_id, written.segment_metas(0).vector_index_tablet_id());
+    ASSERT_TRUE(written.segment_metas(1).has_vector_index_tablet_id());
+    EXPECT_EQ(9999, written.segment_metas(1).vector_index_tablet_id());
+    EXPECT_FALSE(written.segment_metas(2).has_vector_index_tablet_id());
+    EXPECT_FALSE(written.segment_metas(3).has_vector_index_tablet_id());
+}
+
 TEST_F(MetaFileTest, test_apply_opcompaction_delete_delvec_with_segment_id) {
     const int64_t tablet_id = 31002;
     auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -868,11 +868,10 @@ TEST_F(MetaFileTest, test_apply_opwrite_del_op_offset_uses_max_segment_id) {
     EXPECT_EQ(118, metadata->next_rowset_id());
 }
 
-// The publish funnel is the SOLE producer of SegmentMetadataPB::vector_index_tablet_id: writers
-// never set it; apply stamps the publishing tablet (= the tablet that wrote the segment) on every
-// segment recording vector_index_ids. Segments arriving from a tablet-split cross-publish
-// (shared=true) were written by ANOTHER tablet and must be carried verbatim.
-TEST_F(MetaFileTest, test_apply_opwrite_stamps_vector_index_owner) {
+// The partial-update replace path refreshes vector_index_tablet_id wholesale from the replace
+// FileInfo (apply_replace_segment): a recorded owner overwrites whatever the replaced segment
+// carried, and an unset owner (-1) clears a stale one. Non-replaced segments are carried verbatim.
+TEST_F(MetaFileTest, test_apply_opwrite_replace_refreshes_vector_index_owner) {
     const int64_t tablet_id = 31003;
     auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
     auto metadata = std::make_shared<TabletMetadata>();
@@ -884,37 +883,43 @@ TEST_F(MetaFileTest, test_apply_opwrite_stamps_vector_index_owner) {
     TxnLogPB_OpWrite op_write;
     auto* rowset = op_write.mutable_rowset();
     {
-        // ids recorded, no owner (the normal writer output): apply stamps the publishing tablet.
-        auto* plain = rowset->add_segment_metas();
-        plain->set_filename("plain.dat");
-        plain->add_vector_index_ids(100);
-        // pre-set owner (e.g. carried metadata): preserved, never overwritten.
-        auto* has_owner = rowset->add_segment_metas();
-        has_owner->set_filename("has_owner.dat");
-        has_owner->add_vector_index_ids(100);
-        has_owner->set_vector_index_tablet_id(9999);
-        // ids without owner but shared (split cross-publish): written by another tablet,
-        // stamping the local id would be wrong — must stay absent.
-        auto* shared_seg = rowset->add_segment_metas();
-        shared_seg->set_filename("shared.dat");
-        shared_seg->add_vector_index_ids(100);
-        shared_seg->set_shared(true);
-        // no vector indexes: no owner field at all.
-        auto* no_vi = rowset->add_segment_metas();
-        no_vi->set_filename("no_vi.dat");
+        // Replaced by a rewrite that recorded an owner: refreshed to the FileInfo's value.
+        auto* replaced = rowset->add_segment_metas();
+        replaced->set_filename("partial0.dat");
+        replaced->add_vector_index_ids(100);
+        // Replaced by a rewrite without vector indexes: the stale pre-set owner must be cleared.
+        auto* stale_owner = rowset->add_segment_metas();
+        stale_owner->set_filename("partial1.dat");
+        stale_owner->add_vector_index_ids(100);
+        stale_owner->set_vector_index_tablet_id(7777);
+        // Not replaced: carried verbatim.
+        auto* untouched = rowset->add_segment_metas();
+        untouched->set_filename("untouched.dat");
+        untouched->add_vector_index_ids(100);
+        untouched->set_vector_index_tablet_id(9999);
     }
 
-    builder.apply_opwrite(op_write, {}, {});
+    std::map<int, FileInfo> replace_segments;
+    FileInfo rewrite0{.path = "rewrite0.dat", .size = 1024};
+    rewrite0.vector_index_ids.push_back(100);
+    rewrite0.vector_index_tablet_id = tablet_id;
+    replace_segments[0] = rewrite0;
+    FileInfo rewrite1{.path = "rewrite1.dat", .size = 2048}; // no ids, no owner
+    replace_segments[1] = rewrite1;
+
+    builder.apply_opwrite(op_write, replace_segments, {});
 
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& written = metadata->rowsets(0);
-    ASSERT_EQ(4, written.segment_metas_size());
+    ASSERT_EQ(3, written.segment_metas_size());
+    EXPECT_EQ("rewrite0.dat", written.segment_metas(0).filename());
     ASSERT_TRUE(written.segment_metas(0).has_vector_index_tablet_id());
     EXPECT_EQ(tablet_id, written.segment_metas(0).vector_index_tablet_id());
-    ASSERT_TRUE(written.segment_metas(1).has_vector_index_tablet_id());
-    EXPECT_EQ(9999, written.segment_metas(1).vector_index_tablet_id());
-    EXPECT_FALSE(written.segment_metas(2).has_vector_index_tablet_id());
-    EXPECT_FALSE(written.segment_metas(3).has_vector_index_tablet_id());
+    EXPECT_EQ("rewrite1.dat", written.segment_metas(1).filename());
+    EXPECT_EQ(0, written.segment_metas(1).vector_index_ids_size());
+    EXPECT_FALSE(written.segment_metas(1).has_vector_index_tablet_id());
+    ASSERT_TRUE(written.segment_metas(2).has_vector_index_tablet_id());
+    EXPECT_EQ(9999, written.segment_metas(2).vector_index_tablet_id());
 }
 
 TEST_F(MetaFileTest, test_apply_opcompaction_delete_delvec_with_segment_id) {

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -323,8 +323,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_builds_vi_for_unmodif
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -357,8 +357,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_rewrite_above_threshold_reco
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
 }
 
@@ -417,8 +417,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_carries_vi_for_update
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     // The vector column is raw-copied (no column writer), so the footer flag may stay unset; what
@@ -467,8 +467,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_keeps_async
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
     check_vector_data(version, /*bias=*/0.1f);
 }
@@ -509,8 +509,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_builds_sync
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -565,8 +565,8 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_copy_only_rewrite_keeps_sche
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
     // The rewrite records the writing tablet as the .vi owner (split-stable naming).
-    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
-    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
+    ASSERT_TRUE(seg_meta.has_segment_vector_index_uid());
+    ASSERT_EQ(seg_meta.segment_vector_index_uid(), _tablet_metadata->id());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -322,9 +322,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_builds_vi_for_unmodif
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
@@ -358,9 +356,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_rewrite_above_threshold_reco
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -420,9 +416,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_carries_vi_for_update
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
@@ -472,9 +466,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_keeps_async
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -516,9 +508,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_builds_sync
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
@@ -574,9 +564,7 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_copy_only_rewrite_keeps_sche
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
-    // The rewrite records the writing tablet as the .vi owner across every rewrite path
-    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
-    // .vi name from the child id and misses the file written under this tablet.
+    // The rewrite records the writing tablet as the .vi owner (split-stable naming).
     ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
     ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
 }

--- a/be/test/storage/lake/partial_update_vector_index_test.cpp
+++ b/be/test/storage/lake/partial_update_vector_index_test.cpp
@@ -322,6 +322,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_builds_vi_for_unmodif
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -353,6 +358,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_rewrite_above_threshold_reco
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
 }
 
@@ -410,6 +420,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_sync_rewrite_carries_vi_for_update
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     // The vector column is raw-copied (no column writer), so the footer flag may stay unset; what
@@ -457,6 +472,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_keeps_async
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
     check_vector_data(version, /*bias=*/0.1f);
 }
@@ -496,6 +516,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_auto_increment_rewrite_builds_sync
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
     ASSERT_OK(fs::path_exist(vi_location(seg_meta.filename())) ? Status::OK()
                                                                : Status::NotFound(vi_location(seg_meta.filename())));
     ASSERT_EQ(read_footer(seg_meta.filename()).vector_index_storage_type(), VECTOR_INDEX_STORAGE_STANDALONE);
@@ -549,6 +574,11 @@ TEST_F(LakePartialUpdateVectorIndexTest, test_async_copy_only_rewrite_keeps_sche
     auto seg_meta = rewritten_segment_meta(version);
     ASSERT_EQ(seg_meta.vector_index_ids_size(), 1);
     ASSERT_EQ(seg_meta.vector_index_ids(0), kIndexId);
+    // The rewrite records the writing tablet as the .vi owner across every rewrite path
+    // (sync / async / auto-increment / copy-only); otherwise a later tablet split derives the
+    // .vi name from the child id and misses the file written under this tablet.
+    ASSERT_TRUE(seg_meta.has_vector_index_tablet_id());
+    ASSERT_EQ(seg_meta.vector_index_tablet_id(), _tablet_metadata->id());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1422,9 +1422,11 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_write_vi_files) {
     meta_seg1->set_filename("seg1.dat");
     meta_seg1->add_vector_index_ids(100);
     meta_seg1->add_vector_index_ids(200);
+    meta_seg1->set_vector_index_tablet_id(_tablet_metadata->id());
     auto* meta_seg2 = op_write->mutable_rowset()->add_segment_metas();
     meta_seg2->set_filename("seg2.dat");
     meta_seg2->add_vector_index_ids(100);
+    meta_seg2->set_vector_index_tablet_id(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1461,16 +1463,20 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_vi_files) {
     auto* meta_a = output_rowset->add_segment_metas();
     meta_a->set_filename("reused_a.dat");
     meta_a->add_vector_index_ids(100);
+    meta_a->set_vector_index_tablet_id(_tablet_metadata->id());
     auto* meta_x = output_rowset->add_segment_metas();
     meta_x->set_filename("new_x.dat");
     meta_x->add_vector_index_ids(100);
     meta_x->add_vector_index_ids(200);
+    meta_x->set_vector_index_tablet_id(_tablet_metadata->id());
     auto* meta_y = output_rowset->add_segment_metas();
     meta_y->set_filename("new_y.dat");
     meta_y->add_vector_index_ids(100);
+    meta_y->set_vector_index_tablet_id(_tablet_metadata->id());
     auto* meta_b = output_rowset->add_segment_metas();
     meta_b->set_filename("reused_b.dat");
     meta_b->add_vector_index_ids(100);
+    meta_b->set_vector_index_tablet_id(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1510,10 +1516,12 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_schema_change_vi_files) {
     auto* meta_sc1 = rowset->add_segment_metas();
     meta_sc1->set_filename("sc_seg1.dat");
     meta_sc1->add_vector_index_ids(300);
+    meta_sc1->set_vector_index_tablet_id(_tablet_metadata->id());
     auto* meta_sc2 = rowset->add_segment_metas();
     meta_sc2->set_filename("sc_seg2.dat");
     meta_sc2->add_vector_index_ids(300);
     meta_sc2->add_vector_index_ids(400);
+    meta_sc2->set_vector_index_tablet_id(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1545,6 +1553,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_replication_vi_files) {
     auto* meta_repl = op_write->mutable_rowset()->add_segment_metas();
     meta_repl->set_filename("repl_seg1.dat");
     meta_repl->add_vector_index_ids(500);
+    meta_repl->set_vector_index_tablet_id(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1595,6 +1604,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_partial_segment_metas) {
     meta_a->set_filename("seg_a.dat");
     meta_a->add_vector_index_ids(100);
     meta_a->add_vector_index_ids(200);
+    meta_a->set_vector_index_tablet_id(_tablet_metadata->id());
     op_write->mutable_rowset()->add_segment_metas()->set_filename("seg_b.dat");
     op_write->mutable_rowset()->add_segment_metas()->set_filename("seg_c.dat");
 
@@ -1639,6 +1649,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_partial_segment_m
     auto* meta_reused = output_rowset->add_segment_metas();
     meta_reused->set_filename("reused.dat");
     meta_reused->add_vector_index_ids(100);
+    meta_reused->set_vector_index_tablet_id(_tablet_metadata->id());
     output_rowset->add_segment_metas()->set_filename("new_a.dat");
     output_rowset->add_segment_metas()->set_filename("new_b.dat");
 

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1422,11 +1422,11 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_write_vi_files) {
     meta_seg1->set_filename("seg1.dat");
     meta_seg1->add_vector_index_ids(100);
     meta_seg1->add_vector_index_ids(200);
-    meta_seg1->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_seg1->set_segment_vector_index_uid(_tablet_metadata->id());
     auto* meta_seg2 = op_write->mutable_rowset()->add_segment_metas();
     meta_seg2->set_filename("seg2.dat");
     meta_seg2->add_vector_index_ids(100);
-    meta_seg2->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_seg2->set_segment_vector_index_uid(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1463,20 +1463,20 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_vi_files) {
     auto* meta_a = output_rowset->add_segment_metas();
     meta_a->set_filename("reused_a.dat");
     meta_a->add_vector_index_ids(100);
-    meta_a->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_a->set_segment_vector_index_uid(_tablet_metadata->id());
     auto* meta_x = output_rowset->add_segment_metas();
     meta_x->set_filename("new_x.dat");
     meta_x->add_vector_index_ids(100);
     meta_x->add_vector_index_ids(200);
-    meta_x->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_x->set_segment_vector_index_uid(_tablet_metadata->id());
     auto* meta_y = output_rowset->add_segment_metas();
     meta_y->set_filename("new_y.dat");
     meta_y->add_vector_index_ids(100);
-    meta_y->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_y->set_segment_vector_index_uid(_tablet_metadata->id());
     auto* meta_b = output_rowset->add_segment_metas();
     meta_b->set_filename("reused_b.dat");
     meta_b->add_vector_index_ids(100);
-    meta_b->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_b->set_segment_vector_index_uid(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1516,12 +1516,12 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_schema_change_vi_files) {
     auto* meta_sc1 = rowset->add_segment_metas();
     meta_sc1->set_filename("sc_seg1.dat");
     meta_sc1->add_vector_index_ids(300);
-    meta_sc1->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_sc1->set_segment_vector_index_uid(_tablet_metadata->id());
     auto* meta_sc2 = rowset->add_segment_metas();
     meta_sc2->set_filename("sc_seg2.dat");
     meta_sc2->add_vector_index_ids(300);
     meta_sc2->add_vector_index_ids(400);
-    meta_sc2->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_sc2->set_segment_vector_index_uid(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1553,7 +1553,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_replication_vi_files) {
     auto* meta_repl = op_write->mutable_rowset()->add_segment_metas();
     meta_repl->set_filename("repl_seg1.dat");
     meta_repl->add_vector_index_ids(500);
-    meta_repl->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_repl->set_segment_vector_index_uid(_tablet_metadata->id());
 
     std::vector<std::string> files_to_delete;
     collect_files_in_log(_tablet_mgr.get(), txn_log, &files_to_delete);
@@ -1604,7 +1604,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_partial_segment_metas) {
     meta_a->set_filename("seg_a.dat");
     meta_a->add_vector_index_ids(100);
     meta_a->add_vector_index_ids(200);
-    meta_a->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_a->set_segment_vector_index_uid(_tablet_metadata->id());
     op_write->mutable_rowset()->add_segment_metas()->set_filename("seg_b.dat");
     op_write->mutable_rowset()->add_segment_metas()->set_filename("seg_c.dat");
 
@@ -1649,7 +1649,7 @@ TEST_F(LakeRowsetTest, test_collect_files_in_log_op_compaction_partial_segment_m
     auto* meta_reused = output_rowset->add_segment_metas();
     meta_reused->set_filename("reused.dat");
     meta_reused->add_vector_index_ids(100);
-    meta_reused->set_vector_index_tablet_id(_tablet_metadata->id());
+    meta_reused->set_segment_vector_index_uid(_tablet_metadata->id());
     output_rowset->add_segment_metas()->set_filename("new_a.dat");
     output_rowset->add_segment_metas()->set_filename("new_b.dat");
 

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -361,7 +361,7 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
     // The writing tablet is recorded as the .vi owner (split-stable naming).
-    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
+    EXPECT_EQ(seg.segment_vector_index_uid, kTabletId);
 
     std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
     std::string vi_path =
@@ -478,7 +478,7 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_inde
     ASSERT_EQ(1u, seg.vector_index_ids.size());
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
     // record_segment_vector_index_ids (inherited) records the owner too.
-    EXPECT_EQ(kTabletId, seg.vector_index_tablet_id);
+    EXPECT_EQ(kTabletId, seg.segment_vector_index_uid);
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
@@ -542,7 +542,7 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
     // VerticalGeneralTabletWriter::finish records the owner too.
-    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
+    EXPECT_EQ(seg.segment_vector_index_uid, kTabletId);
 
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -360,6 +360,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
     EXPECT_EQ(seg.num_rows, 5);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+    // The writing tablet is recorded as the .vi owner (split-stable naming).
+    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
     std::string vi_path =
@@ -475,6 +477,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_inde
     EXPECT_EQ(5, seg.num_rows);
     ASSERT_EQ(1u, seg.vector_index_ids.size());
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
+    // record_segment_vector_index_ids (inherited) records the owner too.
+    EXPECT_EQ(kTabletId, seg.vector_index_tablet_id);
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
@@ -537,6 +541,8 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
     EXPECT_EQ(seg.num_rows, kRows);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+    // VerticalGeneralTabletWriter::finish records the owner too.
+    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -360,6 +360,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
     EXPECT_EQ(seg.num_rows, 5);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+    // The writing tablet is recorded as the .vi owner so the name stays reader-agnostic across split.
+    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
     std::string vi_path =
@@ -475,6 +477,8 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_inde
     EXPECT_EQ(5, seg.num_rows);
     ASSERT_EQ(1u, seg.vector_index_ids.size());
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
+    // HorizontalPkTabletWriter inherits record_segment_vector_index_ids, so it records the owner too.
+    EXPECT_EQ(kTabletId, seg.vector_index_tablet_id);
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
@@ -537,6 +541,8 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
     EXPECT_EQ(seg.num_rows, kRows);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
+    // VerticalGeneralTabletWriter::finish now records the writing tablet as the .vi owner as well.
+    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));

--- a/be/test/storage/lake/shared_data_vector_index_test.cpp
+++ b/be/test/storage/lake/shared_data_vector_index_test.cpp
@@ -360,8 +360,6 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_writer_vi_via_tablet_mgr) {
     EXPECT_EQ(seg.num_rows, 5);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
-    // The writing tablet is recorded as the .vi owner so the name stays reader-agnostic across split.
-    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string seg_path = _tablet_mgr->segment_location(kTabletId, seg.path);
     std::string vi_path =
@@ -477,8 +475,6 @@ TEST_F(SharedDataTabletWriterVITest, test_horizontal_pk_writer_sync_records_inde
     EXPECT_EQ(5, seg.num_rows);
     ASSERT_EQ(1u, seg.vector_index_ids.size());
     EXPECT_EQ(kIndexId, seg.vector_index_ids[0]);
-    // HorizontalPkTabletWriter inherits record_segment_vector_index_ids, so it records the owner too.
-    EXPECT_EQ(kTabletId, seg.vector_index_tablet_id);
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));
     EXPECT_TRUE(fs::path_exist(vi_path));
@@ -541,8 +537,6 @@ TEST_F(SharedDataTabletWriterVITest, test_vertical_writer_vi) {
     EXPECT_EQ(seg.num_rows, kRows);
     ASSERT_EQ(seg.vector_index_ids.size(), 1);
     EXPECT_EQ(seg.vector_index_ids[0], kIndexId);
-    // VerticalGeneralTabletWriter::finish now records the writing tablet as the .vi owner as well.
-    EXPECT_EQ(seg.vector_index_tablet_id, kTabletId);
 
     std::string vi_path =
             _tablet_mgr->segment_location(kTabletId, gen_vector_index_filename(seg.path, kTabletId, kIndexId));

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -2002,7 +2002,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_shared_vector_index_files) {
                             "filename": "0000000000f159e5_22222222-2222-2222-2222-2222222222b1.dat",
                             "shared": true,
                             "vector_index_ids": [100],
-                            "vector_index_tablet_id": 710
+                            "segment_vector_index_uid": 710
                         }
                     ]
                 }
@@ -2021,7 +2021,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_shared_vector_index_files) {
                             "filename": "0000000000f159e5_22222222-2222-2222-2222-2222222222b1.dat",
                             "shared": true,
                             "vector_index_ids": [100],
-                            "vector_index_tablet_id": 710
+                            "segment_vector_index_uid": 710
                         }
                     ]
                 }
@@ -3119,14 +3119,14 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                                 100,
                                 200
                             ],
-                            "vector_index_tablet_id": 5000
+                            "segment_vector_index_uid": 5000
                         },
                         {
                             "filename": "00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5000
+                            "segment_vector_index_uid": 5000
                         }
                     ]
                 }
@@ -3149,7 +3149,7 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5000
+                            "segment_vector_index_uid": 5000
                         }
                     ]
                 }
@@ -3164,14 +3164,14 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                                 100,
                                 200
                             ],
-                            "vector_index_tablet_id": 5000
+                            "segment_vector_index_uid": 5000
                         },
                         {
                             "filename": "00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5000
+                            "segment_vector_index_uid": 5000
                         }
                     ]
                 }
@@ -3208,7 +3208,7 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
     }
 }
 
-// Test: vacuum names .vi files by the segment's recorded vector_index_tablet_id (the owning tablet),
+// Test: vacuum names .vi files by the segment's recorded segment_vector_index_uid (the owning tablet),
 // not the tablet running the vacuum. This is what lets a segment shared across tablets after a split
 // resolve/GC the same .vi. Here the recorded owner (9999) differs from the vacuumed tablet (6000):
 // only the owner-named .vi must be deleted; a decoy named with the local tablet id must survive.
@@ -3232,7 +3232,7 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_use_recorded_owner_tablet_id) {
                         {
                             "filename": "00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat",
                             "vector_index_ids": [100],
-                            "vector_index_tablet_id": 9999
+                            "segment_vector_index_uid": 9999
                         }
                     ]
                 }
@@ -3262,7 +3262,7 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_use_recorded_owner_tablet_id) {
                         {
                             "filename": "00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat",
                             "vector_index_ids": [100],
-                            "vector_index_tablet_id": 9999
+                            "segment_vector_index_uid": 9999
                         }
                     ]
                 }
@@ -3413,28 +3413,28 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_bbbb0002-0002-0002-0002-000000000002.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_cccc0003-0003-0003-0003-000000000003.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_dddd0004-0004-0004-0004-000000000004.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         }
                     ]
                 }
@@ -3461,21 +3461,21 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e5_mmmm0005-0005-0005-0005-000000000005.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_dddd0004-0004-0004-0004-000000000004.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         }
                     ]
                 }
@@ -3490,14 +3490,14 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_cccc0003-0003-0003-0003-000000000003.dat",
                             "vector_index_ids": [
                                 100
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         }
                     ]
                 }
@@ -3566,7 +3566,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
                             "vector_index_ids": [
                                 300
                             ],
-                            "vector_index_tablet_id": 5200
+                            "segment_vector_index_uid": 5200
                         },
                         {
                             "filename": "00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.dat",
@@ -3574,7 +3574,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
                                 300,
                                 400
                             ],
-                            "vector_index_tablet_id": 5200
+                            "segment_vector_index_uid": 5200
                         }
                     ]
                 }
@@ -3588,7 +3588,7 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
                             "vector_index_ids": [
                                 300
                             ],
-                            "vector_index_tablet_id": 5200
+                            "segment_vector_index_uid": 5200
                         }
                     ]
                 }
@@ -3642,7 +3642,7 @@ TEST_P(LakeVacuumTest, test_find_orphan_vi_files) {
                             "vector_index_ids": [
                                 500
                             ],
-                            "vector_index_tablet_id": 5300
+                            "segment_vector_index_uid": 5300
                         }
                     ]
                 }
@@ -3703,7 +3703,7 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
                             "vector_index_ids": [
                                 700
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat"
@@ -3738,7 +3738,7 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
                             "vector_index_ids": [
                                 700
                             ],
-                            "vector_index_tablet_id": 5400
+                            "segment_vector_index_uid": 5400
                         },
                         {
                             "filename": "00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat"

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3106,6 +3106,95 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
     }
 }
 
+// Test: vacuum names .vi files by the segment's recorded vector_index_tablet_id (the owning tablet),
+// not the tablet running the vacuum. This is what lets a segment shared across tablets after a split
+// resolve/GC the same .vi. Here the recorded owner (9999) differs from the vacuumed tablet (6000):
+// only the owner-named .vi must be deleted; a decoy named with the local tablet id must survive.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_vi_files_use_recorded_owner_tablet_id) {
+    create_data_file("00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat");
+    create_data_file("00000000000c59f1_eeee0002-0002-0002-0002-000000000002.dat");
+    // The real .vi for the compaction-input segment, named by its recorded owner tablet (9999).
+    create_data_file("00000000000c59f0_dddd0001-0001-0001-0001-000000000001_9999_100.vi");
+    // Decoy named by the vacuumed tablet id (6000): must NOT be touched.
+    create_data_file("00000000000c59f0_dddd0001-0001-0001-0001-000000000001_6000_100.vi");
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 6000,
+            "version": 2,
+            "rowsets": [
+                {
+                    "data_size": 4096,
+                    "segment_metas": [
+                        {
+                            "filename": "00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat",
+                            "vector_index_ids": [100],
+                            "vector_index_tablet_id": 9999
+                        }
+                    ]
+                }
+            ],
+            "commit_time": 1
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 6000,
+            "version": 3,
+            "rowsets": [
+                {
+                    "data_size": 100,
+                    "segment_metas": [
+                        {
+                            "filename": "00000000000c59f1_eeee0002-0002-0002-0002-000000000002.dat"
+                        }
+                    ]
+                }
+            ],
+            "compaction_inputs": [
+                {
+                    "data_size": 4096,
+                    "segment_metas": [
+                        {
+                            "filename": "00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat",
+                            "vector_index_ids": [100],
+                            "vector_index_tablet_id": 9999
+                        }
+                    ]
+                }
+            ],
+            "prev_garbage_version": 2,
+            "commit_time": 1
+        }
+        )DEL")));
+
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(6000);
+        info->set_min_version(2);
+        request.set_min_retain_version(3);
+        request.set_grace_timestamp(::time(nullptr) + 10);
+        request.set_min_active_txn_id(99999);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        // The compaction-input segment and its .vi (named by the recorded owner 9999) are deleted.
+        EXPECT_FALSE(file_exist("00000000000c59f0_dddd0001-0001-0001-0001-000000000001.dat"));
+        EXPECT_FALSE(file_exist("00000000000c59f0_dddd0001-0001-0001-0001-000000000001_9999_100.vi"));
+        // The decoy named by the vacuumed tablet id (6000) is untouched: proves vacuum used the
+        // recorded owner, not its own tablet id.
+        EXPECT_TRUE(file_exist("00000000000c59f0_dddd0001-0001-0001-0001-000000000001_6000_100.vi"));
+        // Alive segment survives.
+        EXPECT_TRUE(file_exist("00000000000c59f1_eeee0002-0002-0002-0002-000000000002.dat"));
+    }
+}
+
 // Test: vacuum does NOT blindly delete .vi files when vector_index_ids is empty
 // NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_vacuum_no_blind_vi_deletion) {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -1970,6 +1970,103 @@ TEST_P(LakeVacuumTest, test_delete_tablets_shared_metadata_files) {
     }
 }
 
+// A split-shared segment's .vi is named by the recorded owner, so it is the SAME file for every
+// sibling tablet. It must follow the shared segment's deletion policy: kept while any sibling still
+// references the segment, deleted only once none do. Owner (710) differs from the sibling (711) to
+// prove the .vi name is owner-based, not per-vacuuming-tablet.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_shared_vector_index_files) {
+    const std::string shared_segment = "0000000000f159e5_22222222-2222-2222-2222-2222222222b1.dat";
+    // gen_vector_index_filename(shared_segment, owner=710, index=100)
+    const std::string shared_vi = "0000000000f159e5_22222222-2222-2222-2222-2222222222b1_710_100.vi";
+    // Decoy named by the sibling tablet id (711): must never be touched (proves owner-based naming).
+    const std::string decoy_vi = "0000000000f159e5_22222222-2222-2222-2222-2222222222b1_711_100.vi";
+    create_data_file(shared_segment);
+    create_data_file(shared_vi);
+    create_data_file(decoy_vi);
+
+    auto t710_v1 = json_to_pb<TabletMetadataPB>(R"DEL({"id": 710, "version": 1, "rowsets": []})DEL");
+    auto t711_v1 = json_to_pb<TabletMetadataPB>(R"DEL({"id": 711, "version": 1, "rowsets": []})DEL");
+
+    // Both tablets reference the shared segment, which records owner 710 (carried verbatim by the
+    // split cross-publish CopyFrom), so both resolve the .vi to ..._710_100.vi.
+    auto t710_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 710,
+            "version": 2,
+            "rowsets": [
+                {
+                    "data_size": 4096,
+                    "segment_metas": [
+                        {
+                            "filename": "0000000000f159e5_22222222-2222-2222-2222-2222222222b1.dat",
+                            "shared": true,
+                            "vector_index_ids": [100],
+                            "vector_index_tablet_id": 710
+                        }
+                    ]
+                }
+            ]
+        }
+        )DEL");
+    auto t711_v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 711,
+            "version": 2,
+            "rowsets": [
+                {
+                    "data_size": 4096,
+                    "segment_metas": [
+                        {
+                            "filename": "0000000000f159e5_22222222-2222-2222-2222-2222222222b1.dat",
+                            "shared": true,
+                            "vector_index_ids": [100],
+                            "vector_index_tablet_id": 710
+                        }
+                    ]
+                }
+            ]
+        }
+        )DEL");
+
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v1{{710, *t710_v1}, {711, *t711_v1}};
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v1));
+    std::map<int64_t, TabletMetadataPB> tablet_metas_v2{{710, *t710_v2}, {711, *t711_v2}};
+    ASSERT_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas_v2));
+
+    {
+        // Delete tablet 710 only: 711 still references the shared segment, so its owner-named .vi
+        // must be kept.
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(710);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_TRUE(file_exist(shared_segment));
+        EXPECT_TRUE(file_exist(shared_vi));
+        EXPECT_TRUE(file_exist(decoy_vi));
+    }
+
+    {
+        // Delete both: nothing references the shared segment now, so its .vi is deleted too.
+        DeleteTabletRequest request;
+        DeleteTabletResponse response;
+        request.add_tablet_ids(710);
+        request.add_tablet_ids(711);
+        delete_tablets(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+        EXPECT_FALSE(file_exist(shared_segment));
+        EXPECT_FALSE(file_exist(shared_vi));
+        // The decoy (sibling-id name) was never referenced by metadata, so vacuum leaves it to the
+        // orphan-file sweep, not this path — it must remain untouched here.
+        EXPECT_TRUE(file_exist(decoy_vi));
+    }
+}
+
 // NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_delete_tablets_shared_metadata_files_with_dcg) {
     const std::string shared_dcg_file = "0000000000f359e4_33333333-3333-3333-3333-3333333333c1.dat";

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3118,13 +3118,15 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                             "vector_index_ids": [
                                 100,
                                 200
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5000
                         },
                         {
                             "filename": "00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5000
                         }
                     ]
                 }
@@ -3146,7 +3148,8 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                             "filename": "00000000000a59e5_cccc3333-3333-3333-3333-333333333333.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5000
                         }
                     ]
                 }
@@ -3160,13 +3163,15 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {
                             "vector_index_ids": [
                                 100,
                                 200
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5000
                         },
                         {
                             "filename": "00000000000a59e4_bbbb2222-2222-2222-2222-222222222222.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5000
                         }
                     ]
                 }
@@ -3407,25 +3412,29 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "filename": "00000000000e59e4_aaaa0001-0001-0001-0001-000000000001.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_bbbb0002-0002-0002-0002-000000000002.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_cccc0003-0003-0003-0003-000000000003.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_dddd0004-0004-0004-0004-000000000004.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         }
                     ]
                 }
@@ -3451,19 +3460,22 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "filename": "00000000000e59e4_aaaa0001-0001-0001-0001-000000000001.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e5_mmmm0005-0005-0005-0005-000000000005.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_dddd0004-0004-0004-0004-000000000004.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         }
                     ]
                 }
@@ -3477,13 +3489,15 @@ TEST_P(LakeVacuumTest, test_vacuum_vi_files_partial_compaction) {
                             "filename": "00000000000e59e4_bbbb0002-0002-0002-0002-000000000002.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_cccc0003-0003-0003-0003-000000000003.dat",
                             "vector_index_ids": [
                                 100
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         }
                     ]
                 }
@@ -3551,14 +3565,16 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
                             "filename": "00000000000c59e4_1111aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.dat",
                             "vector_index_ids": [
                                 300
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5200
                         },
                         {
                             "filename": "00000000000c59e4_2222bbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.dat",
                             "vector_index_ids": [
                                 300,
                                 400
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5200
                         }
                     ]
                 }
@@ -3571,7 +3587,8 @@ TEST_P(LakeVacuumTest, test_delete_tablets_vi_files) {
                             "filename": "00000000000c59e3_3333cccc-cccc-cccc-cccc-cccccccccccc.dat",
                             "vector_index_ids": [
                                 300
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5200
                         }
                     ]
                 }
@@ -3624,7 +3641,8 @@ TEST_P(LakeVacuumTest, test_find_orphan_vi_files) {
                             "filename": "00000000000d59e4_aaaa1111-1111-1111-1111-111111111111.dat",
                             "vector_index_ids": [
                                 500
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5300
                         }
                     ]
                 }
@@ -3684,7 +3702,8 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
                             "filename": "00000000000e59e4_p1111111-1111-1111-1111-111111111111.dat",
                             "vector_index_ids": [
                                 700
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat"
@@ -3718,7 +3737,8 @@ TEST_P(LakeVacuumTest, test_vacuum_partial_segment_metas) {
                             "filename": "00000000000e59e4_p1111111-1111-1111-1111-111111111111.dat",
                             "vector_index_ids": [
                                 700
-                            ]
+                            ],
+                            "vector_index_tablet_id": 5400
                         },
                         {
                             "filename": "00000000000e59e4_p2222222-2222-2222-2222-222222222222.dat"

--- a/be/test/storage/lake/vector_index_build_task_test.cpp
+++ b/be/test/storage/lake/vector_index_build_task_test.cpp
@@ -164,6 +164,7 @@ protected:
             auto* segment_meta = rowset->add_segment_metas();
             segment_meta->set_filename(seg_name);
             segment_meta->add_vector_index_ids(kIndexId);
+            segment_meta->set_vector_index_tablet_id(kTabletId);
         }
 
         if (built_version > 0) {
@@ -439,6 +440,7 @@ TEST_F(VectorIndexBuildTaskTest, test_partial_failure_watermark_stops_at_failed_
         auto* segment_meta = rs->add_segment_metas();
         segment_meta->set_filename(seg_ok);
         segment_meta->add_vector_index_ids(kIndexId);
+        segment_meta->set_vector_index_tablet_id(kTabletId);
     }
     {
         auto* rs = metadata->add_rowsets();
@@ -449,6 +451,7 @@ TEST_F(VectorIndexBuildTaskTest, test_partial_failure_watermark_stops_at_failed_
         auto* segment_meta = rs->add_segment_metas();
         segment_meta->set_filename(seg_bad);
         segment_meta->add_vector_index_ids(kIndexId);
+        segment_meta->set_vector_index_tablet_id(kTabletId);
     }
     CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
 
@@ -492,6 +495,7 @@ TEST_F(VectorIndexBuildTaskTest, test_prepare_carries_segment_size_and_encryptio
     segment_meta->set_size(2048);          // exercises has_size branch
     segment_meta->set_encryption_meta(""); // exercises has_encryption_meta branch (empty meta is fine)
     segment_meta->add_vector_index_ids(kIndexId);
+    segment_meta->set_vector_index_tablet_id(kTabletId);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
 
     BuildVectorIndexRequest request;

--- a/be/test/storage/lake/vector_index_build_task_test.cpp
+++ b/be/test/storage/lake/vector_index_build_task_test.cpp
@@ -164,7 +164,7 @@ protected:
             auto* segment_meta = rowset->add_segment_metas();
             segment_meta->set_filename(seg_name);
             segment_meta->add_vector_index_ids(kIndexId);
-            segment_meta->set_vector_index_tablet_id(kTabletId);
+            segment_meta->set_segment_vector_index_uid(kTabletId);
         }
 
         if (built_version > 0) {
@@ -440,7 +440,7 @@ TEST_F(VectorIndexBuildTaskTest, test_partial_failure_watermark_stops_at_failed_
         auto* segment_meta = rs->add_segment_metas();
         segment_meta->set_filename(seg_ok);
         segment_meta->add_vector_index_ids(kIndexId);
-        segment_meta->set_vector_index_tablet_id(kTabletId);
+        segment_meta->set_segment_vector_index_uid(kTabletId);
     }
     {
         auto* rs = metadata->add_rowsets();
@@ -451,7 +451,7 @@ TEST_F(VectorIndexBuildTaskTest, test_partial_failure_watermark_stops_at_failed_
         auto* segment_meta = rs->add_segment_metas();
         segment_meta->set_filename(seg_bad);
         segment_meta->add_vector_index_ids(kIndexId);
-        segment_meta->set_vector_index_tablet_id(kTabletId);
+        segment_meta->set_segment_vector_index_uid(kTabletId);
     }
     CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
 
@@ -495,7 +495,7 @@ TEST_F(VectorIndexBuildTaskTest, test_prepare_carries_segment_size_and_encryptio
     segment_meta->set_size(2048);          // exercises has_size branch
     segment_meta->set_encryption_meta(""); // exercises has_encryption_meta branch (empty meta is fine)
     segment_meta->add_vector_index_ids(kIndexId);
-    segment_meta->set_vector_index_tablet_id(kTabletId);
+    segment_meta->set_segment_vector_index_uid(kTabletId);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
 
     BuildVectorIndexRequest request;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -222,16 +222,17 @@ message SegmentMetadataPB {
     // Offset of this segment inside a bundle file. Use has_bundle_file_offset()
     // to test presence: 0 is a legitimate value (first segment in a bundle).
     optional int64 bundle_file_offset = 12;
-    // Tablet id under which this segment's vector index (.vi) files were written. The .vi
-    // filename embeds it ("<segment_base>_<vector_index_tablet_id>_<index_id>.vi") so that
-    // bundle-file segments sharing one physical file across tablets still get distinct .vi
-    // files. It is RECORDED here (instead of using the reading tablet's id) so the name is
-    // stable and reader-agnostic: carried verbatim by CopyFrom across tablet SPLIT, letting
-    // every child that shares this segment resolve the same .vi. Always stamped by the writer in
-    // the same step that records vector_index_ids, so a segment carrying vector_index_ids always
-    // carries this owner too. Consumers (read / GC / async build) only read it for vector-indexed
-    // segments and DCHECK its presence -- there is no fall back to the reading tablet's id.
-    optional int64 vector_index_tablet_id = 13;
+    // Per-segment unique id embedded in this segment's vector index (.vi) filenames
+    // ("<segment_base>_<segment_vector_index_uid>_<index_id>.vi") so that bundle-file segments
+    // sharing one physical file across tablets still get distinct .vi files. Its VALUE is the id of
+    // the tablet that WROTE the segment, used purely as a unique key (do not treat it as a live
+    // tablet reference): it is RECORDED here, instead of using the reading tablet's id, so the name
+    // is stable and reader-agnostic -- carried verbatim by CopyFrom across tablet SPLIT so every
+    // child sharing this segment resolves the same .vi. Always stamped by the writer in the same
+    // step that records vector_index_ids, so a segment carrying vector_index_ids always carries this
+    // uid too. Consumers (read / GC / async build) only read it for vector-indexed segments and
+    // DCHECK its presence -- there is no fall back to the reading tablet's id.
+    optional int64 segment_vector_index_uid = 13;
 }
 
 message RowsetMetadataPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -227,10 +227,9 @@ message SegmentMetadataPB {
     // bundle-file segments sharing one physical file across tablets still get distinct .vi
     // files. It is RECORDED here (instead of using the reading tablet's id) so the name is
     // stable and reader-agnostic: carried verbatim by CopyFrom across tablet SPLIT, letting
-    // every child that shares this segment resolve the same .vi. Stamped in one place at
-    // publish time (fill_missing_vector_index_owner: the publishing tablet is the writing
-    // tablet for every non-shared segment); absent on segments produced before this field
-    // existed, where readers fall back to the current tablet id.
+    // every child that shares this segment resolve the same .vi. Recorded by the writer
+    // together with vector_index_ids; absent on segments produced before this field existed,
+    // where readers fall back to the current tablet id.
     optional int64 vector_index_tablet_id = 13;
 }
 

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -227,9 +227,10 @@ message SegmentMetadataPB {
     // bundle-file segments sharing one physical file across tablets still get distinct .vi
     // files. It is RECORDED here (instead of using the reading tablet's id) so the name is
     // stable and reader-agnostic: carried verbatim by CopyFrom across tablet SPLIT, letting
-    // every child that shares this segment resolve the same .vi. Recorded by the writer
-    // together with vector_index_ids; absent on segments produced before this field existed,
-    // where readers fall back to the current tablet id.
+    // every child that shares this segment resolve the same .vi. Always stamped by the writer in
+    // the same step that records vector_index_ids, so a segment carrying vector_index_ids always
+    // carries this owner too. Consumers (read / GC / async build) only read it for vector-indexed
+    // segments and DCHECK its presence -- there is no fall back to the reading tablet's id.
     optional int64 vector_index_tablet_id = 13;
 }
 

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -222,6 +222,15 @@ message SegmentMetadataPB {
     // Offset of this segment inside a bundle file. Use has_bundle_file_offset()
     // to test presence: 0 is a legitimate value (first segment in a bundle).
     optional int64 bundle_file_offset = 12;
+    // Tablet id under which this segment's vector index (.vi) files were written. The .vi
+    // filename embeds it ("<segment_base>_<vector_index_tablet_id>_<index_id>.vi") so that
+    // bundle-file segments sharing one physical file across tablets still get distinct .vi
+    // files. It is RECORDED here (instead of using the reading tablet's id) so the name is
+    // stable and reader-agnostic: carried verbatim by CopyFrom across tablet SPLIT, letting
+    // every child that shares this segment resolve the same .vi. Set together with
+    // vector_index_ids; absent on segments produced before this field existed, where readers
+    // fall back to the current tablet id.
+    optional int64 vector_index_tablet_id = 13;
 }
 
 message RowsetMetadataPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -227,9 +227,10 @@ message SegmentMetadataPB {
     // bundle-file segments sharing one physical file across tablets still get distinct .vi
     // files. It is RECORDED here (instead of using the reading tablet's id) so the name is
     // stable and reader-agnostic: carried verbatim by CopyFrom across tablet SPLIT, letting
-    // every child that shares this segment resolve the same .vi. Set together with
-    // vector_index_ids; absent on segments produced before this field existed, where readers
-    // fall back to the current tablet id.
+    // every child that shares this segment resolve the same .vi. Stamped in one place at
+    // publish time (fill_missing_vector_index_owner: the publishing tablet is the writing
+    // tablet for every non-shared segment); absent on segments produced before this field
+    // existed, where readers fall back to the current tablet id.
     optional int64 vector_index_tablet_id = 13;
 }
 


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #75542, which added vector-index (`.vi`) support for shared-data bundle-file
segments. That PR names each `.vi` `<segment_base>_<tablet_id>_<index_id>.vi`, embedding the
tablet id to disambiguate segments that share one physical bundle file across tablets. It uses
the id of the tablet **touching** the segment, which is not reader-agnostic.

After a tablet split, a single segment is shared by multiple child tablets
(`SegmentMetadataPB.shared`, carried verbatim via `CopyFrom`). Each child reads the shared
segment with its **own** tablet id, so it derives a different `.vi` name than the one the writer
actually produced:

- **Read**: the child looks up `..._<child_id>_<index_id>.vi`, which does not exist → NotFound
  → silent fall back to brute-force vector search (results stay correct, but slow).
- **GC / vacuum**: orphan protection and deletion also reconstruct the name from the local
  tablet id, so the real `.vi` (named after the writer) is neither protected nor collected under
  the name every referencing tablet computes — it can be deleted while still referenced, or
  leaked.

## What I'm doing:

Record the **writing** tablet's id in a new persisted field
`SegmentMetadataPB.vector_index_tablet_id` and derive every `.vi` name from that recorded owner
instead of the local tablet id. Because the field is carried verbatim across split via
`CopyFrom`, every child that shares the segment resolves the exact same `.vi` the writer wrote.

- The `.vi` filename **format is unchanged** (`<segment_base>_<owner_tablet_id>_<index_id>.vi`);
  only the source of the embedded id changes from "the tablet touching the segment" to "the
  recorded owner".
- The owner is stamped at **write time**, in the same step that records `vector_index_ids`: the
  tablet writers (normal write and the deferred-async initial write) and the segment rewrite
  (partial-update / auto-increment). `to_proto` persists it and the publish apply carries it
  verbatim. From there it is threaded through `FileInfo` / `SegmentReadOptions` and consumed by
  the read path (`segment_iterator`), the async build (`vector_index_build_task`), and GC
  (`vacuum` / `transactions`).
- **Invariant, no fallback**: a segment that records `vector_index_ids` always records this owner
  too, and every consumer reads the owner only for a vector-indexed segment and `DCHECK`s its
  presence — there is no fall back to the reading tablet id. A future write path that records ids
  but forgets the owner fails loudly in tests instead of silently degrading to brute-force reads
  and mis-named GC. This PR is a follow-up to #75542 (unreleased) and ships together with it, so
  no released version ever persisted a vector-indexed segment without the owner.
- A **split-shared** `.vi` is named by the recorded owner, so it is one physical file referenced
  by every sibling tablet. It follows its segment's shared-file lifecycle in GC: routed through
  the shared-file deleter / retained while any sibling still references it, and delay-deleted like
  the shared segment. A **bundle-only** `.vi` stays per-tablet (the filename embeds the writer id)
  and keeps ordinary per-tablet deletion.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
