### PR TITLE
[Refactor] Move Parquet scan state into FormatScanContext

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -97,8 +97,8 @@ Status HiveDataSource::_check_all_slots_nullable() {
         if (!slot->is_nullable()) {
             // Check if the non-nullable column has a default value
             // If it has a default value, allow scanning as old data files can be filled with the default
-            if (_scanner_ctx.materialize_slot_default_values.find(slot->id()) ==
-                _scanner_ctx.materialize_slot_default_values.end()) {
+            if (_scanner_ctx.format_scan_context.materialize_slot_default_values.find(slot->id()) ==
+                _scanner_ctx.format_scan_context.materialize_slot_default_values.end()) {
                 return Status::RuntimeError(fmt::format(
                         "All columns must be nullable for external table. Column '{}' is not nullable, You can rebuild "
                         "the"
@@ -258,7 +258,7 @@ void HiveDataSource::_init_global_late_materialization_context(RuntimeState* sta
                     ctx->hdfs_scan_node = hdfs_scan_node;
                     return ctx;
                 }));
-        _scanner_ctx.scan_range_id = glm_ctx->assign_scan_range_id(_scan_range);
+        _scanner_ctx.format_scan_context.scan_range_id = glm_ctx->assign_scan_range_id(_scan_range);
     }
 }
 
@@ -274,7 +274,8 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
     if (hdfs_scan_node.__isset.min_max_conjuncts) {
         RETURN_IF_ERROR(ExprFactory::create_expr_trees(&_pool, hdfs_scan_node.min_max_conjuncts,
-                                                       &_scanner_ctx.conjuncts.min_max_ctxs, state));
+                                                       &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs,
+                                                       state));
     }
 
     if (hdfs_scan_node.__isset.partition_conjuncts) {
@@ -287,9 +288,9 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
         _scanner_ctx.format_scan_context.options.case_sensitive = hdfs_scan_node.case_sensitive;
     }
 
-    RETURN_IF_ERROR(ExprExecutor::prepare(_scanner_ctx.conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::prepare(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::prepare(_partition_filter.conjunct_ctxs, state));
-    RETURN_IF_ERROR(ExprExecutor::open(_scanner_ctx.conjuncts.min_max_ctxs, state));
+    RETURN_IF_ERROR(ExprExecutor::open(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, state));
     RETURN_IF_ERROR(ExprExecutor::open(_partition_filter.conjunct_ctxs, state));
     _update_has_any_predicate();
 
@@ -298,11 +299,12 @@ Status HiveDataSource::_init_conjunct_ctxs(RuntimeState* state) {
     // Build all_ctxs: clone of (min_max_ctxs ∪ scan conjuncts), used to build
     // ScanConjunctsManager / PredicateTree inside each scanner's context.
     std::vector<ExprContext*> cloned;
-    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _scanner_ctx.conjuncts.min_max_ctxs, &cloned));
-    for (auto* ctx : cloned) _scanner_ctx.conjuncts.all_ctxs.emplace_back(ctx);
+    RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(
+            state, &_pool, _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, &cloned));
+    for (auto* ctx : cloned) _scanner_ctx.format_scan_context.conjuncts.all_ctxs.emplace_back(ctx);
     cloned.clear();
     RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _conjunct_ctxs, &cloned));
-    for (auto* ctx : cloned) _scanner_ctx.conjuncts.all_ctxs.emplace_back(ctx);
+    for (auto* ctx : cloned) _scanner_ctx.format_scan_context.conjuncts.all_ctxs.emplace_back(ctx);
 
     return Status::OK();
 }
@@ -348,8 +350,8 @@ Status HiveDataSource::_init_partition_values() {
     // back to the ordinary partition conjuncts — same behaviour as the old code.
     std::vector<ExprContext*> ctxs;
     for (SlotId slotId : _scan_range.identity_partition_slot_ids) {
-        auto it = _scanner_ctx.conjuncts.by_slot.find(slotId);
-        if (it != _scanner_ctx.conjuncts.by_slot.end()) {
+        auto it = _scanner_ctx.format_scan_context.conjuncts.by_slot.find(slotId);
+        if (it != _scanner_ctx.format_scan_context.conjuncts.by_slot.end()) {
             ctxs.insert(ctxs.end(), it->second.begin(), it->second.end());
         }
     }
@@ -451,7 +453,8 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
             if (_scanner_ctx.hive_table != nullptr) {
                 auto default_value = _scanner_ctx.hive_table->get_column_default_value(slots[i]);
                 if (default_value.has_value()) {
-                    _scanner_ctx.materialize_slot_default_values.emplace(slots[i]->id(), *default_value);
+                    _scanner_ctx.format_scan_context.materialize_slot_default_values.emplace(slots[i]->id(),
+                                                                                             *default_value);
                 }
             }
         }
@@ -532,7 +535,7 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
         std::vector<SlotId> slot_ids;
         root_expr->get_slot_ids(&slot_ids);
         for (SlotId slot_id : slot_ids) {
-            _scanner_ctx.conjuncts.slots_in_conjunct.insert(slot_id);
+            _scanner_ctx.format_scan_context.conjuncts.slots_in_conjunct.insert(slot_id);
         }
 
         // For some conjunct like (a < 1) or (a > 7)
@@ -558,23 +561,23 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
             }
         }
         if (!single_slot || slot_ids.empty() || !single_field) {
-            _scanner_ctx.conjuncts.scanner_ctxs.emplace_back(ctx);
+            _scanner_ctx.format_scan_context.conjuncts.scanner_ctxs.emplace_back(ctx);
             for (SlotId slot_id : slot_ids) {
-                _scanner_ctx.conjuncts.slots_of_multi_field.insert(slot_id);
+                _scanner_ctx.format_scan_context.conjuncts.slots_of_multi_field.insert(slot_id);
             }
             continue;
         }
 
         SlotId slot_id = slot_ids[0];
         if (slot_by_id.find(slot_id) != slot_by_id.end()) {
-            _scanner_ctx.conjuncts.by_slot[slot_id].emplace_back(ctx);
+            _scanner_ctx.format_scan_context.conjuncts.by_slot[slot_id].emplace_back(ctx);
         }
     }
     // rewrite dict
     auto* fragment_dict_state = state->fragment_dict_state();
     DCHECK(fragment_dict_state != nullptr);
     RETURN_IF_ERROR(fragment_dict_state->mutable_dict_optimize_parser()->rewrite_conjuncts(
-            state, &_scanner_ctx.conjuncts.scanner_ctxs));
+            state, &_scanner_ctx.format_scan_context.conjuncts.scanner_ctxs));
     return Status::OK();
 }
 
@@ -816,7 +819,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     if (const auto* hdfs_desc = dynamic_cast<const HdfsTableDescriptor*>(_scanner_ctx.hive_table)) {
         _scanner_ctx.avro_schema_json = hdfs_desc->get_avro_schema_json();
     }
-    _scanner_ctx.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
+    _scanner_ctx.format_scan_context.lazy_column_coalesce_counter = &_provider->_lazy_column_coalesce_counter;
     if (state->query_options().__isset.connector_max_split_size) {
         _scanner_ctx.format_scan_context.options.connector_max_split_size =
                 state->query_options().connector_max_split_size;
@@ -833,6 +836,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     // Reset per-range table-specific state before populating.
     _scanner_ctx.table_specific = {};
+    _scanner_ctx.format_scan_context.lake_schema = nullptr;
     _scanner_ctx.format_scan_context.split = {};
     for (const auto& delete_file : scan_range.delete_files) {
         _scanner_ctx.table_specific.iceberg_delete_files.emplace_back(&delete_file);
@@ -845,12 +849,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
 
     if (dynamic_cast<const IcebergTableDescriptor*>(_scanner_ctx.hive_table)) {
         auto tbl = dynamic_cast<const IcebergTableDescriptor*>(_scanner_ctx.hive_table);
-        _scanner_ctx.table_specific.iceberg_schema = tbl->get_iceberg_schema();
+        _scanner_ctx.format_scan_context.lake_schema = tbl->get_iceberg_schema();
     }
 
     if (dynamic_cast<const PaimonTableDescriptor*>(_scanner_ctx.hive_table)) {
         auto tbl = dynamic_cast<const PaimonTableDescriptor*>(_scanner_ctx.hive_table);
-        _scanner_ctx.table_specific.iceberg_schema = tbl->get_paimon_schema();
+        _scanner_ctx.format_scan_context.lake_schema = tbl->get_paimon_schema();
     }
 
     if (scan_range.__isset.paimon_deletion_file && !scan_range.paimon_deletion_file.path.empty()) {
@@ -988,12 +992,12 @@ void HiveDataSource::close(RuntimeState* state) {
     // (ExprContext::clone() shares _root, it does NOT deep-copy the tree).
     // Release predicates here while _pool is still alive.
     _scanner_ctx.predicates = {};
-    ExprExecutor::close(_scanner_ctx.conjuncts.min_max_ctxs, state);
+    ExprExecutor::close(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, state);
     ExprExecutor::close(_partition_filter.conjunct_ctxs, state);
     ExprExecutor::close(_scanner_ctx.partition_expr_ctxs, state);
     ExprExecutor::close(_scanner_ctx.extended_col_expr_ctxs, state);
-    ExprExecutor::close(_scanner_ctx.conjuncts.scanner_ctxs, state);
-    for (auto& it : _scanner_ctx.conjuncts.by_slot) {
+    ExprExecutor::close(_scanner_ctx.format_scan_context.conjuncts.scanner_ctxs, state);
+    for (auto& it : _scanner_ctx.format_scan_context.conjuncts.by_slot) {
         ExprExecutor::close(it.second, state);
     }
 }

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -372,7 +372,6 @@ set(EXEC_NON_PIPELINE_FILES
     hdfs_scanner/hdfs_scanner_parquet.cpp
     hdfs_scanner/hdfs_scanner_orc.cpp
     hdfs_scanner/hdfs_scanner_avro.cpp
-    hdfs_scanner/hdfs_scanner_context.cpp
     hdfs_scanner/hdfs_scanner.cpp
     hdfs_scanner/jni_scanner.cpp
     file_scanner/avro_cpp_scanner.cpp

--- a/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/cache_select_scanner.cpp
@@ -98,8 +98,8 @@ Status CacheSelectScanner::_fetch_orc() {
         OrcChunkReader::build_column_name_set(&known_column_names, &_scanner_ctx->hive_column_names, reader->getType(),
                                               _scanner_ctx->format_scan_context.options.case_sensitive,
                                               _scanner_ctx->format_scan_context.options.orc_use_column_names);
-        RETURN_IF_ERROR(_scanner_ctx->update_materialized_columns(known_column_names));
-        ASSIGN_OR_RETURN(auto skip, _scanner_ctx->should_skip_by_evaluating_not_existed_slots());
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.update_materialized_columns(known_column_names));
+        ASSIGN_OR_RETURN(auto skip, _scanner_ctx->format_scan_context.should_skip_by_evaluating_not_existed_slots());
         if (skip) {
             LOG(INFO) << "CacheSelectScanner: orc skip file for non existed slot conjuncts.";
             return Status::EndOfFile("");
@@ -185,7 +185,7 @@ Status CacheSelectScanner::_fetch_parquet() {
             4096, _file.get(), _file->get_size().value(), _scanner_ctx->datacache_options,
             _shared_buffered_input_stream.get(), nullptr);
 
-    RETURN_IF_ERROR(reader->init(_scanner_ctx));
+    RETURN_IF_ERROR(reader->init(&_scanner_ctx->format_scan_context));
 
     std::vector<SharedBufferedInputStream::IORange> io_ranges{};
     RETURN_IF_ERROR(reader->collect_scan_io_ranges(&io_ranges));

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -89,14 +89,32 @@ Status HdfsScanner::_build_scanner_context() {
     // Clear fields that this function populates so the call is idempotent
     // (same ctx pointer may be reused across scanners in tests).
     ctx.format_scan_context.partition_values.clear();
-    ctx.extended_values.clear();
+    ctx.format_scan_context.extended_values.clear();
     ctx.format_scan_context.materialized_columns.clear();
     ctx.format_scan_context.partition_columns.clear();
-    ctx.extended_columns.clear();
+    ctx.format_scan_context.extended_columns.clear();
     ctx.format_scan_context.reserved_field_slots.clear();
-    ctx.conjunct_ctxs_by_slot.clear();
-    ctx.can_use_file_record_count = false;
-    ctx.is_first_split = false;
+    ctx.format_scan_context.not_existed_slots.clear();
+    ctx.format_scan_context.conjunct_ctxs_by_slot.clear();
+    ctx.format_scan_context.conjunct_ctxs_of_non_existed_slots.clear();
+    ctx.format_scan_context.has_file_record_count = false;
+    ctx.format_scan_context.file_record_count = 0;
+    ctx.format_scan_context.is_first_split = false;
+    ctx.format_scan_context.first_row_id.reset();
+    ctx.format_scan_context.min_max_values.clear();
+    ctx.format_scan_context.extended_column_exprs.clear();
+    ctx.format_scan_context.predicate_tree = nullptr;
+    ctx.format_scan_context.runtime_filter_scan_range_pruner = nullptr;
+
+    ctx.format_scan_context.scan_range_offset = ctx.scan_range->offset;
+    ctx.format_scan_context.scan_range_length = ctx.scan_range->length;
+    ctx.format_scan_context.min_max_values = ctx.scan_range->min_max_values;
+    if (ctx.scan_range->__isset.extended_columns) {
+        ctx.format_scan_context.extended_column_exprs = ctx.scan_range->extended_columns;
+    }
+    if (ctx.scan_range->__isset.first_row_id) {
+        ctx.format_scan_context.first_row_id = ctx.scan_range->first_row_id;
+    }
 
     Columns& partition_values = ctx.format_scan_context.partition_values;
 
@@ -110,7 +128,7 @@ Status HdfsScanner::_build_scanner_context() {
     }
 
     // evaluate extended column values
-    Columns& extended_values = ctx.extended_values;
+    Columns& extended_values = ctx.format_scan_context.extended_values;
     for (size_t i = 0; i < _scanner_ctx->extended_col_slots.size(); i++) {
         int extended_col_idx = _scanner_ctx->index_in_extended_columns[i];
         ASSIGN_OR_RETURN(auto extended_value_column, ctx.extended_col_expr_ctxs[extended_col_idx]->evaluate(nullptr));
@@ -120,7 +138,7 @@ Status HdfsScanner::_build_scanner_context() {
 
     // conjunct_ctxs_by_slot is a mutable per-scanner shallow copy of by_slot;
     // update_with_none_existed_slot() erases entries when columns are absent.
-    ctx.conjunct_ctxs_by_slot = _scanner_ctx->conjuncts.by_slot;
+    ctx.format_scan_context.conjunct_ctxs_by_slot = _scanner_ctx->format_scan_context.conjuncts.by_slot;
 
     // build columns of materialized and partition.
     for (size_t i = 0; i < _scanner_ctx->materialize_slots.size(); i++) {
@@ -133,8 +151,8 @@ Status HdfsScanner::_build_scanner_context() {
             column.idx_in_chunk = _scanner_ctx->materialize_index_in_chunk[i];
             // A slot must be decoded eagerly if it is an output column OR if it
             // appears in a multi-field conjunct that the reader cannot push down.
-            column.decode_needed =
-                    slot->is_output_column() || _scanner_ctx->conjuncts.slots_of_multi_field.count(slot->id());
+            column.decode_needed = slot->is_output_column() ||
+                                   _scanner_ctx->format_scan_context.conjuncts.slots_of_multi_field.count(slot->id());
             ctx.format_scan_context.materialized_columns.emplace_back(column);
         }
     }
@@ -152,7 +170,7 @@ Status HdfsScanner::_build_scanner_context() {
         FormatColumnInfo column;
         column.slot_desc = slot;
         column.idx_in_chunk = _scanner_ctx->extended_col_index_in_chunk[i];
-        ctx.extended_columns.emplace_back(column);
+        ctx.format_scan_context.extended_columns.emplace_back(column);
     }
 
     ctx.slot_descs = _scanner_ctx->tuple_desc->slots();
@@ -160,7 +178,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.format_scan_context.stats = &_app_stats;
 
     ScanConjunctsManagerOptions opts;
-    opts.conjunct_ctxs_ptr = &_scanner_ctx->conjuncts.all_ctxs;
+    opts.conjunct_ctxs_ptr = &_scanner_ctx->format_scan_context.conjuncts.all_ctxs;
     opts.tuple_desc = _scanner_ctx->tuple_desc;
     // Must use the fragment-scoped pool (runtime_state->obj_pool()), not
     // _scanner_ctx->obj_pool.  BoxedExpr::expr_context() deep-copies Expr
@@ -185,16 +203,19 @@ Status HdfsScanner::_build_scanner_context() {
                                                                           ctx.predicates.predicate_free_pool));
     ctx.predicates.runtime_filter_scan_range_pruner = std::make_unique<RuntimeScanRangePruner>(
             ctx.predicates.predicate_parser.get(), ctx.predicates.conjuncts_manager->unarrived_runtime_filters());
+    ctx.format_scan_context.predicate_tree = &ctx.predicates.predicate_tree;
+    ctx.format_scan_context.runtime_filter_scan_range_pruner = ctx.predicates.runtime_filter_scan_range_pruner.get();
 
-    ctx.update_return_count_columns();
+    ctx.format_scan_context.update_return_count_columns();
     if (ctx.scan_range->__isset.record_count && ctx.scan_range->delete_files.empty()) {
-        ctx.can_use_file_record_count = true;
+        ctx.format_scan_context.has_file_record_count = true;
+        ctx.format_scan_context.file_record_count = ctx.scan_range->record_count;
     }
     if (ctx.scan_range->__isset.is_first_split) {
-        ctx.is_first_split = ctx.scan_range->is_first_split;
+        ctx.format_scan_context.is_first_split = ctx.scan_range->is_first_split;
     }
 
-    ctx.update_min_max_columns();
+    ctx.format_scan_context.update_min_max_columns();
     return Status::OK();
 }
 
@@ -207,27 +228,27 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     }
 
     // short circuit for ___count___ optimization.
-    if (_scanner_ctx->can_use_count_optimization()) {
+    if (_scanner_ctx->format_scan_context.can_use_count_optimization()) {
         int64_t file_record_count = 0;
-        if (_scanner_ctx->is_first_split) {
-            file_record_count = _scanner_ctx->scan_range->record_count;
+        if (_scanner_ctx->format_scan_context.is_first_split) {
+            file_record_count = _scanner_ctx->format_scan_context.file_record_count;
         }
         // append_side_columns_to_chunk fills per-row count (value=1),
         // partition, and extended columns first.  The next call overwrites the
         // count column with the aggregated file record count.
-        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, 1));
-        _scanner_ctx->append_or_update_count_column_to_chunk(chunk, 1, file_record_count);
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(chunk, 1));
+        _scanner_ctx->format_scan_context.append_or_update_count_column_to_chunk(chunk, 1, file_record_count);
         _scanner_ctx->no_more_chunks = true;
         _app_stats.rows_read += 1;
         return Status::OK();
     }
 
     // short circuit for min/max optimization.
-    if (_scanner_ctx->can_use_min_max_optimization()) {
+    if (_scanner_ctx->format_scan_context.can_use_min_max_optimization()) {
         // 3 means we output 3 values: min, max, and null
         const size_t row_count = 3;
         (*chunk)->set_num_rows(row_count);
-        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, row_count));
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(chunk, row_count));
         _scanner_ctx->no_more_chunks = true;
         _app_stats.rows_read += row_count;
         return Status::OK();
@@ -254,7 +275,8 @@ Status HdfsScanner::open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_build_scanner_context());
     // short circuit for ___count___ optimization.
     // short circuit for min/max optimization.
-    if (_scanner_ctx->can_use_count_optimization() || _scanner_ctx->can_use_min_max_optimization()) {
+    if (_scanner_ctx->format_scan_context.can_use_count_optimization() ||
+        _scanner_ctx->format_scan_context.can_use_min_max_optimization()) {
         return Status::OK();
     }
     RETURN_IF_ERROR(do_open(runtime_state));
@@ -271,7 +293,8 @@ void HdfsScanner::close() noexcept {
     }
     // short circuit for ___count___ optimization.
     // short circuit for min/max optimization.
-    if (_scanner_ctx->can_use_count_optimization() || _scanner_ctx->can_use_min_max_optimization()) {
+    if (_scanner_ctx->format_scan_context.can_use_count_optimization() ||
+        _scanner_ctx->format_scan_context.can_use_min_max_optimization()) {
         return;
     }
     VLOG_FILE << "close file success: " << _scanner_ctx->file_path << ", scan range = ["

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_avro.cpp
@@ -119,8 +119,8 @@ Status HdfsAvroScanner::do_get_next(RuntimeState* state, ChunkPtr* chunk) {
             }
         }
     }
-    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(&ck, row_count));
-    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(&ck));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(&ck, row_count));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.evaluate_all_predicates(&ck));
 
     // Note: _app_stats.rows_read is updated by the base class HdfsScanner::get_next
     // after do_get_next returns. Do NOT update it here to avoid double-counting.

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
@@ -123,6 +123,8 @@ struct TableSpecificData {
 // (_scanner_ctx) and _init_scanner() assigns its pointer; per-range fields are
 // overwritten in-place without copying.
 struct HdfsScannerContext {
+    HdfsScannerContext() { format_scan_context.predicate_tree = &predicates.predicate_tree; }
+
     // ===== per-range fields =====
     const THdfsScanRange* scan_range = nullptr;
     FileSystem* fs = nullptr;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_context.h
@@ -108,7 +108,6 @@ struct HdfsScannerProfile {
 struct TableSpecificData {
     std::vector<const TIcebergDeleteFile*> iceberg_delete_files;
     std::shared_ptr<TDeletionVectorDescriptor> deletion_vector_descriptor;
-    const TIcebergSchema* iceberg_schema = nullptr;
     std::shared_ptr<TPaimonDeletionFile> paimon_deletion_file;
 };
 
@@ -126,11 +125,9 @@ struct TableSpecificData {
 struct HdfsScannerContext {
     // ===== per-range fields =====
     const THdfsScanRange* scan_range = nullptr;
-    int32_t scan_range_id = -1;
     FileSystem* fs = nullptr;
     std::string file_path;
     int64_t file_size = -1;
-    bool is_first_split = false;
     std::string table_location;
     DataCacheOptions datacache_options{};
     TableSpecificData table_specific;
@@ -139,14 +136,12 @@ struct HdfsScannerContext {
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
     const TupleDescriptor* tuple_desc = nullptr;
     FormatScanContext format_scan_context;
-    FormatScannerConjuncts conjuncts;
     HdfsScannerProfile profile;
 
     // ===== column descriptors =====
     // ---- materialized columns ----
     std::vector<SlotDescriptor*> materialize_slots;
     std::vector<int> materialize_index_in_chunk;
-    std::unordered_map<SlotId, std::string> materialize_slot_default_values;
 
     // ---- partition columns ----
     std::vector<SlotDescriptor*> partition_slots;
@@ -166,7 +161,6 @@ struct HdfsScannerContext {
 
     // ===== working state =====
     std::vector<SlotDescriptor*> slot_descs;
-    std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
 
     // ExprContexts for partition column values (evaluated from hdfs file path).
     // Filled by HiveDataSource before init(); evaluated once in _build_scanner_context()
@@ -174,31 +168,13 @@ struct HdfsScannerContext {
     // HiveDataSource's ObjectPool.
     std::vector<ExprContext*> partition_expr_ctxs;
 
-    // Extended column metadata (iceberg data_seq_num, etc.).
-    std::vector<FormatColumnInfo> extended_columns;
-
     // ExprContexts for extended column values.  Same lifetime model as partition_expr_ctxs.
     std::vector<ExprContext*> extended_col_expr_ctxs;
-
-    // Evaluated extended column values.
-    Columns extended_values;
-
-    bool can_use_file_record_count = false;
 
     // used by short circuit cases:
     // get_next just returns chunk for once.
     // and it returns EOF the next time.
     bool no_more_chunks = false;
-
-    // ___count___ column for COUNT(*) optimization.
-    // Separated from not_existed_slots because it is an execution marker,
-    // not a schema-evolution missing column.
-    std::optional<SlotDescriptor*> _count_slot;
-
-    std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
-
-    // TODO: probably should be removed in later version.
-    std::atomic<int32_t>* lazy_column_coalesce_counter = nullptr;
 
     // ===== infrastructure =====
     // ObjectPool for allocations built by _build_scanner_context().
@@ -223,64 +199,9 @@ struct HdfsScannerContext {
     } predicates;
 
     // ===== methods =====
-    bool is_lazy_materialization_slot(SlotId slot_id) const;
-
     std::string formatted_name(const std::string& name) const {
         return format_scan_context.options.case_sensitive ? name : boost::algorithm::to_lower_copy(name);
     }
-
-    bool can_use_count_optimization() const;
-    bool has_count_column() const { return _count_slot.has_value(); }
-
-    bool can_use_min_max_optimization() const;
-
-    void update_with_none_existed_slot(SlotDescriptor* slot);
-    void update_return_count_columns();
-    void update_min_max_columns();
-
-    // update materialized column against data file.
-    // and to update not_existed slots and conjuncts.
-    // and to update `conjunct_ctxs_by_slot` field.
-    Status update_materialized_columns(const std::unordered_set<std::string>& names);
-    // "not existed columns" are materialized columns not found in file
-    // this usually happens when use changes schema. for example
-    // user create table with 3 fields A, B, C, and there is one file F1
-    // but user change schema and add one field like D.
-    // when user select(A, B, C, D), then D is the non-existed column in file F1.
-    Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-    // If there is no partition column in the chunk, append partition column to chunk,
-    // otherwise update partition column in chunk
-    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-    // Emit `output_rows` rows of `value` for the ___count___ column.
-    // Idempotent: if the chunk already has a ___count___ column, this is a no-op.
-    // Used by both the count-opt aggregated path (output_rows=1, value=row_count)
-    // and the per-row fallback (output_rows=row_count, value=1).
-    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value);
-    MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot, const TExprMinMaxValue& value, size_t row_count);
-
-    void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-    // Append all side columns (not-existed, partition, extended, count) at once.
-    // Safe when any category is empty — each sub-function is a no-op in that case.
-    Status append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
-
-    void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
-                                          const std::vector<FormatColumnInfo>& columns, const Columns& values);
-
-    // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
-    StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
-
-    // other helper functions.
-    bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
-    Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
-
-    // Evaluate both single-slot conjuncts (conjunct_ctxs_by_slot) and multi-slot
-    // conjuncts (conjuncts.scanner_ctxs) on the chunk in place.  Safe to call
-    // when either category is empty — each sub-step is a no-op.
-    Status evaluate_all_predicates(ChunkPtr* chunk);
-
-    void merge_split_tasks();
 };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_json.cpp
@@ -228,8 +228,8 @@ Status HdfsJsonScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk
 
     if ((*chunk)->num_rows() > 0) {
         size_t rows_read = (*chunk)->num_rows();
-        RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, rows_read));
-        RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(chunk, rows_read));
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.evaluate_all_predicates(chunk));
     }
 
     return st;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_orc.cpp
@@ -88,7 +88,7 @@ OrcRowReaderFilter::OrcRowReaderFilter(const HdfsScannerContext& scanner_ctx, Or
         : _scanner_ctx(scanner_ctx), _reader(reader), _writer_tzoffset_in_seconds(reader->tzoffset_in_seconds()) {
     if (_scanner_ctx.min_max_tuple_desc != nullptr) {
         VLOG_FILE << "OrcRowReaderFilter: min_max_tuple_desc = " << _scanner_ctx.min_max_tuple_desc->debug_string();
-        for (ExprContext* ctx : _scanner_ctx.conjuncts.min_max_ctxs) {
+        for (ExprContext* ctx : _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs) {
             VLOG_FILE << "OrcRowReaderFilter: min_max_ctx = " << ctx->root()->debug_string();
         }
     }
@@ -171,7 +171,7 @@ bool OrcRowReaderFilter::filterMinMax(size_t rowGroupIdx,
 
     VLOG_FILE << "stripe = " << _current_stripe_index << ", row_group = " << rowGroupIdx
               << ", min_chunk = " << min_chunk->debug_row(0) << ", max_chunk = " << max_chunk->debug_row(0);
-    for (auto& min_max_conjunct_ctx : _scanner_ctx.conjuncts.min_max_ctxs) {
+    for (auto& min_max_conjunct_ctx : _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs) {
         // TODO: add a warning log here
         auto min_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), min_chunk.get());
         auto max_col = EVALUATE_NULL_IF_ERROR(min_max_conjunct_ctx, min_max_conjunct_ctx->root(), max_chunk.get());
@@ -208,7 +208,7 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
     if (!_init_use_dict_filter_slots) {
         for (const auto& col : _scanner_ctx.format_scan_context.materialized_columns) {
             SlotDescriptor* slot = col.slot_desc;
-            if (!_scanner_ctx.can_use_dict_filter_on_slot(slot)) {
+            if (!_scanner_ctx.format_scan_context.can_use_dict_filter_on_slot(slot)) {
                 continue;
             }
             const orc::Type* orc_type = _reader->get_orc_type_by_slot_id(slot->id());
@@ -301,8 +301,8 @@ bool OrcRowReaderFilter::filterOnPickStringDictionary(
         }
 
         // do evaluation with dictionary.
-        Status status = ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx.conjunct_ctxs_by_slot.at(slot_id),
-                                                                dict_value_chunk.get(), filter_ptr);
+        Status status = ChunkPredicateEvaluator::eval_conjuncts(
+                _scanner_ctx.format_scan_context.conjunct_ctxs_by_slot.at(slot_id), dict_value_chunk.get(), filter_ptr);
         if (!status.ok()) {
             LOG(WARNING) << "eval conjuncts fails: " << status.message();
             _dict_filter_eval_cache.erase(slot_id);
@@ -405,8 +405,8 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     OrcChunkReader::build_column_name_set(&known_column_names, &_scanner_ctx->hive_column_names, reader->getType(),
                                           _scanner_ctx->format_scan_context.options.case_sensitive,
                                           _scanner_ctx->format_scan_context.options.orc_use_column_names);
-    RETURN_IF_ERROR(_scanner_ctx->update_materialized_columns(known_column_names));
-    ASSIGN_OR_RETURN(auto skip, _scanner_ctx->should_skip_by_evaluating_not_existed_slots());
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.update_materialized_columns(known_column_names));
+    ASSIGN_OR_RETURN(auto skip, _scanner_ctx->format_scan_context.should_skip_by_evaluating_not_existed_slots());
     if (skip) {
         LOG(INFO) << "HdfsOrcScanner: do_open. skip file for non existed slot conjuncts.";
         _should_skip_file = true;
@@ -417,7 +417,7 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
     for (const auto& column : _scanner_ctx->format_scan_context.materialized_columns) {
         auto col_name = Utils::format_name(column.name(), _scanner_ctx->format_scan_context.options.case_sensitive);
         if (known_column_names.find(col_name) == known_column_names.end()) continue;
-        bool is_lazy_slot = _scanner_ctx->is_lazy_materialization_slot(column.slot_id());
+        bool is_lazy_slot = _scanner_ctx->format_scan_context.is_lazy_materialization_slot(column.slot_id());
         if (is_lazy_slot) {
             _lazy_load_ctx.lazy_load_slots.emplace_back(column.slot_desc);
             _lazy_load_ctx.lazy_load_indices.emplace_back(src_slot_index);
@@ -433,8 +433,8 @@ Status HdfsOrcScanner::resolve_columns(orc::Reader* reader) {
         // put materialized columns' conjunctions into _eval_conjunct_ctxs_by_materialized_slot
         // for example, partition column's conjunctions will not put into _eval_conjunct_ctxs_by_materialized_slot
         {
-            auto it = _scanner_ctx->conjuncts.by_slot.find(column.slot_id());
-            if (it != _scanner_ctx->conjuncts.by_slot.end()) {
+            auto it = _scanner_ctx->format_scan_context.conjuncts.by_slot.find(column.slot_id());
+            if (it != _scanner_ctx->format_scan_context.conjuncts.by_slot.end()) {
                 _eval_conjunct_ctxs_by_materialized_slot.emplace(it->first, it->second);
             }
         }
@@ -460,7 +460,7 @@ Status HdfsOrcScanner::build_split_tasks(orc::Reader* reader, const std::vector<
         ctx->end_offset = info.offset() + info.length();
         _scanner_ctx->format_scan_context.split.split_tasks.emplace_back(std::move(ctx));
     }
-    _scanner_ctx->merge_split_tasks();
+    _scanner_ctx->format_scan_context.merge_split_tasks();
     // if only one split task, clear it, no need to do split work.
     if (_scanner_ctx->format_scan_context.split.split_tasks.size() <= 1) {
         _scanner_ctx->format_scan_context.split.split_tasks.clear();
@@ -477,7 +477,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     if (_input_stream == nullptr) {
         _input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
                                                             _shared_buffered_input_stream.get());
-        _input_stream->set_lazy_column_coalesce_counter(_scanner_ctx->lazy_column_coalesce_counter);
+        _input_stream->set_lazy_column_coalesce_counter(_scanner_ctx->format_scan_context.lazy_column_coalesce_counter);
         _input_stream->set_app_stats(&_app_stats);
     }
     ORCHdfsFileStream* orc_hdfs_file_stream = _input_stream.get();
@@ -541,7 +541,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
 
     std::vector<Expr*> conjuncts{};
     if (_use_orc_sargs) {
-        for (const auto& it : _scanner_ctx->conjunct_ctxs_by_slot) {
+        for (const auto& it : _scanner_ctx->format_scan_context.conjunct_ctxs_by_slot) {
             for (const auto& it2 : it.second) {
                 conjuncts.push_back(it2->root());
             }
@@ -549,7 +549,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
         // also fold multi-slot predicates into the search argument; ORC can use them
         // for stripe-level skipping even though the post-read pass in get_next() is
         // still needed for correctness.
-        for (const auto& it : _scanner_ctx->conjuncts.scanner_ctxs) {
+        for (const auto& it : _scanner_ctx->format_scan_context.conjuncts.scanner_ctxs) {
             conjuncts.push_back(it->root());
         }
     }
@@ -580,8 +580,8 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         ASSIGN_OR_RETURN(rows_read, _do_get_next(chunk));
     }
 
-    _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, rows_read);
-    _scanner_ctx->append_or_update_extended_column_to_chunk(chunk, rows_read);
+    _scanner_ctx->format_scan_context.append_or_update_partition_column_to_chunk(chunk, rows_read);
+    _scanner_ctx->format_scan_context.append_or_update_extended_column_to_chunk(chunk, rows_read);
 
     DCHECK_EQ(rows_read, chunk->get()->num_rows());
 
@@ -590,9 +590,10 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
     // ORC already folded these into search arguments during do_open() for
     // stripe-level skipping, but that is an approximate optimisation only; this
     // row-level pass is still required for correctness.
-    if (rows_read > 0 && !_scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+    if (rows_read > 0 && !_scanner_ctx->format_scan_context.conjuncts.scanner_ctxs.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
-        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(_scanner_ctx->conjuncts.scanner_ctxs, chunk->get()));
+        RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(
+                _scanner_ctx->format_scan_context.conjuncts.scanner_ctxs, chunk->get()));
         rows_read = (*chunk)->num_rows();
     }
 
@@ -619,7 +620,7 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next_count(ChunkPtr* chunk) {
 
     if (!st.is_end_of_file()) return st;
     if (read_num_values == 0) return Status::EndOfFile("No more rows to read");
-    _scanner_ctx->append_or_update_count_column_to_chunk(chunk, 1, read_num_values);
+    _scanner_ctx->format_scan_context.append_or_update_count_column_to_chunk(chunk, 1, read_num_values);
     return 1;
 }
 
@@ -667,7 +668,8 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             }
 
             // we need to append none existed column before do eval, just for count(*) optimization
-            RETURN_IF_ERROR(_scanner_ctx->append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
+            RETURN_IF_ERROR(
+                    _scanner_ctx->format_scan_context.append_or_update_not_existed_columns_to_chunk(chunk, rows_read));
 
             // do stats before we filter rows which does not match.
             _app_stats.raw_rows_read += rows_read;
@@ -701,8 +703,8 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
             if (rows_read != 0 && rows_read != ck->num_rows()) {
                 ck->filter(_chunk_filter);
             }
-            if (_scanner_ctx->has_count_column()) {
-                _scanner_ctx->append_or_update_count_column_to_chunk(chunk, rows_read, 1);
+            if (_scanner_ctx->format_scan_context.has_count_column()) {
+                _scanner_ctx->format_scan_context.append_or_update_count_column_to_chunk(chunk, rows_read, 1);
             }
         }
 
@@ -714,10 +716,10 @@ StatusOr<size_t> HdfsOrcScanner::_do_get_next(ChunkPtr* chunk) {
         bool require_load_lazy_columns = rows_read > 0;
         if (require_load_lazy_columns) {
             // still need to load lazy column
-            _scanner_ctx->lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
+            _scanner_ctx->format_scan_context.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
         } else {
             // dont need to load lazy column
-            _scanner_ctx->lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
+            _scanner_ctx->format_scan_context.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
             _app_stats.late_materialize_skip_rows += origin_rows_read;
             continue;
         }

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_parquet.cpp
@@ -263,7 +263,7 @@ Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {
                                                     _scanner_ctx->datacache_options,
                                                     _shared_buffered_input_stream.get(), _skip_rows_ctx);
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
-    RETURN_IF_ERROR(_reader->init(_scanner_ctx));
+    RETURN_IF_ERROR(_reader->init(&_scanner_ctx->format_scan_context));
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_partition.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_partition.cpp
@@ -29,8 +29,8 @@ Status HdfsPartitionScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* 
         column->append_default(1);
         (*chunk)->append_column(std::move(column), slot->id());
     }
-    _scanner_ctx->append_or_update_partition_column_to_chunk(chunk, 1);
-    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
+    _scanner_ctx->format_scan_context.append_or_update_partition_column_to_chunk(chunk, 1);
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.evaluate_all_predicates(chunk));
     return Status::OK();
 }
 

--- a/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner_text.cpp
@@ -278,7 +278,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
             if (column.name() == "___count___") continue;
             names.emplace(column.name());
         }
-        RETURN_IF_ERROR(_scanner_ctx->update_materialized_columns(names));
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.update_materialized_columns(names));
     }
 
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
@@ -387,8 +387,8 @@ Status HdfsTextScanner::_parse_csv(int chunk_size, ChunkPtr* chunk) {
         }
     }
 
-    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, rows_read));
-    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(chunk, rows_read));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.evaluate_all_predicates(chunk));
 
     // Check chunk's row number for each column
     chunk->get()->check_or_die();

--- a/be/src/exec/hdfs_scanner/jni_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/jni_scanner.cpp
@@ -400,8 +400,8 @@ Status JniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     ASSIGN_OR_RETURN(size_t chunk_size, fill_empty_chunk(chunk));
     // Partition and not-existed columns must be appended before predicate evaluation
     // because ctxs_by_slot may reference non-file or partition slots.
-    RETURN_IF_ERROR(_scanner_ctx->append_side_columns_to_chunk(chunk, chunk_size));
-    RETURN_IF_ERROR(_scanner_ctx->evaluate_all_predicates(chunk));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.append_side_columns_to_chunk(chunk, chunk_size));
+    RETURN_IF_ERROR(_scanner_ctx->format_scan_context.evaluate_all_predicates(chunk));
     return Status::OK();
 }
 
@@ -465,7 +465,7 @@ Status JniScanner::update_jni_scanner_params() {
             auto col_name = column.formatted_name(_scanner_ctx->format_scan_context.options.case_sensitive);
             names.insert(col_name);
         }
-        RETURN_IF_ERROR(_scanner_ctx->update_materialized_columns(names));
+        RETURN_IF_ERROR(_scanner_ctx->format_scan_context.update_materialized_columns(names));
     }
 
     std::string required_fields;

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -139,10 +139,12 @@ Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file
     scanner_ctx->datacache_options = _ctx.datacache_options;
     scanner_ctx->format_scan_context.options = _ctx.format_scan_context.options;
     scanner_ctx->format_scan_context.options.enable_split_tasks = false;
-    scanner_ctx->table_specific.iceberg_schema = &iceberg_schema;
+    scanner_ctx->format_scan_context.lake_schema = &iceberg_schema;
+    scanner_ctx->format_scan_context.scan_range_offset = scan_range.offset;
+    scanner_ctx->format_scan_context.scan_range_length = scan_range.length;
     scanner_ctx->scan_range = &scan_range;
-    scanner_ctx->lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
-    RETURN_IF_ERROR(reader->init(scanner_ctx.get()));
+    scanner_ctx->format_scan_context.lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
+    RETURN_IF_ERROR(reader->init(&scanner_ctx->format_scan_context));
 
     while (true) {
         ASSIGN_OR_RETURN(ChunkPtr chunk,

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -22,6 +22,7 @@ ADD_BE_LIB(FormatCore
         io/async_flush_output_stream.cpp
         io/formatted_output_stream_file.cpp
         reserved_columns.h
+        scan_context.cpp
         scan_context.h
         utils.h
         )

--- a/be/src/formats/parquet/column_materializer.cpp
+++ b/be/src/formats/parquet/column_materializer.cpp
@@ -22,6 +22,7 @@
 #include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "common/config_scan_io_fwd.h"
+#include "common/runtime_profile.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr.h"
 #include "formats/parquet/read_range_planner.h"
@@ -95,8 +96,8 @@ Status ColumnMaterializer::init_read_chunk() {
     for (const auto& column : _param.read_cols) {
         read_slots.emplace_back(column.slot_desc);
     }
-    if (!_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (auto* slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (!_param.scan_ctx->reserved_field_slots.empty()) {
+        for (auto* slot : _param.scan_ctx->reserved_field_slots) {
             read_slots.push_back(slot);
         }
     }
@@ -120,8 +121,8 @@ ChunkPtr ColumnMaterializer::create_read_chunk(const std::vector<SlotId>& slot_i
         ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot_id);
         chunk->append_column(column, slot_id);
     }
-    if (include_reserved_fields && !_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (const auto* slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (include_reserved_fields && !_param.scan_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scan_ctx->reserved_field_slots) {
             ColumnPtr& column = _read_chunk->get_column_by_slot_id(slot->id());
             chunk->append_column(column, slot->id());
         }
@@ -162,8 +163,8 @@ StatusOr<size_t> ColumnMaterializer::read_active_range_round_by_round(const Rang
     DeferOp defer([&]() { _column_read_order_ctx->update_ctx(round_cost, first_selectivity); });
     size_t hit_count = 0;
 
-    if (!_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (const auto* slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (!_param.scan_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scan_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             RETURN_IF_ERROR(read_slot(slot_id, range, filter, chunk));
             if (_post_read_conjuncts_by_slot.find(slot_id) != _post_read_conjuncts_by_slot.end()) {
@@ -249,11 +250,11 @@ StatusOr<size_t> ColumnMaterializer::eval_slot_conjuncts(const std::vector<ExprC
 
 Status ColumnMaterializer::read_range(const std::vector<int>& read_columns, const Range<uint64_t>& range,
                                       const Filter* filter, ChunkPtr* chunk, bool ignore_reserved_field) {
-    if (read_columns.empty() && _param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
+    if (read_columns.empty() && _param.scan_ctx->reserved_field_slots.empty()) {
         return Status::OK();
     }
-    if (!ignore_reserved_field && !_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (const auto& slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (!ignore_reserved_field && !_param.scan_ctx->reserved_field_slots.empty()) {
+        for (const auto& slot : _param.scan_ctx->reserved_field_slots) {
             RETURN_IF_ERROR(read_slot(slot->id(), range, filter, chunk));
         }
     }
@@ -375,8 +376,8 @@ Status ColumnMaterializer::emit_physical_columns(ChunkPtr& active_chunk, ChunkPt
                                             active_chunk->get_column_by_slot_id(slot_id)));
         }
     }
-    if (!_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (const auto* slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (!_param.scan_ctx->reserved_field_slots.empty()) {
+        for (const auto* slot : _param.scan_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             RETURN_IF_ERROR(fill_dst_column(slot_id, (*dst)->get_column_by_slot_id(slot_id),
                                             active_chunk->get_column_by_slot_id(slot_id)));
@@ -431,8 +432,8 @@ void ColumnMaterializer::classify_columns(const std::unordered_set<SlotId>& defe
         ++read_col_idx;
     }
 
-    if (!_param.scanner_ctx->format_scan_context.reserved_field_slots.empty()) {
-        for (auto* slot : _param.scanner_ctx->format_scan_context.reserved_field_slots) {
+    if (!_param.scan_ctx->reserved_field_slots.empty()) {
+        for (auto* slot : _param.scan_ctx->reserved_field_slots) {
             SlotId slot_id = slot->id();
             auto it = conjunct_ctxs_by_slot.find(slot_id);
             if (it != conjunct_ctxs_by_slot.end()) {

--- a/be/src/formats/parquet/column_materializer.h
+++ b/be/src/formats/parquet/column_materializer.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "cache/scan/shared_buffered_input_stream.h"
+#include "column/chunk.h"
 #include "common/global_types.h"
 #include "common/status.h"
 #include "common/statusor.h"

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -53,14 +54,14 @@ FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
 
 FileReader::~FileReader() = default;
 
-Status FileReader::init(HdfsScannerContext* ctx) {
+Status FileReader::init(FormatScanContext* ctx) {
     _scanner_ctx = ctx;
-    if (ctx->format_scan_context.options.use_file_metacache) {
+    if (ctx->options.use_file_metacache) {
         _cache = DataCache::GetInstance()->page_cache();
     }
 
     // parse FileMetadata
-    FileMetaDataParser file_metadata_parser{_file, &ctx->format_scan_context, _cache, &_datacache_options, _file_size};
+    FileMetaDataParser file_metadata_parser{_file, ctx, _cache, &_datacache_options, _file_size};
     ASSIGN_OR_RETURN(_file_metadata, file_metadata_parser.get_file_metadata());
 
     // set existed SlotDescriptor in this parquet file
@@ -73,32 +74,30 @@ Status FileReader::init(HdfsScannerContext* ctx) {
         return Status::OK();
     }
     RETURN_IF_ERROR(_build_split_tasks());
-    if (_scanner_ctx->format_scan_context.split.split_tasks.size() > 0) {
-        _scanner_ctx->format_scan_context.split.has_split_tasks = true;
+    if (_scanner_ctx->split.split_tasks.size() > 0) {
+        _scanner_ctx->split.has_split_tasks = true;
         _is_file_filtered = true;
         return Status::OK();
     }
 
-    if (_scanner_ctx->predicates.runtime_filter_scan_range_pruner != nullptr) {
+    if (_scanner_ctx->runtime_filter_scan_range_pruner != nullptr) {
         _runtime_filter_scan_range_pruner =
-                std::make_shared<RuntimeScanRangePruner>(*_scanner_ctx->predicates.runtime_filter_scan_range_pruner);
+                std::make_shared<RuntimeScanRangePruner>(*_scanner_ctx->runtime_filter_scan_range_pruner);
     }
     RETURN_IF_ERROR(_init_group_readers());
     return Status::OK();
 }
 
 std::shared_ptr<MetaHelper> FileReader::_build_meta_helper() {
-    if (_scanner_ctx->table_specific.iceberg_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
+    if (_scanner_ctx->lake_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
         // Use LakeMetaHelper only when both an Iceberg/Paimon lake schema is present AND
         // the parquet file carries field ids.  Without field ids, the lake schema cannot
         // be matched reliably and we fall back to ParquetMetaHelper which handles
         // col_unique_id / col_physical_name / name lookup chains correctly.
-        return std::make_shared<LakeMetaHelper>(_file_metadata.get(),
-                                                _scanner_ctx->format_scan_context.options.case_sensitive,
-                                                _scanner_ctx->table_specific.iceberg_schema);
+        return std::make_shared<LakeMetaHelper>(_file_metadata.get(), _scanner_ctx->options.case_sensitive,
+                                                _scanner_ctx->lake_schema);
     } else {
-        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(),
-                                                   _scanner_ctx->format_scan_context.options.case_sensitive);
+        return std::make_shared<ParquetMetaHelper>(_file_metadata.get(), _scanner_ctx->options.case_sensitive);
     }
 }
 
@@ -119,8 +118,7 @@ Status FileReader::_build_split_tasks() {
     // don't do split in following cases:
     // 1. this feature is not enabled
     // 2. we have already done split before (that's why `split_context` is nullptr)
-    if (!_scanner_ctx->format_scan_context.options.enable_split_tasks ||
-        _scanner_ctx->format_scan_context.split_context != nullptr) {
+    if (!_scanner_ctx->options.enable_split_tasks || _scanner_ctx->split_context != nullptr) {
         return Status::OK();
     }
 
@@ -150,22 +148,21 @@ Status FileReader::_build_split_tasks() {
         split_ctx->end_offset = end_offset;
         split_ctx->file_metadata = _file_metadata;
         split_ctx->skip_rows_ctx = _skip_rows_ctx;
-        _scanner_ctx->format_scan_context.split.split_tasks.emplace_back(std::move(split_ctx));
+        _scanner_ctx->split.split_tasks.emplace_back(std::move(split_ctx));
     }
     _scanner_ctx->merge_split_tasks();
     // if only one split task, clear it, no need to do split work.
-    if (_scanner_ctx->format_scan_context.split.split_tasks.size() <= 1) {
-        _scanner_ctx->format_scan_context.split.split_tasks.clear();
+    if (_scanner_ctx->split.split_tasks.size() <= 1) {
+        _scanner_ctx->split.split_tasks.clear();
     }
 
     if (VLOG_OPERATOR_IS_ON) {
         std::stringstream ss;
-        for (const FileScanSplitContextPtr& ctx : _scanner_ctx->format_scan_context.split.split_tasks) {
+        for (const FileScanSplitContextPtr& ctx : _scanner_ctx->split.split_tasks) {
             ss << "[" << ctx->start_offset << "," << ctx->end_offset << "]";
         }
         VLOG_OPERATOR << "FileReader: do_open. split task for " << _file->filename()
-                      << ", split_tasks.size = " << _scanner_ctx->format_scan_context.split.split_tasks.size()
-                      << ", range = " << ss.str();
+                      << ", split_tasks.size = " << _scanner_ctx->split.split_tasks.size() << ", range = " << ss.str();
     }
     return Status::OK();
 }
@@ -175,10 +172,12 @@ Status FileReader::_build_split_tasks() {
 bool FileReader::_filter_group(const GroupReaderPtr& group_reader) {
     bool& filtered = group_reader->get_is_group_filtered();
     filtered = false;
-    auto visitor = PredicateFilterEvaluator{_scanner_ctx->predicates.predicate_tree, group_reader.get(),
-                                            _scanner_ctx->format_scan_context.options.parquet_page_index_enable,
-                                            _scanner_ctx->format_scan_context.options.parquet_bloom_filter_enable};
-    auto sparse_range = _scanner_ctx->predicates.predicate_tree.visit(visitor);
+    DCHECK(_scanner_ctx->predicate_tree != nullptr);
+    const PredicateTree& predicate_tree = *_scanner_ctx->predicate_tree;
+    auto visitor = PredicateFilterEvaluator{predicate_tree, group_reader.get(),
+                                            _scanner_ctx->options.parquet_page_index_enable,
+                                            _scanner_ctx->options.parquet_bloom_filter_enable};
+    auto sparse_range = predicate_tree.visit(visitor);
     _group_reader_param.stats->bloom_filter_tried_counter += visitor.counter.bloom_filter_tried_counter;
     _group_reader_param.stats->bloom_filter_success_counter += visitor.counter.bloom_filter_success_counter;
     _group_reader_param.stats->statistics_tried_counter += visitor.counter.statistics_tried_counter;
@@ -204,7 +203,7 @@ StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& gro
     bool filter = false;
     if (_runtime_filter_scan_range_pruner != nullptr) {
         RETURN_IF_ERROR(_runtime_filter_scan_range_pruner->update_range_if_arrived(
-                _scanner_ctx->format_scan_context.global_dictmaps,
+                _scanner_ctx->global_dictmaps,
                 [this, &filter, &group_reader](auto cid, const PredicateList& predicates) {
                     PredicateCompoundNode<CompoundNodeType::AND> pred_tree;
                     for (const auto& pred : predicates) {
@@ -238,18 +237,19 @@ StatusOr<bool> FileReader::_update_rf_and_filter_group(const GroupReaderPtr& gro
 }
 
 void FileReader::_prepare_read_columns(std::unordered_set<std::string>& existed_column_names) {
-    _meta_helper->prepare_read_columns(_scanner_ctx->format_scan_context.materialized_columns,
-                                       &_scanner_ctx->format_scan_context.column_access_paths,
+    _meta_helper->prepare_read_columns(_scanner_ctx->materialized_columns, &_scanner_ctx->column_access_paths,
                                        _group_reader_param.read_cols, existed_column_names);
     _no_materialized_column_scan =
-            (_group_reader_param.read_cols.empty() && _scanner_ctx->format_scan_context.reserved_field_slots.empty());
+            (_group_reader_param.read_cols.empty() && _scanner_ctx->reserved_field_slots.empty());
 }
 
 bool FileReader::_select_row_group(const tparquet::RowGroup& row_group) {
     size_t row_group_start = ParquetUtils::get_row_group_start_offset(row_group);
-    const auto* scan_range = _scanner_ctx->scan_range;
-    size_t scan_start = scan_range->offset;
-    size_t scan_end = scan_range->length + scan_start;
+    size_t scan_start = _scanner_ctx->scan_range_offset;
+    const size_t scan_length = _scanner_ctx->scan_range_length;
+    size_t scan_end = std::numeric_limits<size_t>::max() - scan_start <= scan_length
+                              ? std::numeric_limits<size_t>::max()
+                              : scan_start + scan_length;
     if (row_group_start >= scan_start && row_group_start < scan_end) {
         return true;
     }
@@ -262,10 +262,10 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
         std::vector<SharedBufferedInputStream::IORange> ranges;
         int64_t end_offset = 0;
         ColumnIOTypeFlags flags = 0;
-        if (_scanner_ctx->format_scan_context.options.parquet_page_index_enable) {
+        if (_scanner_ctx->options.parquet_page_index_enable) {
             flags |= ColumnIOType::PAGE_INDEX;
         }
-        if (_scanner_ctx->format_scan_context.options.parquet_bloom_filter_enable) {
+        if (_scanner_ctx->options.parquet_bloom_filter_enable) {
             flags |= ColumnIOType::BLOOM_FILTER;
         }
         group_reader->collect_io_ranges(&ranges, &end_offset, flags);
@@ -275,26 +275,23 @@ Status FileReader::_collect_row_group_io(std::shared_ptr<GroupReader>& group_rea
 }
 
 Status FileReader::_init_group_readers() {
-    const HdfsScannerContext& fd_scanner_ctx = *_scanner_ctx;
-
     // _group_reader_param is used by all group readers.
     // scanner_ctx replaces 11 individual field copies; GroupReader accesses
     // context-derived data (timezone, options, partitions, slots, dicts, etc.)
     // through the pointer.  File-infrastructure fields (sb_stream, file, etc.)
     // and hot fields (stats, lazy_column_coalesce_counter) remain direct copies.
-    _group_reader_param.scanner_ctx = _scanner_ctx;
-    _group_reader_param.conjunct_ctxs_by_slot = fd_scanner_ctx.conjunct_ctxs_by_slot;
-    _group_reader_param.stats = fd_scanner_ctx.format_scan_context.stats;
+    _group_reader_param.scan_ctx = _scanner_ctx;
+    _group_reader_param.conjunct_ctxs_by_slot = _scanner_ctx->conjunct_ctxs_by_slot;
+    _group_reader_param.stats = _scanner_ctx->stats;
     _group_reader_param.sb_stream = _sb_stream;
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
-    _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
+    _group_reader_param.lazy_column_coalesce_counter = _scanner_ctx->lazy_column_coalesce_counter;
     _group_reader_param.modification_time = _datacache_options.modification_time;
     _group_reader_param.file_size = _file_size;
     _group_reader_param.datacache_options = &_datacache_options;
-    _group_reader_param.scan_range_id = fd_scanner_ctx.scan_range_id;
-    _group_reader_param.scan_range = fd_scanner_ctx.scan_range;
+    _group_reader_param.scan_range_id = _scanner_ctx->scan_range_id;
 
     int64_t row_group_first_row = 0;
     // select and create row group readers.
@@ -414,7 +411,7 @@ Status FileReader::get_next(ChunkPtr* chunk) {
 Status FileReader::_exec_no_materialized_column_scan(ChunkPtr* chunk) {
     if (_scan_row_count < _total_row_count) {
         size_t read_size = 0;
-        if (_scanner_ctx->format_scan_context.options.use_count_opt) {
+        if (_scanner_ctx->options.use_count_opt) {
             read_size = _total_row_count - _scan_row_count;
             // append_side_columns_to_chunk fills per-row count (value=1),
             // partition, and extended columns first.  The next call overwrites

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -246,10 +246,7 @@ void FileReader::_prepare_read_columns(std::unordered_set<std::string>& existed_
 bool FileReader::_select_row_group(const tparquet::RowGroup& row_group) {
     size_t row_group_start = ParquetUtils::get_row_group_start_offset(row_group);
     size_t scan_start = _scanner_ctx->scan_range_offset;
-    const size_t scan_length = _scanner_ctx->scan_range_length;
-    size_t scan_end = std::numeric_limits<size_t>::max() - scan_start <= scan_length
-                              ? std::numeric_limits<size_t>::max()
-                              : scan_start + scan_length;
+    size_t scan_end = _scanner_ctx->scan_range_length + scan_start;
     if (row_group_start >= scan_start && row_group_start < scan_end) {
         return true;
     }

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -20,16 +20,17 @@
 #include <string>
 #include <vector>
 
+#include "cache/cache_options.h"
 #include "cache/disk_cache/block_cache.h"
 #include "cache/scan/shared_buffered_input_stream.h"
 #include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "common/statusor.h"
-#include "exec/hdfs_scanner/hdfs_scanner_context.h"
 #include "formats/parquet/group_reader.h"
 #include "formats/parquet/meta_helper.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/split_context.h"
+#include "formats/scan_context.h"
 #include "gen_cpp/parquet_types.h"
 
 namespace tparquet {
@@ -40,7 +41,6 @@ class RowGroup;
 
 namespace starrocks {
 class RandomAccessFile;
-struct HdfsScannerContext;
 class BlockCache;
 class StoragePageCache;
 class SlotDescriptor;
@@ -63,7 +63,7 @@ public:
                SharedBufferedInputStream* sb_stream = nullptr, SkipRowsContextPtr skipRowsContext = nullptr);
     ~FileReader();
 
-    Status init(HdfsScannerContext* scanner_ctx);
+    Status init(FormatScanContext* scanner_ctx);
 
     Status get_next(ChunkPtr* chunk);
 
@@ -115,7 +115,7 @@ private:
 
     // not exist column conjuncts eval false, file can be skipped
     bool _is_file_filtered = false;
-    HdfsScannerContext* _scanner_ctx = nullptr;
+    FormatScanContext* _scanner_ctx = nullptr;
     SharedBufferedInputStream* _sb_stream = nullptr;
     GroupReaderParam _group_reader_param;
     std::shared_ptr<MetaHelper> _meta_helper = nullptr;

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -240,7 +240,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         //    slot is a partition/not-existed/extended side column that
         //    hasn't been populated yet.
         if ((*row_count) > 0) {
-            RETURN_IF_ERROR(_param.scanner_ctx->append_side_columns_to_chunk(chunk, (*row_count)));
+            RETURN_IF_ERROR(_param.scan_ctx->append_side_columns_to_chunk(chunk, (*row_count)));
         }
         break;
     }
@@ -286,7 +286,7 @@ StatusOr<bool> GroupReader::_read_and_filter_active_columns(const Range<uint64_t
 // ── 3. Evaluate compound predicates ──────
 
 StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>& r, RowGroupScanState& state) {
-    if (_param.scanner_ctx->conjuncts.scanner_ctxs.empty()) {
+    if (_param.scan_ctx->conjuncts.scanner_ctxs.empty()) {
         return true;
     }
 
@@ -295,8 +295,7 @@ StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>&
     // virtual slot, fetch the needed hidden sources and project the virtual
     // slots early.  active_chunk is rebuilt per range so stale slots cannot leak.
     if (!_variant->empty()) {
-        auto early_projected =
-                _variant->referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs);
+        auto early_projected = _variant->referenced_variant_virtual_slot_ids(_param.scan_ctx->conjuncts.scanner_ctxs);
         if (!early_projected.empty()) {
             RETURN_IF_ERROR(_variant->fetch_and_project_virtual_slots(early_projected, r, state.active_chunk,
                                                                       _variant->projection_timezone()));
@@ -307,7 +306,7 @@ StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>&
     // partition / not-existed / extended slots can be evaluated correctly.
     if (state.active_chunk->num_rows() > 0) {
         RETURN_IF_ERROR(
-                _param.scanner_ctx->append_side_columns_to_chunk(&state.active_chunk, state.active_chunk->num_rows()));
+                _param.scan_ctx->append_side_columns_to_chunk(&state.active_chunk, state.active_chunk->num_rows()));
     }
 
     // Finalize all active columns to logical form before compound conjunct eval.
@@ -316,9 +315,9 @@ StatusOr<bool> GroupReader::_evaluate_compound_predicates(const Range<uint64_t>&
         RETURN_IF_ERROR(_column_materializer->finalize_active_slot(slot_id, state.active_chunk));
     }
 
-    ASSIGN_OR_RETURN(size_t compound_hit, ChunkPredicateEvaluator::eval_conjuncts_into_filter(
-                                                  _param.scanner_ctx->conjuncts.scanner_ctxs, state.active_chunk.get(),
-                                                  &state.chunk_filter));
+    ASSIGN_OR_RETURN(size_t compound_hit,
+                     ChunkPredicateEvaluator::eval_conjuncts_into_filter(
+                             _param.scan_ctx->conjuncts.scanner_ctxs, state.active_chunk.get(), &state.chunk_filter));
     if (compound_hit == 0) {
         _param.stats->late_materialize_skip_rows += state.row_count;
         return false;
@@ -429,11 +428,7 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_reserved_iceberg_column_reader(co
 }
 
 StatusOr<Datum> GroupReader::_get_extended_bigint_value(SlotId slot_id) const {
-    if (_param.scan_range == nullptr || !_param.scan_range->__isset.extended_columns) {
-        return Status::NotFound(fmt::format("Cannot find extended column for slot {}", slot_id));
-    }
-
-    const auto& extended_columns = _param.scan_range->extended_columns;
+    const auto& extended_columns = _param.scan_ctx->extended_column_exprs;
     auto it = extended_columns.find(slot_id);
     if (it == extended_columns.end()) {
         return Status::NotFound(fmt::format("Cannot find extended column value for slot {}", slot_id));
@@ -460,12 +455,12 @@ Status GroupReader::_create_column_readers() {
     _global_dict_applied_in_group = false;
     ColumnReaderOptions& opts = _column_reader_opts;
     opts.file_meta_data = _param.file_metadata;
-    if (_param.scanner_ctx == nullptr) {
+    if (_param.scan_ctx == nullptr) {
         return Status::InternalError("GroupReader: scanner_ctx must not be null");
     }
-    opts.timezone = _param.scanner_ctx->format_scan_context.timezone;
-    opts.case_sensitive = _param.scanner_ctx->format_scan_context.options.case_sensitive;
-    opts.use_file_pagecache = _param.scanner_ctx->format_scan_context.options.use_file_pagecache;
+    opts.timezone = _param.scan_ctx->timezone;
+    opts.case_sensitive = _param.scan_ctx->options.case_sensitive;
+    opts.use_file_pagecache = _param.scan_ctx->options.use_file_pagecache;
     opts.chunk_size = _param.chunk_size;
     opts.stats = _param.stats;
     opts.file = _param.file;
@@ -489,8 +484,8 @@ Status GroupReader::_create_column_readers() {
     _variant->register_zone_map_readers();
 
     // create for partition values
-    const auto& partition_columns = _param.scanner_ctx->format_scan_context.partition_columns;
-    const auto& partition_values = _param.scanner_ctx->format_scan_context.partition_values;
+    const auto& partition_columns = _param.scan_ctx->partition_columns;
+    const auto& partition_values = _param.scan_ctx->partition_values;
     for (size_t i = 0; i < partition_columns.size(); i++) {
         const auto& column = partition_columns[i];
         const auto* slot_desc = column.slot_desc;
@@ -499,11 +494,11 @@ Status GroupReader::_create_column_readers() {
     }
 
     // create for not existed column
-    for (const auto* slot : _param.scanner_ctx->format_scan_context.not_existed_slots) {
+    for (const auto* slot : _param.scan_ctx->not_existed_slots) {
         _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(kNullDatum));
     }
 
-    const auto& reserved_slots = _param.scanner_ctx->format_scan_context.reserved_field_slots;
+    const auto& reserved_slots = _param.scan_ctx->reserved_field_slots;
     if (!reserved_slots.empty()) {
         bool use_legacy_lookup_row_id =
                 std::any_of(reserved_slots.begin(), reserved_slots.end(), [](const SlotDescriptor* slot) {
@@ -515,14 +510,14 @@ Status GroupReader::_create_column_readers() {
                 ASSIGN_OR_RETURN(auto reader,
                                  _create_reserved_iceberg_column_reader(slot, formats::kIcebergRowIdColumnId));
                 std::optional<int64_t> first_row_id = std::nullopt;
-                if (_param.scan_range != nullptr && _param.scan_range->__isset.first_row_id) {
+                if (_param.scan_ctx->first_row_id.has_value()) {
                     // IcebergRowIdReader emits `first_row_id + i` where `i` is a file-local row
                     // index (it already includes the row-group start), so the base must be the
                     // file-level first_row_id. A row-group-level base double-counts the row-group
                     // start and shifts the emitted _row_id for every row group after the first,
                     // diverging from the physical _row_id column of compacted files. The file-level
                     // base also keeps the reader's zone-map filters (base + rg_first_row) correct.
-                    first_row_id = std::optional<int64_t>(_param.scan_range->first_row_id);
+                    first_row_id = _param.scan_ctx->first_row_id;
                 } else if (use_legacy_lookup_row_id) {
                     // Legacy (non-lineage) GLM keys rows by file-local position: the base is 0.
                     first_row_id = std::optional<int64_t>(0);
@@ -580,8 +575,8 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
             schema_node->type == ColumnType::STRUCT) {
             // Physical VARIANT columns use _get_variant_shredded_hints; this path
             // is for non-virtual VARIANT columns that appear directly in the SELECT list.
-            VariantShreddedReadHints hints = build_variant_shredded_hints(
-                    &_param.scanner_ctx->format_scan_context.column_access_paths, column.slot_desc->col_name());
+            VariantShreddedReadHints hints =
+                    build_variant_shredded_hints(&_param.scan_ctx->column_access_paths, column.slot_desc->col_name());
             ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create_variant_column_reader(_column_reader_opts,
                                                                                               schema_node, hints));
         } else if (column.t_lake_schema_field == nullptr) {
@@ -592,7 +587,7 @@ StatusOr<ColumnReaderPtr> GroupReader::_create_column_reader(const GroupReaderPa
                              ColumnReaderFactory::create(_column_reader_opts, schema_node, column.slot_type(),
                                                          column.t_lake_schema_field));
         }
-        auto* global_dictmaps = _param.scanner_ctx->format_scan_context.global_dictmaps;
+        auto* global_dictmaps = _param.scan_ctx->global_dictmaps;
         if (global_dictmaps->contains(column.slot_id())) {
             GlobalDictReaderKind kind = GlobalDictReaderKind::kNone;
             ASSIGN_OR_RETURN(column_reader, ColumnReaderFactory::create(

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "cache/cache_options.h"
 #include "cache/scan/shared_buffered_input_stream.h"
 #include "column/column_access_path.h"
 #include "column/vectorized_fwd.h"
@@ -30,12 +31,12 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "common/statusor.h"
-#include "exec/hdfs_scanner/hdfs_scanner_context.h"
 #include "exprs/expr_context.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/metadata.h"
 #include "formats/parquet/utils.h"
+#include "formats/scan_context.h"
 #include "gen_cpp/parquet_types.h"
 #include "runtime/descriptors.h"
 #include "storage/primitive/range.h"
@@ -43,10 +44,8 @@
 namespace starrocks {
 class RandomAccessFile;
 struct FormatScannerStats;
-struct HdfsScannerContext;
 class ExprContext;
 class TIcebergSchemaField;
-class THdfsScanRange;
 
 namespace parquet {
 class ColumnMaterializer;
@@ -86,7 +85,7 @@ struct GroupReaderParam {
     // Always non-null when used from FileReader; may be null in unit tests.
     // Non-const because unit tests need to populate the context fields after
     // construction; GroupReader treats it as read-only by convention.
-    HdfsScannerContext* scanner_ctx = nullptr;
+    FormatScanContext* scan_ctx = nullptr;
 
     // conjunct_ctxs that column is materialized in group reader
     // Mutable per-group-reader shallow copy of the scanner context's by_slot map;
@@ -116,7 +115,6 @@ struct GroupReaderParam {
     // Kept directly in GroupReaderParam for test-compatibility; also used by
     // _get_extended_bigint_value() to read extended_columns from the scan range.
     int32_t scan_range_id = -1;
-    const THdfsScanRange* scan_range = nullptr;
 };
 
 class GroupReader {

--- a/be/src/formats/parquet/variant_projection.cpp
+++ b/be/src/formats/parquet/variant_projection.cpp
@@ -399,7 +399,7 @@ VariantProjectionHandler::~VariantProjectionHandler() = default;
 // ── _build_shredded_hints ────────────────────────────────────────────────────
 
 VariantShreddedReadHints VariantProjectionHandler::_build_shredded_hints(std::string_view column_name) const {
-    return build_variant_shredded_hints(&_param.scanner_ctx->format_scan_context.column_access_paths, column_name);
+    return build_variant_shredded_hints(&_param.scan_ctx->column_access_paths, column_name);
 }
 
 // ── setup_readers ────────────────────────────────────────────────────────────
@@ -499,8 +499,8 @@ std::unordered_set<SlotId> VariantProjectionHandler::deferred_conjunct_physical_
         }
     }
     // Also force physical sources of virtual slots referenced in compound (multi-slot) conjuncts.
-    if (_param.scanner_ctx != nullptr) {
-        for (SlotId vsid : referenced_variant_virtual_slot_ids(_param.scanner_ctx->conjuncts.scanner_ctxs)) {
+    if (_param.scan_ctx != nullptr) {
+        for (SlotId vsid : referenced_variant_virtual_slot_ids(_param.scan_ctx->conjuncts.scanner_ctxs)) {
             auto proj_it = _projections.find(vsid);
             if (proj_it != _projections.end() && proj_it->second.source_slot_id >= 0) {
                 result.insert(proj_it->second.source_slot_id);
@@ -1003,12 +1003,11 @@ const cctz::time_zone& VariantProjectionHandler::projection_timezone() {
         return _timezone_obj;
     }
     _timezone_resolved = true;
-    if (_param.scanner_ctx->format_scan_context.timezone.empty()) {
+    if (_param.scan_ctx->timezone.empty()) {
         return _timezone_obj;
     }
-    if (!TimezoneUtils::find_cctz_time_zone(_param.scanner_ctx->format_scan_context.timezone, _timezone_obj)) {
-        LOG(WARNING) << "VariantProjectionHandler: fallback to UTC for invalid timezone: "
-                     << _param.scanner_ctx->format_scan_context.timezone;
+    if (!TimezoneUtils::find_cctz_time_zone(_param.scan_ctx->timezone, _timezone_obj)) {
+        LOG(WARNING) << "VariantProjectionHandler: fallback to UTC for invalid timezone: " << _param.scan_ctx->timezone;
         _timezone_obj = cctz::utc_time_zone();
     }
     return _timezone_obj;

--- a/be/src/formats/scan_context.cpp
+++ b/be/src/formats/scan_context.cpp
@@ -12,18 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "exec/hdfs_scanner/hdfs_scanner_context.h"
+#include "formats/scan_context.h"
 
+#include <fmt/format.h>
+
+#include <algorithm>
 #include <map>
 #include <utility>
 
+#include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/datum_convert.h"
 #include "column/runtime_type_traits.h"
+#include "common/runtime_profile.h"
 #include "exprs/chunk_predicate_evaluator.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
 #include "runtime/type_info_allocator_adapter.h"
-#include "storage/types.h"
 #include "types/timestamp_value.h"
+#include "types/type_info.h"
 
 namespace starrocks {
 
@@ -55,7 +62,7 @@ static Status fill_default_value_for_not_existed_slot(SlotDescriptor* slot_desc,
     return Status::OK();
 }
 
-bool HdfsScannerContext::is_lazy_materialization_slot(SlotId slot_id) const {
+bool FormatScanContext::is_lazy_materialization_slot(SlotId slot_id) const {
     // if there are no conjuncts at all, every slot must be read eagerly.
     if (conjuncts.by_slot.empty() && conjuncts.scanner_ctxs.empty()) {
         return false;
@@ -71,18 +78,17 @@ bool HdfsScannerContext::is_lazy_materialization_slot(SlotId slot_id) const {
     return true;
 }
 
-bool HdfsScannerContext::can_use_count_optimization() const {
-    return format_scan_context.options.use_count_opt && can_use_file_record_count;
+bool FormatScanContext::can_use_count_optimization() const {
+    return options.use_count_opt && has_file_record_count;
 }
 
-bool HdfsScannerContext::can_use_min_max_optimization() const {
+bool FormatScanContext::can_use_min_max_optimization() const {
     // @TODO for iceberg _row_id column, we can support min/max optimization in the future
-    return format_scan_context.options.use_min_max_opt && format_scan_context.materialized_columns.empty() &&
-           format_scan_context.reserved_field_slots.empty();
+    return options.use_min_max_opt && materialized_columns.empty() && reserved_field_slots.empty();
 }
 
-void HdfsScannerContext::update_with_none_existed_slot(SlotDescriptor* slot) {
-    format_scan_context.not_existed_slots.push_back(slot);
+void FormatScanContext::update_with_none_existed_slot(SlotDescriptor* slot) {
+    not_existed_slots.push_back(slot);
     SlotId slot_id = slot->id();
     if (conjunct_ctxs_by_slot.find(slot_id) != conjunct_ctxs_by_slot.end()) {
         for (ExprContext* expr_ctx : conjunct_ctxs_by_slot[slot_id]) {
@@ -92,32 +98,31 @@ void HdfsScannerContext::update_with_none_existed_slot(SlotDescriptor* slot) {
     }
 }
 
-void HdfsScannerContext::update_return_count_columns() {
+void FormatScanContext::update_return_count_columns() {
     _count_slot.reset();
     std::vector<FormatColumnInfo> updated_columns;
-    for (auto& column : format_scan_context.materialized_columns) {
+    for (auto& column : materialized_columns) {
         if (column.name() == kCountOptColumnName) {
             _count_slot = column.slot_desc;
         } else {
             updated_columns.emplace_back(column);
         }
     }
-    format_scan_context.materialized_columns.swap(updated_columns);
+    materialized_columns.swap(updated_columns);
 }
 
-void HdfsScannerContext::update_min_max_columns() {
-    if (!format_scan_context.options.use_min_max_opt) {
+void FormatScanContext::update_min_max_columns() {
+    if (!options.use_min_max_opt) {
         return;
     }
     std::vector<FormatColumnInfo> updated_columns;
-    const std::map<int32_t, TExprMinMaxValue>& min_max_values = scan_range->min_max_values;
-    for (auto& column : format_scan_context.materialized_columns) {
+    for (auto& column : materialized_columns) {
         if (min_max_values.find(column.slot_id()) != min_max_values.end()) {
             // This column has file-level min/max statistics.  Move it to
             // not_existed_slots so that the min-max column is filled with
             // statistics values instead of reading the actual data from the file.
             update_with_none_existed_slot(column.slot_desc);
-        } else if (format_scan_context.options.can_use_any_column) {
+        } else if (options.can_use_any_column) {
             // This column has no min/max statistics (e.g. STRING or TIMESTAMP type
             // which are not yet supported, or a placeholder column injected by
             // PruneHDFSScanColumnRule when every queried column is a partition column).
@@ -133,37 +138,37 @@ void HdfsScannerContext::update_min_max_columns() {
     // into not_existed_slots.  reserved_field_slots are meta/hidden columns whose
     // values are irrelevant to the min/max query result, so filling them with defaults
     // is safe and allows can_use_min_max_optimization() to return true.
-    if (format_scan_context.options.can_use_any_column) {
-        for (SlotDescriptor* slot_desc : format_scan_context.reserved_field_slots) {
+    if (options.can_use_any_column) {
+        for (SlotDescriptor* slot_desc : reserved_field_slots) {
             update_with_none_existed_slot(slot_desc);
         }
-        format_scan_context.reserved_field_slots.clear();
+        reserved_field_slots.clear();
     }
-    format_scan_context.materialized_columns.swap(updated_columns);
+    materialized_columns.swap(updated_columns);
 }
 
-Status HdfsScannerContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
+Status FormatScanContext::update_materialized_columns(const std::unordered_set<std::string>& names) {
     std::vector<FormatColumnInfo> updated_columns;
-    for (auto& column : format_scan_context.materialized_columns) {
-        auto col_name = column.formatted_name(format_scan_context.options.case_sensitive);
+    for (auto& column : materialized_columns) {
+        auto col_name = column.formatted_name(options.case_sensitive);
         if (names.find(col_name) == names.end()) {
             update_with_none_existed_slot(column.slot_desc);
         } else {
             updated_columns.emplace_back(column);
         }
     }
-    format_scan_context.materialized_columns.swap(updated_columns);
+    materialized_columns.swap(updated_columns);
     return Status::OK();
 }
 
-Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+Status FormatScanContext::append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
     ChunkPtr& ck = (*chunk);
-    if (format_scan_context.not_existed_slots.empty()) return Status::OK();
+    if (not_existed_slots.empty()) return Status::OK();
 
-    for (auto* slot_desc : format_scan_context.not_existed_slots) {
-        if (format_scan_context.options.use_min_max_opt) {
-            auto it = scan_range->min_max_values.find(slot_desc->id());
-            if (it != scan_range->min_max_values.end()) {
+    for (auto* slot_desc : not_existed_slots) {
+        if (options.use_min_max_opt) {
+            auto it = min_max_values.find(slot_desc->id());
+            if (it != min_max_values.end()) {
                 MutableColumnPtr col = create_min_max_value_column(slot_desc, it->second, row_count);
                 ck->append_or_update_column(std::move(col), slot_desc->id());
                 continue;
@@ -191,7 +196,7 @@ Status HdfsScannerContext::append_or_update_not_existed_columns_to_chunk(ChunkPt
     return Status::OK();
 }
 
-void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value) {
+void FormatScanContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value) {
     if (!_count_slot.has_value()) return;
     auto* slot_desc = _count_slot.value();
     ChunkPtr& ck = (*chunk);
@@ -204,8 +209,8 @@ void HdfsScannerContext::append_or_update_count_column_to_chunk(ChunkPtr* chunk,
     ck->set_num_rows(output_rows);
 }
 
-MutableColumnPtr HdfsScannerContext::create_min_max_value_column(SlotDescriptor* slot_desc,
-                                                                 const TExprMinMaxValue& value, size_t row_count) {
+MutableColumnPtr FormatScanContext::create_min_max_value_column(SlotDescriptor* slot_desc,
+                                                                const TExprMinMaxValue& value, size_t row_count) {
     auto col = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
     std::vector<Datum> data;
     if (value.has_null) {
@@ -295,7 +300,7 @@ MutableColumnPtr HdfsScannerContext::create_min_max_value_column(SlotDescriptor*
     return col;
 }
 
-Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter) {
+Status FormatScanContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter) {
     size_t chunk_size = (*chunk)->num_rows();
     if (conjunct_ctxs_by_slot.size()) {
         filter->assign(chunk_size, 1);
@@ -314,8 +319,8 @@ Status HdfsScannerContext::evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Fi
     return Status::OK();
 }
 
-Status HdfsScannerContext::evaluate_all_predicates(ChunkPtr* chunk) {
-    SCOPED_RAW_TIMER(&format_scan_context.stats->expr_filter_ns);
+Status FormatScanContext::evaluate_all_predicates(ChunkPtr* chunk) {
+    SCOPED_RAW_TIMER(&stats->expr_filter_ns);
     size_t chunk_size = (*chunk)->num_rows();
     if (chunk_size > 0 && !conjunct_ctxs_by_slot.empty()) {
         Filter filter(chunk_size, 1);
@@ -337,30 +342,29 @@ Status HdfsScannerContext::evaluate_all_predicates(ChunkPtr* chunk) {
     return Status::OK();
 }
 
-StatusOr<bool> HdfsScannerContext::should_skip_by_evaluating_not_existed_slots() {
-    if (format_scan_context.not_existed_slots.size() == 0) return false;
+StatusOr<bool> FormatScanContext::should_skip_by_evaluating_not_existed_slots() {
+    if (not_existed_slots.size() == 0) return false;
 
     // build chunk for evaluation.
     ChunkPtr chunk = std::make_shared<Chunk>();
     RETURN_IF_ERROR(append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     // do evaluation.
     {
-        SCOPED_RAW_TIMER(&format_scan_context.stats->expr_filter_ns);
+        SCOPED_RAW_TIMER(&stats->expr_filter_ns);
         RETURN_IF_ERROR(ChunkPredicateEvaluator::eval_conjuncts(conjunct_ctxs_of_non_existed_slots, chunk.get()));
     }
     return !(chunk->has_rows());
 }
 
-void HdfsScannerContext::append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
-    append_or_update_column_to_chunk(chunk, row_count, format_scan_context.partition_columns,
-                                     format_scan_context.partition_values);
+void FormatScanContext::append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
+    append_or_update_column_to_chunk(chunk, row_count, partition_columns, partition_values);
 }
 
-void HdfsScannerContext::append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
+void FormatScanContext::append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count) {
     append_or_update_column_to_chunk(chunk, row_count, extended_columns, extended_values);
 }
 
-Status HdfsScannerContext::append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
+Status FormatScanContext::append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count) {
     RETURN_IF_ERROR(append_or_update_not_existed_columns_to_chunk(chunk, row_count));
     append_or_update_partition_column_to_chunk(chunk, row_count);
     append_or_update_extended_column_to_chunk(chunk, row_count);
@@ -370,9 +374,9 @@ Status HdfsScannerContext::append_side_columns_to_chunk(ChunkPtr* chunk, size_t 
     return Status::OK();
 }
 
-void HdfsScannerContext::append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
-                                                          const std::vector<FormatColumnInfo>& columns,
-                                                          const Columns& values) {
+void FormatScanContext::append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
+                                                         const std::vector<FormatColumnInfo>& columns,
+                                                         const Columns& values) {
     if (columns.size() == 0) return;
 
     ChunkPtr& ck = (*chunk);
@@ -396,7 +400,7 @@ void HdfsScannerContext::append_or_update_column_to_chunk(ChunkPtr* chunk, size_
     ck->set_num_rows(row_count);
 }
 
-bool HdfsScannerContext::can_use_dict_filter_on_slot(SlotDescriptor* slot) const {
+bool FormatScanContext::can_use_dict_filter_on_slot(SlotDescriptor* slot) const {
     if (!slot->type().is_string_type()) {
         return false;
     }
@@ -416,10 +420,8 @@ bool HdfsScannerContext::can_use_dict_filter_on_slot(SlotDescriptor* slot) const
     return true;
 }
 
-void HdfsScannerContext::merge_split_tasks() {
-    DCHECK(predicates.conjuncts_manager != nullptr);
-    merge_file_scan_split_tasks(&format_scan_context.split.split_tasks,
-                                format_scan_context.options.connector_max_split_size);
+void FormatScanContext::merge_split_tasks() {
+    merge_file_scan_split_tasks(&split.split_tasks, options.connector_max_split_size);
 }
 
 } // namespace starrocks

--- a/be/src/formats/scan_context.h
+++ b/be/src/formats/scan_context.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <boost/algorithm/string.hpp>
 #include <cstdint>
+#include <limits>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -26,15 +30,22 @@
 #include "column/column.h"
 #include "column/column_access_path.h"
 #include "column/global_dict/types.h"
+#include "column/vectorized_fwd.h"
 #include "common/global_types.h"
+#include "common/status.h"
+#include "common/statusor.h"
 #include "compute_env/query/file_scan_split_context.h"
 #include "formats/deletion_bitmap.h"
+#include "gen_cpp/Exprs_types.h"
 #include "runtime/descriptors.h"
 
 namespace starrocks {
 
 class ExprContext;
+class PredicateTree;
+class RuntimeScanRangePruner;
 struct FileScanSplitContext;
+class TIcebergSchema;
 
 struct SkipRowsContext {
     DeletionBitmapPtr deletion_bitmap;
@@ -213,12 +224,29 @@ struct FormatScanContext {
     FormatScannerStats* stats = nullptr;
     const FileScanSplitContext* split_context = nullptr;
 
+    // All conjunct contexts and slot metadata derived from the scan plan node.
+    FormatScannerConjuncts conjuncts;
+
+    // Mutable per-reader shallow copy of conjuncts.by_slot.  Missing-column
+    // discovery erases entries for columns absent from the file.
+    std::unordered_map<SlotId, std::vector<ExprContext*>> conjunct_ctxs_by_slot;
+
+    // Conjuncts whose referenced slots are missing from the data file.
+    std::vector<ExprContext*> conjunct_ctxs_of_non_existed_slots;
+
     // Materialized columns read from the data file.
     std::vector<FormatColumnInfo> materialized_columns;
+    std::unordered_map<SlotId, std::string> materialize_slot_default_values;
 
     // Partition column metadata and pre-evaluated constant values.
     std::vector<FormatColumnInfo> partition_columns;
     Columns partition_values;
+
+    // Extended column metadata (iceberg data_seq_num, etc.).
+    std::vector<FormatColumnInfo> extended_columns;
+
+    // Evaluated extended column values.
+    Columns extended_values;
 
     // Columns requested by the query but absent from the data file.
     std::vector<SlotDescriptor*> not_existed_slots;
@@ -234,11 +262,93 @@ struct FormatScanContext {
 
     std::string timezone;
 
+    // Scan-range data needed by format readers without depending on
+    // THdfsScanRange.
+    int64_t scan_range_offset = 0;
+    int64_t scan_range_length = std::numeric_limits<int64_t>::max();
+    int32_t scan_range_id = -1;
+    std::map<int32_t, TExprMinMaxValue> min_max_values;
+    std::map<int32_t, TExpr> extended_column_exprs;
+    std::optional<int64_t> first_row_id;
+    int64_t file_record_count = 0;
+    bool has_file_record_count = false;
+    bool is_first_split = false;
+
+    // Table/lake schema used by Parquet schema evolution matching.
+    const TIcebergSchema* lake_schema = nullptr;
+
+    // Non-owning predicate state built by upper scan orchestration.
+    const PredicateTree* predicate_tree = nullptr;
+    RuntimeScanRangePruner* runtime_filter_scan_range_pruner = nullptr;
+
+    // TODO: probably should be removed in later version.
+    std::atomic<int32_t>* lazy_column_coalesce_counter = nullptr;
+
     struct SplitState {
         std::vector<FileScanSplitContextPtr> split_tasks;
         bool has_split_tasks = false;
         size_t estimated_mem_usage_per_split_task = 0;
     } split;
+
+    bool is_lazy_materialization_slot(SlotId slot_id) const;
+    bool can_use_count_optimization() const;
+    bool has_count_column() const { return _count_slot.has_value(); }
+    bool can_use_min_max_optimization() const;
+
+    void update_with_none_existed_slot(SlotDescriptor* slot);
+    void update_return_count_columns();
+    void update_min_max_columns();
+
+    // update materialized column against data file.
+    // and to update not_existed slots and conjuncts.
+    // and to update `conjunct_ctxs_by_slot` field.
+    Status update_materialized_columns(const std::unordered_set<std::string>& names);
+
+    // "not existed columns" are materialized columns not found in file
+    // this usually happens when use changes schema. for example
+    // user create table with 3 fields A, B, C, and there is one file F1
+    // but user change schema and add one field like D.
+    // when user select(A, B, C, D), then D is the non-existed column in file F1.
+    Status append_or_update_not_existed_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // If there is no partition column in the chunk, append partition column to chunk,
+    // otherwise update partition column in chunk
+    void append_or_update_partition_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // Emit `output_rows` rows of `value` for the ___count___ column.
+    // Idempotent: if the chunk already has a ___count___ column, this is a no-op.
+    // Used by both the count-opt aggregated path (output_rows=1, value=row_count)
+    // and the per-row fallback (output_rows=row_count, value=1).
+    void append_or_update_count_column_to_chunk(ChunkPtr* chunk, size_t output_rows, int64_t value);
+    MutableColumnPtr create_min_max_value_column(SlotDescriptor* slot_desc, const TExprMinMaxValue& value,
+                                                 size_t row_count);
+    void append_or_update_extended_column_to_chunk(ChunkPtr* chunk, size_t row_count);
+
+    // Append all side columns (not-existed, partition, extended, count) at once.
+    // Safe when any category is empty — each sub-function is a no-op in that case.
+    Status append_side_columns_to_chunk(ChunkPtr* chunk, size_t row_count);
+    void append_or_update_column_to_chunk(ChunkPtr* chunk, size_t row_count,
+                                          const std::vector<FormatColumnInfo>& columns, const Columns& values);
+
+    // if we can skip this file by evaluating conjuncts of non-existed columns with default value.
+    StatusOr<bool> should_skip_by_evaluating_not_existed_slots();
+
+    // other helper functions.
+    bool can_use_dict_filter_on_slot(SlotDescriptor* slot) const;
+    Status evaluate_on_conjunct_ctxs_by_slot(ChunkPtr* chunk, Filter* filter);
+
+    // Evaluate both single-slot conjuncts (conjunct_ctxs_by_slot) and multi-slot
+    // conjuncts (conjuncts.scanner_ctxs) on the chunk in place.  Safe to call
+    // when either category is empty — each sub-step is a no-op.
+    Status evaluate_all_predicates(ChunkPtr* chunk);
+
+    void merge_split_tasks();
+
+private:
+    // ___count___ column for COUNT(*) optimization.
+    // Separated from not_existed_slots because it is an execution marker,
+    // not a schema-evolution missing column.
+    std::optional<SlotDescriptor*> _count_slot;
 };
 
 } // namespace starrocks

--- a/be/test/exec/hdfs_scanner/cache_select_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/cache_select_scanner_test.cpp
@@ -112,7 +112,7 @@ HdfsScannerContext* CacheSelectScannerTest::_create_ctx(const std::string& file,
     ctx->materialize_index_in_chunk = materialize_index_in_chunk;
     ctx->materialize_slots = mat_slots;
     ctx->partition_slots = part_slots;
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     return ctx;
 }
 

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -332,7 +332,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
     ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
-    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_OK(ctx.format_scan_context.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     ASSERT_EQ(1, chunk->num_rows());
     EXPECT_EQ("[42, NULL]", chunk->debug_row(0));
 }
@@ -346,7 +346,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
     ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
-    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_OK(ctx.format_scan_context.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     ASSERT_EQ(1, chunk->num_rows());
     EXPECT_EQ("['']", chunk->debug_row(0));
 }
@@ -360,7 +360,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
     ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
-    ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
+    ASSERT_OK(ctx.format_scan_context.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
     ASSERT_EQ(1, chunk->num_rows());
     EXPECT_EQ("['']", chunk->debug_row(0));
 }
@@ -373,7 +373,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonString) {
     ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
-    auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
+    auto status = ctx.format_scan_context.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
     EXPECT_FALSE(status.ok());
 }
 
@@ -390,7 +390,7 @@ TEST_F(HdfsScannerTest, TestCreateMinMaxValueColumnForDatetimeSupportsNegativeMi
     min_max_value.__set_min_int_value(-1);
     min_max_value.__set_max_int_value(0);
 
-    auto col = ctx.create_min_max_value_column(tuple_desc->slots()[0], min_max_value, 2);
+    auto col = ctx.format_scan_context.create_min_max_value_column(tuple_desc->slots()[0], min_max_value, 2);
     ASSERT_EQ(2, col->size());
     EXPECT_EQ("1969-12-31 23:59:59.999999", col->debug_item(0));
     EXPECT_EQ("1970-01-01 00:00:00", col->debug_item(1));
@@ -3327,7 +3327,7 @@ TEST_F(HdfsScannerTest, TestParquetIcebergCaseSensitive) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     _debug_rows_per_call = 10;
     Status status = scanner->init(_runtime_state, ctx);

--- a/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner/hdfs_scanner_test.cpp
@@ -149,7 +149,7 @@ HdfsScannerContext* HdfsScannerTest::_create_ctx(const std::string& file, THdfsS
     ctx->materialize_index_in_chunk = materialize_index_in_chunk;
     ctx->materialize_slots = mat_slots;
     ctx->partition_slots = part_slots;
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     return ctx;
 }
 
@@ -329,7 +329,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithDefaultValue) {
     HdfsScannerContext ctx;
     ctx.format_scan_context.not_existed_slots.push_back(tuple_desc->slots()[0]);
     ctx.format_scan_context.not_existed_slots.push_back(tuple_desc->slots()[1]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
+    ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "42");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -343,7 +343,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNullable) {
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
     ctx.format_scan_context.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -357,7 +357,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonNullable) {
     auto* tuple_desc = _create_tuple_desc_with_nullable(descs, false);
     HdfsScannerContext ctx;
     ctx.format_scan_context.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     ASSERT_OK(ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1));
@@ -370,7 +370,7 @@ TEST_F(HdfsScannerTest, TestFillNotExistedColumnWithEmptyDefaultNonString) {
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
     ctx.format_scan_context.not_existed_slots.push_back(tuple_desc->slots()[0]);
-    ctx.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
+    ctx.format_scan_context.materialize_slot_default_values.emplace(tuple_desc->slots()[0]->id(), "");
 
     ChunkPtr chunk = RuntimeChunkHelper::new_chunk(*tuple_desc, 0);
     auto status = ctx.append_or_update_not_existed_columns_to_chunk(&chunk, 1);
@@ -381,7 +381,7 @@ TEST_F(HdfsScannerTest, TestCreateMinMaxValueColumnForDatetimeSupportsNegativeMi
     SlotDesc descs[] = {{"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME)}, {""}};
     auto* tuple_desc = _create_tuple_desc(descs);
     HdfsScannerContext ctx;
-    ctx.is_first_split = true;
+    ctx.format_scan_context.is_first_split = true;
 
     TExprMinMaxValue min_max_value;
     min_max_value.__set_type(TExprNodeType::INT_LITERAL);
@@ -681,7 +681,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerCon
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::BIGINT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
     {
@@ -690,7 +690,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerCon
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::BIGINT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
     // PART_Y is always 20
@@ -701,7 +701,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerCon
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[1], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
     {
@@ -710,7 +710,7 @@ static void extend_mtypes_orc_min_max_conjuncts(ObjectPool* pool, HdfsScannerCon
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[1], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 }
 
@@ -760,8 +760,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterNoRows) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {20, 30, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, ctx, thres);
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     ctx->partition_expr_ctxs = std::move(part_ctxs);
     Status status = scanner->init(_runtime_state, ctx);
@@ -793,8 +793,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows1) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {2000, 5000, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, ctx, thres);
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     ctx->partition_expr_ctxs = std::move(part_ctxs);
     Status status = scanner->init(_runtime_state, ctx);
@@ -826,8 +826,8 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithMinMaxFilterRows2) {
     // id min/max = 2629/5212, PART_Y min/max=20/20
     std::vector<int> thres = {3000, 10000, 20, 20};
     extend_mtypes_orc_min_max_conjuncts(&_pool, ctx, thres);
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     ctx->partition_expr_ctxs = std::move(part_ctxs);
     Status status = scanner->init(_runtime_state, ctx);
@@ -894,10 +894,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[0], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
         std::cout << "equal expr = " << expr_ctx->root()->debug_string() << std::endl;
-        ctx->conjuncts.by_slot[0].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[0].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -980,10 +980,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDiffEncodeDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[1], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
         std::cout << "equal expr = " << expr_ctx->root()->debug_string() << std::endl;
-        ctx->conjuncts.by_slot[1].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[1].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1079,11 +1079,11 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDatetimeMinMaxFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::DATETIME,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());
@@ -1177,10 +1177,10 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithPaddingCharDictFilter) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, tuple_desc->slots()[0], TPrimitiveType::VARCHAR, lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
         std::cout << "less&eq expr = " << expr_ctx->root()->debug_string() << std::endl;
-        ctx->conjuncts.by_slot[0].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[0].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1300,11 +1300,11 @@ TEST_F(HdfsScannerTest, TestOrcDecodeMinMaxDateTime) {
             push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, min_max_tuple_desc->slots()[0],
                                         TPrimitiveType::DATETIME, lit_node);
             ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-            ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+            ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
         }
 
-        ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-        ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+        ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+        ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
         auto scanner = std::make_shared<HdfsOrcScanner>();
         Status status = scanner->init(_runtime_state, ctx);
@@ -1351,11 +1351,11 @@ TEST_F(HdfsScannerTest, TestOrcDecodeMinMaxWithTypeMismatch) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GT, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     auto scanner = std::make_shared<HdfsOrcScanner>();
     Status status = scanner->init(_runtime_state, ctx);
@@ -1497,10 +1497,10 @@ TEST_F(HdfsScannerTest, TestOrcLazyLoad) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, tuple_desc->slots()[0], TPrimitiveType::INT, lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
         std::cout << "greater&eq expr = " << expr_ctx->root()->debug_string() << std::endl;
-        ctx->conjuncts.by_slot[0].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[0].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1563,10 +1563,10 @@ TEST_F(HdfsScannerTest, TestOrcMapLazyLoadWithSubfieldSeleted) {
         TExprNode lit_node = create_int_literal_node(TPrimitiveType::INT, 3);
         push_binary_pred_texpr_node(nodes, TExprOpcode::EQ, tuple_desc->slots()[0], TPrimitiveType::INT, lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.by_slot[0].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[0].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1623,10 +1623,10 @@ TEST_F(HdfsScannerTest, TestOrcBooleanConjunct) {
         lit_node.__set_slot_ref(t_slot_ref);
         nodes.emplace_back(lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.by_slot[0].push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.by_slot[0].push_back(expr_ctx);
     }
 
-    for (auto& it : ctx->conjuncts.by_slot) {
+    for (auto& it : ctx->format_scan_context.conjuncts.by_slot) {
         ASSERT_OK(ExprExecutor::prepare(it.second, _runtime_state));
         ASSERT_OK(ExprExecutor::open(it.second, _runtime_state));
     }
@@ -1721,11 +1721,11 @@ TEST_F(HdfsScannerTest, TestOrcCompoundConjunct) {
 
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
         std::cout << expr_ctx->root()->debug_string() << std::endl;
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.scanner_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.scanner_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.scanner_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.scanner_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());
@@ -1910,12 +1910,12 @@ TEST_F(HdfsScannerTest, TestParqueTypeMismatchDecodeMinMax) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
     }
 
     ctx->min_max_tuple_desc = min_max_tuple_desc;
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());
@@ -2657,8 +2657,8 @@ TEST_F(HdfsScannerTest, TestParquetUppercaseFiledPredicate) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[1], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2666,12 +2666,12 @@ TEST_F(HdfsScannerTest, TestParquetUppercaseFiledPredicate) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[1], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());
@@ -2823,8 +2823,8 @@ TEST_F(HdfsScannerTest, TestParquetDictTwoPage) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2832,12 +2832,12 @@ TEST_F(HdfsScannerTest, TestParquetDictTwoPage) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::VARCHAR,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());
@@ -2868,9 +2868,9 @@ TEST_F(HdfsScannerTest, TestMinMaxFilterWhenContainsComplexTypes) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::GE, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.all_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.all_ctxs.push_back(expr_ctx);
     }
     {
         std::vector<TExprNode> nodes;
@@ -2878,13 +2878,13 @@ TEST_F(HdfsScannerTest, TestMinMaxFilterWhenContainsComplexTypes) {
         push_binary_pred_texpr_node(nodes, TExprOpcode::LE, min_max_tuple_desc->slots()[0], TPrimitiveType::INT,
                                     lit_node);
         ExprContext* expr_ctx = create_expr_context(&_pool, nodes);
-        ctx->conjuncts.min_max_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.scanner_ctxs.push_back(expr_ctx);
-        ctx->conjuncts.all_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.min_max_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.scanner_ctxs.push_back(expr_ctx);
+        ctx->format_scan_context.conjuncts.all_ctxs.push_back(expr_ctx);
     }
 
-    ASSERT_OK(ExprExecutor::prepare(ctx->conjuncts.min_max_ctxs, _runtime_state));
-    ASSERT_OK(ExprExecutor::open(ctx->conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::prepare(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctx->format_scan_context.conjuncts.min_max_ctxs, _runtime_state));
 
     Status status = scanner->init(_runtime_state, ctx);
     EXPECT_TRUE(status.ok());

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -51,9 +51,10 @@ protected:
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
 
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
         ctx->format_scan_context.timezone = "Asia/Shanghai";
         ctx->format_scan_context.stats = &g_hdfs_stats;
+        ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
         return ctx;
     }
 
@@ -95,7 +96,7 @@ protected:
         ctx->scan_range = (_create_scan_range(filepath));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (is_failed) {
             EXPECT_TRUE(!status.ok());
             return;

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -94,6 +94,8 @@ protected:
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
         ctx->scan_range = (_create_scan_range(filepath));
+        ctx->format_scan_context.scan_range_offset = ctx->scan_range->offset;
+        ctx->format_scan_context.scan_range_length = ctx->scan_range->length;
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -179,7 +179,7 @@ protected:
     static void _append_column_for_chunk(LogicalType column_type, ChunkPtr* chunk);
 
     THdfsScanRange* _create_scan_range(const std::string& file_path, size_t scan_length = 0);
-    static void _set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range);
+    static void _set_scan_range(HdfsScannerContext* ctx, const THdfsScanRange* scan_range);
 
     // Description: A simple parquet file that all columns are null
     // one row group
@@ -443,7 +443,7 @@ std::shared_ptr<FileReader> FileReaderTest::_create_file_reader(const std::strin
     return std::make_shared<FileReader>(chunk_size, file_ptr, file_size, _mock_datacache_options());
 }
 
-void FileReaderTest::_set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range) {
+void FileReaderTest::_set_scan_range(HdfsScannerContext* ctx, const THdfsScanRange* scan_range) {
     ctx->scan_range = scan_range;
     ctx->format_scan_context.scan_range_offset = scan_range->offset;
     ctx->format_scan_context.scan_range_length = scan_range->length;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -179,6 +179,7 @@ protected:
     static void _append_column_for_chunk(LogicalType column_type, ChunkPtr* chunk);
 
     THdfsScanRange* _create_scan_range(const std::string& file_path, size_t scan_length = 0);
+    static void _set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range);
 
     // Description: A simple parquet file that all columns are null
     // one row group
@@ -442,20 +443,26 @@ std::shared_ptr<FileReader> FileReaderTest::_create_file_reader(const std::strin
     return std::make_shared<FileReader>(chunk_size, file_ptr, file_size, _mock_datacache_options());
 }
 
+void FileReaderTest::_set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range) {
+    ctx->scan_range = scan_range;
+    ctx->format_scan_context.scan_range_offset = scan_range->offset;
+    ctx->format_scan_context.scan_range_length = scan_range->length;
+}
+
 HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_descs, const std::string& file_path,
                                                          int64_t scan_length) {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     _scanner_ctx.format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     _scanner_ctx.runtime_filter_collector = _rf_probe_collector;
-    _scanner_ctx.scan_range = _create_scan_range(file_path, scan_length);
+    _set_scan_range(&_scanner_ctx, _create_scan_range(file_path, scan_length));
     _scanner_ctx.format_scan_context.options.parquet_bloom_filter_enable = true;
     _scanner_ctx.format_scan_context.options.parquet_page_index_enable = true;
 
     ctx->format_scan_context.lazy_column_coalesce_counter =
             _scanner_ctx.format_scan_context.lazy_column_coalesce_counter;
     ctx->runtime_filter_collector = _scanner_ctx.runtime_filter_collector;
-    ctx->scan_range = _scanner_ctx.scan_range;
+    _set_scan_range(ctx, _scanner_ctx.scan_range);
     ctx->format_scan_context.options.parquet_bloom_filter_enable =
             _scanner_ctx.format_scan_context.options.parquet_bloom_filter_enable;
     ctx->format_scan_context.options.parquet_page_index_enable =

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -423,13 +423,15 @@ DataCacheOptions FileReaderTest::_mock_datacache_options() {
 HdfsScannerContext* FileReaderTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    _scanner_ctx.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_ctx.format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     _scanner_ctx.runtime_filter_collector = _rf_probe_collector;
 
-    ctx->lazy_column_coalesce_counter = _scanner_ctx.lazy_column_coalesce_counter;
+    ctx->format_scan_context.lazy_column_coalesce_counter =
+            _scanner_ctx.format_scan_context.lazy_column_coalesce_counter;
     ctx->runtime_filter_collector = _scanner_ctx.runtime_filter_collector;
     ctx->format_scan_context.timezone = "Asia/Shanghai";
     ctx->format_scan_context.stats = &g_hdfs_stats;
+    ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
     return ctx;
 }
 
@@ -444,13 +446,14 @@ HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_d
                                                          int64_t scan_length) {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    _scanner_ctx.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    _scanner_ctx.format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     _scanner_ctx.runtime_filter_collector = _rf_probe_collector;
     _scanner_ctx.scan_range = _create_scan_range(file_path, scan_length);
     _scanner_ctx.format_scan_context.options.parquet_bloom_filter_enable = true;
     _scanner_ctx.format_scan_context.options.parquet_page_index_enable = true;
 
-    ctx->lazy_column_coalesce_counter = _scanner_ctx.lazy_column_coalesce_counter;
+    ctx->format_scan_context.lazy_column_coalesce_counter =
+            _scanner_ctx.format_scan_context.lazy_column_coalesce_counter;
     ctx->runtime_filter_collector = _scanner_ctx.runtime_filter_collector;
     ctx->scan_range = _scanner_ctx.scan_range;
     ctx->format_scan_context.options.parquet_bloom_filter_enable =
@@ -460,6 +463,7 @@ HdfsScannerContext* FileReaderTest::_create_scan_context(Utils::SlotDesc* slot_d
 
     ctx->format_scan_context.timezone = "Asia/Shanghai";
     ctx->format_scan_context.stats = &g_hdfs_stats;
+    ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
@@ -535,7 +539,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_min_max() {
 
     // create min max conjuncts
     // c1 >= 1
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &_scanner_ctx.conjuncts.min_max_ctxs);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 1, &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
     return ctx;
 }
 
@@ -547,7 +551,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_filter_file() {
     auto* ctx = _create_scan_context(slot_descs, _file2_path, 850);
     // create conjuncts
     // c5 >= 1
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 4, 1, &ctx->conjunct_ctxs_by_slot[4]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 4, 1, &ctx->format_scan_context.conjunct_ctxs_by_slot[4]);
     return ctx;
 }
 
@@ -555,7 +559,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_dict_filter() {
     auto* ctx = _create_file2_base_context();
     // create conjuncts
     // c3 = "c"
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "c", &ctx->conjunct_ctxs_by_slot[2]);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "c", &ctx->format_scan_context.conjunct_ctxs_by_slot[2]);
     return ctx;
 }
 
@@ -563,7 +567,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_other_filter() {
     auto* ctx = _create_file2_base_context();
     // create conjuncts
     // c1 >= 4
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     return ctx;
 }
 
@@ -571,7 +575,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_skip_group() {
     auto* ctx = _create_file2_base_context();
     // create conjuncts
     // c1 > 10000
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 10000, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 10000, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     return ctx;
 }
 
@@ -586,14 +590,14 @@ HdfsScannerContext* FileReaderTest::_create_file3_base_context() {
 
 HdfsScannerContext* FileReaderTest::_create_context_for_multi_filter() {
     auto ctx = _create_file3_base_context();
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "c", &ctx->conjunct_ctxs_by_slot[2]);
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "c", &ctx->format_scan_context.conjunct_ctxs_by_slot[2]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     return ctx;
 }
 
 HdfsScannerContext* FileReaderTest::_create_context_for_late_materialization() {
     auto ctx = _create_file3_base_context();
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4080, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 4080, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     return ctx;
 }
 
@@ -622,7 +626,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_struct_column() {
     auto* ctx = _create_file4_base_context();
     // create conjuncts
     // c3 = "c", c2 is not in slots, so the slot_id=1
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "c", &ctx->conjunct_ctxs_by_slot[1]);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "c", &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
     return ctx;
 }
 
@@ -630,7 +634,7 @@ HdfsScannerContext* FileReaderTest::_create_context_for_upper_pred() {
     auto* ctx = _create_file4_base_context();
     // create conjuncts
     // B1 = "C", c2,c4 is not in slots, so the slot_id=2
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "C", &ctx->conjunct_ctxs_by_slot[2]);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 2, "C", &ctx->format_scan_context.conjunct_ctxs_by_slot[2]);
     return ctx;
 }
 
@@ -675,10 +679,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_in_filter(Slot
 
     std::vector<ExprContext*> expr_ctxs{expr_ctx};
     auto scan_ctx = _create_scan_context(slot_descs, _all_null_parquet_file);
-    scan_ctx->conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
+    scan_ctx->format_scan_context.conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->conjunct_ctxs_by_slot[slot_id], nullptr, tuple_desc,
-                                           _runtime_state, scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(scan_ctx->format_scan_context.conjunct_ctxs_by_slot[slot_id], nullptr,
+                                           tuple_desc, _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -692,10 +696,10 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_in_filter_norm
 
     std::vector<ExprContext*> expr_ctxs{expr_ctx};
     auto scan_ctx = _create_scan_context(slot_descs, _filter_row_group_path_1);
-    scan_ctx->conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
+    scan_ctx->format_scan_context.conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(scan_ctx->conjunct_ctxs_by_slot[slot_id], nullptr, tuple_desc,
-                                           _runtime_state, scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(scan_ctx->format_scan_context.conjunct_ctxs_by_slot[slot_id], nullptr,
+                                           tuple_desc, _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -708,11 +712,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_min_max_all_nu
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _all_null_parquet_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -725,11 +729,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -742,11 +746,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -759,11 +763,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -776,11 +780,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -793,11 +797,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -810,11 +814,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -827,11 +831,11 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_has_null_page_
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto scan_ctx = _create_scan_context(slot_descs, slot_descs, _has_null_page_file);
-    _scanner_ctx.conjuncts.min_max_ctxs.insert(_scanner_ctx.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(),
-                                               expr_ctxs.end());
+    _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.insert(
+            _scanner_ctx.format_scan_context.conjuncts.min_max_ctxs.end(), expr_ctxs.begin(), expr_ctxs.end());
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.conjuncts.min_max_ctxs, nullptr, tuple_desc, _runtime_state,
-                                           scan_ctx);
+    ParquetUTBase::setup_conjuncts_manager(_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs, nullptr, tuple_desc,
+                                           _runtime_state, scan_ctx);
 
     return scan_ctx;
 }
@@ -849,6 +853,7 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_filter_row_gro
     rf_list->unarrived_runtime_filters.emplace_back(rf_desc);
     rf_list->slot_descs.emplace_back(ctx->slot_descs[0]);
     ctx->predicates.runtime_filter_scan_range_pruner = std::make_unique<RuntimeScanRangePruner>(pred_parser, *rf_list);
+    ctx->format_scan_context.runtime_filter_scan_range_pruner = ctx->predicates.runtime_filter_scan_range_pruner.get();
 
     return ctx;
 }
@@ -884,8 +889,8 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_filter_row_gro
     ctx->format_scan_context.partition_values.emplace_back(partition_col5);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[slot_id], _rf_probe_collector, tuple_desc,
-                                           _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[slot_id], _rf_probe_collector,
+                                           tuple_desc, _runtime_state, ctx);
 
     return ctx;
 }
@@ -916,7 +921,7 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_filter_page_in
     RETURN_IF_ERROR(expr_ctx->open(_runtime_state));
     std::vector<ExprContext*> expr_ctxs{expr_ctx};
     auto ctx = _create_scan_context(slot_descs, _filter_row_group_path_1);
-    ctx->conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({slot_id, expr_ctxs});
 
     ColumnPtr partition_col3 = ColumnHelper::create_const_column<TYPE_INT>(5, 1);
     ColumnPtr partition_col4 = ColumnHelper::create_const_column<TYPE_INT>(2, 1);
@@ -929,8 +934,8 @@ StatusOr<HdfsScannerContext*> FileReaderTest::_create_context_for_filter_page_in
     ctx->format_scan_context.partition_values.emplace_back(partition_col5);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[slot_id], _rf_probe_collector, tuple_desc,
-                                           _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[slot_id], _rf_probe_collector,
+                                           tuple_desc, _runtime_state, ctx);
 
     return ctx;
 }
@@ -1185,7 +1190,7 @@ TEST_F(FileReaderTest, TestInit) {
 
     // init
     auto* ctx = _create_file1_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 }
 
@@ -1194,7 +1199,7 @@ TEST_F(FileReaderTest, TestGetNext) {
 
     // init
     auto* ctx = _create_file1_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1220,7 +1225,7 @@ TEST_F(FileReaderTest, TestGetNextWithSkipID) {
 
     // init
     auto* ctx = _create_file1_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1237,7 +1242,7 @@ TEST_F(FileReaderTest, TestGetNextPartition) {
     auto file_reader = _create_file_reader(_file1_path);
     // init
     auto* ctx = _create_context_for_partition();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1254,7 +1259,7 @@ TEST_F(FileReaderTest, TestGetNextEmpty) {
     auto file_reader = _create_file_reader(_file1_path);
     // init
     auto* ctx = _create_context_for_not_exist();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1271,7 +1276,7 @@ TEST_F(FileReaderTest, TestMinMaxConjunct) {
     auto file_reader = _create_file_reader(_file2_path);
     // init
     auto* ctx = _create_context_for_min_max();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1288,7 +1293,7 @@ TEST_F(FileReaderTest, TestFilterFile) {
     auto file_reader = _create_file_reader(_file2_path);
     // init
     auto* ctx = _create_context_for_filter_file();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // check file is filtered
@@ -1313,7 +1318,7 @@ TEST_F(FileReaderTest, TestGetNextDictFilter) {
                                                     shared_buffered_input_stream.get());
     // init
     auto* ctx = _create_context_for_dict_filter();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // c3 is dict filter column
@@ -1344,7 +1349,7 @@ TEST_F(FileReaderTest, TestGetNextOtherFilter) {
     auto file_reader = _create_file_reader(_file2_path);
     // init
     auto* ctx = _create_context_for_other_filter();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // c1 is other conjunct filter column
@@ -1366,7 +1371,7 @@ TEST_F(FileReaderTest, TestSkipRowGroup) {
     auto file_reader = _create_file_reader(_file2_path);
     // c1 > 10000
     auto* ctx = _create_context_for_skip_group();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1383,7 +1388,7 @@ TEST_F(FileReaderTest, TestMultiFilterWithMultiPage) {
     auto file_reader = _create_file_reader(_file3_path);
     // c3 = "c", c1 >= 4
     auto* ctx = _create_context_for_multi_filter();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // c3 is dict filter column
@@ -1419,7 +1424,7 @@ TEST_F(FileReaderTest, TestOtherFilterWithMultiPage) {
 
     // c1 >= 4080
     auto* ctx = _create_context_for_late_materialization();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // c0 is conjunct filter column
@@ -1443,7 +1448,7 @@ TEST_F(FileReaderTest, TestReadStructUpperColumns) {
 
     // init
     auto* ctx = _create_context_for_struct_column();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // c3 is dict filter column
@@ -1476,7 +1481,7 @@ TEST_F(FileReaderTest, TestReadWithUpperPred) {
 
     // init
     auto* ctx = _create_context_for_upper_pred();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1500,7 +1505,7 @@ TEST_F(FileReaderTest, TestReadArray2dColumn) {
 
     //init
     auto* ctx = _create_file5_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1529,7 +1534,7 @@ TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
 
     // init
     auto* ctx = _create_file6_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // get next
@@ -1549,7 +1554,7 @@ TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
 
     //init
     auto* ctx = _create_file_map_char_key_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1580,7 +1585,7 @@ TEST_F(FileReaderTest, TestReadMapColumn) {
 
     //init
     auto* ctx = _create_file_map_base_context();
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1633,7 +1638,7 @@ TEST_F(FileReaderTest, TestReadStruct) {
     auto ctx = _create_scan_context(slot_descs, _file4_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1681,7 +1686,7 @@ TEST_F(FileReaderTest, TestReadStructSubField) {
     auto ctx = _create_scan_context(slot_descs, _file4_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1734,7 +1739,7 @@ TEST_F(FileReaderTest, TestReadStructAbsentSubField) {
     auto ctx = _create_scan_context(slot_descs, _file4_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1765,7 +1770,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitive) {
     auto ctx = _create_scan_context(slot_descs, _file4_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1793,7 +1798,7 @@ TEST_F(FileReaderTest, TestReadStructCaseSensitiveError) {
     ctx->format_scan_context.options.case_sensitive = true;
     // --------------finish init context---------------
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
 
     auto chunk = std::make_shared<Chunk>();
@@ -1818,7 +1823,7 @@ TEST_F(FileReaderTest, TestReadStructNull) {
     auto ctx = _create_scan_context(slot_descs, _file_struct_null_path);
     // --------------finish init context---------------
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
 
     auto chunk = std::make_shared<Chunk>();
@@ -1846,7 +1851,7 @@ TEST_F(FileReaderTest, TestReadBinary) {
     auto ctx = _create_scan_context(slot_descs, _file_binary_path);
     // --------------finish init context---------------
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
 
     auto chunk = std::make_shared<Chunk>();
@@ -1866,7 +1871,7 @@ TEST_F(FileReaderTest, TestReadMapColumnWithPartialMaterialize) {
     //init
     auto* ctx = _create_file_map_partial_materialize_context();
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -1922,7 +1927,7 @@ TEST_F(FileReaderTest, TestReadNotNull) {
     auto ctx = _create_scan_context(slot_descs, _file_col_not_null_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     ASSERT_EQ(file_reader->row_group_size(), 1);
@@ -1957,7 +1962,7 @@ TEST_F(FileReaderTest, TestTwoNestedLevelArray) {
     auto ctx = _create_scan_context(slot_descs, filepath);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     ASSERT_EQ(file_reader->row_group_size(), 1);
@@ -2004,7 +2009,7 @@ TEST_F(FileReaderTest, TestReadMapNull) {
     auto ctx = _create_scan_context(slot_descs, _file_map_null_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     ASSERT_EQ(file_reader->row_group_size(), 1);
@@ -2044,7 +2049,7 @@ TEST_F(FileReaderTest, TestReadArrayMap) {
     auto ctx = _create_scan_context(slot_descs, _file_array_map_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
 
     // Illegal parquet files, not support it anymore
     ASSERT_FALSE(status.ok());
@@ -2099,7 +2104,7 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         auto ctx = _create_scan_context(slot_descs, filepath);
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         ASSERT_TRUE(status.ok());
 
         EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -2153,7 +2158,7 @@ TEST_F(FileReaderTest, TestStructArrayNull) {
         auto ctx = _create_scan_context(slot_descs, filepath);
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         ASSERT_TRUE(status.ok());
 
         EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -2223,7 +2228,7 @@ TEST_F(FileReaderTest, TestComplexTypeNotNull) {
     auto ctx = _create_scan_context(slot_descs, filepath);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -2273,7 +2278,7 @@ TEST_F(FileReaderTest, TestHudiMORTwoNestedLevelArray) {
     auto ctx = _create_scan_context(slot_descs, filepath);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
 
     // Illegal parquet files, will treat illegal column as null
     ASSERT_TRUE(status.ok()) << status.message();
@@ -2324,10 +2329,10 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutRequiredComplexType) {
 
     auto ctx = _create_scan_context(slot_descs, filepath);
 
-    _create_int_conjunct_ctxs(TExprOpcode::EQ, 0, 8000, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::EQ, 0, 8000, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 3);
@@ -2388,10 +2393,10 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutOptionalComplexType) {
     };
     auto ctx = _create_scan_context(slot_descs, filepath);
 
-    _create_int_conjunct_ctxs(TExprOpcode::EQ, 0, 8000, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::EQ, 0, 8000, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     EXPECT_EQ(file_reader->row_group_size(), 3);
@@ -2467,7 +2472,7 @@ TEST_F(FileReaderTest, CheckDictOutofBouds) {
 
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     auto chunk = std::make_shared<Chunk>();
@@ -2516,7 +2521,7 @@ TEST_F(FileReaderTest, CheckLargeParquetHeader) {
 
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     auto chunk = std::make_shared<Chunk>();
@@ -2599,10 +2604,11 @@ TEST_F(FileReaderTest, TestMinMaxForIcebergTable) {
     ParquetUTBase::append_int_conjunct(TExprOpcode::GE, 2, 5, &t_conjuncts);
     ParquetUTBase::append_int_conjunct(TExprOpcode::LE, 2, 5, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     ASSERT_EQ(file_reader->row_group_size(), 1);
@@ -2698,16 +2704,16 @@ TEST_F(FileReaderTest, TestRandomReadWith2PageSize) {
                     in_oprands.emplace(num);
                 }
                 auto ctx = _create_file_random_read_context(file_path, slot_descs);
-                ctx->conjunct_ctxs_by_slot[0].clear();
+                ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
                 std::vector<TExpr> t_conjuncts;
                 ParquetUTBase::create_in_predicate_int_conjunct_ctxs(TExprOpcode::FILTER_IN, 0, in_oprands,
                                                                      &t_conjuncts);
                 ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                    &ctx->conjunct_ctxs_by_slot[0]);
+                                                    &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
                 auto file_reader = _create_file_reader(file_path);
 
-                Status status = file_reader->init(ctx);
+                Status status = file_reader->init(&ctx->format_scan_context);
                 ASSERT_TRUE(status.ok());
                 size_t total_row_nums = 0;
                 while (!status.is_end_of_file()) {
@@ -2794,7 +2800,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
 
     std::vector<std::string> subfield_path({"c_struct", "c0"});
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
-                                                    &ctx->conjunct_ctxs_by_slot[3]);
+                                                    &ctx->format_scan_context.conjunct_ctxs_by_slot[3]);
     // Use a small chunk size so that the scan takes multiple rounds and some ranges are fully
     // filtered out by the dict filter (hit_count == 0), exercising the temporary dict-code
     // column restore path in ScalarColumnReader.
@@ -2806,7 +2812,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictFilter) {
     chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
     chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     const auto& dict_column_indices = file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
     const auto& dict_column_sub_field_paths =
@@ -2852,7 +2858,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictCodeNoLeakOnSkippedFill) {
 
     std::vector<std::string> subfield_path({"c_struct", "c0"});
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "55",
-                                                    &ctx->conjunct_ctxs_by_slot[3]);
+                                                    &ctx->format_scan_context.conjunct_ctxs_by_slot[3]);
 
     // Small chunk size: first chunk (rows 1-30) has no match for c_struct.c0='55',
     // so hit_count==0 and fill is skipped — this is what triggers the bug.
@@ -2864,7 +2870,7 @@ TEST_F(FileReaderTest, TestStructSubfieldDictCodeNoLeakOnSkippedFill) {
     chunk->append_column(ColumnHelper::create_column(type_struct, true), chunk->num_columns());
     chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // After a successful fill (get_next returns >0 rows), verify that the inner
@@ -2932,7 +2938,7 @@ TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 3, type_struct_in_struct, subfield_path, "0",
                                                     &expr_ctxs);
     auto ctx = _create_file_struct_in_struct_read_context(struct_in_struct_file_path);
-    ctx->conjunct_ctxs_by_slot.insert({3, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({3, expr_ctxs});
 
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
                                                     std::filesystem::file_size(struct_in_struct_file_path));
@@ -2970,13 +2976,14 @@ TEST_F(FileReaderTest, TestStructSubfieldZonemap) {
     };
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     // RETURN_IF_ERROR(ExprExecutor::clone_if_not_exists(state, &_pool, _min_max_conjunct_ctxs, &cloned_conjunct_ctxs));
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[3], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[3], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
     for (const auto& [cid, col_children] : ctx->predicates.predicate_tree.root().col_children_map()) {
         for (const auto& child : col_children) {
             std::cout << "pred type" << child.col_pred()->type() << "pred" << child.debug_string() << std::endl;
         }
     }
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(1, file_reader->_group_reader_param.stats->filtered_row_groups);
     EXPECT_EQ(0, file_reader->_row_group_readers.size());
@@ -2995,7 +3002,7 @@ TEST_F(FileReaderTest, bloom_filter_reader) {
     Utils::SlotDesc slot_descs[] = {{"c0", TYPE_BOOLEAN_DESC}, {"c1", TYPE_VARCHAR_DESC}, {""}};
     auto file_reader = _create_file_reader(bloom_filter_file);
     auto ctx = _create_file_random_read_context(bloom_filter_file, slot_descs);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     //auto chunk = std::make_shared<Chunk>();
     // chunk->append_column(ColumnHelper::create_column(TYPE_BOOLEAN_DESC, true), chunk->num_columns());
     // chunk->append_column(ColumnHelper::create_column(TYPE_VARCHAR_DESC, true), chunk->num_columns());
@@ -3063,15 +3070,17 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_not_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "2", &ctx->conjunct_ctxs_by_slot[1]);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "2", &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
     // --------------finish init context---------------
     auto file_reader = _create_file_reader(file);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
 
     EXPECT_EQ(file_reader->row_group_size(), 0);
 }
@@ -3090,15 +3099,17 @@ TEST_F(FileReaderTest, bloom_filter_reader_test_hit) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::EQ, 1, "A", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "A", &ctx->conjunct_ctxs_by_slot[1]);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 1, "A", &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
     // --------------finish init context---------------
     auto file_reader = _create_file_reader(file);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
 }
@@ -3109,7 +3120,7 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop) {
             "./be/test/formats/parquet/test_data/bloom_filter_by_parquet_hadoop_1.parquet";
     auto file_reader = _create_file_reader(bloom_filter_file);
     auto ctx = _create_file_random_read_context(bloom_filter_file, slot_descs);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
     std::vector<char> buffer;
@@ -3156,15 +3167,17 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop2) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(bloom_filter_file);
     //auto ctx = _create_file_random_read_context(bloom_filter_file, slot_descs);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
     std::vector<char> buffer;
@@ -3239,15 +3252,17 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop3) {
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 1, 6, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->conjunct_ctxs_by_slot[1]);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    _create_int_conjunct_ctxs(TExprOpcode::EQ, 1, 6, &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(bloom_filter_file);
     //auto ctx = _create_file_random_read_context(bloom_filter_file, slot_descs);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
     std::vector<char> buffer;
@@ -3385,20 +3400,21 @@ TEST_F(FileReaderTest, read_parquet_bloom_filter_by_parquet_hadoop4) {
     ASSERT_OK(ExprExecutor::open(expr_ctxs, _runtime_state));
 
     auto ctx = _create_scan_context(slot_descs, slot_descs, bloom_filter_file);
-    ctx->conjunct_ctxs_by_slot.insert({3, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({3, expr_ctxs});
 
     // ParquetUTBase::append_int_conjunct(TExprOpcode::EQ, 2, 6, &t_conjuncts);
     // ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     // _create_int_conjunct_ctxs(TExprOpcode::EQ, 2, 6, &ctx->conjunct_ctxs_by_slot[1]);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[3], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[3], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
     for (const auto& [cid, col_children] : ctx->predicates.predicate_tree.root().col_children_map()) {
         for (const auto& child : col_children) {
             std::cout << "pred type" << child.col_pred()->type() << "pred" << child.debug_string() << std::endl;
         }
     }
     auto file_reader = _create_file_reader(bloom_filter_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     ASSERT_TRUE(file_reader->get_file_metadata() != nullptr);
     EXPECT_EQ(file_reader->row_group_size(), 0);
@@ -3431,11 +3447,11 @@ TEST_F(FileReaderTest, TestReadRoundByRound) {
 
     auto ctx = _create_file_random_read_context(file_path, slot_descs);
     // c0 >= 100
-    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 100, &ctx->conjunct_ctxs_by_slot[0]);
+    _create_int_conjunct_ctxs(TExprOpcode::GE, 0, 100, &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     // c1 <= 100
-    _create_int_conjunct_ctxs(TExprOpcode::LE, 1, 100, &ctx->conjunct_ctxs_by_slot[1]);
+    _create_int_conjunct_ctxs(TExprOpcode::LE, 1, 100, &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
     auto file_reader = _create_file_reader(file_path);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -3458,7 +3474,7 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
 
     std::vector<std::string> subfield_path({"c_struct", "c0"});
     _create_struct_subfield_predicate_conjunct_ctxs(TExprOpcode::EQ, 1, type_struct_in_struct, subfield_path, "55",
-                                                    &ctx->conjunct_ctxs_by_slot[1]);
+                                                    &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
     auto file_reader = _create_file_reader(struct_in_struct_file_path);
 
     auto chunk = std::make_shared<Chunk>();
@@ -3466,7 +3482,7 @@ TEST_F(FileReaderTest, TestStructSubfieldNoDecodeNotOutput) {
                          chunk->num_columns());
     chunk->append_column(ColumnHelper::create_column(type_struct_in_struct, true), chunk->num_columns());
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     const auto& dict_column_indices = file_reader->_row_group_readers[0]->_column_materializer->dict_column_indices();
     const auto& dict_column_sub_field_paths =
@@ -3504,7 +3520,7 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
     auto* ctx = _create_file1_base_context();
     ctx->format_scan_context.stats->footer_cache_read_count = 0;
     ctx->format_scan_context.stats->footer_cache_write_count = 0;
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     ASSERT_EQ(ctx->format_scan_context.stats->footer_cache_read_count, 0);
     ASSERT_EQ(ctx->format_scan_context.stats->footer_cache_write_count, 1);
 
@@ -3539,7 +3555,7 @@ TEST_F(FileReaderTest, TestTime) {
     auto ctx = _create_scan_context(slot_descs, filepath);
     // --------------finish init context---------------
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     EXPECT_EQ(file_reader->row_group_size(), 1);
 
     auto chunk = std::make_shared<Chunk>();
@@ -3584,13 +3600,14 @@ TEST_F(FileReaderTest, TestReadNoMinMaxStatistics) {
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_string_conjunct(TExprOpcode::GE, 0, "2", &t_conjuncts);
     ParquetUTBase::append_string_conjunct(TExprOpcode::LE, 0, "2", &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &_scanner_ctx.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &_scanner_ctx.format_scan_context.conjuncts.min_max_ctxs);
 
     // attr_value = '2'
-    _create_string_conjunct_ctxs(TExprOpcode::EQ, 0, "2", &ctx->conjunct_ctxs_by_slot[0]);
+    _create_string_conjunct_ctxs(TExprOpcode::EQ, 0, "2", &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
     // --------------finish init context---------------
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
 
@@ -3613,9 +3630,10 @@ TEST_F(FileReaderTest, TestIsNotNullStatistics) {
     auto* ctx = _create_file1_base_context();
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::is_null_pred(0, false, &t_conjuncts);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     EXPECT_EQ(file_reader->row_group_size(), 0);
 }
 
@@ -3633,13 +3651,14 @@ TEST_F(FileReaderTest, TestIsNullStatistics) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(small_page_file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({0, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({0, expr_ctxs});
 
     // setup OlapScanConjunctsManager
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[0], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[0], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(file_reader->row_group_size(), 0);
 }
@@ -3652,7 +3671,7 @@ TEST_F(FileReaderTest, TestMapKeyIsStruct) {
             {"c0", TYPE_INT_DESC}, {"c1", TYPE_INT_DESC}, {"c2", TYPE_VARCHAR_DESC}, {"c3", TYPE_INT_ARRAY_DESC}, {""},
     };
     auto ctx = _create_file_random_read_context(filename, slot_descs);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_FALSE(status.ok());
     ASSERT_EQ("Map keys must be primitive type.", status.message());
 }
@@ -3673,13 +3692,14 @@ TEST_F(FileReaderTest, TestInFilterStatitics) {
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
 
     auto ctx = _create_file_random_read_context(multi_rg_file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({0, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({0, expr_ctxs});
 
     // setup OlapScanConjunctsManager
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[0], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[0], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     EXPECT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3693,7 +3713,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_1) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, false);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
 }
 
@@ -3707,7 +3727,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_2) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 2, 5, false);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3721,7 +3741,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_3) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 7, 10, false);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 0);
 }
 
@@ -3735,7 +3755,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_4) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, true);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3750,7 +3770,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_5) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, true);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3765,7 +3785,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_6) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, true);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 0);
 }
 
@@ -3780,7 +3800,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_7) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, true);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3795,7 +3815,7 @@ TEST_F(FileReaderTest, filter_row_group_with_rf_8) {
     auto ret = _create_context_for_filter_row_group_1(slot_id, 5, 6, true);
     ASSERT_TRUE(ret.ok());
 
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 2);
 }
 
@@ -3805,7 +3825,7 @@ TEST_F(FileReaderTest, update_rf_and_filter_row_group) {
     auto file_reader = _create_file_reader(_filter_row_group_path_3);
     ASSIGN_OR_ASSERT_FAIL(auto* ctx, _create_context_for_filter_row_group_update_rf(slot_id));
 
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 3);
 
     ChunkPtr chunk = _create_int_chunk();
@@ -3837,7 +3857,7 @@ TEST_F(FileReaderTest, filter_page_index_with_rf_has_null) {
     auto ret = _create_context_for_filter_page_index(slot_id, 92880, 92990, true);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([0,20000), [40000,40100))");
@@ -3850,7 +3870,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_bool) {
     auto ret = _create_context_for_has_null_page_bool(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([0,90000))");
@@ -3863,7 +3883,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_smallint) {
     auto ret = _create_context_for_has_null_page_smallint(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3876,7 +3896,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_int) {
     auto ret = _create_context_for_has_null_page_int32(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3889,7 +3909,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_bigint) {
     auto ret = _create_context_for_has_null_page_int64(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3902,7 +3922,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_datetime) {
     auto ret = _create_context_for_has_null_page_datetime(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3915,7 +3935,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_string) {
     auto ret = _create_context_for_has_null_page_string(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3928,7 +3948,7 @@ TEST_F(FileReaderTest, all_type_has_null_page_decimal) {
     auto ret = _create_context_for_has_null_page_decimal(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
     const auto& group_readers = file_reader->group_readers();
     ASSERT_EQ(group_readers[0]->get_range().to_string(), "([40000,90000))");
@@ -3941,7 +3961,7 @@ TEST_F(FileReaderTest, all_null_group_in_filter) {
     auto ret = _create_context_for_in_filter(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 0);
 }
 
@@ -3952,7 +3972,7 @@ TEST_F(FileReaderTest, in_filter_filter_one_group) {
     auto ret = _create_context_for_in_filter_normal(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 1);
 }
 
@@ -3963,7 +3983,7 @@ TEST_F(FileReaderTest, min_max_filter_all_null_group) {
     auto ret = _create_context_for_min_max_all_null_group(slot_id);
 
     ASSERT_TRUE(ret.ok());
-    ASSERT_OK(file_reader->init(ret.value()));
+    ASSERT_OK(file_reader->init(&ret.value()->format_scan_context));
     ASSERT_EQ(file_reader->row_group_size(), 0);
 }
 
@@ -3994,13 +4014,14 @@ TEST_F(FileReaderTest, low_card_reader) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(small_page_file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({1, expr_ctxs});
     ctx->format_scan_context.global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(small_page_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -4049,14 +4070,15 @@ TEST_F(FileReaderTest, low_card_reader_filter_group) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(small_page_file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({1, expr_ctxs});
     ctx->format_scan_context.global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     tuple_desc->decoded_slots()[1]->type().type = TYPE_VARCHAR;
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(small_page_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(file_reader->row_group_size(), 0);
 }
@@ -4087,7 +4109,7 @@ TEST_F(FileReaderTest, low_card_reader_dict_not_match) {
     ctx->format_scan_context.global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(small_page_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     while (!status.is_end_of_file()) {
         chunk->reset();
@@ -4127,7 +4149,7 @@ TEST_F(FileReaderTest, no_matched_reader) {
     ctx->format_scan_context.global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_EQ("Global dictionary not match", status.code_as_string());
 }
 
@@ -4162,7 +4184,7 @@ TEST_F(FileReaderTest, low_rows_reader) {
     ctx->format_scan_context.global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
 
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
@@ -4232,7 +4254,7 @@ TEST_F(FileReaderTest, low_rows_reader_empty_not_null_not_match) {
     ctx->format_scan_context.global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
 
     ASSERT_TRUE(status.ok());
     chunk->reset();
@@ -4272,7 +4294,7 @@ TEST_F(FileReaderTest, low_rows_reader_empty_not_null) {
     ctx->format_scan_context.global_dictmaps = &dict_map;
 
     auto file_reader = _create_file_reader(low_rows_file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
 
     ASSERT_TRUE(status.ok());
 
@@ -4336,14 +4358,15 @@ TEST_F(FileReaderTest, low_rows_reader_filter_group) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({1, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({1, expr_ctxs});
     ctx->format_scan_context.global_dictmaps = &dict_map;
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     tuple_desc->decoded_slots()[1]->type().type = TYPE_VARCHAR;
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[1], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[1], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     EXPECT_EQ(file_reader->row_group_size(), 0);
 }
@@ -4369,13 +4392,14 @@ TEST_F(FileReaderTest, plain_string_decode) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(file, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({0, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({0, expr_ctxs});
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[0], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[0], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(file);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -4413,13 +4437,14 @@ TEST_F(FileReaderTest, test_filter_to_dict_decoder) {
     std::vector<ExprContext*> expr_ctxs;
     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &expr_ctxs);
     auto ctx = _create_file_random_read_context(file_path, slot_descs);
-    ctx->conjunct_ctxs_by_slot.insert({0, expr_ctxs});
+    ctx->format_scan_context.conjunct_ctxs_by_slot.insert({0, expr_ctxs});
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    ParquetUTBase::setup_conjuncts_manager(ctx->conjunct_ctxs_by_slot[0], nullptr, tuple_desc, _runtime_state, ctx);
+    ParquetUTBase::setup_conjuncts_manager(ctx->format_scan_context.conjunct_ctxs_by_slot[0], nullptr, tuple_desc,
+                                           _runtime_state, ctx);
 
     auto file_reader = _create_file_reader(file_path);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -4445,7 +4470,7 @@ TEST_F(FileReaderTest, test_data_page_v2) {
     Utils::SlotDesc slot_descs[] = {{"id", TYPE_INT_DESC}, {"name", TYPE_VARCHAR_DESC}, {""}};
     auto ctx = _create_file_random_read_context(file_path, slot_descs);
     auto file_reader = _create_file_reader(file_path);
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
     size_t total_row_nums = 0;
     while (!status.is_end_of_file()) {
@@ -4477,7 +4502,7 @@ TEST_F(FileReaderTest, test_read_variant) {
     auto ctx = _create_scan_context(slot_descs, variant_file_path);
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << "Failed to initialize file reader: " << status.message();
 
     EXPECT_EQ(file_reader->row_group_size(), 1);
@@ -4553,7 +4578,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding) {
     Utils::SlotDesc slot_descs[] = {{"data", variant_type}, {""}};
     auto ctx = _create_scan_context(slot_descs, variant_file_path);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
     ASSERT_EQ(file_reader->row_group_size(), 1);
 
@@ -4627,7 +4652,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_access_paths) {
     column_access_paths.emplace_back(std::move(root));
     ctx->format_scan_context.column_access_paths = std::move(column_access_paths);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     auto chunk = std::make_shared<Chunk>();
@@ -4688,7 +4713,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_access_paths_nulls) {
     column_access_paths.emplace_back(std::move(root));
     ctx->format_scan_context.column_access_paths = std::move(column_access_paths);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     auto chunk = std::make_shared<Chunk>();
@@ -4742,7 +4767,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_prefix_access_path) {
     column_access_paths.emplace_back(std::move(root));
     ctx->format_scan_context.column_access_paths = std::move(column_access_paths);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     auto chunk = std::make_shared<Chunk>();
@@ -4789,7 +4814,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_prefix_access_path_null_
     column_access_paths.emplace_back(std::move(root));
     _scanner_ctx.format_scan_context.column_access_paths = std::move(column_access_paths);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     auto chunk = std::make_shared<Chunk>();
@@ -4834,7 +4859,7 @@ TEST_F(FileReaderTest, test_read_variant_shredding_with_whole_column_access_path
     column_access_paths.emplace_back(std::move(root_or).value());
     _scanner_ctx.format_scan_context.column_access_paths = std::move(column_access_paths);
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok()) << status.message();
 
     auto chunk = std::make_shared<Chunk>();

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2598,7 +2598,7 @@ TEST_F(FileReaderTest, TestMinMaxForIcebergTable) {
             {""},
     };
     auto ctx = _create_scan_context(slot_descs, min_max_slots, filepath);
-    _scanner_ctx.table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     std::vector<TExpr> t_conjuncts;
     ParquetUTBase::append_int_conjunct(TExprOpcode::GE, 2, 5, &t_conjuncts);
@@ -3533,7 +3533,7 @@ TEST_F(FileReaderTest, TestReadFooterCache) {
     ctx2->format_scan_context.stats->footer_cache_read_count = 0;
     ctx2->format_scan_context.stats->footer_cache_write_count = 0;
     ctx2->format_scan_context.stats->footer_cache_read_ns = 0;
-    Status status2 = file_reader2->init(ctx2);
+    Status status2 = file_reader2->init(&ctx2->format_scan_context);
     ASSERT_TRUE(status2.ok());
     ASSERT_EQ(ctx2->format_scan_context.stats->footer_cache_read_count, 1);
     ASSERT_EQ(ctx2->format_scan_context.stats->footer_cache_write_count, 0);

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -51,7 +51,7 @@ protected:
         auto ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
 
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
 
         std::vector<Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {
@@ -67,6 +67,7 @@ protected:
         ctx->scan_range = (_create_scan_range(_file_path, file_size));
         ctx->format_scan_context.timezone = "Asia/Shanghai";
         ctx->format_scan_context.stats = &g_hdfs_stats;
+        ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
 
         return ctx;
     }
@@ -121,7 +122,7 @@ protected:
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), file_size);
 
-        auto st = file_reader->init(ctx);
+        auto st = file_reader->init(&ctx->format_scan_context);
         if (!st.ok()) {
             std::cout << st.to_string() << std::endl;
             return nullptr;

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -65,6 +65,8 @@ protected:
         parquet::Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
         ctx->scan_range = (_create_scan_range(_file_path, file_size));
+        ctx->format_scan_context.scan_range_offset = ctx->scan_range->offset;
+        ctx->format_scan_context.scan_range_length = ctx->scan_range->length;
         ctx->format_scan_context.timezone = "Asia/Shanghai";
         ctx->format_scan_context.stats = &g_hdfs_stats;
         ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;

--- a/be/test/formats/parquet/group_reader_test.cpp
+++ b/be/test/formats/parquet/group_reader_test.cpp
@@ -25,7 +25,6 @@
 #include "column/variant_encoder.h"
 #include "common/config_exec_fwd.h"
 #include "compute_env/global_dict/parser.h"
-#include "exec/hdfs_scanner/hdfs_scanner_context.h"
 #include "exprs/chunk_predicate_evaluator.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
@@ -804,8 +803,6 @@ GroupReaderParam* GroupReaderTest::_create_group_reader_param() {
 
     // Minimal scanner context so GroupReader::_create_column_readers() can
     // dereference scanner_ctx->options without crashing.
-    auto* scanner_ctx = _pool.add(new HdfsScannerContext());
-
     auto* param = _pool.add(new GroupReaderParam());
     param->read_cols.emplace_back(c1);
     param->read_cols.emplace_back(c2);
@@ -814,7 +811,8 @@ GroupReaderParam* GroupReaderTest::_create_group_reader_param() {
     param->read_cols.emplace_back(c5);
     param->read_cols.emplace_back(c6);
     param->stats = &g_hdfs_stats;
-    param->scanner_ctx = scanner_ctx;
+    param->scan_ctx = _pool.add(new FormatScanContext());
+    param->scan_ctx->stats = param->stats;
     return param;
 }
 
@@ -2199,7 +2197,6 @@ TEST_F(GroupReaderTest, StructColumnReaderFillDstColumnMissingSubfieldReader) {
 
 TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNullScanRange) {
     auto* param = _create_group_reader_param();
-    param->scan_range = nullptr;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2219,7 +2216,6 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNullScanRange) {
 
 TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNoExtendedColumns) {
     auto* param = _create_group_reader_param();
-    param->scan_range = _pool.add(new THdfsScanRange());
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2239,9 +2235,7 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueNoExtendedColumns) {
 
 TEST_F(GroupReaderTest, TestGetExtendedBigIntValueSlotNotFound) {
     auto* param = _create_group_reader_param();
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(std::map<int32_t, TExpr>());
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = std::map<int32_t, TExpr>();
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2267,9 +2261,7 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueEmptyNodes) {
     expr.nodes = std::vector<TExprNode>();
     extended_columns[0] = expr;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(extended_columns);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = extended_columns;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2297,9 +2289,7 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueWrongNodeType) {
     expr.nodes.push_back(node);
     extended_columns[0] = expr;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(extended_columns);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = extended_columns;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2330,9 +2320,7 @@ TEST_F(GroupReaderTest, TestGetExtendedBigIntValueSuccess) {
     expr.nodes.push_back(node);
     extended_columns[0] = expr;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(extended_columns);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = extended_columns;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2376,8 +2364,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, formats::kIcebergRowIdColumnName,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2399,8 +2387,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdReturnsNull) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, formats::kIcebergRowIdColumnName,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2433,8 +2421,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdUsesRowPositionForLooku
             new SlotDescriptor(101, "_scan_range_id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(scan_range_id_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2443,9 +2431,6 @@ TEST_F(GroupReaderTest, TestIcebergRowIdWithoutFirstRowIdUsesRowPositionForLooku
     param->file = file;
     param->file_metadata = file_meta;
     param->chunk_size = config::vector_chunk_size;
-
-    auto* scan_range = new THdfsScanRange();
-    param->scan_range = _pool.add(scan_range);
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 7);
@@ -2470,8 +2455,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdSecondRowGroupUsesFileLevelFirstRowId) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, formats::kIcebergRowIdColumnName,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2481,9 +2466,7 @@ TEST_F(GroupReaderTest, TestIcebergRowIdSecondRowGroupUsesFileLevelFirstRowId) {
     param->file_metadata = file_meta;
     param->chunk_size = config::vector_chunk_size;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_first_row_id(1000);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->first_row_id = 1000;
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto group_reader = std::make_unique<GroupReader>(*param, 0, skip_rows_ctx, 7);
@@ -2504,8 +2487,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, formats::kIcebergLastUpdatedSequenceNumberColumnName,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2517,9 +2500,7 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberColumnReaderCreation
     expr.nodes.push_back(node);
     extended_columns[101] = expr;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(extended_columns);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = extended_columns;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2541,8 +2522,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberNullExtendedLiteralR
     auto* seq_slot = _pool.add(new SlotDescriptor(101, formats::kIcebergLastUpdatedSequenceNumberColumnName,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     std::map<int32_t, TExpr> extended_columns;
     TExpr expr;
@@ -2551,9 +2532,7 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSequenceNumberNullExtendedLiteralR
     expr.nodes.push_back(node);
     extended_columns[101] = expr;
 
-    auto* scan_range = new THdfsScanRange();
-    scan_range->__set_extended_columns(extended_columns);
-    param->scan_range = _pool.add(scan_range);
+    param->scan_ctx->extended_column_exprs = extended_columns;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -2730,7 +2709,7 @@ TEST_F(GroupReaderTest, TestCreateReservedIcebergColumnReaderFound) {
     param->file = file;
     param->file_metadata = file_meta;
     param->chunk_size = config::vector_chunk_size;
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->timezone = "UTC";
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
@@ -2752,8 +2731,8 @@ TEST_F(GroupReaderTest, TestIcebergRowIdPhysicalColumnReaderCreation) {
     auto* row_id_slot = _pool.add(new SlotDescriptor(100, formats::kIcebergRowIdColumnName,
                                                      TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     // Build file metadata WITH physical _row_id column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -2781,8 +2760,8 @@ TEST_F(GroupReaderTest, TestIcebergLastUpdatedSeqNumPhysicalColumnReaderCreation
     auto* seq_slot = _pool.add(new SlotDescriptor(101, formats::kIcebergLastUpdatedSequenceNumberColumnName,
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(seq_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     // Build file metadata WITH physical _last_updated_sequence_number column (field_id matches)
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -3258,8 +3237,8 @@ TEST_F(GroupReaderTest, TestIcebergBothPhysicalColumnsCreation) {
                                                   TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT)));
     reserved_slots->push_back(row_id_slot);
     reserved_slots->push_back(seq_slot);
-    param->scanner_ctx->format_scan_context.reserved_field_slots = *_pool.add(reserved_slots);
-    param->scanner_ctx->format_scan_context.timezone = "UTC";
+    param->scan_ctx->reserved_field_slots = *_pool.add(reserved_slots);
+    param->scan_ctx->timezone = "UTC";
 
     // Build file metadata with both physical iceberg columns
     auto t_file_meta = build_t_filemeta_with_iceberg_columns(&_pool, param,
@@ -4053,7 +4032,7 @@ TEST_F(GroupReaderTest, GetVariantShreddedHintsReturnsEmptyOnInvalidAccessPath) 
     field_arr->children().emplace_back(std::move(offset_0));
     root->children().emplace_back(std::move(field_arr));
     column_access_paths.emplace_back(std::move(root));
-    param->scanner_ctx->format_scan_context.column_access_paths = std::move(column_access_paths);
+    param->scan_ctx->column_access_paths = std::move(column_access_paths);
 
     SkipRowsContextPtr skip_rows_ctx = std::make_shared<SkipRowsContext>();
     auto* group_reader = _pool.add(new GroupReader(*param, 0, skip_rows_ctx, 0));
@@ -5082,7 +5061,7 @@ TEST_F(GroupReaderTest, LateMaterializeSkipRowsCompoundConjunctFiltersAll) {
     std::vector<ExprContext*> scanner_ctxs;
     ASSERT_OK(
             create_int_eq_conjunct_ctxs(&_pool, &runtime_state, param->read_cols[0].slot_id(), 999999, &scanner_ctxs));
-    param->scanner_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
+    param->scan_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
 
     FileMetaData* file_meta;
     ASSERT_OK(_create_filemeta(&file_meta, param));
@@ -5109,8 +5088,8 @@ TEST_F(GroupReaderTest, LateMaterializeSkipRowsCompoundConjunctFiltersAll) {
 // Covers: HdfsScannerContext::evaluate_all_predicates evaluates
 //         scanner_ctxs when slot-by-slot conjuncts are absent.
 TEST_F(GroupReaderTest, EvaluateAllPredicatesWithScannerCtxs) {
-    auto* scanner_ctx = _pool.add(new HdfsScannerContext());
-    scanner_ctx->format_scan_context.stats = &g_hdfs_stats;
+    auto* scan_ctx = _pool.add(new FormatScanContext());
+    scan_ctx->stats = &g_hdfs_stats;
 
     // Create a BIGINT chunk with 2 rows: values [0, 1].
     auto chunk = std::make_shared<Chunk>();
@@ -5124,9 +5103,9 @@ TEST_F(GroupReaderTest, EvaluateAllPredicatesWithScannerCtxs) {
     RuntimeState runtime_state{TQueryGlobals()};
     std::vector<ExprContext*> scanner_ctxs;
     ASSERT_OK(create_bigint_eq_conjunct_ctxs(&_pool, &runtime_state, slot_id, 0, &scanner_ctxs));
-    scanner_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
+    scan_ctx->conjuncts.scanner_ctxs = scanner_ctxs;
 
-    ASSERT_OK(scanner_ctx->evaluate_all_predicates(&chunk));
+    ASSERT_OK(scan_ctx->evaluate_all_predicates(&chunk));
     EXPECT_EQ(1u, chunk->num_rows());
     EXPECT_EQ(0, chunk->get_column_by_slot_id(slot_id)->get(0).get_int64());
 

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -158,7 +158,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -241,7 +241,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -304,7 +304,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -373,7 +373,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -450,7 +450,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -596,7 +596,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id, field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -661,7 +661,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -706,7 +706,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_id};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor rename_id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -762,7 +762,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
 
     std::vector<TIcebergSchemaField> fields{field_col, field_id};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -820,7 +820,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
 
     std::vector<TIcebergSchemaField> fields{field_col};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -880,7 +880,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
 
     std::vector<TIcebergSchemaField> fields{field_c1, field_c2, field_c3};
     schema.__set_fields(fields);
-    ctx->table_specific.iceberg_schema = &schema;
+    ctx->format_scan_context.lake_schema = &schema;
 
     TypeDescriptor rename_c1 = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
     TypeDescriptor c2 = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
@@ -942,7 +942,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        ctx->table_specific.iceberg_schema = &schema;
+        ctx->format_scan_context.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1001,7 +1001,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_col};
         schema.__set_fields(fields);
-        ctx->table_specific.iceberg_schema = &schema;
+        ctx->format_scan_context.lake_schema = &schema;
 
         TypeDescriptor col = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
 
@@ -1159,7 +1159,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col};
         schema.__set_fields(fields);
-        ctx->table_specific.iceberg_schema = &schema;
+        ctx->format_scan_context.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 
@@ -1237,7 +1237,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
 
         std::vector<TIcebergSchemaField> fields{field_id, field_col_map};
         schema.__set_fields(fields);
-        ctx->table_specific.iceberg_schema = &schema;
+        ctx->format_scan_context.lake_schema = &schema;
 
         TypeDescriptor id = TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT);
 

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -113,6 +113,12 @@ protected:
         return scan_range;
     }
 
+    void _set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range) {
+        ctx->scan_range = scan_range;
+        ctx->format_scan_context.scan_range_offset = scan_range->offset;
+        ctx->format_scan_context.scan_range_length = scan_range->length;
+    }
+
     std::shared_ptr<RowDescriptor> _row_desc = nullptr;
     RuntimeState* _runtime_state = nullptr;
     ObjectPool _pool;
@@ -181,7 +187,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     TupleDescriptor* tuple_desc = parquet::Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -253,7 +259,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -321,7 +327,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -390,7 +396,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -473,7 +479,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -621,7 +627,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -670,7 +676,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -715,7 +721,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -776,7 +782,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -832,7 +838,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+    _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -891,7 +897,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(no_field_id_file_path));
+    _set_scan_range(ctx, _create_scan_range(no_field_id_file_path));
     // --------------finish init context---------------
 
     Status status = file_reader->init(&ctx->format_scan_context);
@@ -956,7 +962,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1013,7 +1019,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1057,7 +1063,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1097,7 +1103,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1179,7 +1185,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(struct_map_array_file_path));
+        _set_scan_range(ctx, _create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1255,7 +1261,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(struct_map_array_file_path));
+        _set_scan_range(ctx, _create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1303,7 +1309,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);
@@ -1346,7 +1352,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
         ctx->slot_descs = tuple_desc->slots();
-        ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
+        _set_scan_range(ctx, _create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
         Status status = file_reader->init(&ctx->format_scan_context);

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -97,9 +97,10 @@ protected:
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
         auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+        ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
 
         ctx->format_scan_context.stats = &g_hdfs_stats;
+        ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
         return ctx;
     }
 
@@ -183,7 +184,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -255,7 +256,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructEvolutionPadNull) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -323,7 +324,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -392,7 +393,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -475,7 +476,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -614,7 +615,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 
         // create min max conjuncts
         // new_conjunct is null
-        _create_null_conjunct_ctxs(2, &ctx->conjuncts.min_max_ctxs, _pool, _runtime_state);
+        _create_null_conjunct_ctxs(2, &ctx->format_scan_context.conjuncts.min_max_ctxs, _pool, _runtime_state);
     }
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
@@ -623,7 +624,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -672,7 +673,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -717,7 +718,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -778,7 +779,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -834,7 +835,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
     ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -893,7 +894,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     ctx->scan_range = (_create_scan_range(no_field_id_file_path));
     // --------------finish init context---------------
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     if (!status.ok()) {
         std::cout << status.message() << std::endl;
     }
@@ -958,7 +959,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1015,7 +1016,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1059,7 +1060,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1099,7 +1100,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestHiveWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1181,7 +1182,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1257,7 +1258,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(struct_map_array_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1305,7 +1306,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }
@@ -1348,7 +1349,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestInnerStructWithoutSubfield) {
         ctx->scan_range = (_create_scan_range(add_struct_subfield_file_path));
         // --------------finish init context---------------
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         if (!status.ok()) {
             std::cout << status.message() << std::endl;
         }

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -53,6 +53,7 @@ protected:
     HdfsScannerContext* _create_scan_context();
 
     THdfsScanRange* _create_scan_range(const std::string& file_path, size_t scan_length = 0);
+    static void _set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range);
 
     HdfsScannerContext* _create_file_random_read_context(const std::string& file_path);
     HdfsScannerContext* _create_file_only_c0_context(const std::string& file_path);
@@ -82,6 +83,12 @@ HdfsScannerContext* PageIndexTest::_create_scan_context() {
     return ctx;
 }
 
+void PageIndexTest::_set_scan_range(HdfsScannerContext* ctx, THdfsScanRange* scan_range) {
+    ctx->scan_range = scan_range;
+    ctx->format_scan_context.scan_range_offset = scan_range->offset;
+    ctx->format_scan_context.scan_range_length = scan_range->length;
+}
+
 HdfsScannerContext* PageIndexTest::_create_file_random_read_context(const std::string& file_path) {
     auto ctx = _create_scan_context();
 
@@ -100,7 +107,7 @@ HdfsScannerContext* PageIndexTest::_create_file_random_read_context(const std::s
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _set_scan_range(ctx, _create_scan_range(file_path));
 
     return ctx;
 }
@@ -116,7 +123,7 @@ HdfsScannerContext* PageIndexTest::_create_file_only_c0_context(const std::strin
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _set_scan_range(ctx, _create_scan_range(file_path));
 
     return ctx;
 }
@@ -134,7 +141,7 @@ HdfsScannerContext* PageIndexTest::_create_file_c0_c1_c2_context(const std::stri
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = (_create_scan_range(file_path));
+    _set_scan_range(ctx, _create_scan_range(file_path));
 
     return ctx;
 }
@@ -678,7 +685,7 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
     ctx->slot_descs = tuple_desc->slots();
-    ctx->scan_range = _create_scan_range(file_path);
+    _set_scan_range(ctx, _create_scan_range(file_path));
     ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
     std::vector<TExpr> t_conjuncts;

--- a/be/test/formats/parquet/page_index_test.cpp
+++ b/be/test/formats/parquet/page_index_test.cpp
@@ -72,12 +72,13 @@ std::unique_ptr<RandomAccessFile> PageIndexTest::_create_file(const std::string&
 HdfsScannerContext* PageIndexTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
-    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    ctx->format_scan_context.lazy_column_coalesce_counter = lazy_column_coalesce_counter;
 
     ctx->format_scan_context.timezone = "Asia/Shanghai";
     ctx->format_scan_context.stats = &g_hdfs_stats;
     ctx->format_scan_context.options.parquet_page_index_enable = true;
     ctx->format_scan_context.options.parquet_bloom_filter_enable = true;
+    ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
     return ctx;
 }
 
@@ -241,8 +242,8 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
 
                 auto ctx = _create_file_random_read_context(file_path);
                 auto file = _create_file(file_path);
-                ctx->conjunct_ctxs_by_slot[0].clear();
-                ctx->conjuncts.min_max_ctxs.clear();
+                ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
+                ctx->format_scan_context.conjuncts.min_max_ctxs.clear();
 
                 if (single_flag) {
                     Utils::SlotDesc min_max_slots[] = {
@@ -256,13 +257,13 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, oprands[1], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &ctx->conjuncts.min_max_ctxs);
+                                                        &ctx->format_scan_context.conjuncts.min_max_ctxs);
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &ctx->conjunct_ctxs_by_slot[0]);
+                                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
                     expected_row = std::max(oprands[1] - oprands[0] - 1, 0);
                 } else {
-                    ctx->conjunct_ctxs_by_slot[1].clear();
+                    ctx->format_scan_context.conjunct_ctxs_by_slot[1].clear();
                     Utils::SlotDesc min_max_slots[] = {
                             {"c0", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 0},
                             {"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT), 1},
@@ -277,15 +278,15 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                     ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 1, oprands[3], &t_conjuncts);
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
-                                                        &ctx->conjuncts.min_max_ctxs);
+                                                        &ctx->format_scan_context.conjuncts.min_max_ctxs);
 
                     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0], t_conjuncts[1]};
                     std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[2], t_conjuncts[3]};
 
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0,
-                                                        &ctx->conjunct_ctxs_by_slot[0]);
+                                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
                     ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1,
-                                                        &ctx->conjunct_ctxs_by_slot[1]);
+                                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
 
                     int low_bound = std::max(oprands[0], index == 0 ? 20001 - oprands[3] : 100001 - oprands[3]);
                     int up_bound = std::min(oprands[1], index == 0 ? 20001 - oprands[2] : 100001 - oprands[2]);
@@ -297,7 +298,7 @@ TEST_F(PageIndexTest, TestRandomReadWith2PageSize) {
                 auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
                                                                 std::filesystem::file_size(file_path));
 
-                Status status = file_reader->init(ctx);
+                Status status = file_reader->init(&ctx->format_scan_context);
                 ASSERT_TRUE(status.ok());
                 size_t total_row_nums = 0;
                 while (!status.is_end_of_file()) {
@@ -367,16 +368,18 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
 
         auto ctx = _create_file_only_c0_context(small_page_file);
         auto file = _create_file(small_page_file);
-        ctx->conjunct_ctxs_by_slot[0].clear();
-        ctx->conjuncts.min_max_ctxs.clear();
+        ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
+        ctx->format_scan_context.conjuncts.min_max_ctxs.clear();
         ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 0, 5500, &t_conjuncts);
         ParquetUTBase::append_int_conjunct(TExprOpcode::LT, 0, 7500, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjuncts.min_max_ctxs);
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                            &ctx->format_scan_context.conjuncts.min_max_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                            &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
         // tuple desc
         Utils::SlotDesc slot_descs[] = {
@@ -385,10 +388,10 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : ctx->conjuncts.min_max_ctxs) {
+        for (auto* expr : ctx->format_scan_context.conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
-        for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
+        for (auto* expr : ctx->format_scan_context.conjunct_ctxs_by_slot[0]) {
             all_conjuncts.push_back(expr);
         }
         ParquetUTBase::setup_conjuncts_manager(all_conjuncts, nullptr, tuple_desc, _runtime_state, ctx);
@@ -396,7 +399,7 @@ TEST_F(PageIndexTest, TestCollectIORangeWithPageIndex) {
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
                                                         std::filesystem::file_size(small_page_file));
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         ASSERT_TRUE(status.ok());
 
         // two row groups, but one is filtered.
@@ -458,9 +461,9 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
 
         auto ctx = _create_file_c0_c1_c2_context(small_page_file);
         auto file = _create_file(small_page_file);
-        ctx->conjunct_ctxs_by_slot[0].clear();
-        ctx->conjunct_ctxs_by_slot[1].clear();
-        ctx->conjuncts.min_max_ctxs.clear();
+        ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
+        ctx->format_scan_context.conjunct_ctxs_by_slot[1].clear();
+        ctx->format_scan_context.conjuncts.min_max_ctxs.clear();
         ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
         std::vector<TExpr> t_conjuncts;
@@ -469,13 +472,16 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         // c1: 20000->1, c1 > 5000
         ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 5000, &t_conjuncts);
 
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjuncts.min_max_ctxs);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                            &ctx->format_scan_context.conjuncts.min_max_ctxs);
 
         std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0,
+                                            &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
         std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[1]};
-        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1, &ctx->conjunct_ctxs_by_slot[1]);
+        ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1,
+                                            &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
 
         // tuple desc
         Utils::SlotDesc slot_descs[] = {
@@ -486,13 +492,13 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
         };
         TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
         std::vector<ExprContext*> all_conjuncts{};
-        for (auto* expr : ctx->conjuncts.min_max_ctxs) {
+        for (auto* expr : ctx->format_scan_context.conjuncts.min_max_ctxs) {
             all_conjuncts.push_back(expr);
         }
-        for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
+        for (auto* expr : ctx->format_scan_context.conjunct_ctxs_by_slot[0]) {
             all_conjuncts.push_back(expr);
         }
-        for (auto* expr : ctx->conjunct_ctxs_by_slot[1]) {
+        for (auto* expr : ctx->format_scan_context.conjunct_ctxs_by_slot[1]) {
             all_conjuncts.push_back(expr);
         }
         ParquetUTBase::setup_conjuncts_manager(all_conjuncts, nullptr, tuple_desc, _runtime_state, ctx);
@@ -503,7 +509,7 @@ TEST_F(PageIndexTest, TestTwoColumnIntersectPageIndex) {
                                                         std::filesystem::file_size(small_page_file), DataCacheOptions(),
                                                         shared_buffer.get());
 
-        Status status = file_reader->init(ctx);
+        Status status = file_reader->init(&ctx->format_scan_context);
         ASSERT_TRUE(status.ok());
 
         // two row groups.
@@ -565,9 +571,9 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
 
     auto ctx = _create_file_c0_c1_c2_context(small_page_file);
     auto file = _create_file(small_page_file);
-    ctx->conjunct_ctxs_by_slot[0].clear();
-    ctx->conjunct_ctxs_by_slot[1].clear();
-    ctx->conjuncts.min_max_ctxs.clear();
+    ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
+    ctx->format_scan_context.conjunct_ctxs_by_slot[1].clear();
+    ctx->format_scan_context.conjuncts.min_max_ctxs.clear();
     ctx->min_max_tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, min_max_slots);
 
     std::vector<TExpr> t_conjuncts;
@@ -576,13 +582,16 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
     // c1: 20000->1, c1 > 500
     ParquetUTBase::append_int_conjunct(TExprOpcode::GT, 1, 500, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &ctx->format_scan_context.conjuncts.min_max_ctxs);
 
     std::vector<TExpr> t_conjuncts_slot0{t_conjuncts[0]};
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0, &ctx->conjunct_ctxs_by_slot[0]);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot0,
+                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
     std::vector<TExpr> t_conjuncts_slot1{t_conjuncts[1]};
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1, &ctx->conjunct_ctxs_by_slot[1]);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts_slot1,
+                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[1]);
 
     auto shared_buffer = std::make_shared<SharedBufferedInputStream>(file->stream(), small_page_file,
                                                                      std::filesystem::file_size(small_page_file));
@@ -590,7 +599,7 @@ TEST_F(PageIndexTest, TestPageIndexNoPageFiltered) {
                                                     std::filesystem::file_size(small_page_file), DataCacheOptions(),
                                                     shared_buffer.get());
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     // two row groups.
@@ -663,8 +672,8 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
 
     auto ctx = _create_scan_context();
     auto file = _create_file(file_path);
-    ctx->conjunct_ctxs_by_slot[0].clear();
-    ctx->conjuncts.min_max_ctxs.clear();
+    ctx->format_scan_context.conjunct_ctxs_by_slot[0].clear();
+    ctx->format_scan_context.conjuncts.min_max_ctxs.clear();
 
     TupleDescriptor* tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
     Utils::make_column_info_vector(tuple_desc, &ctx->format_scan_context.materialized_columns);
@@ -677,14 +686,16 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
     // this triggers page index filtering
     ParquetUTBase::append_bigint_conjunct(TExprOpcode::GT, 0, 2, &t_conjuncts);
 
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjuncts.min_max_ctxs);
-    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts, &ctx->conjunct_ctxs_by_slot[0]);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &ctx->format_scan_context.conjuncts.min_max_ctxs);
+    ParquetUTBase::create_conjunct_ctxs(&_pool, _runtime_state, &t_conjuncts,
+                                        &ctx->format_scan_context.conjunct_ctxs_by_slot[0]);
 
     std::vector<ExprContext*> all_conjuncts;
-    for (auto* expr : ctx->conjuncts.min_max_ctxs) {
+    for (auto* expr : ctx->format_scan_context.conjuncts.min_max_ctxs) {
         all_conjuncts.push_back(expr);
     }
-    for (auto* expr : ctx->conjunct_ctxs_by_slot[0]) {
+    for (auto* expr : ctx->format_scan_context.conjunct_ctxs_by_slot[0]) {
         all_conjuncts.push_back(expr);
     }
     ParquetUTBase::setup_conjuncts_manager(all_conjuncts, nullptr, tuple_desc, _runtime_state, ctx);
@@ -695,7 +706,7 @@ TEST_F(PageIndexTest, TestEmptyNullCountsInColumnIndex) {
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path),
                                          DataCacheOptions(), shared_buffer.get());
 
-    Status status = file_reader->init(ctx);
+    Status status = file_reader->init(&ctx->format_scan_context);
     ASSERT_TRUE(status.ok());
 
     size_t total_row_nums = 0;

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -18,6 +18,7 @@
 
 #include "common/config_exec_fwd.h"
 #include "common/status.h"
+#include "exec/hdfs_scanner/hdfs_scanner_context.h"
 #include "formats/parquet/file_reader.h"
 #include "fs/fs.h"
 #include "runtime/descriptor_helper.h"

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -31,9 +31,10 @@ public:
               _file(_create_file(filepath)),
               _scanner_ctx(std::make_shared<HdfsScannerContext>()),
               _scan_stats(std::make_shared<FormatScannerStats>()) {
-        _scanner_ctx->lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        _scanner_ctx->format_scan_context.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
         _scanner_ctx->format_scan_context.timezone = "Asia/Shanghai";
         _scanner_ctx->format_scan_context.stats = _scan_stats.get();
+        _scanner_ctx->format_scan_context.predicate_tree = &_scanner_ctx->predicates.predicate_tree;
     }
     ~ParquetCLIReader() {
         _file_reader = nullptr;
@@ -56,10 +57,11 @@ public:
         FormatScannerStats stats;
         ctx.format_scan_context.stats = &stats;
         ctx.scan_range = scan_range;
-        ctx.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx.format_scan_context.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx.format_scan_context.predicate_tree = &ctx.predicates.predicate_tree;
         std::shared_ptr<FileReader> reader =
                 std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
-        RETURN_IF_ERROR(reader->init(&ctx));
+        RETURN_IF_ERROR(reader->init(&ctx.format_scan_context));
         file_metadata = reader->get_file_metadata();
 
         std::vector<SlotDesc> slot_descs;
@@ -83,7 +85,7 @@ public:
         _scanner_ctx->scan_range = scan_range;
 
         _file_reader = std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
-        RETURN_IF_ERROR(_file_reader->init(_scanner_ctx.get()));
+        RETURN_IF_ERROR(_file_reader->init(&_scanner_ctx->format_scan_context));
 
         return Status::OK();
     }

--- a/be/test/formats/parquet/parquet_cli_reader.h
+++ b/be/test/formats/parquet/parquet_cli_reader.h
@@ -58,6 +58,8 @@ public:
         FormatScannerStats stats;
         ctx.format_scan_context.stats = &stats;
         ctx.scan_range = scan_range;
+        ctx.format_scan_context.scan_range_offset = scan_range->offset;
+        ctx.format_scan_context.scan_range_length = scan_range->length;
         ctx.format_scan_context.lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
         ctx.format_scan_context.predicate_tree = &ctx.predicates.predicate_tree;
         std::shared_ptr<FileReader> reader =
@@ -84,6 +86,8 @@ public:
         _scanner_ctx->slot_descs = tuple_desc->slots();
         _make_column_info_vector(tuple_desc, &_scanner_ctx->format_scan_context.materialized_columns);
         _scanner_ctx->scan_range = scan_range;
+        _scanner_ctx->format_scan_context.scan_range_offset = scan_range->offset;
+        _scanner_ctx->format_scan_context.scan_range_length = scan_range->length;
 
         _file_reader = std::make_shared<FileReader>(4096, _file.get(), std::filesystem::file_size(_filepath));
         RETURN_IF_ERROR(_file_reader->init(&_scanner_ctx->format_scan_context));

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -69,6 +69,8 @@ protected:
         ctx->slot_descs = tuple_desc->slots();
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
         ctx->scan_range = _create_scan_range(_file_path, file_size);
+        ctx->format_scan_context.scan_range_offset = ctx->scan_range->offset;
+        ctx->format_scan_context.scan_range_length = ctx->scan_range->length;
         ctx->format_scan_context.timezone = "Asia/Shanghai";
         ctx->format_scan_context.stats = &_hdfs_stats;
         ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;

--- a/be/test/formats/parquet/parquet_file_writer_test.cpp
+++ b/be/test/formats/parquet/parquet_file_writer_test.cpp
@@ -54,7 +54,7 @@ protected:
     HdfsScannerContext* _create_scan_context(const std::vector<TypeDescriptor>& type_descs) {
         auto ctx = _pool.add(new HdfsScannerContext());
 
-        ctx->lazy_column_coalesce_counter = &_lazy_column_coalesce_counter;
+        ctx->format_scan_context.lazy_column_coalesce_counter = &_lazy_column_coalesce_counter;
 
         std::vector<parquet::Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {
@@ -71,6 +71,7 @@ protected:
         ctx->scan_range = _create_scan_range(_file_path, file_size);
         ctx->format_scan_context.timezone = "Asia/Shanghai";
         ctx->format_scan_context.stats = &_hdfs_stats;
+        ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
 
         return ctx;
     }
@@ -99,7 +100,7 @@ protected:
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
         auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
 
-        auto st = file_reader->init(ctx);
+        auto st = file_reader->init(&ctx->format_scan_context);
         if (!st.ok()) {
             std::cout << st.to_string() << std::endl;
             return nullptr;
@@ -825,7 +826,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsAllRequired) {
     ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     // Check that both columns are REQUIRED
@@ -866,7 +867,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsMixed) {
     ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     // Check first column is OPTIONAL
@@ -909,7 +910,7 @@ TEST_F(ParquetFileWriterTest, TestNullableColumnsDefaultEmpty) {
     ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     // Check that both columns are OPTIONAL (default behavior)
@@ -953,7 +954,7 @@ TEST_F(ParquetFileWriterTest, TestIcebergDeleteFileColumnsRequired) {
     ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     // Verify column names
@@ -1021,7 +1022,7 @@ TEST_F(ParquetFileWriterTest, TestColumnDictionaryEncodingDisabled) {
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
 
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     ASSERT_EQ(file_metadata->t_metadata().row_groups.size(), 1);
@@ -1103,7 +1104,7 @@ TEST_F(ParquetFileWriterTest, TestColumnDictionaryEncodingEnabledByDefault) {
     auto file_reader = std::make_shared<parquet::FileReader>(config::vector_chunk_size, file.get(), file_size);
 
     auto ctx = _create_scan_context(type_descs);
-    ASSERT_OK(file_reader->init(ctx));
+    ASSERT_OK(file_reader->init(&ctx->format_scan_context));
     auto file_metadata = file_reader->get_file_metadata();
 
     const auto& row_group = file_metadata->t_metadata().row_groups[0];

--- a/be/test/formats/parquet/parquet_footer_test.cpp
+++ b/be/test/formats/parquet/parquet_footer_test.cpp
@@ -41,7 +41,7 @@ TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
     auto file = open_file(file_path);
     auto file_reader =
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
-    Status status = file_reader->init(&ctx);
+    Status status = file_reader->init(&ctx.format_scan_context);
     EXPECT_TRUE(status.is_corruption());
 }
 
@@ -50,7 +50,7 @@ TEST_F(ParquetFooterTest, TestEncryptedParquetFile) {
     auto file = open_file(file_path);
     auto file_reader =
             std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
-    Status status = file_reader->init(&ctx);
+    Status status = file_reader->init(&ctx.format_scan_context);
     EXPECT_TRUE(status.is_not_supported());
 }
 

--- a/be/test/formats/parquet/parquet_ut_base.cpp
+++ b/be/test/formats/parquet/parquet_ut_base.cpp
@@ -275,6 +275,8 @@ void ParquetUTBase::setup_conjuncts_manager(std::vector<ExprContext*>& conjuncts
                                                                     ctx->predicates.predicate_free_pool);
     ASSERT_TRUE(st.ok());
     ctx->predicates.predicate_tree = st.value();
+    ctx->format_scan_context.predicate_tree = &ctx->predicates.predicate_tree;
+    ctx->format_scan_context.runtime_filter_scan_range_pruner = ctx->predicates.runtime_filter_scan_range_pruner.get();
 }
 
 void ParquetUTBase::create_dictmapping_string_conjunct(TExprOpcode::type opcode, starrocks::SlotId slot_id,

--- a/be/test/formats/parquet/parquet_ut_base.h
+++ b/be/test/formats/parquet/parquet_ut_base.h
@@ -19,6 +19,7 @@
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
+#include "exec/hdfs_scanner/hdfs_scanner_context.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "gen_cpp/Exprs_types.h"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
