### PR TITLE
[Enhancement] Cap per-compaction input bytes for lake primary-key compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -458,6 +458,13 @@ CONF_mInt64(update_compaction_result_bytes, "1073741824");
 CONF_mInt32(update_compaction_delvec_file_io_amp_ratio, "2");
 // This config defines the maximum percentage of data allowed per compaction
 CONF_mDouble(update_compaction_ratio_threshold, "0.5");
+// Absolute upper bound (bytes) on the input size picked for a single lake primary-key
+// compaction. 0 = disabled (legacy behavior: cap =
+// max(update_compaction_result_bytes, tablet_data_size * update_compaction_ratio_threshold)).
+// When > 0 the effective per-compaction result-bytes cap is clamped to this value so that a
+// single large compaction on a hot PK tablet cannot produce a multi-second synchronous publish
+// that stalls the tablet's serialized ingest version chain (realtime-ingest tail latency).
+CONF_mInt64(lake_pk_compaction_max_result_bytes, "0");
 // This config controls max memory that we can use for partial update.
 CONF_mInt64(partial_update_memory_limit_per_worker, "2147483648"); // 2GB
 

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -77,6 +77,14 @@ CONF_mInt32(update_compaction_delvec_file_io_amp_ratio, "2");
 // This config defines the maximum percentage of data allowed per compaction
 CONF_mDouble(update_compaction_ratio_threshold, "0.5");
 
+// Absolute upper bound (bytes) on the input size picked for a single lake primary-key
+// compaction. 0 = disabled (legacy behavior: cap =
+// max(update_compaction_result_bytes, tablet_data_size * update_compaction_ratio_threshold)).
+// When > 0 the effective per-compaction result-bytes cap is clamped to this value so that a
+// single large compaction on a hot PK tablet cannot produce a multi-second synchronous publish
+// that stalls the tablet's serialized ingest version chain (realtime-ingest tail latency).
+CONF_mInt64(lake_pk_compaction_max_result_bytes, "0");
+
 CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 
 // if compaction of a tablet failed, this tablet should not be chosen to

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -689,6 +689,7 @@
         "update_compaction_result_bytes",
         "update_compaction_delvec_file_io_amp_ratio",
         "update_compaction_ratio_threshold",
+        "lake_pk_compaction_max_result_bytes",
         "repair_compaction_interval_seconds",
         "min_compaction_failure_interval_sec",
         "min_cumulative_compaction_failure_interval_sec",

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -332,6 +332,18 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
     std::vector<RowsetCandidate> rowset_vec;
     const int64_t compaction_data_size_threshold =
             static_cast<int64_t>((double)_get_data_size(tablet_metadata) * config::update_compaction_ratio_threshold);
+    // Effective per-compaction input-bytes cap. Legacy behavior is
+    // max(update_compaction_result_bytes, data_size * ratio); on a large hot PK tablet that lets a
+    // single compaction grow to multiple GB, whose synchronous publish (compact_mapper read +
+    // index apply) stalls the tablet's serialized ingest version chain and drives the realtime
+    // ingest tail. When lake_pk_compaction_max_result_bytes > 0 we clamp the cap to it so each
+    // compaction stays small and its publish cannot block queued ingest publishes.
+    int64_t per_compaction_result_bytes_cap =
+            std::max(config::update_compaction_result_bytes, compaction_data_size_threshold);
+    if (config::lake_pk_compaction_max_result_bytes > 0) {
+        per_compaction_result_bytes_cap =
+                std::min(per_compaction_result_bytes_cap, config::lake_pk_compaction_max_result_bytes);
+    }
     // 1. generate rowset candidate vector
     for (int i = 0, sz = tablet_metadata->rowsets_size(); i < sz; i++) {
         const RowsetMetadataPB& rowset_pb = tablet_metadata->rowsets(i);
@@ -367,8 +379,7 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
             has_dels->push_back(rowset_candidate.delete_bytes() > 0);
         }
 
-        if (cur_compaction_result_bytes >
-            std::max(config::update_compaction_result_bytes, compaction_data_size_threshold)) {
+        if (cur_compaction_result_bytes > per_compaction_result_bytes_cap) {
             reach_max_input_per_compaction = true;
             break;
         }
@@ -387,8 +398,7 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
                 has_dels->push_back(rowset_candidate.delete_bytes() > 0);
             }
 
-            if (cur_compaction_result_bytes >
-                std::max(config::update_compaction_result_bytes, compaction_data_size_threshold)) {
+            if (cur_compaction_result_bytes > per_compaction_result_bytes_cap) {
                 break;
             }
             if (rowset_indexes.size() >= config::lake_pk_compaction_max_input_rowsets) {


### PR DESCRIPTION
## Why

Under a skewed realtime-ingest workload where writes concentrate on one large hot primary-key tablet (e.g. a PK-range distributed table with a zipf tenant head), the lake `PrimaryCompactionPolicy` per-compaction input cap is

```
max(update_compaction_result_bytes, tablet_data_size * update_compaction_ratio_threshold)
```

On a large hot tablet the data-proportional term dominates and lets a single compaction grow to multiple GB. Publishing that compaction is synchronous (compact_mapper read + primary-index apply — measured ~14s for a ~2GB rowset) and it runs on the tablet's **serialized** version chain, so all queued realtime-ingest publishes wait behind it. Result: a long realtime-ingest tail (per-batch p99). A HASH-distributed table scatters the hot tenants across many tablets/nodes, so no single tablet builds a compaction that large and the tail does not appear.

## What

Add a mutable BE config `lake_pk_compaction_max_result_bytes`:

- Default `0` = **disabled**, preserving the exact legacy cap and behavior.
- When `> 0`, the effective per-compaction input-bytes cap is clamped to this value, bounding each compaction's synchronous publish cost so it cannot stall queued ingest publishes on a hot PK tablet.

The clamp is applied in `PrimaryCompactionPolicy::pick_rowset_indexes` at both the primary-level and real-time other-level pick loops. No behavior change unless the operator sets the config.

## Test

Config-gated, default-off, no behavior change at default. Evaluated on a skewed range-vs-hash realtime-ingest benchmark (draft; measuring whether the range ingest tail closes to within the hash baseline).