### PR TITLE
[Refactor] Extract generic JVM helper from JVMFunctionHelper

### DIFF
--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -33,7 +33,7 @@ namespace starrocks {
 
 Status JniScanner::_check_jni_exception(JNIEnv* env, const std::string& message) {
     if (jthrowable thr = env->ExceptionOccurred(); thr) {
-        std::string jni_error_message = JVMFunctionHelper::getInstance().dumpExceptionString(thr);
+        std::string jni_error_message = JVMHelper::getInstance().dumpExceptionString(thr);
         env->ExceptionDescribe();
         env->ExceptionClear();
         env->DeleteLocalRef(thr);
@@ -49,7 +49,10 @@ Status JniScanner::do_init(RuntimeState* runtime_state, const HdfsScannerContext
 
 Status JniScanner::do_open(RuntimeState* state) {
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    // NativeMethodHelper registration still lives in JVMFunctionHelper. Initialize it
+    // before Java off-heap scanners call Platform.allocateMemory/freeMemory.
+    JVMFunctionHelper::getInstance();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     RETURN_IF_ERROR(update_jni_scanner_params());
     if (env->EnsureLocalCapacity(_jni_scanner_params.size() * 2 + 6) < 0) {
         RETURN_IF_ERROR(_check_jni_exception(env, "Failed to ensure the local capacity."));
@@ -63,7 +66,7 @@ Status JniScanner::do_open(RuntimeState* state) {
 
 void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
     if (_jni_scanner_obj != nullptr) {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         if (_jni_scanner_close != nullptr) {
             env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
         }
@@ -71,7 +74,7 @@ void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
         _jni_scanner_obj = nullptr;
     }
     if (_jni_scanner_cls != nullptr) {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         env->DeleteLocalRef(_jni_scanner_cls);
         _jni_scanner_cls = nullptr;
     }
@@ -404,7 +407,7 @@ Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
 }
 
 StatusOr<size_t> JniScanner::fill_empty_chunk(ChunkPtr* chunk) {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     long chunk_meta;
     RETURN_IF_ERROR(_get_next_chunk(env, &chunk_meta));
     reset_chunk_meta(chunk_meta);

--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -39,7 +39,7 @@ namespace starrocks {
 
 #define CHECK_JAVA_EXCEPTION(env, error_message)                                        \
     if (jthrowable thr = env->ExceptionOccurred(); thr) {                               \
-        std::string err = JVMFunctionHelper::getInstance().dumpExceptionString(thr);    \
+        std::string err = JVMHelper::getInstance().dumpExceptionString(thr);            \
         env->ExceptionClear();                                                          \
         env->DeleteLocalRef(thr);                                                       \
         return Status::InternalError(fmt::format("{}, error: {}", error_message, err)); \
@@ -84,8 +84,7 @@ Status JDBCScanner::close(RuntimeState* state) {
 
 Status JDBCScanner::_init_jdbc_bridge() {
     // 1. construct JDBCBridge
-    auto& h = JVMFunctionHelper::getInstance();
-    auto* env = h.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     auto jdbc_bridge_cls = env->FindClass(JDBC_BRIDGE_CLASS_NAME);
     DCHECK(jdbc_bridge_cls != nullptr);
@@ -108,7 +107,7 @@ Status JDBCScanner::_init_jdbc_bridge() {
 
 Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
     // scan
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jclass scan_context_cls = env->FindClass(JDBC_SCAN_CONTEXT_CLASS_NAME);
     DCHECK(scan_context_cls != nullptr);
@@ -191,7 +190,7 @@ Status JDBCScanner::_init_jdbc_scan_context(RuntimeState* state) {
 }
 
 Status JDBCScanner::_init_jdbc_scanner() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jmethodID get_scanner =
             env->GetMethodID(_jdbc_bridge_cls->clazz(), "getScanner",
@@ -243,7 +242,7 @@ StatusOr<LogicalType> JDBCScanner::_precheck_data_type(const std::string& java_c
 }
 
 Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jmethodID get_result_column_class_names =
             env->GetMethodID(_jdbc_scanner_cls->clazz(), "getResultColumnClassNames", "()Ljava/util/List;");
@@ -253,7 +252,7 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
     CHECK_JAVA_EXCEPTION(env, "get JDBC result column class name failed")
     LOCAL_REF_GUARD_ENV(env, column_class_names);
 
-    auto& helper = JVMFunctionHelper::getInstance();
+    auto& jvm = JVMHelper::getInstance();
     JavaListStub list_stub(column_class_names);
     ASSIGN_OR_RETURN(int len, list_stub.size());
 
@@ -261,7 +260,7 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
     for (int i = 0; i < len; i++) {
         ASSIGN_OR_RETURN(jobject jelement, list_stub.get(i));
         LOCAL_REF_GUARD_ENV(env, jelement);
-        std::string class_name = helper.to_string((jstring)(jelement));
+        std::string class_name = jvm.to_string((jstring)(jelement));
         ASSIGN_OR_RETURN(auto ret_type, _precheck_data_type(class_name, _slot_descs[i]));
         _column_class_names.emplace_back(class_name);
         _result_column_types.emplace_back(ret_type);
@@ -293,7 +292,7 @@ Status JDBCScanner::_init_column_class_name(RuntimeState* state) {
 }
 
 Status JDBCScanner::_init_jdbc_util() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // init JDBCUtil method
     auto jdbc_util_cls = env->FindClass(JDBC_UTIL_CLASS_NAME);
@@ -311,7 +310,7 @@ Status JDBCScanner::_init_jdbc_util() {
 }
 
 Status JDBCScanner::_has_next(bool* result) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     jboolean ret = env->CallBooleanMethod(_jdbc_scanner.handle(), _scanner_has_next);
     CHECK_JAVA_EXCEPTION(env, "call JDBCScanner hasNext failed")
     *result = ret;
@@ -319,7 +318,7 @@ Status JDBCScanner::_has_next(bool* result) {
 }
 
 Status JDBCScanner::_get_next_chunk(jobject* chunk, size_t* num_rows) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     SCOPED_TIMER(_profile.io_timer);
     COUNTER_UPDATE(_profile.io_counter, 1);
     *chunk = env->CallObjectMethod(_jdbc_scanner.handle(), _scanner_get_next_chunk);
@@ -330,7 +329,7 @@ Status JDBCScanner::_get_next_chunk(jobject* chunk, size_t* num_rows) {
 }
 
 Status JDBCScanner::_close_jdbc_scanner() {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     if (_jdbc_scanner.handle() == nullptr) {
         return Status::OK();
     }
@@ -351,7 +350,7 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
     // get result from JNI
     {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         JavaListStub list_stub(jchunk);
         COUNTER_UPDATE(_profile.rows_read_counter, num_rows);
         (*chunk)->reset();

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -100,7 +100,7 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
     // for input boxing, writeResult for output drain); slots without STRUCT are stored
     // as null-handle entries and the existing fast paths run unchanged.
     {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         // UDAF `update(State, sql_args...)` — SQL args start at parameter index 1. The
         // method itself returns void, so suppress the helper's return-type pass by
         // passing a default-constructed (TYPE_UNKNOWN) sql_return_type — otherwise the
@@ -130,7 +130,7 @@ static Status build_udaf_unique_context(std::shared_ptr<JavaUDAFSharedContext> u
     ASSIGN_OR_RETURN(agg_ctx->handle, agg_ctx->ctx->udaf_class.newInstance());
 
     // Create a per-aggregator AggBatchCallStub with the shared stub class/method cloned as new global refs
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     JVMClass stub_clazz(env->NewGlobalRef(agg_ctx->ctx->update_stub_clazz.clazz()));
     jobject stub_method = env->NewGlobalRef(agg_ctx->ctx->update_stub_method.handle());
     agg_ctx->update_batch_call_stub = std::make_unique<AggBatchCallStub>(

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -120,7 +120,7 @@ public:
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t batch_size,
                                      MutableColumnPtr& dst) const final {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         // 1 convert input as state
         // 1.1 create state list
@@ -164,14 +164,14 @@ public:
 
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
-        helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
+        env->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
         int totalLength = std::accumulate(slice_sz.begin(), slice_sz.end(), 0, [](auto l, auto r) { return l + r; });
         // 4 prepare serialize buffer
         udf_ctxs->buffer_data.resize(totalLength);
         udf_ctxs->buffer =
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
         // chunk size
-        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        auto buffer_array = JVMHelper::getInstance().create_object_array(udf_ctxs->buffer->handle(), batch_size);
         RETURN_IF_UNLIKELY_NULL(buffer_array, (void)0);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {rets, buffer_array};
@@ -230,12 +230,13 @@ public:
     void update_batch(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                       AggDataPtr* states) const override {
         auto& helper = JVMFunctionHelper::getInstance();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
-        helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
-        auto defer = DeferOp([&helper]() { helper.getEnv()->PopLocalFrame(nullptr); });
+        env->PushLocalFrame(num_cols * 3 + 1);
+        auto defer = DeferOp([env]() { env->PopLocalFrame(nullptr); });
 
         {
             auto states_arr = JavaDataTypeConverter::convert_to_states(ctx, states, state_offset, batch_size);
@@ -252,12 +253,13 @@ public:
 
     void update_batch_selectively(FunctionContext* ctx, size_t batch_size, size_t state_offset, const Column** columns,
                                   AggDataPtr* states, const Filter& filter) const override {
-        auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
+        auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
-        helper.getEnv()->PushLocalFrame(num_cols * 3 + 1);
+        env->PushLocalFrame(num_cols * 3 + 1);
         auto defer = DeferOp([env = env]() { env->PopLocalFrame(nullptr); });
         {
             auto states_arr = JavaDataTypeConverter::convert_to_states_with_filter(ctx, states, state_offset,
@@ -278,7 +280,7 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         std::vector<jobject> args;
         int num_cols = ctx->get_num_args();
         env->PushLocalFrame(num_cols * 3 + 1);
@@ -301,7 +303,7 @@ public:
     void _merge_batch_process(FunctionContext* ctx, StatesProvider&& states_provider, MergeCaller&& caller,
                               const Column* column, size_t start, size_t size) const {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         // get state lists
         auto state_array = states_provider();
         RETURN_IF_UNLIKELY_NULL(state_array, (void)0);
@@ -335,7 +337,7 @@ public:
                      AggDataPtr* states) const override {
         // batch merge
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
 
@@ -379,12 +381,12 @@ public:
         auto& helper = JVMFunctionHelper::getInstance();
         auto* udf_ctxs = get_java_udaf_context(ctx);
         DCHECK(udf_ctxs != nullptr);
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto provider = [&]() {
             auto state_handle = reinterpret_cast<JavaUDAFState*>(state)->handle;
             auto res = helper.convert_handle_to_jobject(ctx, state_handle);
             LOCAL_REF_GUARD_ENV(env, res);
-            return helper.create_object_array(res, size);
+            return JVMHelper::getInstance().create_object_array(res, size);
         };
         auto merger = [&](jobject state_array, jobject buffer_array) {
             jobject state_and_buffer[2] = {state_array, buffer_array};
@@ -397,7 +399,7 @@ public:
     void batch_serialize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                          size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
 
         const size_t origin_chunk_size = to->size();
@@ -427,7 +429,7 @@ public:
 
         int length = env->GetArrayLength(serialize_szs);
         std::vector<int> slice_sz(length);
-        helper.getEnv()->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
+        env->GetIntArrayRegion(serialize_szs, 0, length, slice_sz.data());
         int totalLength = std::accumulate(slice_sz.begin(), slice_sz.end(), 0, [](auto l, auto r) { return l + r; });
         // step 3 prepare serialize buffer
         udf_ctxs->buffer_data.resize(totalLength);
@@ -435,7 +437,7 @@ public:
                 std::make_unique<DirectByteBuffer>(udf_ctxs->buffer_data.data(), udf_ctxs->buffer_data.size());
 
         // step 4 call serialize
-        auto buffer_array = helper.create_object_array(udf_ctxs->buffer->handle(), batch_size);
+        auto buffer_array = JVMHelper::getInstance().create_object_array(udf_ctxs->buffer->handle(), batch_size);
         LOCAL_REF_GUARD_ENV(env, buffer_array);
         jobject state_and_buffer[2] = {state_array, buffer_array};
         helper.batch_update_state(ctx, udf_ctxs->handle.handle(), udf_ctxs->ctx->serialize->method.handle(),
@@ -453,7 +455,7 @@ public:
     void batch_finalize(FunctionContext* ctx, size_t batch_size, const Buffer<AggDataPtr>& agg_states,
                         size_t state_offset, Column* to) const override {
         auto& helper = JVMFunctionHelper::getInstance();
-        auto* env = helper.getEnv();
+        auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
 
         const size_t origin_chunk_size = to->size();

--- a/be/src/exprs/agg/java_window_function.cpp
+++ b/be/src/exprs/agg/java_window_function.cpp
@@ -79,7 +79,7 @@ static Status build_window_unique_context(std::shared_ptr<JavaUDAFSharedContext>
     ASSIGN_OR_RETURN(udaf_ctx->handle, udaf_ctx->ctx->udaf_class.newInstance());
 
     // Create a new FunctionStates instance; clone method refs from the shared context.
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     auto& state_clazz = JVMFunctionHelper::getInstance().function_state_clazz();
     ASSIGN_OR_RETURN(auto instance, state_clazz.newInstance());
     udaf_ctx->states = std::make_unique<UDAFStateList>(

--- a/be/src/exprs/agg/java_window_function.h
+++ b/be/src/exprs/agg/java_window_function.h
@@ -52,8 +52,7 @@ public:
         }
 
         std::vector<jobject> args;
-        auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         DeferOp defer = DeferOp([&]() {
             // clean up arrays
             for (auto& arg : args) {
@@ -78,12 +77,11 @@ public:
 
     void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                     size_t end) const override {
-        auto& helper = JVMFunctionHelper::getInstance();
         auto* udaf_ctx = get_java_udaf_context(ctx);
         DCHECK(udaf_ctx != nullptr);
         jvalue val = udaf_ctx->_func->finalize(this->data(state).handle);
         // insert values to column
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         const auto& return_type = ctx->get_return_type();
         const bool error_if_overflow = ctx->error_if_overflow();
         int sz = end - start;

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -53,7 +53,7 @@ struct UDFFunctionCallHelper {
 
     StatusOr<ColumnPtr> call(FunctionContext* ctx, Columns& columns, size_t size) {
         auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         int num_cols = ctx->get_num_args();
         std::vector<const Column*> input_cols;
 
@@ -219,8 +219,7 @@ StatusOr<std::shared_ptr<JavaUDFContext>> JavaFunctionCallExpr::_build_udf_func_
     // UdfTypeDesc tree is the single source of type info shared with both the input
     // boxing path (via JNI field accessors) and the unified Java writeResult helper.
     {
-        auto& helper = JVMFunctionHelper::getInstance();
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         std::vector<TypeDescriptor> sql_arg_types;
         sql_arg_types.reserve(_children.size());
         for (const auto& child : _children) {

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -123,7 +123,7 @@ Status JavaUDTFState::open() {
     // per-row element type, so pass `unwrap_return_array_layer=true` to drop the array
     // layer off the reflective formal type before pairing it with `_ret_type`.
     {
-        JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
         ASSIGN_OR_RETURN(_process_type_descs,
                          build_method_udf_type_descs(env, _process->method.handle(), _arg_type_descs, _ret_type,
                                                      /*state_offset=*/0, /*unwrap_return_array_layer=*/true));
@@ -177,8 +177,7 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     const Columns& cols = state->get_columns();
     auto* stateUDTF = down_cast<JavaUDTFState*>(state);
 
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jmethodID methodID = env->GetMethodID(stateUDTF->get_udtf_clazz(), stateUDTF->method_process()->name.c_str(),
                                           stateUDTF->method_process()->signature.c_str());
@@ -229,10 +228,11 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
 
         rets[i] = env->CallObjectMethodA(stateUDTF->handle(), methodID, call_stack.data());
 
-        if (auto jthr = helper.getEnv()->ExceptionOccurred(); jthr != nullptr) {
-            std::string err = fmt::format("execute UDF Function meet Exception:{}", helper.dumpExceptionString(jthr));
+        if (auto jthr = env->ExceptionOccurred(); jthr != nullptr) {
+            std::string err = fmt::format("execute UDF Function meet Exception:{}",
+                                          JVMHelper::getInstance().dumpExceptionString(jthr));
             LOG(WARNING) << err;
-            helper.getEnv()->ExceptionClear();
+            env->ExceptionClear();
             state->set_status(Status::InternalError(err));
             return std::make_pair(Columns{}, nullptr);
         }
@@ -271,10 +271,11 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
     res.emplace_back(std::move(col));
 
     // TODO: add error msg to Function State
-    if (auto jthr = helper.getEnv()->ExceptionOccurred(); jthr != nullptr) {
-        std::string err = fmt::format("execute UDF Function meet Exception:{}", helper.dumpExceptionString(jthr));
+    if (auto jthr = env->ExceptionOccurred(); jthr != nullptr) {
+        std::string err = fmt::format("execute UDF Function meet Exception:{}",
+                                      JVMHelper::getInstance().dumpExceptionString(jthr));
         LOG(WARNING) << err;
-        helper.getEnv()->ExceptionClear();
+        env->ExceptionClear();
     }
 
     return std::make_pair(std::move(res), std::move(offsets_col));

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -54,6 +54,7 @@ set(RUNTIME_SRCS
     global_thread_pools.cpp
     java/java_env.cpp
     java/java_global_ref.cpp
+    java/jvm_helper.cpp
     java/jvm_class.cpp
 )
 

--- a/be/src/runtime/java/jvm_helper.cpp
+++ b/be/src/runtime/java/jvm_helper.cpp
@@ -1,0 +1,390 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/java/jvm_helper.h"
+
+#include <algorithm>
+#include <iterator>
+#include <sstream>
+#include <string>
+
+#include "base/logging.h"
+#include "base/status.h"
+#include "fmt/core.h"
+#include "runtime/java/java_env.h"
+
+#define JNI_FIND_CLASS(clazz_name)                                                                 \
+    [](JNIEnv* env, const char* name) {                                                            \
+        auto clazz = env->FindClass(name);                                                         \
+        CHECK(clazz != nullptr) << "not found class" << name << " plz check JDK and jni-packages"; \
+        auto g_clazz = env->NewGlobalRef(clazz);                                                   \
+        env->DeleteLocalRef(clazz);                                                                \
+        return (jclass)g_clazz;                                                                    \
+    }(_env, clazz_name)
+
+#define ADD_NUMBERIC_CLASS(prim_clazz, clazz, sign)                                                           \
+    {                                                                                                         \
+        _class_##prim_clazz = JNI_FIND_CLASS("java/lang/" #clazz);                                            \
+        CHECK(_class_##prim_clazz);                                                                           \
+        _value_of_##prim_clazz =                                                                              \
+                _env->GetStaticMethodID(_class_##prim_clazz, "valueOf", "(" #sign ")Ljava/lang/" #clazz ";"); \
+        CHECK(_value_of_##prim_clazz) << "Not Found"                                                          \
+                                      << "(" #sign ")Ljava/lang/" #clazz ";";                                 \
+        _val_##prim_clazz = _env->GetMethodID(_class_##prim_clazz, #prim_clazz "Value", "()" #sign);          \
+        CHECK(_val_##prim_clazz);                                                                             \
+    }
+
+#define DEFINE_NEW_BOX(prim_clazz, cxx_type, CLAZZ, CallType)                                        \
+    jobject JVMHelper::new##CLAZZ(cxx_type value) {                                                  \
+        return getEnv()->CallStaticObjectMethod(_class_##prim_clazz, _value_of_##prim_clazz, value); \
+    }                                                                                                \
+    cxx_type JVMHelper::val##cxx_type(jobject obj) { return getEnv()->Call##CallType##Method(obj, _val_##prim_clazz); }
+
+#define SET_METHOD_ID(target, clazz, name, signature)   \
+    target = _env->GetMethodID(clazz, name, signature); \
+    DCHECK(target != nullptr);
+
+namespace starrocks {
+
+JVMHelper& JVMHelper::getInstance() {
+    if (_env == nullptr) {
+        _env = getJNIEnv();
+        CHECK(_env != nullptr) << "couldn't got a JNIEnv";
+    }
+    static JVMHelper helper;
+    return helper;
+}
+
+std::pair<JNIEnv*, JVMHelper&> JVMHelper::getInstanceWithEnv() {
+    auto& instance = getInstance();
+    return {instance.getEnv(), instance};
+}
+
+void JVMHelper::_init() {
+    _object_class = JNI_FIND_CLASS("java/lang/Object");
+    _object_array_class = JNI_FIND_CLASS("[Ljava/lang/Object;");
+    _string_class = JNI_FIND_CLASS("java/lang/String");
+    _jarrays_class = JNI_FIND_CLASS("java/util/Arrays");
+    _exception_util_class = JNI_FIND_CLASS("org/apache/commons/lang3/exception/ExceptionUtils");
+    _big_decimal_class = JNI_FIND_CLASS("java/math/BigDecimal");
+    _local_date_class = JNI_FIND_CLASS("java/time/LocalDate");
+    _local_datetime_class = JNI_FIND_CLASS("java/time/LocalDateTime");
+
+    CHECK(_object_class);
+    CHECK(_object_array_class);
+    CHECK(_string_class);
+    CHECK(_jarrays_class);
+    CHECK(_exception_util_class);
+    CHECK(_big_decimal_class);
+    CHECK(_local_date_class);
+    CHECK(_local_datetime_class);
+
+    _object_to_string = _env->GetMethodID(_object_class, "toString", "()Ljava/lang/String;");
+    CHECK(_object_to_string);
+    _object_equals = _env->GetMethodID(_object_class, "equals", "(Ljava/lang/Object;)Z");
+    CHECK(_object_equals);
+    _arrays_to_string = _env->GetStaticMethodID(_jarrays_class, "toString", "([Ljava/lang/Object;)Ljava/lang/String;");
+    CHECK(_arrays_to_string);
+
+    _big_decimal_ctor_string = _env->GetMethodID(_big_decimal_class, "<init>", "(Ljava/lang/String;)V");
+    CHECK(_big_decimal_ctor_string);
+    _big_decimal_value_of_ll = _env->GetStaticMethodID(_big_decimal_class, "valueOf", "(JI)Ljava/math/BigDecimal;");
+    CHECK(_big_decimal_value_of_ll);
+
+    _local_date_of_epoch_day = _env->GetStaticMethodID(_local_date_class, "ofEpochDay", "(J)Ljava/time/LocalDate;");
+    CHECK(_local_date_of_epoch_day);
+    _local_date_to_epoch_day = _env->GetMethodID(_local_date_class, "toEpochDay", "()J");
+    CHECK(_local_date_to_epoch_day);
+
+    ADD_NUMBERIC_CLASS(boolean, Boolean, Z);
+    ADD_NUMBERIC_CLASS(byte, Byte, B);
+    ADD_NUMBERIC_CLASS(short, Short, S);
+    ADD_NUMBERIC_CLASS(int, Integer, I);
+    ADD_NUMBERIC_CLASS(long, Long, J);
+    ADD_NUMBERIC_CLASS(float, Float, F);
+    ADD_NUMBERIC_CLASS(double, Double, D);
+
+    jclass charsets = JNI_FIND_CLASS("java/nio/charset/StandardCharsets");
+    DCHECK(charsets != nullptr);
+    auto fieldId = _env->GetStaticFieldID(charsets, "UTF_8", "Ljava/nio/charset/Charset;");
+    DCHECK(fieldId != nullptr);
+
+    auto charset = _env->GetStaticObjectField(charsets, fieldId);
+    _utf8_charsets = _env->NewGlobalRef(charset);
+    _env->DeleteLocalRef(charset);
+
+    DCHECK(_utf8_charsets != nullptr);
+    _string_construct_with_bytes = _env->GetMethodID(_string_class, "<init>", "([BLjava/nio/charset/Charset;)V");
+    DCHECK(_string_construct_with_bytes != nullptr);
+
+    _direct_buffer_class = JNI_FIND_CLASS("java/nio/ByteBuffer");
+    SET_METHOD_ID(_direct_buffer_clear, _direct_buffer_class, "clear", "()Ljava/nio/Buffer;");
+
+    auto list_clazz = JNI_FIND_CLASS("java/util/List");
+    DCHECK(list_clazz);
+    _list_meta.list_class = new JVMClass(list_clazz);
+    auto array_list_clazz = JNI_FIND_CLASS("java/util/ArrayList");
+    DCHECK(array_list_clazz);
+    _list_meta.array_list_class = new JVMClass(array_list_clazz);
+
+    SET_METHOD_ID(_list_meta.list_get, list_clazz, "get", "(I)Ljava/lang/Object;");
+    SET_METHOD_ID(_list_meta.list_size, list_clazz, "size", "()I");
+    SET_METHOD_ID(_list_meta.list_add, list_clazz, "add", "(Ljava/lang/Object;)Z");
+
+    auto map_clazz = JNI_FIND_CLASS("java/util/Map");
+    DCHECK(map_clazz);
+    _map_class = new JVMClass(map_clazz);
+}
+
+#define CHECK_FUNCTION_EXCEPTION(_env, name)                   \
+    if (auto e = _env->ExceptionOccurred()) {                  \
+        LOCAL_REF_GUARD(e);                                    \
+        _env->ExceptionClear();                                \
+        LOG(WARNING) << "Exception happened when call " #name; \
+        return "";                                             \
+    }
+
+#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                            \
+    if (jthrowable jthr = env->ExceptionOccurred()) {                     \
+        LOCAL_REF_GUARD(jthr);                                            \
+        std::string msg = fmt::format(errmsg, dumpExceptionString(jthr)); \
+        LOG(WARNING) << msg;                                              \
+        env->ExceptionClear();                                            \
+        return Status::RuntimeError(msg);                                 \
+    }
+
+Status JVMHelper::_check_exception_status() {
+    RETURN_ERROR_IF_EXCEPTION(_env, "exception happened when invoke method: {}");
+    return Status::OK();
+}
+
+std::string JVMHelper::array_to_string(jobject object) {
+    auto* env = getEnv();
+    env->ExceptionClear();
+    jobject jstr = env->CallStaticObjectMethod(_jarrays_class, _arrays_to_string, object);
+    LOCAL_REF_GUARD(jstr);
+    CHECK_FUNCTION_EXCEPTION(env, "array_to_string")
+    return to_cxx_string((jstring)jstr);
+}
+
+bool JVMHelper::equals(jobject obj1, jobject obj2) {
+    auto* env = getEnv();
+    env->ExceptionClear();
+    auto res = env->CallBooleanMethod(obj1, _object_equals, obj2);
+    if (auto e = env->ExceptionOccurred()) {
+        LOCAL_REF_GUARD(e);
+        env->ExceptionClear();
+        LOG(WARNING) << "Exception happened when call equals";
+        return false;
+    }
+    return res;
+}
+
+std::string JVMHelper::to_string(jobject obj) {
+    auto* env = getEnv();
+    env->ExceptionClear();
+    auto res = env->CallObjectMethod(obj, _object_to_string);
+    LOCAL_REF_GUARD(res);
+    CHECK_FUNCTION_EXCEPTION(env, "to_string")
+    return to_cxx_string((jstring)res);
+}
+
+std::string JVMHelper::to_cxx_string(jstring str) {
+    if (str == nullptr) {
+        return "<null>";
+    }
+    auto* env = getEnv();
+    std::string res;
+    const char* charflow = env->GetStringUTFChars(str, nullptr);
+    res = charflow;
+    env->ReleaseStringUTFChars(str, charflow);
+    return res;
+}
+
+std::string JVMHelper::dumpExceptionString(jthrowable throwable) {
+    auto* env = getEnv();
+    auto get_stack_trace =
+            env->GetStaticMethodID(_exception_util_class, "getStackTrace", "(Ljava/lang/Throwable;)Ljava/lang/String;");
+    CHECK(get_stack_trace != nullptr) << "Not Found JNI method getStackTrace";
+    jobject stack_traces = env->CallStaticObjectMethod(_exception_util_class, get_stack_trace, (jobject)throwable);
+    LOCAL_REF_GUARD(stack_traces);
+    // don't call return if xxx, to avoid recursive
+    env->ExceptionClear();
+    return to_cxx_string((jstring)stack_traces);
+}
+
+jmethodID JVMHelper::getToStringMethod(jclass clazz) {
+    return getEnv()->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
+}
+
+StatusOr<jstring> JVMHelper::to_jstring(const std::string& str) {
+    auto* env = getEnv();
+    auto res = env->NewStringUTF(str.c_str());
+    if (UNLIKELY(res == nullptr)) {
+        env->ExceptionClear();
+        return Status::InternalError(fmt::format("NewStringUTF failed for: {}", str));
+    }
+    return res;
+}
+
+jmethodID JVMHelper::getMethod(jclass clazz, const std::string& method, const std::string& sig) {
+    return getEnv()->GetMethodID(clazz, method.c_str(), sig.c_str());
+}
+
+jmethodID JVMHelper::getStaticMethod(jclass clazz, const std::string& method, const std::string& sig) {
+    return getEnv()->GetStaticMethodID(clazz, method.c_str(), sig.c_str());
+}
+
+jobject JVMHelper::create_array(int sz) {
+    auto* env = getEnv();
+    auto res = env->NewObjectArray(sz, _object_class, nullptr);
+    RETURN_IF_JNI_EXCEPTION(env, "create_array: NewObjectArray failed", nullptr);
+    return res;
+}
+
+jobject JVMHelper::create_object_array(jobject o, int num_rows) {
+    auto* env = getEnv();
+    jobjectArray res_arr = env->NewObjectArray(num_rows, _object_array_class, o);
+    RETURN_IF_JNI_EXCEPTION(env, "create_object_array: NewObjectArray failed", nullptr);
+    return res_arr;
+}
+
+jobjectArray JVMHelper::build_object_array(jclass clazz, jobject* arr, int sz) {
+    auto* env = getEnv();
+    jobjectArray res_arr = env->NewObjectArray(sz, clazz, nullptr);
+    RETURN_IF_JNI_EXCEPTION(env, "build_object_array: NewObjectArray failed", nullptr);
+    for (int i = 0; i < sz; ++i) {
+        env->SetObjectArrayElement(res_arr, i, arr[i]);
+    }
+    return res_arr;
+}
+
+DEFINE_NEW_BOX(boolean, uint8_t, Boolean, Boolean);
+DEFINE_NEW_BOX(byte, int8_t, Byte, Byte);
+DEFINE_NEW_BOX(short, int16_t, Short, Short);
+DEFINE_NEW_BOX(int, int32_t, Integer, Int);
+DEFINE_NEW_BOX(long, int64_t, Long, Long);
+DEFINE_NEW_BOX(float, float, Float, Float);
+DEFINE_NEW_BOX(double, double, Double, Double);
+
+jobject JVMHelper::newString(const char* data, size_t size) {
+    auto* env = getEnv();
+    auto bytesArr = env->NewByteArray(size);
+    RETURN_IF_JNI_EXCEPTION(env, "newString: NewByteArray failed", nullptr);
+    LOCAL_REF_GUARD(bytesArr);
+    env->SetByteArrayRegion(bytesArr, 0, size, reinterpret_cast<const jbyte*>(data));
+    jobject nstr = env->NewObject(_string_class, _string_construct_with_bytes, bytesArr, _utf8_charsets);
+    RETURN_IF_JNI_EXCEPTION(env, "newString: NewObject failed", nullptr);
+    return nstr;
+}
+
+jobject JVMHelper::newBigDecimal(const std::string& s) {
+    auto* env = getEnv();
+    jobject jstr = newString(s.data(), s.size());
+    if (jstr == nullptr) {
+        return nullptr;
+    }
+    LOCAL_REF_GUARD(jstr);
+    jobject bd = env->NewObject(_big_decimal_class, _big_decimal_ctor_string, jstr);
+    RETURN_IF_JNI_EXCEPTION(env, "newBigDecimal: NewObject failed", nullptr);
+    return bd;
+}
+
+jobject JVMHelper::newBigDecimal(int64_t unscaled, int scale) {
+    auto* env = getEnv();
+    jobject bd = env->CallStaticObjectMethod(_big_decimal_class, _big_decimal_value_of_ll, static_cast<jlong>(unscaled),
+                                             static_cast<jint>(scale));
+    RETURN_IF_JNI_EXCEPTION(env, "newBigDecimal(long, int): CallStatic failed", nullptr);
+    return bd;
+}
+
+Slice JVMHelper::sliceVal(jstring jstr, std::string* buffer) {
+    auto* env = getEnv();
+    const size_t utf_length = env->GetStringUTFLength(jstr);
+    buffer->resize(utf_length);
+    const size_t string_length = env->GetStringLength(jstr);
+    env->GetStringUTFRegion(jstr, 0, string_length, buffer->data());
+    return {buffer->data(), buffer->length()};
+}
+
+jobject JVMHelper::newLocalDateFromEpochDay(int64_t epoch_day) {
+    auto* env = getEnv();
+    jobject ld =
+            env->CallStaticObjectMethod(_local_date_class, _local_date_of_epoch_day, static_cast<jlong>(epoch_day));
+    RETURN_IF_JNI_EXCEPTION(env, "newLocalDateFromEpochDay: ofEpochDay failed", nullptr);
+    return ld;
+}
+
+int64_t JVMHelper::valLocalDateToEpochDay(jobject obj) {
+    return getEnv()->CallLongMethod(obj, _local_date_to_epoch_day);
+}
+
+std::string JVMHelper::to_jni_class_name(const std::string& name) {
+    std::string jni_class_name;
+    auto inserter = std::inserter(jni_class_name, jni_class_name.end());
+    std::transform(name.begin(), name.end(), inserter, [](auto ele) {
+        if (ele == '.') {
+            return '/';
+        }
+        return ele;
+    });
+    return jni_class_name;
+}
+
+DirectByteBuffer::DirectByteBuffer(void* ptr, int capacity) {
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto lref = env->NewDirectByteBuffer(ptr, capacity);
+    LOCAL_REF_GUARD(lref);
+    _handle = env->NewGlobalRef(lref);
+    _capacity = capacity;
+    _data = ptr;
+}
+
+DirectByteBuffer::~DirectByteBuffer() {
+    if (_handle != nullptr) {
+        auto st = JavaEnv::GetInstance()->call_function_in_pthread([this]() {
+            JNIEnv* env = JVMHelper::getInstance().getEnv();
+            env->DeleteGlobalRef(_handle);
+            _handle = nullptr;
+            return Status::OK();
+        });
+        LOG_IF(WARNING, !st.ok()) << "failed to delete direct byte buffer global ref: " << st;
+    }
+}
+
+Status JavaListStub::add(jobject element) {
+    auto [env, helper] = JVMHelper::getInstanceWithEnv();
+    const auto& meta = helper.list_meta();
+    env->CallVoidMethod(_list, meta.list_add, element);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
+    return Status::OK();
+}
+
+StatusOr<jobject> JavaListStub::get(int index) {
+    auto [env, helper] = JVMHelper::getInstanceWithEnv();
+    const auto& meta = helper.list_meta();
+    auto res = env->CallObjectMethod(_list, meta.list_get, index);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
+    return res;
+}
+
+StatusOr<size_t> JavaListStub::size() {
+    auto [env, helper] = JVMHelper::getInstanceWithEnv();
+    const auto& meta = helper.list_meta();
+    auto res = env->CallIntMethod(_list, meta.list_size);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
+    return res;
+}
+
+} // namespace starrocks

--- a/be/src/runtime/java/jvm_helper.h
+++ b/be/src/runtime/java/jvm_helper.h
@@ -1,0 +1,240 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <jni.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/logging.h"
+#include "base/string/slice.h"
+#include "base/utility/defer_op.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "fmt/core.h"
+#include "runtime/java/jvm_class.h"
+
+#define DEFINE_JAVA_PRIM_TYPE(TYPE) \
+    jclass _class_##TYPE;           \
+    jmethodID _value_of_##TYPE;     \
+    jmethodID _val_##TYPE;
+
+#define DECLARE_NEW_BOX(PRIM_CLAZZ, TYPE, CLAZZ) \
+    jobject new##CLAZZ(TYPE value);              \
+    TYPE val##TYPE(jobject obj);                 \
+    jclass TYPE##_class() { return _class_##PRIM_CLAZZ; }
+
+namespace starrocks {
+
+struct ListMeta {
+    JVMClass* list_class;
+    JVMClass* array_list_class;
+
+    jmethodID list_get;
+    jmethodID list_size;
+    jmethodID list_add;
+};
+
+// Restrictions on use:
+// can only be used in pthread, not in bthread
+// thread local helper
+class JVMHelper {
+public:
+    static JVMHelper& getInstance();
+    static std::pair<JNIEnv*, JVMHelper&> getInstanceWithEnv();
+    JVMHelper(const JVMHelper&) = delete;
+
+    JNIEnv* getEnv() { return _env; }
+
+    std::string array_to_string(jobject object);
+    bool equals(jobject obj1, jobject obj2);
+    std::string to_string(jobject obj);
+    std::string to_cxx_string(jstring str);
+    std::string dumpExceptionString(jthrowable throwable);
+    jmethodID getToStringMethod(jclass clazz);
+    StatusOr<jstring> to_jstring(const std::string& str);
+    jmethodID getMethod(jclass clazz, const std::string& method, const std::string& sig);
+    jmethodID getStaticMethod(jclass clazz, const std::string& method, const std::string& sig);
+
+    jobject create_array(int sz);
+    jobject create_object_array(jobject o, int num_rows);
+    jobjectArray build_object_array(jclass clazz, jobject* arr, int sz);
+
+    DECLARE_NEW_BOX(boolean, uint8_t, Boolean)
+    DECLARE_NEW_BOX(byte, int8_t, Byte)
+    DECLARE_NEW_BOX(short, int16_t, Short)
+    DECLARE_NEW_BOX(int, int32_t, Integer)
+    DECLARE_NEW_BOX(long, int64_t, Long)
+    DECLARE_NEW_BOX(float, float, Float)
+    DECLARE_NEW_BOX(double, double, Double)
+
+    const ListMeta& list_meta() const { return _list_meta; }
+    JVMClass& map_class() { return *_map_class; }
+
+    jobject newString(const char* data, size_t size);
+    jobject newBigDecimal(const std::string& s);
+    jobject newBigDecimal(int64_t unscaled, int scale);
+    Slice sliceVal(jstring jstr, std::string* buffer);
+
+    jclass object_class() { return _object_class; }
+    jclass object_array_class() { return _object_array_class; }
+    jclass string_clazz() { return _string_class; }
+    jclass big_decimal_class() { return _big_decimal_class; }
+    jclass local_date_class() { return _local_date_class; }
+    jclass local_datetime_class() { return _local_datetime_class; }
+    jclass direct_buffer_class() { return _direct_buffer_class; }
+    jmethodID direct_buffer_clear() { return _direct_buffer_clear; }
+
+    jobject newLocalDateFromEpochDay(int64_t epoch_day);
+    int64_t valLocalDateToEpochDay(jobject obj);
+
+    static std::string to_jni_class_name(const std::string& name);
+
+private:
+    JVMHelper() { _init(); }
+    void _init();
+    Status _check_exception_status();
+
+private:
+    inline static thread_local JNIEnv* _env = nullptr;
+
+    DEFINE_JAVA_PRIM_TYPE(boolean);
+    DEFINE_JAVA_PRIM_TYPE(byte);
+    DEFINE_JAVA_PRIM_TYPE(short);
+    DEFINE_JAVA_PRIM_TYPE(int);
+    DEFINE_JAVA_PRIM_TYPE(long);
+    DEFINE_JAVA_PRIM_TYPE(float);
+    DEFINE_JAVA_PRIM_TYPE(double);
+
+    jclass _object_class;
+    jclass _object_array_class;
+    jclass _string_class;
+    jclass _jarrays_class;
+    jclass _exception_util_class;
+    jclass _big_decimal_class;
+    jclass _local_date_class;
+    jclass _local_datetime_class;
+
+    jmethodID _object_to_string;
+    jmethodID _object_equals;
+    jmethodID _arrays_to_string;
+    jmethodID _string_construct_with_bytes;
+    jmethodID _big_decimal_ctor_string;
+    jmethodID _big_decimal_value_of_ll;
+    jmethodID _local_date_of_epoch_day;
+    jmethodID _local_date_to_epoch_day;
+
+    ListMeta _list_meta;
+    JVMClass* _map_class = nullptr;
+
+    jobject _utf8_charsets;
+
+    jclass _direct_buffer_class;
+    jmethodID _direct_buffer_clear;
+};
+
+// local object reference guard.
+// The objects inside are automatically call DeleteLocalRef in the life object.
+#define LOCAL_REF_GUARD(lref)                                                     \
+    ::starrocks::DeferOp VARNAME_LINENUM(guard)([&lref]() {                       \
+        if (lref) {                                                               \
+            ::starrocks::JVMHelper::getInstance().getEnv()->DeleteLocalRef(lref); \
+            lref = nullptr;                                                       \
+        }                                                                         \
+    })
+
+#define LOCAL_REF_GUARD_ENV(env, lref)                           \
+    ::starrocks::DeferOp VARNAME_LINENUM(guard)([&lref, env]() { \
+        if (lref) {                                              \
+            env->DeleteLocalRef(lref);                           \
+            lref = nullptr;                                      \
+        }                                                        \
+    })
+
+#define RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, prefix)                          \
+    if (auto e = env->ExceptionOccurred()) {                                            \
+        LOCAL_REF_GUARD(e);                                                             \
+        std::string err = ::starrocks::JVMHelper::getInstance().dumpExceptionString(e); \
+        env->ExceptionClear();                                                          \
+        return ::starrocks::Status::InternalError(fmt::format("{}, {}", prefix, err));  \
+    }
+
+#define RETURN_ERROR_IF_JNI_EXCEPTION(env) RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "JNI Exception")
+
+#define RETURN_IF_JNI_EXCEPTION(env, errmsg, ret)                                                              \
+    if (jthrowable jthr = env->ExceptionOccurred()) {                                                          \
+        LOCAL_REF_GUARD(jthr);                                                                                 \
+        std::string msg =                                                                                      \
+                fmt::format("{},{}", errmsg, ::starrocks::JVMHelper::getInstance().dumpExceptionString(jthr)); \
+        LOG(WARNING) << msg;                                                                                   \
+        env->ExceptionClear();                                                                                 \
+        return ret;                                                                                            \
+    }
+
+// Used for Java direct buffers over native memory.
+// DirectByteBuffer does not hold ownership of this memory space.
+class DirectByteBuffer {
+public:
+    static constexpr const char* JNI_CLASS_NAME = "java/nio/ByteBuffer";
+
+    DirectByteBuffer(void* data, int capacity);
+    ~DirectByteBuffer();
+
+    DirectByteBuffer(const DirectByteBuffer&) = delete;
+    DirectByteBuffer& operator=(const DirectByteBuffer& other) = delete;
+
+    DirectByteBuffer(DirectByteBuffer&& other) noexcept {
+        _handle = other._handle;
+        _data = other._data;
+        _capacity = other._capacity;
+
+        other._handle = nullptr;
+        other._data = nullptr;
+        other._capacity = 0;
+    }
+
+    DirectByteBuffer& operator=(DirectByteBuffer&& other) noexcept {
+        DirectByteBuffer tmp(std::move(other));
+        std::swap(this->_handle, tmp._handle);
+        std::swap(this->_data, tmp._data);
+        std::swap(this->_capacity, tmp._capacity);
+        return *this;
+    }
+
+    jobject handle() { return _handle; }
+    void* data() { return _data; }
+    int capacity() { return _capacity; }
+
+private:
+    jobject _handle;
+    void* _data;
+    int _capacity;
+};
+
+class JavaListStub {
+public:
+    JavaListStub(jobject list) : _list(list) {}
+    Status add(jobject element);
+    StatusOr<jobject> get(int index);
+    StatusOr<size_t> size();
+
+private:
+    jobject _list;
+};
+
+} // namespace starrocks

--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -205,33 +205,34 @@ Status JavaArrayConverter::do_visit(const MapColumn& column) {
 template <LogicalType TYPE>
 jvalue cast_to_jvalue(RunTimeCppType<TYPE> data_value, JVMFunctionHelper& helper);
 
-#define DEFINE_CAST_TO_JVALUE(TYPE, APPLY_FUNC)                                                \
-    template <>                                                                                \
-    jvalue cast_to_jvalue<TYPE>(RunTimeCppType<TYPE> data_value, JVMFunctionHelper & helper) { \
-        return {.l = APPLY_FUNC};                                                              \
+#define DEFINE_CAST_TO_JVALUE(TYPE, APPLY_FUNC)                                                                 \
+    template <>                                                                                                 \
+    jvalue cast_to_jvalue<TYPE>(RunTimeCppType<TYPE> data_value, [[maybe_unused]] JVMFunctionHelper & helper) { \
+        return {.l = APPLY_FUNC};                                                                               \
     }
 
 // Build a java.math.BigDecimal jobject for row `row_num` of a DECIMAL column. Unified helper
 // used by both the single-value path (cast_to_jvalue) and the batch const-column path.
 static jobject decimal_cell_to_bigdecimal(const TypeDescriptor& td, const Column* col, int row_num,
-                                          JVMFunctionHelper& helper) {
+                                          [[maybe_unused]] JVMFunctionHelper& helper) {
+    auto& jvm = JVMHelper::getInstance();
     switch (td.type) {
     case TYPE_DECIMAL32: {
         auto* spec = down_cast<const RunTimeColumnType<TYPE_DECIMAL32>*>(col);
-        return helper.newBigDecimal(static_cast<int64_t>(spec->immutable_data()[row_num]), td.scale);
+        return jvm.newBigDecimal(static_cast<int64_t>(spec->immutable_data()[row_num]), td.scale);
     }
     case TYPE_DECIMAL64: {
         auto* spec = down_cast<const RunTimeColumnType<TYPE_DECIMAL64>*>(col);
-        return helper.newBigDecimal(spec->immutable_data()[row_num], td.scale);
+        return jvm.newBigDecimal(spec->immutable_data()[row_num], td.scale);
     }
     case TYPE_DECIMAL128: {
         auto* spec = down_cast<const RunTimeColumnType<TYPE_DECIMAL128>*>(col);
-        return helper.newBigDecimal(
+        return jvm.newBigDecimal(
                 DecimalV3Cast::to_string<int128_t>(spec->immutable_data()[row_num], td.precision, td.scale));
     }
     case TYPE_DECIMAL256: {
         auto* spec = down_cast<const RunTimeColumnType<TYPE_DECIMAL256>*>(col);
-        return helper.newBigDecimal(
+        return jvm.newBigDecimal(
                 DecimalV3Cast::to_string<int256_t>(spec->immutable_data()[row_num], td.precision, td.scale));
     }
     default:
@@ -274,21 +275,20 @@ static Status append_decimal_string_to_column(const TypeDescriptor& td, const st
     return Status::OK();
 }
 
-DEFINE_CAST_TO_JVALUE(TYPE_BOOLEAN, helper.newBoolean(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_TINYINT, helper.newByte(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_SMALLINT, helper.newShort(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_INT, helper.newInteger(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_BIGINT, helper.newLong(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_FLOAT, helper.newFloat(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_DOUBLE, helper.newDouble(data_value));
-DEFINE_CAST_TO_JVALUE(TYPE_VARCHAR, helper.newString(data_value.get_data(), data_value.get_size()));
+DEFINE_CAST_TO_JVALUE(TYPE_BOOLEAN, JVMHelper::getInstance().newBoolean(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_TINYINT, JVMHelper::getInstance().newByte(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_SMALLINT, JVMHelper::getInstance().newShort(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_INT, JVMHelper::getInstance().newInteger(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_BIGINT, JVMHelper::getInstance().newLong(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_FLOAT, JVMHelper::getInstance().newFloat(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_DOUBLE, JVMHelper::getInstance().newDouble(data_value));
+DEFINE_CAST_TO_JVALUE(TYPE_VARCHAR, JVMHelper::getInstance().newString(data_value.get_data(), data_value.get_size()));
 DEFINE_CAST_TO_JVALUE(TYPE_DATE, helper.newLocalDate(data_value._julian));
 DEFINE_CAST_TO_JVALUE(TYPE_DATETIME, helper.newLocalDateTime(data_value.timestamp()));
 
 void release_jvalue(bool is_box, jvalue val) {
     if (is_box && val.l) {
-        auto& helper = JVMFunctionHelper::getInstance();
-        helper.getEnv()->DeleteLocalRef(val.l);
+        JVMHelper::getInstance().getEnv()->DeleteLocalRef(val.l);
     }
 }
 
@@ -340,11 +340,11 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
     }
 
     switch (type) {
-#define CREATE_BOX_TYPE(NAME, TYPE)                                     \
-    case NAME: {                                                        \
-        auto spec_col = down_cast<const RunTimeColumnType<NAME>*>(col); \
-        const auto container = spec_col->immutable_data();              \
-        return jvalue{.l = helper.new##TYPE(container[row_num])};       \
+#define CREATE_BOX_TYPE(NAME, TYPE)                                                 \
+    case NAME: {                                                                    \
+        auto spec_col = down_cast<const RunTimeColumnType<NAME>*>(col);             \
+        const auto container = spec_col->immutable_data();                          \
+        return jvalue{.l = JVMHelper::getInstance().new##TYPE(container[row_num])}; \
     }
 
         CREATE_BOX_TYPE(TYPE_BOOLEAN, Boolean)
@@ -358,7 +358,7 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
     case TYPE_VARCHAR: {
         auto spec_col = down_cast<const BinaryColumn*>(col);
         Slice slice = spec_col->get_slice(row_num);
-        v.l = helper.newString(slice.get_data(), slice.get_size());
+        v.l = JVMHelper::getInstance().newString(slice.get_data(), slice.get_size());
         break;
     }
     case TYPE_DATE: {
@@ -381,13 +381,14 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
     case TYPE_ARRAY: {
         auto spec_col = down_cast<const ArrayColumn*>(col);
         auto [offset, size] = spec_col->get_element_offset_size(row_num);
-        const ListMeta& meta = helper.list_meta();
+        auto& jvm = JVMHelper::getInstance();
+        const ListMeta& meta = jvm.list_meta();
         ASSIGN_OR_RETURN(auto object, meta.array_list_class->newLocalInstance());
         LOCAL_REF_GUARD(object);
         JavaListStub list_stub(object);
         jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
         DeferOp drop_elem_desc([&]() {
-            if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+            if (elem_desc) jvm.getEnv()->DeleteLocalRef(elem_desc);
         });
         for (size_t i = offset; i < offset + size; ++i) {
             ASSIGN_OR_RETURN(auto e, cast_to_jvalue(type_desc.children[0], true, spec_col->elements_column().get(), i,
@@ -403,7 +404,8 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
     case TYPE_MAP: {
         auto spec_col = down_cast<const MapColumn*>(col);
         auto [offset, size] = spec_col->get_map_offset_size(row_num);
-        const ListMeta& meta = helper.list_meta();
+        auto& jvm = JVMHelper::getInstance();
+        const ListMeta& meta = jvm.list_meta();
         ASSIGN_OR_RETURN(auto key_lists, meta.array_list_class->newLocalInstance());
         LOCAL_REF_GUARD(key_lists);
         JavaListStub key_list_stub(key_lists);
@@ -414,11 +416,11 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
 
         jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
         DeferOp drop_key_desc([&]() {
-            if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+            if (key_desc) jvm.getEnv()->DeleteLocalRef(key_desc);
         });
         jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
         DeferOp drop_val_desc([&]() {
-            if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+            if (val_desc) jvm.getEnv()->DeleteLocalRef(val_desc);
         });
         for (size_t i = offset; i < offset + size; ++i) {
             ASSIGN_OR_RETURN(auto key,
@@ -446,7 +448,8 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         if (record_class == nullptr) {
             return Status::InternalError("STRUCT cast_to_jvalue: missing formal record class on UdfTypeDesc");
         }
-        DeferOp drop_record_class([&]() { helper.getEnv()->DeleteLocalRef(record_class); });
+        auto& jvm = JVMHelper::getInstance();
+        DeferOp drop_record_class([&]() { jvm.getEnv()->DeleteLocalRef(record_class); });
 
         if (!col->is_struct()) {
             return Status::InternalError("expected StructColumn for STRUCT slot");
@@ -462,7 +465,7 @@ StatusOr<jvalue> cast_to_jvalue(const TypeDescriptor& type_desc, bool is_boxed, 
         // bringing up a parallel single-row record-construction path: it takes
         // per-field Object[1] arrays and a null bitmap and returns Object[1] holding
         // the constructed record (or null when row 0 is null).
-        JNIEnv* env = helper.getEnv();
+        JNIEnv* env = jvm.getEnv();
         jclass object_clazz = env->FindClass("java/lang/Object");
         DeferOp drop_object_clazz([&]() { env->DeleteLocalRef(object_clazz); });
         jobjectArray field_arrays = env->NewObjectArray(num_fields, object_clazz, nullptr);
@@ -518,10 +521,9 @@ static Status handle_decimal_overflow(JNIEnv* env, const TypeDescriptor& td, Col
         return Status::OK();
     }
     if (error_if_overflow) {
-        auto& helper = JVMFunctionHelper::getInstance();
         std::string msg;
         if (jthrowable jthr = env->ExceptionOccurred(); jthr != nullptr) {
-            msg = helper.dumpExceptionString(jthr);
+            msg = JVMHelper::getInstance().dumpExceptionString(jthr);
             env->DeleteLocalRef(jthr);
         }
         env->ExceptionClear();
@@ -538,6 +540,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
                      bool error_if_overflow) {
     DCHECK(is_box);
     auto& helper = JVMFunctionHelper::getInstance();
+    auto& jvm = JVMHelper::getInstance();
     Column* data_col = col;
     if (col->is_nullable() && type_desc.type != LogicalType::TYPE_VARCHAR && type_desc.type != LogicalType::TYPE_CHAR) {
         auto* nullable_column = down_cast<NullableColumn*>(col);
@@ -550,7 +553,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
     switch (type_desc.type) {
 #define ASSIGN_BOX_TYPE(NAME, TYPE)                                                \
     case NAME: {                                                                   \
-        auto data = helper.val##TYPE(val.l);                                       \
+        auto data = jvm.val##TYPE(val.l);                                          \
         down_cast<RunTimeColumnType<NAME>*>(data_col)->get_data()[row_num] = data; \
         break;                                                                     \
     }
@@ -578,7 +581,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             col->append_nulls(1);
         } else {
             std::string buffer;
-            auto slice = helper.sliceVal((jstring)val.l, &buffer);
+            auto slice = jvm.sliceVal((jstring)val.l, &buffer);
             col->append_datum(Datum(slice));
         }
         break;
@@ -588,7 +591,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         // DECIMAL32/64: ask Java for the unscaled value as a long. If the helper raised
         // an ArithmeticException (precision overflow or value > long range), translate it
         // — `unscaled` and the data column slot must not be touched in that branch.
-        auto* env = helper.getEnv();
+        auto* env = jvm.getEnv();
         jlong unscaled = helper.unscaled_long(val.l, type_desc.precision, type_desc.scale);
         if (env->ExceptionCheck()) {
             return handle_decimal_overflow(env, type_desc, col, row_num, error_if_overflow);
@@ -608,7 +611,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         // the int128/int256 cell at row_num. Same overflow short-circuit as the narrow path
         // — `bytes` is null when the helper threw, so we must not fall through to
         // GetByteArrayRegion.
-        auto* env = helper.getEnv();
+        auto* env = jvm.getEnv();
         const int byte_width = (type_desc.type == TYPE_DECIMAL128) ? 16 : 32;
         jbyteArray bytes = helper.unscaled_le_bytes(val.l, type_desc.precision, type_desc.scale, byte_width);
         if (env->ExceptionCheck()) {
@@ -637,6 +640,7 @@ Status assign_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
 Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, jvalue val, bool error_if_overflow,
                      jobject type_desc_obj) {
     auto& helper = JVMFunctionHelper::getInstance();
+    auto& jvm = JVMHelper::getInstance();
     if (col->is_nullable() && val.l == nullptr) {
         col->append_nulls(1);
         return Status::OK();
@@ -655,11 +659,11 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         }
     } else {
         switch (type_desc.type) {
-#define APPEND_BOX_TYPE(NAME, TYPE)          \
-    case NAME: {                             \
-        auto data = helper.val##TYPE(val.l); \
-        col->append_datum(Datum(data));      \
-        break;                               \
+#define APPEND_BOX_TYPE(NAME, TYPE)       \
+    case NAME: {                          \
+        auto data = jvm.val##TYPE(val.l); \
+        col->append_datum(Datum(data));   \
+        break;                            \
     }
 
             APPEND_BOX_TYPE(TYPE_BOOLEAN, uint8_t)
@@ -684,7 +688,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         }
         case TYPE_VARCHAR: {
             std::string buffer;
-            auto slice = helper.sliceVal((jstring)val.l, &buffer);
+            auto slice = jvm.sliceVal((jstring)val.l, &buffer);
             col->append_datum(Datum(slice));
             break;
         }
@@ -692,8 +696,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
         case TYPE_DECIMAL64:
         case TYPE_DECIMAL128:
         case TYPE_DECIMAL256: {
-            RETURN_IF_ERROR(
-                    append_decimal_string_to_column(type_desc, helper.to_string(val.l), col, error_if_overflow));
+            RETURN_IF_ERROR(append_decimal_string_to_column(type_desc, jvm.to_string(val.l), col, error_if_overflow));
             break;
         }
         case TYPE_ARRAY: {
@@ -706,7 +709,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             auto* array_column = down_cast<ArrayColumn*>(data_column);
             jobject elem_desc = get_type_desc_child(helper, type_desc_obj, 0);
             DeferOp drop_elem_desc([&]() {
-                if (elem_desc) helper.getEnv()->DeleteLocalRef(elem_desc);
+                if (elem_desc) jvm.getEnv()->DeleteLocalRef(elem_desc);
             });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto element, list_stub.get(i));
@@ -736,11 +739,11 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
 
             jobject key_desc = get_type_desc_child(helper, type_desc_obj, 0);
             DeferOp drop_key_desc([&]() {
-                if (key_desc) helper.getEnv()->DeleteLocalRef(key_desc);
+                if (key_desc) jvm.getEnv()->DeleteLocalRef(key_desc);
             });
             jobject val_desc = get_type_desc_child(helper, type_desc_obj, 1);
             DeferOp drop_val_desc([&]() {
-                if (val_desc) helper.getEnv()->DeleteLocalRef(val_desc);
+                if (val_desc) jvm.getEnv()->DeleteLocalRef(val_desc);
             });
             for (size_t i = 0; i < len; ++i) {
                 ASSIGN_OR_RETURN(auto key_element, key_list_stub.get(i));
@@ -779,7 +782,7 @@ Status append_jvalue(const TypeDescriptor& type_desc, bool is_box, Column* col, 
             // Look up record component accessors via reflection on Class<?>.
             // The record instance's runtime class is the formal record type the FE
             // analyzer bound to this STRUCT slot; getRecordComponents lives on Class.
-            JNIEnv* env = helper.getEnv();
+            JNIEnv* env = jvm.getEnv();
             jclass record_class = env->GetObjectClass(val.l);
             DeferOp drop_record_class([&]() { env->DeleteLocalRef(record_class); });
             jclass class_clazz = env->FindClass("java/lang/Class");
@@ -845,19 +848,19 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         return Status::OK();
     }
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
 
     switch (type_desc.type) {
-#define INSTANCE_OF_TYPE(NAME, TYPE)                                                            \
-    case NAME: {                                                                                \
-        if (!env->IsInstanceOf(val, helper.TYPE##_class())) {                                   \
-            auto clazz = env->GetObjectClass(val);                                              \
-            LOCAL_REF_GUARD(clazz);                                                             \
-            return Status::InternalError(fmt::format("Type not matched, expect {}, but got {}", \
-                                                     helper.to_string(helper.TYPE##_class()),   \
-                                                     helper.to_string(clazz)));                 \
-        }                                                                                       \
-        break;                                                                                  \
+#define INSTANCE_OF_TYPE(NAME, TYPE)                                                                            \
+    case NAME: {                                                                                                \
+        if (!env->IsInstanceOf(val, jvm.TYPE##_class())) {                                                      \
+            auto clazz = env->GetObjectClass(val);                                                              \
+            LOCAL_REF_GUARD(clazz);                                                                             \
+            return Status::InternalError(fmt::format("Type not matched, expect {}, but got {}",                 \
+                                                     jvm.to_string(jvm.TYPE##_class()), jvm.to_string(clazz))); \
+        }                                                                                                       \
+        break;                                                                                                  \
     }
         INSTANCE_OF_TYPE(TYPE_BOOLEAN, uint8_t)
         INSTANCE_OF_TYPE(TYPE_TINYINT, int8_t)
@@ -867,11 +870,11 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         INSTANCE_OF_TYPE(TYPE_FLOAT, float)
         INSTANCE_OF_TYPE(TYPE_DOUBLE, double)
     case TYPE_VARCHAR: {
-        if (!env->IsInstanceOf(val, helper.string_clazz())) {
+        if (!env->IsInstanceOf(val, jvm.string_clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
-                    fmt::format("Type not matched, expect string, but got {}", helper.to_string(clazz)));
+                    fmt::format("Type not matched, expect string, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
@@ -879,38 +882,38 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
     case TYPE_DECIMAL64:
     case TYPE_DECIMAL128:
     case TYPE_DECIMAL256: {
-        if (!env->IsInstanceOf(val, helper.big_decimal_class())) {
+        if (!env->IsInstanceOf(val, jvm.big_decimal_class())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
-                    fmt::format("Type not matched, expect java.math.BigDecimal, but got {}", helper.to_string(clazz)));
+                    fmt::format("Type not matched, expect java.math.BigDecimal, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
     case TYPE_DATE: {
-        if (!env->IsInstanceOf(val, helper.local_date_class())) {
+        if (!env->IsInstanceOf(val, jvm.local_date_class())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
-                    fmt::format("Type not matched, expect java.time.LocalDate, but got {}", helper.to_string(clazz)));
+                    fmt::format("Type not matched, expect java.time.LocalDate, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
     case TYPE_DATETIME: {
-        if (!env->IsInstanceOf(val, helper.local_datetime_class())) {
+        if (!env->IsInstanceOf(val, jvm.local_datetime_class())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(fmt::format("Type not matched, expect java.time.LocalDateTime, but got {}",
-                                                     helper.to_string(clazz)));
+            return Status::InternalError(
+                    fmt::format("Type not matched, expect java.time.LocalDateTime, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
     case TYPE_ARRAY: {
-        if (!env->IsInstanceOf(val, helper.list_meta().list_class->clazz())) {
+        if (!env->IsInstanceOf(val, jvm.list_meta().list_class->clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(
-                    fmt::format("Type not matched, expect List, but got {}", helper.to_string(clazz)));
+                    fmt::format("Type not matched, expect List, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
@@ -918,8 +921,7 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
         if (!env->IsInstanceOf(val, helper.map_meta().map_class->clazz())) {
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
-            return Status::InternalError(
-                    fmt::format("Type not matched, expect Map, but got {}", helper.to_string(clazz)));
+            return Status::InternalError(fmt::format("Type not matched, expect Map, but got {}", jvm.to_string(clazz)));
         }
         break;
     }
@@ -939,7 +941,7 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
             auto clazz = env->GetObjectClass(val);
             LOCAL_REF_GUARD(clazz);
             return Status::InternalError(fmt::format("Type not matched, expect record {}, but got {}",
-                                                     helper.to_string(record_class), helper.to_string(clazz)));
+                                                     jvm.to_string(record_class), jvm.to_string(clazz)));
         }
         break;
     }
@@ -957,8 +959,7 @@ Status check_type_matched(const TypeDescriptor& type_desc, jobject val, jobject 
     }
 
 jobject JavaDataTypeConverter::convert_to_states(FunctionContext* ctx, uint8_t** data, size_t offset, int num_rows) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
     RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
@@ -971,8 +972,7 @@ jobject JavaDataTypeConverter::convert_to_states(FunctionContext* ctx, uint8_t**
 
 jobject JavaDataTypeConverter::convert_to_states_with_filter(FunctionContext* ctx, uint8_t** data, size_t offset,
                                                              const uint8_t* filter, int num_rows) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     int inputs[num_rows];
     jintArray arr = env->NewIntArray(num_rows);
     RETURN_NULL_WITH_REPORT_ERROR(arr == nullptr, ctx, "OOM may happened in Java Heap");
@@ -1199,7 +1199,7 @@ static jobject get_type_desc_child(JVMFunctionHelper& helper, jobject type_desc,
     if (type_desc == nullptr) {
         return nullptr;
     }
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     jobjectArray children = (jobjectArray)env->GetObjectField(type_desc, helper.udf_type_desc_children_field());
     if (children == nullptr) {
         return nullptr;
@@ -1212,7 +1212,7 @@ static jclass get_type_desc_record_class(JVMFunctionHelper& helper, jobject type
     if (type_desc == nullptr) {
         return nullptr;
     }
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     return reinterpret_cast<jclass>(env->GetObjectField(type_desc, helper.udf_type_desc_record_class_field()));
 }
 
@@ -1272,7 +1272,7 @@ static StatusOr<jobject> box_column(JVMFunctionHelper& helper, const TypeDescrip
 
 static StatusOr<jobject> build_list_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                 const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     JniLocalFrame frame(env, BOXING_FRAME_HEADROOM);
     if (!frame.ok()) {
         return Status::InternalError("failed to push JNI local frame for ARRAY boxing");
@@ -1310,7 +1310,7 @@ static StatusOr<jobject> build_list_boxed_array(JVMFunctionHelper& helper, const
 
 static StatusOr<jobject> build_map_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     JniLocalFrame frame(env, BOXING_FRAME_HEADROOM);
     if (!frame.ok()) {
         return Status::InternalError("failed to push JNI local frame for MAP boxing");
@@ -1353,7 +1353,7 @@ static StatusOr<jobject> build_map_boxed_array(JVMFunctionHelper& helper, const 
 
 static StatusOr<jobject> build_struct_boxed_array(JVMFunctionHelper& helper, const TypeDescriptor& type_desc,
                                                   const Column* column, jobject type_desc_obj, int num_rows) {
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     // Capacity sized for the per-level fixed locals plus one in-flight sub_result;
     // sub_results are explicitly DeleteLocalRef'd inside the per-field loop so the
     // frame footprint stays bounded regardless of field count.
@@ -1606,7 +1606,7 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
                                                      int num_rows, std::vector<jobject>* res,
                                                      const std::vector<jobject>* arg_type_descs) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     for (int i = 0; i < num_cols; ++i) {
         jobject arg = nullptr;
         const TypeDescriptor& arg_type = *ctx->get_arg_type(i);
@@ -1615,12 +1615,12 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
                                         : nullptr;
         if (columns[i]->only_null() ||
             (columns[i]->is_nullable() && down_cast<const NullableColumn*>(columns[i])->null_count() == num_rows)) {
-            arg = helper.create_array(num_rows);
+            arg = JVMHelper::getInstance().create_array(num_rows);
         } else if (columns[i]->is_constant()) {
             auto* data_column = down_cast<const ConstColumn*>(columns[i])->data_column_raw_ptr();
             data_column->as_mutable_raw_ptr()->resize(1);
             ASSIGN_OR_RETURN(jvalue jval, cast_to_jvalue(arg_type, true, data_column, 0, type_desc_obj));
-            arg = helper.create_object_array(jval.l, num_rows);
+            arg = JVMHelper::getInstance().create_object_array(jval.l, num_rows);
             env->DeleteLocalRef(jval.l);
         } else {
             ASSIGN_OR_RETURN(arg, box_column(helper, arg_type, columns[i], type_desc_obj, num_rows));

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -14,9 +14,7 @@
 
 #include "udf/java/java_udf.h"
 
-#include <iterator>
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include "base/utility/defer_op.h"
@@ -26,7 +24,6 @@
 #include "exprs/function_context.h"
 #include "fmt/core.h"
 #include "jni.h"
-#include "runtime/java/java_env.h"
 #include "types/date_value.h"
 #include "types/logical_type.h"
 #include "types/timestamp_value.h"
@@ -37,33 +34,13 @@
 
 // find a jclass and return a global jclass ref
 #define JNI_FIND_CLASS(clazz_name)                                                                 \
-    [](const char* name) {                                                                         \
-        auto clazz = _env->FindClass(name);                                                        \
+    [](JNIEnv* env, const char* name) {                                                            \
+        auto clazz = env->FindClass(name);                                                         \
         CHECK(clazz != nullptr) << "not found class" << name << " plz check JDK and jni-packages"; \
-        auto g_clazz = _env->NewGlobalRef(clazz);                                                  \
-        _env->DeleteLocalRef(clazz);                                                               \
+        auto g_clazz = env->NewGlobalRef(clazz);                                                   \
+        env->DeleteLocalRef(clazz);                                                                \
         return (jclass)g_clazz;                                                                    \
-    }(clazz_name)
-
-#define ADD_NUMBERIC_CLASS(prim_clazz, clazz, sign)                                                           \
-    {                                                                                                         \
-        _class_##prim_clazz = JNI_FIND_CLASS("java/lang/" #clazz);                                            \
-        CHECK(_class_##prim_clazz);                                                                           \
-        _value_of_##prim_clazz =                                                                              \
-                _env->GetStaticMethodID(_class_##prim_clazz, "valueOf", "(" #sign ")Ljava/lang/" #clazz ";"); \
-        CHECK(_value_of_##prim_clazz) << "Not Found"                                                          \
-                                      << "(" #sign ")Ljava/lang/" #clazz ";";                                 \
-        _val_##prim_clazz = _env->GetMethodID(_class_##prim_clazz, #prim_clazz "Value", "()" #sign);          \
-        CHECK(_val_##prim_clazz);                                                                             \
-    }
-
-#define DEFINE_NEW_BOX(prim_clazz, cxx_type, CLAZZ, CallType)                                    \
-    jobject JVMFunctionHelper::new##CLAZZ(cxx_type value) {                                      \
-        return _env->CallStaticObjectMethod(_class_##prim_clazz, _value_of_##prim_clazz, value); \
-    }                                                                                            \
-    cxx_type JVMFunctionHelper::val##cxx_type(jobject obj) {                                     \
-        return _env->Call##CallType##Method(obj, _val_##prim_clazz);                             \
-    }
+    }(JVMHelper::getInstance().getEnv(), clazz_name)
 
 namespace starrocks {
 
@@ -99,14 +76,14 @@ constexpr const char* CREATE_BOXED_STRUCT_SIGNATURE =
 // helper once per query batch.
 constexpr const char* WRITE_RESULT_SIGNATURE = "(ILjava/lang/Object;JLcom/starrocks/udf/UdfTypeDesc;)V";
 
-#define INIT_STATIC_METHOD(target, clazz, name, signature)    \
-    target = _env->GetStaticMethodID(clazz, name, signature); \
+#define INIT_STATIC_METHOD(target, clazz, name, signature)   \
+    target = env->GetStaticMethodID(clazz, name, signature); \
     CHECK(target != nullptr) << "not found method:" << name << " plz check your jni-packages";
 
 #define INIT_HELPER_METHOD(target, name, signature) INIT_STATIC_METHOD(target, _udf_helper_class, name, signature);
 
-#define SET_METHOD_ID(target, clazz, name, signature)   \
-    target = _env->GetMethodID(clazz, name, signature); \
+#define SET_METHOD_ID(target, clazz, name, signature)  \
+    target = env->GetMethodID(clazz, name, signature); \
     DCHECK(target != nullptr);
 
 #pragma GCC diagnostic push
@@ -123,84 +100,30 @@ static JNINativeMethod java_native_methods[] = {
 #pragma GCC diagnostic pop
 
 StatusOr<jobject> MapMeta::newLocalInstance(jobject keys, jobject values) const {
-    JNIEnv* env = getJNIEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     auto res = env->NewObject(immutable_map_class->clazz(), immutable_map_constructor, keys, values);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return res;
 }
 
 JVMFunctionHelper& JVMFunctionHelper::getInstance() {
-    if (_env == nullptr) {
-        _env = getJNIEnv();
-        CHECK(_env != nullptr) << "couldn't got a JNIEnv";
-    }
+    JVMHelper::getInstance();
     static JVMFunctionHelper helper;
     return helper;
 }
 
-std::pair<JNIEnv*, JVMFunctionHelper&> JVMFunctionHelper::getInstanceWithEnv() {
-    auto& instance = getInstance();
-    return {instance.getEnv(), instance};
-}
-
 void JVMFunctionHelper::_init() {
-    _object_class = JNI_FIND_CLASS("java/lang/Object");
-    _object_array_class = JNI_FIND_CLASS("[Ljava/lang/Object;");
-    _string_class = JNI_FIND_CLASS("java/lang/String");
-    _jarrays_class = JNI_FIND_CLASS("java/util/Arrays");
-    _exception_util_class = JNI_FIND_CLASS("org/apache/commons/lang3/exception/ExceptionUtils");
-    _big_decimal_class = JNI_FIND_CLASS("java/math/BigDecimal");
-
-    CHECK(_object_class);
-    CHECK(_string_class);
-    CHECK(_jarrays_class);
-    CHECK(_exception_util_class);
-    CHECK(_big_decimal_class);
-    _big_decimal_ctor_string = _env->GetMethodID(_big_decimal_class, "<init>", "(Ljava/lang/String;)V");
-    CHECK(_big_decimal_ctor_string);
-    _big_decimal_value_of_ll = _env->GetStaticMethodID(_big_decimal_class, "valueOf", "(JI)Ljava/math/BigDecimal;");
-    CHECK(_big_decimal_value_of_ll);
-
-    _local_date_class = JNI_FIND_CLASS("java/time/LocalDate");
-    CHECK(_local_date_class);
-    _local_date_of_epoch_day = _env->GetStaticMethodID(_local_date_class, "ofEpochDay", "(J)Ljava/time/LocalDate;");
-    CHECK(_local_date_of_epoch_day);
-    _local_date_to_epoch_day = _env->GetMethodID(_local_date_class, "toEpochDay", "()J");
-    CHECK(_local_date_to_epoch_day);
-
-    _local_datetime_class = JNI_FIND_CLASS("java/time/LocalDateTime");
-    CHECK(_local_datetime_class);
-
-    ADD_NUMBERIC_CLASS(boolean, Boolean, Z);
-    ADD_NUMBERIC_CLASS(byte, Byte, B);
-    ADD_NUMBERIC_CLASS(short, Short, S);
-    ADD_NUMBERIC_CLASS(int, Integer, I);
-    ADD_NUMBERIC_CLASS(long, Long, J);
-    ADD_NUMBERIC_CLASS(float, Float, F);
-    ADD_NUMBERIC_CLASS(double, Double, D);
-
-    jclass charsets = JNI_FIND_CLASS("java/nio/charset/StandardCharsets");
-    DCHECK(charsets != nullptr);
-    auto fieldId = _env->GetStaticFieldID(charsets, "UTF_8", "Ljava/nio/charset/Charset;");
-    DCHECK(fieldId != nullptr);
-
-    auto charset = _env->GetStaticObjectField(charsets, fieldId);
-    _utf8_charsets = _env->NewGlobalRef(charset);
-    _env->DeleteLocalRef(charset);
-
-    DCHECK(_utf8_charsets != nullptr);
-    _string_construct_with_bytes = _env->GetMethodID(_string_class, "<init>", "([BLjava/nio/charset/Charset;)V");
-    DCHECK(_string_construct_with_bytes != nullptr);
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // init JNI native methods
-    std::string native_method_name = JVMFunctionHelper::to_jni_class_name(CLASS_NATIVE_METHOD_HELPER_NAME);
+    std::string native_method_name = JVMHelper::to_jni_class_name(CLASS_NATIVE_METHOD_HELPER_NAME);
     jclass native_method_class = JNI_FIND_CLASS(native_method_name.c_str());
     DCHECK(native_method_class != nullptr);
-    int res = _env->RegisterNatives(native_method_class, java_native_methods,
-                                    sizeof(java_native_methods) / sizeof(java_native_methods[0]));
+    int res = env->RegisterNatives(native_method_class, java_native_methods,
+                                   sizeof(java_native_methods) / sizeof(java_native_methods[0]));
 
     // init UDF Helper
-    std::string name = JVMFunctionHelper::to_jni_class_name(CLASS_UDF_HELPER_NAME);
+    std::string name = JVMHelper::to_jni_class_name(CLASS_UDF_HELPER_NAME);
     _udf_helper_class = JNI_FIND_CLASS(name.c_str());
     DCHECK(_udf_helper_class != nullptr);
     DCHECK_EQ(res, 0);
@@ -215,15 +138,14 @@ void JVMFunctionHelper::_init() {
     // input boxing recursion (which reads children / recordClass per STRUCT slot)
     // and for the per-UDF type desc construction in _build_udf_func_desc.
     {
-        std::string td_name = JVMFunctionHelper::to_jni_class_name("com.starrocks.udf.UdfTypeDesc");
+        std::string td_name = JVMHelper::to_jni_class_name("com.starrocks.udf.UdfTypeDesc");
         _udf_type_desc_class = JNI_FIND_CLASS(td_name.c_str());
         DCHECK(_udf_type_desc_class != nullptr);
-        _udf_type_desc_ctor = _env->GetMethodID(_udf_type_desc_class, "<init>",
-                                                "(I[Lcom/starrocks/udf/UdfTypeDesc;IILjava/lang/Class;)V");
+        _udf_type_desc_ctor = env->GetMethodID(_udf_type_desc_class, "<init>",
+                                               "(I[Lcom/starrocks/udf/UdfTypeDesc;IILjava/lang/Class;)V");
         DCHECK(_udf_type_desc_ctor != nullptr);
-        _udf_type_desc_record_class = _env->GetFieldID(_udf_type_desc_class, "recordClass", "Ljava/lang/Class;");
-        _udf_type_desc_children =
-                _env->GetFieldID(_udf_type_desc_class, "children", "[Lcom/starrocks/udf/UdfTypeDesc;");
+        _udf_type_desc_record_class = env->GetFieldID(_udf_type_desc_class, "recordClass", "Ljava/lang/Class;");
+        _udf_type_desc_children = env->GetFieldID(_udf_type_desc_class, "children", "[Lcom/starrocks/udf/UdfTypeDesc;");
         DCHECK(_udf_type_desc_record_class != nullptr && _udf_type_desc_children != nullptr);
     }
     INIT_HELPER_METHOD(_get_decimal_boxed_result, "getDecimalResultFromBoxedArray", "(IIIILjava/lang/Object;JZ)V");
@@ -271,181 +193,77 @@ void JVMFunctionHelper::_init() {
     INIT_HELPER_METHOD(_local_datetime_from_packed, "localDateTimeFromPackedTimestamp", "(J)Ljava/time/LocalDateTime;");
     INIT_HELPER_METHOD(_local_datetime_to_packed, "packedTimestampFromLocalDateTime", "(Ljava/time/LocalDateTime;)J");
 
-    // init bytebuffer
-    _direct_buffer_class = JNI_FIND_CLASS("java/nio/ByteBuffer");
-    SET_METHOD_ID(_direct_buffer_clear, _direct_buffer_class, "clear", "()Ljava/nio/Buffer;");
-
-    // init list meta
-    auto list_clazz = JNI_FIND_CLASS("java/util/List");
-    DCHECK(list_clazz);
-    _list_meta.list_class = new JVMClass(list_clazz);
-    auto array_list_clazz = JNI_FIND_CLASS("java/util/ArrayList");
-    DCHECK(array_list_clazz);
-    _list_meta.array_list_class = new JVMClass(array_list_clazz);
-
-    SET_METHOD_ID(_list_meta.list_get, list_clazz, "get", "(I)Ljava/lang/Object;");
-    SET_METHOD_ID(_list_meta.list_size, list_clazz, "size", "()I");
-    SET_METHOD_ID(_list_meta.list_add, list_clazz, "add", "(Ljava/lang/Object;)Z");
-
     // init immutable map meta
     auto immutable_map_clazz = JNI_FIND_CLASS("com/starrocks/udf/ImmutableMap");
     DCHECK(immutable_map_clazz != nullptr);
     _map_meta.immutable_map_class = new JVMClass(immutable_map_clazz);
-    auto map_clazz = JNI_FIND_CLASS("java/util/Map");
-    DCHECK(map_clazz);
-    _map_meta.map_class = new JVMClass(map_clazz);
+    _map_meta.map_class = &JVMHelper::getInstance().map_class();
     _map_meta.immutable_map_constructor =
-            _env->GetMethodID(_map_meta.immutable_map_class->clazz(), "<init>", "(Ljava/util/List;Ljava/util/List;)V");
+            env->GetMethodID(_map_meta.immutable_map_class->clazz(), "<init>", "(Ljava/util/List;Ljava/util/List;)V");
 
-    name = JVMFunctionHelper::to_jni_class_name(UDAFStateList::clazz_name);
+    name = JVMHelper::to_jni_class_name(UDAFStateList::clazz_name);
     jclass loaded_clazz = JNI_FIND_CLASS(name.c_str());
     _function_states_clazz = new JVMClass(loaded_clazz);
-}
-
-jobjectArray JVMFunctionHelper::_build_object_array(jclass clazz, jobject* arr, int sz) {
-    jobjectArray res_arr = _env->NewObjectArray(sz, _object_array_class, nullptr);
-    RETURN_IF_JNI_EXCEPTION(_env, "_build_object_array: NewObjectArray failed", nullptr);
-    for (int i = 0; i < sz; ++i) {
-        _env->SetObjectArrayElement(res_arr, i, arr[i]);
-    }
-    return res_arr;
 }
 
 JVMClass& JVMFunctionHelper::function_state_clazz() {
     return *_function_states_clazz;
 }
 
-#define CHECK_FUNCTION_EXCEPTION(_env, name)                   \
-    if (auto e = _env->ExceptionOccurred()) {                  \
-        LOCAL_REF_GUARD(e);                                    \
-        _env->ExceptionClear();                                \
-        LOG(WARNING) << "Exception happened when call " #name; \
-        return "";                                             \
-    }
-
-#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                                   \
-    if (jthrowable jthr = env->ExceptionOccurred()) {                            \
-        LOCAL_REF_GUARD(jthr);                                                   \
-        std::string msg = fmt::format(errmsg, helper.dumpExceptionString(jthr)); \
-        LOG(WARNING) << msg;                                                     \
-        env->ExceptionClear();                                                   \
-        return Status::RuntimeError(msg);                                        \
+#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                                                     \
+    if (jthrowable jthr = env->ExceptionOccurred()) {                                              \
+        LOCAL_REF_GUARD(jthr);                                                                     \
+        std::string msg = fmt::format(errmsg, JVMHelper::getInstance().dumpExceptionString(jthr)); \
+        LOG(WARNING) << msg;                                                                       \
+        env->ExceptionClear();                                                                     \
+        return Status::RuntimeError(msg);                                                          \
     }
 
 Status JVMFunctionHelper::_check_exception_status() {
-    auto& helper = *this;
-    RETURN_ERROR_IF_EXCEPTION(_env, "exception happened when invoke method: {}");
+    auto* env = JVMHelper::getInstance().getEnv();
+    RETURN_ERROR_IF_EXCEPTION(env, "exception happened when invoke method: {}");
     return Status::OK();
 }
 
-std::string JVMFunctionHelper::array_to_string(jobject object) {
-    _env->ExceptionClear();
-    std::string value;
-    jmethodID arrayToStringMethod =
-            _env->GetStaticMethodID(_jarrays_class, "toString", "([Ljava/lang/Object;)Ljava/lang/String;");
-    DCHECK(arrayToStringMethod != nullptr);
-    jobject jstr = _env->CallStaticObjectMethod(_jarrays_class, arrayToStringMethod, object);
-    LOCAL_REF_GUARD(jstr);
-    CHECK_FUNCTION_EXCEPTION(_env, "array_to_string")
-    value = to_cxx_string((jstring)jstr);
-    return value;
-}
-
-std::string JVMFunctionHelper::to_string(jobject obj) {
-    _env->ExceptionClear();
-    std::string value;
-    auto method = getToStringMethod(_object_class);
-    auto res = _env->CallObjectMethod(obj, method);
-    LOCAL_REF_GUARD(res);
-    CHECK_FUNCTION_EXCEPTION(_env, "to_string")
-    value = to_cxx_string((jstring)res);
-    return value;
-}
-
-std::string JVMFunctionHelper::to_cxx_string(jstring str) {
-    if (str == nullptr) {
-        return "<null>";
-    }
-    std::string res;
-    const char* charflow = _env->GetStringUTFChars((jstring)str, nullptr);
-    res = charflow;
-    _env->ReleaseStringUTFChars((jstring)str, charflow);
-    return res;
-}
-
-std::string JVMFunctionHelper::dumpExceptionString(jthrowable throwable) {
-    // toString
-    auto get_stack_trace = _env->GetStaticMethodID(_exception_util_class, "getStackTrace",
-                                                   "(Ljava/lang/Throwable;)Ljava/lang/String;");
-    CHECK(get_stack_trace != nullptr) << "Not Found JNI method getStackTrace";
-    jobject stack_traces = _env->CallStaticObjectMethod(_exception_util_class, get_stack_trace, (jobject)throwable);
-    LOCAL_REF_GUARD(stack_traces);
-    // don't call return if xxx, to avoid recursive
-    _env->ExceptionClear();
-    return to_cxx_string((jstring)stack_traces);
-}
-
-jmethodID JVMFunctionHelper::getToStringMethod(jclass clazz) {
-    return _env->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
-}
-
-StatusOr<jstring> JVMFunctionHelper::to_jstring(const std::string& str) {
-    auto res = _env->NewStringUTF(str.c_str());
-    if (UNLIKELY(res == nullptr)) {
-        _env->ExceptionClear();
-        return Status::InternalError(fmt::format("NewStringUTF failed for: {}", str));
-    }
-    return res;
-}
-
-jmethodID JVMFunctionHelper::getMethod(jclass clazz, const std::string& method, const std::string& sig) {
-    return _env->GetMethodID(clazz, method.c_str(), sig.c_str());
-}
-
-jmethodID JVMFunctionHelper::getStaticMethod(jclass clazz, const std::string& method, const std::string& sig) {
-    return _env->GetStaticMethodID(clazz, method.c_str(), sig.c_str());
-}
-
-jobject JVMFunctionHelper::create_array(int sz) {
-    auto res = _env->NewObjectArray(sz, _object_class, nullptr);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_array: NewObjectArray failed", nullptr);
-    return res;
-}
-
 jobject JVMFunctionHelper::create_boxed_array(int type, int num_rows, bool nullable, DirectByteBuffer* buffs, int sz) {
-    jobjectArray input_arr = _env->NewObjectArray(sz, _direct_buffer_class, nullptr);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_boxed_array: NewObjectArray failed", nullptr);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    jobjectArray input_arr = env->NewObjectArray(sz, jvm.direct_buffer_class(), nullptr);
+    RETURN_IF_JNI_EXCEPTION(env, "create_boxed_array: NewObjectArray failed", nullptr);
     LOCAL_REF_GUARD(input_arr);
     for (int i = 0; i < sz; ++i) {
-        _env->SetObjectArrayElement(input_arr, i, buffs[i].handle());
+        env->SetObjectArrayElement(input_arr, i, buffs[i].handle());
     }
     jobject res =
-            _env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_array, type, num_rows, nullable, input_arr);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_boxed_array", nullptr);
+            env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_array, type, num_rows, nullable, input_arr);
+    RETURN_IF_JNI_EXCEPTION(env, "create_boxed_array", nullptr);
     return res;
 }
 
 StatusOr<jobject> JVMFunctionHelper::create_boxed_decimal_array(int type, int scale, int num_rows, jobject null_buff,
                                                                 jobject data_buff) {
-    jobject res = _env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_decimal_array, type, num_rows, scale,
-                                               null_buff, data_buff);
-    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(_env, "create_boxed_decimal_array");
+    auto* env = JVMHelper::getInstance().getEnv();
+    jobject res = env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_decimal_array, type, num_rows, scale,
+                                              null_buff, data_buff);
+    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "create_boxed_decimal_array");
     return res;
 }
 
 StatusOr<jobject> JVMFunctionHelper::create_boxed_struct_array(jclass record_class, int num_rows, jobject null_buff,
                                                                jobject field_arrays) {
-    jobject res = _env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_struct_array, num_rows, null_buff,
-                                               record_class, field_arrays);
-    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(_env, "create_boxed_struct_array");
+    auto* env = JVMHelper::getInstance().getEnv();
+    jobject res = env->CallStaticObjectMethod(_udf_helper_class, _create_boxed_struct_array, num_rows, null_buff,
+                                              record_class, field_arrays);
+    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "create_boxed_struct_array");
     return res;
 }
 
 StatusOr<jobject> JVMFunctionHelper::new_udf_type_desc(jint logical_type, jobjectArray children, jint precision,
                                                        jint scale, jobject record_class) {
-    jobject obj = _env->NewObject(_udf_type_desc_class, _udf_type_desc_ctor, logical_type, children, precision, scale,
-                                  record_class);
-    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(_env, "new_udf_type_desc");
+    auto* env = JVMHelper::getInstance().getEnv();
+    jobject obj = env->NewObject(_udf_type_desc_class, _udf_type_desc_ctor, logical_type, children, precision, scale,
+                                 record_class);
+    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "new_udf_type_desc");
     return obj;
 }
 
@@ -467,25 +285,21 @@ Status JVMFunctionHelper::write_result(jobject result, int num_rows, jlong colum
     // the pre-refactor writeElementsByType behavior). For top-level DECIMAL returns,
     // BE callers can route through get_result_from_boxed_array with explicit
     // precision/scale instead.
-    _env->CallStaticVoidMethod(_udf_helper_class, _write_result, num_rows, result, column_addr, type_desc);
-    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(_env, "write_result");
+    auto* env = JVMHelper::getInstance().getEnv();
+    env->CallStaticVoidMethod(_udf_helper_class, _write_result, num_rows, result, column_addr, type_desc);
+    RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "write_result");
     return Status::OK();
 }
 
-jobject JVMFunctionHelper::create_object_array(jobject o, int num_rows) {
-    jobjectArray res_arr = _env->NewObjectArray(num_rows, _object_array_class, o);
-    RETURN_IF_JNI_EXCEPTION(_env, "create_object_array: NewObjectArray failed", nullptr);
-    return res_arr;
-}
-
 jobject JVMFunctionHelper::batch_create_bytebuf(unsigned char* ptr, const uint32_t* offset, int begin, int end) {
+    auto* env = JVMHelper::getInstance().getEnv();
     int size = end - begin;
-    auto offsets = _env->NewIntArray(size + 1);
-    RETURN_IF_JNI_EXCEPTION(_env, "batch_create_bytebuf: NewIntArray failed", nullptr);
-    _env->SetIntArrayRegion(offsets, 0, size + 1, (const int32_t*)offset);
+    auto offsets = env->NewIntArray(size + 1);
+    RETURN_IF_JNI_EXCEPTION(env, "batch_create_bytebuf: NewIntArray failed", nullptr);
+    env->SetIntArrayRegion(offsets, 0, size + 1, (const int32_t*)offset);
     LOCAL_REF_GUARD(offsets);
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _batch_create_bytebuf, ptr, offsets, size);
-    RETURN_IF_JNI_EXCEPTION(_env, "batch_create_bytebuf", nullptr);
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _batch_create_bytebuf, ptr, offsets, size);
+    RETURN_IF_JNI_EXCEPTION(env, "batch_create_bytebuf", nullptr);
     return res;
 }
 
@@ -500,19 +314,23 @@ void JVMFunctionHelper::batch_update(FunctionContext* ctx, jobject udaf, jobject
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    jobjectArray input_arr = jvm.build_object_array(jvm.object_array_class(), input, cols);
     LOCAL_REF_GUARD(input_arr);
-    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, udaf_ctx->states->handle(), states,
-                               input_arr);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    env->CallStaticVoidMethod(_udf_helper_class, _batch_update, udaf, update, udaf_ctx->states->handle(), states,
+                              input_arr);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
 }
 
 void JVMFunctionHelper::batch_update_state(FunctionContext* ctx, jobject udaf, jobject update, jobject* input,
                                            int cols) {
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    jobjectArray input_arr = jvm.build_object_array(jvm.object_array_class(), input, cols);
     LOCAL_REF_GUARD(input_arr);
-    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_state, udaf, update, input_arr);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    env->CallStaticVoidMethod(_udf_helper_class, _batch_update_state, udaf, update, input_arr);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
 }
 
 void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject udaf, jobject update, jobject states,
@@ -520,11 +338,13 @@ void JVMFunctionHelper::batch_update_if_not_null(FunctionContext* ctx, jobject u
     auto* udaf_ctx = get_java_udaf_context(ctx);
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    jobjectArray input_arr = jvm.build_object_array(jvm.object_array_class(), input, cols);
     LOCAL_REF_GUARD(input_arr);
-    _env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update, udaf_ctx->states->handle(),
-                               states, input_arr);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    env->CallStaticVoidMethod(_udf_helper_class, _batch_update_if_not_null, udaf, update, udaf_ctx->states->handle(),
+                              states, input_arr);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
 }
 
 StatusOr<jobject> JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject* input, int cols, int rows) {
@@ -533,22 +353,26 @@ StatusOr<jobject> JVMFunctionHelper::batch_call(BatchEvaluateStub* stub, jobject
 
 jobject JVMFunctionHelper::batch_call(FunctionContext* ctx, jobject caller, jobject method, jobject* input, int cols,
                                       int rows) {
-    jobjectArray input_arr = _build_object_array(_object_array_class, input, cols);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    jobjectArray input_arr = jvm.build_object_array(jvm.object_array_class(), input, cols);
     LOCAL_REF_GUARD(input_arr);
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _batch_call, caller, method, rows, input_arr);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _batch_call, caller, method, rows, input_arr);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
     return res;
 }
 
 jobject JVMFunctionHelper::batch_call(FunctionContext* ctx, jobject caller, jobject method, int rows) {
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _batch_call_no_args, caller, method, rows);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _batch_call_no_args, caller, method, rows);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
     return res;
 }
 
 jobject JVMFunctionHelper::int_batch_call(FunctionContext* ctx, jobject callers, jobject method, int rows) {
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _int_batch_call, callers, method, rows);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _int_batch_call, callers, method, rows);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
     return res;
 }
 
@@ -570,17 +394,19 @@ static void invoke_boxed_result(JNIEnv* env, jclass helper_class, jmethodID get_
 
 Status JVMFunctionHelper::get_result_from_boxed_array(int type, Column* col, jobject jcolumn, int rows, int precision,
                                                       int scale, bool error_if_overflow) {
-    invoke_boxed_result(_env, _udf_helper_class, _get_boxed_result, _get_decimal_boxed_result, type, precision, scale,
+    auto* env = JVMHelper::getInstance().getEnv();
+    invoke_boxed_result(env, _udf_helper_class, _get_boxed_result, _get_decimal_boxed_result, type, precision, scale,
                         col, jcolumn, rows, error_if_overflow);
-    RETURN_ERROR_IF_JNI_EXCEPTION(_env);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return Status::OK();
 }
 
 void JVMFunctionHelper::get_result_from_boxed_array(FunctionContext* ctx, int type, Column* col, jobject jcolumn,
                                                     int rows, int precision, int scale, bool error_if_overflow) {
-    invoke_boxed_result(_env, _udf_helper_class, _get_boxed_result, _get_decimal_boxed_result, type, precision, scale,
+    auto* env = JVMHelper::getInstance().getEnv();
+    invoke_boxed_result(env, _udf_helper_class, _get_boxed_result, _get_decimal_boxed_result, type, precision, scale,
                         col, jcolumn, rows, error_if_overflow);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
 }
 
 // convert UDAF ctx to jobject
@@ -589,7 +415,7 @@ jobject JVMFunctionHelper::convert_handle_to_jobject(FunctionContext* ctx, int s
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
     auto* states = udaf_ctx->states.get();
-    return states->get_state(ctx, _env, state);
+    return states->get_state(ctx, JVMHelper::getInstance().getEnv(), state);
 }
 
 jobject JVMFunctionHelper::convert_handles_to_jobjects(FunctionContext* ctx, jobject state_ids) {
@@ -597,66 +423,32 @@ jobject JVMFunctionHelper::convert_handles_to_jobjects(FunctionContext* ctx, job
     DCHECK(udaf_ctx != nullptr);
     DCHECK(udaf_ctx->states != nullptr);
     auto* states = udaf_ctx->states.get();
-    return states->get_state(ctx, _env, state_ids);
+    return states->get_state(ctx, JVMHelper::getInstance().getEnv(), state_ids);
 }
 
 StatusOr<jobject> JVMFunctionHelper::extract_key_list(jobject map) {
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _extract_keys_from_map, map);
-    RETURN_ERROR_IF_JNI_EXCEPTION(_env);
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _extract_keys_from_map, map);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return res;
 }
 
 StatusOr<jobject> JVMFunctionHelper::extract_val_list(jobject map) {
-    auto res = _env->CallStaticObjectMethod(_udf_helper_class, _extract_values_from_map, map);
-    RETURN_ERROR_IF_JNI_EXCEPTION(_env);
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto res = env->CallStaticObjectMethod(_udf_helper_class, _extract_values_from_map, map);
+    RETURN_ERROR_IF_JNI_EXCEPTION(env);
     return res;
 }
 
-DEFINE_NEW_BOX(boolean, uint8_t, Boolean, Boolean);
-DEFINE_NEW_BOX(byte, int8_t, Byte, Byte);
-DEFINE_NEW_BOX(short, int16_t, Short, Short);
-DEFINE_NEW_BOX(int, int32_t, Integer, Int);
-DEFINE_NEW_BOX(long, int64_t, Long, Long);
-DEFINE_NEW_BOX(float, float, Float, Float);
-DEFINE_NEW_BOX(double, double, Double, Double);
-
-jobject JVMFunctionHelper::newString(const char* data, size_t size) {
-    auto bytesArr = _env->NewByteArray(size);
-    RETURN_IF_JNI_EXCEPTION(_env, "newString: NewByteArray failed", nullptr);
-    LOCAL_REF_GUARD(bytesArr);
-    _env->SetByteArrayRegion(bytesArr, 0, size, reinterpret_cast<const jbyte*>(data));
-    jobject nstr = _env->NewObject(_string_class, _string_construct_with_bytes, bytesArr, _utf8_charsets);
-    RETURN_IF_JNI_EXCEPTION(_env, "newString: NewObject failed", nullptr);
-    return nstr;
-}
-
-jobject JVMFunctionHelper::newBigDecimal(const std::string& s) {
-    jobject jstr = newString(s.data(), s.size());
-    if (jstr == nullptr) {
-        return nullptr;
-    }
-    LOCAL_REF_GUARD(jstr);
-    jobject bd = _env->NewObject(_big_decimal_class, _big_decimal_ctor_string, jstr);
-    RETURN_IF_JNI_EXCEPTION(_env, "newBigDecimal: NewObject failed", nullptr);
-    return bd;
-}
-
-jobject JVMFunctionHelper::newBigDecimal(int64_t unscaled, int scale) {
-    jobject bd = _env->CallStaticObjectMethod(_big_decimal_class, _big_decimal_value_of_ll,
-                                              static_cast<jlong>(unscaled), static_cast<jint>(scale));
-    RETURN_IF_JNI_EXCEPTION(_env, "newBigDecimal(long, int): CallStatic failed", nullptr);
-    return bd;
-}
-
 jlong JVMFunctionHelper::unscaled_long(jobject big_decimal, int precision, int scale) {
-    return _env->CallStaticLongMethod(_udf_helper_class, _bd_unscaled_long, big_decimal, static_cast<jint>(precision),
-                                      static_cast<jint>(scale));
+    return JVMHelper::getInstance().getEnv()->CallStaticLongMethod(
+            _udf_helper_class, _bd_unscaled_long, big_decimal, static_cast<jint>(precision), static_cast<jint>(scale));
 }
 
 jbyteArray JVMFunctionHelper::unscaled_le_bytes(jobject big_decimal, int precision, int scale, int byte_width) {
-    return (jbyteArray)_env->CallStaticObjectMethod(_udf_helper_class, _bd_unscaled_le_bytes, big_decimal,
-                                                    static_cast<jint>(precision), static_cast<jint>(scale),
-                                                    static_cast<jint>(byte_width));
+    return (jbyteArray)JVMHelper::getInstance().getEnv()->CallStaticObjectMethod(
+            _udf_helper_class, _bd_unscaled_le_bytes, big_decimal, static_cast<jint>(precision),
+            static_cast<jint>(scale), static_cast<jint>(byte_width));
 }
 
 // DateValue stores days as Julian day; LocalDate exposes them as days-since-1970-01-01.
@@ -664,99 +456,35 @@ jbyteArray JVMFunctionHelper::unscaled_le_bytes(jobject big_decimal, int precisi
 static constexpr jlong UNIX_EPOCH_JULIAN_DAYS = 2440588;
 
 jobject JVMFunctionHelper::newLocalDate(int32_t julian) {
-    jobject ld = _env->CallStaticObjectMethod(_local_date_class, _local_date_of_epoch_day,
-                                              static_cast<jlong>(julian) - UNIX_EPOCH_JULIAN_DAYS);
-    RETURN_IF_JNI_EXCEPTION(_env, "newLocalDate: ofEpochDay failed", nullptr);
+    auto* env = JVMHelper::getInstance().getEnv();
+    jobject ld = JVMHelper::getInstance().newLocalDateFromEpochDay(static_cast<jlong>(julian) - UNIX_EPOCH_JULIAN_DAYS);
+    RETURN_IF_JNI_EXCEPTION(env, "newLocalDate: ofEpochDay failed", nullptr);
     return ld;
 }
 
 int32_t JVMFunctionHelper::valLocalDate(jobject obj) {
-    jlong epoch_day = _env->CallLongMethod(obj, _local_date_to_epoch_day);
+    jlong epoch_day = JVMHelper::getInstance().valLocalDateToEpochDay(obj);
     return static_cast<int32_t>(epoch_day + UNIX_EPOCH_JULIAN_DAYS);
 }
 
 jobject JVMFunctionHelper::newLocalDateTime(int64_t packed_timestamp) {
-    jobject ldt = _env->CallStaticObjectMethod(_udf_helper_class, _local_datetime_from_packed,
-                                               static_cast<jlong>(packed_timestamp));
-    RETURN_IF_JNI_EXCEPTION(_env, "newLocalDateTime: localDateTimeFromPackedTimestamp failed", nullptr);
+    auto* env = JVMHelper::getInstance().getEnv();
+    jobject ldt = env->CallStaticObjectMethod(_udf_helper_class, _local_datetime_from_packed,
+                                              static_cast<jlong>(packed_timestamp));
+    RETURN_IF_JNI_EXCEPTION(env, "newLocalDateTime: localDateTimeFromPackedTimestamp failed", nullptr);
     return ldt;
 }
 
 int64_t JVMFunctionHelper::valLocalDateTime(jobject obj) {
-    return _env->CallStaticLongMethod(_udf_helper_class, _local_datetime_to_packed, obj);
-}
-
-Slice JVMFunctionHelper::sliceVal(jstring jstr, std::string* buffer) {
-    const size_t utf_length = _env->GetStringUTFLength(jstr);
-    buffer->resize(utf_length);
-    const size_t string_length = _env->GetStringLength(jstr);
-    _env->GetStringUTFRegion(jstr, 0, string_length, buffer->data());
-    return {buffer->data(), buffer->length()};
-}
-
-std::string JVMFunctionHelper::to_jni_class_name(const std::string& name) {
-    std::string jni_class_name;
-    auto inserter = std::inserter(jni_class_name, jni_class_name.end());
-    std::transform(name.begin(), name.end(), inserter, [](auto ele) {
-        if (ele == '.') {
-            return '/';
-        }
-        return ele;
-    });
-    return jni_class_name;
+    return JVMHelper::getInstance().getEnv()->CallStaticLongMethod(_udf_helper_class, _local_datetime_to_packed, obj);
 }
 
 void JVMFunctionHelper::clear(DirectByteBuffer* buffer, FunctionContext* ctx) {
-    auto res = _env->CallNonvirtualObjectMethod(buffer->handle(), _direct_buffer_class, _direct_buffer_clear);
+    auto& jvm = JVMHelper::getInstance();
+    auto* env = jvm.getEnv();
+    auto res = env->CallNonvirtualObjectMethod(buffer->handle(), jvm.direct_buffer_class(), jvm.direct_buffer_clear());
     LOCAL_REF_GUARD(res);
-    CHECK_UDF_CALL_EXCEPTION(_env, ctx);
-}
-
-DirectByteBuffer::DirectByteBuffer(void* ptr, int capacity) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
-    auto lref = env->NewDirectByteBuffer(ptr, capacity);
-    LOCAL_REF_GUARD(lref);
-    _handle = env->NewGlobalRef(lref);
-    _capacity = capacity;
-    _data = ptr;
-}
-
-DirectByteBuffer::~DirectByteBuffer() {
-    if (_handle != nullptr) {
-        auto st = JavaEnv::GetInstance()->call_function_in_pthread([this]() {
-            auto& helper = JVMFunctionHelper::getInstance();
-            JNIEnv* env = helper.getEnv();
-            env->DeleteGlobalRef(_handle);
-            _handle = nullptr;
-            return Status::OK();
-        });
-        LOG_IF(WARNING, !st.ok()) << "failed to delete direct byte buffer global ref: " << st;
-    }
-}
-
-Status JavaListStub::add(jobject element) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-    const auto& meta = helper.list_meta();
-    env->CallVoidMethod(_list, meta.list_add, element);
-    RETURN_ERROR_IF_JNI_EXCEPTION(env);
-    return Status::OK();
-}
-
-StatusOr<jobject> JavaListStub::get(int index) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-    const auto& meta = helper.list_meta();
-    auto res = env->CallObjectMethod(_list, meta.list_get, index);
-    RETURN_ERROR_IF_JNI_EXCEPTION(env);
-    return res;
-}
-
-StatusOr<size_t> JavaListStub::size() {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
-    const auto& meta = helper.list_meta();
-    auto res = env->CallIntMethod(_list, meta.list_size);
-    RETURN_ERROR_IF_JNI_EXCEPTION(env);
-    return res;
+    CHECK_UDF_CALL_EXCEPTION(env, ctx);
 }
 
 } // namespace starrocks

--- a/be/src/udf/java/java_udf.h
+++ b/be/src/udf/java/java_udf.h
@@ -17,25 +17,14 @@
 #include <unordered_map>
 #include <utility>
 
-#include "base/string/slice.h"
 #include "common/status.h"
 #include "common/statusor.h"
 #include "exprs/function_context.h"
 #include "jni.h"
-#include "runtime/java/java_global_ref.h"
 #include "runtime/java/jvm_class.h"
+#include "runtime/java/jvm_helper.h"
 #include "types/logical_type.h"
 #include "udf/java/type_traits.h"
-
-#define DEFINE_JAVA_PRIM_TYPE(TYPE) \
-    jclass _class_##TYPE;           \
-    jmethodID _value_of_##TYPE;     \
-    jmethodID _val_##TYPE;
-
-#define DECLARE_NEW_BOX(PRIM_CLAZZ, TYPE, CLAZZ) \
-    jobject new##CLAZZ(TYPE value);              \
-    TYPE val##TYPE(jobject obj);                 \
-    jclass TYPE##_class() { return _class_##PRIM_CLAZZ; }
 
 namespace starrocks {
 class DirectByteBuffer;
@@ -45,17 +34,6 @@ class JavaUdfClassLoader;
 class JavaUdfClassAnalyzer;
 struct JavaUdfMethodDescriptor;
 
-struct ListMeta {
-    // List class
-    JVMClass* list_class;
-    JVMClass* array_list_class;
-
-    // List method
-    jmethodID list_get;
-    jmethodID list_size;
-    jmethodID list_add;
-};
-
 struct MapMeta {
     JVMClass* map_class;
     JVMClass* immutable_map_class;
@@ -63,29 +41,13 @@ struct MapMeta {
     StatusOr<jobject> newLocalInstance(jobject keys, jobject values) const;
 };
 
-// Restrictions on use:
-// can only be used in pthread, not in bthread
-// thread local helper
+// StarRocks UDF-specific JNI helper. Generic JDK/JNI utilities and the thread-local
+// JNIEnv live in JVMHelper; this class caches only UDF helper classes and methods.
 class JVMFunctionHelper {
 public:
     static JVMFunctionHelper& getInstance();
-    static std::pair<JNIEnv*, JVMFunctionHelper&> getInstanceWithEnv();
     JVMFunctionHelper(const JVMFunctionHelper&) = delete;
-    // get env
-    JNIEnv* getEnv() { return _env; }
-    // Arrays.toString()
-    std::string array_to_string(jobject object);
-    // Object::toString()
-    bool equals(jobject obj1, jobject obj2);
-    std::string to_string(jobject obj);
-    std::string to_cxx_string(jstring str);
-    std::string dumpExceptionString(jthrowable throwable);
-    jmethodID getToStringMethod(jclass clazz);
-    StatusOr<jstring> to_jstring(const std::string& str);
-    jmethodID getMethod(jclass clazz, const std::string& method, const std::string& sig);
-    jmethodID getStaticMethod(jclass clazz, const std::string& method, const std::string& sig);
-    // create a object array
-    jobject create_array(int sz);
+
     // convert column data to Java Object Array
     jobject create_boxed_array(int type, int num_rows, bool nullable, DirectByteBuffer* buffs, int sz);
     // Convert a DECIMAL column to a BigDecimal[] Java array. `type` is the LogicalType
@@ -138,12 +100,12 @@ public:
 
     template <class... Args>
     StatusOr<jobject> invoke_static_method(jmethodID method, Args&&... args) {
-        jobject res = _env->CallStaticObjectMethod(_udf_helper_class, method, args...);
+        auto* env = JVMHelper::getInstance().getEnv();
+        jobject res = env->CallStaticObjectMethod(_udf_helper_class, method, args...);
         RETURN_IF_ERROR(_check_exception_status());
         return res;
     }
-    // create object array with the same elements
-    jobject create_object_array(jobject o, int num_rows);
+
     jobject batch_create_bytebuf(unsigned char* ptr, const uint32_t* offset, int begin, int end);
 
     // batch update single
@@ -201,36 +163,10 @@ public:
     // convert handle list to jobject array (Object[])
     jobject convert_handles_to_jobjects(FunctionContext* ctx, jobject state_ids);
 
-    DECLARE_NEW_BOX(boolean, uint8_t, Boolean)
-    DECLARE_NEW_BOX(byte, int8_t, Byte)
-    DECLARE_NEW_BOX(short, int16_t, Short)
-    DECLARE_NEW_BOX(int, int32_t, Integer)
-    DECLARE_NEW_BOX(long, int64_t, Long)
-    DECLARE_NEW_BOX(float, float, Float)
-    DECLARE_NEW_BOX(double, double, Double)
-
-    const ListMeta& list_meta() const { return _list_meta; }
     const MapMeta& map_meta() const { return _map_meta; }
 
     StatusOr<jobject> extract_key_list(jobject map);
     StatusOr<jobject> extract_val_list(jobject map);
-
-    jobject newString(const char* data, size_t size);
-
-    // Construct a new java.math.BigDecimal from its string representation.
-    // Returns a local ref (nullptr on failure, error pushed via JNI exception).
-    jobject newBigDecimal(const std::string& s);
-
-    // Fast path: build a BigDecimal via BigDecimal.valueOf(unscaledVal, scale).
-    // Avoids the string-parsing cost used by the (String) constructor and is suitable
-    // for DECIMAL32 / DECIMAL64 whose unscaled value fits in int64_t.
-    jobject newBigDecimal(int64_t unscaled, int scale);
-
-    Slice sliceVal(jstring jstr, std::string* buffer);
-    jclass string_clazz() { return _string_class; }
-    jclass big_decimal_class() { return _big_decimal_class; }
-    jclass local_date_class() { return _local_date_class; }
-    jclass local_datetime_class() { return _local_datetime_class; }
 
     // Box/unbox a StarRocks DateValue (int32 Julian day) as a java.time.LocalDate.
     // Round-trips StarRocks's internal Julian-day encoding.
@@ -241,61 +177,25 @@ public:
     // as a java.time.LocalDateTime.
     jobject newLocalDateTime(int64_t packed_timestamp);
     int64_t valLocalDateTime(jobject obj);
-    // replace '.' as '/'
-    // eg: java.lang.Integer -> java/lang/Integer
-    static std::string to_jni_class_name(const std::string& name);
 
     // reset Buffer set read/write position to zero
     void clear(DirectByteBuffer* buffer, FunctionContext* ctx);
-
-    jclass object_class() { return _object_class; }
 
     JVMClass& function_state_clazz();
 
 private:
     JVMFunctionHelper() { _init(); };
     void _init();
-    // pack input array to java object array
-    jobjectArray _build_object_array(jclass clazz, jobject* arr, int sz);
-
     Status _check_exception_status();
 
 private:
-    inline static thread_local JNIEnv* _env;
-
-    DEFINE_JAVA_PRIM_TYPE(boolean);
-    DEFINE_JAVA_PRIM_TYPE(byte);
-    DEFINE_JAVA_PRIM_TYPE(short);
-    DEFINE_JAVA_PRIM_TYPE(int);
-    DEFINE_JAVA_PRIM_TYPE(long);
-    DEFINE_JAVA_PRIM_TYPE(float);
-    DEFINE_JAVA_PRIM_TYPE(double);
-
-    jclass _object_class;
-    jclass _object_array_class;
-    jclass _string_class;
-    jclass _jarrays_class;
-    jclass _exception_util_class;
-    jclass _big_decimal_class;
-    jclass _local_date_class;
-    jclass _local_datetime_class;
-
-    jmethodID _string_construct_with_bytes;
-    jmethodID _big_decimal_ctor_string;
-    jmethodID _big_decimal_value_of_ll;
-    // java.time.LocalDate.ofEpochDay(long) / java.time.LocalDate.toEpochDay()
-    jmethodID _local_date_of_epoch_day;
-    jmethodID _local_date_to_epoch_day;
     // UDFHelper.localDateTimeFromPackedTimestamp(long) / packedTimestampFromLocalDateTime(LocalDateTime)
     jmethodID _local_datetime_from_packed;
     jmethodID _local_datetime_to_packed;
 
-    ListMeta _list_meta;
     MapMeta _map_meta;
     jmethodID _extract_keys_from_map;
     jmethodID _extract_values_from_map;
-
-    jobject _utf8_charsets;
 
     jclass _udf_helper_class;
     jclass _udf_type_desc_class;
@@ -318,111 +218,18 @@ private:
     jmethodID _batch_call_no_args;
     jmethodID _int_batch_call;
     jmethodID _get_boxed_result;
-    jclass _direct_buffer_class;
-    jmethodID _direct_buffer_clear;
 
     JVMClass* _function_states_clazz = nullptr;
 };
 
-// local object reference guard.
-// The objects inside are automatically call DeleteLocalRef in the life object.
-#define LOCAL_REF_GUARD(lref)                                                \
-    DeferOp VARNAME_LINENUM(guard)([&lref]() {                               \
-        if (lref) {                                                          \
-            JVMFunctionHelper::getInstance().getEnv()->DeleteLocalRef(lref); \
-            lref = nullptr;                                                  \
-        }                                                                    \
-    })
-
-#define LOCAL_REF_GUARD_ENV(env, lref)              \
-    DeferOp VARNAME_LINENUM(guard)([&lref, env]() { \
-        if (lref) {                                 \
-            env->DeleteLocalRef(lref);              \
-            lref = nullptr;                         \
-        }                                           \
-    })
-
 // check JNI Exception and set error in FunctionContext
-#define CHECK_UDF_CALL_EXCEPTION(env, ctx)                                         \
-    if (auto e = env->ExceptionOccurred()) {                                       \
-        LOCAL_REF_GUARD(e);                                                        \
-        std::string msg = JVMFunctionHelper::getInstance().dumpExceptionString(e); \
-        LOG(WARNING) << "Exception: " << msg;                                      \
-        ctx->set_error(msg.c_str());                                               \
-        env->ExceptionClear();                                                     \
+#define CHECK_UDF_CALL_EXCEPTION(env, ctx)                                 \
+    if (auto e = env->ExceptionOccurred()) {                               \
+        LOCAL_REF_GUARD(e);                                                \
+        std::string msg = JVMHelper::getInstance().dumpExceptionString(e); \
+        LOG(WARNING) << "Exception: " << msg;                              \
+        ctx->set_error(msg.c_str());                                       \
+        env->ExceptionClear();                                             \
     }
-
-#define RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, prefix)                     \
-    if (auto e = env->ExceptionOccurred()) {                                       \
-        LOCAL_REF_GUARD(e);                                                        \
-        std::string err = JVMFunctionHelper::getInstance().dumpExceptionString(e); \
-        env->ExceptionClear();                                                     \
-        return Status::InternalError(fmt::format("{}, {}", prefix, err));          \
-    }
-
-#define RETURN_ERROR_IF_JNI_EXCEPTION(env) RETURN_ERROR_IF_JNI_EXCEPTION_WITH_PREFIX(env, "JNI Exception")
-
-#define RETURN_IF_JNI_EXCEPTION(env, errmsg, ret)                                                                   \
-    if (jthrowable jthr = env->ExceptionOccurred()) {                                                               \
-        LOCAL_REF_GUARD(jthr);                                                                                      \
-        std::string msg = fmt::format("{},{}", errmsg, JVMFunctionHelper::getInstance().dumpExceptionString(jthr)); \
-        LOG(WARNING) << msg;                                                                                        \
-        env->ExceptionClear();                                                                                      \
-        return ret;                                                                                                 \
-    }
-
-// Used for UDAF serialization and deserialization,
-// providing a C++ memory space for Java to access.
-// DirectByteBuffer does not hold ownership of this memory space
-// Handle will be freed during destructuring,
-// but no operations will be done on this memory space
-class DirectByteBuffer {
-public:
-    static constexpr const char* JNI_CLASS_NAME = "java/nio/ByteBuffer";
-
-    DirectByteBuffer(void* data, int capacity);
-    ~DirectByteBuffer();
-
-    DirectByteBuffer(const DirectByteBuffer&) = delete;
-    DirectByteBuffer& operator=(const DirectByteBuffer& other) = delete;
-
-    DirectByteBuffer(DirectByteBuffer&& other) noexcept {
-        _handle = other._handle;
-        _data = other._data;
-        _capacity = other._capacity;
-
-        other._handle = nullptr;
-        other._data = nullptr;
-        other._capacity = 0;
-    }
-
-    DirectByteBuffer& operator=(DirectByteBuffer&& other) noexcept {
-        DirectByteBuffer tmp(std::move(other));
-        std::swap(this->_handle, tmp._handle);
-        std::swap(this->_data, tmp._data);
-        std::swap(this->_capacity, tmp._capacity);
-        return *this;
-    }
-
-    jobject handle() { return _handle; }
-    void* data() { return _data; }
-    int capacity() { return _capacity; }
-
-private:
-    jobject _handle;
-    void* _data;
-    int _capacity;
-};
-
-class JavaListStub {
-public:
-    JavaListStub(jobject list) : _list(list) {}
-    Status add(jobject element);
-    StatusOr<jobject> get(int index);
-    StatusOr<size_t> size();
-
-private:
-    jobject _list;
-};
 
 } // namespace starrocks

--- a/be/src/udf/java/java_udf_context.cpp
+++ b/be/src/udf/java/java_udf_context.cpp
@@ -46,7 +46,7 @@ void clear_java_udaf_states(FunctionContext* ctx) {
         return;
     }
 
-    auto env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     udaf_ctx->states->clear(ctx, env);
 }
 
@@ -73,7 +73,7 @@ UDAFStateList::UDAFStateList(JavaGlobalRef&& handle, JavaGlobalRef&& get, JavaGl
           _add_method(std::move(add)),
           _remove_method(std::move(remove)),
           _clear_method(std::move(clear)) {
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     _get_method_id = env->FromReflectedMethod(_get_method.handle());
     _batch_get_method_id = env->FromReflectedMethod(_batch_get_method.handle());
     _add_method_id = env->FromReflectedMethod(_add_method.handle());
@@ -114,7 +114,7 @@ JavaUDAFSharedContext::~JavaUDAFSharedContext() = default;
 JavaUDAFUniqueContext::~JavaUDAFUniqueContext() = default;
 
 int UDAFFunction::create() {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     jmethodID create = _ctx->ctx->create->get_method_id();
     auto obj = env->CallObjectMethod(_udaf_handle, create);
     LOCAL_REF_GUARD(obj);
@@ -123,7 +123,8 @@ int UDAFFunction::create() {
 }
 
 void UDAFFunction::destroy(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID destory = _ctx->ctx->destory->get_method_id();
@@ -135,7 +136,7 @@ void UDAFFunction::destroy(int state) {
 
 jvalue UDAFFunction::finalize(int state) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID finalize = _ctx->ctx->finalize->get_method_id();
@@ -153,7 +154,7 @@ void AggBatchCallStub::batch_update_single(int num_rows, jobject state, jobject*
     for (int i = 0; i < cols; ++i) {
         jni_inputs[3 + i].l = input[i];
     }
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     env->CallStaticVoidMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()), jni_inputs);
     CHECK_UDF_CALL_EXCEPTION(env, _ctx);
 }
@@ -165,7 +166,7 @@ StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input
     for (int i = 0; i < cols; ++i) {
         jni_inputs[2 + i].l = input[i];
     }
-    auto* env = JVMFunctionHelper::getInstance().getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     auto res = env->CallStaticObjectMethodA(_stub_clazz.clazz(), env->FromReflectedMethod(_stub_method.handle()),
                                             jni_inputs);
     RETURN_ERROR_IF_JNI_EXCEPTION(env);
@@ -173,14 +174,15 @@ StatusOr<jobject> BatchEvaluateStub::batch_evaluate(int num_rows, jobject* input
 }
 
 void UDAFFunction::update(jvalue* val) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     jmethodID update = _ctx->ctx->update->get_method_id();
     env->CallVoidMethodA(_udaf_handle, update, val);
     CHECK_UDF_CALL_EXCEPTION(env, _function_context);
 }
 
 void UDAFFunction::merge(int state, jobject buffer) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID merge = _ctx->ctx->merge->get_method_id();
@@ -189,7 +191,8 @@ void UDAFFunction::merge(int state, jobject buffer) {
 }
 
 void UDAFFunction::serialize(int state, jobject buffer) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID serialize = _ctx->ctx->serialize->get_method_id();
@@ -198,7 +201,8 @@ void UDAFFunction::serialize(int state, jobject buffer) {
 }
 
 int UDAFFunction::serialize_size(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID serialize_size = _ctx->ctx->serialize_size->get_method_id();
@@ -208,7 +212,8 @@ int UDAFFunction::serialize_size(int state) {
 }
 
 void UDAFFunction::reset(int state) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
     jmethodID reset = _ctx->ctx->reset->get_method_id();
@@ -218,7 +223,8 @@ void UDAFFunction::reset(int state) {
 
 jobject UDAFFunction::window_update_batch(int state, int peer_group_start, int peer_group_end, int frame_start,
                                           int frame_end, int col_sz, jobject* cols) {
-    auto [env, helper] = JVMFunctionHelper::getInstanceWithEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
+    auto& helper = JVMFunctionHelper::getInstance();
     auto obj = helper.convert_handle_to_jobject(_function_context, state);
     LOCAL_REF_GUARD(obj);
 

--- a/be/src/udf/java/java_udf_reflection.cpp
+++ b/be/src/udf/java/java_udf_reflection.cpp
@@ -29,12 +29,12 @@ namespace {
 constexpr const char* CLASS_LOADER_NAME = "com.starrocks.udf.UDFClassLoader";
 constexpr const char* CLASS_ANALYZER_NAME = "com.starrocks.udf.UDFClassAnalyzer";
 
-#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                              \
-    if (auto e = env->ExceptionOccurred()) {                                \
-        LOCAL_REF_GUARD(e);                                                 \
-        auto msg = JVMFunctionHelper::getInstance().dumpExceptionString(e); \
-        env->ExceptionClear();                                              \
-        return Status::InternalError(fmt::format(errmsg, msg));             \
+#define RETURN_ERROR_IF_EXCEPTION(env, errmsg)                      \
+    if (auto e = env->ExceptionOccurred()) {                        \
+        LOCAL_REF_GUARD(e);                                         \
+        auto msg = JVMHelper::getInstance().dumpExceptionString(e); \
+        env->ExceptionClear();                                      \
+        return Status::InternalError(fmt::format(errmsg, msg));     \
     }
 
 } // namespace
@@ -45,11 +45,11 @@ JavaUdfClassLoader::~JavaUdfClassLoader() {
 }
 
 Status JavaUdfClassLoader::init() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
     if (env == nullptr) {
         return Status::InternalError("Init JNIEnv fail");
     }
-    std::string name = JVMFunctionHelper::to_jni_class_name(CLASS_LOADER_NAME);
+    std::string name = JVMHelper::to_jni_class_name(CLASS_LOADER_NAME);
     jclass clazz = env->FindClass(name.c_str());
     LOCAL_REF_GUARD(clazz);
 
@@ -94,14 +94,14 @@ Status JavaUdfClassLoader::init() {
 }
 
 StatusOr<JVMClass> JavaUdfClassLoader::getClass(const std::string& className) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    auto& jvm = JVMHelper::getInstance();
+    JNIEnv* env = jvm.getEnv();
     CHECK(env != nullptr) << "couldn't got a JNIEnv";
 
     // class Name java.lang.Object -> java/lang/Object
-    std::string jni_class_name = JVMFunctionHelper::to_jni_class_name(className);
+    std::string jni_class_name = JVMHelper::to_jni_class_name(className);
     // invoke class loader
-    ASSIGN_OR_RETURN(jstring jstr_name, helper.to_jstring(jni_class_name));
+    ASSIGN_OR_RETURN(jstring jstr_name, jvm.to_jstring(jni_class_name));
     LOCAL_REF_GUARD(jstr_name);
 
     auto loaded_clazz = env->CallObjectMethod(_handle.handle(), _get_class, jstr_name);
@@ -118,11 +118,11 @@ StatusOr<JVMClass> JavaUdfClassLoader::getClass(const std::string& className) {
 
 StatusOr<JVMClass> JavaUdfClassLoader::genCallStub(const std::string& stubClassName, jclass clazz, jobject method,
                                                    int type, int numActualVarArgs) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    auto& jvm = JVMHelper::getInstance();
+    JNIEnv* env = jvm.getEnv();
 
-    std::string jni_class_name = JVMFunctionHelper::to_jni_class_name(stubClassName);
-    ASSIGN_OR_RETURN(jstring jstr_name, helper.to_jstring(jni_class_name));
+    std::string jni_class_name = JVMHelper::to_jni_class_name(stubClassName);
+    ASSIGN_OR_RETURN(jstring jstr_name, jvm.to_jstring(jni_class_name));
     LOCAL_REF_GUARD(jstr_name);
 
     // generate call stub; pass numActualVarArgs for varargs methods
@@ -136,17 +136,17 @@ StatusOr<JVMClass> JavaUdfClassLoader::genCallStub(const std::string& stubClassN
 }
 
 jmethodID JavaUdfMethodDescriptor::get_method_id() const {
-    return JVMFunctionHelper::getInstance().getEnv()->FromReflectedMethod(method.handle());
+    return JVMHelper::getInstance().getEnv()->FromReflectedMethod(method.handle());
 }
 
 Status JavaUdfClassAnalyzer::has_method(jclass clazz, const std::string& method, bool* has) {
     DCHECK(clazz != nullptr);
     DCHECK(has != nullptr);
 
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = getJNIEnv();
+    auto& jvm = JVMHelper::getInstance();
+    JNIEnv* env = jvm.getEnv();
 
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    std::string anlyzer_clazz_name = JVMHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
 
@@ -160,7 +160,7 @@ Status JavaUdfClassAnalyzer::has_method(jclass clazz, const std::string& method,
         return Status::InternalError("couldn't found hasMethod method");
     }
 
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, jvm.to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     *has = env->CallStaticBooleanMethod(class_analyzer, hasMethod, method_name, (jobject)clazz);
@@ -189,9 +189,9 @@ void JavaUdfClassAnalyzer::strip_jni_generic_types(std::string* sign) {
 Status JavaUdfClassAnalyzer::get_signature(jclass clazz, const std::string& method, std::string* sign) {
     DCHECK(clazz != nullptr);
     DCHECK(sign != nullptr);
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    auto& jvm = JVMHelper::getInstance();
+    JNIEnv* env = jvm.getEnv();
+    std::string anlyzer_clazz_name = JVMHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
 
@@ -204,7 +204,7 @@ Status JavaUdfClassAnalyzer::get_signature(jclass clazz, const std::string& meth
         return Status::InternalError("couldn't found getSignature method");
     }
 
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, jvm.to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     jobject result_sign = env->CallStaticObjectMethod(class_analyzer, getSign, method_name, (jobject)clazz);
@@ -215,7 +215,7 @@ Status JavaUdfClassAnalyzer::get_signature(jclass clazz, const std::string& meth
     if (result_sign == nullptr) {
         return Status::InternalError(fmt::format("couldn't found method:{}", method));
     }
-    *sign = helper.to_string(result_sign);
+    *sign = jvm.to_string(result_sign);
     // Strip generic type parameters from signature to produce standard JNI method descriptor.
     // Java's getGenericParameterTypes() may produce signatures with generic info that:
     // 1. JNI GetMethodID cannot match against the erased method descriptor, returning NULL.
@@ -228,10 +228,10 @@ Status JavaUdfClassAnalyzer::get_signature(jclass clazz, const std::string& meth
 }
 
 StatusOr<jobject> JavaUdfClassAnalyzer::get_method_object(jclass clazz, const std::string& method) {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    auto& jvm = JVMHelper::getInstance();
+    JNIEnv* env = jvm.getEnv();
 
-    std::string anlyzer_clazz_name = JVMFunctionHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
+    std::string anlyzer_clazz_name = JVMHelper::to_jni_class_name(CLASS_ANALYZER_NAME);
     jclass class_analyzer = env->FindClass(anlyzer_clazz_name.c_str());
     LOCAL_REF_GUARD(class_analyzer);
     DCHECK(class_analyzer);
@@ -239,7 +239,7 @@ StatusOr<jobject> JavaUdfClassAnalyzer::get_method_object(jclass clazz, const st
     jmethodID getMethodObject = env->GetStaticMethodID(
             class_analyzer, "getMethodObject", "(Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/reflect/Method;");
     DCHECK(getMethodObject);
-    ASSIGN_OR_RETURN(jstring method_name, helper.to_jstring(method.c_str()));
+    ASSIGN_OR_RETURN(jstring method_name, jvm.to_jstring(method.c_str()));
     LOCAL_REF_GUARD(method_name);
 
     jobject method_object = env->CallStaticObjectMethod(class_analyzer, getMethodObject, method_name, (jobject)clazz);

--- a/be/src/udf/java/jvm_metrics.cpp
+++ b/be/src/udf/java/jvm_metrics.cpp
@@ -23,13 +23,13 @@
 #include "runtime/java/java_env.h"
 #include "udf/java/java_udf.h"
 
-#define CHECK_JNI_EXCEPTION(env, message)                                                          \
-    if (jthrowable thr = env->ExceptionOccurred(); thr) {                                          \
-        std::string jni_error_message = JVMFunctionHelper::getInstance().dumpExceptionString(thr); \
-        env->ExceptionDescribe();                                                                  \
-        env->ExceptionClear();                                                                     \
-        env->DeleteLocalRef(thr);                                                                  \
-        return Status::InternalError(fmt::format("{}, error: {}", message, jni_error_message));    \
+#define CHECK_JNI_EXCEPTION(env, message)                                                       \
+    if (jthrowable thr = env->ExceptionOccurred(); thr) {                                       \
+        std::string jni_error_message = JVMHelper::getInstance().dumpExceptionString(thr);      \
+        env->ExceptionDescribe();                                                               \
+        env->ExceptionClear();                                                                  \
+        env->DeleteLocalRef(thr);                                                               \
+        return Status::InternalError(fmt::format("{}, error: {}", message, jni_error_message)); \
     }
 
 namespace starrocks {
@@ -49,7 +49,7 @@ Status JVMMetrics::init() {
         return Status::InternalError("get JNIEnv failed");
     }
 
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jclass management_factory_cls = env->FindClass("java/lang/management/ManagementFactory");
     CHECK_JNI_EXCEPTION(env, "find class ManagementFactory failed")
@@ -188,7 +188,7 @@ Status JVMMetrics::update() {
 }
 
 StatusOr<MemoryUsage> JVMMetrics::get_heap_memory_usage() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject memory_usage = env->CallObjectMethod(_memory_mxbean_obj.handle(), _get_heap_memory_usage);
     CHECK_JNI_EXCEPTION(env, "get heap memory usage failed")
@@ -204,7 +204,7 @@ StatusOr<MemoryUsage> JVMMetrics::get_heap_memory_usage() {
 }
 
 StatusOr<MemoryUsage> JVMMetrics::get_non_heap_memory_usage() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject memory_usage = env->CallObjectMethod(_memory_mxbean_obj.handle(), _get_non_heap_memory_usage);
     CHECK_JNI_EXCEPTION(env, "get non heap memory usage failed")
@@ -220,7 +220,7 @@ StatusOr<MemoryUsage> JVMMetrics::get_non_heap_memory_usage() {
 }
 
 StatusOr<std::vector<MemoryPool>> JVMMetrics::get_memory_pools() {
-    JNIEnv* env = JVMFunctionHelper::getInstance().getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject memory_pools = env->CallStaticObjectMethod(_management_factory_cls->clazz(), _get_memory_pool_mxbeans);
     CHECK_JNI_EXCEPTION(env, "get memory pool mxbeans failed")
@@ -238,7 +238,7 @@ StatusOr<std::vector<MemoryPool>> JVMMetrics::get_memory_pools() {
         jstring name = (jstring)env->CallObjectMethod(memory_pool, _get_name);
         CHECK_JNI_EXCEPTION(env, "get memory pool name failed")
         LOCAL_REF_GUARD_ENV(env, name);
-        std::string name_str = JVMFunctionHelper::getInstance().to_cxx_string(name);
+        std::string name_str = JVMHelper::getInstance().to_cxx_string(name);
 
         jobject usage = env->CallObjectMethod(memory_pool, _get_usage);
         CHECK_JNI_EXCEPTION(env, "get memory pool usage failed")

--- a/be/test/exec/hdfs_scanner/jni_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/jni_scanner_test.cpp
@@ -16,11 +16,16 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdlib>
+#include <string>
+
 #include "common/config_exec_fwd.h"
 #include "common/util/thrift_util.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors_ext.h"
+#include "runtime/java/java_env.h"
 #include "runtime/runtime_state.h"
+#include "udf/java/java_udf.h"
 
 namespace starrocks {
 
@@ -427,6 +432,51 @@ TEST_F(JniScannerTest, test_close_without_jni_init) {
 
     // If we reach here, the test passed (no crash occurred)
     ASSERT_TRUE(true);
+}
+
+TEST_F(JniScannerTest, test_jvm_function_helper_registers_native_method_helper) {
+    if (std::getenv("JAVA_HOME") == nullptr) {
+        GTEST_SKIP() << "JAVA_HOME is not set";
+    }
+
+    JNIEnv* env = getJNIEnv();
+    if (env == nullptr) {
+        GTEST_SKIP() << "JVM is unavailable";
+    }
+
+    JVMFunctionHelper::getInstance();
+
+    auto take_exception_message = [&]() {
+        jthrowable thr = env->ExceptionOccurred();
+        if (thr == nullptr) {
+            return std::string();
+        }
+        std::string message = JVMHelper::getInstance().dumpExceptionString(thr);
+        env->ExceptionClear();
+        env->DeleteLocalRef(thr);
+        return message;
+    };
+
+    jclass native_method_helper = env->FindClass("com/starrocks/utils/NativeMethodHelper");
+    ASSERT_NE(nullptr, native_method_helper) << take_exception_message();
+
+    jmethodID malloc_method = env->GetStaticMethodID(native_method_helper, "memoryTrackerMalloc", "(J)J");
+    ASSERT_NE(nullptr, malloc_method) << take_exception_message();
+    jmethodID free_method = env->GetStaticMethodID(native_method_helper, "memoryTrackerFree", "(J)V");
+    ASSERT_NE(nullptr, free_method) << take_exception_message();
+
+    jlong address = env->CallStaticLongMethod(native_method_helper, malloc_method, static_cast<jlong>(8));
+    if (std::string message = take_exception_message(); !message.empty()) {
+        FAIL() << message;
+    }
+    ASSERT_NE(0, address);
+
+    env->CallStaticVoidMethod(native_method_helper, free_method, address);
+    if (std::string message = take_exception_message(); !message.empty()) {
+        FAIL() << message;
+    }
+
+    env->DeleteLocalRef(native_method_helper);
 }
 
 } // namespace starrocks

--- a/be/test/runtime/CMakeLists.txt
+++ b/be/test/runtime/CMakeLists.txt
@@ -32,6 +32,7 @@ set(RUNTIME_TEST_FILES
     # this before serde_core_test, whose HLL tests exercise that allocator.
     runtime_env_test.cpp
     java_env_test.cpp
+    jvm_helper_test.cpp
     runtime_state_core_test.cpp
     runtime_filter_core_test.cpp
     serde_core_test.cpp

--- a/be/test/runtime/jvm_helper_test.cpp
+++ b/be/test/runtime/jvm_helper_test.cpp
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/java/jvm_helper.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <string>
+
+#include "base/testutil/assert.h"
+#include "runtime/java/java_env.h"
+
+namespace starrocks {
+namespace {
+
+class JVMHelperTest : public testing::Test {
+protected:
+    void SetUp() override {
+        if (std::getenv("JAVA_HOME") == nullptr) {
+            GTEST_SKIP() << "JAVA_HOME is not set";
+        }
+
+        _env = getJNIEnv();
+        if (_env == nullptr) {
+            GTEST_SKIP() << "JVM is unavailable";
+        }
+    }
+
+    JNIEnv* env() const { return _env; }
+
+private:
+    JNIEnv* _env = nullptr;
+};
+
+} // namespace
+
+TEST_F(JVMHelperTest, GetInstanceInitializesThreadLocalEnv) {
+    auto [helper_env, helper] = JVMHelper::getInstanceWithEnv();
+    ASSERT_NE(helper_env, nullptr);
+    ASSERT_EQ(helper_env, helper.getEnv());
+    ASSERT_EQ(helper_env, getJNIEnv());
+}
+
+TEST_F(JVMHelperTest, ConvertsStringAndObjectArrays) {
+    auto& helper = JVMHelper::getInstance();
+    auto* env = this->env();
+
+    ASSIGN_OR_ASSERT_FAIL(jstring first, helper.to_jstring("alpha"));
+    LOCAL_REF_GUARD_ENV(env, first);
+    ASSIGN_OR_ASSERT_FAIL(jstring second, helper.to_jstring("beta"));
+    LOCAL_REF_GUARD_ENV(env, second);
+
+    ASSERT_EQ("alpha", helper.to_cxx_string(first));
+
+    jobject elements[] = {first, second};
+    jobjectArray array = helper.build_object_array(helper.object_class(), elements, 2);
+    ASSERT_NE(array, nullptr);
+    LOCAL_REF_GUARD_ENV(env, array);
+    ASSERT_EQ("[alpha, beta]", helper.array_to_string(array));
+}
+
+TEST_F(JVMHelperTest, BoxesPrimitiveAndBigDecimalValues) {
+    auto& helper = JVMHelper::getInstance();
+    auto* env = this->env();
+
+    jobject integer = helper.newInteger(123);
+    ASSERT_NE(integer, nullptr);
+    LOCAL_REF_GUARD_ENV(env, integer);
+    ASSERT_EQ(123, helper.valint32_t(integer));
+
+    jobject big_decimal = helper.newBigDecimal(12345, 2);
+    ASSERT_NE(big_decimal, nullptr);
+    LOCAL_REF_GUARD_ENV(env, big_decimal);
+    ASSERT_EQ("123.45", helper.to_string(big_decimal));
+}
+
+TEST_F(JVMHelperTest, ConvertsLocalDateEpochDay) {
+    auto& helper = JVMHelper::getInstance();
+    auto* env = this->env();
+
+    jobject local_date = helper.newLocalDateFromEpochDay(0);
+    ASSERT_NE(local_date, nullptr);
+    LOCAL_REF_GUARD_ENV(env, local_date);
+    ASSERT_EQ(0, helper.valLocalDateToEpochDay(local_date));
+}
+
+TEST_F(JVMHelperTest, UsesJavaListStub) {
+    auto& helper = JVMHelper::getInstance();
+    auto* env = this->env();
+
+    ASSIGN_OR_ASSERT_FAIL(jobject list, helper.list_meta().array_list_class->newLocalInstance());
+    LOCAL_REF_GUARD_ENV(env, list);
+
+    ASSIGN_OR_ASSERT_FAIL(jstring first, helper.to_jstring("x"));
+    LOCAL_REF_GUARD_ENV(env, first);
+    ASSIGN_OR_ASSERT_FAIL(jstring second, helper.to_jstring("y"));
+    LOCAL_REF_GUARD_ENV(env, second);
+
+    JavaListStub stub(list);
+    ASSERT_OK(stub.add(first));
+    ASSERT_OK(stub.add(second));
+    ASSIGN_OR_ASSERT_FAIL(auto size, stub.size());
+    ASSERT_EQ(2, size);
+
+    ASSIGN_OR_ASSERT_FAIL(jobject value, stub.get(1));
+    LOCAL_REF_GUARD_ENV(env, value);
+    ASSERT_EQ("y", helper.to_cxx_string(static_cast<jstring>(value)));
+}
+
+TEST_F(JVMHelperTest, WrapsDirectByteBuffer) {
+    std::array<char, 4> data{'a', 'b', 'c', 'd'};
+    DirectByteBuffer buffer(data.data(), data.size());
+
+    ASSERT_NE(buffer.handle(), nullptr);
+    ASSERT_EQ(data.data(), env()->GetDirectBufferAddress(buffer.handle()));
+    ASSERT_EQ(data.size(), env()->GetDirectBufferCapacity(buffer.handle()));
+}
+
+} // namespace starrocks

--- a/be/test/udf/java/java_data_converter_test.cpp
+++ b/be/test/udf/java/java_data_converter_test.cpp
@@ -100,11 +100,11 @@ TEST_F(DataConverterTest, cast_to_jval) {
         offsets_data.emplace_back(20);
         std::string target;
         auto arr_col = ArrayColumn::create(std::move(nullable), std::move(offsets));
-        auto& instance = JVMFunctionHelper::getInstance();
+        auto& jvm = JVMHelper::getInstance();
         for (size_t i = 0; i < 3; ++i) {
             ASSIGN_OR_ASSERT_FAIL(jvalue v, cast_to_jvalue(tdesc, true, arr_col.get(), i));
             jobject obj = v.l;
-            target = target + instance.to_string(obj);
+            target = target + jvm.to_string(obj);
             LOCAL_REF_GUARD(obj);
         }
         ASSERT_EQ(target, "[0, 1][2, 3, 4, 5, 6, 7, 8, 9][10, 11, 12, 13, 14, 15, 16, 17, 18, 19]");
@@ -181,8 +181,7 @@ TEST_F(DataConverterTest, cast_to_jval) {
         ASSIGN_OR_ASSERT_FAIL(jvalue val, cast_to_jvalue(tdesc, true, map_column.get(), 0));
         jobject obj = val.l;
         LOCAL_REF_GUARD(obj);
-        auto& instance = JVMFunctionHelper::getInstance();
-        std::string result = instance.to_string(obj);
+        std::string result = JVMHelper::getInstance().to_string(obj);
         ASSERT_EQ("{0=20, 1=19}", result);
     }
 }
@@ -370,7 +369,7 @@ TEST_F(DataConverterTest, assign_jvalue_decimal_null) {
 // row is nulled and Status is OK.
 TEST_F(DataConverterTest, assign_jvalue_decimal_overflow) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
     auto narrow_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 5, 2); // narrow target
     auto wide_tdesc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, 38, 0);
 
@@ -422,7 +421,7 @@ TEST_F(DataConverterTest, assign_jvalue_decimal_overflow) {
 // is exercised.
 TEST_F(DataConverterTest, check_type_matched_decimal) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // BigDecimal -> DECIMAL is OK (also tests the four LogicalType variants).
     auto src = build_decimal_col<TYPE_DECIMAL64, int64_t>(18, 4, "1234.5678");
@@ -440,7 +439,7 @@ TEST_F(DataConverterTest, check_type_matched_decimal) {
     EXPECT_OK(check_type_matched(wide_tdesc, nullptr));
 
     // String -> DECIMAL is rejected.
-    jobject jstr = helper.newString("not-a-decimal", 13);
+    jobject jstr = JVMHelper::getInstance().newString("not-a-decimal", 13);
     LOCAL_REF_GUARD(jstr);
     auto st = check_type_matched(wide_tdesc, jstr);
     EXPECT_FALSE(st.ok());
@@ -451,7 +450,7 @@ TEST_F(DataConverterTest, check_type_matched_decimal) {
 // which is the batched UDF input path for native DECIMAL columns.
 TEST_F(DataConverterTest, convert_to_boxed_array_decimal) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     auto run = [&](LogicalType type, int precision, int scale, const ColumnPtr& col) {
         auto tdesc = TypeDescriptor::create_decimalv3_type(type, precision, scale);
@@ -686,7 +685,7 @@ TEST_F(DataConverterTest, check_type_matched_date_datetime) {
     EXPECT_FALSE(check_type_matched(dt_td, date_obj).ok());
 
     // String against DATE / DATETIME is rejected.
-    jobject jstr = helper.newString("not-a-date", 10);
+    jobject jstr = JVMHelper::getInstance().newString("not-a-date", 10);
     LOCAL_REF_GUARD(jstr);
     EXPECT_FALSE(check_type_matched(date_td, jstr).ok());
     EXPECT_FALSE(check_type_matched(dt_td, jstr).ok());
@@ -698,7 +697,7 @@ TEST_F(DataConverterTest, check_type_matched_date_datetime) {
 // must be registered against createBoxedLocalDate{,Time}Array in _method_map.
 TEST_F(DataConverterTest, convert_to_boxed_array_date_datetime) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     auto run = [&](LogicalType type, const ColumnPtr& col) {
         TypeDescriptor td(type);
@@ -735,7 +734,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_date_datetime) {
 // is false; the elements then hit the int32/int64/int128/int256 branches.
 TEST_F(DataConverterTest, convert_to_boxed_array_array_of_decimal) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     auto run = [&](LogicalType type, int precision, int scale) {
         TypeDescriptor element = TypeDescriptor::create_decimalv3_type(type, precision, scale);
@@ -768,7 +767,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_array_of_decimal) {
 // across the type spectrum used by the UDF analyzer.
 TEST_F(DataConverterTest, build_udf_type_desc_scalar_leaves) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     auto check_leaf = [&](const TypeDescriptor& td) {
         ASSIGN_OR_ASSERT_FAIL(jobject desc, build_udf_type_desc(env, td, /*formal_type=*/nullptr));
@@ -802,7 +801,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_scalar_leaves) {
 // is gated on the per-slot UdfTypeDesc being non-null.
 TEST_F(DataConverterTest, convert_to_boxed_array_with_null_descs) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // ARRAY<INT> column with one populated row.
     TypeDescriptor td = TypeDescriptor::create_array_type(TypeDescriptor(TYPE_INT));
@@ -825,7 +824,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_with_null_descs) {
 // cover the non-STRUCT constant branch alongside the STRUCT-aware routing.
 TEST_F(DataConverterTest, convert_to_boxed_array_constant_short_circuit) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     TypeDescriptor td(TYPE_INT);
     auto inner = ColumnHelper::create_column(td, false);
@@ -847,7 +846,7 @@ TEST_F(DataConverterTest, convert_to_boxed_array_constant_short_circuit) {
 // branch is not stranded uncovered.
 TEST_F(DataConverterTest, convert_to_boxed_array_all_null_short_circuit) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     TypeDescriptor td(TYPE_BIGINT);
     auto col = ColumnHelper::create_column(td, true);
@@ -908,7 +907,7 @@ TypeDescriptor make_test_struct_typedesc() {
 // the right shape.
 TEST_F(DataConverterTest, build_udf_type_desc_struct_via_reflected_method) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "structReturn", "()Lcom/starrocks/udf/UdfTestStructRecord;");
     ASSERT_NE(formal, nullptr);
@@ -951,7 +950,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_struct_via_reflected_method) {
 // child carries the formal record class.
 TEST_F(DataConverterTest, build_udf_type_desc_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "arrayOfStruct", "()Ljava/util/List;");
     ASSERT_NE(formal, nullptr);
@@ -987,7 +986,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_array_of_struct) {
 // type arguments" recursion.
 TEST_F(DataConverterTest, build_udf_type_desc_map_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "mapOfStruct", "()Ljava/util/Map;");
     ASSERT_NE(formal, nullptr);
@@ -1027,7 +1026,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_map_of_struct) {
 // keep threading the formal record class through children[0].children[0].
 TEST_F(DataConverterTest, build_udf_type_desc_array_of_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     jobject formal = reflected_return_generic_type(env, "arrayOfArrayOfStruct", "()Ljava/util/List;");
     ASSERT_NE(formal, nullptr);
@@ -1063,7 +1062,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_array_of_array_of_struct) {
 // slot to make sure type_to_raw_class's negative path returns Status::Internal.
 TEST_F(DataConverterTest, build_udf_type_desc_struct_rejects_non_class_formal) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     // null formal at a STRUCT slot → "formal Java type is null".
     TypeDescriptor td = make_test_struct_typedesc();
@@ -1078,7 +1077,7 @@ TEST_F(DataConverterTest, build_udf_type_desc_struct_rejects_non_class_formal) {
 // JNI bridge.
 TEST_F(DataConverterTest, convert_to_boxed_array_struct_input) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // Construct UdfTypeDesc for STRUCT<key INT, value VARCHAR> with
     // UdfTestStructRecord as recordClass.
@@ -1120,11 +1119,11 @@ TEST_F(DataConverterTest, convert_to_boxed_array_struct_input) {
     ASSERT_NE(value_accessor, nullptr);
     jobject key_box = env->CallObjectMethod(row0, key_accessor);
     LOCAL_REF_GUARD(key_box);
-    EXPECT_EQ(1, helper.valint32_t(key_box));
+    EXPECT_EQ(1, JVMHelper::getInstance().valint32_t(key_box));
     jstring value_jstr = (jstring)env->CallObjectMethod(row0, value_accessor);
     LOCAL_REF_GUARD(value_jstr);
     std::string buf;
-    EXPECT_EQ("hello", helper.sliceVal(value_jstr, &buf).to_string());
+    EXPECT_EQ("hello", JVMHelper::getInstance().sliceVal(value_jstr, &buf).to_string());
 
     env->DeleteLocalRef(res[0]);
 }
@@ -1155,7 +1154,7 @@ jint read_logical_type(JVMFunctionHelper& helper, JNIEnv* env, jobject desc) {
 // Skips the JNI walk over Method.getGenericParameterTypes entirely.
 TEST_F(DataConverterTest, build_method_udf_type_descs_no_struct_short_circuit) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // Any method handle works since we early-return before reading it.
     jobject method = reflected_test_support_method(
@@ -1183,7 +1182,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_no_struct_short_circuit) {
 // to avoid walking update.getGenericReturnType() which is `void`).
 TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_state_offset) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // void udafUpdateWithStruct(State state, UdfTestStructRecord record)
     jobject method = reflected_test_support_method(
@@ -1218,7 +1217,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_state_offset) {
 // desc carries logicalType=ARRAY with an element child carrying the record class.
 TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_finalize_array_of_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(env, "udafFinalizeArrayOfStruct",
                                                    "(Lcom/starrocks/udf/UdfTestSupport$State;)Ljava/util/List;");
@@ -1253,7 +1252,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udaf_finalize_array_of_str
 // the array class (Class<Record[]>).
 TEST_F(DataConverterTest, build_method_udf_type_descs_udtf_unwrap_return_array) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // UdfTestStructRecord[] udtfProcessReturnsRecordArray(UdfTestStructRecord)
     jobject method = reflected_test_support_method(
@@ -1292,7 +1291,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_udtf_unwrap_return_array) 
 // method to confirm the path is wired.
 TEST_F(DataConverterTest, build_method_udf_type_descs_struct_return_without_unwrap_fails) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",
@@ -1313,7 +1312,7 @@ TEST_F(DataConverterTest, build_method_udf_type_descs_struct_return_without_unwr
 // non-null record instance whose components match the column row.
 TEST_F(DataConverterTest, cast_to_jvalue_struct_per_row) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     // Build the per-arg UdfTypeDesc from a method shape — same path UDTF uses.
     jobject method = reflected_test_support_method(
@@ -1343,7 +1342,7 @@ TEST_F(DataConverterTest, cast_to_jvalue_struct_per_row) {
     jmethodID key_acc = env->GetMethodID(record_cls, "key", "()Ljava/lang/Integer;");
     jobject key_box = env->CallObjectMethod(v0_obj, key_acc);
     LOCAL_REF_GUARD(key_box);
-    EXPECT_EQ(42, helper.valint32_t(key_box));
+    EXPECT_EQ(42, JVMHelper::getInstance().valint32_t(key_box));
 
     // Row 1 — null. cast_to_jvalue must short-circuit to {.l = nullptr} via the
     // NullableColumn prologue, without reading the per-row record_class.
@@ -1371,7 +1370,7 @@ TEST_F(DataConverterTest, cast_to_jvalue_struct_requires_type_desc) {
 // shape and values.
 TEST_F(DataConverterTest, append_jvalue_struct_per_row_roundtrip) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",
@@ -1401,7 +1400,7 @@ TEST_F(DataConverterTest, append_jvalue_struct_per_row_roundtrip) {
 // declared record class and rejects an unrelated runtime class.
 TEST_F(DataConverterTest, check_type_matched_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    auto* env = helper.getEnv();
+    auto* env = JVMHelper::getInstance().getEnv();
 
     jobject method = reflected_test_support_method(
             env, "udtfProcessReturnsRecordArray",

--- a/be/test/udf/java/java_udf_test.cpp
+++ b/be/test/udf/java/java_udf_test.cpp
@@ -147,7 +147,7 @@ TEST_F(JavaUDFTest, local_date_helper_roundtrip) {
         ASSERT_NE(ld, nullptr);
         LOCAL_REF_GUARD(ld);
         EXPECT_EQ(v._julian, helper.valLocalDate(ld));
-        EXPECT_TRUE(_env->IsInstanceOf(ld, helper.local_date_class()));
+        EXPECT_TRUE(_env->IsInstanceOf(ld, JVMHelper::getInstance().local_date_class()));
     }
 }
 
@@ -167,7 +167,7 @@ TEST_F(JavaUDFTest, local_datetime_helper_roundtrip) {
         ASSERT_NE(ldt, nullptr);
         LOCAL_REF_GUARD(ldt);
         EXPECT_EQ(v.timestamp(), helper.valLocalDateTime(ldt));
-        EXPECT_TRUE(_env->IsInstanceOf(ldt, helper.local_datetime_class()));
+        EXPECT_TRUE(_env->IsInstanceOf(ldt, JVMHelper::getInstance().local_datetime_class()));
     }
 }
 
@@ -184,7 +184,7 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_date) {
     LOCAL_REF_GUARD(ld0);
     LOCAL_REF_GUARD(ld2);
 
-    jobjectArray arr = _env->NewObjectArray(3, helper.local_date_class(), nullptr);
+    jobjectArray arr = _env->NewObjectArray(3, JVMHelper::getInstance().local_date_class(), nullptr);
     ASSERT_NE(arr, nullptr);
     LOCAL_REF_GUARD(arr);
     _env->SetObjectArrayElement(arr, 0, ld0);
@@ -215,7 +215,7 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_datetime) {
     LOCAL_REF_GUARD(ldt0);
     LOCAL_REF_GUARD(ldt2);
 
-    jobjectArray arr = _env->NewObjectArray(3, helper.local_datetime_class(), nullptr);
+    jobjectArray arr = _env->NewObjectArray(3, JVMHelper::getInstance().local_datetime_class(), nullptr);
     ASSERT_NE(arr, nullptr);
     LOCAL_REF_GUARD(arr);
     _env->SetObjectArrayElement(arr, 0, ldt0);
@@ -240,12 +240,12 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_decimal_dispatch) {
     auto& helper = JVMFunctionHelper::getInstance();
 
     // BigDecimal[] { "12345.67", null, "0.00" } over DECIMAL64(9,2).
-    jobject bd0 = helper.newBigDecimal(static_cast<int64_t>(1234567), 2);
+    jobject bd0 = JVMHelper::getInstance().newBigDecimal(static_cast<int64_t>(1234567), 2);
     LOCAL_REF_GUARD(bd0);
-    jobject bd2 = helper.newBigDecimal(static_cast<int64_t>(0), 2);
+    jobject bd2 = JVMHelper::getInstance().newBigDecimal(static_cast<int64_t>(0), 2);
     LOCAL_REF_GUARD(bd2);
 
-    jobjectArray arr = _env->NewObjectArray(3, helper.big_decimal_class(), nullptr);
+    jobjectArray arr = _env->NewObjectArray(3, JVMHelper::getInstance().big_decimal_class(), nullptr);
     ASSERT_NE(arr, nullptr);
     LOCAL_REF_GUARD(arr);
     _env->SetObjectArrayElement(arr, 0, bd0);
@@ -275,7 +275,7 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_with_function_context) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context({td}, td));
 
     // Integer[] { 1, 2, 3 } via valueOf.
-    jclass integer_cls = helper.int32_t_class();
+    jclass integer_cls = JVMHelper::getInstance().int32_t_class();
     jmethodID value_of = _env->GetStaticMethodID(integer_cls, "valueOf", "(I)Ljava/lang/Integer;");
     ASSERT_NE(value_of, nullptr);
     jobjectArray arr = _env->NewObjectArray(3, integer_cls, nullptr);
@@ -300,7 +300,7 @@ TEST_F(JavaUDFTest, get_result_from_boxed_array_with_function_context) {
 // jfieldIDs the BE input boxer relies on.
 TEST_F(JavaUDFTest, new_udf_type_desc_scalar_leaf) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     ASSIGN_OR_ASSERT_FAIL(jobject desc,
                           helper.new_udf_type_desc(/*logicalType=*/TYPE_INT, /*children=*/nullptr,
@@ -323,7 +323,7 @@ TEST_F(JavaUDFTest, new_udf_type_desc_scalar_leaf) {
 // the cached field IDs.
 TEST_F(JavaUDFTest, new_udf_type_desc_decimal_and_struct) {
     auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
+    JNIEnv* env = JVMHelper::getInstance().getEnv();
 
     // DECIMAL64(18,4)
     {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
