### PR TITLE
[BugFix] Handle NOT NULL -> nullable flat-JSON columns in compaction read path (fix JsonMergeIterator CHECK crash) (backport #75680)

### DIFF
--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -36,6 +36,56 @@
 
 namespace starrocks {
 
+namespace {
+
+struct JsonOutputColumns {
+    JsonColumn* json_column;
+    NullColumn* null_column; // nullptr when the output column is non-nullable
+};
+
+// Split the output column into its JSON data part and (optional) null part.
+JsonOutputColumns extract_json_output(Column* output) {
+    if (output->is_nullable()) {
+        auto* nullable = down_cast<NullableColumn*>(output);
+        return {down_cast<JsonColumn*>(nullable->data_column().get()),
+                down_cast<NullColumn*>(nullable->null_column().get())};
+    }
+    return {down_cast<JsonColumn*>(output), nullptr};
+}
+
+// Read the segment's null stream into the output null column via `read_nulls`.
+// The segment's stored nullability and the output column's nullability can
+// legitimately differ after fast schema evolution, so mismatches must not crash:
+// a segment with a null stream cannot be read into a non-nullable output, fail
+// with InternalError instead.
+template <typename ReadNullsFn>
+Status read_json_null_stream(Column* output, NullColumn* null_column, ColumnIterator* null_iter,
+                             ReadNullsFn read_nulls) {
+    if (null_iter != nullptr && null_column != nullptr) {
+        RETURN_IF_ERROR(read_nulls(null_column));
+        down_cast<NullableColumn*>(output)->update_has_null();
+    } else if (null_iter != nullptr && null_column == nullptr) {
+        return Status::InternalError("flat json: segment has a JSON null stream but the output column is non-nullable");
+    }
+    return Status::OK();
+}
+
+// Call after a successful data read. When the segment was written NOT NULL (no
+// null stream) but the output column is nullable -- a JSON column relaxed to
+// nullable by metadata-only fast schema evolution -- every row produced is
+// non-null, so append matching not-null flags to keep the null column in sync.
+void finish_json_read(Column* output, JsonColumn* json_column, NullColumn* null_column, ColumnIterator* null_iter,
+                      size_t rows_before_read) {
+    if (null_iter == nullptr && null_column != nullptr) {
+        DCHECK_GE(json_column->size(), rows_before_read);
+        constexpr uint8_t kNotNull = 0;
+        null_column->append_value_multiple_times(&kNotNull, json_column->size() - rows_before_read);
+    }
+    output->check_or_die();
+}
+
+} // namespace
+
 class JsonFlatColumnIterator final : public ColumnIterator {
 public:
     JsonFlatColumnIterator(ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
@@ -195,75 +245,54 @@ Status JsonFlatColumnIterator::_read(JsonColumn* json_column, FUNC read_fn) {
 }
 
 Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
-    if (dst->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(dst);
-
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-    } else {
-        json_column = down_cast<JsonColumn*>(dst);
-    }
+    auto [json_column, null_column] = extract_json_output(dst);
 
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
-        down_cast<NullableColumn*>(dst)->update_has_null();
-    }
+    RETURN_IF_ERROR(read_json_null_stream(dst, null_column, _null_iter.get(),
+                                          [&](NullColumn* nulls) { return _null_iter->next_batch(n, nulls); }));
 
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
+    const size_t before = json_column->size();
     auto ret = _read(json_column, read);
-    dst->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(dst, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 
 Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
-    if (dst->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(dst);
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-    } else {
-        json_column = down_cast<JsonColumn*>(dst);
-    }
-
-    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+    auto [json_column, null_column] = extract_json_output(dst);
 
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
-        down_cast<NullableColumn*>(dst)->update_has_null();
-    }
+    RETURN_IF_ERROR(read_json_null_stream(dst, null_column, _null_iter.get(),
+                                          [&](NullColumn* nulls) { return _null_iter->next_batch(range, nulls); }));
 
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
+    const size_t before = json_column->size();
     auto ret = _read(json_column, read);
-    dst->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(dst, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 
 Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
+    auto [json_column, null_column] = extract_json_output(values);
+
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        auto* nullable_column = down_cast<NullableColumn*>(values);
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-        RETURN_IF_ERROR(_null_iter->fetch_values_by_rowid(rowids, size, null_column));
-        nullable_column->update_has_null();
-    } else {
-        json_column = down_cast<JsonColumn*>(values);
-    }
+    RETURN_IF_ERROR(read_json_null_stream(values, null_column, _null_iter.get(), [&](NullColumn* nulls) {
+        return _null_iter->fetch_values_by_rowid(rowids, size, nulls);
+    }));
 
     // 2. Read flat column
     auto read = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
-
+    const size_t before = json_column->size();
     auto ret = _read(json_column, read);
-    values->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(values, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 
@@ -528,77 +557,51 @@ Status JsonMergeIterator::_merge(JsonColumn* dst, FUNC func) {
 }
 
 Status JsonMergeIterator::next_batch(size_t* n, Column* dst) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
-    if (dst->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(dst);
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-    } else {
-        json_column = down_cast<JsonColumn*>(dst);
-    }
-
-    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+    auto [json_column, null_column] = extract_json_output(dst);
 
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
-        down_cast<NullableColumn*>(dst)->update_has_null();
-    }
+    RETURN_IF_ERROR(read_json_null_stream(dst, null_column, _null_iter.get(),
+                                          [&](NullColumn* nulls) { return _null_iter->next_batch(n, nulls); }));
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(n, column); };
+    const size_t before = json_column->size();
     auto ret = _merge(json_column, func);
-    dst->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(dst, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 
 Status JsonMergeIterator::next_batch(const SparseRange<>& range, Column* dst) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
-    if (dst->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(dst);
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-    } else {
-        json_column = down_cast<JsonColumn*>(dst);
-    }
-
-    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+    auto [json_column, null_column] = extract_json_output(dst);
 
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
-        down_cast<NullableColumn*>(dst)->update_has_null();
-    }
+    RETURN_IF_ERROR(read_json_null_stream(dst, null_column, _null_iter.get(),
+                                          [&](NullColumn* nulls) { return _null_iter->next_batch(range, nulls); }));
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->next_batch(range, column); };
+    const size_t before = json_column->size();
     auto ret = _merge(json_column, func);
-    dst->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(dst, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 
 Status JsonMergeIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* dst) {
-    JsonColumn* json_column = nullptr;
-    NullColumn* null_column = nullptr;
-    if (dst->is_nullable()) {
-        auto* nullable_column = down_cast<NullableColumn*>(dst);
-        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
-        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-    } else {
-        json_column = down_cast<JsonColumn*>(dst);
-    }
-
-    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+    auto [json_column, null_column] = extract_json_output(dst);
 
     // 1. Read null column
-    if (_null_iter != nullptr) {
-        RETURN_IF_ERROR(_null_iter->fetch_values_by_rowid(rowids, size, null_column));
-        down_cast<NullableColumn*>(dst)->update_has_null();
-    }
+    RETURN_IF_ERROR(read_json_null_stream(dst, null_column, _null_iter.get(), [&](NullColumn* nulls) {
+        return _null_iter->fetch_values_by_rowid(rowids, size, nulls);
+    }));
 
     auto func = [&](ColumnIterator* iter, Column* column) { return iter->fetch_values_by_rowid(rowids, size, column); };
+    const size_t before = json_column->size();
     auto ret = _merge(json_column, func);
-    dst->check_or_die();
+    if (ret.ok()) {
+        finish_json_read(dst, json_column, null_column, _null_iter.get(), before);
+    }
     return ret;
 }
 

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -264,6 +265,94 @@ protected:
             return down_cast<JsonColumn*>(down_cast<NullableColumn*>(col.get())->data_column().get());
         }
         return down_cast<JsonColumn*>(col.get());
+    }
+
+    // One written segment plus everything needed to read it back.
+    struct SegmentHandle {
+        std::shared_ptr<MemoryFileSystem> fs;
+        std::string fname;
+        std::shared_ptr<Segment> segment;
+        std::shared_ptr<ColumnMetaPB> meta;
+        std::unique_ptr<ColumnReader> reader;
+        size_t num_rows = 0;
+    };
+
+    // Write one JSON segment from `jsons`; segment nullability follows jsons[0]->is_nullable().
+    SegmentHandle write_segment(Columns& jsons, bool need_flat, const std::string& fname) {
+        SegmentHandle handle;
+        handle.fs = std::make_shared<MemoryFileSystem>();
+        EXPECT_TRUE(handle.fs->create_dir(TEST_DIR).ok());
+        handle.fname = TEST_DIR + fname;
+        handle.meta = std::make_shared<ColumnMetaPB>();
+        handle.segment = create_dummy_segment(handle.fs, handle.fname);
+
+        TabletColumn json_tablet_column = create_with_default_value<TYPE_JSON>("");
+
+        ASSIGN_OR_ABORT(auto wfile, handle.fs->new_writable_file(handle.fname));
+        ColumnWriterOptions writer_opts;
+        writer_opts.need_flat = need_flat;
+        writer_opts.meta = handle.meta.get();
+        writer_opts.meta->set_column_id(0);
+        writer_opts.meta->set_unique_id(0);
+        writer_opts.meta->set_type(TYPE_JSON);
+        writer_opts.meta->set_length(0);
+        writer_opts.meta->set_encoding(DEFAULT_ENCODING);
+        writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+        writer_opts.meta->set_is_nullable(jsons[0]->is_nullable());
+        writer_opts.need_zone_map = false;
+        writer_opts.is_compaction = true;
+
+        ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &json_tablet_column, wfile.get()));
+        EXPECT_OK(writer->init());
+        for (auto& json : jsons) {
+            EXPECT_TRUE(writer->append(*json).ok());
+            handle.num_rows += json->size();
+        }
+        EXPECT_TRUE(writer->finish().ok());
+        EXPECT_TRUE(writer->write_data().ok());
+        EXPECT_TRUE(writer->write_ordinal_index().ok());
+        EXPECT_TRUE(wfile->close().ok());
+
+        handle.segment->set_num_rows(handle.num_rows);
+        auto res = ColumnReader::create(handle.meta.get(), handle.segment.get(), nullptr);
+        EXPECT_TRUE(res.ok());
+        handle.reader = std::move(res).value();
+        return handle;
+    }
+
+    enum class ReadMode { kBatch, kRange, kByRowid };
+
+    // Read the whole segment into `dst` through one of the three iterator read paths.
+    // With `path == nullptr` a flat segment is read through JsonMergeIterator; with a
+    // from-compaction access path it is read through JsonFlatColumnIterator.
+    Status read_segment(const SegmentHandle& handle, ReadMode mode, Column* dst, ColumnAccessPath* path = nullptr) {
+        ASSIGN_OR_RETURN(auto iter, handle.reader->new_iterator(path));
+        ASSIGN_OR_RETURN(auto read_file, handle.fs->new_random_access_file(handle.fname));
+
+        ColumnIteratorOptions iter_opts;
+        OlapReaderStatistics stats;
+        iter_opts.stats = &stats;
+        iter_opts.read_file = read_file.get();
+        RETURN_IF_ERROR(iter->init(iter_opts));
+        RETURN_IF_ERROR(iter->seek_to_first());
+
+        switch (mode) {
+        case ReadMode::kBatch: {
+            size_t n = handle.num_rows;
+            return iter->next_batch(&n, dst);
+        }
+        case ReadMode::kRange: {
+            SparseRange<> range;
+            range.add(Range<>(0, static_cast<rowid_t>(handle.num_rows)));
+            return iter->next_batch(range, dst);
+        }
+        case ReadMode::kByRowid: {
+            std::vector<rowid_t> rowids(handle.num_rows);
+            std::iota(rowids.begin(), rowids.end(), 0);
+            return iter->fetch_values_by_rowid(rowids.data(), rowids.size(), dst);
+        }
+        }
+        return Status::OK();
     }
 
 private:
@@ -1475,5 +1564,205 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactRemainLevel) {
               read_col->debug_item(7));
     EXPECT_EQ(R"({"a": 28, "b": "efg8", "c": {"d": 38, "e": 381}, "f4": {"m": 548, "n": 248}})",
               read_col->debug_item(18));
+}
+
+// Regression for the NOT NULL -> nullable flat-JSON compaction crash.
+//
+// A JSON column relaxed from NOT NULL to nullable via metadata-only fast schema evolution leaves old
+// segments physically NOT NULL (no null sub-stream -> reader builds _null_iter == nullptr) while the
+// compaction output column is nullable (null_column != nullptr). The merge read path used to CHECK that
+// the two nullabilities matched and aborted (SIGABRT). It must instead synthesize an all-not-null null
+// column, because a NOT NULL segment by construction contains no null values.
+TEST_F(FlatJsonColumnCompactTest, CompactJsonNotNullToNullableSchemaEvolution) {
+    // clang-format off
+    // Non-nullable inputs -> segment is written NOT NULL (no null stream).
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", false),
+            normal_json(R"({"a": 2, "b": 22})", false),
+            normal_json(R"({"a": 3, "b": 23})", false),
+            normal_json(R"({"a": 4, "b": 24})", false),
+            normal_json(R"({"a": 5, "b": 25})", false),
+    };
+    // clang-format on
+
+    auto handle = write_segment(jsons, /*need_flat=*/true, "/notnull_to_nullable.data");
+    // Segment was stored flat and NOT NULL.
+    EXPECT_TRUE(handle.meta->json_meta().is_flat());
+    EXPECT_FALSE(handle.meta->is_nullable());
+
+    // All three read paths carry the fix; compaction uses the SparseRange overload in production.
+    for (auto mode : {ReadMode::kBatch, ReadMode::kRange, ReadMode::kByRowid}) {
+        // Output column relaxed to nullable, as compaction sees it after the ALTER.
+        ColumnPtr col = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+        auto st = read_segment(handle, mode, col.get());
+        ASSERT_TRUE(st.ok()) << "mode=" << static_cast<int>(mode) << " " << st.to_string();
+
+        auto* nullable = down_cast<NullableColumn*>(col.get());
+        ASSERT_EQ(5, nullable->size()) << "mode=" << static_cast<int>(mode);
+        // Synthesized null bytes are all 0 (not-null) and the column reports no nulls.
+        EXPECT_FALSE(nullable->has_null());
+        const auto& null_data = nullable->null_column()->get_data();
+        ASSERT_EQ(5, null_data.size());
+        for (size_t i = 0; i < null_data.size(); i++) {
+            EXPECT_EQ(0, null_data[i]) << "mode=" << static_cast<int>(mode) << " row " << i;
+        }
+        // JSON values read back correctly.
+        EXPECT_EQ(R"({"a": 1, "b": 21})", col->debug_item(0));
+        EXPECT_EQ(R"({"a": 2, "b": 22})", col->debug_item(1));
+        EXPECT_EQ(R"({"a": 3, "b": 23})", col->debug_item(2));
+        EXPECT_EQ(R"({"a": 4, "b": 24})", col->debug_item(3));
+        EXPECT_EQ(R"({"a": 5, "b": 25})", col->debug_item(4));
+    }
+}
+
+// Compaction merges segments of mixed physical nullability into one nullable output after the
+// NOT NULL -> nullable ALTER: old segments have no null stream, new ones do. Reading them
+// sequentially into the same output also exercises the backfill with a non-empty destination
+// (the `before` offset), which a single-segment read cannot catch.
+TEST_F(FlatJsonColumnCompactTest, CompactJsonMixedNullabilitySegments) {
+    // clang-format off
+    Columns not_null_a = {
+            normal_json(R"({"a": 1, "b": 21})", false),
+            normal_json(R"({"a": 2, "b": 22})", false),
+            normal_json(R"({"a": 3, "b": 23})", false),
+    };
+    Columns nullable_b = {
+            normal_json(R"({"a": 4, "b": 24})", true),
+            normal_json(R"({"a": 5, "b": 25})", true),
+            normal_json(R"({"a": 6, "b": 26})", true),
+            normal_json(R"({"a": 7, "b": 27})", true),
+            normal_json(R"(NULL)", true),
+    };
+    Columns not_null_c = {
+            normal_json(R"({"a": 8, "b": 28})", false),
+            normal_json(R"({"a": 9, "b": 29})", false),
+            normal_json(R"({"a": 10, "b": 30})", false),
+    };
+    // clang-format on
+
+    auto handle_a = write_segment(not_null_a, /*need_flat=*/true, "/mixed_a.data");
+    auto handle_b = write_segment(nullable_b, /*need_flat=*/true, "/mixed_b.data");
+    auto handle_c = write_segment(not_null_c, /*need_flat=*/true, "/mixed_c.data");
+    EXPECT_FALSE(handle_a.meta->is_nullable());
+    EXPECT_TRUE(handle_b.meta->is_nullable());
+    EXPECT_FALSE(handle_c.meta->is_nullable());
+
+    ColumnPtr col = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+    ASSERT_OK(read_segment(handle_a, ReadMode::kBatch, col.get())); // backfill with empty dst
+    ASSERT_OK(read_segment(handle_b, ReadMode::kBatch, col.get())); // regular null-stream read
+    ASSERT_OK(read_segment(handle_c, ReadMode::kBatch, col.get())); // backfill with non-empty dst
+
+    auto* nullable = down_cast<NullableColumn*>(col.get());
+    ASSERT_EQ(11, nullable->size());
+    EXPECT_TRUE(nullable->has_null());
+    const auto& null_data = nullable->null_column()->get_data();
+    ASSERT_EQ(11, null_data.size());
+    for (size_t i = 0; i < null_data.size(); i++) {
+        EXPECT_EQ(i == 7 ? 1 : 0, null_data[i]) << "row " << i;
+    }
+    EXPECT_EQ(R"({"a": 1, "b": 21})", col->debug_item(0));
+    EXPECT_EQ(R"({"a": 4, "b": 24})", col->debug_item(3));
+    EXPECT_EQ(R"(NULL)", col->debug_item(7));
+    EXPECT_EQ(R"({"a": 8, "b": 28})", col->debug_item(8));
+    EXPECT_EQ(R"({"a": 10, "b": 30})", col->debug_item(10));
+}
+
+// The inverse mismatch -- a segment with a null stream read into a non-nullable output -- cannot be
+// satisfied and used to abort on the same CHECK. It must fail with InternalError instead of
+// crashing the process.
+TEST_F(FlatJsonColumnCompactTest, CompactJsonNullableSegmentToNonNullableOutputError) {
+    // clang-format off
+    // 1 NULL out of 5 rows (20%) stays under the default json_flat_null_factor, so the segment is
+    // written flat with a null stream.
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", true),
+            normal_json(R"({"a": 2, "b": 22})", true),
+            normal_json(R"({"a": 3, "b": 23})", true),
+            normal_json(R"({"a": 4, "b": 24})", true),
+            normal_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    auto handle = write_segment(jsons, /*need_flat=*/true, "/nullable_to_notnull.data");
+    EXPECT_TRUE(handle.meta->json_meta().is_flat());
+    EXPECT_TRUE(handle.meta->is_nullable());
+
+    for (auto mode : {ReadMode::kBatch, ReadMode::kRange, ReadMode::kByRowid}) {
+        ColumnPtr col = JsonColumn::create();
+        auto st = read_segment(handle, mode, col.get());
+        ASSERT_FALSE(st.ok()) << "mode=" << static_cast<int>(mode);
+        EXPECT_TRUE(st.is_internal_error()) << "mode=" << static_cast<int>(mode) << " " << st.to_string();
+    }
+}
+
+// Same NOT NULL -> nullable schema-evolution scenario as above, but read through
+// JsonFlatColumnIterator (compaction access path) instead of JsonMergeIterator.
+TEST_F(FlatJsonColumnCompactTest, CompactJsonNotNullToNullableSchemaEvolutionWithPaths) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", false),
+            normal_json(R"({"a": 2, "b": 22})", false),
+            normal_json(R"({"a": 3, "b": 23})", false),
+            normal_json(R"({"a": 4, "b": 24})", false),
+            normal_json(R"({"a": 5, "b": 25})", false),
+    };
+    // clang-format on
+
+    auto handle = write_segment(jsons, /*need_flat=*/true, "/notnull_to_nullable_paths.data");
+    EXPECT_TRUE(handle.meta->json_meta().is_flat());
+    EXPECT_FALSE(handle.meta->is_nullable());
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b");
+    root->set_from_compaction(true);
+
+    for (auto mode : {ReadMode::kBatch, ReadMode::kRange, ReadMode::kByRowid}) {
+        ColumnPtr col = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+        auto st = read_segment(handle, mode, col.get(), root.get());
+        ASSERT_TRUE(st.ok()) << "mode=" << static_cast<int>(mode) << " " << st.to_string();
+
+        auto* nullable = down_cast<NullableColumn*>(col.get());
+        ASSERT_EQ(5, nullable->size()) << "mode=" << static_cast<int>(mode);
+        EXPECT_FALSE(nullable->has_null());
+        const auto& null_data = nullable->null_column()->get_data();
+        ASSERT_EQ(5, null_data.size());
+        for (size_t i = 0; i < null_data.size(); i++) {
+            EXPECT_EQ(0, null_data[i]) << "mode=" << static_cast<int>(mode) << " row " << i;
+        }
+        // Values survive the flat read; row 0 carries a=1, row 4 carries a=5.
+        EXPECT_NE(std::string::npos, col->debug_item(0).find("a: 1")) << col->debug_item(0);
+        EXPECT_NE(std::string::npos, col->debug_item(4).find("a: 5")) << col->debug_item(4);
+    }
+}
+
+// Inverse mismatch through JsonFlatColumnIterator: nullable flat segment into a
+// non-nullable output must fail with InternalError instead of crashing.
+TEST_F(FlatJsonColumnCompactTest, CompactJsonNullableToNonNullableOutputErrorWithPaths) {
+    // clang-format off
+    Columns jsons = {
+            normal_json(R"({"a": 1, "b": 21})", true),
+            normal_json(R"({"a": 2, "b": 22})", true),
+            normal_json(R"({"a": 3, "b": 23})", true),
+            normal_json(R"({"a": 4, "b": 24})", true),
+            normal_json(R"(NULL)", true),
+    };
+    // clang-format on
+
+    auto handle = write_segment(jsons, /*need_flat=*/true, "/nullable_to_notnull_paths.data");
+    EXPECT_TRUE(handle.meta->json_meta().is_flat());
+    EXPECT_TRUE(handle.meta->is_nullable());
+
+    ASSIGN_OR_ABORT(auto root, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "a");
+    ColumnAccessPath::insert_json_path(root.get(), LogicalType::TYPE_JSON, "b");
+    root->set_from_compaction(true);
+
+    for (auto mode : {ReadMode::kBatch, ReadMode::kRange, ReadMode::kByRowid}) {
+        ColumnPtr col = JsonColumn::create();
+        auto st = read_segment(handle, mode, col.get(), root.get());
+        ASSERT_FALSE(st.ok()) << "mode=" << static_cast<int>(mode);
+        EXPECT_TRUE(st.is_internal_error()) << "mode=" << static_cast<int>(mode) << " " << st.to_string();
+    }
 }
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

We hit a BE/CN crash loop on a shared-data cluster after a user ran
`ALTER TABLE t MODIFY COLUMN c json NULL` on a flat-JSON column that was originally `NOT NULL`.
Fast schema evolution makes that ALTER metadata-only, so the old segments on object storage are
never rewritten — they stay physically NOT NULL with no null sub-stream. The next background
compaction then reads those segments into a now-nullable output column and dies here:

```
CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
```

The reader has `_null_iter == nullptr` (segment has no null stream) but the output is nullable
(`null_column != nullptr`), so the CHECK fires and SIGABRTs the whole process. Compaction retries,
crashes again, and the node never recovers. Reproduced on 4.0.12.

The thing is, this state is perfectly legal. A NOT NULL segment can't contain nulls, so the reader
just needs to fill the null map with "not null" instead of aborting.

## What I'm doing:

Fix is read-side only, all in `be/src/storage/rowset/json_column_iterator.cpp`. No writer, FE,
thrift or proto changes.

All 6 read methods on `JsonMergeIterator` and `JsonFlatColumnIterator` (both `next_batch`
overloads and `fetch_values_by_rowid` on each) now handle the two mismatch cases instead of
CHECKing:

- Segment NOT NULL, output nullable (the schema-evolution case): after the merge/read succeeds,
  append not-null flags to the output's null column for exactly the rows produced
  (`json_column->size() - before`), then `update_has_null()`. Same
  `append_value_multiple_times(&NOT_NULL, n)` idiom the flat-JSON writer already uses.
- Segment nullable, output non-nullable: there's nowhere to put the null flags, so return
  `Status::InternalError` instead of killing the process.

While in there I fixed two adjacent problems in the same family:
`JsonFlatColumnIterator::next_batch(size_t*)` never had the CHECK at all and would silently
under-fill the null column in release builds, and
`JsonFlatColumnIterator::fetch_values_by_rowid` down_cast the destination to `JsonColumn`
whenever the segment had no null stream — UB if the destination was actually nullable. Also moved
`check_or_die()` behind the success path, since running it on a half-filled column after a failed
read would just abort in a different place.

Tests added to `FlatJsonColumnCompactTest`:

- `CompactJsonNotNullToNullableSchemaEvolution` — NOT NULL flat segment read into a nullable
  column through all three read paths. This SIGABRTs without the fix. Asserts row count, that
  every synthesized null byte is 0, and that the JSON values round-trip.
- `CompactJsonMixedNullabilitySegments` — NOT NULL + nullable + NOT NULL segments merged into one
  output, so the backfill also runs against a non-empty destination and sits next to a real NULL.
- `CompactJsonNullableSegmentToNonNullableOutputError` — the inverse mismatch returns
  `InternalError` on all three paths instead of crashing.

Scope note: only the flat-JSON read paths (`JsonMergeIterator` / `JsonFlatColumnIterator`)
couple the segment's stored nullability to the output column like this. Non-flat JSON segments
are read through `ScalarColumnIterator`, and dynamic flattening (`JsonDynamicFlatIterator`)
reads through a `clone_empty()` proxy -- both maintain the output null column through the
Column append API and have no nullability-mismatch coupling, so they need no change.

The mismatch policy lives in two file-local helpers (`read_json_null_stream` /
`finish_json_read`) shared by all six read methods, so the planned ARRAY/MAP follow-up can
reuse the same shape instead of copy-pasting it.

One heads-up for reviewers: `array_column_iterator.cpp` (3x) and `map_column_iterator.cpp` (1x)
have the exact same CHECK and the same crash vector for ARRAY/MAP columns after the same kind of
ALTER. I'm deliberately not touching them here to keep this backportable and easy to review —
follow-up PR coming.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

(3.4 and 3.3 need manual backports — same as the earlier compaction crash fixes #63553 / #70539.)
<hr>This is a manual backport of pull request #75680 to branch-3.5. The automatic Mergify backport (#75723) could not apply cleanly because this branch predates the mutable-column accessor refactor, so the conflicts were resolved by hand (same adaptation in both: NullableColumn::data_column().get()/null_column().get() instead of the *_raw_ptr() accessors, and Columns-based test helpers). Verified locally: the full FlatJsonColumnCompactTest suite passes in an ASAN build on this branch.



