### PR TITLE
[BugFix] Send the per-session token for Iceberg REST catalogs using security=jwt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityConfig.java
@@ -155,8 +155,15 @@ class OAuth2SecurityConfigBuilder {
             config = config.setServerUri(URI.create(serverUri));
         }
 
-        // check OAuth2SecurityConfig is valid
-        if (!config.credentialOrTokenPresent() || !config.scopePresentOnlyWithCredential()) {
+        // check OAuth2SecurityConfig is valid. JWT is exempt from the
+        // credential/token-present check: in JWT mode there is deliberately no static
+        // token or credential in the catalog properties. The token is the logged-in
+        // user's JWT, supplied per session at request time (see
+        // IcebergRESTCatalog.buildContext). Applying the OAUTH2 guard here would
+        // discard the JWT security mode entirely and fall back to NONE, so the
+        // per-session token would never be attached to REST calls.
+        if (config.getSecurity() != JWT
+                && (!config.credentialOrTokenPresent() || !config.scopePresentOnlyWithCredential())) {
             return new OAuth2SecurityConfig();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/OAuth2SecurityProperties.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg.rest;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.auth.AuthProperties;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 
 import java.util.Map;
@@ -46,6 +47,11 @@ public class OAuth2SecurityProperties {
         } else if (securityConfig.getSecurity() == IcebergRESTCatalog.Security.JWT) {
             // for JWT disable the token-refresh
             propertiesBuilder.put(OAuth2Properties.TOKEN_REFRESH_ENABLED, "false");
+            // The JWT is supplied per session at request time (SessionContext credentials
+            // from IcebergRESTCatalog.buildContext), not as a static catalog token. Select
+            // the OAuth2 auth manager explicitly so those per-session credentials are sent
+            // as the bearer; otherwise the REST client uses no auth and drops the token.
+            propertiesBuilder.put(AuthProperties.AUTH_TYPE, AuthProperties.AUTH_TYPE_OAUTH2);
         }
 
         this.securityProperties = propertiesBuilder.buildOrThrow();


### PR DESCRIPTION
## Why I'm doing:

An external Iceberg REST catalog created with iceberg.catalog.security=jwt never sent the logged-in user's JWT to the REST server. Every REST call except GET /v1/config went out with no Authorization header, so a server that requires auth rejected them and the catalog was unusable: queries failed during planning at namespace resolution with "Not authorized: missing bearer token".

Two things combined:

1. OAuth2SecurityConfigBuilder.build() discarded the config and fell back to NONE whenever no static token or credential was present. In jwt mode there is deliberately neither (the token is the user's JWT, supplied per session), so the guard that is correct for oauth2 mode threw away jwt mode entirely.

2. With security downgraded to NONE, RESTSessionCatalog was initialized without an OAuth2 auth manager, so the per-session token that buildContext() builds had nothing to attach it to and was silently dropped.

Fix: exempt JWT from the credential/token-present check in build(), and for JWT set rest.auth.type=oauth2 so the OAuth2 auth manager is selected and the per-session credentials are sent as the bearer. Token refresh stays disabled for jwt, so it remains pure passthrough with no token exchange.

Verified on 4.1.1: before the change, GET /v1/<warehouse>/namespaces/<db> reached the server with no Authorization header (401); after it, that call and the following loadTable arrive with the user's JWT as the bearer and return 200.


## What I'm doing:

Fixes #75792 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
