### PR TITLE
[BugFix] CN nodes should emit metrics with starrocks_cn_ prefix instead of starrocks_be_

### DIFF
--- a/be/src/common/metrics/process_metrics_registry.cpp
+++ b/be/src/common/metrics/process_metrics_registry.cpp
@@ -19,6 +19,6 @@
 namespace starrocks {
 
 ProcessMetricsRegistry::ProcessMetricsRegistry(std::string root_registry_name)
-        : _root_registry(std::move(root_registry_name)) {}
+        : _root_registry(root_registry_name), _table_metrics_mgr(std::move(root_registry_name)) {}
 
 } // namespace starrocks

--- a/be/src/common/util/table_metrics.h
+++ b/be/src/common/util/table_metrics.h
@@ -51,7 +51,8 @@ using TableMetricsPtr = std::shared_ptr<TableMetrics>;
 // so the real deletion will be done asynchronously by daemon thread.
 class TableMetricsManager {
 public:
-    TableMetricsManager() : _last_cleanup_ts(MonotonicSeconds()) {}
+    explicit TableMetricsManager(std::string prefix = "starrocks_be")
+            : _metrics(std::move(prefix)), _last_cleanup_ts(MonotonicSeconds()) {}
 
     MetricRegistry* metric_registry() { return &_metrics; }
 
@@ -72,7 +73,7 @@ public:
 private:
     bool can_install_metrics();
 
-    MetricRegistry _metrics{"starrocks_be"};
+    MetricRegistry _metrics;
     using MutexType = starrocks::bthreads::BThreadSharedMutex;
     using MetricsMap =
             phmap::parallel_flat_hash_map<uint64_t, TableMetricsPtr, phmap::Hash<uint64_t>, phmap::EqualTo<uint64_t>,

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -159,7 +159,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     int start_step = 1;
     // Metric singletons keep registry back-pointers, so the process registry must outlive shutdown.
-    static auto* process_metrics_registry = new ProcessMetricsRegistry("starrocks_be");
+    static auto* process_metrics_registry = new ProcessMetricsRegistry(as_cn ? "starrocks_cn" : "starrocks_be");
 
     auto daemon = std::make_unique<Daemon>();
     daemon->init(as_cn, paths, process_metrics_registry);

--- a/be/test/http/metrics_action_test.cpp
+++ b/be/test/http/metrics_action_test.cpp
@@ -156,14 +156,14 @@ TEST_F(MetricsActionTest, prometheus_output_with_table_metrics) {
     ProcessMetricsRegistry registry("test");
     enable_table_metrics(&registry);
     s_expect_response =
-            "# TYPE starrocks_be_table_load_bytes counter\n"
-            "starrocks_be_table_load_bytes{table_id=\"42\"} 0\n"
-            "# TYPE starrocks_be_table_load_rows counter\n"
-            "starrocks_be_table_load_rows{table_id=\"42\"} 0\n"
-            "# TYPE starrocks_be_table_scan_read_bytes counter\n"
-            "starrocks_be_table_scan_read_bytes{table_id=\"42\"} 0\n"
-            "# TYPE starrocks_be_table_scan_read_rows counter\n"
-            "starrocks_be_table_scan_read_rows{table_id=\"42\"} 11\n";
+            "# TYPE test_table_load_bytes counter\n"
+            "test_table_load_bytes{table_id=\"42\"} 0\n"
+            "# TYPE test_table_load_rows counter\n"
+            "test_table_load_rows{table_id=\"42\"} 0\n"
+            "# TYPE test_table_scan_read_bytes counter\n"
+            "test_table_scan_read_bytes{table_id=\"42\"} 0\n"
+            "# TYPE test_table_scan_read_rows counter\n"
+            "test_table_scan_read_rows{table_id=\"42\"} 11\n";
     HttpRequest request(_evhttp_req);
     MetricsAction action(&registry, &mock_send_reply);
     action.handle(&request);


### PR DESCRIPTION
## Why I'm doing:

CN (Compute Node) processes emit all Prometheus metrics with the `starrocks_be_` prefix, making it impossible to distinguish BE from CN metrics without relying on external labels like pod name or Kubernetes `job` label. This causes:
- Mixed BE+CN data in monitoring dashboards
- False positive alerts on BE-specific thresholds triggered by CN pods
- Inaccurate capacity planning when metrics are aggregated

### The Problem

In a cluster with 3 BE pods and 2 CN pods, querying any `starrocks_be_*` metric returns results from **all 5 pods**:

```promql
starrocks_be_disks_total_capacity
```

```
starrocks_be_disks_total_capacity{pod="my-cluster-be-0"} 107374182400
starrocks_be_disks_total_capacity{pod="my-cluster-be-1"} 107374182400
starrocks_be_disks_total_capacity{pod="my-cluster-be-2"} 107374182400
starrocks_be_disks_total_capacity{pod="my-cluster-cn-0"} 53687091200   # <-- CN pod with BE prefix!
starrocks_be_disks_total_capacity{pod="my-cluster-cn-1"} 53687091200   # <-- CN pod with BE prefix!
```

Scraping the `/metrics` endpoint directly on a CN pod shows the same issue — every metric uses `starrocks_be_`:

```
# TYPE starrocks_be_process_mem_bytes gauge
starrocks_be_process_mem_bytes 1073741824
# TYPE starrocks_be_process_thread_num gauge
starrocks_be_process_thread_num 128
```

### Root Cause

The `as_cn` flag is already available at the metric registry creation site but is ignored:

```cpp
void start_be(const std::vector<StorePath>& paths, bool as_cn) {
    std::string process_name = as_cn ? "CN" : "BE";  // as_cn used for logging...
    // ...but hardcoded here:
    static auto* process_metrics_registry = new ProcessMetricsRegistry("starrocks_be");
```

Additionally, `TableMetricsManager` in `table_metrics.h` hardcodes its own `MetricRegistry _metrics{"starrocks_be"}`, so even if the root registry prefix were fixed, table-level metrics would still use `starrocks_be_`.

## What I'm doing:

Use the existing `as_cn` flag to set the metric registry prefix to `"starrocks_cn"` when running in CN mode, and propagate the prefix to `TableMetricsManager` which had its own hardcoded `"starrocks_be"` registry.

### Changes (4 files, ~10 lines):

1. **`be/src/service/service_be/starrocks_be.cpp`**: Use `as_cn ? "starrocks_cn" : "starrocks_be"` for `ProcessMetricsRegistry`
2. **`be/src/common/util/table_metrics.h`**: Accept prefix via constructor parameter instead of hardcoding `"starrocks_be"`
3. **`be/src/common/metrics/process_metrics_registry.cpp`**: Forward the registry name to both `_root_registry` and `_table_metrics_mgr`
4. **`be/test/http/metrics_action_test.cpp`**: Update test expectations — registry created with prefix `"test"` now correctly produces `test_table_*` metrics instead of `starrocks_be_table_*`

### After This Fix

BE pods continue to emit metrics with `starrocks_be_` prefix (unchanged):
```
starrocks_be_process_mem_bytes 2147483648
starrocks_be_disks_total_capacity 107374182400
starrocks_be_compaction_deltas_total{type="base"} 42
```

CN pods now emit metrics with `starrocks_cn_` prefix:
```
starrocks_cn_process_mem_bytes 1073741824
starrocks_cn_disks_total_capacity 53687091200
starrocks_cn_compaction_deltas_total{type="base"} 0
```

This matches the convention where FE uses `starrocks_fe_` prefix, and allows users to:
- Build separate Grafana dashboards for BE vs CN without relying on pod name parsing
- Set different alert thresholds for BE-specific and CN-specific metrics
- Aggregate correctly: `sum(starrocks_be_disks_total_capacity)` gives BE-only capacity
- Query both when needed: `{__name__=~"starrocks_(be|cn)_process_mem_bytes"}`

Fixes #75741

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: CN metric names change from `starrocks_be_*` to `starrocks_cn_*`

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
