### PR TITLE
[BugFix] Reconstruct intermediate flat-JSON object instead of returning NULL

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -594,7 +594,22 @@ StatusOr<ColumnIteratorUPtr> Segment::_new_extended_column_iterator(const Tablet
         std::string_view leaf = paths.back();
         may_contains = column_reader->get_remain_filter()->test_bytes(leaf.data(), leaf.size());
     }
-    if (column_reader->is_flat_json() && !may_contains) {
+    // An intermediate node (e.g. "o") whose descendants are stored as flattened sub-columns
+    // (e.g. "o.inner") is present in this segment even though no sub-column is named exactly
+    // "o". Such a node must be reconstructed by the JsonExtractIterator below, not reported as
+    // absent -- otherwise extracting an intermediate JSON object through a json-path-rewrite
+    // extended column (e.g. get_json_string(j, '$.o')) wrongly returns NULL.
+    bool has_flatten_descendant = false;
+    if (sub_readers) {
+        const std::string prefix = std::string(field_name) + ".";
+        for (auto& sub_reader : *sub_readers) {
+            if (std::string_view(sub_reader->name()).starts_with(prefix)) {
+                has_flatten_descendant = true;
+                break;
+            }
+        }
+    }
+    if (column_reader->is_flat_json() && !may_contains && !has_flatten_descendant) {
         // create an iterator always return NULL for fields that don't exist in this segment
         auto default_null_iter = std::make_unique<DefaultValueColumnIterator>(false, "", true, get_type_info(column),
                                                                               column.length(), num_rows());

--- a/test/sql/test_json/R/test_flat_json_intermediate_object
+++ b/test/sql/test_json/R/test_flat_json_intermediate_object
@@ -1,0 +1,47 @@
+-- name: test_flat_json_intermediate_object
+-- Regression for extracting an intermediate (non-leaf) JSON OBJECT from a flat_json table.
+-- On a flat_json.enable=true table the nested object `o` is flattened into leaf sub-columns
+-- (o.inner). With cbo_prune_json_subfield / cbo_json_v2_rewrite on, get_json_string(j,'$.o') is
+-- rewritten into a typed read of the extended column j.o; the segment reader used to find no
+-- sub-column named exactly "o" and return NULL, instead of reconstructing the object from its
+-- o.* leaves.
+set cbo_prune_json_subfield = true;
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 1
+  properties("replication_num"="1","flat_json.enable"="true");
+-- result:
+-- !result
+insert into t select generate_series,
+  parse_json(concat('{"o":{"inner":', generate_series, '},"leaf":', generate_series, '}'))
+  from table(generate_series(1,300));
+-- result:
+-- !result
+select get_json_string(j,'$.o') from t order by id limit 2;
+-- result:
+{"inner": 1}
+{"inner": 2}
+-- !result
+select cast(json_query(j,'$.o') as string) from t order by id limit 2;
+-- result:
+{"inner": 1}
+{"inner": 2}
+-- !result
+select cast(j->'$.o' as string) from t order by id limit 2;
+-- result:
+{"inner": 1}
+{"inner": 2}
+-- !result
+select get_json_int(j,'$.o.inner') from t order by id limit 2;
+-- result:
+1
+2
+-- !result
+select count(*) from t where get_json_string(j,'$.o') is not null;
+-- result:
+300
+-- !result

--- a/test/sql/test_json/R/test_json_subfield_prune_wrong_result
+++ b/test/sql/test_json/R/test_json_subfield_prune_wrong_result
@@ -6,11 +6,9 @@
 -- NULL, which -- because the read also drives the pushed-down predicate -- silently dropped
 -- rows. This test asserts rule-on == rule-off for the dotted key (cases b / b').
 --
--- NOTE: case (a) below (a path ending at an intermediate OBJECT, $.o) is a SEPARATE,
--- still-open issue: rule-on returns NULL where rule-off returns the sub-object. The
--- rule-on result recorded here is the current (incorrect) behavior, NOT the desired one;
--- it is kept only to pin the contrast and will be updated when the intermediate-object
--- case is fixed.
+-- Case (a) below (a path ending at an intermediate OBJECT, $.o) is served correctly too:
+-- the flat reader reconstructs the sub-object from its flattened leaves, so rule-on ==
+-- rule-off returns the sub-object instead of NULL.
 create table t(id int, j json) duplicate key(id)
   distributed by hash(id) buckets 1 properties("replication_num"="1");
 -- result:
@@ -33,8 +31,8 @@ set cbo_prune_json_subfield = true;
 -- !result
 select id, cast(json_query(j,'$.o') as string) from t order by id;
 -- result:
-1	None
-2	None
+1	{"inner": 10}
+2	{"inner": 20}
 -- !result
 set cbo_prune_json_subfield = false;
 -- result:

--- a/test/sql/test_json/T/test_flat_json_intermediate_object
+++ b/test/sql/test_json/T/test_flat_json_intermediate_object
@@ -1,0 +1,20 @@
+-- name: test_flat_json_intermediate_object
+-- Regression for extracting an intermediate (non-leaf) JSON OBJECT from a flat_json table.
+-- On a flat_json.enable=true table the nested object `o` is flattened into leaf sub-columns
+-- (o.inner). With cbo_prune_json_subfield / cbo_json_v2_rewrite on, get_json_string(j,'$.o') is
+-- rewritten into a typed read of the extended column j.o; the segment reader used to find no
+-- sub-column named exactly "o" and return NULL, instead of reconstructing the object from its
+-- o.* leaves.
+set cbo_prune_json_subfield = true;
+set cbo_json_v2_rewrite = true;
+create table t(id int, j json) duplicate key(id)
+  distributed by hash(id) buckets 1
+  properties("replication_num"="1","flat_json.enable"="true");
+insert into t select generate_series,
+  parse_json(concat('{"o":{"inner":', generate_series, '},"leaf":', generate_series, '}'))
+  from table(generate_series(1,300));
+select get_json_string(j,'$.o') from t order by id limit 2;
+select cast(json_query(j,'$.o') as string) from t order by id limit 2;
+select cast(j->'$.o' as string) from t order by id limit 2;
+select get_json_int(j,'$.o.inner') from t order by id limit 2;
+select count(*) from t where get_json_string(j,'$.o') is not null;

--- a/test/sql/test_json/T/test_json_subfield_prune_wrong_result
+++ b/test/sql/test_json/T/test_json_subfield_prune_wrong_result
@@ -6,11 +6,9 @@
 -- NULL, which -- because the read also drives the pushed-down predicate -- silently dropped
 -- rows. This test asserts rule-on == rule-off for the dotted key (cases b / b').
 --
--- NOTE: case (a) below (a path ending at an intermediate OBJECT, $.o) is a SEPARATE,
--- still-open issue: rule-on returns NULL where rule-off returns the sub-object. The
--- rule-on result recorded here is the current (incorrect) behavior, NOT the desired one;
--- it is kept only to pin the contrast and will be updated when the intermediate-object
--- case is fixed.
+-- Case (a) below (a path ending at an intermediate OBJECT, $.o) is served correctly too:
+-- the flat reader reconstructs the sub-object from its flattened leaves, so rule-on ==
+-- rule-off returns the sub-object instead of NULL.
 create table t(id int, j json) duplicate key(id)
   distributed by hash(id) buckets 1 properties("replication_num"="1");
 insert into t values


### PR DESCRIPTION
## Why I'm doing:

get_json_string(j,'$.o') on a flat_json.enable=true table returned NULL when the nested object `o` was flattened into leaf sub-columns (o.inner) and the segment had no remain. cbo_prune_json_subfield / cbo_json_v2_rewrite rewrite the call into a typed read of the extended column j.o; Segment::_new_extended_column_iterator found no sub-column named exactly "o" and short-circuited to a NULL default, before the JsonExtractIterator that would reconstruct the object from its o.* leaves.

Treat a field that is a prefix of an existing flat sub-column as present (an intermediate object node with flattened descendants) so the reconstruction path runs. Also fixes json_query / -> on such intermediate objects.

Add regression test test/sql/test_json/test_flat_json_intermediate_object.

## What I'm doing:

```
create table t(id int, j json) duplicate key(id)
  distributed by hash(id) buckets 1
  properties("replication_num"="1","flat_json.enable"="true");
insert into t select generate_series,
  parse_json(concat('{"o":{"inner":', generate_series, '},"leaf":', generate_series, '}'))
  from table(generate_series(1,300));

mysql> select get_json_string(j,'$.o') from t order by id limit 2;
+---------------------------+
| get_json_string(j, '$.o') |
+---------------------------+
| NULL                      |
| NULL                      |
+---------------------------+
2 rows in set (0.05 sec)

mysql> set cbo_prune_json_subfield=false;
Query OK, 0 rows affected (0.00 sec)

mysql> select get_json_string(j,'$.o') from t order by id limit 2;
+---------------------------+
| get_json_string(j, '$.o') |
+---------------------------+
| {"inner": 1}              |
| {"inner": 2}              |
+---------------------------+
2 rows in set (0.03 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
