### PR TITLE
[Enhancement] Defer over-large lake PK compaction to unblock ingest publish

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1523,6 +1523,22 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // level's compact_level which can be stale after pick_max_level merges levels.
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
 // Enable cleanup of orphan delvec entries during compaction.
 // Orphan delvecs are leaked metadata entries from a historical bug that reference
 // non-existent segments and prevent delvec file garbage collection.

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -219,6 +219,23 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
+
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -722,6 +722,7 @@
         "lake_pk_compaction_emergency_score",
         "lake_pk_compaction_delvec_benefit_weight",
         "lake_pk_compaction_size_overflow_ratio",
+        "lake_pk_compaction_defer_large_result_bytes",
         "enable_light_pk_compaction_publish",
         "enable_lake_compaction_use_partial_segments",
         "enable_lake_compaction_range_split",

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -398,6 +398,36 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         }
     }
 
+    // Defer an over-large compaction so its ~O(GB) synchronous publish (compact_mapper read +
+    // PK-index apply) does not stall the hot tablet's serialized ingest version chain. The
+    // compaction is kept full-size (no shrinking -> no churn); it is simply not submitted this
+    // round -> pick returns empty -> segment score 0 -> FE de-prioritizes it. Bounded by the
+    // read-pressure emergency valve (same signal as skip_sparse_low_score_level [D]) so rowsets
+    // cannot pile up unbounded: once the tablet's read pressure crosses emergency_score the
+    // large compaction proceeds. Cheap SST/index compaction is unaffected (independent path).
+    if (config::lake_pk_compaction_defer_large_result_bytes > 0 &&
+        static_cast<int64_t>(cur_compaction_result_bytes) > config::lake_pk_compaction_defer_large_result_bytes) {
+        double tablet_read_pressure = 0.0;
+        for (const auto& rc : rowset_vec) {
+            tablet_read_pressure += rc.score;
+        }
+        const bool emergency = config::lake_pk_compaction_emergency_score > 0.0 &&
+                               tablet_read_pressure >= config::lake_pk_compaction_emergency_score;
+        if (!emergency) {
+            VLOG(2) << strings::Substitute(
+                    "lake PK compaction deferred (large result): tablet=$0 result_bytes=$1 > defer=$2 "
+                    "read_pressure=$3 (em=$4)",
+                    tablet_metadata->id(), cur_compaction_result_bytes,
+                    config::lake_pk_compaction_defer_large_result_bytes, tablet_read_pressure,
+                    config::lake_pk_compaction_emergency_score);
+            rowset_indexes.clear();
+            if (has_dels != nullptr) {
+                has_dels->clear();
+            }
+            return rowset_indexes;
+        }
+    }
+
     return rowset_indexes;
 }
 


### PR DESCRIPTION
On a hot lake primary-key tablet under a skewed realtime-write workload, a single large compaction transaction publishes **synchronously** in the tablet's strict per-tablet version order (`lake::publish_version` / `acquire_publish_tablet`). A multi-GB compaction's publish (`compact_mapper` read + PK-index apply, ~14s for a 2GB output rowset) blocks every queued realtime-ingest publish behind it on the same tablet, producing a large ingest P99 tail when one contiguous hot key-head funnels onto a single tablet.

## Change
Add a mutable BE config `lake_pk_compaction_defer_large_result_bytes` (default `0` = disabled). When `>0`, `PrimaryCompactionPolicy::pick_rowset_indexes` **defers** (returns empty ⇒ segment score 0 ⇒ FE de-prioritizes) a compaction whose projected output exceeds the threshold, **unless** the tablet's read-pressure crosses the existing `lake_pk_compaction_emergency_score` valve.

Unlike `lake_pk_compaction_max_result_bytes` (which *shrinks* each compaction and causes churn/pileup), this keeps compactions **full-size but rare** on hot tablets, and the emergency valve bounds rowset accumulation. Cheap SST/index compaction is unaffected (independent path).

Default-off ⇒ no behavior change until set; non-hot tablets whose compactions never reach this size are unaffected even when set.

## Note
Draft / benchmark-driven engine change; not intended for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)