### PR TITLE
[BugFix] Keep no-op MODIFY COLUMN on the schema-change path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -769,7 +769,7 @@ public class SchemaChangeHandler extends AlterHandler {
             return false;
         }
         fillKeyAndAggregationTypeForModColumn(olapTable, modColumn);
-        return oriColumn.equalsIgnoreComment(modColumn);
+        return oriColumn.equalsIgnoreComment(modColumn) && !Objects.equals(oriColumn.getComment(), modColumn.getComment());
     }
 
     // User can modify column type and column position

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -1155,6 +1155,45 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         Assertions.assertEquals("", table.getColumn("v1").getComment(), exception.getMessage());
     }
 
+    @Test
+    public void testNoOpModifyColumnCanCombineWithOtherClause() throws Exception {
+        createTable("CREATE TABLE test.noop_batch_dup (k1 INT, v1 INT, v2 INT) DUPLICATE KEY(k1) "
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("noop_batch_dup");
+        // "MODIFY COLUMN v1 INT" changes nothing (no-op); batched with a real change on v2.
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(
+                "ALTER TABLE test.noop_batch_dup MODIFY COLUMN v1 INT, MODIFY COLUMN v2 BIGINT;");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        // Must not throw the comment-combine error; the no-op clause stays on the schema-change path.
+        handler.process(alterTableStmt.getAlterClauseList(), db, table);
+
+        List<AlterJobV2> jobs = handler.getUnfinishedAlterJobV2ByTableId(table.getId());
+        Assertions.assertFalse(jobs.isEmpty());
+        waitAlterJobDone(handler.getAlterJobsV2());
+        // Remove the job this test created from the shared global alterJobsV2 map so it does not skew the
+        // absolute job-count assertions in sibling tests
+        jobs.forEach(job -> handler.getAlterJobsV2().remove(job.getJobId()));
+    }
+
+    @Test
+    public void testNoOpModifyColumnCanCombineWithOtherClauseOnPrimaryKeyTable() throws Exception {
+        createTable("CREATE TABLE test.noop_batch_pk (k1 INT NOT NULL, v10 VARCHAR(40) NULL, v11 INT NULL) "
+                + "PRIMARY KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) db.getTable("noop_batch_pk");
+        // "MODIFY COLUMN v10 VARCHAR(40)" is a no-op (v10 already is VARCHAR(40)); batched with a real change on v11.
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(
+                "ALTER TABLE test.noop_batch_pk MODIFY COLUMN v10 VARCHAR(40), MODIFY COLUMN v11 BIGINT;");
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        handler.process(alterTableStmt.getAlterClauseList(), db, table);
+
+        List<AlterJobV2> jobs = handler.getUnfinishedAlterJobV2ByTableId(table.getId());
+        Assertions.assertFalse(jobs.isEmpty());
+        waitAlterJobDone(handler.getAlterJobsV2());
+        jobs.forEach(job -> handler.getAlterJobsV2().remove(job.getJobId()));
+    }
+
     private void assertCommentOnlyModify(String tableName, String alterSql, String columnName, String expectedComment)
             throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");


### PR DESCRIPTION
## Why I'm doing:

A batch `ALTER TABLE` that contains a **no-op** `MODIFY COLUMN` clause (a clause whose column definition is identical to the stored column) fails with:

```
ERROR 1064 (HY000): MODIFY COLUMN COMMENT can not be combined with other alter operations
```

This is a regression introduced by #75325. `isCommentOnlyModification()` only checked `oriColumn.equalsIgnoreComment(modColumn)`, so a clause that changes *nothing at all* (comment included) is also treated as "comment-only" and misrouted to the lightweight `ModifyColumnComment` path — which forbids being combined with other clauses.

Reproduction (from StarRocks/StarRocksTest#11503):

```sql
CREATE TABLE t (
    k1 int NOT NULL,
    v10 largeint NULL
) PRIMARY KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3;

-- first modify succeeds
ALTER TABLE t MODIFY COLUMN v10 VARCHAR(40);

-- after the schema change finishes, a batch ALTER whose v10 clause is now a no-op:
ALTER TABLE t MODIFY COLUMN v10 VARCHAR(40), MODIFY COLUMN k1 int;
-- ERROR 1064 (HY000): MODIFY COLUMN COMMENT can not be combined with other alter operations
```

Before #75325 the no-op `MODIFY COLUMN` went through the normal `processModifyColumn` schema-change flow and batching worked fine.

## What I'm doing:

Only route a `MODIFY COLUMN` to the comment-only path when the comment **actually differs**. A fully no-op clause now stays on the regular `processModifyColumn` (schema-change) path, so it can be batched with other `MODIFY COLUMN` clauses again, matching the behavior before #75325.

```java
// SchemaChangeHandler.isCommentOnlyModification()
return oriColumn.equalsIgnoreComment(modColumn)
        && !Objects.equals(oriColumn.getComment(), modColumn.getComment());
```

Added regression tests covering a no-op `MODIFY COLUMN` batched with a real change on both a duplicate-key table and a primary-key table.

Related issue: StarRocks/StarRocksTest#11503

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
