### PR TITLE
[Enhancement] Store union-aggregate state once in IVM materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -582,6 +582,11 @@ public class InsertPlanner {
         try (Timer ignore2 = Tracers.watchScope("Optimizer")) {
             OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
             optimizerContext.setSourceTablesCount(sourceTablesCount);
+            if (session.getSessionVariable().isEnableIVMRefresh()) {
+                // Position i of outputColumns writes targetTable fullSchema[i]; IvmRewriter relies on
+                // this pairing to bind aggregates to MV state columns (bindStateColumnsForAggregate).
+                optimizerContext.getTvrOptContext().setIvmInsertOutputColumns(outputColumns);
+            }
             Optimizer optimizer = OptimizerFactory.create(optimizerContext);
             optimizedPlan = optimizer.optimize(
                     preOptimizePlanContext.root,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer.mv;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
@@ -402,8 +403,18 @@ public class IVMAnalyzer {
             return false;
         }
 
+        // Select items that are exactly one aggregate call; only these can collapse (a wrapped
+        // aggregate like bitmap_count(bitmap_union(x)) still needs the hidden state column).
+        Set<Expr> bareAggregateItems = Sets.newHashSet();
+        for (SelectListItem item : selectRelation.getSelectList().getItems()) {
+            if (item.getExpr() instanceof FunctionCallExpr) {
+                bareAggregateItems.add(item.getExpr());
+            }
+        }
+
         // getAggregate() is non-null post-analysis, so for no aggregates this loop just no-ops.
         List<IVMAggFunctionInfo> newAggFuncInfos = Lists.newArrayList();
+        Set<IVMAggFunctionInfo> collapsedInfos = Sets.newIdentityHashSet();
         ExprSubstitutionMap substitutionMap = new ExprSubstitutionMap();
         for (FunctionCallExpr aggFuncExpr : aggregateExprs) {
             // Distinct flag is dropped by the combinator rewrite below, so incremental
@@ -423,10 +434,17 @@ public class IVMAnalyzer {
 
             IVMAggFunctionInfo aggFunctionInfo = new IVMAggFunctionInfo(aggFuncExpr, aggFuncName,
                     intermediateAggFuncExpr, newAggFuncName);
-            Expr stateMergeFuncExpr = buildStateMergeFuncExpr(aggFunctionInfo);
-
             newAggFuncInfos.add(aggFunctionInfo);
-            substitutionMap.put(aggFuncExpr, stateMergeFuncExpr);
+
+            // A metric-state union's finalize is the identity (the merged state IS the result), so
+            // the select item itself becomes the state column — no separate hidden copy. The refresh
+            // side finds it via IvmRewriter.bindStateColumnsForAggregate.
+            if (isCollapsibleUnionAggregate(aggFuncExpr, bareAggregateItems)) {
+                collapsedInfos.add(aggFunctionInfo);
+                substitutionMap.put(aggFuncExpr, intermediateAggFuncExpr);
+            } else {
+                substitutionMap.put(aggFuncExpr, buildStateMergeFuncExpr(aggFunctionInfo));
+            }
         }
 
         List<FunctionCallExpr> newAggFuncs = newAggFuncInfos.stream()
@@ -454,8 +472,11 @@ public class IVMAnalyzer {
                     Expr newExpr = substituteWithMap(item.getExpr().clone(), substitutionMap);
                     newItems.add(new SelectListItem(newExpr, item.getAlias()));
                 });
-        // add agg state func expr
+        // add agg state func expr (collapsed unions already sit in the select items above)
         for (IVMAggFunctionInfo aggFunctionInfo : newAggFuncInfos) {
+            if (collapsedInfos.contains(aggFunctionInfo)) {
+                continue;
+            }
             newItems.add(new SelectListItem(aggFunctionInfo.newAggFunc, aggFunctionInfo.newAggFuncName));
         }
         selectList.setItems(newItems);
@@ -468,8 +489,9 @@ public class IVMAnalyzer {
                     Expr newExpr = substituteWithMap(expr.clone(), substitutionMap);
                     newOutputExpressions.add(newExpr);
                 });
-        // add extra exprs
+        // add extra exprs (collapsed unions already sit in the substituted outputs above)
         newAggFuncInfos.stream()
+                .filter(aggFunctionInfo -> !collapsedInfos.contains(aggFunctionInfo))
                 .forEach(aggFunctionInfo -> newOutputExpressions.add(aggFunctionInfo.newAggFunc));
         selectRelation.setOutputExpr(newOutputExpressions);
 
@@ -541,6 +563,18 @@ public class IVMAnalyzer {
         String aggStateFuncName = AggStateUtils.aggStateCombineFunctionName(aggFuncName);
         FunctionCallExpr aggStateFuncExpr = new FunctionCallExpr(aggStateFuncName, aggFuncExpr.getChildren());
         return aggStateFuncExpr;
+    }
+
+    /**
+     * True when the aggregate's state column can double as its visible output column. Requires
+     * both an identity finalize (bitmap_union/hll_union/percentile_union: the merged state IS the
+     * result value) and a select item that is exactly this aggregate (so that item can carry the
+     * state). A genuine agg-state union combinator (avg_union over an AGG_STATE_UNION column)
+     * satisfies the same identity property and should join this predicate when IVM supports it.
+     */
+    private static boolean isCollapsibleUnionAggregate(FunctionCallExpr aggFuncExpr, Set<Expr> bareAggregateItems) {
+        return AggStateUtils.METRIC_STATE_UNION_FUNCTIONS.contains(aggFuncExpr.getFunctionName())
+                && bareAggregateItems.contains(aggFuncExpr);
     }
 
     private Expr buildStateMergeFuncExpr(IVMAggFunctionInfo aggFunctionInfo) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmTrialRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IvmTrialRewriter.java
@@ -105,6 +105,9 @@ public final class IvmTrialRewriter {
             // fires and appendPkLoadOpColumn runs — mirrors production refresh.
             optimizerContext.setStatement(buildSyntheticInsertStmt(mockMv, rewrittenQuery));
             optimizerContext.getQueryMaterializationContext().setOverrideTargetMv(mockMv);
+            // The trial bypasses InsertPlanner, so stash the ordered outputs here as it would
+            // (position i writes mock schema[i]) for IvmRewriter.bindStateColumnsForAggregate.
+            optimizerContext.getTvrOptContext().setIvmInsertOutputColumns(logicalPlan.getOutputColumn());
             // RULE_BASED skips Memo / cost-based; the mock MV has no statistics or partitions.
             optimizerContext.setOptimizerOptions(OptimizerOptions.newRuleBaseOpt());
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmDeltaAggregateRule.java
@@ -113,25 +113,24 @@ public class IvmDeltaAggregateRule extends TransformationRule {
         Preconditions.checkState(rowIdColumn != null, "__ROW_ID__ column must exist in MV");
         int encodeRowIdVersion = mv.getEncodeRowIdVersion();
 
-        List<Column> aggStateColumns = mv.getFullSchema().stream()
-                .filter(col -> col.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX))
-                .collect(Collectors.toList());
-
         // Step 2: Create MV scan
         LogicalOlapScanOperator mvScan = MvRewritePreprocessor.createScanMvOperator(
                 mv, columnRefFactory, PCellSortedSet.of(), true);
         ColumnRefOperator mvRowIdRef = mvScan.getColumnMetaToColRefMap().get(rowIdColumn);
         Map<Column, ColumnRefOperator> mvColMetaToRefMap = mvScan.getColumnMetaToColRefMap();
-        List<ColumnRefOperator> mvAggStateRefs = aggStateColumns.stream()
-                .map(mvColMetaToRefMap::get)
-                .collect(Collectors.toList());
 
-        // Step 3: Collect input aggregate info
+        // Step 3: Collect input aggregate info and the aggregate -> state-column binding
+        // (built by IvmRewriter.bindStateColumnsForAggregate; keyed by ref id so the pairing
+        // holds for any column layout).
         List<ColumnRefOperator> groupingKeys = inputAggOp.getGroupingKeys();
         Map<ColumnRefOperator, CallOperator> inputAggMap = inputAggOp.getAggregations();
-        Preconditions.checkState(aggStateColumns.size() == inputAggMap.size(),
-                "MV __AGG_STATE__ columns size %s must match aggregate map size %s",
-                aggStateColumns.size(), inputAggMap.size());
+        Map<Integer, String> stateColumnByAggRefId =
+                context.getTvrOptContext().getIvmStateColumnNameByAggRefId();
+        Preconditions.checkState(stateColumnByAggRefId != null,
+                "IVM aggregate state-column binding is missing for MV %s", mv.getName());
+        Preconditions.checkState(stateColumnByAggRefId.size() == inputAggMap.size(),
+                "state-column binding size %s must match aggregate map size %s",
+                stateColumnByAggRefId.size(), inputAggMap.size());
 
         // Step 4: Build intermediate aggregate operator (same _combine funcs, new ColumnRefs)
         Map<ScalarOperator, ColumnRefOperator> oldToNewRefMap = Maps.newHashMap();
@@ -161,19 +160,27 @@ public class IvmDeltaAggregateRule extends TransformationRule {
             projMap.putAll(inputAggOp.getProjection().getColumnRefMap());
         }
 
+        // Iteration is id-sorted only to keep plans deterministic; the pairing itself is by ref id.
         List<ColumnRefOperator> inputAggCallRefs = inputAggMap.keySet().stream()
                 .sorted(Comparator.comparingInt(ColumnRefOperator::getId))
                 .collect(Collectors.toList());
-        Preconditions.checkState(inputAggCallRefs.size() == mvAggStateRefs.size(),
-                "Input agg call refs size %s must match MV agg state refs size %s",
-                inputAggCallRefs.size(), mvAggStateRefs.size());
-        for (int i = 0; i < inputAggCallRefs.size(); i++) {
-            ColumnRefOperator origRef = inputAggCallRefs.get(i);
+        for (ColumnRefOperator origRef : inputAggCallRefs) {
             CallOperator origCall = inputAggMap.get(origRef);
             ColumnRefOperator intermediateRef = oldToNewRefMap.get(origCall);
             Preconditions.checkState(intermediateRef != null,
                     "Intermediate ref should not be null for: %s", origCall);
-            ColumnRefOperator mvStateRef = mvAggStateRefs.get(i);
+            String stateColumnName = stateColumnByAggRefId.get(origRef.getId());
+            Preconditions.checkState(stateColumnName != null,
+                    "no MV state column bound for aggregate %s (%s)", origCall, origRef);
+            Column stateColumn = mv.getColumn(stateColumnName);
+            Preconditions.checkState(stateColumn != null,
+                    "MV %s has no column '%s' bound for aggregate %s", mv.getName(), stateColumnName, origCall);
+            ColumnRefOperator mvStateRef = mvColMetaToRefMap.get(stateColumn);
+            Preconditions.checkState(mvStateRef != null,
+                    "MV scan lost column '%s' of MV %s", stateColumnName, mv.getName());
+            Preconditions.checkState(stateColumn.getType().matchesType(origRef.getType()),
+                    "state column '%s' type %s does not match aggregate %s output type %s",
+                    stateColumnName, stateColumn.getType(), origCall, origRef.getType());
             ScalarOperator stateUnion = IvmOpUtils.buildStateUnionScalarOperator(
                     origCall, intermediateRef, mvStateRef);
             projMap.put(origRef, stateUnion);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -14,9 +14,11 @@
 
 package com.starrocks.sql.optimizer.rule.ivm;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.gson.JsonSyntaxException;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
@@ -34,7 +36,9 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -110,6 +114,7 @@ public class IvmRewriter {
             tree.setChild(0, OptExpression.create(
                     new LogicalDeltaOperator(true, actionColumn), trialPlan));
             deriveLogicalProperty(tree);
+            bindStateColumnsForAggregate(optimizerContext, trialPlan);
             scheduler.rewriteIterative(tree, rootTaskContext, RuleSet.IVM_DELTA_REWRITE_RULES);
 
             // Phase 2: Convergence check — every Delta/Version marker must have been
@@ -255,6 +260,74 @@ public class IvmRewriter {
             return op.getProjection().getColumnRefMap();
         }
         return null;
+    }
+
+    /**
+     * Binds each aggregate output to the MV column that stores its state, keyed by ColumnRef id
+     * (consumed by {@link IvmDeltaAggregateRule}); no-op for non-aggregate plans.
+     *
+     * <p>A state column is recognized structurally: an INSERT output whose expression resolves,
+     * through pass-through projections, to a bare aggregation output ref. That matches the hidden
+     * __AGG_STATE_ columns and collapsed union columns (whose visible output IS the state), and
+     * excludes finalized outputs like CASE(sum_state_merge(...)), group keys and __ROW_ID__.
+     * Keying by ref id instead of zipping prefix-filtered schema positions against id-sorted
+     * aggregates keeps the pairing correct for any column layout.</p>
+     */
+    private static void bindStateColumnsForAggregate(OptimizerContext optimizerContext, OptExpression plan) {
+        List<ColumnRefOperator> outputColumns =
+                optimizerContext.getTvrOptContext().getIvmInsertOutputColumns();
+        if (outputColumns == null) {
+            return;
+        }
+        Map<ColumnRefOperator, ScalarOperator> translations = Maps.newHashMap();
+        LogicalAggregationOperator aggOperator = null;
+        OptExpression node = plan;
+        while (node != null) {
+            Operator op = node.getOp();
+            if (op.getProjection() != null) {
+                translations.putAll(op.getProjection().getColumnRefMap());
+            }
+            if (op instanceof LogicalProjectOperator) {
+                translations.putAll(((LogicalProjectOperator) op).getColumnRefMap());
+            } else if (op instanceof LogicalAggregationOperator) {
+                aggOperator = (LogicalAggregationOperator) op;
+                break;
+            } else if (!(op instanceof LogicalFilterOperator) && !(op instanceof LogicalTopNOperator)) {
+                break;
+            }
+            node = node.getInputs().isEmpty() ? null : node.inputAt(0);
+        }
+        if (aggOperator == null) {
+            return;
+        }
+        MaterializedView mv = loadTargetMv(optimizerContext);
+        if (mv == null) {
+            return;
+        }
+        List<Column> schema = mv.getFullSchema();
+        Preconditions.checkState(outputColumns.size() == schema.size(),
+                "IVM insert output count %s must match MV '%s' schema size %s",
+                outputColumns.size(), mv.getName(), schema.size());
+        Map<Integer, String> stateColumnByAggRefId = Maps.newHashMap();
+        for (int i = 0; i < outputColumns.size(); i++) {
+            ScalarOperator resolved = outputColumns.get(i);
+            for (int hop = 0; hop < 8 && resolved instanceof ColumnRefOperator
+                    && translations.containsKey(resolved); hop++) {
+                ScalarOperator next = translations.get(resolved);
+                if (next == resolved) {
+                    break;
+                }
+                resolved = next;
+            }
+            if (resolved instanceof ColumnRefOperator
+                    && aggOperator.getAggregations().containsKey((ColumnRefOperator) resolved)) {
+                stateColumnByAggRefId.put(((ColumnRefOperator) resolved).getId(), schema.get(i).getName());
+            }
+        }
+        Preconditions.checkState(stateColumnByAggRefId.size() == aggOperator.getAggregations().size(),
+                "every aggregate of MV '%s' must bind to exactly one state column, bound %s of %s",
+                mv.getName(), stateColumnByAggRefId.size(), aggOperator.getAggregations().size());
+        optimizerContext.getTvrOptContext().setIvmStateColumnNameByAggRefId(stateColumnByAggRefId);
     }
 
     static MaterializedView loadTargetMv(OptimizerContext optimizerContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tvr/common/TvrOptContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tvr/common/TvrOptContext.java
@@ -21,15 +21,44 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.List;
+import java.util.Map;
 
 public class TvrOptContext {
     private final SessionVariable sessionVariable;
 
     private final Supplier<MaterializedView> lazyMV;
 
+    // Ordered INSERT output columns (position i writes target fullSchema[i]), stashed by
+    // InsertPlanner before optimization so IvmRewriter can bind aggregates to MV state columns.
+    private List<ColumnRefOperator> ivmInsertOutputColumns;
+
+    // Aggregate output ColumnRef id -> MV state column name, derived by IvmRewriter and
+    // consumed by IvmDeltaAggregateRule to locate each aggregate's state column by key
+    // instead of by schema position.
+    private Map<Integer, String> ivmStateColumnNameByAggRefId;
+
     public TvrOptContext(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
         this.lazyMV = () -> loadTvrTargetMV();
+    }
+
+    public void setIvmInsertOutputColumns(List<ColumnRefOperator> ivmInsertOutputColumns) {
+        this.ivmInsertOutputColumns = ivmInsertOutputColumns;
+    }
+
+    public List<ColumnRefOperator> getIvmInsertOutputColumns() {
+        return ivmInsertOutputColumns;
+    }
+
+    public void setIvmStateColumnNameByAggRefId(Map<Integer, String> ivmStateColumnNameByAggRefId) {
+        this.ivmStateColumnNameByAggRefId = ivmStateColumnNameByAggRefId;
+    }
+
+    public Map<Integer, String> getIvmStateColumnNameByAggRefId() {
+        return ivmStateColumnNameByAggRefId;
     }
 
     private MaterializedView loadTvrTargetMV() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/mv/IVMAnalyzerTest.java
@@ -158,6 +158,70 @@ public class IVMAnalyzerTest extends MVIVMIcebergTestBase {
     }
 
     /**
+     * A bare union-aggregate select item collapses to a single column: the state IS the visible
+     * output, so no hidden __AGG_STATE_ copy is stored. Creating the MV runs the CREATE-time
+     * trial, so this also exercises IvmRewriter.bindStateColumnsForAggregate end to end.
+     */
+    @Test
+    public void testUnionAggregateCollapsesStateColumn() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_collapse "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, bitmap_union(bitmap_hash(c1)) AS b "
+                + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_collapse");
+            Column collapsed = mv.getColumn("b");
+            assertTrue(collapsed != null && !collapsed.isHidden(), "collapsed union column must be visible");
+            for (Column c : mv.getFullSchema()) {
+                assertFalse(c.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX),
+                        "collapsed union MV must have no hidden state copy, got: " + c.getName());
+            }
+        });
+    }
+
+    /** Mixed aggregates: only the finalizable one keeps a hidden state column; unions collapse. */
+    @Test
+    public void testMixedAggregatesKeepOnlyFinalizableStateColumn() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_collapse_mixed "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, hll_union(hll_hash(c1)) AS h, sum(c1) AS ss, bitmap_union(bitmap_hash(c1)) AS b "
+                + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_collapse_mixed");
+            long hiddenStates = mv.getFullSchema().stream()
+                    .filter(c -> c.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX))
+                    .count();
+            assertEquals(1, hiddenStates, "only sum must keep a hidden state column");
+            assertTrue(mv.getFullSchema().stream()
+                            .anyMatch(c -> c.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX + "_sum")),
+                    "the hidden state column must belong to sum");
+            assertFalse(mv.getColumn("h").isHidden(), "collapsed hll_union column must be visible");
+            assertFalse(mv.getColumn("b").isHidden(), "collapsed bitmap_union column must be visible");
+        });
+    }
+
+    /** A wrapped union (bitmap_count(bitmap_union(...))) cannot collapse: the visible output is the
+     *  finalized count, so the hidden state column must stay. */
+    @Test
+    public void testWrappedUnionAggregateKeepsStateColumn() throws Exception {
+        String ddl = "CREATE MATERIALIZED VIEW mv_collapse_wrapped "
+                + "REFRESH DEFERRED MANUAL "
+                + "PROPERTIES (\"refresh_mode\" = \"incremental\") "
+                + "AS SELECT id, bitmap_count(bitmap_union(bitmap_hash(c1))) AS cnt "
+                + "FROM `iceberg0`.`unpartitioned_db`.`t_numeric` GROUP BY id";
+        starRocksAssert.withMaterializedView(ddl, () -> {
+            MaterializedView mv = getMv("test", "mv_collapse_wrapped");
+            assertFalse(mv.getColumn("cnt").isHidden(), "finalized count column must be visible");
+            assertTrue(mv.getFullSchema().stream()
+                            .anyMatch(c -> c.getName().startsWith(IvmOpUtils.COLUMN_AGG_STATE_PREFIX + "_bitmap_union")
+                                    && c.isHidden()),
+                    "wrapped union must keep its hidden state column");
+        });
+    }
+
+    /**
      * GROUP BY without aggregates (a DISTINCT-on-keys MV) must yield QUERY_COMPUTED, not
      * AUTO_INCREMENT — otherwise the MV row-id type disagrees with the refresh plan.
      */

--- a/test/sql/test_materialized_view_ivm/R/test_ivm_union_state_dedup
+++ b/test/sql/test_materialized_view_ivm/R/test_ivm_union_state_dedup
@@ -1,0 +1,213 @@
+-- name: test_ivm_union_state_dedup
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  k int,
+  v int,
+  s varchar(20),
+  s2 varchar(20),
+  d decimal(10, 2),
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into t1 values
+  (1, 100, 'a', 'p', 1.00, '2023-12-01'),
+  (1, 200, 'a', 'q', 2.00, '2023-12-01'),
+  (2, 300, 'b', 'r', 3.00, '2023-12-02');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+set enable_materialized_view_rewrite = false;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_pure PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     bitmap_union(bitmap_hash(s)) AS b,
+     hll_union(hll_hash(s)) AS h,
+     percentile_union(percentile_hash(d)) AS p
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_mixed PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     hll_union(hll_hash(s)) AS h,
+     sum(v) AS ss,
+     bitmap_union(bitmap_hash(s2)) AS b
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_two_bmp PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     bitmap_union(bitmap_hash(s)) AS b1,
+     bitmap_union(bitmap_hash(s2)) AS b2
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_wrapped PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2))) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_pure WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_mixed WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_two_bmp WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_wrapped WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b), hll_cardinality(h), round(percentile_approx_raw(p, 0.5), 3) FROM mv_pure ORDER BY k, dt;
+-- result:
+1	2023-12-01	1	1	1.5
+2	2023-12-02	1	1	3.0
+-- !result
+SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed ORDER BY k, dt;
+-- result:
+1	2023-12-01	1	300	2
+2	2023-12-02	1	300	1
+-- !result
+SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp ORDER BY k, dt;
+-- result:
+1	2023-12-01	1	2
+2	2023-12-02	1	1
+-- !result
+SELECT k, dt, cnt FROM mv_wrapped ORDER BY k, dt;
+-- result:
+1	2023-12-01	2
+2	2023-12-02	1
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b), hll_cardinality(h) FROM mv_pure
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), hll_cardinality(hll_union(hll_hash(s)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed
+  EXCEPT
+  SELECT k, dt, hll_cardinality(hll_union(hll_hash(s))), sum(v), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, cnt FROM mv_wrapped
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
+  (1, 300, 'c', 's', 4.00, '2023-12-01'),
+  (2, 400, 'b', 'r', 5.00, '2023-12-02');
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv_pure WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_mixed WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_two_bmp WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_wrapped WITH SYNC MODE;
+SELECT k, dt, bitmap_count(b), hll_cardinality(h), round(percentile_approx_raw(p, 0.5), 3) FROM mv_pure ORDER BY k, dt;
+-- result:
+1	2023-12-01	2	2	2.0
+2	2023-12-02	1	1	4.0
+-- !result
+SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed ORDER BY k, dt;
+-- result:
+1	2023-12-01	2	600	3
+2	2023-12-02	1	700	1
+-- !result
+SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp ORDER BY k, dt;
+-- result:
+1	2023-12-01	2	3
+2	2023-12-02	1	1
+-- !result
+SELECT k, dt, cnt FROM mv_wrapped ORDER BY k, dt;
+-- result:
+1	2023-12-01	3
+2	2023-12-02	1
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b), hll_cardinality(h) FROM mv_pure
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), hll_cardinality(hll_union(hll_hash(s)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed
+  EXCEPT
+  SELECT k, dt, hll_cardinality(hll_union(hll_hash(s))), sum(v), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+SELECT count(*) FROM (
+  SELECT k, dt, cnt FROM mv_wrapped
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+-- result:
+0
+-- !result
+drop database db_${uuid0} force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_ivm/T/test_ivm_union_state_dedup
+++ b/test/sql/test_materialized_view_ivm/T/test_ivm_union_state_dedup
@@ -1,0 +1,166 @@
+-- name: test_ivm_union_state_dedup
+-- A union-family aggregate (bitmap_union / hll_union / percentile_union) collapses to a single
+-- column in an incremental MV: the visible output IS the intermediate state, so no hidden
+-- __AGG_STATE_ copy is stored. This test exercises the paths that whitelist_widening does not:
+--   * delta refresh (second refresh after inserting more rows) merges into the collapsed column
+--   * mixed layout: collapsed unions alongside a finalizable sum in one MV
+--   * two same-signature unions bound to distinct source columns
+--   * a wrapped union (bitmap_count(bitmap_union(...))) that must NOT collapse
+-- Each MV's finalized output is checked against a fresh GROUP BY over the base table (diff = 0),
+-- initially and again after the delta.
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table t1 (
+  k int,
+  v int,
+  s varchar(20),
+  s2 varchar(20),
+  d decimal(10, 2),
+  dt date
+) partition by(dt);
+
+insert into t1 values
+  (1, 100, 'a', 'p', 1.00, '2023-12-01'),
+  (1, 200, 'a', 'q', 2.00, '2023-12-01'),
+  (2, 300, 'b', 'r', 3.00, '2023-12-02');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+set enable_materialized_view_rewrite = false;
+
+-- ============================================================
+-- S1: pure unions (bitmap + hll + percentile) — all collapse
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_pure PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     bitmap_union(bitmap_hash(s)) AS b,
+     hll_union(hll_hash(s)) AS h,
+     percentile_union(percentile_hash(d)) AS p
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+
+-- ============================================================
+-- S2: mixed — collapsed hll + finalizable sum + collapsed bitmap
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_mixed PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     hll_union(hll_hash(s)) AS h,
+     sum(v) AS ss,
+     bitmap_union(bitmap_hash(s2)) AS b
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+
+-- ============================================================
+-- S3: two same-signature bitmap_union columns on distinct sources
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_two_bmp PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt,
+     bitmap_union(bitmap_hash(s)) AS b1,
+     bitmap_union(bitmap_hash(s2)) AS b2
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+
+-- ============================================================
+-- S4: wrapped union — must NOT collapse (visible output is finalized count)
+-- ============================================================
+CREATE MATERIALIZED VIEW mv_wrapped PARTITION BY dt
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "incremental")
+AS SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2))) AS cnt
+   FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1
+   GROUP BY k, dt;
+
+[UC]REFRESH MATERIALIZED VIEW mv_pure WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_mixed WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_two_bmp WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_wrapped WITH SYNC MODE;
+
+-- initial values (readable)
+SELECT k, dt, bitmap_count(b), hll_cardinality(h), round(percentile_approx_raw(p, 0.5), 3) FROM mv_pure ORDER BY k, dt;
+SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed ORDER BY k, dt;
+SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp ORDER BY k, dt;
+SELECT k, dt, cnt FROM mv_wrapped ORDER BY k, dt;
+
+-- initial diff = 0 (MV incremental output equals a fresh GROUP BY)
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b), hll_cardinality(h) FROM mv_pure
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), hll_cardinality(hll_union(hll_hash(s)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed
+  EXCEPT
+  SELECT k, dt, hll_cardinality(hll_union(hll_hash(s))), sum(v), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, cnt FROM mv_wrapped
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+
+-- ============================================================
+-- DELTA: append into both partitions, refresh incrementally
+-- ============================================================
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values
+  (1, 300, 'c', 's', 4.00, '2023-12-01'),
+  (2, 400, 'b', 'r', 5.00, '2023-12-02');
+
+[UC]REFRESH MATERIALIZED VIEW mv_pure WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_mixed WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_two_bmp WITH SYNC MODE;
+[UC]REFRESH MATERIALIZED VIEW mv_wrapped WITH SYNC MODE;
+
+-- post-delta values (readable)
+SELECT k, dt, bitmap_count(b), hll_cardinality(h), round(percentile_approx_raw(p, 0.5), 3) FROM mv_pure ORDER BY k, dt;
+SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed ORDER BY k, dt;
+SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp ORDER BY k, dt;
+SELECT k, dt, cnt FROM mv_wrapped ORDER BY k, dt;
+
+-- post-delta diff = 0
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b), hll_cardinality(h) FROM mv_pure
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), hll_cardinality(hll_union(hll_hash(s)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, hll_cardinality(h), ss, bitmap_count(b) FROM mv_mixed
+  EXCEPT
+  SELECT k, dt, hll_cardinality(hll_union(hll_hash(s))), sum(v), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, bitmap_count(b1), bitmap_count(b2) FROM mv_two_bmp
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s))), bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+SELECT count(*) FROM (
+  SELECT k, dt, cnt FROM mv_wrapped
+  EXCEPT
+  SELECT k, dt, bitmap_count(bitmap_union(bitmap_hash(s2)))
+    FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 GROUP BY k, dt) t;
+
+-- cleanup
+drop database db_${uuid0} force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;


### PR DESCRIPTION
## Why I'm doing:

Three-union IVM support (`bitmap_union` / `hll_union` / `percentile_union`) recently landed. For those aggregates an incremental MV stores the same state twice: the visible column is an identity finalize of the merged state, and a hidden `__AGG_STATE_` column holds the very same state that refresh merges into. For BITMAP/HLL sketches that doubles the state storage for no benefit.

## What I'm doing:

Collapse the visible column and the hidden state column into one for union-family aggregates: the select item itself becomes the intermediate aggregate under the user's alias, so a single visible column is both the queryable output and the refresh merge target. Finalizable aggregates (`sum`/`avg`/…) keep the visible-finalize + hidden-state pair, and a wrapped aggregate such as `bitmap_count(bitmap_union(x))` still keeps its hidden state column.

Collapsing relocates union state out of the appended `__AGG_STATE_` section, which broke the refresh side's positional pairing — it zipped prefix-filtered schema positions against id-sorted aggregate `ColumnRef`s, two independently derived orders that only align while every state column sits appended in aggregate order. This replaces that with an explicit binding keyed by `ColumnRef` id: `InsertPlanner` stashes the ordered INSERT outputs on `TvrOptContext`; `IvmRewriter` resolves each output through pass-through projections and, where it lands on a bare aggregation output ref, records `refId -> state column name`; `IvmDeltaAggregateRule` looks up each aggregate's column by id and asserts the types match, so a mis-binding fails loudly instead of merging one aggregate's state into another's column. Nothing is persisted — refresh re-derives the rewritten statement from the original query, so the binding is rebuilt each run.

Incremental union MVs created before this change use the old two-column layout and will fail refresh with a column-count mismatch; recreate them. Three-union IVM is not in a released version, so no supported upgrade is affected.

Fixes #issue: N/A — internal IVM storage optimization, no tracking issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
