### PR TITLE
[BugFix] Support ENGINE clause in CREATE TABLE AS SELECT (CTAS)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateTableAsSelectStmt.java
@@ -22,8 +22,10 @@ import java.util.List;
 /**
  * Represents a CREATE TABLE AS SELECT (CTAS) statement
  * Syntax:
- * CREATE TABLE table_name [( column_name_list )]
- * opt_engine opt_partition opt_properties KW_AS query_stmt
+ * CREATE [TEMPORARY] TABLE [IF NOT EXISTS] table_name [( column_name_list )]
+ * [ENGINE = engine_name] [key_desc] [COMMENT 'comment']
+ * [partition_desc] [distribution_desc] [order_by_desc] [properties]
+ * AS query_stmt
  */
 public class CreateTableAsSelectStmt extends StatementBase {
     private final CreateTableStmt createTableStmt;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1297,7 +1297,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                     tempTableRef,
                     null,
                     context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
-                    "",
+                    context.engineDesc() == null ? "" :
+                            ((Identifier) visit(context.engineDesc().identifier())).getValue(),
                     null,
                     context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
                     partitionDesc,
@@ -1327,7 +1328,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 tableRef,
                 null,
                 context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
-                "",
+                context.engineDesc() == null ? "" :
+                        ((Identifier) visit(context.engineDesc().identifier())).getValue(),
                 null,
                 context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
                 partitionDesc,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -537,4 +537,33 @@ public class CTASAnalyzerTest {
             ctx.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
         }
     }
+
+    @Test
+    public void testCTASParsesEngineClause() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table ctas_with_engine engine=olap as select * from test;";
+
+        CreateTableAsSelectStmt stmt = (CreateTableAsSelectStmt)
+                UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, ctx);
+        Assertions.assertEquals("olap", stmt.getCreateTableStmt().getEngineName());
+    }
+
+    @Test
+    public void testCTASWithoutEngineClauseParsesEmptyEngine() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table ctas_without_engine as select * from test;";
+
+        CreateTableAsSelectStmt stmt = (CreateTableAsSelectStmt)
+                UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, ctx);
+        Assertions.assertEquals("", stmt.getCreateTableStmt().getEngineName());
+    }
+
+    @Test
+    public void testCTASWithExplicitOlapEngineAnalyzesSuccessfully() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table ctas_explicit_olap engine=olap as select * from test;";
+
+        CreateTableAsSelectStmt stmt = (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Assertions.assertEquals("olap", stmt.getCreateTableStmt().getEngineName());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -602,4 +602,34 @@ public class CreateTableAnalyzerTest {
             Config.enable_range_distribution = oldEnableRangeDistribution;
         }
     }
+
+    @Test
+    public void testAnalyzeEngineNameUnifiedCatalogRequiresEngine() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withCatalog("create external catalog test_unified_requires_engine properties (" +
+                "\"type\"=\"unified\", \"unified.metastore.type\"=\"hive\", " +
+                "\"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")");
+
+        String sql = "CREATE TABLE test_unified_requires_engine.db.t (a INT)";
+        Throwable exception = assertThrows(SemanticException.class, () -> {
+            CreateTableStmt createTableStmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser
+                    .parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+            CreateTableAnalyzer.analyzeEngineName(createTableStmt, "test_unified_requires_engine");
+        });
+        assertThat(exception.getMessage(), containsString("requires engine clause"));
+    }
+
+    @Test
+    public void testAnalyzeEngineNameUnifiedCatalogAcceptsExplicitEngine() throws Exception {
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withCatalog("create external catalog test_unified_accepts_engine properties (" +
+                "\"type\"=\"unified\", \"unified.metastore.type\"=\"hive\", " +
+                "\"hive.metastore.uris\"=\"thrift://127.0.0.1:9083\")");
+
+        String sql = "CREATE TABLE test_unified_accepts_engine.db.t (a INT) ENGINE=hive";
+        CreateTableStmt createTableStmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser
+                .parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+        CreateTableAnalyzer.analyzeEngineName(createTableStmt, "test_unified_accepts_engine");
+        Assertions.assertEquals("hive", createTableStmt.getEngineName());
+    }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -558,6 +558,7 @@ ifNotExists:
 createTableAsSelectStatement
     : CREATE TEMPORARY? TABLE (IF NOT EXISTS)? qualifiedName
         ('(' (identifier (',' identifier)*  (',' indexDesc)* | indexDesc (',' indexDesc)*) ')')?
+        engineDesc?
         keyDesc?
         comment?
         partitionDesc?


### PR DESCRIPTION
## Why I'm doing:
CTAS (`CREATE TABLE ... AS SELECT`) targeting a Unified catalog (Hive metastore) always failed. The semantic analyzer requires an explicit `ENGINE = engine_name` for any table created in a Unified catalog, but the CTAS grammar had no way to express `ENGINE` at all — the parser silently produced an empty engine name for every CTAS statement. This made CTAS into a Unified catalog structurally impossible, regardless of what the user typed:

```
CREATE TABLE hive_dev.dbt.t ENGINE=hive AS SELECT ...   -- syntax error, ENGINE not allowed in CTAS
CREATE TABLE hive_dev.dbt.t AS SELECT ...                -- "requires engine clause" from the analyzer
```

## What I'm doing:
- Added an optional `engineDesc` clause to the `createTableAsSelectStatement` grammar rule, in the same position it already occupies in the plain `CREATE TABLE` rule.
- Updated `AstBuilder` to read the parsed `ENGINE = xxx` value instead of hardcoding an empty string when building the CTAS statement.
- Refreshed the stale `CreateTableAsSelectStmt` Javadoc to match the now-supported syntax.
- Added parser/analyzer unit tests covering: CTAS parses and propagates the engine name, CTAS without `ENGINE` keeps its previous empty-engine behavior, and a Unified catalog still requires an explicit engine but now accepts one.

No semantic analyzer changes were needed — it already resolved a real engine name correctly; the only gap was that CTAS's parser had no way to supply one. This is now valid:

```sql
CREATE TABLE hive_dev.dbt.t
ENGINE = hive
PROPERTIES ("file_format" = "parquet")
AS SELECT 1 AS a, "x" AS b;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
