### PR TITLE
[BugFix] Report per-physical bucket count for lake SHOW PARTITIONS/partitions_meta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -411,7 +411,8 @@ public class PartitionsProcDir implements ProcDirInterface {
                 .stream().map(Column::getName).collect(Collectors.toList()))); // Partition key
         partitionInfo.add(findRangeOrListValues(tblPartitionInfo, partition.getId())); // List or Range
         partitionInfo.add(distributionKeyAsString(table, partition.getDistributionInfo())); // DistributionKey
-        partitionInfo.add(partition.getDistributionInfo().getBucketNum()); // Buckets
+        partitionInfo.add(physicalPartition.getBucketNum() > 0 ?
+                physicalPartition.getBucketNum() : partition.getDistributionInfo().getBucketNum()); // Buckets
         partitionInfo.add(new ByteSizeValue(physicalPartition.storageDataSize())); // DataSize
         long storageSize = physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize();
         partitionInfo.add(new ByteSizeValue(storageSize)); // StorageSize

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -494,8 +494,10 @@ public class InformationSchemaDataSource {
         DistributionInfo distributionInfo = partition.getDistributionInfo();
         // DISTRIBUTION_KEY
         partitionMetaInfo.setDistribution_key(PartitionsProcDir.distributionKeyAsString(table, distributionInfo));
-        // BUCKETS
-        partitionMetaInfo.setBuckets(distributionInfo.getBucketNum());
+        // BUCKETS: each physical partition can carry its own bucket count (e.g. ADD PHYSICAL PARTITION),
+        // so prefer the per-physical value and fall back to the table-level distribution default.
+        partitionMetaInfo.setBuckets(physicalPartition.getBucketNum() > 0 ?
+                physicalPartition.getBucketNum() : distributionInfo.getBucketNum());
         // REPLICATION_NUM
         partitionMetaInfo.setReplication_num(partitionInfo.getReplicationNum(partition.getId()));
         // DATA_SIZE

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.clone.BalanceStat;
 import com.starrocks.common.AnalysisException;
@@ -34,10 +35,22 @@ import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class PartitionsProcDirTest {
+
+    // "Buckets" is column index 9 in both the cloud-native and olap title lists.
+    private static final int BUCKETS_COLUMN_INDEX = 9;
+
+    private static Map<String, String> bucketsByPartitionId(BaseProcResult result) {
+        Map<String, String> bucketsById = new HashMap<>();
+        for (List<String> row : result.getRows()) {
+            bucketsById.put(row.get(0), row.get(BUCKETS_COLUMN_INDEX));
+        }
+        return bucketsById;
+    }
 
     @Test
     public void testFetchResultForCloudNativeTable() throws AnalysisException {
@@ -126,5 +139,81 @@ public class PartitionsProcDirTest {
         Assertions.assertEquals("NORMAL", list1.get(5));
         Assertions.assertEquals("province", list1.get(6));
         Assertions.assertEquals("true", list1.get(21)); // tablet balanced
+    }
+
+    @Test
+    public void testFetchResultForCloudNativeTableReportsPerPhysicalBucketNum() throws AnalysisException {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        DataCacheInfo dataCache = new DataCacheInfo(true, false);
+        long partitionId = 1025;
+        listPartition.setDataCacheInfo(partitionId, dataCache);
+
+        // Table-level default distribution is 3 buckets; each physical partition carries its own bucketNum.
+        LakeTable cloudNativeTable = new LakeTable(1024L, "cloud_native_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        Map<String, Long> indexNameToMetaId = cloudNativeTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
+
+        long defaultPhysicalId = 1035;
+        Partition partition = new Partition(partitionId, defaultPhysicalId, "p1", index, new RandomDistributionInfo(3));
+
+        // A physical partition added later (as ADD PHYSICAL PARTITION does) with a different bucket count.
+        long biggerPhysicalId = 1036;
+        PhysicalPartition biggerPhysical = new PhysicalPartition(biggerPhysicalId, partitionId, index);
+        biggerPhysical.setBucketNum(5);
+        partition.addSubPartition(biggerPhysical);
+
+        // A physical partition whose per-physical bucketNum is unset (0) must fall back to the table default.
+        long legacyPhysicalId = 1037;
+        PhysicalPartition legacyPhysical = new PhysicalPartition(legacyPhysicalId, partitionId, index);
+        legacyPhysical.setBucketNum(0);
+        partition.addSubPartition(legacyPhysical);
+
+        cloudNativeTable.addPartition(partition);
+        db.registerTableUnlocked(cloudNativeTable);
+
+        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, cloudNativeTable, false).fetchResult();
+
+        Map<String, String> bucketsById = bucketsByPartitionId(result);
+        Assertions.assertEquals("3", bucketsById.get(String.valueOf(defaultPhysicalId)));
+        Assertions.assertEquals("5", bucketsById.get(String.valueOf(biggerPhysicalId)));
+        Assertions.assertEquals("3", bucketsById.get(String.valueOf(legacyPhysicalId)));
+    }
+
+    @Test
+    public void testFetchResultForOlapTableReportsPerPhysicalBucketNum() throws AnalysisException {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        index.setBalanceStat(BalanceStat.BALANCED_STAT);
+        Map<String, Long> indexNameToMetaId = olapTable.getIndexNameToMetaId();
+        indexNameToMetaId.put("index1", index.getMetaId());
+
+        long defaultPhysicalId = 1035;
+        Partition partition = new Partition(partitionId, defaultPhysicalId, "p1", index, new RandomDistributionInfo(3));
+
+        long biggerPhysicalId = 1036;
+        PhysicalPartition biggerPhysical = new PhysicalPartition(biggerPhysicalId, partitionId, index);
+        biggerPhysical.setBucketNum(5);
+        partition.addSubPartition(biggerPhysical);
+
+        olapTable.addPartition(partition);
+        db.registerTableUnlocked(olapTable);
+
+        BaseProcResult result = (BaseProcResult) new PartitionsProcDir(db, olapTable, false).fetchResult();
+
+        Map<String, String> bucketsById = bucketsByPartitionId(result);
+        Assertions.assertEquals("3", bucketsById.get(String.valueOf(defaultPhysicalId)));
+        Assertions.assertEquals("5", bucketsById.get(String.valueOf(biggerPhysicalId)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/LakeInformationSchemaDataSourceTest.java
@@ -17,6 +17,7 @@ package com.starrocks.service;
 import com.google.gson.Gson;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.UserIdentity;
@@ -25,6 +26,7 @@ import com.starrocks.common.PatternMatcher;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TAuthInfo;
@@ -296,6 +298,47 @@ public class LakeInformationSchemaDataSourceTest {
         } finally {
             Config.enable_experimental_vector = prevEnableExperimentalVector;
         }
+    }
+
+    /**
+     * partitions_meta must report each physical partition's own bucket count, not the table-level
+     * default. Add a physical partition whose bucket count differs from the table default and assert
+     * BUCKETS is per-physical (the default physical keeps the table default; the added one reports its own).
+     */
+    @Test
+    public void testGetLakePartitionsMetaReportsPerPhysicalBucketNum() throws Exception {
+        starRocksAssert.withDatabase("db_pp_buckets").useDatabase("db_pp_buckets");
+        starRocksAssert.withTable("CREATE TABLE db_pp_buckets.t (k1 INT, v1 BIGINT) " +
+                "DUPLICATE KEY(k1) DISTRIBUTED BY RANDOM BUCKETS 3 " +
+                "PROPERTIES ('replication_num' = '1');");
+
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        // Add a physical partition whose bucket count (5) differs from the table default (3).
+        metastore.addPhysicalPartition("db_pp_buckets", "t", null, 5);
+
+        OlapTable table = (OlapTable) metastore.getTable("db_pp_buckets", "t");
+        Partition partition = table.getPartitions().iterator().next();
+        long defaultPhysicalId = partition.getDefaultPhysicalPartition().getId();
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TGetPartitionsMetaRequest req = new TGetPartitionsMetaRequest();
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setPattern("db_pp_buckets");
+        authInfo.setUser("root");
+        authInfo.setUser_ip("%");
+        req.setAuth_info(authInfo);
+        TGetPartitionsMetaResponse response = impl.getPartitionsMeta(req);
+
+        Map<Long, Integer> bucketsByPartitionId = new HashMap<>();
+        for (TPartitionMetaInfo meta : response.getPartitions_meta_infos()) {
+            if (meta.getTable_name().equals("t")) {
+                bucketsByPartitionId.put(meta.getPartition_id(), meta.getBuckets());
+            }
+        }
+        Assertions.assertEquals(2, bucketsByPartitionId.size());
+        Assertions.assertEquals(Integer.valueOf(3), bucketsByPartitionId.get(defaultPhysicalId));
+        Assertions.assertTrue(bucketsByPartitionId.containsValue(5),
+                "expected an added physical partition reporting 5 buckets, got: " + bucketsByPartitionId);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

On shared-data (`run_mode = shared_data` / lake) tables, `SHOW PARTITIONS` and `information_schema.partitions_meta` report every physical partition's **Buckets** as the table-level distribution default instead of the physical partition's own bucket count.

Reproduce on any shared-data cluster:

```sql
CREATE TABLE db.t (k1 INT, v1 BIGINT) DUPLICATE KEY(k1) DISTRIBUTED BY RANDOM BUCKETS 3;
ADMIN EXECUTE ON FRONTEND 'metastore.addPhysicalPartition("db","t","t",5,2)';
SHOW PARTITIONS FROM db.t;   -- BUG: all rows show Buckets=3; EXPECTED: 3,5,5
```

The tablets are actually created correctly (the two added physical partitions each have 5 tablets, verifiable via `SHOW PROC '/dbs/db/t/partitions/<physicalPartitionId>/<indexId>/'`), so this is purely a read/reporting bug, not a data issue.

## What I'm doing:

The per-physical bucket count is stored in `PhysicalPartition.bucketNum` (set by the write path `createPhysicalPartition` → `setBucketNum(distributionInfo.getBucketNum())`). The logical `Partition` holds a single shared `DistributionInfo` whose `bucketNum` stays at the table default and is not updated when a physical partition with a different bucket count is added.

The OLAP read path (`PartitionsProcDir.getOlapPartitionInfo`) already prefers `physicalPartition.getBucketNum()` when `> 0`, falling back to the distribution default otherwise. The lake read path and `information_schema.partitions_meta` used `distributionInfo.getBucketNum()` directly — the bug.

This PR makes both lake read paths mirror the OLAP path:

- `PartitionsProcDir.getLakePartitionInfo` (the `SHOW PARTITIONS` Buckets column).
- `InformationSchemaDataSource.genPartitionMetaInfo` (the `partitions_meta` BUCKETS column) — the physical partition is already in scope there, and the same change also aligns the OLAP rows of `partitions_meta` with what `SHOW PARTITIONS` already reports.

Both use `physicalPartition.getBucketNum() > 0 ? physicalPartition.getBucketNum() : <table default>`. The `> 0` guard preserves the fallback for legacy metadata deserialized before `PhysicalPartition.bucketNum` existed.

This only corrects a wrong reported value — no internal FE/BE logic consumes these values for decisions (verified: `SHOW PARTITIONS` output is display-only, the `partitions_meta` `WHERE Buckets` filter runs in-memory over the same displayed value, and the only internal `partitions_meta` consumer, `PartitionSelector`, selects `PARTITION_NAME` only).

Tests:
- `PartitionsProcDirTest`: lake table reports per-physical Buckets (default `3`, added `5`, and a `bucketNum == 0` physical falls back to the table default), plus an OLAP regression guard.
- `LakeInformationSchemaDataSourceTest`: `partitions_meta` reports per-physical Buckets after `addPhysicalPartition` with a bucket count different from the table default.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
