### PR TITLE
[BugFix] Catch memory alloc exception in NLJoinProbeOperator::pull_chunk

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -595,7 +595,6 @@ Status NLJoinProbeOperator::_permute_probe_row(const ChunkPtr& chunk) {
     DCHECK(_curr_build_chunk);
     size_t cur_build_chunk_rows = _curr_build_chunk->num_rows();
     COUNTER_UPDATE(_permute_rows_counter, cur_build_chunk_rows);
-    TRY_CATCH_ALLOC_SCOPE_START()
     for (size_t i = 0; i < _col_types.size(); i++) {
         bool is_probe = i < _probe_column_count;
         SlotDescriptor* slot = _col_types[i];
@@ -608,7 +607,6 @@ Status NLJoinProbeOperator::_permute_probe_row(const ChunkPtr& chunk) {
             dst_col->append(*src_col);
         }
     }
-    TRY_CATCH_ALLOC_SCOPE_END()
     return Status::OK();
 }
 
@@ -683,14 +681,18 @@ Status NLJoinProbeOperator::_permute_right_join(size_t chunk_size) {
 // 2. Apply the conjuncts, and append it to output buffer
 // 3. Maintain match index and implement left join and right join
 StatusOr<ChunkPtr> NLJoinProbeOperator::pull_chunk(RuntimeState* state) {
+    StatusOr<ChunkPtr> res;
+    TRY_CATCH_ALLOC_SCOPE_START()
     _check_post_probe();
     size_t chunk_size = state->chunk_size();
 
     if (_join_op == TJoinOp::INNER_JOIN) {
-        return _pull_chunk_for_inner_join(chunk_size);
+        res = _pull_chunk_for_inner_join(chunk_size);
     } else {
-        return _pull_chunk_for_other_join(chunk_size);
+        res = _pull_chunk_for_other_join(chunk_size);
     }
+    TRY_CATCH_ALLOC_SCOPE_END()
+    return res;
 }
 
 // eval conjuncts for nest loop join, apply common exprs and conjuncts first


### PR DESCRIPTION
## Why I'm doing

```
W20260703 16:02:32.198756 21129003009728 mem_hook.cpp:130] large memory alloc, query_id:019f26ff-cca6-752c-9c01-edc624da1415 instance: 019f26ff
-cca6-752c-9c01-edc624da1417 acquire:20024893456 bytes, is_bad_alloc_caught: 0, stack:
    @          0xe9734c1  starrocks::get_stack_trace[abi:cxx11]()
    @          0x93578ba  malloc
    @          0x92e82fb  starrocks::AllocatorFactory<starrocks::Allocator, starrocks::MemHookAllocator>::checked_alloc(unsigned long)
    @          0xb83db55  std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char
> > >::resize(unsigned long)
    @          0xe66ae17  starrocks::BinaryColumnBase<unsigned int>::_append_binary_impl(starrocks::AdaptiveOffsets const&, unsigned char const
*, unsigned long, unsigned long)
    @          0xe58d969  starrocks::ArrayColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0xe58dd33  starrocks::ArrayColumn::append_value_multiple_times(starrocks::Column const&, unsigned int, unsigned int)
    @          0xe68c71f  starrocks::NullableColumn::append_value_multiple_times(starrocks::Column const&, unsigned int, unsigned int)
    @          0x9dd7319  starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_base_left(std::shared_ptr<starrocks::Chunk>*)
    @          0x9dd877a  starrocks::pipeline::NLJoinProbeOperator::_permute_chunk_for_inner_join(unsigned long)
    @          0x9dd9de7  starrocks::pipeline::NLJoinProbeOperator::_pull_chunk_for_inner_join(unsigned long)
    @          0x9ddba0a  starrocks::pipeline::NLJoinProbeOperator::pull_chunk(starrocks::RuntimeState*)
    @          0xb30efc7  starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9d25196  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xe9a233b  starrocks::ThreadPool::dispatch_thread()
    @          0xe9991ef  starrocks::Thread::supervise_thread(void*)
    @     0x13379c09caa4  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x13379c129c6c  (/usr/lib/x86_64-linux-gnu/libc.so.6+0x129c6b)
```

`NLJoinProbeOperator::pull_chunk` can allocate large output chunks while permuting the cross product of the probe and build sides. Only the other join path's `_permute_probe_row` was guarded by `TRY_CATCH_ALLOC_SCOPE` (added in #55603); the inner join path (`_permute_chunk_for_inner_join` → `_permute_chunk_base_left/right`), `_init_output_chunk`, `_permute_left_join`, and `_permute_right_join` were unprotected.

When the query memory limit is hit inside these unprotected paths, the thrown `std::bad_alloc` escapes `pull_chunk`. It is only caught by the executor-level `TRY_CATCH_ALL`, which exists in `NDEBUG` builds only (so `DEBUG` builds crash), and does not perform proper mem-tracker accounting. This can lead to BE OOM/abort instead of a graceful `Memory limit exceeded` error.

## What I'm doing

Wrap the whole body of `NLJoinProbeOperator::pull_chunk` in `TRY_CATCH_ALLOC_SCOPE_START/END`, so allocation failures on every join path (inner / other / left / right) are converted into `Status::MemoryLimitExceeded` and returned cleanly at the operator boundary. The driver then cancels the fragment normally instead of relying on the release-only top-level catch.

Also removes the now-redundant `TRY_CATCH_ALLOC_SCOPE` inside `_permute_probe_row`: it is only reachable via `pull_chunk`, so the outer scope already covers it. The `Status` return type and `RETURN_IF_ERROR` / `ASSIGN_OR_RETURN` plumbing are kept for error propagation.

This extends the fix in #55603 (which only covered the other join `_permute_probe_row` hotspot) to cover all `pull_chunk` allocation paths, including inner join.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
