### PR TITLE
[Enhancement] Elide the MERGE duplicate check when the source is provably unique

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/MergeIntoPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/MergeIntoPlanner.java
@@ -36,12 +36,18 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.MergeIntoStmt;
 import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -65,6 +71,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class MergeIntoPlanner {
 
@@ -240,7 +248,174 @@ public class MergeIntoPlanner {
         // Insert EnforceUniqueRowLocatorNode to check that each target row is matched at most once.
         // Key columns are _file and _pos, identified by SLOT ID — the BE resolves the
         // chunk columns through the chunk's slot-id map.
-        insertEnforceUniqueRowLocatorNode(execPlan, mergeTargetContext);
+        // Elide the check when source uniqueness over the ON keys already guarantees
+        // at-most-one match (see canElideEnforceUnique).
+        if (!canElideEnforceUnique(mergeIntoStmt)) {
+            insertEnforceUniqueRowLocatorNode(execPlan, mergeTargetContext);
+        }
+    }
+
+    /**
+     * MERGE requires at most one source row to match each target row. If the source
+     * relation is known to be unique on key set U, and every column in U is covered
+     * by an equality predicate between target and source in the ON clause, then any
+     * fixed target row can match at most one source row: two matching source rows
+     * would have identical U values, contradicting source uniqueness. In that case
+     * the runtime EnforceUniqueRowLocatorNode is redundant and can be safely omitted.
+     */
+    private boolean canElideEnforceUnique(MergeIntoStmt mergeIntoStmt) {
+        Set<String> sourceUniqueKeyColumns = extractSourceUniqueKeyColumns(mergeIntoStmt.getSourceRelation());
+        if (sourceUniqueKeyColumns.isEmpty()) {
+            return false;
+        }
+
+        Set<String> sourceJoinKeyColumns = collectSourceJoinKeyColumns(mergeIntoStmt);
+        return sourceJoinKeyColumns.containsAll(sourceUniqueKeyColumns);
+    }
+
+    private static Set<String> extractSourceUniqueKeyColumns(Relation sourceRelation) {
+        SelectRelation selectRelation = unwrapSelectRelation(sourceRelation);
+        if (selectRelation == null) {
+            return newCaseInsensitiveSet();
+        }
+
+        if (selectRelation.isDistinct()) {
+            return collectUnambiguousOutputNames(selectRelation.getColumnOutputNames());
+        }
+
+        List<Expr> groupBy = selectRelation.getGroupBy();
+        if (groupBy == null || groupBy.isEmpty()
+                || (selectRelation.getGroupingSetsList() != null && !selectRelation.getGroupingSetsList().isEmpty())
+                || (selectRelation.getGroupingFunctionCallExprs() != null
+                && !selectRelation.getGroupingFunctionCallExprs().isEmpty())) {
+            return newCaseInsensitiveSet();
+        }
+
+        Set<String> uniqueKeyColumns = newCaseInsensitiveSet();
+        List<Expr> outputExprs = selectRelation.getOutputExpression();
+        List<String> outputNames = selectRelation.getColumnOutputNames();
+        for (Expr groupByExpr : groupBy) {
+            String outputName = findOutputNameForExpression(groupByExpr, outputExprs, outputNames);
+            if (outputName == null || !uniqueKeyColumns.add(outputName)) {
+                return newCaseInsensitiveSet();
+            }
+        }
+        return uniqueKeyColumns;
+    }
+
+    private static SelectRelation unwrapSelectRelation(Relation relation) {
+        if (relation instanceof SubqueryRelation subqueryRelation) {
+            QueryRelation queryRelation = subqueryRelation.getQueryStatement().getQueryRelation();
+            return queryRelation instanceof SelectRelation selectRelation ? selectRelation : null;
+        }
+        return relation instanceof SelectRelation selectRelation ? selectRelation : null;
+    }
+
+    private static Set<String> collectUnambiguousOutputNames(List<String> outputNames) {
+        Set<String> uniqueNames = newCaseInsensitiveSet();
+        if (outputNames == null || outputNames.isEmpty()) {
+            return uniqueNames;
+        }
+        for (String outputName : outputNames) {
+            if (outputName == null || !uniqueNames.add(outputName)) {
+                return newCaseInsensitiveSet();
+            }
+        }
+        return uniqueNames;
+    }
+
+    private static String findOutputNameForExpression(Expr expr, List<Expr> outputExprs, List<String> outputNames) {
+        if (outputExprs == null || outputNames == null || outputExprs.size() != outputNames.size()) {
+            return null;
+        }
+
+        // Relate a GROUP BY key to an output column only when it is a plain SlotRef, matched by column
+        // name (aggregation may reassign slot ids). A non-SlotRef key (e.g. GROUP BY f(x)) is not
+        // matched: a toSql() string compare can collide for distinct exprs and wrongly elide the check.
+        // Returning null just keeps EnforceUnique (conservative and always safe).
+        if (!(expr instanceof SlotRef groupBySlot) || groupBySlot.getColumnName() == null) {
+            return null;
+        }
+        for (int i = 0; i < outputExprs.size(); i++) {
+            if (outputExprs.get(i) instanceof SlotRef outputSlot
+                    && groupBySlot.getColumnName().equalsIgnoreCase(outputSlot.getColumnName())) {
+                return outputNames.get(i);
+            }
+        }
+        return null;
+    }
+
+    private static Set<String> collectSourceJoinKeyColumns(MergeIntoStmt mergeIntoStmt) {
+        Set<String> sourceJoinKeyColumns = newCaseInsensitiveSet();
+        String sourceName = resolveSourceName(mergeIntoStmt.getSourceRelation(), mergeIntoStmt.getSourceAlias());
+        String targetName = mergeIntoStmt.getTargetAlias() == null
+                ? mergeIntoStmt.getTable().getName()
+                : mergeIntoStmt.getTargetAlias();
+        if (sourceName == null || targetName == null) {
+            return sourceJoinKeyColumns;
+        }
+        // If source and target share one identifier (e.g. a USING subquery aliased to the target's
+        // bare name), isSlotFromRelation cannot tell their slots apart, so a target-only ON key
+        // (target.k = target.k) would be miscounted as covering the source key and wrongly elide the
+        // check. Credit nothing and keep the runtime EnforceUnique check.
+        if (sourceName.equalsIgnoreCase(targetName)) {
+            return sourceJoinKeyColumns;
+        }
+
+        for (Expr conjunct : AnalyzerUtils.extractConjuncts(mergeIntoStmt.getMergeCondition())) {
+            if (!(conjunct instanceof BinaryPredicate binaryPredicate)
+                    || binaryPredicate.getOp() != BinaryType.EQ) {
+                continue;
+            }
+
+            Expr left = binaryPredicate.getChild(0);
+            Expr right = binaryPredicate.getChild(1);
+            if (left instanceof SlotRef leftSlot && right instanceof SlotRef rightSlot) {
+                addSourceJoinKeyColumn(sourceJoinKeyColumns, leftSlot, rightSlot, sourceName, targetName);
+                addSourceJoinKeyColumn(sourceJoinKeyColumns, rightSlot, leftSlot, sourceName, targetName);
+            }
+        }
+        return sourceJoinKeyColumns;
+    }
+
+    private static void addSourceJoinKeyColumn(Set<String> sourceJoinKeyColumns, SlotRef sourceSlot,
+                                               SlotRef targetSlot, String sourceName, String targetName) {
+        if (!isSlotFromRelation(sourceSlot, sourceName) || !isSlotFromRelation(targetSlot, targetName)
+                || sourceSlot.getColumnName() == null) {
+            return;
+        }
+        // Cover this ON key only when both sides are type-equivalent. The AST keeps bare SlotRefs
+        // across an implicit cast (added later on the ScalarOperator), so a VARCHAR-vs-INT key still
+        // reads as SlotRef = SlotRef here; that coercion is non-injective (distinct '1','01' match one
+        // target row), so source uniqueness over the raw column does not imply an at-most-one match.
+        if (sourceSlot.getType() == null || targetSlot.getType() == null
+                || !sourceSlot.getType().matchesType(targetSlot.getType())) {
+            return;
+        }
+        sourceJoinKeyColumns.add(sourceSlot.getColumnName());
+    }
+
+    private static String resolveSourceName(Relation sourceRelation, String sourceAlias) {
+        if (sourceAlias != null) {
+            return sourceAlias;
+        }
+        if (sourceRelation.getResolveTableName() != null) {
+            return sourceRelation.getResolveTableName().getTbl();
+        }
+        if (sourceRelation instanceof TableRelation tableRelation) {
+            return tableRelation.getName().getTbl();
+        }
+        return null;
+    }
+
+    private static boolean isSlotFromRelation(SlotRef slotRef, String relationName) {
+        return slotRef.getTblName() != null
+                && slotRef.getTblName().getTbl() != null
+                && slotRef.getTblName().getTbl().equalsIgnoreCase(relationName);
+    }
+
+    private static Set<String> newCaseInsensitiveSet() {
+        return new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeIntoPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MergeIntoPlanTest.java
@@ -100,6 +100,120 @@ public class MergeIntoPlanTest extends PlanTestBase {
 
 
     @Test
+    public void testMergeElidesEnforceUniqueWhenSourceDistinctKeysCoverOnKeys() throws Exception {
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT DISTINCT id, date FROM iceberg0.unpartitioned_db.t0_v2) AS s " +
+                "ON t.id = s.id AND t.date = s.date " +
+                "WHEN MATCHED THEN UPDATE SET data = 'updated'";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertFalse(containsEnforceUnique(execPlan),
+                "MERGE should elide ENFORCE UNIQUE when source DISTINCT keys are covered by ON keys");
+    }
+
+    @Test
+    public void testMergeKeepsEnforceUniqueWhenSourceDistinctKeysDoNotCoverOnKeys() throws Exception {
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT DISTINCT id, data FROM iceberg0.unpartitioned_db.t0_v2) AS s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN UPDATE SET data = s.data";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertTrue(containsEnforceUnique(execPlan),
+                "MERGE must keep ENFORCE UNIQUE when ON keys do not cover source DISTINCT keys");
+    }
+
+    @Test
+    public void testMergeElidesEnforceUniqueWhenSourceGroupByKeysCoverOnKeys() throws Exception {
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT id, date FROM iceberg0.unpartitioned_db.t0_v2 GROUP BY id, date) AS s " +
+                "ON t.id = s.id AND t.date = s.date " +
+                "WHEN MATCHED THEN UPDATE SET data = 'updated'";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertFalse(containsEnforceUnique(execPlan),
+                "MERGE should elide ENFORCE UNIQUE when source GROUP BY keys are covered by ON keys");
+    }
+
+    @Test
+    public void testMergeKeepsEnforceUniqueForGroupingSetsSource() throws Exception {
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT id, date FROM iceberg0.unpartitioned_db.t0_v2 " +
+                "       GROUP BY GROUPING SETS ((id, date), (id))) AS s " +
+                "ON t.id = s.id AND t.date = s.date " +
+                "WHEN MATCHED THEN UPDATE SET data = 'updated'";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertTrue(containsEnforceUnique(execPlan),
+                "MERGE must keep ENFORCE UNIQUE for grouping sets source");
+    }
+
+    @Test
+    public void testMergeKeepsEnforceUniqueWhenOnKeyTypesMismatch() throws Exception {
+        // Source DISTINCT key 'id' is STRING (aliased from data); target id is INT. The ON equality
+        // needs an implicit, non-injective cast, so distinct source values ('1', '01') can match the
+        // same target row — source uniqueness over the raw STRING does NOT imply an at-most-one match.
+        // The check must NOT be elided even though the ON key textually covers the DISTINCT key.
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT DISTINCT data AS id FROM iceberg0.unpartitioned_db.t0_v2) AS s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN UPDATE SET data = s.id";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertTrue(containsEnforceUnique(execPlan),
+                "MERGE must keep ENFORCE UNIQUE when the ON key needs an implicit (non-injective) cast");
+    }
+
+    @Test
+    public void testMergeKeepsEnforceUniqueForNonSlotRefGroupByKey() throws Exception {
+        // GROUP BY is a non-SlotRef expression (abs(id)). Even though the group-by makes the output
+        // 'id' unique, uniqueness is NOT proven via fragile SQL-text matching of the expression, so the
+        // runtime duplicate check is conservatively kept.
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
+                "USING (SELECT abs(id) AS id FROM iceberg0.unpartitioned_db.t0_v2 GROUP BY abs(id)) AS s " +
+                "ON t.id = s.id " +
+                "WHEN MATCHED THEN UPDATE SET data = 'updated'";
+        ExecPlan execPlan = getMergeExecPlan(sql);
+        assertTrue(containsEnforceUnique(execPlan),
+                "MERGE must keep ENFORCE UNIQUE when source uniqueness rests on a non-SlotRef GROUP BY key");
+    }
+
+    @Test
+    public void testMergeRejectsMergeJoinImplementationOnElidePath() {
+        // Same backend limitation as testMergeRejectsMergeJoinImplementation, but on the
+        // canElideEnforceUnique path: a DISTINCT source whose unique key set is fully covered by the
+        // ON keys lets setupIcebergMergeSink skip insertEnforceUniqueRowLocatorNode (and the dedup
+        // distribution check inside it). The MERGE_JOIN_NODE rejection must still fire, otherwise an
+        // unexecutable sort-merge join reaches the BE.
+        String prevJoinImplementationMode = connectContext.getSessionVariable().getJoinImplementationMode();
+        try {
+            connectContext.getSessionVariable().setJoinImplementationMode("merge");
+            String sql = "MERGE INTO iceberg0.partitioned_db.t1_v2 AS t " +
+                    "USING (SELECT DISTINCT id, data, date FROM iceberg0.partitioned_db.t1_v2) AS s " +
+                    "ON t.id = s.id AND t.data = s.data AND t.date = s.date " +
+                    "WHEN MATCHED THEN UPDATE SET data = s.data";
+            Exception e = assertThrows(Exception.class, () -> getMergeExecPlan(sql));
+            assertTrue(e.getMessage() != null && e.getMessage().toLowerCase().contains("unsupported join shape"),
+                    "MERGE under join_implementation_mode=merge must be rejected even when the duplicate "
+                            + "check is elided; got: " + e.getMessage());
+        } finally {
+            connectContext.getSessionVariable().setJoinImplementationMode(prevJoinImplementationMode);
+        }
+    }
+
+    @Test
+    public void testMergeKeepsEnforceUniqueWhenSourceNameCollidesWithTarget() {
+        // Source aliased to the target's bare name collides on "t0_v2", and a target-only ON
+        // (target.id = target.id) is independent of the source. canElideEnforceUnique must not
+        // miscount the target slot as a covered source key and drop the check; with the check kept,
+        // the source-independent ON is a multi-row cross join that the dedup validation rejects.
+        // (Before the fix the check was silently elided and a corrupt plan returned.)
+        String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 " +
+                "USING (SELECT DISTINCT id FROM iceberg0.unpartitioned_db.t0_v2) AS t0_v2 " +
+                "ON iceberg0.unpartitioned_db.t0_v2.id = iceberg0.unpartitioned_db.t0_v2.id " +
+                "WHEN MATCHED THEN UPDATE SET data = 'x'";
+        Exception e = assertThrows(Exception.class, () -> getMergeExecPlan(sql));
+        assertTrue(e.getMessage() != null && e.getMessage().toLowerCase().contains("unsupported join shape"),
+                "Source/target name collision must not elide the duplicate check; the source-independent "
+                        + "ON must be rejected, not silently planned. got: " + e.getMessage());
+    }
+
+    @Test
     public void testMergePlanContainsEnforceUnique() throws Exception {
         String sql = "MERGE INTO iceberg0.unpartitioned_db.t0_v2 AS t " +
                 "USING (SELECT 1 AS id, 'new' AS data, '2024-01-01' AS date) AS s " +


### PR DESCRIPTION
## Why I'm doing:

The base MERGE INTO pipeline always inserts a runtime `EnforceUniqueRowLocatorNode` to reject a target row matched by more than one source row. When the source is already unique on a key set that the ON clause fully covers, at most one source row can match each target row, so that runtime check is provably redundant — a wasted per-row dedup-tracking node on the path that feeds the row-delta sink.


## What I'm doing:

Elide the duplicate check when source uniqueness over the ON keys guarantees an at-most-one match (`canElideEnforceUnique`). Uniqueness is credited only conservatively, so a wrong elision can never drop a needed check:

- The source must be **DISTINCT**, or **GROUP BY** whose keys map to output columns by `SlotRef` column name; a non-`SlotRef` key (e.g. `GROUP BY f(x)`) is not credited (no fragile `toSql()` text matching).
- The two sides of an ON equi-key must be **type-equivalent**. The analyzed AST keeps bare `SlotRef`s across an implicit cast, so a non-injective coercion (e.g. `VARCHAR = INT`) is rejected — distinct source values (`'1'`, `'01'`) could otherwise match one target row.
- When the source and target are referenced by the **same identifier** (e.g. a USING subquery aliased to the target's bare name), no key is credited, so a target-only ON predicate (`target.k = target.k`) cannot be miscounted as covering a source key.

The backend-executability check on the join shape still runs on the elide path, so `join_implementation_mode=merge` is rejected with a clear error even when the duplicate check is elided.

Tested with targeted cases in `MergeIntoPlanTest` (elide / keep, type mismatch, non-SlotRef GROUP BY, grouping sets, name collision, and merge-join rejection on the elide path).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
