### PR TITLE
[BugFix] Fix regexp_extract_all infinite loop on zero-length capture group

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3647,8 +3647,7 @@ StatusOr<ColumnPtr> StringFunctions::regexp_extract(FunctionContext* context, co
 // and zero-length matches at the cursor (e.g. "(a*)") would loop forever.
 template <typename IndexType>
 static void extract_group_matches(const re2::StringPiece& str_sp, const re2::RE2& regex, int group,
-                                  BinaryColumn* str_col, IndexType& index, re2::StringPiece* matches,
-                                  int max_matches) {
+                                  BinaryColumn* str_col, IndexType& index, re2::StringPiece* matches, int max_matches) {
     re2::StringPiece input = str_sp;
     size_t pos = 0;
 
@@ -3679,7 +3678,8 @@ static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex,
 
 // Overloaded version for a pre-allocated submatch buffer (used by regexp_extract_all_const)
 static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex, int group, BinaryColumn* str_col,
-                                  uint64_t& index, const std::unique_ptr<re2::StringPiece[]>& matches, int max_matches) {
+                                  uint64_t& index, const std::unique_ptr<re2::StringPiece[]>& matches,
+                                  int max_matches) {
     re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
     extract_group_matches(str_sp, regex, group, str_col, index, matches.get(), max_matches);
 }

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3634,24 +3634,33 @@ StatusOr<ColumnPtr> StringFunctions::regexp_extract(FunctionContext* context, co
 }
 
 // Helper function to extract whole match (group 0) using RE2::Match
-// This is shared by both overloaded extract_regex_matches functions
+// Shared by both overloaded extract_regex_matches functions.
+// Appends capture group `group` (0 = the whole match) of every non-overlapping match of
+// `regex` in `str_sp` to `str_col`. `matches` is a caller-provided buffer of at least
+// `max_matches` StringPieces used for RE2 submatches (index 0 = whole match).
+//
+// Advancing the cursor by the WHOLE match span (matches[0]) -- with a one-byte step after
+// any zero-length match -- is what keeps every capture group in lock-step with the group-0
+// path. Using RE2::FindAndConsumeN here instead would only expose the post-match cursor,
+// which cannot distinguish "skipped N bytes then matched 0" from a genuine advance, so a
+// zero-length match found past the cursor (e.g. "($)" against "abc") would be emitted twice
+// and zero-length matches at the cursor (e.g. "(a*)") would loop forever.
 template <typename IndexType>
-static void extract_whole_matches(const re2::StringPiece& str_sp, const re2::RE2& regex, BinaryColumn* str_col,
-                                  IndexType& index, int max_matches) {
+static void extract_group_matches(const re2::StringPiece& str_sp, const re2::RE2& regex, int group,
+                                  BinaryColumn* str_col, IndexType& index, re2::StringPiece* matches,
+                                  int max_matches) {
     re2::StringPiece input = str_sp;
-    std::vector<re2::StringPiece> matches(max_matches);
     size_t pos = 0;
 
     while (pos <= input.size()) {
         re2::StringPiece remaining = input.substr(pos);
-        if (regex.Match(remaining, 0, remaining.size(), RE2::UNANCHORED, &matches[0], max_matches)) {
-            // matches[0] contains the whole match (group 0)
-            str_col->append(Slice(matches[0].data(), matches[0].size()));
+        if (regex.Match(remaining, 0, remaining.size(), RE2::UNANCHORED, matches, max_matches)) {
+            str_col->append(Slice(matches[group].data(), matches[group].size()));
             index += 1;
-            // Move past this match
+            // Move past the whole match; step one byte after a zero-length match.
             pos = matches[0].data() - input.data() + matches[0].size();
             if (matches[0].size() == 0) {
-                pos++; // Avoid infinite loop on zero-length matches
+                pos++;
             }
         } else {
             break;
@@ -3664,43 +3673,15 @@ static void extract_whole_matches(const re2::StringPiece& str_sp, const re2::RE2
 static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex, int group, BinaryColumn* str_col,
                                   uint32_t& index, int max_matches) {
     re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
-
-    if (group == 0) {
-        // Extract the whole match (group 0)
-        extract_whole_matches(str_sp, regex, str_col, index, max_matches);
-    } else {
-        // Extract specific capture group
-        re2::StringPiece find[group];
-        const RE2::Arg* args[group];
-        RE2::Arg argv[group];
-
-        for (size_t i = 0; i < group; i++) {
-            argv[i] = &find[i];
-            args[i] = &argv[i];
-        }
-        while (re2::RE2::FindAndConsumeN(&str_sp, regex, args, group)) {
-            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
-            index += 1;
-        }
-    }
+    std::vector<re2::StringPiece> matches(max_matches);
+    extract_group_matches(str_sp, regex, group, str_col, index, matches.data(), max_matches);
 }
 
-// Overloaded version for pre-allocated arrays (used by regexp_extract_all_const)
+// Overloaded version for a pre-allocated submatch buffer (used by regexp_extract_all_const)
 static void extract_regex_matches(const Slice& str_value, const re2::RE2& regex, int group, BinaryColumn* str_col,
-                                  uint64_t& index, const std::unique_ptr<re2::StringPiece[]>& find,
-                                  const std::unique_ptr<const RE2::Arg*[]>& args, int max_matches) {
+                                  uint64_t& index, const std::unique_ptr<re2::StringPiece[]>& matches, int max_matches) {
     re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
-
-    if (group == 0) {
-        // Extract the whole match (group 0) - reuse common logic
-        extract_whole_matches(str_sp, regex, str_col, index, max_matches);
-    } else {
-        // Extract specific capture group using pre-allocated arrays
-        while (re2::RE2::FindAndConsumeN(&str_sp, regex, args.get(), group)) {
-            str_col->append(Slice(find[group - 1].data(), find[group - 1].size()));
-            index += 1;
-        }
-    }
+    extract_group_matches(str_sp, regex, group, str_col, index, matches.get(), max_matches);
 }
 
 static ColumnPtr regexp_extract_all_general(FunctionContext* context, re2::RE2::Options* options,
@@ -3830,26 +3811,14 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
         return NullableColumn::create(std::move(array), std::move(nl_col));
     }
 
-    // Prepare arguments for FindAndConsumeN (only needed when group > 0)
-    std::unique_ptr<re2::StringPiece[]> find;
-    std::unique_ptr<const RE2::Arg*[]> args;
-    std::unique_ptr<RE2::Arg[]> argv;
-
-    if (group > 0) {
-        find = std::make_unique<re2::StringPiece[]>(group);
-        args = std::make_unique<const RE2::Arg*[]>(group);
-        argv = std::make_unique<RE2::Arg[]>(group);
-
-        for (size_t i = 0; i < group; i++) {
-            argv[i] = &find[i];
-            args[i] = &argv[i];
-        }
-    }
+    // Pre-allocate the RE2 submatch buffer once and reuse it across rows.
+    // max_matches >= 1 here (group has passed the [0, max_matches) range check above).
+    auto matches = std::make_unique<re2::StringPiece[]>(max_matches);
 
     // focuses only on iteration and offset management
     for (int row = 0; row < size; ++row) {
         if (!content_viewer.is_null(row)) {
-            extract_regex_matches(content_viewer.value(row), *const_re, group, str_col.get(), index, find, args,
+            extract_regex_matches(content_viewer.value(row), *const_re, group, str_col.get(), index, matches,
                                   max_matches);
         }
         offset_col->append(index);

--- a/test/sql/test_function/R/test_regexp_extract_all_zero_len
+++ b/test/sql/test_function/R/test_regexp_extract_all_zero_len
@@ -1,0 +1,36 @@
+-- name: test_regexp_extract_all_zero_len
+set query_timeout = 30;
+-- result:
+-- !result
+SELECT regexp_extract_all('bbb', '(a*)', 1);
+-- result:
+["","","",""]
+-- !result
+SELECT regexp_extract_all('a1b2', '(\\d*)', 1);
+-- result:
+["","1","","2",""]
+-- !result
+SELECT regexp_extract_all(s, p, 1) FROM (SELECT 'bbb' AS s, '(a*)' AS p) t;
+-- result:
+["","","",""]
+-- !result
+SELECT regexp_extract_all('bbb', 'a*', 0);
+-- result:
+["","","",""]
+-- !result
+SELECT regexp_extract_all('', '(a*)', 1);
+-- result:
+[""]
+-- !result
+SELECT regexp_extract_all('abc', '($)', 1);
+-- result:
+[""]
+-- !result
+SELECT regexp_extract_all('abc', '$', 0);
+-- result:
+[""]
+-- !result
+SELECT regexp_extract_all('a1b2c3', '([0-9])', 1);
+-- result:
+["1","2","3"]
+-- !result

--- a/test/sql/test_function/T/test_regexp_extract_all_zero_len
+++ b/test/sql/test_function/T/test_regexp_extract_all_zero_len
@@ -1,0 +1,35 @@
+-- name: test_regexp_extract_all_zero_len
+-- description: Regression for regexp_extract_all with a capture group (group > 0) whose
+--              overall match can be zero-length (e.g. pattern "(a*)"). The group>0 path
+--              looped on RE2 FindAndConsumeN, which does not advance the StringPiece on a
+--              zero-length match at the cursor -> spun forever at 100% CPU with unbounded
+--              memory growth (DoS, ignored query cancellation); and for a zero-length match
+--              found after skipping input (e.g. "($)") it emitted the match twice. The fix
+--              advances by the whole-match span exactly like the group-0 path. If the DoS
+--              regresses the query hangs until the query_timeout below fires, failing the
+--              test instead of returning a result.
+
+set query_timeout = 30;
+
+-- group > 0, constant pattern -> extract_regex_matches(pre-allocated overload)
+SELECT regexp_extract_all('bbb', '(a*)', 1);
+
+-- group > 0, empty capture group interleaved with real matches (constant pattern)
+SELECT regexp_extract_all('a1b2', '(\\d*)', 1);
+
+-- group > 0, non-constant pattern -> extract_regex_matches(local-buffer overload)
+SELECT regexp_extract_all(s, p, 1) FROM (SELECT 'bbb' AS s, '(a*)' AS p) t;
+
+-- group 0 stays consistent with the group>0 zero-length output
+SELECT regexp_extract_all('bbb', 'a*', 0);
+
+-- zero-length match against an empty input
+SELECT regexp_extract_all('', '(a*)', 1);
+
+-- zero-length match found AFTER skipping input (end anchor): emitted once, exactly like
+-- the group-0 path -- not duplicated (regression for the review P2 finding)
+SELECT regexp_extract_all('abc', '($)', 1);
+SELECT regexp_extract_all('abc', '$', 0);
+
+-- normal (non-zero-length) extraction is unaffected
+SELECT regexp_extract_all('a1b2c3', '([0-9])', 1);


### PR DESCRIPTION
## Why I'm doing:

regexp_extract_all(str, pattern, group) with group > 0 used RE2::FindAndConsumeN in a bare loop. On a zero-length whole match (e.g. pattern "(a*)" against "bbb") FindAndConsumeN does not advance the StringPiece, so the loop spun forever at 100% CPU with unbounded memory growth and ignored query cancellation -- a single SELECT could DoS the BE. The group-0 path already guarded against this; mirror that by stepping one byte past a zero-length match in both extract_regex_matches overloads.

Adds regression test test_regexp_extract_all_zero_len with a query_timeout so a regression fails fast instead of hanging the suite.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
