### PR TITLE
[Enhancement] Make lake_autovacuum_parallel_partitions mutable with fair LRU vacuum scheduling

### DIFF
--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -370,8 +370,8 @@ This topic introduces the following types of FE configurations:
 - Default: 8
 - Type: Int
 - Unit: -
-- Is mutable: No
-- Description: The maximum number of partitions that can undergo AutoVacuum simultaneously in a shared-data cluster. AutoVacuum is the Garbage Collection after Compactions.
+- Is mutable: Yes
+- Description: The maximum number of partitions that can undergo AutoVacuum simultaneously in a shared-data cluster. AutoVacuum is the Garbage Collection after Compactions. Setting it to `0` or a negative value disables AutoVacuum entirely.
 - Introduced in: v3.1.0
 
 ### `lake_autovacuum_partition_naptime_seconds`

--- a/docs/ja/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/FE_parameters/shared_lake_other.md
@@ -370,8 +370,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - デフォルト：8
 - タイプ：Int
 - 単位：-
-- 変更可能：No
-- 説明：共有データクラスターで同時に AutoVacuum を実行できるパーティションの最大数。AutoVacuum はコンパクション後のガベージコレクションです。
+- 変更可能：Yes
+- 説明：共有データクラスターで同時に AutoVacuum を実行できるパーティションの最大数。AutoVacuum はコンパクション後のガベージコレクションです。`0` または負の値を設定すると、AutoVacuum は完全に無効になります。
 - 導入時期：v3.1.0
 
 ### `lake_autovacuum_partition_naptime_seconds`

--- a/docs/zh/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/FE_parameters/shared_lake_other.md
@@ -370,8 +370,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 默认值: 8
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 存算分离集群中可同时进行 AutoVacuum 的分区最大数量。AutoVacuum 是 Compactions 后的垃圾回收。
+- 是否可变: Yes
+- 描述: 存算分离集群中可同时进行 AutoVacuum 的分区最大数量。AutoVacuum 是 Compactions 后的垃圾回收。设置为 `0` 或负数将完全禁用 AutoVacuum。
 - 引入版本: v3.1.0
 
 ### `lake_autovacuum_partition_naptime_seconds`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3591,7 +3591,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;
 
-    @ConfField(comment = "how many partitions can autovacuum be executed simultaneously at most")
+    @ConfField(mutable = true, comment = "how many partitions can autovacuum be executed simultaneously at most")
     public static int lake_autovacuum_parallel_partitions = 8;
 
     @ConfField(comment = "how many partitions can fullvacuum execute simultaneously at most")

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -27,7 +27,8 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeAggregator;
@@ -47,21 +48,23 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.cngroup.ComputeResource;
-import org.apache.hadoop.util.BlockingThreadPoolExecutorService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
-public class AutovacuumDaemon extends FrontendDaemon {
+public class AutovacuumDaemon extends LeaderDaemon {
     private static final Logger LOG = LogManager.getLogger(AutovacuumDaemon.class);
 
     private static final long MILLISECONDS_PER_SECOND = 1000;
@@ -69,23 +72,165 @@ public class AutovacuumDaemon extends FrontendDaemon {
     private static final long MINUTES_PER_HOUR = 60;
     private static final long MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
 
+    // Queue capacity large enough to absorb the brief window after lake_autovacuum_parallel_partitions is
+    // raised but before the ConfigRefreshDaemon listener has resized the pool. The outer gate in
+    // scheduleVacuumRound() already caps the number of in-flight partitions, so the queue is normally empty.
+    private static final int EXECUTOR_QUEUE_SIZE = 4096;
+
+    // Hard cap on effective parallelism. lake_autovacuum_parallel_partitions is mutable, so clamp it to
+    // this: it keeps in-flight submissions far below EXECUTOR_QUEUE_SIZE, so the pool's BlockedPolicy queue
+    // never fills and never blocks the daemon thread, however aggressively the config is tuned.
+    private static final int MAX_PARALLEL_PARTITIONS = 256;
+
+    // When a collection finds nothing to vacuum, wait this long before scanning again so an idle cluster
+    // is not walked every round. Rounds with a non-empty queue are unaffected.
+    private static final long EMPTY_COLLECT_BACKOFF_MS = 30 * 1000L;
+
     private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
-    private final BlockingThreadPoolExecutorService executorService = BlockingThreadPoolExecutorService.newInstance(
-            Config.lake_autovacuum_parallel_partitions, 0, 1, TimeUnit.HOURS, "autovacuum");
+
+    // LRU-ordered candidates from the last collection, drained across subsequent rounds. A round collects
+    // again only once this queue is empty, so most rounds skip the expensive full scan (see
+    // refillPendingCandidatesIfEmpty).
+    private final Deque<VacuumCandidate> pendingCandidates = new ArrayDeque<>();
+    // Set after a collection that found no candidates; suppresses re-scanning until this time.
+    private long nextCollectTimeMs = 0;
+
+    // Lazily created on the leader (see getExecutorService()). It is resized in place when
+    // lake_autovacuum_parallel_partitions changes, never rebuilt.
+    private ThreadPoolExecutor executorService = null;
+    private boolean executorListenerRegistered = false;
 
     public AutovacuumDaemon() {
-        super("auto-vacuum", 2000);
+        super("auto-vacuum", 2000 /* 2s */);
+    }
+
+    // A fixed-size pool resized in place via the ConfigRefreshDaemon listener (mirrors
+    // PublishVersionDaemon#getTaskExecutor). The pool's BlockedPolicy would block the caller for up to 60s
+    // once its queue fills; that never happens here because the outer gate in scheduleVacuumRound() plus the
+    // MAX_PARALLEL_PARTITIONS clamp keep in-flight work far below EXECUTOR_QUEUE_SIZE. Created lazily so that
+    // unit tests exercising only vacuumPartitionImpl() never register a listener on the global ConfigRefreshDaemon.
+    private ThreadPoolExecutor getExecutorService() {
+        if (executorService == null) {
+            int numThreads = Math.min(Math.max(1, Config.lake_autovacuum_parallel_partitions), MAX_PARALLEL_PARTITIONS);
+            executorService = ThreadPoolManager.newDaemonFixedThreadPool(
+                    numThreads, EXECUTOR_QUEUE_SIZE, "auto_vacuum", true);
+            executorService.allowCoreThreadTimeOut(true);
+            // Register the config-change listener only once per daemon instance.
+            if (!executorListenerRegistered) {
+                GlobalStateMgr.getCurrentState().getConfigRefreshDaemon()
+                        .registerListener(this::adjustExecutorService);
+                executorListenerRegistered = true;
+            }
+        }
+        return executorService;
+    }
+
+    private void adjustExecutorService() {
+        if (executorService == null) {
+            return;
+        }
+        int newNumThreads = Math.min(Config.lake_autovacuum_parallel_partitions, MAX_PARALLEL_PARTITIONS);
+        if (newNumThreads <= 0) {
+            return;
+        }
+        ThreadPoolManager.setFixedThreadPoolSize(executorService, newNumThreads);
     }
 
     @Override
-    protected void runAfterCatalogReady() {
+    protected void onStopped() {
+        // Leader demotion: release leader-session-only state so a follower does not retain it.
+        // executorListenerRegistered stays set so the ConfigRefreshDaemon listener is registered
+        // exactly once per instance across demote/re-elect cycles (mirrors PublishVersionDaemon).
+        ThreadPoolExecutor executor = executorService;
+        if (executor != null) {
+            executor.shutdownNow();
+            executorService = null;
+        }
+        vacuumingPartitions.clear();
+        pendingCandidates.clear();
+        nextCollectTimeMs = 0;
+    }
+
+    @Override
+    protected void runAfterLeaseValid() {
         if (FeConstants.runningUnitTest) {
             return;
         }
+        scheduleVacuumRound();
+    }
 
-        // acquire background resource
-        acquireBackgroundComputeResource();
+    private void scheduleVacuumRound() {
+        // Concurrency is bounded here (the "outer gate"), not by the thread pool capacity. This makes
+        // lake_autovacuum_parallel_partitions take effect at runtime and, crucially, keeps a slow vacuum
+        // from ever blocking this daemon thread. The value is clamped to MAX_PARALLEL_PARTITIONS so
+        // in-flight work stays well below the pool queue and its BlockedPolicy never blocks the daemon. A
+        // non-positive value disables AutoVacuum entirely (see the config docs); adjustExecutorService
+        // likewise leaves the pool untouched for such values.
+        int parallelPartitions = Math.min(Config.lake_autovacuum_parallel_partitions, MAX_PARALLEL_PARTITIONS);
+        if (parallelPartitions <= 0 || vacuumingPartitions.size() >= parallelPartitions) {
+            return;
+        }
+        refillPendingCandidatesIfEmpty();
+        submitPendingCandidates(parallelPartitions);
+    }
 
+    // A full candidate collection walks every db/table under a table lock, which is too expensive to run
+    // every couple of seconds just to fill a few free slots. So collect only once the previous batch has
+    // been fully drained, cache the result ordered oldest-first (LRU), and let subsequent rounds drain from
+    // that cache. Re-collecting and re-sorting each time the queue empties keeps fairness: a partition that
+    // keeps losing the race only gets older and rises toward the front on the next collection, so nothing
+    // starves.
+    private void refillPendingCandidatesIfEmpty() {
+        if (!pendingCandidates.isEmpty()) {
+            return;
+        }
+        // Back off scanning when the previous collection came up empty, so an idle cluster is not walked
+        // on every round.
+        if (System.currentTimeMillis() < nextCollectTimeMs) {
+            return;
+        }
+        List<VacuumCandidate> candidates = collectVacuumCandidates();
+        if (candidates.isEmpty()) {
+            nextCollectTimeMs = System.currentTimeMillis() + EMPTY_COLLECT_BACKOFF_MS;
+            return;
+        }
+        candidates.sort(Comparator.comparingLong(candidate -> candidate.lastVacuumTime));
+        pendingCandidates.addAll(candidates);
+    }
+
+    private void submitPendingCandidates(int parallelPartitions) {
+        while (vacuumingPartitions.size() < parallelPartitions) {
+            VacuumCandidate candidate = pendingCandidates.poll();
+            if (candidate == null) {
+                break;
+            }
+            PhysicalPartition partition = candidate.partition;
+            long partitionId = partition.getId();
+            // The cached candidate may be stale by now (already picked up in an earlier round, or vacuumed
+            // since the last full collection), so re-check before submitting.
+            if (vacuumingPartitions.contains(partitionId) || !shouldVacuum(partition)) {
+                continue;
+            }
+            if (vacuumingPartitions.add(partitionId)) {
+                try {
+                    getExecutorService().execute(
+                            () -> vacuumPartition(candidate.db, candidate.table, partition));
+                } catch (RuntimeException e) {
+                    // Submission failed (e.g. RejectedExecutionException when the pool queue is saturated).
+                    // The task never runs, so vacuumPartition's finally never removes the id; roll it back
+                    // here, otherwise this partition would stay "in flight" forever until an FE restart.
+                    // Stop the round too: a saturated pool would otherwise block on BlockedPolicy for every
+                    // remaining candidate.
+                    vacuumingPartitions.remove(partitionId);
+                    LOG.warn("Failed to submit vacuum task for partition {}, stopping this round", partitionId, e);
+                    break;
+                }
+            }
+        }
+    }
+
+    private List<VacuumCandidate> collectVacuumCandidates() {
+        List<VacuumCandidate> candidates = new ArrayList<>();
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
         for (Long dbId : dbIds) {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
@@ -101,9 +246,10 @@ public class AutovacuumDaemon extends FrontendDaemon {
             }
 
             for (Table table : tables) {
-                vacuumTable(db, table);
+                collectTableCandidates(db, (OlapTable) table, candidates);
             }
         }
+        return candidates;
     }
 
     public boolean shouldVacuum(PhysicalPartition partition) {
@@ -143,24 +289,35 @@ public class AutovacuumDaemon extends FrontendDaemon {
         return true;
     }
 
-    private void vacuumTable(Database db, Table baseTable) {
-        OlapTable table = (OlapTable) baseTable;
-        List<PhysicalPartition> partitions;
-
+    private void collectTableCandidates(Database db, OlapTable table, List<VacuumCandidate> candidates) {
         Locker locker = new Locker();
-        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
         try {
-            partitions = table.getPhysicalPartitions().stream()
-                    .filter(p -> shouldVacuum(p))
-                    .collect(Collectors.toList());
-        } finally {
-            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(baseTable.getId()), LockType.READ);
-        }
-
-        for (PhysicalPartition partition : partitions) {
-            if (vacuumingPartitions.add(partition.getId())) {
-                executorService.execute(() -> vacuumPartition(db, table, partition));
+            for (PhysicalPartition partition : table.getPhysicalPartitions()) {
+                // Skip partitions already being vacuumed so only fresh candidates take part in this round's
+                // fairness ordering (mirrors CompactionScheduler excluding runningCompactions).
+                if (!vacuumingPartitions.contains(partition.getId()) && shouldVacuum(partition)) {
+                    candidates.add(new VacuumCandidate(db, table, partition));
+                }
             }
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    // A snapshot of a partition that needs vacuuming, captured under the table lock. lastVacuumTime is
+    // sampled here so this round's ordering stays stable even if the partition is updated concurrently.
+    private static class VacuumCandidate {
+        private final Database db;
+        private final OlapTable table;
+        private final PhysicalPartition partition;
+        private final long lastVacuumTime;
+
+        VacuumCandidate(Database db, OlapTable table, PhysicalPartition partition) {
+            this.db = db;
+            this.table = table;
+            this.partition = partition;
+            this.lastVacuumTime = partition.getLastVacuumTime();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -143,10 +143,21 @@ public class AutovacuumDaemon extends LeaderDaemon {
         // exactly once per instance across demote/re-elect cycles (mirrors PublishVersionDaemon).
         ThreadPoolExecutor executor = executorService;
         if (executor != null) {
-            executor.shutdownNow();
             executorService = null;
+            // shutdownNow() interrupts running tasks but does not wait for them: a task stuck in a
+            // non-interruptible section can outlive demotion and even re-election. Its entry in
+            // vacuumingPartitions must survive so the next leader session keeps skipping the
+            // partition until the task's finally releases it; clearing the set wholesale would
+            // permit two concurrent vacuums of the same partition (and the straggler's late
+            // finally would then drop the new session's live entry, permitting a third). Only
+            // reservations of drained tasks that never ran are released here, so every entry is
+            // released exactly once: either by its task's finally or by this loop.
+            for (Runnable task : executor.shutdownNow()) {
+                if (task instanceof VacuumTask) {
+                    vacuumingPartitions.remove(((VacuumTask) task).partitionId);
+                }
+            }
         }
-        vacuumingPartitions.clear();
         pendingCandidates.clear();
         nextCollectTimeMs = 0;
     }
@@ -213,8 +224,8 @@ public class AutovacuumDaemon extends LeaderDaemon {
             }
             if (vacuumingPartitions.add(partitionId)) {
                 try {
-                    getExecutorService().execute(
-                            () -> vacuumPartition(candidate.db, candidate.table, partition));
+                    getExecutorService().execute(new VacuumTask(partitionId,
+                            () -> vacuumPartition(candidate.db, candidate.table, partition)));
                 } catch (RuntimeException e) {
                     // Submission failed (e.g. RejectedExecutionException when the pool queue is saturated).
                     // The task never runs, so vacuumPartition's finally never removes the id; roll it back
@@ -302,6 +313,23 @@ public class AutovacuumDaemon extends LeaderDaemon {
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+    }
+
+    // Carries the partition id so onStopped() can identify queued-but-never-run tasks returned by
+    // shutdownNow() and release exactly their vacuumingPartitions reservations.
+    private static class VacuumTask implements Runnable {
+        private final long partitionId;
+        private final Runnable work;
+
+        VacuumTask(long partitionId, Runnable work) {
+            this.partitionId = partitionId;
+            this.work = work;
+        }
+
+        @Override
+        public void run() {
+            work.run();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1692,6 +1692,9 @@ public class GlobalStateMgr {
     void stopLeaderOnlyDaemonThreads() {
         long timeoutMs = Math.max(1000L, Config.leader_demotion_drain_timeout_sec * 1000L);
         // Stop in the reverse order of startLeaderOnlyDaemonThreads().
+        if (autovacuumDaemon != null) {
+            stopOne("autovacuumDaemon", () -> autovacuumDaemon.stopGracefully(timeoutMs));
+        }
         stopOne("tabletCollector", () -> tabletCollector.stopGracefully(timeoutMs));
         stopOne("reportHandler", () -> reportHandler.stopGracefully(timeoutMs));
         stopOne("temporaryTableCleaner", () -> temporaryTableCleaner.stopGracefully(timeoutMs));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -64,6 +64,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -930,86 +931,120 @@ public class VacuumTest {
 
     @Test
     public void testOnStoppedReleasesLeaderSessionState() throws Exception {
-        // On leader demotion onStopped() must release leader-session-only state: shut down and
-        // dereference the executor (so it is recreated on re-election) and clear the in-flight set.
-        AutovacuumDaemon daemon = new AutovacuumDaemon();
+        // On leader demotion onStopped() must shut down and dereference the executor (so it is
+        // recreated on re-election) and release the reservations of queued-but-never-run tasks.
+        // A still-running task keeps its reservation until its own finally releases it: dropping
+        // it early would let a re-elected session vacuum the same partition concurrently with the
+        // straggler, and the straggler's late finally would then drop the new session's live entry.
+        int oldParallel = Config.lake_autovacuum_parallel_partitions;
+        try {
+            // Single-threaded pool: the first task occupies the worker, the second stays queued.
+            Config.lake_autovacuum_parallel_partitions = 1;
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+            ThreadPoolExecutor pool = Deencapsulation.invoke(daemon, "getExecutorService");
+            Set<Long> vacuumingPartitions = Deencapsulation.getField(daemon, "vacuumingPartitions");
 
-        java.lang.reflect.Method getExecutorService =
-                AutovacuumDaemon.class.getDeclaredMethod("getExecutorService");
-        getExecutorService.setAccessible(true);
-        ThreadPoolExecutor pool = (ThreadPoolExecutor) getExecutorService.invoke(daemon);
+            long runningPartition = 123L;
+            long queuedPartition = 456L;
+            vacuumingPartitions.add(runningPartition);
+            vacuumingPartitions.add(queuedPartition);
 
-        java.lang.reflect.Field vacuumingField =
-                AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
-        vacuumingField.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Set<Long> vacuumingPartitions = (Set<Long>) vacuumingField.get(daemon);
-        vacuumingPartitions.add(123L);
-        vacuumingPartitions.add(456L);
+            CountDownLatch started = new CountDownLatch(1);
+            CountDownLatch release = new CountDownLatch(1);
+            // Emulates vacuumPartition() for a straggler stuck in a non-interruptible section: it
+            // survives the shutdownNow() interrupt and only its finally releases its reservation.
+            pool.execute(() -> {
+                try {
+                    started.countDown();
+                    boolean released = false;
+                    while (!released) {
+                        try {
+                            release.await();
+                            released = true;
+                        } catch (InterruptedException ignored) {
+                            // Swallow the shutdownNow() interrupt and keep running.
+                        }
+                    }
+                } finally {
+                    vacuumingPartitions.remove(runningPartition);
+                }
+            });
+            Assertions.assertTrue(started.await(5, TimeUnit.SECONDS));
+            pool.execute(newVacuumTask(queuedPartition, () -> vacuumingPartitions.remove(queuedPartition)));
 
-        java.lang.reflect.Field nextCollectField =
-                AutovacuumDaemon.class.getDeclaredField("nextCollectTimeMs");
-        nextCollectField.setAccessible(true);
-        nextCollectField.setLong(daemon, 999L);
+            Deencapsulation.setField(daemon, "nextCollectTimeMs", 999L);
+            Deencapsulation.invoke(daemon, "onStopped");
 
-        java.lang.reflect.Method onStopped = AutovacuumDaemon.class.getDeclaredMethod("onStopped");
-        onStopped.setAccessible(true);
-        onStopped.invoke(daemon);
+            Assertions.assertTrue(pool.isShutdown());
+            Assertions.assertNull(Deencapsulation.getField(daemon, "executorService"));
+            Assertions.assertTrue(
+                    ((java.util.Collection<?>) Deencapsulation.getField(daemon, "pendingCandidates")).isEmpty());
+            Assertions.assertEquals(0L, (long) Deencapsulation.getField(daemon, "nextCollectTimeMs"));
+            // The queued task will never run its finally, so onStopped() released its reservation...
+            Assertions.assertFalse(vacuumingPartitions.contains(queuedPartition));
+            // ...while the running task's reservation survives, so a re-elected session skips it.
+            Assertions.assertTrue(vacuumingPartitions.contains(runningPartition));
 
-        Assertions.assertTrue(pool.isShutdown());
-        java.lang.reflect.Field executorField =
-                AutovacuumDaemon.class.getDeclaredField("executorService");
-        executorField.setAccessible(true);
-        Assertions.assertNull(executorField.get(daemon));
-        Assertions.assertTrue(vacuumingPartitions.isEmpty());
-        java.lang.reflect.Field pendingField =
-                AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
-        pendingField.setAccessible(true);
-        Assertions.assertTrue(((java.util.Collection<?>) pendingField.get(daemon)).isEmpty());
-        Assertions.assertEquals(0L, nextCollectField.getLong(daemon));
+            // The straggler eventually finishes and releases its own reservation.
+            release.countDown();
+            Assertions.assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+            Assertions.assertTrue(vacuumingPartitions.isEmpty());
+        } finally {
+            Config.lake_autovacuum_parallel_partitions = oldParallel;
+        }
     }
 
     @Test
-    public void testScheduleVacuumRoundOuterGate() throws Exception {
+    public void testScheduleVacuumRoundGatesAndRejectionRollback() throws Exception {
+        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
+        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
         int oldParallel = Config.lake_autovacuum_parallel_partitions;
         try {
+            Config.lake_autovacuum_partition_naptime_seconds = 0;
+            Config.lake_autovacuum_detect_vaccumed_version = false;
+
             AutovacuumDaemon daemon = new AutovacuumDaemon();
-            java.lang.reflect.Method scheduleVacuumRound =
-                    AutovacuumDaemon.class.getDeclaredMethod("scheduleVacuumRound");
-            scheduleVacuumRound.setAccessible(true);
-            java.lang.reflect.Field pendingField =
-                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
-            pendingField.setAccessible(true);
-            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
-            java.lang.reflect.Field vacuumingField =
-                    AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
-            vacuumingField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Set<Long> vacuumingPartitions = (Set<Long>) vacuumingField.get(daemon);
+            java.util.Collection<?> pendingCandidates = Deencapsulation.getField(daemon, "pendingCandidates");
+            Set<Long> vacuumingPartitions = Deencapsulation.getField(daemon, "vacuumingPartitions");
 
             // Non-positive parallelism disables AutoVacuum: the round returns before collecting anything.
             Config.lake_autovacuum_parallel_partitions = 0;
-            scheduleVacuumRound.invoke(daemon);
+            Deencapsulation.invoke(daemon, "scheduleVacuumRound");
             Assertions.assertTrue(pendingCandidates.isEmpty());
 
             // All slots already in flight: the round also returns before collecting.
             Config.lake_autovacuum_parallel_partitions = 2;
             vacuumingPartitions.add(1L);
             vacuumingPartitions.add(2L);
-            try {
-                scheduleVacuumRound.invoke(daemon);
-                Assertions.assertTrue(pendingCandidates.isEmpty());
-            } finally {
-                vacuumingPartitions.remove(1L);
-                vacuumingPartitions.remove(2L);
-            }
+            Deencapsulation.invoke(daemon, "scheduleVacuumRound");
+            Assertions.assertTrue(pendingCandidates.isEmpty());
+            vacuumingPartitions.clear();
+
+            // Free slots and a vacuumable partition, but an injected shut-down pool makes every
+            // execute() throw RejectedExecutionException: the submission must be rolled back so no
+            // partition id is left "in flight" forever.
+            PhysicalPartition p = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+            Assertions.assertNotNull(p);
+            p.setMetadataSwitchVersion(0);
+            p.setVisibleVersion(10L, System.currentTimeMillis());
+            p.setLastVacuumTime(1000L);
+
+            Config.lake_autovacuum_parallel_partitions = 8;
+            ThreadPoolExecutor deadPool = new ThreadPoolExecutor(
+                    1, 1, 0L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+            deadPool.shutdown();
+            Deencapsulation.setField(daemon, "executorService", deadPool);
+            Deencapsulation.invoke(daemon, "scheduleVacuumRound");
+            Assertions.assertTrue(vacuumingPartitions.isEmpty());
         } finally {
+            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
+            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
             Config.lake_autovacuum_parallel_partitions = oldParallel;
         }
     }
 
     @Test
-    public void testRefillOnlyWhenEmpty() throws Exception {
+    public void testRefillOnlyWhenEmptyAndBackoffOnEmptyCollection() throws Exception {
         long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
         boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
         try {
@@ -1023,114 +1058,47 @@ public class VacuumTest {
             p.setLastVacuumTime(1000L);
 
             AutovacuumDaemon daemon = new AutovacuumDaemon();
-            java.lang.reflect.Method refill =
-                    AutovacuumDaemon.class.getDeclaredMethod("refillPendingCandidatesIfEmpty");
-            refill.setAccessible(true);
-            java.lang.reflect.Field pendingField =
-                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
-            pendingField.setAccessible(true);
-            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
+            java.util.Collection<?> pendingCandidates = Deencapsulation.getField(daemon, "pendingCandidates");
 
             // First call fills the queue from a collection.
-            refill.invoke(daemon);
+            Deencapsulation.invoke(daemon, "refillPendingCandidatesIfEmpty");
             int sizeAfterFirst = pendingCandidates.size();
             Assertions.assertTrue(sizeAfterFirst > 0);
 
             // A second call is a no-op while the queue is non-empty: no re-collection, size unchanged.
-            refill.invoke(daemon);
+            Deencapsulation.invoke(daemon, "refillPendingCandidatesIfEmpty");
             Assertions.assertEquals(sizeAfterFirst, pendingCandidates.size());
-        } finally {
-            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
-            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
-        }
-    }
 
-    @Test
-    public void testEmptyCollectionBacksOff() throws Exception {
-        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
-        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
-        try {
-            Config.lake_autovacuum_partition_naptime_seconds = 0;
-            Config.lake_autovacuum_detect_vaccumed_version = false;
-
-            // Make every table's partitions non-vacuumable (empty partitions) so the collection is empty.
+            // Drain the queue and make every table's partitions non-vacuumable (empty partitions):
+            // the next collection comes up empty, arms the back-off, and leaves the queue empty.
+            pendingCandidates.clear();
             for (OlapTable table : new OlapTable[] {olapTable, olapTable2, olapTable7}) {
                 for (PhysicalPartition partition : table.getPhysicalPartitions()) {
                     partition.setMetadataSwitchVersion(0);
                     partition.setVisibleVersion(1L, System.currentTimeMillis());
                 }
             }
-
-            AutovacuumDaemon daemon = new AutovacuumDaemon();
-            java.lang.reflect.Method refill =
-                    AutovacuumDaemon.class.getDeclaredMethod("refillPendingCandidatesIfEmpty");
-            refill.setAccessible(true);
-            java.lang.reflect.Field nextCollectField =
-                    AutovacuumDaemon.class.getDeclaredField("nextCollectTimeMs");
-            nextCollectField.setAccessible(true);
-            java.lang.reflect.Field pendingField =
-                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
-            pendingField.setAccessible(true);
-            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
-
-            // An empty collection arms the back-off and leaves the queue empty.
-            refill.invoke(daemon);
-            long backoffUntil = nextCollectField.getLong(daemon);
+            Deencapsulation.invoke(daemon, "refillPendingCandidatesIfEmpty");
+            long backoffUntil = Deencapsulation.getField(daemon, "nextCollectTimeMs");
             Assertions.assertTrue(backoffUntil > System.currentTimeMillis());
             Assertions.assertTrue(pendingCandidates.isEmpty());
 
             // A subsequent call within the back-off window is skipped: the back-off point does not move.
-            refill.invoke(daemon);
-            Assertions.assertEquals(backoffUntil, nextCollectField.getLong(daemon));
+            Deencapsulation.invoke(daemon, "refillPendingCandidatesIfEmpty");
+            Assertions.assertEquals(backoffUntil, (long) Deencapsulation.getField(daemon, "nextCollectTimeMs"));
         } finally {
             Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
             Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
         }
     }
 
-    @Test
-    public void testSubmitPendingRollsBackOnRejectedExecution() throws Exception {
-        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
-        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
-        int oldParallel = Config.lake_autovacuum_parallel_partitions;
-        try {
-            Config.lake_autovacuum_partition_naptime_seconds = 0;
-            Config.lake_autovacuum_detect_vaccumed_version = false;
-            Config.lake_autovacuum_parallel_partitions = 8;
-
-            PhysicalPartition p = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
-            Assertions.assertNotNull(p);
-            p.setMetadataSwitchVersion(0);
-            p.setVisibleVersion(10L, System.currentTimeMillis());
-            p.setLastVacuumTime(1000L);
-
-            AutovacuumDaemon daemon = new AutovacuumDaemon();
-
-            // Inject a shut-down pool so every execute() throws RejectedExecutionException.
-            ThreadPoolExecutor deadPool = new ThreadPoolExecutor(
-                    1, 1, 0L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-            deadPool.shutdown();
-            java.lang.reflect.Field executorField =
-                    AutovacuumDaemon.class.getDeclaredField("executorService");
-            executorField.setAccessible(true);
-            executorField.set(daemon, deadPool);
-
-            java.lang.reflect.Method scheduleVacuumRound =
-                    AutovacuumDaemon.class.getDeclaredMethod("scheduleVacuumRound");
-            scheduleVacuumRound.setAccessible(true);
-            scheduleVacuumRound.invoke(daemon);
-
-            // The first submission is rejected and rolled back, then the round stops, so no partition id
-            // is left "in flight".
-            java.lang.reflect.Field vacuumingField =
-                    AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
-            vacuumingField.setAccessible(true);
-            Assertions.assertTrue(((Set<?>) vacuumingField.get(daemon)).isEmpty());
-        } finally {
-            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
-            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
-            Config.lake_autovacuum_parallel_partitions = oldParallel;
-        }
+    // VacuumTask is private to AutovacuumDaemon; construct it reflectively so the test can put a
+    // task carrying a partition id into the pool queue exactly as submitPendingCandidates() does.
+    private static Runnable newVacuumTask(long partitionId, Runnable work) throws Exception {
+        Class<?> clazz = Class.forName("com.starrocks.lake.vacuum.AutovacuumDaemon$VacuumTask");
+        java.lang.reflect.Constructor<?> ctor = clazz.getDeclaredConstructor(long.class, Runnable.class);
+        ctor.setAccessible(true);
+        return (Runnable) ctor.newInstance(partitionId, work);
     }
 
     private static Object findCandidate(List<Object> candidates, long partitionId) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -59,11 +59,15 @@ import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
@@ -795,5 +799,358 @@ public class VacuumTest {
             long fullVacuumResult = FullVacuumDaemon.computeMinActiveTxnId(db, olapTable);
             Assertions.assertEquals(50L, fullVacuumResult);
         }
+    }
+
+    @Test
+    public void testParallelPartitionsPoolResize() throws Exception {
+        // lake_autovacuum_parallel_partitions is mutable: the executor is resized in place by
+        // adjustExecutorService() (invoked from the ConfigRefreshDaemon listener) rather than rebuilt.
+        int oldParallel = Config.lake_autovacuum_parallel_partitions;
+        try {
+            Config.lake_autovacuum_parallel_partitions = 8;
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+
+            java.lang.reflect.Method getExecutorService =
+                    AutovacuumDaemon.class.getDeclaredMethod("getExecutorService");
+            getExecutorService.setAccessible(true);
+            java.lang.reflect.Method adjustExecutorService =
+                    AutovacuumDaemon.class.getDeclaredMethod("adjustExecutorService");
+            adjustExecutorService.setAccessible(true);
+
+            // Lazy creation: a fixed pool with core == max == config.
+            ThreadPoolExecutor pool = (ThreadPoolExecutor) getExecutorService.invoke(daemon);
+            Assertions.assertEquals(8, pool.getCorePoolSize());
+            Assertions.assertEquals(8, pool.getMaximumPoolSize());
+
+            // Grow.
+            Config.lake_autovacuum_parallel_partitions = 16;
+            adjustExecutorService.invoke(daemon);
+            Assertions.assertEquals(16, pool.getCorePoolSize());
+            Assertions.assertEquals(16, pool.getMaximumPoolSize());
+
+            // Shrink.
+            Config.lake_autovacuum_parallel_partitions = 4;
+            adjustExecutorService.invoke(daemon);
+            Assertions.assertEquals(4, pool.getCorePoolSize());
+            Assertions.assertEquals(4, pool.getMaximumPoolSize());
+
+            // Values above the hard cap are clamped to MAX_PARALLEL_PARTITIONS (256) so in-flight work
+            // never exceeds the pool queue.
+            Config.lake_autovacuum_parallel_partitions = 1000;
+            adjustExecutorService.invoke(daemon);
+            Assertions.assertEquals(256, pool.getCorePoolSize());
+            Assertions.assertEquals(256, pool.getMaximumPoolSize());
+
+            // Non-positive values are ignored so the pool keeps its previous size (256 from the clamp above).
+            Config.lake_autovacuum_parallel_partitions = 0;
+            adjustExecutorService.invoke(daemon);
+            Assertions.assertEquals(256, pool.getCorePoolSize());
+            Assertions.assertEquals(256, pool.getMaximumPoolSize());
+
+            Config.lake_autovacuum_parallel_partitions = -1;
+            adjustExecutorService.invoke(daemon);
+            Assertions.assertEquals(256, pool.getCorePoolSize());
+            Assertions.assertEquals(256, pool.getMaximumPoolSize());
+        } finally {
+            Config.lake_autovacuum_parallel_partitions = oldParallel;
+        }
+    }
+
+    @Test
+    public void testCollectCandidatesSkipsInFlightAndCapturesLastVacuumTime() throws Exception {
+        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
+        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
+        try {
+            // Make shouldVacuum() deterministic: no naptime gate and no vacuumed-version short-circuit.
+            Config.lake_autovacuum_partition_naptime_seconds = 0;
+            Config.lake_autovacuum_detect_vaccumed_version = false;
+
+            PhysicalPartition p1 = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+            PhysicalPartition p2 = olapTable2.getPhysicalPartitions().stream().findFirst().orElse(null);
+            Assertions.assertNotNull(p1);
+            Assertions.assertNotNull(p2);
+
+            long now = System.currentTimeMillis();
+            // Both partitions are non-empty and fresh, so shouldVacuum() returns true.
+            p1.setMetadataSwitchVersion(0);
+            p1.setVisibleVersion(10L, now);
+            p1.setLastVacuumTime(2000L);   // vacuumed more recently
+            p2.setMetadataSwitchVersion(0);
+            p2.setVisibleVersion(10L, now);
+            p2.setLastVacuumTime(1000L);   // vacuumed longer ago -> should sort first (LRU)
+
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+            java.lang.reflect.Method collectTableCandidates = AutovacuumDaemon.class.getDeclaredMethod(
+                    "collectTableCandidates", Database.class, OlapTable.class, List.class);
+            collectTableCandidates.setAccessible(true);
+
+            // Fresh candidates: both partitions are collected, and each candidate snapshots the
+            // partition's lastVacuumTime used as the LRU ordering key.
+            List<Object> candidates = new ArrayList<>();
+            collectTableCandidates.invoke(daemon, db, olapTable, candidates);
+            collectTableCandidates.invoke(daemon, db, olapTable2, candidates);
+
+            Object c1 = findCandidate(candidates, p1.getId());
+            Object c2 = findCandidate(candidates, p2.getId());
+            Assertions.assertNotNull(c1, "partition p1 should be collected");
+            Assertions.assertNotNull(c2, "partition p2 should be collected");
+            Assertions.assertEquals(2000L, candidateLastVacuumTime(c1));
+            Assertions.assertEquals(1000L, candidateLastVacuumTime(c2));
+
+            // LRU ordering: the partition vacuumed longest ago (p2) comes first after sorting.
+            candidates.sort(Comparator.comparingLong(candidate -> {
+                try {
+                    return candidateLastVacuumTime(candidate);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Assertions.assertEquals(p2.getId(), candidatePartitionId(candidates.get(0)));
+
+            // Partitions already in flight are excluded from the next round's candidates.
+            java.lang.reflect.Field vacuumingField =
+                    AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
+            vacuumingField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Set<Long> vacuumingPartitions = (Set<Long>) vacuumingField.get(daemon);
+            vacuumingPartitions.add(p1.getId());
+            try {
+                List<Object> afterInFlight = new ArrayList<>();
+                collectTableCandidates.invoke(daemon, db, olapTable, afterInFlight);
+                Assertions.assertNull(findCandidate(afterInFlight, p1.getId()),
+                        "in-flight partition must be skipped");
+            } finally {
+                vacuumingPartitions.remove(p1.getId());
+            }
+        } finally {
+            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
+            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
+        }
+    }
+
+    @Test
+    public void testOnStoppedReleasesLeaderSessionState() throws Exception {
+        // On leader demotion onStopped() must release leader-session-only state: shut down and
+        // dereference the executor (so it is recreated on re-election) and clear the in-flight set.
+        AutovacuumDaemon daemon = new AutovacuumDaemon();
+
+        java.lang.reflect.Method getExecutorService =
+                AutovacuumDaemon.class.getDeclaredMethod("getExecutorService");
+        getExecutorService.setAccessible(true);
+        ThreadPoolExecutor pool = (ThreadPoolExecutor) getExecutorService.invoke(daemon);
+
+        java.lang.reflect.Field vacuumingField =
+                AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
+        vacuumingField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Set<Long> vacuumingPartitions = (Set<Long>) vacuumingField.get(daemon);
+        vacuumingPartitions.add(123L);
+        vacuumingPartitions.add(456L);
+
+        java.lang.reflect.Field nextCollectField =
+                AutovacuumDaemon.class.getDeclaredField("nextCollectTimeMs");
+        nextCollectField.setAccessible(true);
+        nextCollectField.setLong(daemon, 999L);
+
+        java.lang.reflect.Method onStopped = AutovacuumDaemon.class.getDeclaredMethod("onStopped");
+        onStopped.setAccessible(true);
+        onStopped.invoke(daemon);
+
+        Assertions.assertTrue(pool.isShutdown());
+        java.lang.reflect.Field executorField =
+                AutovacuumDaemon.class.getDeclaredField("executorService");
+        executorField.setAccessible(true);
+        Assertions.assertNull(executorField.get(daemon));
+        Assertions.assertTrue(vacuumingPartitions.isEmpty());
+        java.lang.reflect.Field pendingField =
+                AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
+        pendingField.setAccessible(true);
+        Assertions.assertTrue(((java.util.Collection<?>) pendingField.get(daemon)).isEmpty());
+        Assertions.assertEquals(0L, nextCollectField.getLong(daemon));
+    }
+
+    @Test
+    public void testScheduleVacuumRoundOuterGate() throws Exception {
+        int oldParallel = Config.lake_autovacuum_parallel_partitions;
+        try {
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+            java.lang.reflect.Method scheduleVacuumRound =
+                    AutovacuumDaemon.class.getDeclaredMethod("scheduleVacuumRound");
+            scheduleVacuumRound.setAccessible(true);
+            java.lang.reflect.Field pendingField =
+                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
+            pendingField.setAccessible(true);
+            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
+            java.lang.reflect.Field vacuumingField =
+                    AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
+            vacuumingField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Set<Long> vacuumingPartitions = (Set<Long>) vacuumingField.get(daemon);
+
+            // Non-positive parallelism disables AutoVacuum: the round returns before collecting anything.
+            Config.lake_autovacuum_parallel_partitions = 0;
+            scheduleVacuumRound.invoke(daemon);
+            Assertions.assertTrue(pendingCandidates.isEmpty());
+
+            // All slots already in flight: the round also returns before collecting.
+            Config.lake_autovacuum_parallel_partitions = 2;
+            vacuumingPartitions.add(1L);
+            vacuumingPartitions.add(2L);
+            try {
+                scheduleVacuumRound.invoke(daemon);
+                Assertions.assertTrue(pendingCandidates.isEmpty());
+            } finally {
+                vacuumingPartitions.remove(1L);
+                vacuumingPartitions.remove(2L);
+            }
+        } finally {
+            Config.lake_autovacuum_parallel_partitions = oldParallel;
+        }
+    }
+
+    @Test
+    public void testRefillOnlyWhenEmpty() throws Exception {
+        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
+        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
+        try {
+            Config.lake_autovacuum_partition_naptime_seconds = 0;
+            Config.lake_autovacuum_detect_vaccumed_version = false;
+
+            PhysicalPartition p = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+            Assertions.assertNotNull(p);
+            p.setMetadataSwitchVersion(0);
+            p.setVisibleVersion(10L, System.currentTimeMillis());
+            p.setLastVacuumTime(1000L);
+
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+            java.lang.reflect.Method refill =
+                    AutovacuumDaemon.class.getDeclaredMethod("refillPendingCandidatesIfEmpty");
+            refill.setAccessible(true);
+            java.lang.reflect.Field pendingField =
+                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
+            pendingField.setAccessible(true);
+            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
+
+            // First call fills the queue from a collection.
+            refill.invoke(daemon);
+            int sizeAfterFirst = pendingCandidates.size();
+            Assertions.assertTrue(sizeAfterFirst > 0);
+
+            // A second call is a no-op while the queue is non-empty: no re-collection, size unchanged.
+            refill.invoke(daemon);
+            Assertions.assertEquals(sizeAfterFirst, pendingCandidates.size());
+        } finally {
+            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
+            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
+        }
+    }
+
+    @Test
+    public void testEmptyCollectionBacksOff() throws Exception {
+        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
+        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
+        try {
+            Config.lake_autovacuum_partition_naptime_seconds = 0;
+            Config.lake_autovacuum_detect_vaccumed_version = false;
+
+            // Make every table's partitions non-vacuumable (empty partitions) so the collection is empty.
+            for (OlapTable table : new OlapTable[] {olapTable, olapTable2, olapTable7}) {
+                for (PhysicalPartition partition : table.getPhysicalPartitions()) {
+                    partition.setMetadataSwitchVersion(0);
+                    partition.setVisibleVersion(1L, System.currentTimeMillis());
+                }
+            }
+
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+            java.lang.reflect.Method refill =
+                    AutovacuumDaemon.class.getDeclaredMethod("refillPendingCandidatesIfEmpty");
+            refill.setAccessible(true);
+            java.lang.reflect.Field nextCollectField =
+                    AutovacuumDaemon.class.getDeclaredField("nextCollectTimeMs");
+            nextCollectField.setAccessible(true);
+            java.lang.reflect.Field pendingField =
+                    AutovacuumDaemon.class.getDeclaredField("pendingCandidates");
+            pendingField.setAccessible(true);
+            java.util.Collection<?> pendingCandidates = (java.util.Collection<?>) pendingField.get(daemon);
+
+            // An empty collection arms the back-off and leaves the queue empty.
+            refill.invoke(daemon);
+            long backoffUntil = nextCollectField.getLong(daemon);
+            Assertions.assertTrue(backoffUntil > System.currentTimeMillis());
+            Assertions.assertTrue(pendingCandidates.isEmpty());
+
+            // A subsequent call within the back-off window is skipped: the back-off point does not move.
+            refill.invoke(daemon);
+            Assertions.assertEquals(backoffUntil, nextCollectField.getLong(daemon));
+        } finally {
+            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
+            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
+        }
+    }
+
+    @Test
+    public void testSubmitPendingRollsBackOnRejectedExecution() throws Exception {
+        long oldNaptime = Config.lake_autovacuum_partition_naptime_seconds;
+        boolean oldDetect = Config.lake_autovacuum_detect_vaccumed_version;
+        int oldParallel = Config.lake_autovacuum_parallel_partitions;
+        try {
+            Config.lake_autovacuum_partition_naptime_seconds = 0;
+            Config.lake_autovacuum_detect_vaccumed_version = false;
+            Config.lake_autovacuum_parallel_partitions = 8;
+
+            PhysicalPartition p = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+            Assertions.assertNotNull(p);
+            p.setMetadataSwitchVersion(0);
+            p.setVisibleVersion(10L, System.currentTimeMillis());
+            p.setLastVacuumTime(1000L);
+
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+
+            // Inject a shut-down pool so every execute() throws RejectedExecutionException.
+            ThreadPoolExecutor deadPool = new ThreadPoolExecutor(
+                    1, 1, 0L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+            deadPool.shutdown();
+            java.lang.reflect.Field executorField =
+                    AutovacuumDaemon.class.getDeclaredField("executorService");
+            executorField.setAccessible(true);
+            executorField.set(daemon, deadPool);
+
+            java.lang.reflect.Method scheduleVacuumRound =
+                    AutovacuumDaemon.class.getDeclaredMethod("scheduleVacuumRound");
+            scheduleVacuumRound.setAccessible(true);
+            scheduleVacuumRound.invoke(daemon);
+
+            // The first submission is rejected and rolled back, then the round stops, so no partition id
+            // is left "in flight".
+            java.lang.reflect.Field vacuumingField =
+                    AutovacuumDaemon.class.getDeclaredField("vacuumingPartitions");
+            vacuumingField.setAccessible(true);
+            Assertions.assertTrue(((Set<?>) vacuumingField.get(daemon)).isEmpty());
+        } finally {
+            Config.lake_autovacuum_partition_naptime_seconds = oldNaptime;
+            Config.lake_autovacuum_detect_vaccumed_version = oldDetect;
+            Config.lake_autovacuum_parallel_partitions = oldParallel;
+        }
+    }
+
+    private static Object findCandidate(List<Object> candidates, long partitionId) throws Exception {
+        for (Object candidate : candidates) {
+            if (candidatePartitionId(candidate) == partitionId) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static long candidatePartitionId(Object candidate) throws Exception {
+        java.lang.reflect.Field field = candidate.getClass().getDeclaredField("partition");
+        field.setAccessible(true);
+        return ((PhysicalPartition) field.get(candidate)).getId();
+    }
+
+    private static long candidateLastVacuumTime(Object candidate) throws Exception {
+        java.lang.reflect.Field field = candidate.getClass().getDeclaredField("lastVacuumTime");
+        field.setAccessible(true);
+        return (long) field.get(candidate);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`lake_autovacuum_parallel_partitions` controls how many partitions AutoVacuum can process
concurrently in a shared-data cluster. Today the value is baked into a
`BlockingThreadPoolExecutorService` at `AutovacuumDaemon` construction time, with two
consequences:

1. It cannot be tuned without restarting the FE.
2. The pool is *blocking*: once it is saturated, `execute()` blocks the single auto-vacuum
   daemon thread, so the whole vacuum loop stalls behind the busiest partitions.

Fixing (2) means the daemon can no longer lean on the pool to throttle — it has to cap
concurrency itself with a non-blocking "outer gate". A non-blocking gate only submits up to the
cap each round and then stops, so the *order* candidates are considered in now matters: with a
fixed metastore order, partitions near the front would always be submitted first and those near
the back could starve. That is why the new scheduling also has to be fair
(least-recently-vacuumed first). (The old blocking pool did not have this problem — it simply
blocked the daemon thread until every candidate was eventually submitted.)

Separately, `AutovacuumDaemon` extended `FrontendDaemon` (a raw `Thread`, started once). On
leader demotion it was never stopped, and because a `Thread` cannot be restarted, once this FE
was demoted and later re-elected AutoVacuum would silently never run again. Vacuum is a
leader-only job, so it should follow the same lease-checked, restartable lifecycle as the other
leader daemons (e.g. `PublishVersionDaemon`).

## What I'm doing:

- **`Config.java`**: mark `lake_autovacuum_parallel_partitions` as `mutable = true` so it can be
  tuned at runtime (default stays `8`).
- **`AutovacuumDaemon`**: replace the construction-time `BlockingThreadPoolExecutorService` with a
  lazily-created, non-blocking `ThreadPoolExecutor` (`ThreadPoolManager.newDaemonFixedThreadPool`)
  that is **resized in place** by a `ConfigRefreshDaemon` listener (`adjustExecutorService`),
  mirroring `PublishVersionDaemon#getTaskExecutor`. The listener is registered once per daemon
  instance; `adjustExecutorService` ignores non-positive values so the pool is never resized to an
  illegal size.
- **Outer concurrency gate**: `scheduleVacuumRound()` bounds in-flight partitions against
  `vacuumingPartitions.size()` vs. the (re-read-every-round) config, instead of relying on the pool
  to block. This makes the config take effect on the next round and guarantees a slow vacuum never
  blocks the daemon thread. The effective value is clamped to `MAX_PARALLEL_PARTITIONS = 256` (well
  below the 4096 pool queue) so the pool's `BlockedPolicy` never fills its queue and never blocks the
  daemon, no matter how large the mutable config is set; `submitPendingCandidates` also stops the
  round on a rejected submission rather than blocking on every remaining candidate. Setting the config
  to `0` or a negative value disables AutoVacuum entirely (documented in the config reference).
- **Queue-driven, fair (LRU) scheduling**: `collectVacuumCandidates()` gathers every partition that
  needs vacuuming (excluding in-flight ones), sorts them oldest-`lastVacuumTime`-first (LRU), and
  caches them in a queue. Each round drains the queue to fill free slots (re-checking in-flight and
  `shouldVacuum` before submitting) and only collects again once the queue is empty — this mirrors
  the original "finish the batch, then re-select" behavior while avoiding a full table-walk every
  round. When a collection finds nothing to vacuum, scanning backs off for 30s so an idle cluster is
  not walked every round. LRU keeps things fair: a partition that keeps losing the race only gets
  older and rises to the front on the next collection, so nothing starves.
- **Leak fix**: if task submission throws (e.g. `RejectedExecutionException` when the queue is
  saturated), roll the partition id back out of `vacuumingPartitions` — otherwise the never-run
  task's `finally` never removes it and the partition would stay "in flight" forever until an FE
  restart.
- **Run AutoVacuum as a `LeaderDaemon`**: migrate `AutovacuumDaemon` from `FrontendDaemon` to
  `LeaderDaemon`, so each round runs only while the leader lease is valid, the daemon self-stops on
  demotion, and the same instance is restartable on re-election (fixing the latent bug where a
  demoted-then-re-elected FE would never vacuum again). `runAfterCatalogReady()` becomes
  `runAfterLeaseValid()`; a new `onStopped()` shuts down and nulls the executor and releases the
  `vacuumingPartitions` reservations of queued-but-never-run tasks (submissions are wrapped in a
  `VacuumTask` carrying the partition id so the drained queue can be identified), while a
  still-running task keeps its reservation until its own `finally` releases it — `shutdownNow()`
  does not wait for running tasks, so a straggler surviving demotion and re-election must keep its
  entry or it could run concurrently with (and then corrupt the tracking of) the new leader
  session's vacuum of the same partition (`executorListenerRegistered` stays set so the config
  listener is registered exactly once per instance); `GlobalStateMgr#stopLeaderOnlyDaemonThreads()`
  now stops it on demotion. The no-op `acquireBackgroundComputeResource()` call is dropped — its
  result was never read (`vacuumPartitionImpl` resolves the compute resource per table).
- **Docs** (`en`/`zh`/`ja` `shared_lake_other.md`): update the `lake_autovacuum_parallel_partitions`
  "Is mutable" field from `No` to `Yes` and document that `0`/negative disables AutoVacuum.
- **UT** (`VacuumTest`): add tests for pool resize (grow / shrink / non-positive guard), candidate
  collection excluding in-flight partitions + LRU ordering, the scheduling gates plus
  task-submission rollback on `RejectedExecutionException`, queue refill only when empty plus the
  empty-collection back-off, and `onStopped` releasing queued-but-never-run reservations while a
  still-running task keeps its entry until its own `finally` releases it. `VacuumTest` passes 16/16.

Invariant preserved: `vacuumPartitionImpl` (the actual per-partition vacuum RPC path) is unchanged.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
