### PR TITLE
[BugFix] Read Iceberg column added by ADD COLUMN before a new snapshot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -138,6 +138,21 @@ public class StarRocksIcebergTableScan
     }
 
     @Override
+    public TableScan useSnapshot(long scanSnapshotId) {
+        // The parent binds the scan to the target snapshot's recorded schema (DataScan#useSnapshotSchema).
+        // A metadata-only ADD COLUMN advances the schema without a new snapshot, so a current-snapshot
+        // read would miss the new column and a filter on it fails with "Cannot find field". Delegate to
+        // the parent (inheriting its validation and context assembly), then rebind only the schema: the
+        // current snapshot uses the current table schema; older snapshots keep theirs for time travel.
+        TableScan scan = super.useSnapshot(scanSnapshotId);
+        Snapshot currentSnapshot = table().currentSnapshot();
+        if (useSnapshotSchema() && currentSnapshot != null && currentSnapshot.snapshotId() == scanSnapshotId) {
+            return newRefinedScan(table(), tableSchema(), ((StarRocksIcebergTableScan) scan).context());
+        }
+        return scan;
+    }
+
+    @Override
     public TableScan metricsReporter(MetricsReporter reporter) {
         if (reporter instanceof IcebergMetricsReporter) {
             this.metricsReporter = (IcebergMetricsReporter) reporter;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -108,6 +108,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -1394,6 +1395,32 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(
                 "Filter{databaseName='db', tableName='table', version=Snapshot@(1), predicate=true, enableColumnStats=false}",
                 filter.toString());
+    }
+
+    @Test
+    public void testGetRemoteFileWithPredicateOnColumnAddedAfterSnapshot() throws IOException {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT),
+                new Column("k3", INT));
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, mockedNativeTableC, Maps.newHashMap());
+
+        mockedNativeTableC.newAppend().appendFile(FILE_B_1).commit();
+        // ADD COLUMN commits new metadata without a new snapshot: the current snapshot still
+        // references the pre-evolution schema id.
+        mockedNativeTableC.updateSchema().addColumn("k3", Types.IntegerType.get()).commit();
+        mockedNativeTableC.refresh();
+
+        long snapshotId = mockedNativeTableC.currentSnapshot().snapshotId();
+        ScalarOperator predicate = new IsNullPredicateOperator(false,
+                new ColumnRefOperator(3, INT, "k3", true));
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                        .setPredicate(predicate).setFieldNames(Lists.newArrayList("k1", "k3")).setLimit(10).build());
+        Assertions.assertEquals(1, res.size());
+        Assertions.assertEquals(3, ((IcebergRemoteFileInfo) res.get(0)).getFileScanTask().file().recordCount());
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -165,3 +165,70 @@ set catalog default_catalog;
 drop catalog iceberg_sql_test_${uuid0};
 -- result:
 -- !result
+
+-- name: test_iceberg_read_new_column_after_add_column
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table evo_read (id int, data string);
+-- result:
+-- !result
+insert into evo_read values (1, 'a'), (2, 'b'), (3, 'c');
+-- result:
+-- !result
+alter table evo_read add column extra string;
+-- result:
+-- !result
+select count(*) from evo_read where extra is null;
+-- result:
+3
+-- !result
+select id, extra from evo_read where extra is not null order by id;
+-- result:
+-- !result
+select id from evo_read where extra = 'x' order by id;
+-- result:
+-- !result
+select id, extra from evo_read order by id;
+-- result:
+1	None
+2	None
+3	None
+-- !result
+insert into evo_read values (4, 'd', 'x');
+-- result:
+-- !result
+select count(*) from evo_read where extra is null;
+-- result:
+3
+-- !result
+select id, extra from evo_read where extra is not null order by id;
+-- result:
+4	x
+-- !result
+select id, extra from evo_read order by id;
+-- result:
+1	None
+2	None
+3	None
+4	x
+-- !result
+drop table evo_read force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -97,3 +97,39 @@ drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 
 set catalog default_catalog;
 drop catalog iceberg_sql_test_${uuid0};
+
+-- name: test_iceberg_read_new_column_after_add_column
+-- Test Point: predicates on a column added by ALTER TABLE ADD COLUMN resolve before any new
+--             write commits a snapshot (old rows backfill NULL), and still work after a write.
+-- Method: query the new column with IS NULL / IS NOT NULL / equality filters right after the
+--         metadata-only ADD COLUMN commit, then again after one INSERT; compare row data.
+-- Scope: Iceberg scan planning (StarRocksIcebergTableScan#useSnapshot schema binding)
+-- Related: https://github.com/StarRocks/StarRocksTest/issues/11432
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+create table evo_read (id int, data string);
+insert into evo_read values (1, 'a'), (2, 'b'), (3, 'c');
+
+-- ADD COLUMN is a metadata-only commit: no new snapshot until the next write, so these reads
+-- must resolve the new column against the current schema, not the snapshot schema.
+alter table evo_read add column extra string;
+
+select count(*) from evo_read where extra is null;
+select id, extra from evo_read where extra is not null order by id;
+select id from evo_read where extra = 'x' order by id;
+select id, extra from evo_read order by id;
+
+insert into evo_read values (4, 'd', 'x');
+
+select count(*) from evo_read where extra is null;
+select id, extra from evo_read where extra is not null order by id;
+select id, extra from evo_read order by id;
+
+drop table evo_read force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... ADD COLUMN` on an Iceberg table is a metadata-only commit: it advances the current schema but does not produce a new snapshot. `StarRocksIcebergTableScan` extends Iceberg's `DataScan`, whose `useSnapshotSchema()` returns `true`, so `useSnapshot(snapshotId)` rebinds the scan to the schema recorded on that snapshot. For a normal (current-snapshot) read, that recorded schema predates the metadata-only `ADD COLUMN`, so pushing a predicate down on the newly added column fails to bind and the query errors out:

```
ERROR 1064 (HY000): Cannot find field 'xxx' in struct: struct<...>
```

The failure is conditional: it only triggers when the new column is referenced in a predicate and no write has committed a snapshot after the `ADD COLUMN`. A pure projection of the new column already works (missing columns are silently backfilled with NULL), and any subsequent write (INSERT/MERGE) commits a new snapshot whose schema includes the column, after which reads recover. `REFRESH EXTERNAL TABLE` and rebuilding the catalog do not help, since this is a schema-binding issue, not a cache issue.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11432

## What I'm doing:

Override `useSnapshot` in `StarRocksIcebergTableScan`: when the target snapshot is the table's current snapshot, scan with the current table schema (so a predicate on a column added by a metadata-only `ADD COLUMN` binds correctly). Older snapshots continue to use the per-snapshot schema, preserving time-travel semantics.

Verification:
- FE UT `IcebergMetadataTest#testGetRemoteFileWithPredicateOnColumnAddedAfterSnapshot` reproduces the exact `Cannot find field` error without the fix and passes with it.
- SQL test `test_iceberg_read_new_column_after_add_column` added to `test_iceberg_alter_table` (predicate on the new column right after `ADD COLUMN`, and again after a write).
- End-to-end on a hive Iceberg catalog: the reported queries error before the fix and return correct results after, on the same cluster.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5