### PR TITLE
[BugFix] Preserve predicateCommonOperators when JoinTuningGuide rebuilds a join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
@@ -42,7 +42,7 @@ public abstract class JoinTuningGuide implements TuningGuide {
         if (needCommute) {
             joinType = JOIN_COMMUTATIVITY_MAP.get(joinOperator.getJoinType());
         }
-        return new PhysicalHashJoinOperator(
+        PhysicalHashJoinOperator newJoinOperator = new PhysicalHashJoinOperator(
                 joinType,
                 joinOperator.getOnPredicate(),
                 joinOperator.getJoinHint(),
@@ -51,6 +51,12 @@ public abstract class JoinTuningGuide implements TuningGuide {
                 joinOperator.getProjection(),
                 joinOperator.getSkewColumn(),
                 joinOperator.getSkewValues());
+        // The predicate may reference common sub-expression columns produced by ScalarOperatorsReuseRule
+        // (see predicateCommonOperators). Those columns are only defined in predicateCommonOperators, so it
+        // must be carried over together with the predicate. Otherwise the rebuilt join keeps a predicate that
+        // references undefined columns and the plan fails InputDependenciesChecker.
+        newJoinOperator.setPredicateCommonOperators(joinOperator.getPredicateCommonOperators());
+        return newJoinOperator;
     }
 
     protected boolean isColocateJoin(OptExpression optExpression) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/feedback/guide/JoinTuningGuidePredicateReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/feedback/guide/JoinTuningGuidePredicateReuseTest.java
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.feedback.guide;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.feedback.NodeExecStats;
+import com.starrocks.qe.feedback.skeleton.JoinNode;
+import com.starrocks.qe.feedback.skeleton.SkeletonBuilder;
+import com.starrocks.qe.feedback.skeleton.SkeletonNode;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
+import com.starrocks.sql.optimizer.validate.InputDependenciesChecker;
+import com.starrocks.sql.plan.DistributedEnvPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+class JoinTuningGuidePredicateReuseTest extends DistributedEnvPlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        DistributedEnvPlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    // A join whose (post-join) predicate reuses a common sub expression carries predicateCommonOperators.
+    // When a JoinTuningGuide rebuilds the join, it must preserve predicateCommonOperators; otherwise the
+    // rebuilt join keeps a predicate referencing columns that are only defined in predicateCommonOperators,
+    // and the plan fails InputDependenciesChecker with
+    // "The required cols {..} cannot obtain from input cols {..}".
+    @Test
+    void testPredicateCommonOperatorsPreservedAfterTuning() throws Exception {
+        // where repeats abs(c_custkey + s_suppkey), reused as a common sub expression on the join predicate.
+        // The inner sub-queries only project the columns they need: customer and supplier both carry a PAD
+        // column, so `select *` over the join would otherwise produce a duplicate output column named PAD.
+        String sql = "select * from (select c_custkey from customer where c_acctbal > 5000 ) c " +
+                "left join (select s_suppkey from supplier where s_acctbal = 1) s on abs(c_custkey) = abs(s_suppkey) " +
+                "where abs(c_custkey + s_suppkey) = 10 or abs(c_custkey + s_suppkey) = 20";
+        ExecPlan execPlan = getExecPlan(sql);
+        OptExpression root = execPlan.getPhysicalPlan();
+
+        Assertions.assertInstanceOf(PhysicalHashJoinOperator.class, root.getOp());
+        PhysicalHashJoinOperator origJoin = (PhysicalHashJoinOperator) root.getOp();
+        Assertions.assertNotNull(origJoin.getPredicateCommonOperators());
+        Assertions.assertFalse(origJoin.getPredicateCommonOperators().isEmpty());
+
+        int leftPlanNodeId = root.inputAt(0).getOp().getPlanNodeId();
+        int rightScanPlanNodeId = root.inputAt(1).inputAt(0).getOp().getPlanNodeId();
+        NodeExecStats left = new NodeExecStats(leftPlanNodeId, 5000000, 5000000, 0, 0, 0);
+        NodeExecStats right = new NodeExecStats(rightScanPlanNodeId, 500000, 500000, 0, 0, 0);
+        Map<Integer, NodeExecStats> map = Maps.newHashMap();
+        map.put(leftPlanNodeId, left);
+        map.put(rightScanPlanNodeId, right);
+        SkeletonBuilder skeletonBuilder = new SkeletonBuilder(map);
+        Pair<SkeletonNode, Map<Integer, SkeletonNode>> pair = skeletonBuilder.buildSkeleton(root);
+        RightChildEstimationErrorTuningGuide guide = new RightChildEstimationErrorTuningGuide((JoinNode) pair.first,
+                JoinTuningGuide.EstimationErrorType.RIGHT_INPUT_UNDERESTIMATED);
+        Optional<OptExpression> res = guide.applyImpl(root);
+        Assertions.assertTrue(res.isPresent());
+
+        OptExpression newPlan = res.get();
+        PhysicalHashJoinOperator newJoin = (PhysicalHashJoinOperator) newPlan.getOp();
+        // The rebuilt join keeps the reused predicate, so it must keep the common operators that define it.
+        Assertions.assertNotNull(newJoin.getPredicateCommonOperators());
+        Assertions.assertEquals(origJoin.getPredicateCommonOperators(), newJoin.getPredicateCommonOperators());
+
+        // Should no longer throw StarRocksPlannerException.
+        InputDependenciesChecker.getInstance().validate(newPlan, null);
+    }
+}

--- a/test/sql/test_feedback/R/test_join_predicate_reuse_feedback
+++ b/test/sql/test_feedback/R/test_join_predicate_reuse_feedback
@@ -1,0 +1,65 @@
+-- name: test_join_predicate_reuse_feedback
+CREATE TABLE `repro_la` (
+  `id` int(11) NULL COMMENT "",
+  `x` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `repro_lb` (
+  `id` int(11) NULL COMMENT "",
+  `v` int(11) NULL COMMENT "",
+  `k` varchar(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into repro_la select generate_series, generate_series from TABLE(generate_series(1, 8));
+-- result:
+-- !result
+insert into repro_lb select generate_series, generate_series * 10, cast(generate_series as varchar) from TABLE(generate_series(1, 8));
+-- result:
+-- !result
+analyze table repro_la;
+analyze table repro_lb;
+set enable_plan_advisor_blacklist = false;
+-- result:
+-- !result
+set broadcast_row_limit = 0;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+function: assert_query_contains("alter plan advisor add SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20", "Add query into plan advisor in FE")
+-- result:
+None
+-- !result
+function: assert_explain_contains("SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20", "RightChildEstimationErrorTuningGuide", "common sub expr")
+-- result:
+None
+-- !result
+SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20;
+-- result:
+-- !result
+set broadcast_row_limit = 15000000;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist = true;
+-- result:
+-- !result
+function: assert_query_contains("truncate plan advisor", "Clear all plan advisor in FE")
+-- result:
+None
+-- !result

--- a/test/sql/test_feedback/T/test_join_predicate_reuse_feedback
+++ b/test/sql/test_feedback/T/test_join_predicate_reuse_feedback
@@ -1,0 +1,71 @@
+-- name: test_join_predicate_reuse_feedback
+-- Regression for: JoinTuningGuide must keep predicateCommonOperators when it rebuilds a join.
+-- A join whose post-join predicate reuses a common sub expression carries predicateCommonOperators
+-- (shown as "common sub expr" in the plan). When a plan-advisor join tuning guide rebuilds the join,
+-- it must preserve predicateCommonOperators; otherwise the rebuilt join keeps a predicate that
+-- references columns only defined in predicateCommonOperators, and the plan fails with
+-- "Invalid plan ... required cols {..} cannot obtain from input cols {..}".
+CREATE TABLE `repro_la` (
+  `id` int(11) NULL COMMENT "",
+  `x` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+
+
+CREATE TABLE `repro_lb` (
+  `id` int(11) NULL COMMENT "",
+  `v` int(11) NULL COMMENT "",
+  `k` varchar(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into repro_la select generate_series, generate_series from TABLE(generate_series(1, 8));
+-- result:
+-- !result
+insert into repro_lb select generate_series, generate_series * 10, cast(generate_series as varchar) from TABLE(generate_series(1, 8));
+-- result:
+-- !result
+analyze table repro_la;
+-- result:
+[REGEX].*
+-- !result
+analyze table repro_lb;
+-- result:
+[REGEX].*
+-- !result
+set enable_plan_advisor_blacklist = false;
+-- result:
+-- !result
+set broadcast_row_limit = 0;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = false;
+-- result:
+-- !result
+function: assert_query_contains("alter plan advisor add SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20", "Add query into plan advisor in FE")
+function: assert_explain_contains("SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20", "RightChildEstimationErrorTuningGuide", "common sub expr")
+-- result:
+None
+-- !result
+SELECT a.id, b.v FROM (SELECT * FROM repro_la WHERE x > 0) a LEFT JOIN (SELECT id, v FROM repro_lb WHERE lower(k) = 'zznotexist') b ON abs(a.id) = abs(b.id) WHERE abs(a.id + b.v) = 10 OR abs(a.id + b.v) = 20;
+-- result:
+-- !result
+set broadcast_row_limit = 15000000;
+-- result:
+-- !result
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist = true;
+-- result:
+-- !result
+function: assert_query_contains("truncate plan advisor", "Clear all plan advisor in FE")


### PR DESCRIPTION
#### Why I'm doing:

When a `JoinTuningGuide` (e.g. `RightChildEstimationErrorTuningGuide`) rebuilds a hash join based on execution feedback, `buildJoinOperator()` copied the join's `predicate` but not its `predicateCommonOperators`. If the join predicate reuses a common sub-expression (extracted by `ScalarOperatorsReuseRule` into `predicateCommonOperators`), the rebuilt join keeps a predicate that references reuse columns defined **only** in those common operators, but the common operators themselves are lost.

As a result the rebuilt plan fails validation in `InputDependenciesChecker` with:

```
Invalid plan ... The required cols {..} cannot obtain from input cols {..}
```

It is intermittent: the first run has no tuning guide and succeeds; a later run applies the recorded guide, rebuilds the join, and drops the map.

#### What I'm doing:

Preserve `predicateCommonOperators` in `JoinTuningGuide.buildJoinOperator()` so the rebuilt join keeps the operators that define the columns its reused predicate depends on. `predicate` and `predicateCommonOperators` are a pair and must always travel together. This is the single entry point all Join tuning guides use to rebuild the operator, so one fix covers them all.

```java
newJoinOperator.setPredicateCommonOperators(joinOperator.getPredicateCommonOperators());
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
