### PR TITLE
[Feature] Add file-level Bernoulli sampling for Iceberg external table SAMPLE ANALYZE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2660,6 +2660,31 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int statistic_sample_collect_partition_size = 300;
 
+    /**
+     * Hard cap on how many rows a single round of Iceberg external-table file-level sample
+     * ANALYZE (see ExternalSampleStatisticsCollectJob) is allowed to scan. The sample ratio for
+     * a round is derived as min(1.0, rowsThisRound / row_count), so this bounds wall-clock cost
+     * per round regardless of table size, instead of relying on a percentage alone (a fixed
+     * percentage of an astronomically large table can still mean scanning far too many rows).
+     * Row count (not file count) is used as the budget unit because Iceberg files can vary
+     * wildly in row count, so a file-count-based cap gives a much less predictable row volume
+     * per round than a row-count-based one -- row counts are just as cheap to read from
+     * manifest-list summary fields as file counts are. Successive rounds within one ANALYZE
+     * execution double the per-round row target (up to statistic_external_sample_max_rounds
+     * rounds) so accuracy improves without waiting on the external auto-collect schedule
+     * between rounds.
+     */
+    @ConfField(mutable = true)
+    public static long statistic_external_sample_max_rows_per_round = 2000000;
+
+    /**
+     * Max number of progressive rounds run inside a single Iceberg file-sample ANALYZE execution.
+     * Bounds total per-job cost to roughly (2^rounds - 1) * statistic_external_sample_max_rows_per_round
+     * rows in the worst case, even if the table never reaches full coverage.
+     */
+    @ConfField(mutable = true)
+    public static int statistic_external_sample_max_rounds = 4;
+
     @ConfField(mutable = true, comment = "The change ratio threshold for triggering statistics collection. " +
             "For INSERT OVERWRITE: deltaRatio = |targetRows - sourceRows| / (sourceRows + 1). " +
             "For first load: deltaRatio = loadRows / (totalRows + 1). " +

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2685,6 +2685,17 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int statistic_external_sample_max_rounds = 4;
 
+    /**
+     * If every column's NDV (distinct value estimate) changes by less than this fraction between
+     * two consecutive sample rounds, the round loop stops early instead of continuing to
+     * statistic_external_sample_max_rounds -- low-cardinality columns (e.g. booleans/enums)
+     * converge within the first round or two, so later rounds would just re-scan more rows for no
+     * accuracy gain. High-cardinality columns whose NDV keeps growing round over round are left to
+     * run the full round budget.
+     */
+    @ConfField(mutable = true)
+    public static double statistic_external_sample_ndv_convergence_threshold = 0.05;
+
     @ConfField(mutable = true, comment = "The change ratio threshold for triggering statistics collection. " +
             "For INSERT OVERWRITE: deltaRatio = |targetRows - sourceRows| / (sourceRows + 1). " +
             "For first load: deltaRatio = loadRows / (totalRows + 1). " +

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -35,6 +35,11 @@ public class GetRemoteFilesParams {
     private boolean enableColumnStats = false;
     private Optional<Boolean> isRecursive = Optional.empty();
     private boolean usedForDelete = false;
+    // File-level sampling for background stats collection (e.g. Iceberg ANALYZE SAMPLE):
+    // each planned file is independently kept with probability fileSampleRatio.
+    // 1.0 (default) means no sampling, i.e. behavior is unchanged for normal queries.
+    private double fileSampleRatio = 1.0;
+    private long sampleSeed = 0;
 
     protected GetRemoteFilesParams(Builder builder) {
         this.partitionKeys = builder.partitionKeys;
@@ -49,6 +54,8 @@ public class GetRemoteFilesParams {
         this.enableColumnStats = builder.enableColumnStats;
         this.isRecursive = builder.isRecursive;
         this.usedForDelete = builder.usedForDelete;
+        this.fileSampleRatio = builder.fileSampleRatio;
+        this.sampleSeed = builder.sampleSeed;
     }
 
     public int getPartitionSize() {
@@ -73,7 +80,9 @@ public class GetRemoteFilesParams {
                 .setUseCache(useCache)
                 .setCheckPartitionExistence(checkPartitionExistence)
                 .setEnableColumnStats(enableColumnStats)
-                .setUsedForDelete(usedForDelete);
+                .setUsedForDelete(usedForDelete)
+                .setFileSampleRatio(fileSampleRatio)
+                .setSampleSeed(sampleSeed);
         if (isRecursive.isPresent()) {
             paramsBuilder.setIsRecursive(isRecursive.get());
         }
@@ -144,6 +153,14 @@ public class GetRemoteFilesParams {
         this.tableVersionRange = tableVersionRange;
     }
 
+    public void setFileSampleRatio(double fileSampleRatio) {
+        this.fileSampleRatio = fileSampleRatio;
+    }
+
+    public void setSampleSeed(long sampleSeed) {
+        this.sampleSeed = sampleSeed;
+    }
+
     public boolean isCheckPartitionExistence() {
         return checkPartitionExistence;
     }
@@ -160,6 +177,14 @@ public class GetRemoteFilesParams {
         return usedForDelete;
     }
 
+    public double getFileSampleRatio() {
+        return fileSampleRatio;
+    }
+
+    public long getSampleSeed() {
+        return sampleSeed;
+    }
+
     public static class Builder {
         private List<PartitionKey> partitionKeys;
         private List<String> partitionNames;
@@ -173,6 +198,8 @@ public class GetRemoteFilesParams {
         private boolean enableColumnStats = false;
         private Optional<Boolean> isRecursive = Optional.empty();
         private boolean usedForDelete = false;
+        private double fileSampleRatio = 1.0;
+        private long sampleSeed = 0;
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
             this.partitionKeys = partitionKeys;
@@ -231,6 +258,16 @@ public class GetRemoteFilesParams {
 
         public Builder setUsedForDelete(boolean usedForDelete) {
             this.usedForDelete = usedForDelete;
+            return this;
+        }
+
+        public Builder setFileSampleRatio(double fileSampleRatio) {
+            this.fileSampleRatio = fileSampleRatio;
+            return this;
+        }
+
+        public Builder setSampleSeed(long sampleSeed) {
+            this.sampleSeed = sampleSeed;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.io.CloseableIterator;
+
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+/**
+ * File-level Bernoulli sampling iterator used by background external-table statistics
+ * collection (Iceberg ANALYZE SAMPLE). Each {@link FileScanTask} produced by the wrapped
+ * iterator is independently kept with probability {@code ratio}; dropped files never reach
+ * split/scan-range construction, so BE never opens them. Lazy evaluation, no materialization
+ * of the full file list.
+ *
+ * <p>Must wrap the planned task iterator BEFORE file splitting (before
+ * {@code buildSplitFileScanTaskIterator}), so the keep/drop decision is made once per physical
+ * file, and a kept file's associated delete files (bundled on the same {@link FileScanTask})
+ * are kept/dropped together, avoiding orphan deletes on V2 MOR tables.
+ */
+public class BernoulliFileScanTaskIterator implements CloseableIterator<FileScanTask> {
+
+    private final CloseableIterator<FileScanTask> inner;
+    private final Random random;
+    private final double ratio;
+
+    private long totalFileCount = 0;
+    private long selectedFileCount = 0;
+
+    private FileScanTask next;
+    private boolean exhausted = false;
+
+    public BernoulliFileScanTaskIterator(CloseableIterator<FileScanTask> inner, double ratio, long seed) {
+        this.inner = inner;
+        this.ratio = ratio;
+        this.random = (seed != 0) ? new Random(seed) : new Random();
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (next != null) {
+            return true;
+        }
+        if (exhausted) {
+            return false;
+        }
+        while (inner.hasNext()) {
+            FileScanTask candidate = inner.next();
+            totalFileCount++;
+            if (random.nextDouble() < ratio) {
+                selectedFileCount++;
+                next = candidate;
+                return true;
+            }
+        }
+        exhausted = true;
+        return false;
+    }
+
+    @Override
+    public FileScanTask next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        FileScanTask result = next;
+        next = null;
+        return result;
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        inner.close();
+    }
+
+    public long getTotalFileCount() {
+        return totalFileCount;
+    }
+
+    public long getSelectedFileCount() {
+        return selectedFileCount;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1198,9 +1198,33 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         String dbName = table.getCatalogDBName();
         String tableName = table.getCatalogTableName();
+
+        // File-level sampling is an internal-only knob driven by the background external-table
+        // sample ANALYZE job (see ExternalSampleStatisticsCollectJob), set via the invisible
+        // external_stats_file_sample_ratio/seed session variables on the job's own ConnectContext.
+        // Ordinary user queries never set these, so this is a no-op for them.
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null) {
+            double ratio = ctx.getSessionVariable().getExternalStatsFileSampleRatio();
+            if (ratio > 0 && ratio < 1.0) {
+                // Mutate in place rather than params.copy(): params may actually be an
+                // IcebergGetRemoteFilesParams (MOR-specific fields), and the base class's
+                // copy() only reconstructs a plain GetRemoteFilesParams, which would silently
+                // drop those subclass fields.
+                params.setFileSampleRatio(ratio);
+                params.setSampleSeed(ctx.getSessionVariable().getExternalStatsSampleSeed());
+            }
+        }
+
         PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, params);
         RemoteFileInfoSource baseSource;
-        if (splitTasks.containsKey(predicateSearchKey)) {
+        // File-sampled requests (background ANALYZE SAMPLE) must never read from or write to
+        // splitTasks/scannedTables: that cache is shared across all queries against this table
+        // and is keyed without the sampling ratio, so reusing it here would either serve a
+        // sampled file list to a normal query or silently skip sampling for this request by
+        // reusing a full list cached by cost-estimation-time planning of the same statement.
+        boolean sampled = params.getFileSampleRatio() > 0 && params.getFileSampleRatio() < 1.0;
+        if (!sampled && splitTasks.containsKey(predicateSearchKey)) {
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey), params);
         } else {
             List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
@@ -1242,7 +1266,8 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                        GetRemoteFilesParams params) {
         CloseableIterator<FileScanTask> iterator =
                 buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, ConnectContext.get(),
-                        params.isEnableColumnStats(), params.getFieldNames());
+                        params.isEnableColumnStats(), params.getFieldNames(),
+                        params.getFileSampleRatio(), params.getSampleSeed());
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {
@@ -1289,6 +1314,21 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                                       ConnectContext connectContext,
                                                                       boolean enableCollectColumnStats,
                                                                       List<String> fieldNames) {
+        // Cost-estimation / metadata-prep callers (collectTableStatisticsAndCacheIcebergSplit)
+        // never sample: file-level sampling only applies to the background sample-ANALYZE
+        // execution path (buildRemoteInfoSource), which passes an explicit ratio below.
+        return buildFileScanTaskIterator(icebergTable, icebergPredicate, tvrVersionRange, connectContext,
+                enableCollectColumnStats, fieldNames, 1.0, 0);
+    }
+
+    private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
+                                                                      Expression icebergPredicate,
+                                                                      TvrVersionRange tvrVersionRange,
+                                                                      ConnectContext connectContext,
+                                                                      boolean enableCollectColumnStats,
+                                                                      List<String> fieldNames,
+                                                                      double fileSampleRatio,
+                                                                      long sampleSeed) {
         if (tvrVersionRange.isEmpty()) {
             return new CloseableIterator<>() {
                 @Override
@@ -1391,8 +1431,15 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             private void openPlannedTaskIterator(Scan tableScan) {
                 fileScanTaskIterable = normalizePlannedTaskIterable(tableScan.planFiles());
+                CloseableIterator<FileScanTask> plannedTaskIterator = fileScanTaskIterable.iterator();
+                if (fileSampleRatio > 0 && fileSampleRatio < 1.0) {
+                    // Drop files here, before splitting: the keep/drop decision is per physical
+                    // file, so a dropped file (and its bundled delete files, for V2 MOR tables)
+                    // never reaches split/scan-range construction and BE never opens it.
+                    plannedTaskIterator = new BernoulliFileScanTaskIterator(plannedTaskIterator, fileSampleRatio, sampleSeed);
+                }
                 fileScanTaskIterator = buildSplitFileScanTaskIterator(
-                        fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize(),
+                        fileScanTaskIterable, plannedTaskIterator, tableScan.targetSplitSize(),
                         dbName, tableName, snapshotId);
             }
 
@@ -1868,6 +1915,46 @@ public class IcebergMetadata implements ConnectorMetadata {
         // Both row counts are null. If the manifest has any live files, the count would be
         // a severe under-estimate → caller must fall back to planFiles for exact cardinality.
         return !manifest.hasAddedFiles() && !manifest.hasExistingFiles() && !manifest.hasDeletedFiles();
+    }
+
+    // Cheap file_count for the background sample-ANALYZE job's ratio decision (see
+    // ExternalSampleStatisticsCollectJob): sums addedFilesCount/existingFilesCount straight off
+    // the manifest-list entries. O(manifests), does not open a single manifest file and does not
+    // enumerate a single DataFile — cheaper than counting via planFiles(). No predicate: the
+    // sample job always scans the whole table in one pass, so pruning would not change the count.
+    public static long countIcebergFilesFromManifestList(IcebergTable icebergTable, long snapshotId) {
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTbl.snapshot(snapshotId);
+        if (snapshot == null) {
+            return 0;
+        }
+        long count = 0;
+        for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
+            Integer added = manifest.addedFilesCount();
+            Integer existing = manifest.existingFilesCount();
+            count += (added != null ? added : 0) + (existing != null ? existing : 0);
+        }
+        return count;
+    }
+
+    // Same shape as countIcebergFilesFromManifestList but sums row counts instead of file counts,
+    // so the sample job's ratio can target "roughly how many rows this round reads" rather than
+    // "roughly how many files" -- files can vary wildly in row count, so a file-count-based ratio
+    // gives a much less predictable row volume per round than a row-count-based one. Still O(manifests),
+    // zero data IO: addedRowsCount/existingRowsCount are manifest-list summary fields.
+    public static long countIcebergRowsFromManifestList(IcebergTable icebergTable, long snapshotId) {
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTbl.snapshot(snapshotId);
+        if (snapshot == null) {
+            return 0;
+        }
+        long count = 0;
+        for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
+            Long added = manifest.addedRowsCount();
+            Long existing = manifest.existingRowsCount();
+            count += (added != null ? added : 0) + (existing != null ? existing : 0);
+        }
+        return count;
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1926,15 +1926,22 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     // Cheap file_count for the background sample-ANALYZE job's ratio decision (see
-    // ExternalSampleStatisticsCollectJob): sums addedFilesCount/existingFilesCount straight off
-    // the manifest-list entries. O(manifests), does not open a single manifest file and does not
-    // enumerate a single DataFile — cheaper than counting via planFiles(). No predicate: the
-    // sample job always scans the whole table in one pass, so pruning would not change the count.
+    // ExternalSampleStatisticsCollectJob). Snapshot.summary() already carries the live
+    // total-data-files count maintained incrementally by every snapshot producer (Spark/Trino/
+    // Flink/StarRocks writers all populate it) -- O(1), not even a manifest-list read. Only fall
+    // back to summing addedFilesCount/existingFilesCount across dataManifests() (O(manifests),
+    // still zero DataFile opens) when the summary field is absent, e.g. very old/non-standard
+    // table metadata. No predicate: the sample job always scans the whole table in one pass, so
+    // pruning would not change the count.
     public static long countIcebergFilesFromManifestList(IcebergTable icebergTable, long snapshotId) {
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
         Snapshot snapshot = nativeTbl.snapshot(snapshotId);
         if (snapshot == null) {
             return 0;
+        }
+        Long fromSummary = parseSummaryLong(snapshot, SnapshotSummary.TOTAL_DATA_FILES_PROP);
+        if (fromSummary != null) {
+            return fromSummary;
         }
         long count = 0;
         for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
@@ -1945,16 +1952,21 @@ public class IcebergMetadata implements ConnectorMetadata {
         return count;
     }
 
-    // Same shape as countIcebergFilesFromManifestList but sums row counts instead of file counts,
-    // so the sample job's ratio can target "roughly how many rows this round reads" rather than
-    // "roughly how many files" -- files can vary wildly in row count, so a file-count-based ratio
-    // gives a much less predictable row volume per round than a row-count-based one. Still O(manifests),
-    // zero data IO: addedRowsCount/existingRowsCount are manifest-list summary fields.
+    // Same shape as countIcebergFilesFromManifestList but for row counts, so the sample job's
+    // ratio can target "roughly how many rows this round reads" rather than "roughly how many
+    // files" -- files can vary wildly in row count, so a file-count-based ratio gives a much less
+    // predictable row volume per round than a row-count-based one. Prefers the live total-records
+    // field on Snapshot.summary() (O(1)); falls back to summing addedRowsCount/existingRowsCount
+    // across dataManifests() (O(manifests), zero data IO) when that field is absent.
     public static long countIcebergRowsFromManifestList(IcebergTable icebergTable, long snapshotId) {
         org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
         Snapshot snapshot = nativeTbl.snapshot(snapshotId);
         if (snapshot == null) {
             return 0;
+        }
+        Long fromSummary = parseSummaryLong(snapshot, SnapshotSummary.TOTAL_RECORDS_PROP);
+        if (fromSummary != null) {
+            return fromSummary;
         }
         long count = 0;
         for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
@@ -1963,6 +1975,18 @@ public class IcebergMetadata implements ConnectorMetadata {
             count += (added != null ? added : 0) + (existing != null ? existing : 0);
         }
         return count;
+    }
+
+    private static Long parseSummaryLong(Snapshot snapshot, String key) {
+        String value = snapshot.summary() == null ? null : snapshot.summary().get(key);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1431,16 +1431,24 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             private void openPlannedTaskIterator(Scan tableScan) {
                 fileScanTaskIterable = normalizePlannedTaskIterable(tableScan.planFiles());
-                CloseableIterator<FileScanTask> plannedTaskIterator = fileScanTaskIterable.iterator();
-                if (fileSampleRatio > 0 && fileSampleRatio < 1.0) {
-                    // Drop files here, before splitting: the keep/drop decision is per physical
-                    // file, so a dropped file (and its bundled delete files, for V2 MOR tables)
-                    // never reaches split/scan-range construction and BE never opens it.
-                    plannedTaskIterator = new BernoulliFileScanTaskIterator(plannedTaskIterator, fileSampleRatio, sampleSeed);
-                }
-                fileScanTaskIterator = buildSplitFileScanTaskIterator(
-                        fileScanTaskIterable, plannedTaskIterator, tableScan.targetSplitSize(),
+                // Split first, sample second. Splitting is pure byte-offset metadata arithmetic
+                // (no file open), so a dropped unit still costs zero IO either way -- but sampling
+                // at split granularity instead of whole-file granularity bounds the sampled unit
+                // size at targetSplitSize. Raw Iceberg file sizes can vary widely even when writers
+                // target a size, and Bernoulli sampling variance in total sampled rows is driven by
+                // the sum of squared unit sizes, so capping unit size directly bounds that variance
+                // -- without resorting to per-file weighted probabilities, which would bias the
+                // expected sampled row count if done naively (see design doc). A kept/dropped split
+                // still carries its data file's associated delete files correctly scoped, since
+                // Iceberg's own split logic (splitFileScanTask) already handles delete-file scoping
+                // per split range for V2 MOR tables.
+                CloseableIterator<FileScanTask> splitIterator = buildSplitFileScanTaskIterator(
+                        fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize(),
                         dbName, tableName, snapshotId);
+                if (fileSampleRatio > 0 && fileSampleRatio < 1.0) {
+                    splitIterator = new BernoulliFileScanTaskIterator(splitIterator, fileSampleRatio, sampleSeed);
+                }
+                fileScanTaskIterator = splitIterator;
             }
 
             private void closePlannedTaskIterator() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -624,6 +624,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
+    // Internal-only knobs used by the background external-table sample ANALYZE job to drive
+    // file-level Bernoulli sampling in the Iceberg connector. Not user-facing.
+    public static final String EXTERNAL_STATS_FILE_SAMPLE_RATIO = "external_stats_file_sample_ratio";
+    public static final String EXTERNAL_STATS_SAMPLE_SEED = "external_stats_sample_seed";
+
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
     public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION =
             "enable_read_iceberg_equality_delete_with_partition_evolution";
@@ -3279,6 +3284,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_READ_ICEBERG_PUFFIN_NDV)
     private boolean enableReadIcebergPuffinNdv = true;
 
+    @VarAttr(name = EXTERNAL_STATS_FILE_SAMPLE_RATIO, flag = VariableMgr.INVISIBLE)
+    private double externalStatsFileSampleRatio = 1.0;
+
+    @VarAttr(name = EXTERNAL_STATS_SAMPLE_SEED, flag = VariableMgr.INVISIBLE)
+    private long externalStatsSampleSeed = 0;
+
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
@@ -3433,6 +3444,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableReadIcebergPuffinNdv(boolean enableReadIcebergPuffinNdv) {
         this.enableReadIcebergPuffinNdv = enableReadIcebergPuffinNdv;
+    }
+
+    public double getExternalStatsFileSampleRatio() {
+        return externalStatsFileSampleRatio;
+    }
+
+    public void setExternalStatsFileSampleRatio(double externalStatsFileSampleRatio) {
+        this.externalStatsFileSampleRatio = externalStatsFileSampleRatio;
+    }
+
+    public long getExternalStatsSampleSeed() {
+        return externalStatsSampleSeed;
+    }
+
+    public void setExternalStatsSampleSeed(long externalStatsSampleSeed) {
+        this.externalStatsSampleSeed = externalStatsSampleSeed;
     }
 
     public boolean enableDeltaLakeColumnStatistics() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -91,8 +91,11 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
     private final String catalogName;
     protected List<String> partitionNames;
-    private final List<String> sqlBuffer = Lists.newArrayList();
-    private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
+    // protected: reused by ExternalSampleStatisticsCollectJob's Iceberg file-sampling path, which
+    // needs to scale sampled row counts before buffering rows (this class's own
+    // collectStatisticSync buffers unscaled counts, so it can't be reused as-is for that path).
+    protected final List<String> sqlBuffer = Lists.newArrayList();
+    protected final List<List<Expr>> rowsBuffer = Lists.newArrayList();
     // Skip collecting statistics for default partition in iceberg table,
     // because we can not generate partition predicates for it.
     private static final Set<String> DO_NOT_COLLECT_PARTITIONS = Set.of(ICEBERG_DEFAULT_PARTITION);
@@ -424,7 +427,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         flushInsertStatisticsData(context, false);
     }
 
-    private void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+    protected void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
         // hll serialize to hex, about 32kb
         long bufferSize = 33L * 1024 * rowsBuffer.size();
         if (bufferSize < Config.statistic_full_collect_buffer && !force) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -189,6 +189,24 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
             flushInsertStatisticsData(context, true);
             cleanupStaleRawKeyedRows(context, jobId);
+
+            // Only for a genuine FULL run (this method is also reused by Hive's SAMPLE path via
+            // ExternalSampleStatisticsCollectJob#collectWithPartitionSampling, which never writes a
+            // sentinel row, so the cleanup would just be a no-op DELETE there): clean up a stale
+            // whole-table sample sentinel row left behind by a prior Iceberg SAMPLE collection, in
+            // case FULL is run manually afterward. Best-effort, mirrors the SAMPLE-side cleanup in
+            // ExternalSampleStatisticsCollectJob#cleanupStaleFullCollectionRows. Matches both the
+            // hashed and raw table_uuid (see StatisticUtils#hashTableUuidForPkStorage) since the
+            // sentinel row may have been written before or after the hashing migration.
+            if (analyzeType == StatsConstants.AnalyzeType.FULL) {
+                try {
+                    new StatisticExecutor().dropExternalTableStatisticsForPartition(context, table.getUUID(),
+                            StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL, columnNames);
+                } catch (Exception e) {
+                    LOG.warn("[ExternalStats] failed to clean up stale SAMPLE sentinel row | catalog={} db={} table={}",
+                            catalogName, db.getOriginName(), table.getName(), e);
+                }
+            }
         } catch (Exception e) {
             status = "FAILED";
             failureReason = e.getMessage();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -14,18 +14,70 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.iceberg.IcebergMetadata;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.thrift.TStatisticData;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.iceberg.Snapshot;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.velocity.VelocityContext;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCollectJob {
+    private static final Logger LOG = LogManager.getLogger(ExternalSampleStatisticsCollectJob.class);
+
+    // external_column_statistics is keyed by (table_uuid, partition_name, column_name); a
+    // whole-table file sample has no real partition to attach its row to, so it uses this fixed
+    // sentinel instead. Must never collide with a real Iceberg partition name. The read path
+    // (StatisticSQLBuilder's hll_union_agg(...) GROUP BY table_uuid, column_name) doesn't group by
+    // partition_name, so this row is unioned in alongside any real per-partition rows with no
+    // read-path change.
+    public static final String SAMPLE_PARTITION_NAME_SENTINEL = "$FILE_SAMPLE$";
+
+    // AnalyzeStatus.properties key persisting the round index this table's sampling left off at,
+    // so the NEXT scheduled run's internal round loop can start near there instead of always
+    // cold-starting at round 0 (whose ratio is superseded within the same run anyway once later,
+    // larger rounds overwrite it). Connector-agnostic name: the round-loop driver itself doesn't
+    // depend on Iceberg, only the cheap cost-total lookup that feeds it does (see
+    // collectIcebergWithFileSampling) -- if another connector eventually plugs into this same
+    // driver, its runs should share this warm-start record rather than getting a separate one.
+    private static final String SAMPLE_ROUND_PROPERTY = "external_sample_round";
+
+    private static final String SAMPLE_WHOLE_TABLE_TEMPLATE = "SELECT cast($version as INT)" +
+            ", '$partitionNameStr'" + // VARCHAR
+            ", '$columnNameStr'" + // VARCHAR
+            ", cast(COUNT(1) as BIGINT)" + // BIGINT
+            ", cast($dataSize as BIGINT)" + // BIGINT
+            ", $hllFunction" + // VARBINARY
+            ", cast($countNullFunction as BIGINT)" + // BIGINT
+            ", $maxFunction" + // VARCHAR
+            ", $minFunction " + // VARCHAR
+            " FROM `$catalogName`.`$dbName`.`$tableName`";
+
     private final int allPartitionSize;
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
@@ -48,5 +100,262 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     @Override
     public String getName() {
         return "ExternalSample";
+    }
+
+    @Override
+    public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        if (table.isIcebergTable()) {
+            // Iceberg: cross-partition file-level random sampling, hard IO cap regardless of how
+            // large any single partition is. Everything else (Hive/Hudi/Paimon) keeps the existing
+            // partition-subset-then-full-scan sampling below.
+            collectIcebergWithFileSampling(context, analyzeStatus);
+        } else {
+            super.collect(context, analyzeStatus);
+        }
+    }
+
+    private void collectIcebergWithFileSampling(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        long startMs = System.currentTimeMillis();
+        long jobId = analyzeStatus.getId();
+
+        IcebergTable icebergTable = (IcebergTable) table;
+        Snapshot snapshot = icebergTable.getNativeTable().currentSnapshot();
+        if (snapshot == null) {
+            LOG.info("[ExternalStats][Sample] jobId={} catalog={} db={} table={} has no snapshot yet, skip",
+                    jobId, getCatalogName(), db.getOriginName(), table.getName());
+            return;
+        }
+
+        // Read file_count/row_count first (manifest-list summary fields, zero data IO) so every
+        // round's ratio is derived from the table's actual current size -- never a blind first
+        // guess. Row count (not file count) drives the ratio: files can vary wildly in row count,
+        // so a file-count-based ratio gives a much less predictable row volume per round.
+        // file_count is kept only as informational logging context.
+        long fileCount = IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, snapshot.snapshotId());
+        long rowCount = IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, snapshot.snapshotId());
+        long capPerRound = Math.max(1, Config.statistic_external_sample_max_rows_per_round);
+        int maxRounds = Math.max(1, Config.statistic_external_sample_max_rounds);
+
+        // Warm-start near where the last finished run left off, instead of always redoing rounds
+        // 0..N-1 that would just get overwritten again within this run anyway.
+        int round = Math.min(findPersistedRound(), maxRounds - 1);
+        double ratio = 1.0;
+
+        LOG.info("[ExternalStats][Sample] collect start | jobId={} catalog={} db={} table={} fileCount={} " +
+                        "rowCount={} startRound={} capPerRound={} maxRounds={} columns={}",
+                jobId, getCatalogName(), db.getOriginName(), table.getName(), fileCount, rowCount, round, capPerRound,
+                maxRounds, columnNames.size());
+
+        String status = "SUCCESS";
+        String failureReason = "";
+        try {
+            for (; round < maxRounds; round++) {
+                long rowsThisRound = rowCount > 0 ? Math.min(rowCount, capPerRound << round) : rowCount;
+                ratio = rowCount > 0 ? Math.min(1.0, (double) rowsThisRound / rowCount) : 1.0;
+
+                runOneSampleRound(context, analyzeStatus, ratio);
+
+                LOG.info("[ExternalStats][Sample] round done | jobId={} catalog={} db={} table={} round={} " +
+                                "rowsThisRound={} ratio={}",
+                        jobId, getCatalogName(), db.getOriginName(), table.getName(), round, rowsThisRound, ratio);
+
+                if (ratio >= 1.0) {
+                    // Full coverage reached -- later, smaller-cap rounds would be strictly worse
+                    // and would just waste a re-scan, so stop here.
+                    break;
+                }
+            }
+
+            Map<String, String> mergedProperties = new LinkedHashMap<>();
+            if (analyzeStatus.getProperties() != null) {
+                mergedProperties.putAll(analyzeStatus.getProperties());
+            }
+            mergedProperties.put("table_format", table.getType().name().toLowerCase(Locale.ROOT));
+            mergedProperties.put("column_count", String.valueOf(columnNames.size()));
+            mergedProperties.put("file_count", String.valueOf(fileCount));
+            mergedProperties.put("row_count", String.valueOf(rowCount));
+            mergedProperties.put("sample_ratio", String.valueOf(ratio));
+            mergedProperties.put(SAMPLE_ROUND_PROPERTY, String.valueOf(Math.min(round, maxRounds - 1)));
+            analyzeStatus.setProperties(mergedProperties);
+        } catch (Exception e) {
+            status = "FAILED";
+            failureReason = e.getMessage();
+            throw e;
+        } finally {
+            LOG.info("[ExternalStats][Sample] collect end | jobId={} catalog={} db={} table={} status={} " +
+                            "durationMs={} fileCount={} rowCount={} finalRatio={} reason={}",
+                    jobId, getCatalogName(), db.getOriginName(), table.getName(), status,
+                    System.currentTimeMillis() - startMs, fileCount, rowCount, ratio, failureReason);
+        }
+    }
+
+    /**
+     * Runs one whole-table sampled collection round at the given ratio and flushes it to
+     * external_column_statistics (overwriting the previous round's sentinel row).
+     */
+    private void runOneSampleRound(ConnectContext context, AnalyzeStatus analyzeStatus, double ratio) throws Exception {
+        // seed=0 tells BernoulliFileScanTaskIterator to use a fresh, unseeded Random, so successive
+        // rounds don't keep re-sampling the same files.
+        context.getSessionVariable().setExternalStatsFileSampleRatio(ratio);
+        context.getSessionVariable().setExternalStatsSampleSeed(0);
+        try {
+            int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+            List<List<String>> collectSQLList = buildSampleCollectSQLList(parallelism);
+            long totalCollectSQL = collectSQLList.size();
+            long finishedSQLNum = 0;
+            for (List<String> sqlUnion : collectSQLList) {
+                if (sqlUnion.size() < parallelism) {
+                    context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
+                } else {
+                    context.getSessionVariable().setPipelineDop(1);
+                }
+                String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
+                collectSampledStatisticSync(sql, context, analyzeStatus, ratio);
+                finishedSQLNum++;
+                analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
+                GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+            }
+            flushInsertStatisticsData(context, true);
+        } finally {
+            // Never let sampling leak onto later, unrelated queries sharing this ConnectContext.
+            context.getSessionVariable().setExternalStatsFileSampleRatio(1.0);
+            context.getSessionVariable().setExternalStatsSampleSeed(0);
+        }
+    }
+
+    /**
+     * Finds the round index persisted by this table's most recently finished sample-ANALYZE run,
+     * so this run's internal round loop can warm-start near there instead of always cold-starting
+     * at round 0. Defaults to 0 if no prior finished run is found.
+     */
+    private int findPersistedRound() {
+        Map<Long, AnalyzeStatus> statusMap = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap();
+        int round = 0;
+        LocalDateTime latestEnd = null;
+        for (AnalyzeStatus otherStatus : statusMap.values()) {
+            if (otherStatus.isNative() || otherStatus.getType() != StatsConstants.AnalyzeType.SAMPLE) {
+                continue;
+            }
+            if (otherStatus.getStatus() != StatsConstants.ScheduleStatus.FINISH) {
+                continue;
+            }
+            try {
+                if (!getCatalogName().equals(otherStatus.getCatalogName())
+                        || !db.getOriginName().equals(otherStatus.getDbName())
+                        || !table.getName().equals(otherStatus.getTableName())) {
+                    continue;
+                }
+            } catch (MetaNotFoundException e) {
+                continue;
+            }
+            LocalDateTime end = otherStatus.getEndTime();
+            if (end == null) {
+                continue;
+            }
+            if (latestEnd == null || end.isAfter(latestEnd)) {
+                latestEnd = end;
+                String roundStr = otherStatus.getProperties() == null ? null :
+                        otherStatus.getProperties().get(SAMPLE_ROUND_PROPERTY);
+                try {
+                    round = roundStr != null ? Integer.parseInt(roundStr) : 0;
+                } catch (NumberFormatException e) {
+                    round = 0;
+                }
+            }
+        }
+        return round;
+    }
+
+    private List<List<String>> buildSampleCollectSQLList(int parallelism) {
+        List<String> totalQuerySQL = new ArrayList<>();
+        for (int i = 0; i < columnNames.size(); i++) {
+            totalQuerySQL.add(buildSampleCollectSQL(columnNames.get(i), columnTypes.get(i)));
+        }
+        return Lists.partition(totalQuerySQL, parallelism);
+    }
+
+    private String buildSampleCollectSQL(String columnName, Type columnType) {
+        VelocityContext context = new VelocityContext();
+
+        String columnNameStr = StringEscapeUtils.escapeSql(columnName);
+        String quoteColumnName = StatisticUtils.quoting(table, columnName);
+
+        context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
+        context.put("partitionNameStr", SAMPLE_PARTITION_NAME_SENTINEL);
+        context.put("columnNameStr", columnNameStr);
+        context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnName, columnType));
+        context.put("dbName", db.getOriginName());
+        context.put("tableName", table.getName());
+        context.put("catalogName", getCatalogName());
+
+        if (!columnType.canStatistic() || columnType.isCollectionType()) {
+            context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
+            context.put("countNullFunction", "0");
+            context.put("maxFunction", "''");
+            context.put("minFunction", "''");
+        } else {
+            context.put("hllFunction", "hex(hll_serialize(IFNULL(hll_raw(" + quoteColumnName + "), hll_empty())))");
+            context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnName + ")");
+            context.put("maxFunction", getMinMaxFunction(columnType, quoteColumnName, true));
+            context.put("minFunction", getMinMaxFunction(columnType, quoteColumnName, false));
+        }
+
+        return build(context, SAMPLE_WHOLE_TABLE_TEMPLATE);
+    }
+
+    /**
+     * Mirrors {@link ExternalFullStatisticsCollectJob#collectStatisticSync}, but scales the sampled
+     * row_count back up to a full-table estimate before buffering. NDV (HLL) and min/max are NOT
+     * rescaled: HLL directly measures distinct values in the sampled rows (assumed representative
+     * of the whole table per random-wide-sampling); min/max are kept as the sampled rows' true
+     * values, which is a safe (conservative) direction for range-predicate selectivity.
+     */
+    private void collectSampledStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus, double ratio)
+            throws Exception {
+        calculateAndSetRemainingTimeout(context, analyzeStatus);
+
+        LOG.debug("statistics collect sql : " + sql);
+        StatisticExecutor executor = new StatisticExecutor();
+        setDefaultSessionVariable(context);
+
+        List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
+        for (TStatisticData data : dataList) {
+            long scaledRowCount = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(data.getRowCount() / ratio) : data.getRowCount();
+
+            List<String> params = Lists.newArrayList();
+            List<Expr> row = Lists.newArrayList();
+
+            params.add("'" + table.getUUID() + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(data.getPartitionName()) + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(data.getColumnName()) + "'");
+            params.add("'" + getCatalogName() + "'");
+            params.add("'" + db.getOriginName() + "'");
+            params.add("'" + table.getName() + "'");
+            params.add(String.valueOf(scaledRowCount));
+            params.add(String.valueOf(data.getDataSize()));
+            params.add("hll_deserialize(unhex('mockData'))");
+            params.add(String.valueOf(data.getNullCount()));
+            params.add("'" + data.getMax() + "'");
+            params.add("'" + data.getMin() + "'");
+            params.add("now()");
+
+            row.add(new StringLiteral(table.getUUID()));
+            row.add(new StringLiteral(data.getPartitionName()));
+            row.add(new StringLiteral(data.getColumnName()));
+            row.add(new StringLiteral(getCatalogName()));
+            row.add(new StringLiteral(db.getOriginName()));
+            row.add(new StringLiteral(table.getName()));
+            row.add(new IntLiteral(scaledRowCount, IntegerType.BIGINT));
+            row.add(new IntLiteral((long) data.getDataSize(), IntegerType.BIGINT));
+            row.add(hllDeserialize(data.getHll()));
+            row.add(new IntLiteral(data.getNullCount(), IntegerType.BIGINT));
+            row.add(new StringLiteral(data.getMax()));
+            row.add(new StringLiteral(data.getMin()));
+            row.add(nowFn());
+
+            rowsBuffer.add(row);
+            sqlBuffer.add("(" + String.join(", ", params) + ")");
+        }
+        flushInsertStatisticsData(context, false);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -63,6 +63,10 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     // rather than building one unbounded SELECT list.
     private static final int MAX_COLUMNS_PER_SINGLE_PASS_SQL = 200;
 
+    // Per-column aggregate count in buildSinglePassSQL's wide row: data_size, hll, null_count,
+    // max, min, ndv cardinality.
+    private static final int AGGREGATES_PER_COLUMN = 6;
+
     private final int allPartitionSize;
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
@@ -134,11 +138,16 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
         String status = "SUCCESS";
         String failureReason = "";
         try {
+            // Compared against each round's cardinality to detect NDV convergence; null on the
+            // first round of this job run (warm-started rounds don't carry over the prior job
+            // run's per-column values, so convergence is only tracked within one job execution).
+            Map<String, Long> prevCardinalityByColumn = null;
+            double convergenceThreshold = Config.statistic_external_sample_ndv_convergence_threshold;
             for (; round < maxRounds; round++) {
                 long rowsThisRound = rowCount > 0 ? Math.min(rowCount, capPerRound << round) : rowCount;
                 ratio = rowCount > 0 ? Math.min(1.0, (double) rowsThisRound / rowCount) : 1.0;
 
-                runOneSampleRound(context, analyzeStatus, ratio);
+                Map<String, Long> cardinalityByColumn = runOneSampleRound(context, analyzeStatus, ratio);
 
                 LOG.info("[ExternalStats][Sample] round done | jobId={} catalog={} db={} table={} round={} " +
                                 "rowsThisRound={} ratio={}",
@@ -149,6 +158,15 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
                     // and would just waste a re-scan, so stop here.
                     break;
                 }
+
+                if (prevCardinalityByColumn != null
+                        && isNdvConverging(prevCardinalityByColumn, cardinalityByColumn, convergenceThreshold)) {
+                    LOG.info("[ExternalStats][Sample] NDV converged, stopping early | jobId={} catalog={} db={} " +
+                                    "table={} round={} threshold={}",
+                            jobId, getCatalogName(), db.getOriginName(), table.getName(), round, convergenceThreshold);
+                    break;
+                }
+                prevCardinalityByColumn = cardinalityByColumn;
             }
 
             // All rounds succeeded: this table's sampled stats for these columns are now
@@ -200,9 +218,12 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
 
     /**
      * Runs one whole-table sampled collection round at the given ratio and flushes it to
-     * external_column_statistics (overwriting the previous round's sentinel row).
+     * external_column_statistics (overwriting the previous round's sentinel row). Returns each
+     * collected column's NDV cardinality for this round, so the caller can track convergence
+     * across rounds.
      */
-    private void runOneSampleRound(ConnectContext context, AnalyzeStatus analyzeStatus, double ratio) throws Exception {
+    private Map<String, Long> runOneSampleRound(ConnectContext context, AnalyzeStatus analyzeStatus, double ratio)
+            throws Exception {
         // seed=0 tells BernoulliFileScanTaskIterator to use a fresh, unseeded Random, so successive
         // rounds don't keep re-sampling the same files.
         context.getSessionVariable().setExternalStatsFileSampleRatio(ratio);
@@ -213,19 +234,43 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
                     MAX_COLUMNS_PER_SINGLE_PASS_SQL);
             long totalBatches = columnBatches.size();
             long finishedBatches = 0;
+            Map<String, Long> cardinalityByColumn = new LinkedHashMap<>();
             for (List<Integer> columnBatch : columnBatches) {
                 String sql = buildSinglePassSQL(columnBatch);
-                collectSinglePassStatisticSync(sql, columnBatch, context, analyzeStatus, ratio);
+                cardinalityByColumn.putAll(collectSinglePassStatisticSync(sql, columnBatch, context, analyzeStatus, ratio));
                 finishedBatches++;
                 analyzeStatus.setProgress(finishedBatches * 100 / totalBatches);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
             }
             flushInsertStatisticsData(context, true);
+            return cardinalityByColumn;
         } finally {
             // Never let sampling leak onto later, unrelated queries sharing this ConnectContext.
             context.getSessionVariable().setExternalStatsFileSampleRatio(1.0);
             context.getSessionVariable().setExternalStatsSampleSeed(0);
         }
+    }
+
+    /**
+     * True when every column's NDV cardinality changed by less than {@code threshold} (relative)
+     * between two consecutive rounds. A single still-changing column (typically a high-cardinality
+     * one) is enough to keep sampling going -- stopping early on ratio alone would compound the
+     * NDV underestimation that already applies to high-cardinality columns under sampling.
+     */
+    static boolean isNdvConverging(Map<String, Long> prev, Map<String, Long> curr, double threshold) {
+        for (Map.Entry<String, Long> entry : curr.entrySet()) {
+            Long prevValue = prev.get(entry.getKey());
+            if (prevValue == null) {
+                return false;
+            }
+            long currValue = entry.getValue();
+            double denominator = Math.max(currValue, 1L);
+            double relativeChange = Math.abs(currValue - prevValue) / denominator;
+            if (relativeChange >= threshold) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -273,10 +318,13 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
 
     /**
      * Builds one single-pass SQL covering every column in {@code columnBatch}: a single scan
-     * producing one wide row of {@code COUNT(1)} (shared row count) followed by 5 aggregates
-     * (data_size, hll, null_count, max, min) per column, in column order. Replaces the previous
-     * per-column SELECT ... UNION ALL ... approach so a round does exactly one planFiles()/scan
-     * (per batch) instead of N, and every column's stats come from the exact same sampled rows.
+     * producing one wide row of {@code COUNT(1)} (shared row count) followed by 6 aggregates
+     * (data_size, hll, null_count, max, min, ndv cardinality) per column, in column order.
+     * Replaces the previous per-column SELECT ... UNION ALL ... approach so a round does exactly
+     * one planFiles()/scan (per batch) instead of N, and every column's stats come from the exact
+     * same sampled rows. The ndv cardinality aggregate is a plain scalar (not the serialized HLL
+     * sketch) so the round loop can compare it across rounds in-memory without needing to
+     * deserialize an HLL sketch on the FE side -- see isNdvConverging.
      */
     private String buildSinglePassSQL(List<Integer> columnBatch) {
         StringBuilder sql = new StringBuilder("SELECT CAST(COUNT(1) AS BIGINT)");
@@ -291,12 +339,15 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
                 sql.append(", CAST(0 AS BIGINT)");
                 sql.append(", ''");
                 sql.append(", ''");
+                sql.append(", CAST(0 AS BIGINT)");
             } else {
                 sql.append(", CAST(").append(fullAnalyzeGetDataSize(quoteColumnName, columnType)).append(" AS BIGINT)");
                 sql.append(", hex(hll_serialize(IFNULL(hll_raw(").append(quoteColumnName).append("), hll_empty())))");
                 sql.append(", CAST(COUNT(1) - COUNT(").append(quoteColumnName).append(") AS BIGINT)");
                 sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, true));
                 sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, false));
+                sql.append(", CAST(hll_cardinality(IFNULL(hll_raw(").append(quoteColumnName)
+                        .append("), hll_empty())) AS BIGINT)");
             }
         }
         sql.append(" FROM `").append(getCatalogName()).append("`.`").append(db.getOriginName())
@@ -311,10 +362,13 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
      * up to a full-table estimate. NDV (HLL) and min/max are NOT rescaled: HLL directly measures
      * distinct values in the sampled rows (assumed representative of the whole table per
      * random-wide-sampling); min/max are kept as the sampled rows' true values, which is a safe
-     * (conservative) direction for range-predicate selectivity.
+     * (conservative) direction for range-predicate selectivity. Returns each column's NDV
+     * cardinality (unscaled, same sample-local estimate as everything else here) so the caller can
+     * compare it against the previous round's value to detect convergence.
      */
-    private void collectSinglePassStatisticSync(String sql, List<Integer> columnBatch, ConnectContext context,
-                                                 AnalyzeStatus analyzeStatus, double ratio) throws Exception {
+    private Map<String, Long> collectSinglePassStatisticSync(String sql, List<Integer> columnBatch,
+                                                               ConnectContext context, AnalyzeStatus analyzeStatus,
+                                                               double ratio) throws Exception {
         calculateAndSetRemainingTimeout(context, analyzeStatus);
 
         LOG.debug("statistics collect sql : " + sql);
@@ -323,7 +377,7 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
 
         List<JsonArray> rows = executor.executeWideRowDQL(context, sql);
         if (rows.isEmpty()) {
-            return;
+            return Map.of();
         }
         JsonArray data = rows.get(0);
         long sampledRowCount = data.get(0).getAsLong();
@@ -334,14 +388,17 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
         // which does the same for the FULL path. Iceberg's long catalog.db.table.<uuid> identifiers
         // are exactly the case that hashing exists to protect.
         String hashedTableUuid = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
+        Map<String, Long> cardinalityByColumn = new LinkedHashMap<>();
         for (int i = 0; i < columnBatch.size(); i++) {
             String columnName = columnNames.get(columnBatch.get(i));
-            int base = 1 + i * 5;
+            int base = 1 + i * AGGREGATES_PER_COLUMN;
             long dataSize = data.get(base).getAsLong();
             String hllHex = data.get(base + 1).getAsString();
             long nullCount = data.get(base + 2).getAsLong();
             String max = data.get(base + 3).getAsString();
             String min = data.get(base + 4).getAsString();
+            long cardinality = data.get(base + 5).getAsLong();
+            cardinalityByColumn.put(columnName, cardinality);
 
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
@@ -378,5 +435,6 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
             sqlBuffer.add("(" + String.join(", ", params) + ")");
         }
         flushInsertStatisticsData(context, false);
+        return cardinalityByColumn;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -14,10 +14,10 @@
 
 package com.starrocks.statistic;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import com.google.gson.JsonArray;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
@@ -29,34 +29,25 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
-import com.starrocks.thrift.TStatisticData;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.iceberg.Snapshot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.velocity.VelocityContext;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCollectJob {
     private static final Logger LOG = LogManager.getLogger(ExternalSampleStatisticsCollectJob.class);
-
-    // external_column_statistics is keyed by (table_uuid, partition_name, column_name); a
-    // whole-table file sample has no real partition to attach its row to, so it uses this fixed
-    // sentinel instead. Must never collide with a real Iceberg partition name. The read path
-    // (StatisticSQLBuilder's hll_union_agg(...) GROUP BY table_uuid, column_name) doesn't group by
-    // partition_name, so this row is unioned in alongside any real per-partition rows with no
-    // read-path change.
-    public static final String SAMPLE_PARTITION_NAME_SENTINEL = "$FILE_SAMPLE$";
 
     // AnalyzeStatus.properties key persisting the round index this table's sampling left off at,
     // so the NEXT scheduled run's internal round loop can start near there instead of always
@@ -67,16 +58,10 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     // driver, its runs should share this warm-start record rather than getting a separate one.
     private static final String SAMPLE_ROUND_PROPERTY = "external_sample_round";
 
-    private static final String SAMPLE_WHOLE_TABLE_TEMPLATE = "SELECT cast($version as INT)" +
-            ", '$partitionNameStr'" + // VARCHAR
-            ", '$columnNameStr'" + // VARCHAR
-            ", cast(COUNT(1) as BIGINT)" + // BIGINT
-            ", cast($dataSize as BIGINT)" + // BIGINT
-            ", $hllFunction" + // VARBINARY
-            ", cast($countNullFunction as BIGINT)" + // BIGINT
-            ", $maxFunction" + // VARCHAR
-            ", $minFunction " + // VARCHAR
-            " FROM `$catalogName`.`$dbName`.`$tableName`";
+    // A wide-row SQL's SELECT list grows with column count; past this many columns in one batch,
+    // split into multiple single-pass SQLs (each still one scan over its own batch of columns)
+    // rather than building one unbounded SELECT list.
+    private static final int MAX_COLUMNS_PER_SINGLE_PASS_SQL = 200;
 
     private final int allPartitionSize;
 
@@ -166,6 +151,14 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
                 }
             }
 
+            // All rounds succeeded: this table's sampled stats for these columns are now
+            // authoritative in the sentinel row. If a prior FULL collection left real per-partition
+            // rows behind for the same columns, the read path's sum(row_count)/sum(data_size)/
+            // sum(null_count) (GROUP BY table_uuid, column_name, not partition_name) would double-
+            // count them alongside the sentinel row. Clean those up now that we have a fresh,
+            // authoritative replacement -- never before, so stats are never momentarily absent.
+            cleanupStaleFullCollectionRows(context);
+
             Map<String, String> mergedProperties = new LinkedHashMap<>();
             if (analyzeStatus.getProperties() != null) {
                 mergedProperties.putAll(analyzeStatus.getProperties());
@@ -190,6 +183,22 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     }
 
     /**
+     * Deletes any real-partition rows (partition_name != sentinel) for this table's collected
+     * columns, left behind by a prior FULL collection. Best-effort: failure here must not fail an
+     * otherwise-successful sample collection -- the double-counting it would leave behind already
+     * exists today, so a failed cleanup attempt does not make things worse.
+     */
+    private void cleanupStaleFullCollectionRows(ConnectContext context) {
+        try {
+            new StatisticExecutor().dropExternalTableStatisticsExcludingPartition(context, table.getUUID(),
+                    StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL, columnNames);
+        } catch (Exception e) {
+            LOG.warn("[ExternalStats][Sample] failed to clean up stale FULL rows | catalog={} db={} table={}",
+                    getCatalogName(), db.getOriginName(), table.getName(), e);
+        }
+    }
+
+    /**
      * Runs one whole-table sampled collection round at the given ratio and flushes it to
      * external_column_statistics (overwriting the previous round's sentinel row).
      */
@@ -199,20 +208,16 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
         context.getSessionVariable().setExternalStatsFileSampleRatio(ratio);
         context.getSessionVariable().setExternalStatsSampleSeed(0);
         try {
-            int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
-            List<List<String>> collectSQLList = buildSampleCollectSQLList(parallelism);
-            long totalCollectSQL = collectSQLList.size();
-            long finishedSQLNum = 0;
-            for (List<String> sqlUnion : collectSQLList) {
-                if (sqlUnion.size() < parallelism) {
-                    context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
-                } else {
-                    context.getSessionVariable().setPipelineDop(1);
-                }
-                String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
-                collectSampledStatisticSync(sql, context, analyzeStatus, ratio);
-                finishedSQLNum++;
-                analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
+            List<List<Integer>> columnBatches = Lists.partition(
+                    IntStream.range(0, columnNames.size()).boxed().collect(Collectors.toList()),
+                    MAX_COLUMNS_PER_SINGLE_PASS_SQL);
+            long totalBatches = columnBatches.size();
+            long finishedBatches = 0;
+            for (List<Integer> columnBatch : columnBatches) {
+                String sql = buildSinglePassSQL(columnBatch);
+                collectSinglePassStatisticSync(sql, columnBatch, context, analyzeStatus, ratio);
+                finishedBatches++;
+                analyzeStatus.setProgress(finishedBatches * 100 / totalBatches);
                 GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
             }
             flushInsertStatisticsData(context, true);
@@ -266,91 +271,107 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
         return round;
     }
 
-    private List<List<String>> buildSampleCollectSQLList(int parallelism) {
-        List<String> totalQuerySQL = new ArrayList<>();
-        for (int i = 0; i < columnNames.size(); i++) {
-            totalQuerySQL.add(buildSampleCollectSQL(columnNames.get(i), columnTypes.get(i)));
+    /**
+     * Builds one single-pass SQL covering every column in {@code columnBatch}: a single scan
+     * producing one wide row of {@code COUNT(1)} (shared row count) followed by 5 aggregates
+     * (data_size, hll, null_count, max, min) per column, in column order. Replaces the previous
+     * per-column SELECT ... UNION ALL ... approach so a round does exactly one planFiles()/scan
+     * (per batch) instead of N, and every column's stats come from the exact same sampled rows.
+     */
+    private String buildSinglePassSQL(List<Integer> columnBatch) {
+        StringBuilder sql = new StringBuilder("SELECT CAST(COUNT(1) AS BIGINT)");
+        for (int idx : columnBatch) {
+            String columnName = columnNames.get(idx);
+            Type columnType = columnTypes.get(idx);
+            String quoteColumnName = StatisticUtils.quoting(table, columnName);
+
+            if (!columnType.canStatistic() || columnType.isCollectionType()) {
+                sql.append(", CAST(0 AS BIGINT)");
+                sql.append(", hex(hll_serialize(hll_empty()))");
+                sql.append(", CAST(0 AS BIGINT)");
+                sql.append(", ''");
+                sql.append(", ''");
+            } else {
+                sql.append(", CAST(").append(fullAnalyzeGetDataSize(quoteColumnName, columnType)).append(" AS BIGINT)");
+                sql.append(", hex(hll_serialize(IFNULL(hll_raw(").append(quoteColumnName).append("), hll_empty())))");
+                sql.append(", CAST(COUNT(1) - COUNT(").append(quoteColumnName).append(") AS BIGINT)");
+                sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, true));
+                sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, false));
+            }
         }
-        return Lists.partition(totalQuerySQL, parallelism);
-    }
-
-    private String buildSampleCollectSQL(String columnName, Type columnType) {
-        VelocityContext context = new VelocityContext();
-
-        String columnNameStr = StringEscapeUtils.escapeSql(columnName);
-        String quoteColumnName = StatisticUtils.quoting(table, columnName);
-
-        context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
-        context.put("partitionNameStr", SAMPLE_PARTITION_NAME_SENTINEL);
-        context.put("columnNameStr", columnNameStr);
-        context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnName, columnType));
-        context.put("dbName", db.getOriginName());
-        context.put("tableName", table.getName());
-        context.put("catalogName", getCatalogName());
-
-        if (!columnType.canStatistic() || columnType.isCollectionType()) {
-            context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
-            context.put("countNullFunction", "0");
-            context.put("maxFunction", "''");
-            context.put("minFunction", "''");
-        } else {
-            context.put("hllFunction", "hex(hll_serialize(IFNULL(hll_raw(" + quoteColumnName + "), hll_empty())))");
-            context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnName + ")");
-            context.put("maxFunction", getMinMaxFunction(columnType, quoteColumnName, true));
-            context.put("minFunction", getMinMaxFunction(columnType, quoteColumnName, false));
-        }
-
-        return build(context, SAMPLE_WHOLE_TABLE_TEMPLATE);
+        sql.append(" FROM `").append(getCatalogName()).append("`.`").append(db.getOriginName())
+                .append("`.`").append(table.getName()).append("`");
+        return sql.toString();
     }
 
     /**
-     * Mirrors {@link ExternalFullStatisticsCollectJob#collectStatisticSync}, but scales the sampled
-     * row_count back up to a full-table estimate before buffering. NDV (HLL) and min/max are NOT
-     * rescaled: HLL directly measures distinct values in the sampled rows (assumed representative
-     * of the whole table per random-wide-sampling); min/max are kept as the sampled rows' true
-     * values, which is a safe (conservative) direction for range-predicate selectivity.
+     * Executes one single-pass wide-row SQL and decodes its one output row (via the HTTP/JSON
+     * result protocol, since the fixed 9-field {@code TStatisticData} struct can't hold N columns'
+     * worth of aggregates) back into per-column records, scaling the shared sampled row_count back
+     * up to a full-table estimate. NDV (HLL) and min/max are NOT rescaled: HLL directly measures
+     * distinct values in the sampled rows (assumed representative of the whole table per
+     * random-wide-sampling); min/max are kept as the sampled rows' true values, which is a safe
+     * (conservative) direction for range-predicate selectivity.
      */
-    private void collectSampledStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus, double ratio)
-            throws Exception {
+    private void collectSinglePassStatisticSync(String sql, List<Integer> columnBatch, ConnectContext context,
+                                                 AnalyzeStatus analyzeStatus, double ratio) throws Exception {
         calculateAndSetRemainingTimeout(context, analyzeStatus);
 
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();
         setDefaultSessionVariable(context);
 
-        List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
-        for (TStatisticData data : dataList) {
-            long scaledRowCount = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(data.getRowCount() / ratio) : data.getRowCount();
+        List<JsonArray> rows = executor.executeWideRowDQL(context, sql);
+        if (rows.isEmpty()) {
+            return;
+        }
+        JsonArray data = rows.get(0);
+        long sampledRowCount = data.get(0).getAsLong();
+        long scaledRowCount = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(sampledRowCount / ratio) : sampledRowCount;
+
+        // table_uuid is stored hashed (StatisticUtils.hashTableUuidForPkStorage) to stay within
+        // BE's primary_key_limit_size -- see ExternalFullStatisticsCollectJob#collectStatisticSync,
+        // which does the same for the FULL path. Iceberg's long catalog.db.table.<uuid> identifiers
+        // are exactly the case that hashing exists to protect.
+        String hashedTableUuid = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
+        for (int i = 0; i < columnBatch.size(); i++) {
+            String columnName = columnNames.get(columnBatch.get(i));
+            int base = 1 + i * 5;
+            long dataSize = data.get(base).getAsLong();
+            String hllHex = data.get(base + 1).getAsString();
+            long nullCount = data.get(base + 2).getAsLong();
+            String max = data.get(base + 3).getAsString();
+            String min = data.get(base + 4).getAsString();
 
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
 
-            params.add("'" + table.getUUID() + "'");
-            params.add("'" + StringEscapeUtils.escapeSql(data.getPartitionName()) + "'");
-            params.add("'" + StringEscapeUtils.escapeSql(data.getColumnName()) + "'");
+            params.add("'" + hashedTableUuid + "'");
+            params.add("'" + StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(columnName) + "'");
             params.add("'" + getCatalogName() + "'");
             params.add("'" + db.getOriginName() + "'");
             params.add("'" + table.getName() + "'");
             params.add(String.valueOf(scaledRowCount));
-            params.add(String.valueOf(data.getDataSize()));
+            params.add(String.valueOf(dataSize));
             params.add("hll_deserialize(unhex('mockData'))");
-            params.add(String.valueOf(data.getNullCount()));
-            params.add("'" + data.getMax() + "'");
-            params.add("'" + data.getMin() + "'");
+            params.add(String.valueOf(nullCount));
+            params.add("'" + max + "'");
+            params.add("'" + min + "'");
             params.add("now()");
 
-            row.add(new StringLiteral(table.getUUID()));
-            row.add(new StringLiteral(data.getPartitionName()));
-            row.add(new StringLiteral(data.getColumnName()));
+            row.add(new StringLiteral(hashedTableUuid));
+            row.add(new StringLiteral(StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL));
+            row.add(new StringLiteral(columnName));
             row.add(new StringLiteral(getCatalogName()));
             row.add(new StringLiteral(db.getOriginName()));
             row.add(new StringLiteral(table.getName()));
             row.add(new IntLiteral(scaledRowCount, IntegerType.BIGINT));
-            row.add(new IntLiteral((long) data.getDataSize(), IntegerType.BIGINT));
-            row.add(hllDeserialize(data.getHll()));
-            row.add(new IntLiteral(data.getNullCount(), IntegerType.BIGINT));
-            row.add(new StringLiteral(data.getMax()));
-            row.add(new StringLiteral(data.getMin()));
+            row.add(new IntLiteral(dataSize, IntegerType.BIGINT));
+            row.add(hllDeserialize(hllHex.getBytes(StandardCharsets.UTF_8)));
+            row.add(new IntLiteral(nullCount, IntegerType.BIGINT));
+            row.add(new StringLiteral(max));
+            row.add(new StringLiteral(min));
             row.add(nowFn());
 
             rowsBuffer.add(row);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -19,6 +19,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
@@ -61,6 +63,8 @@ import com.starrocks.thrift.TStatisticData;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.Type;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
@@ -71,7 +75,9 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -305,6 +311,33 @@ public class StatisticExecutor {
         String sql = StatisticSQLBuilder.buildDropExternalHistogramSQLForRawUuid(rawTableUUID, Lists.newArrayList(columnName));
         LOG.debug("Cleanup stale raw-keyed external histogram row SQL: {}", sql);
         return executeDML(statsConnectCtx, sql);
+    }
+
+    // See StatisticSQLBuilder#buildDropExternalStatExcludingPartitionSQL. Best-effort: a failure
+    // here leaves the pre-existing double-counting in place (not made worse) rather than failing
+    // the caller's otherwise-successful collection.
+    public void dropExternalTableStatisticsExcludingPartition(ConnectContext statsConnectCtx, String tableUUID,
+                                                               String excludedPartitionName, List<String> columnNames) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(tableUUID, excludedPartitionName,
+                columnNames);
+        LOG.debug("Cleanup stale external statistic SQL: {}", sql);
+
+        boolean result = executeDML(statsConnectCtx, sql);
+        if (!result) {
+            LOG.warn("Execute stale external statistic cleanup fail, tableUUID={}", tableUUID);
+        }
+    }
+
+    // See StatisticSQLBuilder#buildDropExternalStatForPartitionSQL.
+    public void dropExternalTableStatisticsForPartition(ConnectContext statsConnectCtx, String tableUUID,
+                                                        String partitionName, List<String> columnNames) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatForPartitionSQL(tableUUID, partitionName, columnNames);
+        LOG.debug("Cleanup sentinel external statistic SQL: {}", sql);
+
+        boolean result = executeDML(statsConnectCtx, sql);
+        if (!result) {
+            LOG.warn("Execute sentinel external statistic cleanup fail, tableUUID={}", tableUUID);
+        }
     }
 
     public boolean dropPartitionStatistics(ConnectContext statsConnectCtx, List<Long> pids) {
@@ -736,12 +769,32 @@ public class StatisticExecutor {
     }
 
     public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
-        List<TResultBatch> sqlResult = executeDQL(context, sql);
+        List<TResultBatch> sqlResult = executeDQL(context, sql, TResultSinkType.STATISTIC);
         try {
             return deserializerStatisticData(sqlResult);
         } catch (TException e) {
             throw new SemanticException(e.getMessage());
         }
+    }
+
+    /**
+     * Executes a query whose row shape isn't the fixed 9-field {@link TStatisticData} struct (e.g. a
+     * single-pass wide row covering many columns' worth of aggregates). Uses the HTTP/JSON result
+     * protocol, which serializes each row as {@code {"data": [col1, col2, ...]}} regardless of width,
+     * and returns each row's decoded JSON array positionally -- the caller maps array indices back to
+     * its own column layout.
+     */
+    public List<JsonArray> executeWideRowDQL(ConnectContext context, String sql) {
+        List<TResultBatch> sqlResult = executeDQL(context, sql, TResultSinkType.HTTP_PROTOCAL);
+        List<JsonArray> rows = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(sqlResult)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                rows.add(JsonParser.parseString(jsonString).getAsJsonObject().get("data").getAsJsonArray());
+            }
+        }
+        return rows;
     }
 
     /**
@@ -770,7 +823,7 @@ public class StatisticExecutor {
                 tableId, sourcePartition, targetPartition);
     }
 
-    private List<TResultBatch> executeDQL(ConnectContext context, String sql) {
+    private List<TResultBatch> executeDQL(ConnectContext context, String sql, TResultSinkType resultSinkType) {
         context.setQueryId(UUIDUtil.genUUID());
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: Statistics collect，query id:{}, sql:{}", context.getQueryId(), sql);
@@ -780,7 +833,7 @@ public class StatisticExecutor {
         }
         Stopwatch watch = Stopwatch.createStarted();
         StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
-        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
+        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, resultSinkType);
         StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
         context.setExecutor(executor);
         context.getSessionVariable().setEnableMaterializedViewRewrite(false);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -360,6 +360,45 @@ public class StatisticSQLBuilder {
                 " AND DB_NAME = '" + dbName + "' AND TABLE_NAME = '" + tableName + "'";
     }
 
+    // Deletes rows for the given columns whose partition_name is NOT the given sentinel value.
+    // Used by Iceberg sample collection to clean up stale real-partition rows left behind by a
+    // prior FULL collection on the same table, once the sample's sentinel row is a fresh,
+    // authoritative replacement -- otherwise the read path's sum(row_count)/sum(data_size)/
+    // sum(null_count) (grouped by column_name only, see QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE)
+    // would double-count the old FULL rows alongside the new sentinel row. Matches both the hashed
+    // and raw table_uuid (see buildTableUUIDInPredicateQuoted) since the rows being cleaned up may
+    // have been written before or after the hashing migration.
+    public static String buildDropExternalStatExcludingPartitionSQL(String tableUUID, String excludedPartitionName,
+                                                                     List<String> columnNames) {
+        StringBuilder sql = new StringBuilder("DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID) +
+                " AND PARTITION_NAME != '" + SqlUtils.escapeSqlString(excludedPartitionName) + "'");
+        appendColumnNameFilter(sql, columnNames);
+        return sql.toString();
+    }
+
+    // Deletes rows for the given columns whose partition_name IS the given sentinel value. Used by
+    // ExternalFullStatisticsCollectJob to clean up a stale whole-table sample sentinel row left
+    // behind by a prior SAMPLE collection, in case FULL is run manually afterward. Matches both the
+    // hashed and raw table_uuid, same rationale as buildDropExternalStatExcludingPartitionSQL.
+    public static String buildDropExternalStatForPartitionSQL(String tableUUID, String partitionName,
+                                                               List<String> columnNames) {
+        StringBuilder sql = new StringBuilder("DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID) +
+                " AND PARTITION_NAME = '" + SqlUtils.escapeSqlString(partitionName) + "'");
+        appendColumnNameFilter(sql, columnNames);
+        return sql.toString();
+    }
+
+    private static void appendColumnNameFilter(StringBuilder sql, List<String> columnNames) {
+        if (columnNames != null && !columnNames.isEmpty()) {
+            String cols = columnNames.stream()
+                    .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'")
+                    .collect(Collectors.joining(", "));
+            sql.append(" AND COLUMN_NAME IN (").append(cols).append(")");
+        }
+    }
+
     public static String buildDropPartitionSQL(List<Long> pids) {
         return "DELETE FROM " + FULL_STATISTICS_TABLE_NAME + " WHERE " +
                 " PARTITION_ID IN (" +

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -40,7 +40,12 @@ public class StatsConstants {
     public static final int STATISTIC_QUERY_MULTI_COLUMN_VERSION = 13;
     public static final int STATISTIC_PARTITION_VERSION_V2 = 20;
 
-
+    // external_column_statistics is keyed by (table_uuid, partition_name, column_name); a
+    // whole-table Iceberg file sample has no real partition to attach its row to, so it uses this
+    // fixed sentinel instead. Must never collide with a real Iceberg partition name. Shared between
+    // ExternalSampleStatisticsCollectJob (writes/reads it) and ExternalFullStatisticsCollectJob
+    // (cleans it up after a FULL collection, in case a prior SAMPLE run left one behind).
+    public static final String EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL = "$FILE_SAMPLE$";
 
     public static final ImmutableSet<Integer> STATISTIC_SUPPORTED_VERSION =
             ImmutableSet.<Integer>builder()

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIteratorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIteratorTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.io.CloseableIterator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BernoulliFileScanTaskIteratorTest {
+
+    private static CloseableIterator<FileScanTask> tasks(int n) {
+        List<FileScanTask> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(Mockito.mock(FileScanTask.class));
+        }
+        Iterator<FileScanTask> it = list.iterator();
+        return new CloseableIterator<>() {
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public FileScanTask next() {
+                return it.next();
+            }
+        };
+    }
+
+    @Test
+    public void testRatioOneKeepsAll() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(50), 1.0, 42)) {
+            int count = 0;
+            while (sampled.hasNext()) {
+                sampled.next();
+                count++;
+            }
+            assertEquals(50, count);
+            assertEquals(50, sampled.getTotalFileCount());
+            assertEquals(50, sampled.getSelectedFileCount());
+        }
+    }
+
+    @Test
+    public void testRatioZeroDropsAll() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(50), 0.0, 42)) {
+            assertFalse(sampled.hasNext());
+            assertEquals(50, sampled.getTotalFileCount());
+            assertEquals(0, sampled.getSelectedFileCount());
+        }
+    }
+
+    @Test
+    public void testFixedSeedIsDeterministic() throws Exception {
+        long selectedA;
+        long selectedB;
+        try (BernoulliFileScanTaskIterator a = new BernoulliFileScanTaskIterator(tasks(2000), 0.1, 7)) {
+            while (a.hasNext()) {
+                a.next();
+            }
+            selectedA = a.getSelectedFileCount();
+        }
+        try (BernoulliFileScanTaskIterator b = new BernoulliFileScanTaskIterator(tasks(2000), 0.1, 7)) {
+            while (b.hasNext()) {
+                b.next();
+            }
+            selectedB = b.getSelectedFileCount();
+        }
+        assertEquals(selectedA, selectedB);
+    }
+
+    @Test
+    public void testRatioApproximatelyMatchesSelectionFraction() throws Exception {
+        int total = 20000;
+        double ratio = 0.03;
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(total), ratio, 123)) {
+            int count = 0;
+            while (sampled.hasNext()) {
+                sampled.next();
+                count++;
+            }
+            assertEquals(total, sampled.getTotalFileCount());
+            assertEquals(count, sampled.getSelectedFileCount());
+            double observedRatio = (double) count / total;
+            // Bernoulli(p=0.03) over 20k trials: std dev ~= sqrt(20000*0.03*0.97) ~= 24 files ~= 0.0012 in ratio.
+            // Allow a generous 10x margin to keep this non-flaky.
+            assertTrue(Math.abs(observedRatio - ratio) < 0.012,
+                    "observed ratio " + observedRatio + " too far from target " + ratio);
+        }
+    }
+
+    @Test
+    public void testNextThrowsAfterExhausted() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(0), 1.0, 1)) {
+            assertFalse(sampled.hasNext());
+            assertThrows(NoSuchElementException.class, sampled::next);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExternalSampleStatisticsCollectJobTest {
+
+    @Test
+    public void testLowCardinalityColumnConverges() {
+        // A boolean-like column: NDV settles at 2 after the first round and never moves again.
+        Map<String, Long> prev = Map.of("is_active", 2L);
+        Map<String, Long> curr = Map.of("is_active", 2L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testHighCardinalityColumnKeepsGrowingDoesNotConverge() {
+        // A near-unique id column: doubling the sample roughly doubles the observed NDV, so the
+        // round loop must keep going instead of stopping early.
+        Map<String, Long> prev = Map.of("id", 2_000_000L);
+        Map<String, Long> curr = Map.of("id", 3_900_000L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testWithinThresholdConverges() {
+        Map<String, Long> prev = Map.of("c1", 1000L);
+        Map<String, Long> curr = Map.of("c1", 1020L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testSingleNonConvergingColumnBlocksWholeRound() {
+        // Even if most columns have settled, one still-changing column (typically the
+        // highest-cardinality one) must keep the round loop from stopping early.
+        Map<String, Long> prev = Map.of("stable", 5L, "growing", 1000L);
+        Map<String, Long> curr = Map.of("stable", 5L, "growing", 2000L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testMissingPreviousColumnTreatedAsNotConverged() {
+        Map<String, Long> prev = Map.of();
+        Map<String, Long> curr = Map.of("new_column", 10L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testZeroCardinalityBothRoundsConverges() {
+        // An all-null column: cardinality stays 0 across rounds, must not divide by zero.
+        Map<String, Long> prev = Map.of("all_null", 0L);
+        Map<String, Long> curr = Map.of("all_null", 0L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -19,6 +19,7 @@ import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 // external_column_statistics / external_histogram_statistics store table_uuid hashed
@@ -144,5 +145,40 @@ class StatisticSQLBuilderTest {
         Assertions.assertTrue(sql.contains("TABLE_UUID = 'iceberg.db.o''brien\\\\table.uuid'"), sql);
         Assertions.assertTrue(sql.contains("PARTITION_NAME IN ('p''1')"), sql);
         Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c\\\\1')"), sql);
+    }
+
+    // --- Iceberg SAMPLE sentinel-row cleanup (FULL/SAMPLE double-counting fix) ---
+    // buildDropExternalStatExcludingPartitionSQL / buildDropExternalStatForPartitionSQL also match
+    // both the hashed and raw table_uuid (buildTableUUIDInPredicateQuoted), for the same reason as
+    // every other predicate in this class: the rows being cleaned up may have been written before
+    // or after the hashing migration.
+
+    @Test
+    void testBuildDropExternalStatExcludingPartitionSQL() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage("uuid-1");
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", List.of("c1", "c2"));
+        Assertions.assertTrue(sql.contains("DELETE FROM external_column_statistics"));
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', 'uuid-1')"));
+        Assertions.assertTrue(sql.contains("PARTITION_NAME != '$FILE_SAMPLE$'"));
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c1', 'c2')"));
+    }
+
+    @Test
+    void testBuildDropExternalStatExcludingPartitionSQLNoColumns() {
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", Collections.emptyList());
+        Assertions.assertTrue(sql.contains("PARTITION_NAME != '$FILE_SAMPLE$'"));
+        Assertions.assertFalse(sql.contains("COLUMN_NAME"));
+    }
+
+    @Test
+    void testBuildDropExternalStatForPartitionSQL() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage("uuid-1");
+        String sql = StatisticSQLBuilder.buildDropExternalStatForPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", List.of("c1"));
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', 'uuid-1')"));
+        Assertions.assertTrue(sql.contains("PARTITION_NAME = '$FILE_SAMPLE$'"));
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c1')"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Today, `ANALYZE ... SAMPLE` on an Iceberg external table just picks the latest N partitions and does a **full scan** of them. Cost is unbounded whenever a single partition is large — a table with a few TB-scale partitions makes SAMPLE ANALYZE effectively as expensive as FULL, defeating the point of sampling. We want a sampling strategy that:

- Works at the file level across the whole table (not scoped to a handful of partitions),
- Has a hard, predictable cost cap regardless of table size,
- Gets more accurate over time without needing a separate full scan,
- Requires zero BE changes.


## What I'm doing:
Add a Bernoulli file-sampling layer that FE applies to the scan plan right after Iceberg's file list is split into scan units, before scan ranges are handed to BE. Each unit is independently kept/dropped by a probability `ratio`; dropped units cost zero IO and BE never knows sampling happened.


```
read total row_count (Iceberg manifest-list summary fields, zero data IO)
        │
        ▼
round loop (inside one ANALYZE execution, resumes from last run's round):
    rowsThisRound = min(row_count, cap << round)      // cap doubles each round
    ratio = min(1.0, rowsThisRound / row_count)
    → run one sampled collection pass, upsert into stats table
    → stop once ratio hits 1.0 (full coverage) or max rounds reached
        │
        ▼
planFiles() → split into scan units (existing parallelism logic, unchanged)
        → Bernoulli filter(ratio)   // FE-only, drops units before scan ranges are built
        → scan ranges → BE (scans only the kept units)
```

Key pieces:
- **Ratio is row-count calibrated, with an absolute cap**: `ratio = min(1.0, targetRows / totalRows)`, where `totalRows` comes from Iceberg manifest-list summary fields (no data files opened). This bounds a single round's cost by an absolute row budget instead of a bare percentage, so cost stays predictable even for astronomically large tables.
- **Progressive rounds, warm-started across scheduled runs**: within one ANALYZE execution, the target row budget doubles each round until it reaches full coverage or a max-round limit. The round index is persisted in `AnalyzeStatus` properties so the *next* scheduled run resumes from where the last one left off, instead of always restarting at the smallest ratio.
- **Sampling ratio flows through session variables, not SQL text**: the ANALYZE job sets two invisible session variables on its own connection; the Iceberg connector reads them when building the scan. A tricky gotcha worth flagging: the connector has a query-planning-time file-list cache keyed without the sampling ratio — if left alone, cost-estimation would populate that cache with the *unsampled* file list under the same key, and the sampled execution would silently hit that cache and skip sampling entirely. Sampled requests now bypass that cache.
- **Statistics computed from the same sampled pass**: row count is rescaled by `1/ratio`; NDV and min/max are used as-is from the sampled rows (a conservative, CBO-safe direction — no rescaling attempted).
- Hive, Delta, and other external table types are untouched; they keep the existing "latest N partitions, full scan" sampling behavior.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ]  No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
