### PR TITLE
[BugFix] Don't delete pass-through-reused PK-index sstables when dropping a compaction during tablet reshard

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -21,6 +21,7 @@
 
 #include "base/utility/defer_op.h"
 #include "common/logging.h"
+#include "gutil/strings/join.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_merger.h"
@@ -342,6 +343,23 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
     return Status::OK();
 }
 
+// Delete the output files of a compaction that is being dropped during a
+// split/merge cross-publish, logging what was removed. This is the only place
+// the reshard path deletes data files, and it is otherwise invisible
+// (delete_files_async only logs at VLOG level), so record it at INFO for
+// post-mortem traceability. Input sstables that the persistent-index compaction
+// reused verbatim as its output ("full contain / only do move") are already
+// excluded by collect_compaction_output_files, so this never deletes a
+// still-referenced file.
+void delete_dropped_compaction_output_files(const TxnLogPB& txn_log, const char* reshard_kind) {
+    auto output_files = tablet_reshard_helper::collect_compaction_output_files(
+            txn_log, StorageEnv::GetInstance()->lake_tablet_manager());
+    LOG(INFO) << "Drop pending compaction during " << reshard_kind << " cross-publish, tablet=" << txn_log.tablet_id()
+              << " txn=" << txn_log.txn_id() << ", delete " << output_files.size() << " compaction output file(s): ["
+              << JoinStrings(output_files, ", ") << "]";
+    delete_files_async(std::move(output_files));
+}
+
 // Transform |txn_log| (which still carries the old tablet id) for publish
 // on the merged tablet. Drops compaction as a no-op (background compaction
 // will rerun it on the merged tablet) and asynchronously deletes the output
@@ -351,8 +369,7 @@ Status convert_txn_log_for_merging(TxnLogPB* txn_log) {
     if (!txn_log->has_op_compaction() && !txn_log->has_op_parallel_compaction()) {
         return Status::OK();
     }
-    delete_files_async(tablet_reshard_helper::collect_compaction_output_file_paths(
-            *txn_log, StorageEnv::GetInstance()->lake_tablet_manager()));
+    delete_dropped_compaction_output_files(*txn_log, "merge");
     txn_log->clear_op_compaction();
     txn_log->clear_op_parallel_compaction();
     return Status::OK();
@@ -382,8 +399,7 @@ Status convert_txn_log_for_splitting(TxnLogPB* txn_log, const TabletMetadataPtr&
                                      const PublishTabletInfo& publish_tablet_info) {
     if (txn_log->has_op_compaction() || txn_log->has_op_parallel_compaction()) {
         if (publish_tablet_info.get_split_index() == 0) {
-            delete_files_async(tablet_reshard_helper::collect_compaction_output_file_paths(
-                    *txn_log, StorageEnv::GetInstance()->lake_tablet_manager()));
+            delete_dropped_compaction_output_files(*txn_log, "split");
         }
         txn_log->clear_op_compaction();
         txn_log->clear_op_parallel_compaction();

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <numeric>
 #include <roaring/roaring.hh>
+#include <unordered_set>
 
 #include "base/uid_util.h"
 #include "common/logging.h"
@@ -613,6 +614,33 @@ void update_rowset_data_stats(RowsetMetadataPB* rowset, int32_t split_count, int
 
 namespace {
 
+// Append the output sstable file paths of |op|, skipping any that alias an input
+// sstable. The persistent-index parallel compaction "full contain / only do move"
+// optimization (LakePersistentIndexParallelCompactMgr) re-emits an input sstable as
+// its own output verbatim, keeping the same physical file and only re-stamping the
+// fileset_id. Such a file is still referenced by the base metadata and every sibling
+// tablet, so it must NOT be queued for deletion when a pending compaction is dropped
+// during a split/merge cross-publish. Templated over the op message so both
+// OpCompaction and OpParallelCompaction share it. This is the deletion-side mirror of
+// MetaFileBuilder::remove_compacted_sst, which applies the same invariant (by
+// filename) to the orphaning side of a normal compaction publish.
+template <typename OpCompactionLike>
+void append_non_reused_output_sstables(const OpCompactionLike& op, int64_t tablet_id, TabletManager* tablet_manager,
+                                       std::vector<std::string>* output_paths) {
+    std::unordered_set<std::string> input_filenames;
+    for (const auto& sstable : op.input_sstables()) {
+        input_filenames.insert(sstable.filename());
+    }
+    if (op.has_output_sstable() && !input_filenames.contains(op.output_sstable().filename())) {
+        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, op.output_sstable().filename()));
+    }
+    for (const auto& sstable : op.output_sstables()) {
+        if (!input_filenames.contains(sstable.filename())) {
+            output_paths->emplace_back(tablet_manager->sst_location(tablet_id, sstable.filename()));
+        }
+    }
+}
+
 // Append output-side files of a single OpCompaction. Used both for the
 // top-level op_compaction and for every op_parallel_compaction.subtask_compactions[*].
 //
@@ -661,12 +689,7 @@ void append_compaction_output_files(const TxnLogPB_OpCompaction& op_compaction, 
     for (const auto& file_meta : op_compaction.ssts()) {
         output_paths->emplace_back(tablet_manager->sst_location(tablet_id, file_meta.name()));
     }
-    if (op_compaction.has_output_sstable()) {
-        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, op_compaction.output_sstable().filename()));
-    }
-    for (const auto& sstable : op_compaction.output_sstables()) {
-        output_paths->emplace_back(tablet_manager->sst_location(tablet_id, sstable.filename()));
-    }
+    append_non_reused_output_sstables(op_compaction, tablet_id, tablet_manager, output_paths);
     if (op_compaction.has_lcrm_file()) {
         output_paths->emplace_back(tablet_manager->lcrm_location(tablet_id, op_compaction.lcrm_file().name()));
     }
@@ -674,7 +697,7 @@ void append_compaction_output_files(const TxnLogPB_OpCompaction& op_compaction, 
 
 } // namespace
 
-std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log, TabletManager* tablet_manager) {
+std::vector<std::string> collect_compaction_output_files(const TxnLogPB& txn_log, TabletManager* tablet_manager) {
     DCHECK(tablet_manager != nullptr);
 
     const int64_t tablet_id = txn_log.tablet_id();
@@ -688,13 +711,7 @@ std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& tx
         for (const auto& subtask : op_parallel_compaction.subtask_compactions()) {
             append_compaction_output_files(subtask, tablet_id, tablet_manager, &output_paths);
         }
-        if (op_parallel_compaction.has_output_sstable()) {
-            output_paths.emplace_back(
-                    tablet_manager->sst_location(tablet_id, op_parallel_compaction.output_sstable().filename()));
-        }
-        for (const auto& sstable : op_parallel_compaction.output_sstables()) {
-            output_paths.emplace_back(tablet_manager->sst_location(tablet_id, sstable.filename()));
-        }
+        append_non_reused_output_sstables(op_parallel_compaction, tablet_id, tablet_manager, &output_paths);
         // orphan_lcrm_files holds the ORIGINAL per-subtask lcrm files copied
         // by the parallel-compaction manager (tablet_parallel_compaction_manager.cpp),
         // distinct from the merged lcrm placed on each subtask_compactions[i]

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -166,12 +166,15 @@ void update_txn_log_data_stats(TxnLogPB* txn_log, int32_t split_count, int32_t s
 //
 // Only output-side files are collected. Input rowsets/sstables are deliberately
 // excluded — they have been absorbed into the merged tablet by the preceding
-// merge publish and remain live; deleting them would corrupt data.
+// merge publish and remain live; deleting them would corrupt data. Output
+// sstables that alias an input sstable (persistent-index "full contain / only
+// do move" reuse, which keeps the same physical file and only re-stamps the
+// fileset_id) are likewise excluded, since they are the live input file itself.
 //
 // No dedup is performed — lake file names are UUID-based per tablet/txn, so
 // collisions are not expected in practice. Matches the no-dedup style of
 // transactions.cpp::collect_files_in_log.
-std::vector<std::string> collect_compaction_output_file_paths(const TxnLogPB& txn_log, TabletManager* tablet_manager);
+std::vector<std::string> collect_compaction_output_files(const TxnLogPB& txn_log, TabletManager* tablet_manager);
 
 // Allocate `total` across `out->size()` buckets in proportion to
 // weights[i] / Σweights using the largest-remainder (Hare-Niemeyer) method,

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -6187,7 +6187,7 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_splitting_op_write_preserved)
 // output_rowset carries only newly written segments, so the helper should
 // treat all of them as new rather than silently skipping them (which would
 // leak segment files).
-TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel_without_new_segment_count) {
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_files_parallel_without_new_segment_count) {
     const int64_t tablet_id = next_id();
     TxnLogPB log;
     log.set_tablet_id(tablet_id);
@@ -6199,7 +6199,7 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
     // Intentionally NOT setting new_segment_offset/new_segment_count to
     // reproduce the shape produced by the parallel-compaction manager.
 
-    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_files(log, _tablet_manager.get());
     EXPECT_THAT(paths,
                 ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "parallel_new_0.dat"),
                                                 _tablet_manager->segment_location(tablet_id, "parallel_new_1.dat")));
@@ -6210,7 +6210,7 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_parallel
 // (new_segment_offset / new_segment_count) should be queued for deletion.
 // Deleting reused segments would corrupt the merged tablet because those
 // segments are still live as input rowsets absorbed by the merge.
-TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_compaction) {
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_files_partial_compaction) {
     const int64_t tablet_id = next_id();
     TxnLogPB log;
     log.set_tablet_id(tablet_id);
@@ -6224,7 +6224,7 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_
     op_compaction->set_new_segment_offset(2);
     op_compaction->set_new_segment_count(2);
 
-    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_files(log, _tablet_manager.get());
     EXPECT_THAT(paths, ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "new_0.dat"),
                                                        _tablet_manager->segment_location(tablet_id, "new_1.dat")));
     EXPECT_THAT(paths,
@@ -6233,12 +6233,12 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_partial_
                 ::testing::Not(::testing::Contains(_tablet_manager->segment_location(tablet_id, "reused_1.dat"))));
 }
 
-// Verifies that collect_compaction_output_file_paths() collects files of every
+// Verifies that collect_compaction_output_files() collects files of every
 // kind — segments (via output_rowset), ssts (compaction-ingested), output_sstable,
 // output_sstables, lcrm_file, plus op_parallel_compaction.output_sstable /
 // output_sstables / orphan_lcrm_files — so regressions don't silently reintroduce
 // leaks by dropping any one category.
-TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_all_kinds) {
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_files_covers_all_kinds) {
     const int64_t tablet_id = next_id();
     TxnLogPB log;
     log.set_tablet_id(tablet_id);
@@ -6259,7 +6259,7 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_a
     op_parallel->add_output_sstables()->set_filename("parallel_out_multi.sst");
     op_parallel->add_orphan_lcrm_files()->set_name("parallel_orphan.crm");
 
-    auto paths = lake::tablet_reshard_helper::collect_compaction_output_file_paths(log, _tablet_manager.get());
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_files(log, _tablet_manager.get());
     EXPECT_THAT(paths,
                 ::testing::UnorderedElementsAre(_tablet_manager->segment_location(tablet_id, "out_seg.dat"),
                                                 _tablet_manager->sst_location(tablet_id, "compact_ingest.sst"),
@@ -6269,6 +6269,56 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_file_paths_covers_a
                                                 _tablet_manager->sst_location(tablet_id, "parallel_out.sst"),
                                                 _tablet_manager->sst_location(tablet_id, "parallel_out_multi.sst"),
                                                 _tablet_manager->lcrm_location(tablet_id, "parallel_orphan.crm")));
+}
+
+// Regression: the persistent-index compaction "full contain / only do move"
+// optimization re-emits an input sstable as its own output verbatim (same
+// filename, only the fileset_id changes). Such a file is still referenced by the
+// base metadata and every sibling tablet, so when a pending compaction is dropped
+// during a split/merge cross-publish it must NOT be queued for deletion. Deleting
+// it removed shared PK-index sstables in production and stalled publishes with
+// "load primary index failed: ... .sst does not exist".
+//
+// Covers both message shapes (op_compaction and op_parallel_compaction) and both
+// output fields. Production emits reused files into the plural output_sstables,
+// so each op reuses via output_sstables; the singular output_sstable is exercised
+// too (reused on op_compaction, genuinely new on op_parallel_compaction).
+TEST_F(LakeTabletReshardTest, test_collect_compaction_output_files_skips_passthrough_reused_sstables) {
+    const int64_t tablet_id = next_id();
+    TxnLogPB log;
+    log.set_tablet_id(tablet_id);
+
+    // op_compaction: "reused.sst" (plural) and "reused_single.sst" (singular) are
+    // pass-through outputs that alias inputs; "compact_new.sst" is genuinely new.
+    auto* op_compaction = log.mutable_op_compaction();
+    op_compaction->add_input_sstables()->set_filename("reused.sst");
+    op_compaction->add_input_sstables()->set_filename("reused_single.sst");
+    op_compaction->mutable_output_sstable()->set_filename("reused_single.sst");
+    op_compaction->add_output_sstables()->set_filename("reused.sst");
+    op_compaction->add_output_sstables()->set_filename("compact_new.sst");
+
+    // op_parallel_compaction: "parallel_reused.sst" is reused via the plural
+    // output_sstables (the shape production actually emits); the singular
+    // output_sstable and the other plural entry are genuinely new.
+    auto* op_parallel = log.mutable_op_parallel_compaction();
+    op_parallel->add_input_sstables()->set_filename("parallel_reused.sst");
+    op_parallel->mutable_output_sstable()->set_filename("parallel_single_new.sst");
+    op_parallel->add_output_sstables()->set_filename("parallel_reused.sst");
+    op_parallel->add_output_sstables()->set_filename("parallel_new.sst");
+
+    auto paths = lake::tablet_reshard_helper::collect_compaction_output_files(log, _tablet_manager.get());
+    // Only the genuinely new outputs are collected for deletion.
+    EXPECT_THAT(paths,
+                ::testing::UnorderedElementsAre(_tablet_manager->sst_location(tablet_id, "compact_new.sst"),
+                                                _tablet_manager->sst_location(tablet_id, "parallel_single_new.sst"),
+                                                _tablet_manager->sst_location(tablet_id, "parallel_new.sst")));
+    // The pass-through reused (still-live) sstables are never queued for deletion,
+    // whether they came through the singular output_sstable or the plural list.
+    EXPECT_THAT(paths, ::testing::Not(::testing::Contains(_tablet_manager->sst_location(tablet_id, "reused.sst"))));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->sst_location(tablet_id, "reused_single.sst"))));
+    EXPECT_THAT(paths,
+                ::testing::Not(::testing::Contains(_tablet_manager->sst_location(tablet_id, "parallel_reused.sst"))));
 }
 
 // LakePersistentIndex::commit() and the size-tiered compaction strategy iterate


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, when a tablet that has a pending (committed-but-unpublished) persistent-index compaction is split or merged, the reshard cross-publish path (`convert_txn_log_for_splitting` / `convert_txn_log_for_merging`) drops that compaction and asynchronously deletes its output files, on the assumption that compaction outputs are freshly-written and unreferenced.

That assumption is broken by the persistent-index parallel compaction "full contain / only do move" optimization, which re-emits an input sstable as its output verbatim — the same physical file, with only its `fileset_id` re-stamped. So the dropped compaction's `output_sstables` can list still-live, shared base-fileset filenames. Deleting them removes PK-index sstables that are still referenced by the whole split family, permanently stalling publishes with `prepare_primary_index: load primary index failed: ... .sst does not exist` and leaving load transactions stuck in `COMMITTED`.

## What I'm doing:

When collecting a dropped compaction's output files for deletion, skip any output sstable whose filename also appears in the op's `input_sstables` (the pass-through reuse). This mirrors the opposite-direction guard already in `MetaFileBuilder::remove_compacted_sst`, and covers both `op_compaction` and `op_parallel_compaction`, so both split and merge cross-publish are fixed. Filename equality is the correct key because the physical path is derived from the filename alone; `fileset_id` cannot discriminate since the move re-stamps it.

Additional changes:
- Rename `collect_compaction_output_file_paths` → `collect_compaction_output_files` to match `append_compaction_output_files`.
- Log (at INFO) which files a reshard drop deletes; previously this deletion was only visible at VLOG level.
- Add a regression test covering the pass-through skip for both `op_compaction` and `op_parallel_compaction`, singular and plural output fields.

Fixes #64986

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5