### PR TITLE
[BugFix] Check driver readiness before profile-report reschedule in event scheduler

### DIFF
--- a/be/src/exec/runtime/schedule/event_scheduler.cpp
+++ b/be/src/exec/runtime/schedule/event_scheduler.cpp
@@ -81,20 +81,23 @@ void EventScheduler::try_schedule(const DriverRawPtr driver) {
     auto* query_runtime_state = driver->query_runtime_state();
     if (runtime_state->is_cancelled() && !driver->is_operator_cancelled()) {
         add_to_ready_queue = true;
-    } else if (!driver->is_finished() && need_report_exec_state(fragment_runtime_state, query_runtime_state)) {
-        add_to_ready_queue = true;
     } else if (driver->pending_finish()) {
         if (!driver->is_still_pending_finish()) {
             driver->set_driver_state(runtime_state->is_cancelled() ? DriverState::CANCELED : DriverState::FINISH);
             add_to_ready_queue = true;
+        } else if (need_report_exec_state(fragment_runtime_state, query_runtime_state)) {
+            // Still waiting on pending I/O: don't change the driver state (it stays PENDING_FINISH), but keep
+            // enqueuing it periodically so the executor's !is_ready() path fires report_exec_state_if_necessary().
+            // Otherwise a long pending-finish driver stops sending runtime profiles until the final finish event.
+            add_to_ready_queue = true;
         }
     } else if (driver->is_finished()) {
         add_to_ready_queue = true;
-    } else {
-        if (driver->check_is_ready()) {
-            driver->set_driver_state(DriverState::READY);
-            add_to_ready_queue = true;
-        }
+    } else if (driver->check_is_ready()) {
+        driver->set_driver_state(DriverState::READY);
+        add_to_ready_queue = true;
+    } else if (need_report_exec_state(fragment_runtime_state, query_runtime_state)) {
+        add_to_ready_queue = true;
     }
 
     if (add_to_ready_queue) {


### PR DESCRIPTION
## Why I'm doing:

EventScheduler::try_schedule previously evaluated the profile-report deadline (need_report_exec_state) with the highest priority after the cancel check, so a driver that was actually ready to run but happened to fall in the report window was diverted to a report-only reschedule: it went to the ready queue without its state advanced to READY, and the executor's !is_ready() path merely fired the report and re-parked it instead of running it.

Reorder the checks so readiness is resolved first: a ready driver is now marked READY and run immediately, and the profile-report reschedule becomes the fallback for a still-blocked driver. To avoid regressing periodic runtime profiles for drivers stuck in PENDING_FINISH on long pending I/O (whose branch short-circuits before the readiness check), the report deadline is also checked inside the still-pending-finish branch, enqueuing the driver without changing its state so FragmentContext::report_exec_state_if_necessary() keeps firing until the driver finishes.

This mirrors the pipeline poller, which likewise keeps rescheduling blocked and pending-finish drivers for profile reporting.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
