### PR TITLE
[BugFix] Make early SST compaction non-fatal to primary-key publish

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -489,9 +489,18 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             }
             if (async_compact_cb) {
                 TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-                bool succ = true;
-                ASSIGN_OR_RETURN(succ, async_compact_cb->wait_for(1000 /* ms timeout */));
-                if (succ) {
+                // Early SST compaction is an opportunistic optimization that keeps the PK
+                // persistent-index LSM shallow. The SSTs are already ingested and valid, so a
+                // compaction failure (e.g. transient thread-pool exhaustion under a hot,
+                // single-node publish burst) must NOT fail publish -- leave the SSTs uncompacted
+                // for background compaction and continue. Otherwise the failed publish is retried
+                // by the FE, producing a large ingest tail latency.
+                auto succ_or = async_compact_cb->wait_for(1000 /* ms timeout */);
+                if (!succ_or.ok()) {
+                    LOG(WARNING) << "early sst compact failed, skip and continue publish. tablet " << tablet->id()
+                                 << ", txn " << txn_id << ": " << succ_or.status();
+                    async_compact_cb = nullptr;
+                } else if (succ_or.value()) {
                     LOG(INFO) << fmt::format("early sst compact finish. tablet {}, txn {}, fileset remain {}, trace {}",
                                              tablet->id(), txn_id,
                                              index.current_fileset_index() - current_fileset_start_idx,
@@ -514,7 +523,14 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     }     // end batch loop
     if (async_compact_cb) {
         TRACE_COUNTER_SCOPE_LATENCY_US("early_sst_compact_wait_us");
-        RETURN_IF_ERROR(async_compact_cb->wait_for());
+        // Non-fatal: see the note above -- a failed early SST compaction leaves valid,
+        // uncompacted SSTs for background compaction rather than failing (and retrying) publish.
+        auto st = async_compact_cb->wait_for();
+        if (!st.ok()) {
+            LOG(WARNING) << "early sst compact failed, skip and continue publish. tablet " << tablet->id() << ", txn "
+                         << txn_id << ": " << st.status();
+        }
+        async_compact_cb = nullptr;
     }
 
     // 3. Handle del files one by one.


### PR DESCRIPTION
## Why

`LakePersistentIndex::early_sst_compact` is an *opportunistic* optimization that keeps the cloud-native PK persistent-index LSM shallow during heavy ingest. The SSTs are already ingested and valid before it runs; the compaction only merges them.

When the parallel-compaction thread pool cannot spawn a worker (`pthread_create` → `EAGAIN`, "Resource temporarily unavailable") under a hot, single-node publish burst on a contended host, `ThreadPool::submit` fails, the async callback carries the error, and `wait_for()` surfaces it via `ASSIGN_OR_RETURN` / `RETURN_IF_ERROR` — **failing the entire `publish_version`**. The FE then retries publish, producing a large realtime-ingest tail latency.

### Observed
On a shared-data PK table with a skewed (zipf) write head whose contiguous hot keys funnel onto a few head tablets on one compute node, that CN logged **523 `Thread pool failed to create thread` errors during a benchmark window**, all under `LakePersistentIndexParallelCompactMgr::async_compact` inside `publish_version` — while sibling CNs and the non-skewed layout saw **zero**. This publish-retry tail is the dominant realtime-ingest P99 regression for that layout.

## What

Treat an early-SST-compaction failure as **non-fatal**: log a warning, drop the callback, and continue publish. The uncompacted (but valid) SSTs are left for background compaction.

No in-memory index state is mutated before the async callback (`apply_opcompaction` runs only inside `wait_for` on success), so skipping it leaves the index consistent.

## Risk

Low. On failure the index simply carries a slightly deeper SST LSM until the next (background or early) compaction; correctness is unaffected because the SSTs were already ingested.