### PR TITLE
[Enhancement] Adapt lake ADD/DROP INDEX Index Delta Group to tablet split/merge

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1329,6 +1329,156 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
     return Status::OK();
 }
 
+// Pack (col_uid, index_type) into a 64-bit key, mirroring index_delta_group_loader.cpp,
+// so tombstone-set membership can be tested cheaply.
+inline uint64_t idg_pack_key(int32_t col_uid, IndexType type) {
+    return (static_cast<uint64_t>(static_cast<uint32_t>(col_uid)) << 32) | static_cast<uint32_t>(type);
+}
+
+// Union |from|'s dropped_keys tombstones into |into| (dedup by packed key). Used when the
+// same physical .idx appears under one target from multiple split-family siblings whose
+// DROP INDEX history diverged: a key dropped in ANY sibling must stay dropped (DROP INDEX
+// is table-wide and monotonic), so first-wins cannot be allowed to resurrect it.
+void union_idg_dropped_keys(IndexDeltaGroupEntryPB* into, const IndexDeltaGroupEntryPB& from) {
+    std::unordered_set<uint64_t> present;
+    for (const auto& dk : into->dropped_keys()) present.insert(idg_pack_key(dk.col_unique_id(), dk.index_type()));
+    for (const auto& dk : from.dropped_keys()) {
+        if (present.insert(idg_pack_key(dk.col_unique_id(), dk.index_type())).second) {
+            *into->add_dropped_keys() = dk;
+        }
+    }
+}
+
+// True iff |e| still has at least one active (non-tombstoned) key. Mirrors the read-path
+// loader's active-key computation (index_delta_group_loader.cpp). A fully-tombstoned entry
+// is logically dead: the loader skips it, AND vacuum relies on the invariant that idg_meta
+// never holds a fully-tombstoned entry (vacuum.cpp: normally apply_drop_index moves such
+// .idx to orphan_files). Merge must not install one or the .idx would look live forever.
+bool idg_entry_has_active_key(const IndexDeltaGroupEntryPB& e) {
+    std::unordered_set<uint64_t> dropped;
+    for (const auto& dk : e.dropped_keys()) dropped.insert(idg_pack_key(dk.col_unique_id(), dk.index_type()));
+    for (const auto& k : e.keys()) {
+        if (dropped.find(idg_pack_key(k.col_unique_id(), k.index_type())) == dropped.end()) return true;
+    }
+    return false;
+}
+
+// merge_idg_meta: remap each source tablet's IDG (.idx) entries into the merged tablet's
+// rssid space, dedup by .idx filename per target segment, and keep them newest-version
+// first. Unlike merge_dcg_meta there is no rebuild-on-conflict path: an .idx indexes
+// unchanging shared segment data, so every source's entry for a given target rssid is built
+// over the same physical segment and is interchangeable; the read-path loader picks the
+// newest visible version per key and honors tombstones.
+//
+// An entry is kept only if BOTH its segment_id is a live segment in its OWN source tablet
+// (source-live) AND its remapped target is a live segment in the merged tablet (target-live).
+// map_rssid falls back to rssid+offset for anything not in shared_rssid_map (it only errors
+// on overflow), so it is not a "segment survived" test: a stale idg entry (segment pruned or
+// compacted out of that source but the entry not cleaned) could otherwise remap -- e.g. the
+// canonical child's stale rssid R maps via R+0 onto a target R that is live only because a
+// sibling supplies that segment -- and mis-apply / dangle a .idx that source no longer owns.
+// Stale entries are dropped; their .idx becomes an orphan reclaimed by the shared-file
+// cleanup once the source tablets are dropped. Writes no new files, so there is no
+// partial-write cleanup to do.
+Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+    // Every segment present after merge_rowsets, mapped to its shared flag. An IDG entry is
+    // kept only if its remapped target is here (target-live), and its .idx shared_file is
+    // DERIVED from the target segment's shared flag (see the emit loop) rather than preserved
+    // from the source: an .idx is shared iff the segment it indexes is shared, so the two must
+    // agree. Preserving a source flag would carry a stale value (e.g. a tablet split before
+    // this fix has segment.shared=true but idg.shared_file=false, because the old split marked
+    // segments shared but not idg) and later mis-route the .idx at vacuum time.
+    std::unordered_map<uint32_t, bool> target_rssid_shared;
+    for (const auto& rowset : new_metadata->rowsets()) {
+        for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+            target_rssid_shared[get_rssid(rowset, i)] = rowset.segment_metas(i).shared();
+        }
+    }
+
+    std::map<uint32_t, std::vector<IndexDeltaGroupEntryPB>> work_by_target;
+    // target rssid -> (.idx filename -> index into work_by_target[target]).
+    std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
+
+    for (const auto& context : merge_contexts) {
+        if (!context.metadata()->has_idg_meta()) continue;
+        // Live source segments in THIS context.
+        std::unordered_set<uint32_t> source_live_rssids;
+        for (const auto& rowset : context.metadata()->rowsets()) {
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                source_live_rssids.insert(get_rssid(rowset, i));
+            }
+        }
+        for (const auto& [segment_id, idg_ver] : context.metadata()->idg_meta().idgs()) {
+            if (source_live_rssids.find(segment_id) == source_live_rssids.end()) {
+                continue; // stale idg entry: segment no longer in this source's rowsets
+            }
+            ASSIGN_OR_RETURN(uint32_t target_rssid, context.map_rssid(segment_id));
+            if (target_rssid_shared.find(target_rssid) == target_rssid_shared.end()) {
+                continue; // defensive: target not a live merged segment
+            }
+            auto& entries = work_by_target[target_rssid];
+            auto& seen = seen_files_by_target[target_rssid];
+            for (const auto& entry : idg_ver.entries()) {
+                if (!entry.has_index_file() || entry.index_file().empty()) continue;
+                auto seen_it = seen.find(entry.index_file());
+                if (seen_it != seen.end()) {
+                    union_idg_dropped_keys(&entries[seen_it->second], entry); // same physical .idx
+                    continue;
+                }
+                // shared_file is derived from the target segment's ownership in the emit loop.
+                seen[entry.index_file()] = entries.size();
+                entries.push_back(entry);
+            }
+        }
+    }
+
+    if (work_by_target.empty()) return Status::OK();
+
+    auto* merged_idgs = new_metadata->mutable_idg_meta()->mutable_idgs();
+    // Fully-tombstoned entries' .idx files are orphan candidates. Collect them first and only
+    // orphan a file that NO surviving entry (under ANY target) still references: vacuum deletes
+    // orphan_files without consulting live idg_meta, so orphaning a still-referenced file would
+    // delete an active index. (.idx names are uuid-unique so a name maps to one target in
+    // practice, but resolving against the full surviving set keeps the orphan set provably safe.)
+    std::unordered_set<std::string> surviving_files;
+    std::map<std::string, FileMetaPB> orphan_candidates;
+    for (auto& [target_rssid, entries] : work_by_target) {
+        // Derive the .idx shared flag from the merged segment's ownership: an .idx is shared
+        // iff the segment it indexes is shared. This corrects a stale source flag (e.g. from a
+        // tablet split before this fix) instead of preserving it, and matches how vacuum treats
+        // the segment/.cols for the same rssid.
+        auto shared_it = target_rssid_shared.find(target_rssid);
+        const bool tgt_shared = shared_it != target_rssid_shared.end() && shared_it->second;
+        std::sort(entries.begin(), entries.end(), [](const IndexDeltaGroupEntryPB& a, const IndexDeltaGroupEntryPB& b) {
+            return a.version() > b.version();
+        });
+        // Drop fully-tombstoned entries (all keys dropped after union): keeping one would
+        // violate vacuum's no-fully-tombstoned-entry invariant.
+        IndexDeltaGroupVerPB ver;
+        for (auto& e : entries) {
+            if (idg_entry_has_active_key(e)) {
+                e.set_shared_file(tgt_shared);
+                surviving_files.insert(e.index_file());
+                *ver.add_entries() = std::move(e);
+            } else if (e.has_index_file() && !e.index_file().empty()) {
+                auto& fm = orphan_candidates[e.index_file()];
+                fm.set_name(e.index_file());
+                if (e.has_file_size()) fm.set_size(e.file_size());
+                if (tgt_shared) fm.set_shared(true);
+            }
+        }
+        if (ver.entries_size() == 0) continue;
+        (*merged_idgs)[target_rssid] = std::move(ver);
+    }
+    // Orphan each dead .idx so vacuum reclaims it, mirroring MetaFileBuilder::apply_drop_index.
+    for (auto& [file, fm] : orphan_candidates) {
+        if (surviving_files.find(file) == surviving_files.end()) {
+            *new_metadata->add_orphan_files() = std::move(fm);
+        }
+    }
+    return Status::OK();
+}
+
 // Phase 0: for every PK canonical rowset that owns at least one shared
 // segment, mask the rowids whose key falls outside ⋃ contributors but inside
 // the merged tablet range.
@@ -2762,6 +2912,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     new_tablet_metadata->clear_delvec_meta();
     new_tablet_metadata->clear_sstable_meta();
     new_tablet_metadata->clear_dcg_meta();
+    new_tablet_metadata->clear_idg_meta();
     new_tablet_metadata->clear_rowset_to_schema();
     new_tablet_metadata->clear_compaction_inputs();
     new_tablet_metadata->clear_orphan_files();
@@ -2816,6 +2967,10 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // Phase 3: Projections (map_rssid uses shared_rssid_map + rssid_offset)
     RETURN_IF_ERROR(merge_dcg_meta(tablet_manager, merge_contexts, merging_tablet.new_tablet_id(), new_version,
                                    txn_info.txn_id(), gap_specs, new_tablet_metadata.get()));
+
+    // Remap the lake ADD INDEX fast-path IDG (.idx) entries into the merged rssid space,
+    // mirroring merge_dcg_meta. Metadata-only (no segment rebuild); see merge_idg_meta.
+    RETURN_IF_ERROR(merge_idg_meta(merge_contexts, new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
         RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, gap_specs, new_version, txn_info.txn_id(),

--- a/be/src/storage/lake/tablet_reshard_helper.cpp
+++ b/be/src/storage/lake/tablet_reshard_helper.cpp
@@ -315,6 +315,17 @@ void set_all_data_files_shared(TxnLogPB* txn_log) {
         }
     }
 
+    if (txn_log->has_op_add_index()) {
+        // ADD INDEX fast-path .idx files, peer of op_schema_change above: on a split
+        // cross-publish this OpAddIndex is applied to every new tablet, so its .idx must be
+        // marked shared or one child could later reclaim a file another child still uses.
+        for (auto& se : *txn_log->mutable_op_add_index()->mutable_segment_entries()) {
+            if (se.has_entry()) {
+                se.mutable_entry()->set_shared_file(true);
+            }
+        }
+    }
+
     if (txn_log->has_op_replication()) {
         // Each replication op_write flows through the same apply_opwrite path on
         // publish (see txn_log_applier.cpp apply_write_log). Share the same rule as
@@ -355,6 +366,12 @@ void set_non_segment_files_shared(TabletMetadataPB* tablet_metadata, bool skip_d
         }
     }
 
+    if (tablet_metadata->has_idg_meta()) {
+        for (auto& idg : *tablet_metadata->mutable_idg_meta()->mutable_idgs()) {
+            set_idg_shared(&idg.second, true);
+        }
+    }
+
     if (tablet_metadata->has_sstable_meta()) {
         for (auto& sstable : *tablet_metadata->mutable_sstable_meta()->mutable_sstables()) {
             sstable.set_shared(true);
@@ -366,6 +383,12 @@ void set_dcg_shared(DeltaColumnGroupVerPB* dcg, bool shared) {
     auto* shared_files = dcg->mutable_shared_files();
     shared_files->Clear();
     shared_files->Resize(dcg->column_files_size(), shared);
+}
+
+void set_idg_shared(IndexDeltaGroupVerPB* idg, bool shared) {
+    for (auto& entry : *idg->mutable_entries()) {
+        entry.set_shared_file(shared);
+    }
 }
 
 void set_all_data_files_shared(TabletMetadataPB* tablet_metadata, bool skip_delvecs) {

--- a/be/src/storage/lake/tablet_reshard_helper.h
+++ b/be/src/storage/lake/tablet_reshard_helper.h
@@ -93,6 +93,11 @@ void set_non_segment_files_shared(TabletMetadataPB* tablet_metadata, bool skip_d
 // ownership propagation (private for an exclusive segment).
 void set_dcg_shared(DeltaColumnGroupVerPB* dcg, bool shared);
 
+// Peer of set_dcg_shared for Index Delta Groups: mark every .idx entry in an IDG version
+// list shared / private. Used by set_non_segment_files_shared (shared) and tablet split's
+// per-segment ownership propagation (private for an exclusive segment).
+void set_idg_shared(IndexDeltaGroupVerPB* idg, bool shared);
+
 StatusOr<TabletRangePB> intersect_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
 StatusOr<TabletRangePB> union_range(const TabletRangePB& lhs_pb, const TabletRangePB& rhs_pb);
 Status update_rowset_range(RowsetMetadataPB* rowset, const TabletRangePB& range);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1122,13 +1122,13 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
 //
 // Propagates per-segment split ownership of |rowset| (computed in |ownership| for
 // the new tablet at |new_tablet_index|) onto |new_tablet_metadata|'s non-segment
-// files (delvec pages, dcg entries), so they follow the per-segment shared decision
-// instead of all staying shared:
-//   - a segment pruned away from this new tablet (keep == false): erase its dcg
-//     entry (sstable projection never consults dcg), and erase its delvec page
-//     unless a surviving has_shared_rssid sstable still needs it (protected_rssids);
-//   - an exclusive kept segment (shared == false): mark its dcg files private, so
-//     vacuum can reclaim them alongside the now-private segment. (Delvec FILES stay
+// files (delvec pages, dcg entries, idg entries), so they follow the per-segment
+// shared decision instead of all staying shared:
+//   - a segment pruned away from this new tablet (keep == false): erase its dcg and
+//     idg entries (sstable projection never consults dcg/idg), and erase its delvec
+//     page unless a surviving has_shared_rssid sstable still needs it (protected_rssids);
+//   - an exclusive kept segment (shared == false): mark its dcg and idg files private,
+//     so vacuum can reclaim them alongside the now-private segment. (Delvec FILES stay
 //     shared: one file holds pages for many segments, so it is not reclaimed per-rssid.)
 //
 // Must run BEFORE apply_segment_ownership_to_new_tablet_rowset, which compacts the
@@ -1144,12 +1144,16 @@ bool propagate_pruned_ownership_to_non_segment_files(const RowsetMetadataPB& row
                             : nullptr;
     auto* dcgs =
             new_tablet_metadata->has_dcg_meta() ? new_tablet_metadata->mutable_dcg_meta()->mutable_dcgs() : nullptr;
+    auto* idgs =
+            new_tablet_metadata->has_idg_meta() ? new_tablet_metadata->mutable_idg_meta()->mutable_idgs() : nullptr;
     bool has_pruned_protected_rssid = false;
     for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
         const uint32_t rssid = get_rssid(rowset, segment_index);
         const auto& segment_ownership = ownership.segments[segment_index];
         if (!segment_ownership.keep[new_tablet_index]) {
             if (dcgs != nullptr) dcgs->erase(rssid);
+            // IDG mirrors DCG: sstable projection never consults idg, so no protected_rssids gate.
+            if (idgs != nullptr) idgs->erase(rssid);
             if (protected_rssids.contains(rssid)) {
                 // Leave the delvec page as-is (all-shared) rather than erasing it: MERGE's
                 // modern sstable projection re-reads this rssid's delvec, so erasing risks
@@ -1169,6 +1173,12 @@ bool propagate_pruned_ownership_to_non_segment_files(const RowsetMetadataPB& row
                 auto dcg_it = dcgs->find(rssid);
                 if (dcg_it != dcgs->end()) {
                     tablet_reshard_helper::set_dcg_shared(&dcg_it->second, /*shared=*/false);
+                }
+            }
+            if (idgs != nullptr) {
+                auto idg_it = idgs->find(rssid);
+                if (idg_it != idgs->end()) {
+                    tablet_reshard_helper::set_idg_shared(&idg_it->second, /*shared=*/false);
                 }
             }
         }

--- a/be/test/storage/lake/tablet_reshard_helper_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_helper_test.cpp
@@ -928,4 +928,47 @@ TEST_F(TabletReshardHelperTest, Reconcile_LeadingAndTrailingGap) {
     expect_window(out[2], 20, 30, true);
 }
 
+TEST_F(TabletReshardHelperTest, set_idg_shared_toggles_all_entries) {
+    IndexDeltaGroupVerPB idg;
+    auto* e0 = idg.add_entries();
+    e0->set_index_file("a.idx");
+    e0->set_shared_file(false);
+    auto* e1 = idg.add_entries();
+    e1->set_index_file("b.idx");
+    e1->set_shared_file(false);
+
+    set_idg_shared(&idg, true);
+    for (const auto& e : idg.entries()) EXPECT_TRUE(e.shared_file());
+
+    set_idg_shared(&idg, false);
+    for (const auto& e : idg.entries()) EXPECT_FALSE(e.shared_file());
+}
+
+TEST_F(TabletReshardHelperTest, set_non_segment_files_shared_marks_idg) {
+    TabletMetadataPB meta;
+    auto& idgs = *meta.mutable_idg_meta()->mutable_idgs();
+    IndexDeltaGroupVerPB idg;
+    idg.add_entries()->set_index_file("c.idx"); // shared_file defaults false
+    idgs[7] = idg;
+
+    set_non_segment_files_shared(&meta);
+    ASSERT_TRUE(meta.idg_meta().idgs().contains(7));
+    for (const auto& e : meta.idg_meta().idgs().at(7).entries()) EXPECT_TRUE(e.shared_file());
+}
+
+TEST_F(TabletReshardHelperTest, set_all_data_files_shared_covers_op_add_index) {
+    // A cross-published OpAddIndex on a split must have its .idx marked shared so a sibling
+    // cannot later reclaim a file the other child still references.
+    TxnLogPB txn_log;
+    auto* se = txn_log.mutable_op_add_index()->add_segment_entries();
+    se->set_segment_id(3);
+    auto* entry = se->mutable_entry();
+    entry->set_index_file("x.idx");
+    entry->set_shared_file(false);
+
+    set_all_data_files_shared(&txn_log);
+    ASSERT_EQ(1, txn_log.op_add_index().segment_entries_size());
+    EXPECT_TRUE(txn_log.op_add_index().segment_entries(0).entry().shared_file());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -280,6 +280,35 @@ protected:
         dcg.add_shared_files(true);
     }
 
+    // IDG (.idx) test helpers, peers of add_dcg_with_columns. add_idg_with_key creates a
+    // single-entry IDG for |segment_id| with one (col_uid, type) key; add_idg_key appends a
+    // second key to that entry; add_idg_dropped_key appends a DROP INDEX tombstone.
+    void add_idg_with_key(TabletMetadataPB* metadata, uint32_t segment_id, const std::string& file_name,
+                          int32_t col_uid, IndexType type, int64_t version, bool shared_file = true) {
+        auto& idg = (*metadata->mutable_idg_meta()->mutable_idgs())[segment_id];
+        auto* e = idg.add_entries();
+        e->set_index_file(file_name);
+        e->set_version(version);
+        e->set_shared_file(shared_file);
+        auto* k = e->add_keys();
+        k->set_col_unique_id(col_uid);
+        k->set_index_type(type);
+    }
+    void add_idg_key(TabletMetadataPB* metadata, uint32_t segment_id, int32_t col_uid, IndexType type) {
+        auto& idg = (*metadata->mutable_idg_meta()->mutable_idgs())[segment_id];
+        ASSERT_GT(idg.entries_size(), 0);
+        auto* k = idg.mutable_entries(0)->add_keys();
+        k->set_col_unique_id(col_uid);
+        k->set_index_type(type);
+    }
+    void add_idg_dropped_key(TabletMetadataPB* metadata, uint32_t segment_id, int32_t col_uid, IndexType type) {
+        auto& idg = (*metadata->mutable_idg_meta()->mutable_idgs())[segment_id];
+        ASSERT_GT(idg.entries_size(), 0);
+        auto* dk = idg.mutable_entries(0)->add_dropped_keys();
+        dk->set_col_unique_id(col_uid);
+        dk->set_index_type(type);
+    }
+
     // Build a two-column INT primary-key tablet schema in |metadata|'s
     // `schema` field. `c0` is the key (also the sort key); `c1` is a plain
     // data column. The returned (c0_uid, c1_uid) can be used to cross-
@@ -10450,6 +10479,533 @@ TEST(ShadowRewriteTransformTest, ShadowRewriteTransformEmptyWhenNoRowset) {
     ASSERT_TRUE(log.has_op_schema_change());
     EXPECT_EQ(9, log.op_schema_change().alter_version());
     EXPECT_EQ(0, log.op_schema_change().rowsets_size());
+}
+
+// =============================================================================
+// Index Delta Group (.idx / idg_meta) reshard adaptation
+// =============================================================================
+
+// SPLIT: shared .idx marked shared on spanning segments; exclusive kept segment .idx marked
+// private; pruned-away segment idg entry erased. Mirrors
+// test_tablet_split_propagates_ownership_to_delvec_dcg for IDG.
+TEST_F(LakeTabletReshardTest, test_tablet_split_propagates_ownership_to_idg) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    auto* rs = metadata.add_rowsets();
+    rs->set_id(2);
+    {
+        auto* m0 = rs->add_segment_metas();
+        m0->set_filename("seg_lo.dat");
+        m0->set_size(512);
+        m0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+        m0->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
+        m0->set_num_rows(50);
+    }
+    {
+        auto* m1 = rs->add_segment_metas();
+        m1->set_filename("seg_hi.dat");
+        m1->set_size(512);
+        m1->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
+        m1->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+        m1->set_num_rows(50);
+    }
+    rs->set_overlapped(true);
+    rs->set_data_size(1024);
+    rs->set_num_rows(100);
+
+    // idg for both segments' rssids (rowset id 2 + segment_idx {0,1} => 2 and 3).
+    add_idg_with_key(&metadata, /*segment_id=*/2, "idx_lo.idx", /*col_uid=*/101, BITMAP, 1);
+    add_idg_with_key(&metadata, /*segment_id=*/3, "idx_hi.idx", /*col_uid=*/102, BITMAP, 1);
+
+    EXPECT_OK(put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding;
+    auto& splitting = *resharding.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(tablet_id);
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    splitting.add_new_tablet_ids(child0);
+    splitting.add_new_tablet_ids(child1);
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, metadata.version(),
+                                              metadata.version() + 1, txn_info, false, tablet_metadatas,
+                                              tablet_ranges));
+
+    for (int64_t child : {child0, child1}) {
+        auto c = tablet_metadatas.at(child);
+        ASSERT_EQ(1, c->rowsets_size());
+        const auto& r = c->rowsets(0);
+        ASSERT_EQ(1, r.segment_metas_size());
+        const uint32_t kept_rssid = r.id() + r.segment_metas(0).segment_idx();
+        const uint32_t pruned_rssid = (kept_rssid == 2) ? 3 : 2;
+
+        // Exclusive kept segment -> its idg is private.
+        ASSERT_TRUE(c->idg_meta().idgs().contains(kept_rssid));
+        for (const auto& e : c->idg_meta().idgs().at(kept_rssid).entries())
+            EXPECT_FALSE(e.shared_file()) << "exclusive segment idg must be private";
+
+        // Pruned-away segment's idg entry erased.
+        EXPECT_FALSE(c->idg_meta().idgs().contains(pruned_rssid))
+                << "pruned segment idg must be erased on the tablet that dropped it";
+    }
+}
+
+// MERGE: two split siblings share one physical .idx; it must dedup to a single entry under
+// the canonical target rssid, marked shared. Mirrors test_tablet_merging_shared_dcg_dedup.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_idg_dedup) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child_with_idg = [&](int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("shared_seg.dat");
+        sm->set_size(100);
+        sm->set_shared(true);
+        stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
+        add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child_with_idg(child_a)));
+    EXPECT_OK(put_tablet_metadata(make_child_with_idg(child_b)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_TRUE(merged->has_idg_meta());
+    ASSERT_EQ(1, merged->idg_meta().idgs().size());
+    auto idg_it = merged->idg_meta().idgs().find(merged->rowsets(0).id());
+    ASSERT_TRUE(idg_it != merged->idg_meta().idgs().end());
+    ASSERT_EQ(1, idg_it->second.entries_size()) << "shared .idx deduped to one entry";
+    EXPECT_EQ("shared.idx", idg_it->second.entries(0).index_file());
+    EXPECT_TRUE(idg_it->second.entries(0).shared_file());
+}
+
+// MERGE: same shared .idx with TWO keys (col5,col6); sibling B tombstones only col5.
+// The deduped entry must be retained (col6 active) with the col5 tombstone unioned in.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_unions_divergent_tombstones) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, bool drop_col5) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("shared_seg.dat");
+        sm->set_size(100);
+        sm->set_shared(true);
+        stamp_physical_identity_uid(rowset, "shared_seg.dat");
+        add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
+        add_idg_key(meta.get(), 1, /*col_uid=*/6, BITMAP); // two keys on the same .idx
+        if (drop_col5) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*drop_col5=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*drop_col5=*/true)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_TRUE(merged->has_idg_meta());
+    auto idg_it = merged->idg_meta().idgs().find(merged->rowsets(0).id());
+    ASSERT_TRUE(idg_it != merged->idg_meta().idgs().end());
+    ASSERT_EQ(1, idg_it->second.entries_size()) << "entry retained: col6 still active";
+    ASSERT_EQ(1, idg_it->second.entries(0).dropped_keys_size()) << "divergent tombstone unioned in";
+    EXPECT_EQ(5, idg_it->second.entries(0).dropped_keys(0).col_unique_id());
+}
+
+// MERGE: single-key shared .idx (col5), sibling B tombstones it -> fully tombstoned
+// after union -> the merged target must have NO idg entry (vacuum no-fully-tombstoned rule).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_drops_fully_tombstoned) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, bool drop_col5) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(3);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("shared_seg.dat");
+        sm->set_size(100);
+        sm->set_shared(true);
+        stamp_physical_identity_uid(rowset, "shared_seg.dat");
+        add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
+        if (drop_col5) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*drop_col5=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*drop_col5=*/true)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    EXPECT_FALSE(merged->has_idg_meta() && merged->idg_meta().idgs().contains(merged->rowsets(0).id()))
+            << "fully-tombstoned IDG entry must not be installed";
+    // Its .idx must be orphaned so vacuum reclaims it (mirrors apply_drop_index).
+    bool orphaned = false;
+    for (const auto& f : merged->orphan_files()) {
+        if (f.name() == "shared.idx") orphaned = true;
+    }
+    EXPECT_TRUE(orphaned) << "fully-tombstoned .idx must be added to orphan_files";
+}
+
+// MERGE: a .idx that is fully-tombstoned under one target but still ACTIVE under another
+// target must NOT be orphaned (vacuum deletes orphan_files without checking live idg_meta).
+// This is defensive: uuid-unique .idx names make one-name-two-targets impossible in prod,
+// but the orphan set must be provably safe regardless. child_a keeps "same.idx" active at
+// its rssid; child_b (distinct uid => remapped rssid) has "same.idx" fully tombstoned.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referenced_file) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::string& seg, bool tombstone) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(2); // child_b's rowset remaps to rssid 2
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(seg);
+        sm->set_size(100);
+        stamp_physical_identity_uid(rowset, seg); // distinct uid per child => both kept
+        add_idg_with_key(meta.get(), 1, "same.idx", /*col_uid=*/5, BITMAP, 1);
+        if (tombstone) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, "seg_a.dat", /*tombstone=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, "seg_b.dat", /*tombstone=*/true)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    // same.idx is still active under child_a's target, so it must NOT be orphaned.
+    for (const auto& f : merged->orphan_files()) {
+        EXPECT_NE("same.idx", f.name()) << "a still-referenced .idx must not be orphaned";
+    }
+    bool active = false;
+    for (const auto& [rssid, ver] : merged->idg_meta().idgs()) {
+        for (const auto& e : ver.entries()) {
+            if (e.index_file() == "same.idx") active = true;
+        }
+    }
+    EXPECT_TRUE(active) << "same.idx must remain an active entry";
+}
+
+// MERGE: a source split before this fix can have segment.shared=true but a stale
+// idg.shared_file=false (the old split marked segments shared but not idg). merge must
+// DERIVE the .idx shared flag from the merged segment's ownership, upgrading the stale
+// false to true, so vacuum does not later delete a shared .idx as if it were private.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_derives_shared_from_segment) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    // child_a: a SHARED segment (referenced by some non-merged sibling) whose idg entry
+    // carries a stale shared_file=false.
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(2);
+    {
+        auto* rowset = meta_a->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("seg_shared.dat");
+        sm->set_size(100);
+        sm->set_shared(true); // shared segment
+        stamp_physical_identity_uid(rowset, "seg_shared.dat");
+    }
+    add_idg_with_key(meta_a.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1, /*shared_file=*/false); // stale
+
+    // child_b: an unrelated private segment (distinct uid) so both rowsets survive the merge.
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(2);
+    {
+        auto* rowset = meta_b->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("seg_b.dat");
+        sm->set_size(100);
+        stamp_physical_identity_uid(rowset, "seg_b.dat");
+    }
+
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_TRUE(merged->has_idg_meta());
+    bool found = false;
+    for (const auto& [rssid, ver] : merged->idg_meta().idgs()) {
+        for (const auto& e : ver.entries()) {
+            if (e.index_file() == "shared.idx") {
+                found = true;
+                EXPECT_TRUE(e.shared_file()) << "shared segment's .idx flag must be derived (upgraded) to true";
+            }
+        }
+    }
+    EXPECT_TRUE(found) << "shared.idx entry must survive the merge";
+}
+
+// MERGE: the canonical child carries a STALE idg entry for a segment it no longer
+// owns, whose remapped target is live only because a sibling supplies that segment. The
+// source-live check must drop it (stale.idx must appear nowhere). next_rowset_id(2) makes
+// child_b remap to rssid 2 so the stale target IS live, exercising the source-live branch.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_skips_stale_source_entry) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(2); // so child_b's rowset remaps to rssid 2
+    {
+        auto* rowset = meta_a->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("seg_a.dat");
+        sm->set_size(100);
+        stamp_physical_identity_uid(rowset, "seg_a.dat");
+    }
+    // Stale idg keyed at rssid 2 -- child_a has NO segment there.
+    add_idg_with_key(meta_a.get(), /*segment_id=*/2, "stale.idx", /*col_uid=*/5, BITMAP, 1);
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(2);
+    {
+        auto* rowset = meta_b->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename("seg_b.dat");
+        sm->set_size(100);
+        stamp_physical_identity_uid(rowset, "seg_b.dat"); // distinct uid => not deduped
+    }
+
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    for (const auto& [rssid, ver] : merged->idg_meta().idgs()) {
+        for (const auto& e : ver.entries()) {
+            EXPECT_NE("stale.idx", e.index_file()) << "stale source idg entry must be skipped";
+        }
+    }
+}
+
+// MERGE: two children with DISTINCT private segments each carry their own real .idx.
+// After merge both survive: one at the natural rssid, the other at the offset-remapped rssid
+// (proves a non-first-source entry is remapped, not dropped).
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_remaps_private_segments) {
+    const int64_t base_version = 1, new_version = 2;
+    const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    auto make_child = [&](int64_t tablet_id, const std::string& seg, const std::string& idx) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(base_version);
+        meta->set_next_rowset_id(2);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(seg);
+        sm->set_size(100);
+        stamp_physical_identity_uid(rowset, seg); // distinct seed per child => distinct uid
+        // Exclusive (private) segment => its .idx is shared_file=false, as split's
+        // propagate_pruned would have marked it. merge must PRESERVE this (not force true).
+        add_idg_with_key(meta.get(), 1, idx, /*col_uid=*/5, BITMAP, 1, /*shared_file=*/false);
+        return meta;
+    };
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, "seg_a.dat", "a.idx")));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, "seg_b.dat", "b.idx")));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(2, merged->rowsets_size()) << "distinct-uid rowsets both kept";
+    ASSERT_TRUE(merged->has_idg_meta());
+    ASSERT_EQ(2, merged->idg_meta().idgs().size()) << "both private .idx remapped and retained";
+    std::set<std::string> files;
+    for (const auto& [rssid, ver] : merged->idg_meta().idgs()) {
+        for (const auto& e : ver.entries()) {
+            files.insert(e.index_file());
+            EXPECT_FALSE(e.shared_file()) << "private-segment .idx flag must be preserved, not forced shared";
+        }
+    }
+    EXPECT_EQ(1u, files.count("a.idx"));
+    EXPECT_EQ(1u, files.count("b.idx"));
 }
 
 // =============================================================================


### PR DESCRIPTION
## Why I'm doing:

The lake ADD/DROP INDEX fast path (#71689) writes per-segment `.idx` files — an Index Delta Group (`idg_meta`) that is a structural twin of Delta Column Groups (`.cols` / `dcg_meta`). Range-distribution tablet split/merge was never taught about `idg_meta`, so a table that used the ADD INDEX fast path and then underwent a tablet split or merge hit two problems:

- **SPLIT (correctness):** children are full metadata copies, but `set_non_segment_files_shared` marked delvec/dcg/sstable shared and not idg. A `.idx` shared by two children stayed `shared_file=false`, so when one child later inlined the index and dropped its entry, vacuum could delete a `.idx` file the sibling still referenced. Exclusive `.idx` were also never marked private, and pruned segments' idg entries were never erased.
- **MERGE (functional):** `merge_tablet` cleared `dcg_meta` but not `idg_meta`, so the merged tablet kept only the first source's `idg_meta` verbatim (wrong rssid space) and dropped every other source's — fast-path indexes silently vanished after a merge.

## What I'm doing:

Treat IDG as a peer of DCG in the reshard metadata transform (BE-only; no proto/thrift/FE changes):

- Added `set_idg_shared`; `set_non_segment_files_shared` and `set_all_data_files_shared(TxnLogPB)` now mark `.idx` entries shared (tablet metadata, and split cross-publish `OpAddIndex`, mirroring the existing `op_schema_change` handling).
- Tablet split's `propagate_pruned_ownership_to_non_segment_files` erases a pruned segment's idg entry and marks an exclusive segment's idg private.
- New `merge_idg_meta` (called after `merge_dcg_meta`): remaps entries via `map_rssid`, restricted to source-live and target-live segments; dedups by `.idx` filename with `dropped_keys` tombstone union; drops fully-tombstoned entries and orphans their `.idx` (only when no surviving entry references it); preserves each entry's `shared_file` flag. It is metadata-only — an `.idx` indexes unchanging shared segment data, so no segment rebuild is needed. `merge_tablet` also clears `idg_meta` before the rebuild.

Cross-publish note: the merge-side `OpAddIndex` rssid-remap is unnecessary because FE serializes ADD/DROP INDEX with reshard via `OlapTable.OlapTableState` (each holds an exclusive non-`NORMAL` state for its full duration), so an index alter can never be in a reshard cross-publish window. The split-side shared-marking is added regardless as cheap defense-in-depth matching the `op_schema_change` handling.

Covered by BE unit tests: split ownership, merge dedup/remap, tombstone union, fully-tombstoned orphaning, orphan-vs-live guard, stale-source skip, private-segment remap, and `OpAddIndex` cross-publish marking (199 reshard + helper tests pass locally).

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

<!-- The Index Delta Group feature (#71689) this adapts is main-only (idg_meta is absent from branch-4.1/4.0/3.5), so no backport applies. -->
