### PR TITLE
[Enhancement] Support partition filter requirement and partition count limit for Iceberg and Delta Lake

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -1693,6 +1693,22 @@ Used for compatibility with JDBC connection pool C3P0. No practical use.
 * **Default**: 0 (No limit)
 * **Introduced in**: v3.3.9
 
+### allow_lake_without_partition_filter
+
+* **Description**: Whether to allow queries on lake tables (Hive, Iceberg, Delta Lake, Paimon, etc.) without a partition filter predicate. When set to `false`, queries that do not contain a valid partition predicate on these tables will be rejected to prevent accidental full-table scans.
+* **Scope**: Session
+* **Default**: `true`
+* **Data type**: Boolean
+* **Alias**: `allow_hive_without_partition_filter`
+
+### scan_lake_partition_num_limit
+
+* **Description**: The maximum number of partitions allowed to be scanned for a single lake table (Hive, Iceberg, Delta Lake, Paimon, etc.). When set to `0`, no limit is applied. When exceeded, the query will return an error. Note that for catalog types that enumerate splits incrementally (Iceberg, Delta Lake), the limit check is performed during scan-range dispatch and the query may fail mid-execution rather than being rejected upfront.
+* **Scope**: Session
+* **Default**: `0` (No limit)
+* **Data type**: Int
+* **Alias**: `scan_hive_partition_num_limit`
+
 ### skip_local_disk_cache
 
 * **Description**: Session flag that instructs the FE, when building scan ranges, to mark each tablet's internal scan range with `skip_disk_cache`. When set to `true`, `OlapScanNode.addScanRangeLocations()` sets `internalRange.setSkip_disk_cache(true)` on the created `TInternalScanRange` objects so downstream BE scan nodes are told to bypass the local disk cache for that scan. It is applied per-session and is evaluated at plan/scan-range construction time. Use this together with `skip_page_cache` (to control page cache skipping) and data-cache related variables (`enable_scan_datacache` / `enable_populate_datacache`) as appropriate.

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -1403,6 +1403,22 @@ JDBC 接続プール C3P0 との互換性のために使用されます。実際
 * **デフォルト**: 0（制限なし）
 * **導入バージョン**: v3.3.9
 
+### allow_lake_without_partition_filter
+
+* **説明**: レイクテーブル（Hive、Iceberg、Delta Lake、Paimon など）に対してパーティションフィルターなしのクエリを許可するかどうか。`false` に設定すると、有効なパーティションフィルターを含まないクエリは拒否され、意図しないフルテーブルスキャンを防止します。
+* **スコープ**: セッション
+* **デフォルト**: `true`
+* **タイプ**: Boolean
+* **エイリアス**: `allow_hive_without_partition_filter`
+
+### scan_lake_partition_num_limit
+
+* **説明**: 単一のレイクテーブル（Hive、Iceberg、Delta Lake、Paimon など）に対してスキャンできるパーティションの最大数。`0` に設定すると制限なし。上限を超えるとクエリはエラーを返します。なお、増分的にスプリットを列挙するカタログタイプ（Iceberg、Delta Lake）では、制限チェックはスキャンレンジのディスパッチ時に行われ、クエリが即座に拒否されるのではなく、実行途中で失敗する場合があります。
+* **スコープ**: セッション
+* **デフォルト**: `0`（制限なし）
+* **タイプ**: Int
+* **エイリアス**: `scan_hive_partition_num_limit`
+
 ### skip_local_disk_cache
 
 * **説明**: FE がスキャンレンジを構築するときに、各タブレットの内部スキャンレンジに `skip_disk_cache` をマークするよう指示するセッションフラグです。`true` に設定すると、`OlapScanNode.addScanRangeLocations()` は作成された `TInternalScanRange` オブジェクトに対して `internalRange.setSkip_disk_cache(true)` を設定するため、下流の BE スキャンノードはそのスキャンでローカルディスクキャッシュをバイパスするよう指示されます。この設定はセッション単位で適用され、プラン／スキャンレンジ構築時に評価されます。ページキャッシュスキップの制御には `skip_page_cache` と組み合わせて使用し、データキャッシュ関連の変数（`enable_scan_datacache` / `enable_populate_datacache`）と併せて適切に利用してください。

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -1452,6 +1452,22 @@ ALTER USER 'jack' SET PROPERTIES ('session.query_timeout' = '600');
 * 默认值：0 (无限制)
 * 引入版本：v3.3.9
 
+### allow_lake_without_partition_filter
+
+* 描述：是否允许对湖仓表（Hive、Iceberg、Delta Lake、Paimon 等）进行无分区过滤条件的查询。当设置为 `false` 时，未包含有效分区过滤条件的查询将被拒绝，以防止意外的全表扫描。
+* 作用域：Session
+* 默认值：`true`
+* 数据类型：Boolean
+* 别名：`allow_hive_without_partition_filter`
+
+### scan_lake_partition_num_limit
+
+* 描述：单张湖仓表（Hive、Iceberg、Delta Lake、Paimon 等）允许扫描的最大分区数。设置为 `0` 表示无限制。超出限制时查询将报错。注意：对于增量式枚举分片的 catalog 类型（Iceberg、Delta Lake），分区数限制在 scan-range 分发阶段检查，查询可能在执行中途失败而非被立即拒绝。
+* 作用域：Session
+* 默认值：`0`（无限制）
+* 数据类型：Int
+* 别名：`scan_hive_partition_num_limit`
+
 ### skip_local_disk_cache
 
 * **描述**: 会话标志，指示 FE 在构建 scan ranges 时为每个 tablet 的内部扫描范围标记 `skip_disk_cache`。当设置为 `true` 时，`OlapScanNode.addScanRangeLocations()` 会在创建的 `TInternalScanRange` 对象上调用 `internalRange.setSkip_disk_cache(true)`，从而通知下游 BE 的扫描节点在该扫描中绕过本地磁盘缓存。该设置按会话应用，并在计划/扫描范围构建时评估。可与 `skip_page_cache`（控制页面缓存跳过）和数据缓存相关变量（`enable_scan_datacache` / `enable_populate_datacache`）结合使用。

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
@@ -15,8 +15,8 @@
 package com.starrocks.connector;
 
 import com.starrocks.catalog.Table;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TScanRangeLocations;
 import org.apache.logging.log4j.LogManager;
@@ -59,7 +59,7 @@ public abstract class ConnectorScanRangeSource implements AutoCloseable {
 
     // Enforces scan_lake_partition_num_limit incrementally as new partitions are discovered during scan-range
     // dispatch.
-    protected static void checkPartitionNumLimit(Table table, int selectedPartitionCount) throws AnalysisException {
+    protected static void checkPartitionNumLimit(Table table, int selectedPartitionCount) {
         ConnectContext connectContext = ConnectContext.get();
         if (connectContext == null) {
             return;
@@ -74,6 +74,6 @@ public abstract class ConnectorScanRangeSource implements AutoCloseable {
                 + selectedPartitionCount + ". Please adjust the SQL or change the limit by set variable "
                 + "scan_lake_partition_num_limit.";
         LOG.warn("{} queryId: {}", msg, DebugUtil.printId(connectContext.getQueryId()));
-        throw new AnalysisException(msg);
+        throw new StarRocksConnectorException(msg);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorScanRangeSource.java
@@ -14,11 +14,19 @@
 
 package com.starrocks.connector;
 
+import com.starrocks.catalog.Table;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TScanRangeLocations;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
 public abstract class ConnectorScanRangeSource implements AutoCloseable {
+    private static final Logger LOG = LogManager.getLogger(ConnectorScanRangeSource.class);
+
     RemoteFilesSampleStrategy strategy = new RemoteFilesSampleStrategy();
 
     protected abstract List<TScanRangeLocations> getSourceOutputs(int maxSize);
@@ -47,5 +55,25 @@ public abstract class ConnectorScanRangeSource implements AutoCloseable {
     @Override
     public void close() throws Exception {
         // default no-op
+    }
+
+    // Enforces scan_lake_partition_num_limit incrementally as new partitions are discovered during scan-range
+    // dispatch.
+    protected static void checkPartitionNumLimit(Table table, int selectedPartitionCount) throws AnalysisException {
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null) {
+            return;
+        }
+        int limit = connectContext.getSessionVariable().getScanLakePartitionNumLimit();
+        if (limit <= 0 || selectedPartitionCount <= limit) {
+            return;
+        }
+        String msg = "Exceeded the limit of number of " + table.getCatalogName() + "." + table.getCatalogDBName()
+                + "." + table.getCatalogTableName() + " partitions to be scanned. "
+                + "Number of partitions allowed: " + limit + ", number of partitions to be scanned: "
+                + selectedPartitionCount + ". Please adjust the SQL or change the limit by set variable "
+                + "scan_lake_partition_num_limit.";
+        LOG.warn("{} queryId: {}", msg, DebugUtil.printId(connectContext.getQueryId()));
+        throw new AnalysisException(msg);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.connector.delta;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
@@ -65,7 +66,8 @@ public class DeltaConnectorScanRangeSource extends ConnectorScanRangeSource {
         this.partitionIdGenerator = partitionIdGenerator;
     }
 
-    private long addPartition(FileScanTask fileScanTask) throws AnalysisException {
+    @VisibleForTesting
+    public long addPartition(FileScanTask fileScanTask) throws AnalysisException {
         List<String> partitionValues = new ArrayList<>();
         table.getPartitionColumnNames().forEach(column -> {
             partitionValues.add(fileScanTask.getPartitionValues().get(column));
@@ -84,6 +86,7 @@ public class DeltaConnectorScanRangeSource extends ConnectorScanRangeSource {
                         filePath.getParent().toString());
         partitionKeys.put(partitionKey, partitionId);
         referencedPartitions.put(partitionId, referencedPartitionInfo);
+        checkPartitionNumLimit(table, partitionKeys.size());
         return partitionId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -224,6 +224,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         }
     }
 
+    // Note: unlike getSourceOutputs(), this path does not call addPartition(), so scan_lake_partition_num_limit is
+    // never enforced here. This is intentional - it's only used by compaction (OPTIMIZE TABLE), not by user SELECTs.
     public List<FileScanTask> getSourceFileScanOutputs(int maxSize, long fileSizeThreshold, boolean allFiles) {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.getScanFiles")) {
             List<FileScanTask> res = new ArrayList<>();
@@ -514,6 +516,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
         partitionKeyToId.put(partition, partitionId);
         referencedPartitions.put(partitionId, referencedPartitionInfo);
+        checkPartitionNumLimit(table, partitionKeyToId.size());
         return partitionId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1048,6 +1048,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ALLOW_HIVE_WITHOUT_PARTITION_FILTER = "allow_hive_without_partition_filter";
 
+    public static final String ALLOW_LAKE_WITHOUT_PARTITION_FILTER = "allow_lake_without_partition_filter";
+
     public static final String SCAN_HIVE_PARTITION_NUM_LIMIT = "scan_hive_partition_num_limit";
 
     public static final String SCAN_OLAP_PARTITION_NUM_LIMIT = "scan_olap_partition_num_limit";
@@ -3143,8 +3145,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_EXPR_PRUNE_PARTITION, flag = VariableMgr.INVISIBLE)
     private boolean enableExprPrunePartition = true;
 
-    @VarAttr(name = ALLOW_HIVE_WITHOUT_PARTITION_FILTER)
-    private boolean allowHiveWithoutPartitionFilter = true;
+    @VarAttr(name = ALLOW_LAKE_WITHOUT_PARTITION_FILTER, alias = ALLOW_HIVE_WITHOUT_PARTITION_FILTER)
+    private boolean allowLakeWithoutPartitionFilter = true;
 
     // For the maximum number of partitions allowed to be scanned in a single olap table, 0 means no limit.
     @VarAttr(name = SCAN_OLAP_PARTITION_NUM_LIMIT)
@@ -5782,12 +5784,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableExprPrunePartition = enableExprPrunePartition;
     }
 
-    public boolean isAllowHiveWithoutPartitionFilter() {
-        return allowHiveWithoutPartitionFilter;
+    public boolean isAllowLakeWithoutPartitionFilter() {
+        return allowLakeWithoutPartitionFilter;
     }
 
-    public void setAllowHiveWithoutPartitionFilter(boolean allowHiveWithoutPartitionFilter) {
-        this.allowHiveWithoutPartitionFilter = allowHiveWithoutPartitionFilter;
+    public void setAllowLakeWithoutPartitionFilter(boolean allowLakeWithoutPartitionFilter) {
+        this.allowLakeWithoutPartitionFilter = allowLakeWithoutPartitionFilter;
     }
 
     public int getScanOlapPartitionNumLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -214,6 +214,10 @@ public class OptExternalPartitionPruner {
                 }
             }
         } else if (partitionPredicate instanceof CompoundPredicateOperator) {
+            CompoundPredicateOperator cpo = (CompoundPredicateOperator) partitionPredicate;
+            if (cpo.isNot()) {
+                return false;
+            }
             ScalarOperator leftChild = partitionPredicate.getChild(0);
             ScalarOperator rightChild = partitionPredicate.getChild(1);
             return containsPartitionColumn(leftChild, partitionColRefSet)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
@@ -243,6 +244,24 @@ public class OptExternalPartitionPruner {
         return false;
     }
 
+    // Shared by Hive/Hudi/ODPS (HMS), Iceberg and Delta Lake: reject the query if it doesn't carry a usable
+    // partition predicate, when allow_lake_without_partition_filter is disabled.
+    private static void checkPartitionFilterRequired(LogicalScanOperator operator, OptimizerContext context,
+                                                      Table table, List<Column> partitionColumns) throws AnalysisException {
+        if (context.getSessionVariable().isAllowLakeWithoutPartitionFilter()) {
+            return;
+        }
+        if (!checkPartitionPredicates(operator, partitionColumns)) {
+            LOG.warn("Partition pruning is invalid. queryId: {}", DebugUtil.printId(context.getQueryId()));
+            throw new AnalysisException("Partition pruning is invalid, please check: "
+                    + "1. The partition predicate must be included. "
+                    + "2. The left and right children of the partition predicate cannot be function parameters. "
+                    + "Table: " + table.getCatalogName() + "." + table.getCatalogDBName()
+                    + "." + table.getCatalogTableName() + " " + "Partition columns: "
+                    + partitionColumns.stream().map(Column::getName).collect(Collectors.joining(", ")));
+        }
+    }
+
     // get equivalence predicate which column ref is partition column
     public static List<Optional<ScalarOperator>> getEffectivePartitionPredicate(LogicalScanOperator operator,
                                                                                 List<Column> partitionColumns,
@@ -309,16 +328,7 @@ public class OptExternalPartitionPruner {
 
             List<Pair<PartitionKey, Long>> partitionKeys = Lists.newArrayList();
             if (!table.isUnPartitioned()) {
-                if (!context.getSessionVariable().isAllowHiveWithoutPartitionFilter()
-                        && !checkPartitionPredicates(operator, partitionColumns)) {
-                    LOG.warn("Partition pruning is invalid. queryId: {}", DebugUtil.printId(context.getQueryId()));
-                    throw new AnalysisException("Partition pruning is invalid, please check: "
-                            + "1. The partition predicate must be included. "
-                            + "2. The left and right children of the partition predicate cannot be function parameters. "
-                            + "Table: " + table.getCatalogName() + "." + table.getCatalogDBName()
-                            + "." + table.getCatalogTableName() + " " + "Partition columns: "
-                            + partitionColumns.stream().map(Column::getName).collect(Collectors.joining(", ")));
-                }
+                checkPartitionFilterRequired(operator, context, table, partitionColumns);
 
                 // get partition names
                 List<String> partitionNames;
@@ -382,6 +392,16 @@ public class OptExternalPartitionPruner {
             for (Column column : partitionColumns) {
                 ColumnRefOperator partitionColumnRefOperator = operator.getColumnReference(column);
                 columnToPartitionValuesMap.put(partitionColumnRefOperator, new ConcurrentSkipListMap<>());
+            }
+            if (!deltaLakeTable.isUnPartitioned()) {
+                checkPartitionFilterRequired(operator, context, table, partitionColumns);
+            }
+        } else if (table instanceof IcebergTable) {
+            // Iceberg splits are enumerated incrementally during scan-range dispatch (not upfront here), so only
+            // the partition-filter-required check (a pure predicate-shape check) can run at optimize time.
+            IcebergTable icebergTable = (IcebergTable) table;
+            if (icebergTable.isPartitioned()) {
+                checkPartitionFilterRequired(operator, context, table, icebergTable.getPartitionColumns());
             }
         }
         LOG.debug("Table: {}, partition values map: {}, null partition map: {}", table.getName(),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.delta;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.planner.PartitionIdGenerator;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import io.delta.kernel.utils.FileStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class DeltaConnectorScanRangeSourceTest {
+    private DeltaLakeTable table;
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        List<Column> columns = ImmutableList.of(
+                new Column("id", IntegerType.INT, true),
+                new Column("date", StringType.STRING, true));
+        table = new DeltaLakeTable(1L, "delta_catalog", "delta_db", "t1", columns, ImmutableList.of("date"),
+                null, null, new MetastoreTable("delta_db", "t1", "file:///tmp/delta/t1", 0));
+
+        connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+    }
+
+    private DeltaConnectorScanRangeSource newScanRangeSource() {
+        return new DeltaConnectorScanRangeSource(table, RemoteFileInfoDefaultSource.EMPTY, PartitionIdGenerator.of());
+    }
+
+    private FileScanTask newFileScanTask(String path, String partitionValue) {
+        FileStatus fileStatus = FileStatus.of(path, 1024, 0);
+        return new FileScanTask(fileStatus, 1, Map.of("date", partitionValue), null);
+    }
+
+    @Test
+    public void testPartitionNumLimitThrowsWhenExceeded() {
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
+            scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
+        });
+    }
+
+    @Test
+    public void testPartitionNumLimitNotExceededWithinLimit() throws Exception {
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(2);
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
+        Assertions.assertEquals(2, scanRangeSource.selectedPartitionCount());
+    }
+
+    @Test
+    public void testPartitionNumLimitDisabledByDefault() throws Exception {
+        // 0 (the default) means unlimited.
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(0);
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
+        Assertions.assertEquals(2, scanRangeSource.selectedPartitionCount());
+    }
+
+    @Test
+    public void testRepeatedPartitionDoesNotCountTwice() throws Exception {
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+
+        // Two files in the same partition should not trip a limit of 1.
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
+        scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-01"));
+        Assertions.assertEquals(1, scanRangeSource.selectedPartitionCount());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
@@ -17,9 +17,9 @@ package com.starrocks.connector.delta;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.qe.ConnectContext;
@@ -91,7 +91,7 @@ public class DeltaConnectorScanRangeSourceTest {
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
         DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource(metadata, format);
 
-        Assertions.assertThrows(AnalysisException.class, () -> {
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
             scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
             scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
         });

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSourceTest.java
@@ -18,13 +18,20 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
+import io.delta.kernel.internal.actions.Format;
+import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.utils.FileStatus;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +39,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+// DeltaLakeTable.getDeltaMetadata() delegates to a real Delta Kernel snapshot, which this test doesn't have
+// (and doesn't need - addPartition() never touches it). getDeltaMetadata() is stubbed via MockUp so the
+// DeltaConnectorScanRangeSource constructor's remoteFileInputFormat lookup doesn't NPE; every other method on
+// the DeltaLakeTable instance runs its real implementation.
 public class DeltaConnectorScanRangeSourceTest {
     private DeltaLakeTable table;
     private ConnectContext connectContext;
@@ -45,10 +56,28 @@ public class DeltaConnectorScanRangeSourceTest {
                 null, null, new MetastoreTable("delta_db", "t1", "file:///tmp/delta/t1", 0));
 
         connectContext = new ConnectContext();
+        connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setThreadLocalInfo();
     }
 
-    private DeltaConnectorScanRangeSource newScanRangeSource() {
+    private DeltaConnectorScanRangeSource newScanRangeSource(@Mocked Metadata metadata, @Mocked Format format) {
+        new Expectations() {
+            {
+                metadata.getFormat();
+                result = format;
+                minTimes = 0;
+
+                format.getProvider();
+                result = "parquet";
+                minTimes = 0;
+            }
+        };
+        new MockUp<DeltaLakeTable>() {
+            @Mock
+            public Metadata getDeltaMetadata() {
+                return metadata;
+            }
+        };
         return new DeltaConnectorScanRangeSource(table, RemoteFileInfoDefaultSource.EMPTY, PartitionIdGenerator.of());
     }
 
@@ -58,9 +87,9 @@ public class DeltaConnectorScanRangeSourceTest {
     }
 
     @Test
-    public void testPartitionNumLimitThrowsWhenExceeded() {
+    public void testPartitionNumLimitThrowsWhenExceeded(@Mocked Metadata metadata, @Mocked Format format) {
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
-        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource(metadata, format);
 
         Assertions.assertThrows(AnalysisException.class, () -> {
             scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
@@ -69,9 +98,10 @@ public class DeltaConnectorScanRangeSourceTest {
     }
 
     @Test
-    public void testPartitionNumLimitNotExceededWithinLimit() throws Exception {
+    public void testPartitionNumLimitNotExceededWithinLimit(@Mocked Metadata metadata, @Mocked Format format)
+            throws Exception {
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(2);
-        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource(metadata, format);
 
         scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
         scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
@@ -79,10 +109,11 @@ public class DeltaConnectorScanRangeSourceTest {
     }
 
     @Test
-    public void testPartitionNumLimitDisabledByDefault() throws Exception {
+    public void testPartitionNumLimitDisabledByDefault(@Mocked Metadata metadata, @Mocked Format format)
+            throws Exception {
         // 0 (the default) means unlimited.
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(0);
-        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource(metadata, format);
 
         scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));
         scanRangeSource.addPartition(newFileScanTask("/path/to/f2.parquet", "2020-01-02"));
@@ -90,9 +121,10 @@ public class DeltaConnectorScanRangeSourceTest {
     }
 
     @Test
-    public void testRepeatedPartitionDoesNotCountTwice() throws Exception {
+    public void testRepeatedPartitionDoesNotCountTwice(@Mocked Metadata metadata, @Mocked Format format)
+            throws Exception {
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
-        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource();
+        DeltaConnectorScanRangeSource scanRangeSource = newScanRangeSource(metadata, format);
 
         // Two files in the same partition should not trip a limit of 1.
         scanRangeSource.addPartition(newFileScanTask("/path/to/f1.parquet", "2020-01-01"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
 import com.starrocks.planner.PartitionIdGenerator;
@@ -25,6 +26,7 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.THdfsScanRange;
 import org.apache.iceberg.FileScanTask;
@@ -694,5 +696,69 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
         THdfsScanRange hdfsScanRange = scanRangeSource.buildScanRange(fileScanTask, fileScanTask.file(), partitionId);
         Assertions.assertFalse(hdfsScanRange.isSetFirst_row_id());
+    }
+
+    private IcebergConnectorScanRangeSource newScanRangeSourceForTableC() {
+        List<Column> schema = new ArrayList<>();
+        schema.add(new Column("id", INT));
+        schema.add(new Column("k1", INT));
+        schema.add(new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema, mockedNativeTableC, Maps.newHashMap());
+        return new IcebergConnectorScanRangeSource(icebergTable, RemoteFileInfoDefaultSource.EMPTY,
+                IcebergMORParams.EMPTY, tupleDescriptor, Optional.empty(), PartitionIdGenerator.of(), false, false);
+    }
+
+    @Test
+    public void testPartitionNumLimitThrowsWhenExceeded() throws Exception {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
+
+        // FILE_B_1 is in partition k2=2, FILE_B_2 is in a different partition k2=3 - two distinct partitions.
+        mockedNativeTableC.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+        IcebergConnectorScanRangeSource scanRangeSource = newScanRangeSourceForTableC();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableC.newScan().planFiles());
+        Assertions.assertEquals(2, fileScanTasks.size());
+
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            for (FileScanTask task : fileScanTasks) {
+                scanRangeSource.addPartition(task);
+            }
+        });
+    }
+
+    @Test
+    public void testPartitionNumLimitNotExceededWithinLimit() throws Exception {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(2);
+
+        mockedNativeTableC.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+        IcebergConnectorScanRangeSource scanRangeSource = newScanRangeSourceForTableC();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableC.newScan().planFiles());
+        Assertions.assertEquals(2, fileScanTasks.size());
+
+        for (FileScanTask task : fileScanTasks) {
+            scanRangeSource.addPartition(task);
+        }
+        Assertions.assertEquals(2, scanRangeSource.selectedPartitionCount());
+    }
+
+    @Test
+    public void testPartitionNumLimitDisabledByDefault() throws Exception {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+        // 0 (the default) means unlimited.
+        connectContext.getSessionVariable().setScanLakePartitionNumLimit(0);
+
+        mockedNativeTableC.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+        IcebergConnectorScanRangeSource scanRangeSource = newScanRangeSourceForTableC();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableC.newScan().planFiles());
+
+        for (FileScanTask task : fileScanTasks) {
+            scanRangeSource.addPartition(task);
+        }
+        Assertions.assertEquals(2, scanRangeSource.selectedPartitionCount());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
 import com.starrocks.planner.PartitionIdGenerator;
@@ -712,6 +713,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     @Test
     public void testPartitionNumLimitThrowsWhenExceeded() throws Exception {
         ConnectContext connectContext = new ConnectContext();
+        connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setThreadLocalInfo();
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(1);
 
@@ -731,6 +733,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     @Test
     public void testPartitionNumLimitNotExceededWithinLimit() throws Exception {
         ConnectContext connectContext = new ConnectContext();
+        connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setThreadLocalInfo();
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(2);
 
@@ -748,6 +751,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     @Test
     public void testPartitionNumLimitDisabledByDefault() throws Exception {
         ConnectContext connectContext = new ConnectContext();
+        connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setThreadLocalInfo();
         // 0 (the default) means unlimited.
         connectContext.getSessionVariable().setScanLakePartitionNumLimit(0);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -18,10 +18,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
@@ -723,7 +723,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableC.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
 
-        Assertions.assertThrows(AnalysisException.class, () -> {
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> {
             for (FileScanTask task : fileScanTasks) {
                 scanRangeSource.addPartition(task);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/DeltaLakePartitionFilterRequiredTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/DeltaLakePartitionFilterRequiredTest.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.connector.metastore.MetastoreTable;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaLakeScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.StringType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+// Delta Lake's split enumeration is lazy (Delta Kernel), so unlike Hive/Iceberg's plan tests, exercising the
+// partition-filter-required check via a full SQL/mock-catalog query would require a working Delta Kernel
+// snapshot. This test instead drives OptExternalPartitionPruner directly against a hand-built DeltaLakeTable +
+// LogicalDeltaLakeScanOperator, which is all the check itself actually needs (predicate shape + static
+// partition-column metadata, no file enumeration).
+public class DeltaLakePartitionFilterRequiredTest extends ConnectorPlanTestBase {
+    private static final String CATALOG_NAME = "delta_catalog";
+    private static final String DB_NAME = "delta_db";
+
+    private ColumnRefOperator partitionColumnRef;
+    private Column partitionColumn;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        connectContext.getSessionVariable().setAllowLakeWithoutPartitionFilter(false);
+        partitionColumn = new Column("date", StringType.STRING, true);
+        partitionColumnRef = new ColumnRefOperator(1, StringType.STRING, "date", true);
+    }
+
+    private LogicalDeltaLakeScanOperator buildScanOperator(boolean partitioned, ScalarOperator predicate) {
+        Column idColumn = new Column("id", IntegerType.INT, true);
+        List<Column> columns = partitioned
+                ? ImmutableList.of(idColumn, partitionColumn)
+                : ImmutableList.of(idColumn);
+        List<String> partitionNames = partitioned ? ImmutableList.of("date") : Collections.emptyList();
+
+        DeltaLakeTable table = new DeltaLakeTable(1L, CATALOG_NAME, DB_NAME, "t1", columns, partitionNames,
+                null, null, new MetastoreTable(DB_NAME, "t1", "file:///tmp/delta/t1", 0));
+
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = Maps.newHashMap();
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = Maps.newHashMap();
+        colRefToColumnMetaMap.put(partitionColumnRef, partitionColumn);
+        columnMetaToColRefMap.put(partitionColumn, partitionColumnRef);
+
+        return new LogicalDeltaLakeScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
+                Operator.DEFAULT_LIMIT, predicate);
+    }
+
+    private void prunePartitions(LogicalScanOperator operator) {
+        OptExternalPartitionPruner.prunePartitions(new OptimizerContext(connectContext), operator);
+    }
+
+    @Test
+    public void testValidPartitionFilterSucceeds() {
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, partitionColumnRef,
+                ConstantOperator.createVarchar("2020-01-01"));
+        Assertions.assertDoesNotThrow(() -> prunePartitions(buildScanOperator(true, predicate)));
+    }
+
+    @Test
+    public void testMissingPartitionFilterThrows() {
+        Assertions.assertThrows(StarRocksPlannerException.class,
+                () -> prunePartitions(buildScanOperator(true, null)));
+    }
+
+    @Test
+    public void testFunctionWrappedPartitionFilterThrows() {
+        CallOperator upper = new CallOperator("upper", StringType.STRING, List.of(partitionColumnRef));
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, upper,
+                ConstantOperator.createVarchar("2020-01-01"));
+        Assertions.assertThrows(StarRocksPlannerException.class,
+                () -> prunePartitions(buildScanOperator(true, predicate)));
+    }
+
+    @Test
+    public void testLikePartitionFilterThrows() {
+        ScalarOperator predicate = new LikePredicateOperator(LikePredicateOperator.LikeType.LIKE,
+                partitionColumnRef, ConstantOperator.createVarchar("2020%"));
+        Assertions.assertThrows(StarRocksPlannerException.class,
+                () -> prunePartitions(buildScanOperator(true, predicate)));
+    }
+
+    @Test
+    public void testUnpartitionedTableAlwaysSucceeds() {
+        Assertions.assertDoesNotThrow(() -> prunePartitions(buildScanOperator(false, null)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
@@ -30,7 +30,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
         super.setUp();
         try {
             connectContext.changeCatalogDb("hive0.partitioned_db");
-            connectContext.getSessionVariable().setAllowHiveWithoutPartitionFilter(false);
+            connectContext.getSessionVariable().setAllowLakeWithoutPartitionFilter(false);
             connectContext.getSessionVariable().setScanLakePartitionNumLimit(10);
         } catch (DdlException e) {
             throw new RuntimeException(e);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergPartitionFilterRequiredTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergPartitionFilterRequiredTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IcebergPartitionFilterRequiredTest extends ConnectorPlanTestBase {
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        try {
+            connectContext.changeCatalogDb("iceberg0.partitioned_db");
+            connectContext.getSessionVariable().setAllowLakeWithoutPartitionFilter(false);
+        } catch (DdlException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testValidPartitionFilter() throws Exception {
+        String sql = "select * from t1 where date = '2020-01-01'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "IcebergScanNode");
+    }
+
+    @Test
+    public void testMissingPartitionFilter() {
+        String sql = "select * from t1";
+        Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql));
+
+        String sql2 = "select * from t1 where id = 1";
+        Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql2));
+    }
+
+    @Test
+    public void testFunctionWrappedPartitionFilter() {
+        String sql = "select * from t1 where upper(date) = '2020-01-01'";
+        Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql));
+    }
+
+    @Test
+    public void testLikeInPartitionColumn() {
+        String sql = "select * from t1 where date like '2020%'";
+        Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql));
+    }
+
+    @Test
+    public void testUnpartitionedTableAlwaysSucceeds() throws Exception {
+        String sql = "select * from iceberg0.unpartitioned_db.t0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "IcebergScanNode");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

see also:
- https://github.com/StarRocks/starrocks/pull/44326
- https://github.com/StarRocks/starrocks/pull/68480

Hive/Hudi/Paimon already let users guard against accidental full-table scans on huge external tables via `allow_hive_without_partition_filter` (reject queries with no partition filter) and `scan_lake_partition_num_limit` (cap how many partitions a single scan may touch). Iceberg and Delta Lake had no equivalent protection, so a `SELECT *` on a large lake table could silently trigger a massive scan and destabilize the cluster.

## What I'm doing:

- Generalize `allow_hive_without_partition_filter` into `allow_lake_without_partition_filter` (old name kept as a backward-compatible alias), and extend the partition-filter-required check to Iceberg and Delta Lake.
- Extend `scan_lake_partition_num_limit` enforcement to Iceberg and Delta Lake as well.

The tricky part is that these two checks can't be enforced the same way for every catalog type, because Iceberg/Delta Lake enumerate splits lazily/incrementally instead of upfront like Hive/Paimon:

```
Hive / Hudi / Paimon (eager)             Iceberg / Delta Lake (lazy/incremental)
────────────────────────────             ───────────────────────────────────────
Optimize time:                           Optimize time:
 ├─ list partitions (cheap)                ├─ predicate-shape check only
 ├─ check filter required  ✓               │   (allow_lake_without_partition_filter)
 └─ check partition count  ✓             Scan-range dispatch (execution):
                                           └─ check partition count as each new
Nothing left to check at dispatch time       partition streams in
                                              (scan_lake_partition_num_limit)
```

- The **filter-required** check only needs the predicate shape plus static partition-column metadata, so it still runs at optimize time in `OptExternalPartitionPruner`, same as Hive.
- The **partition-count-limit** check needs the actual set of partitions touched, which for Iceberg/Delta is only known as files stream in during scan-range dispatch. It's enforced in a new shared `ConnectorScanRangeSource.checkPartitionNumLimit()` helper, called from both `IcebergConnectorScanRangeSource` and `DeltaConnectorScanRangeSource` as each new distinct partition is discovered.
- One resulting behavior difference worth flagging: under the default incremental dispatch mode, an Iceberg/Delta query that busts the limit may fail *mid-flight* (after some scan ranges are already dispatched to BE) rather than being rejected up front like Hive/Paimon.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5