### PR TITLE
[BugFix] Fix query cache normalization crash for tables with sub-partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -130,7 +130,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import javax.annotation.Nullable;
 
@@ -142,7 +141,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
     private final List<TScanRangeLocations> result = new ArrayList<>();
     private final List<String> selectedPartitionNames = Lists.newArrayList();
-    private List<Long> selectedPartitionVersions = Lists.newArrayList();
     private final HashSet<Long> scanBackendIds = new HashSet<>();
     private final List<String> unUsedOutputStringColumns = new ArrayList<>();
     // a bucket seq may map to many tablets, and each tablet has a TScanRangeLocations.
@@ -296,14 +294,11 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
     public void setSelectedPartitionIds(List<Long> selectedPartitionIds) {
         this.selectedPartitionIds = selectedPartitionIds;
+        this.selectedPartitionNum = selectedPartitionIds.size();
     }
 
     public List<String> getSelectedPartitionNames() {
         return selectedPartitionNames;
-    }
-
-    public List<Long> getSelectedPartitionVersions() {
-        return selectedPartitionVersions;
     }
 
     public List<Expr> getPrunedPartitionPredicates() {
@@ -652,7 +647,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         String visibleVersionStr = String.valueOf(visibleVersion);
         boolean fillDataCache = olapTable.isEnableFillDataCache(partition);
         selectedPartitionNames.add(partition.getName());
-        selectedPartitionVersions.add(visibleVersion);
 
         checkSomeAliveComputeNode();
         boolean checkScanRangeSize = false;
@@ -1667,19 +1661,24 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                             .collect(Collectors.toSet());
             normalizer.setSlotsUseAggColumns(aggColumnSlotIds);
         } else {
-            List<Long> partitionIds = getSelectedPartitionIds();
+            // scanPartitionVersions is keyed by physical partition id and is populated in
+            // addScanRangeLocations() with exactly the physical partitions that were actually
+            // scanned, so it is the authoritative physicalPartitionId -> version source -- no need
+            // to re-derive physical ids by re-expanding getSelectedPartitionIds() (logical ids).
+            Map<Long, Long> partitionVersions = getScanPartitionVersions();
 
-            List<Long> physicalPartitionIds = new ArrayList<>();
-            for (Long partitionId : partitionIds) {
-                Partition partition = olapTable.getPartition(partitionId);
-                physicalPartitionIds.addAll(partition.getSubPartitions().stream()
-                        .map(PhysicalPartition::getId).collect(Collectors.toList()));
+            // Sanity check: every physical partition actually scanned must belong to a selected
+            // logical partition. Cheap and harmless; guards against the two structures drifting
+            // apart in the future.
+            Set<Long> selectedLogicalPartitionIds = Sets.newHashSet(getSelectedPartitionIds());
+            for (Long physicalPartitionId : partitionVersions.keySet()) {
+                PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
+                Preconditions.checkState(physicalPartition != null &&
+                        selectedLogicalPartitionIds.contains(physicalPartition.getParentId()));
             }
 
-            List<Long> partitionVersions = getSelectedPartitionVersions();
-            Preconditions.checkState(physicalPartitionIds.size() == partitionVersions.size());
-            List<Pair<Long, Long>> partitionVersionAndIds = IntStream.range(0, physicalPartitionIds.size())
-                    .mapToObj(i -> Pair.create(partitionVersions.get(i), physicalPartitionIds.get(i)))
+            List<Pair<Long, Long>> partitionVersionAndIds = partitionVersions.entrySet().stream()
+                    .map(e -> Pair.create(e.getValue(), e.getKey()))
                     .sorted(Pair.comparingBySecond()).collect(Collectors.toList());
             scanNode.setSelected_partition_ids(
                     partitionVersionAndIds.stream().map(p -> p.second).collect(Collectors.toList()));
@@ -1803,7 +1802,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     public void clearScanNodeForThriftBuild() {
         sortColumn = null;
         selectedPartitionNames.clear();
-        selectedPartitionVersions.clear();
         result.clear();
         scanBackendIds.clear();
         appliedDictStringColumns.clear();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -979,18 +979,20 @@ public class PlanFragmentBuilder {
                     dispatch = RangeColocateScanDispatch.forTable(referenceTable);
                 }
 
-                // Filter out empty partitions from all selected partitions, original selected partition ids may be
-                // only parent partition ids if table contains subpartitions, use the real sub partition ids instead.
+                // Filter out logical partitions that have no non-empty physical sub-partition. The result
+                // keeps deduplicated LOGICAL (parent) partition ids -- matching the convention used by every
+                // other consumer of getSelectedPartitionIds()/setSelectedPartitionIds() in this codebase --
+                // restricted to those logical partitions with at least one non-empty physical sub-partition.
                 // eg:
                 // partition        : 10001 -> (tablet_1)
                 //  subpartition1   : 10002 -> (tablet_2)
-                //  subpartition2   : 10004 -> (tablet_3)
-                // original selected partition id with tablet ids: 10001 -> (tablet_2)
+                //  subpartition2   : 10004 -> (empty)
+                // original selected partition id: 10001
                 // after:
-                // selected partition ids   : 10002
+                // selected partition ids   : 10001 (unchanged -- still the logical id, deduplicated)
                 // selected tablet ids      : tablet_2
                 // total tablets num        : 1
-                List<Long> selectedNonEmptyPartitionIds = Lists.newArrayList();
+                Set<Long> selectedNonEmptyPartitionIds = Sets.newLinkedHashSet();
                 for (Long partitionId : scanNode.getSelectedPartitionIds()) {
                     final Partition partition = referenceTable.getPartition(partitionId);
                     List<TKeyRange> partitionRange = List.of();
@@ -1037,7 +1039,7 @@ public class PlanFragmentBuilder {
                                 localBeId);
                     }
                 }
-                scanNode.setSelectedPartitionIds(selectedNonEmptyPartitionIds);
+                scanNode.setSelectedPartitionIds(Lists.newArrayList(selectedNonEmptyPartitionIds));
                 scanNode.setTotalTabletsNum(totalTabletsNum);
             } catch (StarRocksException e) {
                 throw new StarRocksPlannerException(

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -18,11 +18,16 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.io.CharStreams;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.plan.ExecPlan;
@@ -1590,5 +1595,33 @@ public class QueryCacheTest {
                 "GROUP BY k HAVING COUNT(*) > 100000 ORDER BY l DESC LIMIT 25) as t";
         Optional<PlanFragment> frag = getCachedFragment(sql0);
         Assertions.assertTrue(frag.isPresent());
+    }
+
+    @Test
+    public void testQueryCacheWithEmptySubPartition() throws Exception {
+        // Simulate a table whose logical partition has been split so that it owns an extra,
+        // empty physical sub-partition (no tablets). OlapScanNode.toNormalForm() used to
+        // re-derive physical partition ids by blindly expanding every sub-partition of each
+        // selected logical partition and zip the result positionally against a version list
+        // that only recorded actually-scanned (non-empty) sub-partitions -- a size mismatch
+        // that tripped Preconditions.checkState(). "dates" sits on the broadcast side of the
+        // join in testHashJoin, so its scan node is normalized via the
+        // !isProcessingLeftNode() branch, which is required to exercise that code path at all.
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("qc_db", "dates");
+        Partition partition = table.getPartition("dates");
+        MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getLatestBaseIndex();
+        long emptySubPartitionId = GlobalStateMgr.getCurrentState().getNextId();
+        PhysicalPartition emptyPhysicalPartition = new PhysicalPartition(emptySubPartitionId, partition.getId(),
+                new MaterializedIndex(baseIndex.getId(), MaterializedIndex.IndexState.NORMAL));
+        partition.addSubPartition(emptyPhysicalPartition);
+        try {
+            String sql = "select sum(lo_revenue) as revenue\n" +
+                    "from lineorder join[broadcast] dates on lo_orderdate = d_datekey\n" +
+                    "where d_year = 1993";
+            Assertions.assertDoesNotThrow(() -> UtFrameUtils.getPlanAndFragment(ctx, sql));
+            Assertions.assertTrue(getCachedFragment(sql).isPresent());
+        } finally {
+            partition.removeSubPartition(emptySubPartitionId);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2052,9 +2052,9 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
         String sql = "select * from lineitem_partition limit 2";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "     partitions=7/7\n" +
+        assertContains(plan, "     partitions=1/7\n" +
                 "     rollup: lineitem_partition\n" +
-                "     tabletRatio=1");
+                "     tabletRatio=1/48");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
When a table's logical partition has been split into multiple physical sub-partitions and `enable_query_cache=true`, planning certain queries throws `Preconditions.checkState` inside `OlapScanNode.toNormalForm()` while building the query-cache digest.

Root cause: to build the cache key, `toNormalForm()` re-derived the physical partition ids by expanding every sub-partition of each selected logical partition, then zipped that list *positionally* against a separately-tracked list of scanned partition versions. If a logical partition has any empty sub-partition (pruned away earlier because it has no matching tablets), the re-derived id list ends up longer than the version list:

```
logical partition P
 ├─ sub-partition P1 (non-empty, scanned) ──► version recorded
 └─ sub-partition P2 (empty, pruned)      ──► no version recorded

toNormalForm() re-expands P -> [P1, P2]   (2 ids)
                versions   -> [v1]        (1 version)
                size mismatch -> crash
```

A secondary issue in the same area: the loop that filters out empty partitions could push the same logical partition id multiple times (once per non-empty sub-partition it has), which is a latent correctness bug for other logical-id consumers (e.g. bucket-count lookup).

## What I'm doing:
- `OlapScanNode.toNormalForm()` no longer re-derives physical-partition-id → version pairs by expanding logical ids. It now reads directly from `scanPartitionVersions`, a map that is already populated with exactly the physical partitions actually scanned and their versions — no re-derivation, no positional pairing, no mismatch possible. Added a lightweight sanity check (every scanned physical partition must belong to a selected logical partition) as a cheap guard against future drift.
- `PlanFragmentBuilder`'s empty-partition filtering now dedupes the resulting logical partition id list (`Set` instead of `List`), and `OlapScanNode#setSelectedPartitionIds` keeps `selectedPartitionNum` in sync with it.
- Removed the now-unused flat `selectedPartitionVersions` list/getter, superseded by `scanPartitionVersions`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
