### PR TITLE
[BugFix] Hash `table_uuid` for external table statistics to avoid PK size overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -79,6 +79,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -112,9 +113,18 @@ public class PartitionSelector {
     // why not use `PARTITION_ID` here? because partition_id in partitions_meta is physical partition id which may be confused.
     private static final String PARTITIONS_META_TEMPLATE = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS_META " +
             "WHERE DB_NAME ='%s' and TABLE_NAME='%s' AND %s;";
-    private static final String EXTERNAL_TABLE_PARTITION_META_TEMPLATE = "SELECT PARTITION_NAME, SUM(ROW_COUNT) as ROW_COUNT," +
-            "CAST(SUM(DATA_SIZE) AS BIGINT) as DATA_SIZE FROM _statistics_.external_column_statistics " +
-            "WHERE TABLE_UUID = '%s' AND PARTITION_NAME in ('%s') GROUP BY PARTITION_NAME;";
+    // TABLE_UUID matches both the hashed and raw representations (external_column_statistics
+    // stores table_uuid hashed - see StatisticUtils.hashTableUuidForPkStorage - to stay within
+    // BE's primary_key_limit_size); matching only the raw value here would silently return no
+    // rows once a table's stats have been (re-)collected under the hashed key. The inner subquery
+    // dedups to the freshest row per (PARTITION_NAME, COLUMN_NAME) so a partition isn't counted
+    // twice if both its hashed and raw rows happen to be alive at once.
+    private static final String EXTERNAL_TABLE_PARTITION_META_TEMPLATE =
+            "SELECT PARTITION_NAME, SUM(ROW_COUNT) as ROW_COUNT, CAST(SUM(DATA_SIZE) AS BIGINT) as DATA_SIZE FROM (" +
+            "SELECT *, ROW_NUMBER() OVER (PARTITION BY PARTITION_NAME, COLUMN_NAME ORDER BY UPDATE_TIME DESC) AS RN " +
+            "FROM _statistics_.external_column_statistics " +
+            "WHERE TABLE_UUID IN ('%s', '%s') AND PARTITION_NAME in ('%s')) DEDUP_T " +
+            "WHERE RN = 1 GROUP BY PARTITION_NAME;";
     // NOTE: `json` to `datetime` is not supported yet, so we use `string` here.
     private static final String JSON_QUERY_TEMPLATE = "CAST(CAST(JSON_QUERY(%s, '$[0].[%d]') AS STRING) AS %s)";
 
@@ -810,7 +820,9 @@ public class PartitionSelector {
      * such as Iceberg/Hudi by its table UUID.
      */
     public static Map<String, Pair<Long, Long>> getExternalTablePartitionStats(Table table, Set<String> needPartitionNames) {
-        String sql = String.format(EXTERNAL_TABLE_PARTITION_META_TEMPLATE, table.getUUID(),
+        String rawTableUuid = table.getUUID();
+        String hashedTableUuid = StatisticUtils.hashTableUuidForPkStorage(rawTableUuid);
+        String sql = String.format(EXTERNAL_TABLE_PARTITION_META_TEMPLATE, hashedTableUuid, rawTableUuid,
                 String.join(",", needPartitionNames));
         LOG.info("Get external table partition stats by sql: {}", sql);
         List<TResultBatch> batch = SimpleExecutor.getRepoExecutor().executeDQL(sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -217,11 +217,11 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     // Deletes the stale raw-keyed rows for exactly the (partition, column) pairs this job just
-    // (re-)wrote under the hashed table_uuid. Without this, a partition that gets re-collected
-    // would keep both its old raw-keyed row and its new hashed-keyed row alive at once, and the
-    // SUM-based aggregation in buildQueryExternalFullStatisticsSQL would double-count it. This is
-    // best-effort: a failure here only means the stale row lingers until next collection, it must
-    // never fail a job whose actual stats write already succeeded.
+    // (re-)wrote under the hashed table_uuid. Purely storage hygiene: buildQueryExternalFullStatisticsSQL
+    // dedups by (partition_name, column_name, latest update_time) internally, so a lingering stale
+    // row is never double-counted even if this cleanup fails - it just wastes a bit of space until
+    // the next collection retries it. Best-effort: must never fail a job whose actual stats write
+    // already succeeded.
     private void cleanupStaleRawKeyedRows(ConnectContext context, long jobId) {
         String rawTableUuid = table.getUUID();
         boolean ok = new StatisticExecutor().dropExternalStatRawPartitions(context, rawTableUuid, partitionNames, columnNames);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -185,6 +185,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             }
 
             flushInsertStatisticsData(context, true);
+            cleanupStaleRawKeyedRows(context, jobId);
         } catch (Exception e) {
             status = "FAILED";
             failureReason = e.getMessage();
@@ -212,6 +213,21 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                             "maxPartitionNameLen={} maxColumnNameLen={} estimatedRawPkLen={} limitEstimate={}",
                     jobId, catalogName, db.getOriginName(), table.getName(), rawTableUuid.length(),
                     maxPartitionNameLen, maxColumnNameLen, estimatedRawPkLen, EXTERNAL_STATS_PK_LIMIT_ESTIMATE);
+        }
+    }
+
+    // Deletes the stale raw-keyed rows for exactly the (partition, column) pairs this job just
+    // (re-)wrote under the hashed table_uuid. Without this, a partition that gets re-collected
+    // would keep both its old raw-keyed row and its new hashed-keyed row alive at once, and the
+    // SUM-based aggregation in buildQueryExternalFullStatisticsSQL would double-count it. This is
+    // best-effort: a failure here only means the stale row lingers until next collection, it must
+    // never fail a job whose actual stats write already succeeded.
+    private void cleanupStaleRawKeyedRows(ConnectContext context, long jobId) {
+        String rawTableUuid = table.getUUID();
+        boolean ok = new StatisticExecutor().dropExternalStatRawPartitions(context, rawTableUuid, partitionNames, columnNames);
+        if (!ok) {
+            LOG.warn("[ExternalStats] failed to clean up stale raw-keyed rows | jobId={} catalog={} db={} table={}",
+                    jobId, catalogName, db.getOriginName(), table.getName());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -97,6 +97,13 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     // because we can not generate partition predicates for it.
     private static final Set<String> DO_NOT_COLLECT_PARTITIONS = Set.of(ICEBERG_DEFAULT_PARTITION);
 
+    // Conservative mirror of BE's primary_key_limit_size default (be/src/common/config.h) and its
+    // per-field VARCHAR encoding overhead, used only to decide whether to log a warning below -
+    // table_uuid is always hashed (StatisticUtils.hashTableUuidForPkStorage) regardless of this
+    // estimate, so an inaccurate guess here never causes a correctness problem.
+    private static final int EXTERNAL_STATS_PK_LIMIT_ESTIMATE = 128;
+    private static final int PK_FIELD_OVERHEAD_ESTIMATE = 12;
+
     public ExternalFullStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
                                             List<String> columnNames, List<Type> columnTypes,
                                             StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
@@ -127,6 +134,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         LOG.info("[ExternalStats] collect start | jobId={} catalog={} db={} table={} partitions={} columns={}",
                 jobId, catalogName, db.getOriginName(), table.getName(),
                 partitionNames.size(), columnNames.size());
+        logIfRawKeyWouldExceedPkLimit(jobId);
 
         Map<String, String> extendedInfo = new LinkedHashMap<>();
         extendedInfo.put("table_format", table.getType().name().toLowerCase(Locale.ROOT));
@@ -187,6 +195,23 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
                     jobId, catalogName, db.getOriginName(), table.getName(),
                     status, System.currentTimeMillis() - startMs,
                     partitionNames.size(), columnNames.size(), failureReason);
+        }
+    }
+
+    // table_uuid is always hashed for storage (StatisticUtils.hashTableUuidForPkStorage), so this
+    // never affects correctness. It's a diagnostic-only warning to confirm which tables actually
+    // would have hit "primary key size exceed the limit" pre-hashing (e.g. long Iceberg
+    // catalog/db/table names combined with long partition_name values, see the Demandbase case).
+    private void logIfRawKeyWouldExceedPkLimit(long jobId) {
+        String rawTableUuid = table.getUUID();
+        int maxPartitionNameLen = partitionNames.stream().mapToInt(String::length).max().orElse(0);
+        int maxColumnNameLen = columnNames.stream().mapToInt(String::length).max().orElse(0);
+        int estimatedRawPkLen = rawTableUuid.length() + maxPartitionNameLen + maxColumnNameLen + PK_FIELD_OVERHEAD_ESTIMATE;
+        if (estimatedRawPkLen > EXTERNAL_STATS_PK_LIMIT_ESTIMATE) {
+            LOG.warn("[ExternalStats] table_uuid hashed | jobId={} catalog={} db={} table={} rawTableUuidLen={} " +
+                            "maxPartitionNameLen={} maxColumnNameLen={} estimatedRawPkLen={} limitEstimate={}",
+                    jobId, catalogName, db.getOriginName(), table.getName(), rawTableUuid.length(),
+                    maxPartitionNameLen, maxColumnNameLen, estimatedRawPkLen, EXTERNAL_STATS_PK_LIMIT_ESTIMATE);
         }
     }
 
@@ -344,11 +369,12 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
         List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
 
+        String hashedTableUuid = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
         for (TStatisticData data : dataList) {
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
 
-            params.add("'" + table.getUUID() + "'");
+            params.add("'" + hashedTableUuid + "'");
             params.add("'" + StringEscapeUtils.escapeSql(data.getPartitionName()) + "'");
             params.add("'" + StringEscapeUtils.escapeSql(data.getColumnName()) + "'");
             params.add("'" + catalogName + "'");
@@ -362,7 +388,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             params.add("'" + data.getMin() + "'");
             params.add("now()");
             // int
-            row.add(new StringLiteral(table.getUUID())); // table id, wait to byte
+            row.add(new StringLiteral(hashedTableUuid)); // table id, wait to byte
             row.add(new StringLiteral(data.getPartitionName()));
             row.add(new StringLiteral(data.getColumnName())); // column name, 20 byte
             row.add(new StringLiteral(catalogName));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -99,6 +99,9 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
 
             sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
             collectStatisticSync(sql, context, analyzeStatus);
+            // Best-effort: remove the stale raw-keyed row this column's fresh hashed-keyed row just
+            // superseded, so a later read never has to arbitrate between two rows for one column.
+            new StatisticExecutor().dropExternalHistogramRawColumn(context, table.getUUID(), columnName);
 
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -23,6 +23,8 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.thrift.TStatisticData;
 import com.starrocks.type.Type;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
@@ -34,6 +36,8 @@ import java.util.stream.Collectors;
 import static com.starrocks.statistic.StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME;
 
 public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob {
+    private static final Logger LOG = LogManager.getLogger(ExternalHistogramStatisticsCollectJob.class);
+
     private static final String COLLECT_HISTOGRAM_STATISTIC_TEMPLATE =
             "SELECT '$tableUUID', '$columnNameStr', '$catalogName', '$dbName', '$tableName'," +
                     " histogram(`column_key`, cast($bucketNum as int), cast($sampleRatio as double)), " +
@@ -100,8 +104,12 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
             sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
             collectStatisticSync(sql, context, analyzeStatus);
             // Best-effort: remove the stale raw-keyed row this column's fresh hashed-keyed row just
-            // superseded, so a later read never has to arbitrate between two rows for one column.
-            new StatisticExecutor().dropExternalHistogramRawColumn(context, table.getUUID(), columnName);
+            // superseded. The read side no longer depends on this for correctness (it dedups by
+            // update_time), so this is purely storage hygiene - failures are logged, not fatal.
+            if (!statisticExecutor.dropExternalHistogramRawColumn(context, table.getUUID(), columnName)) {
+                LOG.warn("[ExternalStats] failed to clean up stale raw-keyed histogram row | catalog={} db={} table={} " +
+                        "column={}", catalogName, db.getOriginName(), table.getName(), columnName);
+            }
 
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -130,7 +130,7 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
         String quoteColumName = StatisticUtils.quoting(table, columnName);
 
         VelocityContext context = new VelocityContext();
-        context.put("tableUUID", table.getUUID());
+        context.put("tableUUID", StatisticUtils.hashTableUuidForPkStorage(table.getUUID()));
         context.put("columnName", quoteColumName);
         context.put("columnNameStr", columnName);
         context.put("catalogName", catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -291,6 +291,22 @@ public class StatisticExecutor {
         }
     }
 
+    // Best-effort cleanup of the stale raw-keyed rows superseded by a fresh hashed-key write.
+    // Failure just means the raw row lingers a bit longer (until this partition/column is
+    // collected again); it must never fail the collection job that just succeeded.
+    public boolean dropExternalStatRawPartitions(ConnectContext statsConnectCtx, String rawTableUUID,
+                                                 List<String> partitionNames, List<String> columnNames) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQLForPartitions(rawTableUUID, partitionNames, columnNames);
+        LOG.debug("Cleanup stale raw-keyed external statistic rows SQL: {}", sql);
+        return executeDML(statsConnectCtx, sql);
+    }
+
+    public boolean dropExternalHistogramRawColumn(ConnectContext statsConnectCtx, String rawTableUUID, String columnName) {
+        String sql = StatisticSQLBuilder.buildDropExternalHistogramSQLForRawUuid(rawTableUUID, Lists.newArrayList(columnName));
+        LOG.debug("Cleanup stale raw-keyed external histogram row SQL: {}", sql);
+        return executeDML(statsConnectCtx, sql);
+    }
+
     public boolean dropPartitionStatistics(ConnectContext statsConnectCtx, List<Long> pids) {
         String sql = StatisticSQLBuilder.buildDropPartitionSQL(pids);
         LOG.debug("Expire partition statistic SQL: {}", sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -18,9 +18,9 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.common.util.SqlUtils;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -82,18 +82,26 @@ public class StatisticSQLBuilder {
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
 
-    // Grouped by column_name only (not table_uuid): the predicate already scopes rows to a single
-    // logical table via table_uuid in (hash, raw) (see buildTableUUIDInPredicate), and table_uuid
-    // isn't part of the projection anyway. Grouping by table_uuid too would split a table's rows
-    // into two separate groups whenever both representations are present, silently dropping one
-    // group's aggregated data downstream (only one group survives the caller's per-column map).
+    // table_uuid isn't part of the projection and the predicate already scopes rows to a single
+    // logical table via table_uuid in (hash, raw) (see buildTableUUIDInPredicate), so grouping by
+    // column_name alone is enough to merge a table's data regardless of which representation any
+    // given partition currently uses.
+    //
+    // The inner subquery additionally dedups to at most one row per (partition_name, column_name),
+    // keeping only the one with the latest update_time. This is what actually prevents double-
+    // counting when a partition has been re-collected (fresh row under the hashed key) but its
+    // superseded raw-keyed row hasn't been cleaned up yet - correctness does not depend on that
+    // best-effort cleanup (see ExternalFullStatisticsCollectJob#cleanupStaleRawKeyedRows) succeeding.
     private static final String QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE =
             "SELECT cast(" + STATISTIC_EXTERNAL_QUERY_V2_VERSION + " as INT), column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
                     + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
                     + " max(update_time)"
+                    + " FROM (SELECT *, row_number() over ("
+                    + " partition by partition_name, column_name order by update_time desc) as rn"
                     + " FROM " + StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME
-                    + " WHERE $predicate"
+                    + " WHERE $predicate) dedup_t"
+                    + " WHERE rn = 1"
                     + " GROUP BY column_name";
 
     private static final String QUERY_HISTOGRAM_STATISTIC_TEMPLATE =
@@ -102,11 +110,16 @@ public class StatisticSQLBuilder {
                     + " FROM " + StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME
                     + " WHERE $predicate";
 
+    // Same dedup rationale as QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE, keyed by column_name only
+    // (external_histogram_statistics has no partition dimension).
     private static final String QUERY_EXTERNAL_HISTOGRAM_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_EXTERNAL_HISTOGRAM_VERSION + " as INT), column_name,"
                     + " cast(json_object(\"buckets\", buckets, \"mcv\", mcv) as varchar)"
+                    + " FROM (SELECT *, row_number() over ("
+                    + " partition by column_name order by update_time desc) as rn"
                     + " FROM " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME
-                    + " WHERE $predicate";
+                    + " WHERE $predicate) dedup_t"
+                    + " WHERE rn = 1";
 
     private static final String QUERY_MULTI_COLUMNS_COMBINED_STATISTICS_TEMPLATE =
             "SELECT cast(" + STATISTIC_QUERY_MULTI_COLUMN_VERSION + " as INT), db_id, table_id, column_ids, ndv"
@@ -231,13 +244,26 @@ public class StatisticSQLBuilder {
     // (StatisticUtils.hashTableUuidForPkStorage) to keep the PRIMARY KEY within BE's
     // primary_key_limit_size. Matching on both the hashed and the raw value keeps historical
     // rows (written before this hashing was introduced) visible until they naturally age out.
+    // tableUUID is derived from catalog/db/table names (Table.getUUID()), so it must be escaped
+    // like any other untrusted value before being embedded into a string literal.
     private static String buildTableUUIDInPredicate(String tableUUID) {
-        return "table_uuid in (\"" + StatisticUtils.hashTableUuidForPkStorage(tableUUID) + "\", \"" + tableUUID + "\")";
+        String hash = escapeForDoubleQuotedSqlString(StatisticUtils.hashTableUuidForPkStorage(tableUUID));
+        String raw = escapeForDoubleQuotedSqlString(tableUUID);
+        return "table_uuid in (\"" + hash + "\", \"" + raw + "\")";
     }
 
     // Same as buildTableUUIDInPredicate but single-quoted, for call sites that build their SQL with '...'.
     private static String buildTableUUIDInPredicateQuoted(String tableUUID) {
-        return "table_uuid in ('" + StatisticUtils.hashTableUuidForPkStorage(tableUUID) + "', '" + tableUUID + "')";
+        String hash = SqlUtils.escapeSqlString(StatisticUtils.hashTableUuidForPkStorage(tableUUID));
+        String raw = SqlUtils.escapeSqlString(tableUUID);
+        return "table_uuid in ('" + hash + "', '" + raw + "')";
+    }
+
+    // SqlUtils.escapeSqlString only targets single-quoted literals (escapes backslash then single
+    // quote); this is the double-quoted equivalent (escapes backslash then double quote), for the
+    // handful of templates in this class that use "..." string literals.
+    private static String escapeForDoubleQuotedSqlString(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     public static String buildMultiColumnCombinedStatisticsSQL(List<Long> tableIds) {
@@ -305,15 +331,17 @@ public class StatisticSQLBuilder {
 
     // Cleans up the stale raw-keyed row(s) for exactly the (partition, column) pairs just
     // (re-)written under the hashed table_uuid, so a partition never has both a raw and a hashed
-    // row alive at once (which would otherwise get double-counted by the SUM aggregates in
-    // buildQueryExternalFullStatisticsSQL). Only ever targets the raw uuid - never the hash.
+    // row alive at once. Purely storage hygiene - buildQueryExternalFullStatisticsSQL's dedup-by-
+    // update_time already makes correctness independent of this cleanup succeeding. Only ever
+    // targets the raw uuid - never the hash.
     public static String buildDropExternalStatSQLForPartitions(String rawTableUUID, List<String> partitionNames,
                                                                 List<String> columnNames) {
         String partitionsIn = partitionNames.stream()
-                .map(p -> "'" + StringEscapeUtils.escapeSql(p) + "'").collect(Collectors.joining(", "));
+                .map(p -> "'" + SqlUtils.escapeSqlString(p) + "'").collect(Collectors.joining(", "));
         String columnsIn = columnNames.stream()
-                .map(c -> "'" + StringEscapeUtils.escapeSql(c) + "'").collect(Collectors.joining(", "));
-        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE TABLE_UUID = '" + rawTableUUID + "'" +
+                .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'").collect(Collectors.joining(", "));
+        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE TABLE_UUID = '" + SqlUtils.escapeSqlString(rawTableUUID) + "'" +
                 " AND PARTITION_NAME IN (" + partitionsIn + ")" +
                 " AND COLUMN_NAME IN (" + columnsIn + ")";
     }
@@ -322,9 +350,9 @@ public class StatisticSQLBuilder {
     // (PK is table_uuid + column_name, no partition dimension).
     public static String buildDropExternalHistogramSQLForRawUuid(String rawTableUUID, List<String> columnNames) {
         String columnsIn = columnNames.stream()
-                .map(c -> "'" + StringEscapeUtils.escapeSql(c) + "'").collect(Collectors.joining(", "));
+                .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'").collect(Collectors.joining(", "));
         return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME +
-                " where table_uuid = '" + rawTableUUID + "' and column_name in (" + columnsIn + ")";
+                " where table_uuid = '" + SqlUtils.escapeSqlString(rawTableUUID) + "' and column_name in (" + columnsIn + ")";
     }
 
     public static String buildDropExternalStatSQL(String catalogName, String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -206,18 +206,32 @@ public class StatisticSQLBuilder {
     public static String buildQueryExternalFullStatisticsSQL(String tableUUID, List<String> columnNames,
                                                              List<Type> columnTypes) {
         Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes, true);
+        String tableUUIDPredicate = buildTableUUIDInPredicate(tableUUID);
 
         List<String> querySQL = new ArrayList<>();
         nameGroups.forEach((type, names) -> {
             VelocityContext context = new VelocityContext();
             context.put("type", type);
             context.put("predicate",
-                    "table_uuid = \"" + tableUUID + "\"" + " and column_name in (" +
+                    tableUUIDPredicate + " and column_name in (" +
                             names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")");
             querySQL.add(build(context, QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE));
         });
 
         return Joiner.on(" UNION ALL ").join(querySQL);
+    }
+
+    // external_column_statistics / external_histogram_statistics store table_uuid hashed
+    // (StatisticUtils.hashTableUuidForPkStorage) to keep the PRIMARY KEY within BE's
+    // primary_key_limit_size. Matching on both the hashed and the raw value keeps historical
+    // rows (written before this hashing was introduced) visible until they naturally age out.
+    private static String buildTableUUIDInPredicate(String tableUUID) {
+        return "table_uuid in (\"" + StatisticUtils.hashTableUuidForPkStorage(tableUUID) + "\", \"" + tableUUID + "\")";
+    }
+
+    // Same as buildTableUUIDInPredicate but single-quoted, for call sites that build their SQL with '...'.
+    private static String buildTableUUIDInPredicateQuoted(String tableUUID) {
+        return "table_uuid in ('" + StatisticUtils.hashTableUuidForPkStorage(tableUUID) + "', '" + tableUUID + "')";
     }
 
     public static String buildMultiColumnCombinedStatisticsSQL(List<Long> tableIds) {
@@ -280,7 +294,7 @@ public class StatisticSQLBuilder {
     }
 
     public static String buildDropExternalStatSQL(String tableUUID) {
-        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE TABLE_UUID = '" + tableUUID + "'";
+        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID);
     }
 
     public static String buildDropExternalStatSQL(String catalogName, String dbName, String tableName) {
@@ -329,7 +343,7 @@ public class StatisticSQLBuilder {
 
         List<String> predicateList = Lists.newArrayList();
         if (tableUUID != null) {
-            predicateList.add("table_uuid = '" + tableUUID + "'");
+            predicateList.add(buildTableUUIDInPredicateQuoted(tableUUID));
         }
 
         if (!columnNames.isEmpty()) {
@@ -354,8 +368,8 @@ public class StatisticSQLBuilder {
     }
 
     public static String buildDropExternalHistogramSQL(String tableUUID, List<String> columnNames) {
-        return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME + " where table_uuid = '"
-                + tableUUID + "' and column_name in (" + Joiner.on(", ")
+        return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME + " where "
+                + buildTableUUIDInPredicateQuoted(tableUUID) + " and column_name in (" + Joiner.on(", ")
                 .join(columnNames.stream().map(c -> "'" + c + "'").collect(Collectors.toList())) + ")";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.type.Type;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -81,6 +82,11 @@ public class StatisticSQLBuilder {
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
 
+    // Grouped by column_name only (not table_uuid): the predicate already scopes rows to a single
+    // logical table via table_uuid in (hash, raw) (see buildTableUUIDInPredicate), and table_uuid
+    // isn't part of the projection anyway. Grouping by table_uuid too would split a table's rows
+    // into two separate groups whenever both representations are present, silently dropping one
+    // group's aggregated data downstream (only one group survives the caller's per-column map).
     private static final String QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE =
             "SELECT cast(" + STATISTIC_EXTERNAL_QUERY_V2_VERSION + " as INT), column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
@@ -88,7 +94,7 @@ public class StatisticSQLBuilder {
                     + " max(update_time)"
                     + " FROM " + StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
-                    + " GROUP BY table_uuid, column_name";
+                    + " GROUP BY column_name";
 
     private static final String QUERY_HISTOGRAM_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_HISTOGRAM_VERSION + " as INT), db_id, table_id, column_name,"
@@ -295,6 +301,30 @@ public class StatisticSQLBuilder {
 
     public static String buildDropExternalStatSQL(String tableUUID) {
         return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID);
+    }
+
+    // Cleans up the stale raw-keyed row(s) for exactly the (partition, column) pairs just
+    // (re-)written under the hashed table_uuid, so a partition never has both a raw and a hashed
+    // row alive at once (which would otherwise get double-counted by the SUM aggregates in
+    // buildQueryExternalFullStatisticsSQL). Only ever targets the raw uuid - never the hash.
+    public static String buildDropExternalStatSQLForPartitions(String rawTableUUID, List<String> partitionNames,
+                                                                List<String> columnNames) {
+        String partitionsIn = partitionNames.stream()
+                .map(p -> "'" + StringEscapeUtils.escapeSql(p) + "'").collect(Collectors.joining(", "));
+        String columnsIn = columnNames.stream()
+                .map(c -> "'" + StringEscapeUtils.escapeSql(c) + "'").collect(Collectors.joining(", "));
+        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE TABLE_UUID = '" + rawTableUUID + "'" +
+                " AND PARTITION_NAME IN (" + partitionsIn + ")" +
+                " AND COLUMN_NAME IN (" + columnsIn + ")";
+    }
+
+    // Same cleanup purpose as buildDropExternalStatSQLForPartitions, for external_histogram_statistics
+    // (PK is table_uuid + column_name, no partition dimension).
+    public static String buildDropExternalHistogramSQLForRawUuid(String rawTableUUID, List<String> columnNames) {
+        String columnsIn = columnNames.stream()
+                .map(c -> "'" + StringEscapeUtils.escapeSql(c) + "'").collect(Collectors.joining(", "));
+        return "delete from " + StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME +
+                " where table_uuid = '" + rawTableUUID + "' and column_name in (" + columnsIn + ")";
     }
 
     public static String buildDropExternalStatSQL(String catalogName, String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -444,6 +444,15 @@ public class StatisticUtils {
         }
     }
 
+    // Deterministic, fixed-length (32 hex chars) substitute for the raw table_uuid used as part of the
+    // PK of external_column_statistics / external_histogram_statistics. Iceberg's table_uuid
+    // (catalog.db.table.<36-byte-uuid>) is effectively always longer than this, so hashing it
+    // unconditionally never makes things worse. catalog_name/db_name/table_name are stored as
+    // separate non-key columns on every row, so no traceability is lost by hashing table_uuid.
+    public static String hashTableUuidForPkStorage(String tableUuid) {
+        return Hashing.murmur3_128().hashUnencodedChars(tableUuid).toString();
+    }
+
     public static Optional<Double> convertStatisticsToDouble(Type type, String statistic) {
         if (!type.canStatistic()) {
             throw new StarRocksPlannerException("Error statistic type : " + type.toSql(), ErrorType.INTERNAL_ERROR);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -98,4 +98,51 @@ class StatisticSQLBuilderTest {
         Assertions.assertFalse(sql.contains(hashed),
                 "cleanup delete must never also match the hashed uuid (it holds the fresh data): " + sql);
     }
+
+    @Test
+    void buildQueryExternalFullStatisticsSQLDedupsByLatestUpdateTime() {
+        // Correctness must not depend on the write-side cleanup delete succeeding: if both a
+        // raw-keyed and hashed-keyed row are briefly alive for the same partition/column, the
+        // query must keep only the freshest one (by update_time) before aggregating, not double-
+        // count both.
+        String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL(
+                TABLE_UUID, ImmutableList.of("col1"), ImmutableList.of(IntegerType.BIGINT));
+        Assertions.assertTrue(sql.contains(
+                "row_number() over ( partition by partition_name, column_name order by update_time desc) as rn"), sql);
+        Assertions.assertTrue(sql.contains(") dedup_t WHERE rn = 1 GROUP BY column_name"), sql);
+    }
+
+    @Test
+    void buildQueryConnectorHistogramStatisticsSQLDedupsByLatestUpdateTime() {
+        String sql = StatisticSQLBuilder.buildQueryConnectorHistogramStatisticsSQL(TABLE_UUID, ImmutableList.of("col1"));
+        Assertions.assertTrue(sql.contains(
+                "row_number() over ( partition by column_name order by update_time desc) as rn"), sql);
+        Assertions.assertTrue(sql.contains(") dedup_t WHERE rn = 1"), sql);
+    }
+
+    @Test
+    void tableUUIDPredicatesEscapeQuotesAndBackslashes() {
+        // table_uuid is derived from catalog/db/table names (Table.getUUID()), so it must be
+        // escaped like any other untrusted value before being embedded into a SQL string literal.
+        // StarRocks decodes backslash escapes inside string literals, so doubling quotes alone
+        // (the old StringEscapeUtils.escapeSql behavior) is not sufficient - see SqlUtils.escapeSqlString.
+        String doubleQuoteTrickyUUID = "iceberg.db.o\"brien\\table.uuid"; // contains " and \
+        String doubleQuoted = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL(
+                doubleQuoteTrickyUUID, ImmutableList.of("col1"), ImmutableList.of(IntegerType.BIGINT));
+        Assertions.assertTrue(doubleQuoted.contains("iceberg.db.o\\\"brien\\\\table.uuid\""), doubleQuoted);
+
+        String singleQuoteTrickyUUID = "iceberg.db.o'brien\\table.uuid"; // contains ' and \
+        String singleQuoted = StatisticSQLBuilder.buildDropExternalStatSQL(singleQuoteTrickyUUID);
+        Assertions.assertTrue(singleQuoted.contains("iceberg.db.o''brien\\\\table.uuid'"), singleQuoted);
+    }
+
+    @Test
+    void cleanupDeletesEscapeRawUuidAndNames() {
+        String trickyUUID = "iceberg.db.o'brien\\table.uuid";
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQLForPartitions(
+                trickyUUID, ImmutableList.of("p'1"), ImmutableList.of("c\\1"));
+        Assertions.assertTrue(sql.contains("TABLE_UUID = 'iceberg.db.o''brien\\\\table.uuid'"), sql);
+        Assertions.assertTrue(sql.contains("PARTITION_NAME IN ('p''1')"), sql);
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c\\\\1')"), sql);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+// external_column_statistics / external_histogram_statistics store table_uuid hashed
+// (StatisticUtils.hashTableUuidForPkStorage) to stay within BE's primary_key_limit_size.
+// These tests confirm every query/delete builder that filters by table_uuid matches both
+// the hashed and the raw value, so historical rows written before hashing was introduced
+// stay visible until they naturally age out.
+class StatisticSQLBuilderTest {
+
+    private static final String TABLE_UUID =
+            "iceberg.udp_abx_etl_db1_datawarehouse.tenant.account_buying_group.d6cfa1ed-0000-0000-0000-000000000000";
+
+    @Test
+    void buildQueryExternalFullStatisticsSQLMatchesHashedAndRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL(
+                TABLE_UUID, ImmutableList.of("col1"), ImmutableList.of(IntegerType.BIGINT));
+        Assertions.assertTrue(sql.contains("table_uuid in (\"" + hashed + "\", \"" + TABLE_UUID + "\")"),
+                "query predicate must match both hashed and raw table_uuid: " + sql);
+    }
+
+    @Test
+    void buildDropExternalStatSQLByUuidMatchesHashedAndRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQL(TABLE_UUID);
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', '" + TABLE_UUID + "')"),
+                "delete predicate must match both hashed and raw table_uuid: " + sql);
+    }
+
+    @Test
+    void buildQueryConnectorHistogramStatisticsSQLMatchesHashedAndRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        List<String> columnNames = ImmutableList.of("col1");
+        String sql = StatisticSQLBuilder.buildQueryConnectorHistogramStatisticsSQL(TABLE_UUID, columnNames);
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', '" + TABLE_UUID + "')"),
+                "query predicate must match both hashed and raw table_uuid: " + sql);
+    }
+
+    @Test
+    void buildDropExternalHistogramSQLMatchesHashedAndRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        String sql = StatisticSQLBuilder.buildDropExternalHistogramSQL(TABLE_UUID, ImmutableList.of("col1"));
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', '" + TABLE_UUID + "')"),
+                "delete predicate must match both hashed and raw table_uuid: " + sql);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -64,4 +64,38 @@ class StatisticSQLBuilderTest {
         Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', '" + TABLE_UUID + "')"),
                 "delete predicate must match both hashed and raw table_uuid: " + sql);
     }
+
+    @Test
+    void buildQueryExternalFullStatisticsSQLGroupsByColumnNameOnly() {
+        // Regression test: grouping by table_uuid too would split a table's rows into two groups
+        // whenever both the hashed and raw representations are present, silently dropping one
+        // group's aggregated data downstream (see the collect-vs-read consistency discussion).
+        String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL(
+                TABLE_UUID, ImmutableList.of("col1"), ImmutableList.of(IntegerType.BIGINT));
+        Assertions.assertTrue(sql.endsWith("GROUP BY column_name"), "must group by column_name only: " + sql);
+        Assertions.assertFalse(sql.contains("GROUP BY table_uuid"), "must not group by table_uuid: " + sql);
+    }
+
+    @Test
+    void buildDropExternalStatSQLForPartitionsOnlyMatchesRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQLForPartitions(
+                TABLE_UUID, ImmutableList.of("p1", "p2"), ImmutableList.of("col1", "col2"));
+        Assertions.assertTrue(sql.contains("TABLE_UUID = '" + TABLE_UUID + "'"),
+                "cleanup delete must target only the raw uuid: " + sql);
+        Assertions.assertFalse(sql.contains(hashed),
+                "cleanup delete must never also match the hashed uuid (it holds the fresh data): " + sql);
+        Assertions.assertTrue(sql.contains("PARTITION_NAME IN ('p1', 'p2')"), sql);
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('col1', 'col2')"), sql);
+    }
+
+    @Test
+    void buildDropExternalHistogramSQLForRawUuidOnlyMatchesRawUuid() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage(TABLE_UUID);
+        String sql = StatisticSQLBuilder.buildDropExternalHistogramSQLForRawUuid(TABLE_UUID, ImmutableList.of("col1"));
+        Assertions.assertTrue(sql.contains("table_uuid = '" + TABLE_UUID + "'"),
+                "cleanup delete must target only the raw uuid: " + sql);
+        Assertions.assertFalse(sql.contains(hashed),
+                "cleanup delete must never also match the hashed uuid (it holds the fresh data): " + sql);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
@@ -113,4 +113,21 @@ class StatisticUtilsTest extends PlanTestBase {
             globalDefault.setBigQueryProfileThreshold(savedBigQueryThresholdMs + "ms");
         }
     }
+
+    @Test
+    void hashTableUuidForPkStorageIsDeterministicAndFixedLength() {
+        String tableUuid = "iceberg.udp_abx_etl_db1_datawarehouse.tenant.account_buying_group." +
+                "d6cfa1ed-0000-0000-0000-000000000000";
+        String hash1 = StatisticUtils.hashTableUuidForPkStorage(tableUuid);
+        String hash2 = StatisticUtils.hashTableUuidForPkStorage(tableUuid);
+        Assertions.assertEquals(hash1, hash2, "hash must be deterministic for the same input");
+        Assertions.assertEquals(32, hash1.length(), "murmur3_128 hex-encoded hash must be 32 chars");
+        Assertions.assertTrue(hash1.length() < tableUuid.length(),
+                "hash must be shorter than a realistic long Iceberg table_uuid");
+
+        String otherTableUuid = "iceberg.udp_abx_etl_db1_datawarehouse.tenant.buying_group_member." +
+                "d6cfa1ed-0000-0000-0000-000000000000";
+        Assertions.assertNotEquals(hash1, StatisticUtils.hashTableUuidForPkStorage(otherTableUuid),
+                "different table_uuid values must not collide for realistic inputs");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -147,21 +147,23 @@ public class StatisticsExecutorTest extends PlanTestBase {
         // BE's primary_key_limit_size; queries match both the hashed and raw value so historical
         // rows written before hashing was introduced remain visible.
         String hashedTableUUID = StatisticUtils.hashTableUuidForPkStorage(tableUUID);
+        String tableUUIDPredicate = "table_uuid in (\"" + hashedTableUUID + "\", \"" + tableUUID + "\")";
         new MockUp<StatisticExecutor>() {
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
                 Assertions.assertEquals(
                         "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
-                                "cast(min(cast(min as string)) as string), max(update_time) FROM external_column_statistics " +
-                                "WHERE table_uuid in (\"" + hashedTableUUID + "\", \"" + tableUUID + "\") " +
-                                "and column_name in (\"c2\") GROUP BY column_name UNION ALL " +
+                                "cast(min(cast(min as string)) as string), max(update_time) FROM (SELECT *, row_number() " +
+                                "over ( partition by partition_name, column_name order by update_time desc) as rn " +
+                                "FROM external_column_statistics WHERE " + tableUUIDPredicate +
+                                " and column_name in (\"c2\")) dedup_t WHERE rn = 1 GROUP BY column_name UNION ALL " +
                                 "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
-                                "cast(min(cast(min as bigint)) as string), max(update_time) " +
-                                "FROM external_column_statistics WHERE table_uuid in (\"" + hashedTableUUID + "\", \""
-                                + tableUUID + "\")" +
-                                " and column_name in (\"c1\") GROUP BY column_name", sql);
+                                "cast(min(cast(min as bigint)) as string), max(update_time) FROM (SELECT *, row_number() " +
+                                "over ( partition by partition_name, column_name order by update_time desc) as rn " +
+                                "FROM external_column_statistics WHERE " + tableUUIDPredicate +
+                                " and column_name in (\"c1\")) dedup_t WHERE rn = 1 GROUP BY column_name", sql);
                 return Lists.newArrayList();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -141,7 +141,12 @@ public class StatisticsExecutorTest extends PlanTestBase {
 
     @Test
     public void testQueryStatisticSync() throws AnalysisException {
-        String res;
+        String tableUUID = connectContext.getGlobalStateMgr().getMetadataMgr()
+                .getTable(connectContext, "hive0", "partitioned_db", "t1").getUUID();
+        // table_uuid is stored hashed (StatisticUtils.hashTableUuidForPkStorage) to stay within
+        // BE's primary_key_limit_size; queries match both the hashed and raw value so historical
+        // rows written before hashing was introduced remain visible.
+        String hashedTableUUID = StatisticUtils.hashTableUuidForPkStorage(tableUUID);
         new MockUp<StatisticExecutor>() {
             @Mock
             public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
@@ -149,12 +154,13 @@ public class StatisticsExecutorTest extends PlanTestBase {
                         "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
                                 "cast(min(cast(min as string)) as string), max(update_time) FROM external_column_statistics " +
-                                "WHERE table_uuid = \"hive0.partitioned_db.t1.0\" " +
+                                "WHERE table_uuid in (\"" + hashedTableUUID + "\", \"" + tableUUID + "\") " +
                                 "and column_name in (\"c2\") GROUP BY table_uuid, column_name UNION ALL " +
                                 "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
                                 "cast(min(cast(min as bigint)) as string), max(update_time) " +
-                                "FROM external_column_statistics WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
+                                "FROM external_column_statistics WHERE table_uuid in (\"" + hashedTableUUID + "\", \""
+                                + tableUUID + "\")" +
                                 " and column_name in (\"c1\") GROUP BY table_uuid, column_name", sql);
                 return Lists.newArrayList();
             }
@@ -163,7 +169,6 @@ public class StatisticsExecutorTest extends PlanTestBase {
         ConnectContext context = StatisticUtils.buildConnectContext();
         Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "partitioned_db",
                 "t1");
-        String tableUUID = table.getUUID();
         StatisticExecutor statisticExecutor = new StatisticExecutor();
         statisticExecutor.queryStatisticSync(context, tableUUID, table, ImmutableList.of("c1", "c2"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -155,13 +155,13 @@ public class StatisticsExecutorTest extends PlanTestBase {
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
                                 "cast(min(cast(min as string)) as string), max(update_time) FROM external_column_statistics " +
                                 "WHERE table_uuid in (\"" + hashedTableUUID + "\", \"" + tableUUID + "\") " +
-                                "and column_name in (\"c2\") GROUP BY table_uuid, column_name UNION ALL " +
+                                "and column_name in (\"c2\") GROUP BY column_name UNION ALL " +
                                 "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
                                 "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
                                 "cast(min(cast(min as bigint)) as string), max(update_time) " +
                                 "FROM external_column_statistics WHERE table_uuid in (\"" + hashedTableUUID + "\", \""
                                 + tableUUID + "\")" +
-                                " and column_name in (\"c1\") GROUP BY table_uuid, column_name", sql);
+                                " and column_name in (\"c1\") GROUP BY column_name", sql);
                 return Lists.newArrayList();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -398,16 +398,22 @@ public class StatisticsSQLTest extends PlanTestBase {
 
     @Test
     public void testCacheExternalQueryColumnStatics() {
+        // table_uuid is stored hashed (StatisticUtils.hashTableUuidForPkStorage) to stay within
+        // BE's primary_key_limit_size; queries match both the hashed and raw value so historical
+        // rows written before hashing was introduced remain visible.
+        String hashedTableUUID = StatisticUtils.hashTableUuidForPkStorage("a");
+        String tableUUIDPredicate = "table_uuid in (\"" + hashedTableUUID + "\", \"a\")";
+
         String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a", Lists.newArrayList("col1", "col2"),
                 Lists.newArrayList(IntegerType.INT, IntegerType.INT));
-        assertContains(sql, "table_uuid = \"a\" and column_name in (\"col1\", \"col2\")");
+        assertContains(sql, tableUUIDPredicate + " and column_name in (\"col1\", \"col2\")");
         Assertions.assertEquals(0, StringUtils.countMatches(sql, "UNION ALL"));
 
         sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a",
                 Lists.newArrayList("col1", "col2", "col3"),
                 Lists.newArrayList(IntegerType.INT, IntegerType.BIGINT, IntegerType.LARGEINT));
-        assertContains(sql, "table_uuid = \"a\" and column_name in (\"col1\", \"col2\")");
-        assertContains(sql, "table_uuid = \"a\" and column_name in (\"col3\")");
+        assertContains(sql, tableUUIDPredicate + " and column_name in (\"col1\", \"col2\")");
+        assertContains(sql, tableUUIDPredicate + " and column_name in (\"col3\")");
         Assertions.assertEquals(1, StringUtils.countMatches(sql, "UNION ALL"));
 
         sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a",


### PR DESCRIPTION
## Why I'm doing:
Background auto-ANALYZE of Iceberg external tables can fail writing into `_statistics.external_column_statistics` / `external_histogram_statistics` with BE error `primary key size exceed the limit.`

Root cause: these tables use `table_uuid` (`catalog.db.table.<iceberg-uuid>`) as part of their PRIMARY KEY. For catalogs with long catalog/db/table names combined with long, un-truncated partition names, the encoded key routinely exceeds BE's `primary_key_limit_size` (default 128 bytes):

```
table_uuid("catalog.db.table.<36-byte-uuid>")  ~100B
        + partition_name                       ~20-30B
        + column_name                          ~5-20B
        ------------------------------------------------
                                                > 128B limit  →  write fails forever
```

Once a table hits this, its background stats collection retries indefinitely and never succeeds, leaving the table permanently without external statistics.

## What I'm doing:
Store `table_uuid` as a fixed-length hash instead of the raw string, so the PK size no longer depends on how long the catalog/db/table identifiers happen to be.

- Always hash `table_uuid` (murmur3_128, 32 hex chars) before writing it as part of the PK. `catalog_name`/`db_name`/`table_name` remain as separate columns on every row, so no debuggability is lost.
- On read/delete, match `table_uuid IN (hash, raw)` so historical rows written before this change stay visible.
- After a collection job writes fresh rows under the hashed key, it deletes the now-stale rows still sitting under the raw key for that same partition/column scope, instead of leaving both around:

```
collect job succeeds
  -> INSERT rows keyed by hash(table_uuid)        (new representation)
  -> DELETE rows keyed by raw table_uuid           (only same partition/column scope just written)
```

  This matters because the read query aggregates with `SUM`/`hll_union_agg` grouped by column only (not by `table_uuid`) so that a table split between hashed and raw rows during the transition still reports correct totals in a single query; without the cleanup step, a partition re-collected under the hashed key would keep its old raw-keyed row alive too and get double-counted.
- Added a diagnostic `[ExternalStats]` warning log when a table's raw key would have exceeded the size limit, to help confirm which tables were actually affected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
