### PR TITLE
[BugFix] Reduce lock contention across the insert overwrite code path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
@@ -81,13 +81,14 @@ public class TempPartitions implements Writable, GsonPostProcessable {
             idToPartition.remove(partition.getId());
             nameToPartition.remove(partitionName);
             if (!GlobalStateMgr.isCheckpointThread() && needDropTablet) {
-                TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+                List<Long> tabletIds = Lists.newArrayList();
                 for (MaterializedIndex index :
                         partition.getDefaultPhysicalPartition().getAllMaterializedIndices(IndexExtState.ALL)) {
                     for (Tablet tablet : index.getTablets()) {
-                        invertedIndex.deleteTablet(tablet.getId());
+                        tabletIds.add(tablet.getId());
                     }
                 }
+                GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteTablets(tabletIds);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -84,6 +84,22 @@ import static com.starrocks.load.InsertOverwriteJobState.OVERWRITE_FAILED;
 //     3. if insert successfully, swap the temporary partitions with source partitions
 //     4. if insert failed, remove the temporary partitions created
 //     5. if FE restart, the insert overwrite job will fail.
+//
+// Concurrency: there is NO mutual exclusion between concurrent insert overwrite jobs
+// on the same table or the same partitions. InsertOverwriteJobMgr keeps a list of
+// running jobs per table and never rejects a new one; the table locks taken by the
+// individual phases protect metadata consistency only, not job-level serialization.
+// Overwrites of disjoint partition sets run in parallel without interference. For
+// overlapping partitions the outcome depends on timing:
+//   - if one job commits before another passes prepare()/createTempPartitions(), the
+//     later job fails because its source partition ids no longer exist (the swap
+//     replaces a partition with a new one that keeps the name but gets a new id);
+//   - if both jobs pass prepare(), both succeed and the LAST commit wins: source
+//     partitions are matched by NAME in doCommit(), so the later swap replaces the
+//     earlier job's just-committed partitions, equivalent to running the two
+//     statements serially in commit order.
+// No interleaving corrupts metadata: the swap always runs under the table WRITE lock
+// and re-resolves partitions at commit time.
 public class InsertOverwriteJobRunner {
     private static final Logger LOG = LogManager.getLogger(InsertOverwriteJobRunner.class);
 
@@ -243,8 +259,26 @@ public class InsertOverwriteJobRunner {
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
+
+        // For dynamic overwrite, begin transaction to get txnId early. This allows us
+        // to persist txnId in the log, so that after FE restart, we can identify temp
+        // partitions belonging to this job (prefix: "txn{txnId}_"). Beginning the
+        // transaction only touches transaction manager state, so it runs before the
+        // table lock; if prepare fails after this point, gc() aborts the transaction.
+        if (job.isDynamicOverwrite()) {
+            long txnId = beginTransactionForDynamicOverwrite();
+            job.setTxnId(txnId);
+            LOG.info("dynamic overwrite job {} begin transaction, txnId: {}", job.getJobId(), txnId);
+        }
+
+        // A READ lock is enough here: this section only resolves partition ids to
+        // names and logs the RUNNING state change with an empty WAL applier, so no
+        // table state is mutated. The READ lock keeps the id-to-name mapping stable
+        // (rename/drop requires the table WRITE lock) until the log entry is durable.
+        // It provides NO exclusion between concurrent insert overwrite jobs on the
+        // same table (see the class comment).
         Locker locker = new Locker();
-        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.READ)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
 
@@ -261,34 +295,25 @@ public class InsertOverwriteJobRunner {
             }
             job.setSourcePartitionNames(sourcePartitionNames);
 
-            // For dynamic overwrite, begin transaction here to get txnId early.
-            // This allows us to persist txnId in the log, so that after FE restart,
-            // we can identify temp partitions belonging to this job (prefix: "txn{txnId}_").
-            if (job.isDynamicOverwrite()) {
-                long txnId = beginTransactionForDynamicOverwrite(db, targetTable);
-                job.setTxnId(txnId);
-                LOG.info("dynamic overwrite job {} begin transaction, txnId: {}", job.getJobId(), txnId);
-            }
-
             InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                     InsertOverwriteJobState.OVERWRITE_RUNNING, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
                     job.getTmpPartitionIds(), job.getTxnId());
             GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {});
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
         transferTo(InsertOverwriteJobState.OVERWRITE_RUNNING);
     }
 
-    private long beginTransactionForDynamicOverwrite(Database db, OlapTable targetTable) throws Exception {
+    private long beginTransactionForDynamicOverwrite() throws Exception {
         GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         String label = MetaUtils.genInsertLabel(context.getExecutionId());
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
 
         return transactionMgr.beginTransaction(
-                db.getId(),
-                Lists.newArrayList(targetTable.getId()),
+                dbId,
+                Lists.newArrayList(tableId),
                 label,
                 new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
                         FrontendOptions.getLocalHostAddress()),
@@ -428,21 +453,40 @@ public class InsertOverwriteJobRunner {
 
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
         if (db == null || !db.isExist()) {
+            // the dynamic overwrite transaction needs only dbId and txnId to abort;
+            // clean it up even when the database is gone, otherwise it lingers until
+            // the transaction timeout checker reaps it
+            abortDynamicOverwriteTxnQuietly();
             throw new DmlException("database id:%s does not exist", dbId);
         }
         Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         if (table == null) {
+            abortDynamicOverwriteTxnQuietly();
             throw new DmlException("table:%d does not exist in database:%s", tableId, db.getFullName());
         }
         Preconditions.checkState(table instanceof OlapTable);
         OlapTable targetTable = (OlapTable) table;
 
+        // For dynamic overwrite, the temp partition names come from the load transaction,
+        // and the transaction may still be finalizing. The wait polls with sleeps, so run
+        // it before taking the table lock; it only reads transaction state.
+        if (job.isDynamicOverwrite() && insertStmt != null && job.getTxnId() > 0) {
+            try {
+                waitTransactionSettled();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.warn("interrupted while waiting for insert overwrite transaction {} to settle", job.getTxnId(), e);
+            } catch (Exception e) {
+                LOG.warn("failed to wait for insert overwrite transaction {} to settle", job.getTxnId(), e);
+            }
+        }
+
+        Set<Tablet> sourceTablets = Sets.newHashSet();
         Locker locker = new Locker();
         if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
         try {
-            Set<Tablet> sourceTablets = Sets.newHashSet();
             // Drop temp partitions by partition IDs (for non-dynamic overwrite)
             List<String> partitionNamesToDrop = new ArrayList<>();
             if (job.getTmpPartitionIds() != null) {
@@ -473,21 +517,6 @@ public class InsertOverwriteJobRunner {
                 job.setTmpPartitionIds(tmpPartitionIds);
             }
 
-            // Mark all source tablet ids force delete to drop it directly on BE
-            sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
-
-            // Abort the transaction if it was created in prepare()
-            if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
-                try {
-                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
-                            dbId, job.getTxnId(), "insert overwrite job failed");
-                    LOG.info("dynamic overwrite job {} aborted transaction {}", job.getJobId(), job.getTxnId());
-                } catch (Exception e) {
-                    LOG.warn("failed to abort transaction {} for dynamic overwrite job {}: {}",
-                            job.getTxnId(), job.getJobId(), e.getMessage());
-                }
-            }
-
             InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                     OVERWRITE_FAILED, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
                     job.getTmpPartitionIds(), job.getTxnId());
@@ -501,6 +530,30 @@ public class InsertOverwriteJobRunner {
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
+
+        // Mark all source tablet ids force delete to drop it directly on BE. Best-effort
+        // in-memory hints, no table lock needed.
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().markTabletsForceDelete(sourceTablets);
+
+        abortDynamicOverwriteTxnQuietly();
+    }
+
+    // Abort the transaction created in prepare() for a dynamic overwrite job, if any.
+    // It needs only dbId and txnId and takes transaction manager locks, so it must be
+    // called without the table lock held, and it works even when the target db/table
+    // has been dropped concurrently.
+    private void abortDynamicOverwriteTxnQuietly() {
+        if (!job.isDynamicOverwrite() || job.getTxnId() <= 0) {
+            return;
+        }
+        try {
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                    dbId, job.getTxnId(), "insert overwrite job failed");
+            LOG.info("dynamic overwrite job {} aborted transaction {}", job.getJobId(), job.getTxnId());
+        } catch (Exception e) {
+            LOG.warn("failed to abort transaction {} for dynamic overwrite job {}: {}",
+                    job.getTxnId(), job.getJobId(), e.getMessage());
+        }
     }
 
     /**
@@ -510,8 +563,7 @@ public class InsertOverwriteJobRunner {
      * 2. After FE restart: identify temp partitions by prefix "txn{txnId}_"
      * 3. Cancelled before prepare: no temp partitions to clean up
      */
-    private List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable)
-            throws InterruptedException {
+    private List<String> getDynamicOverwriteTempPartitions(OlapTable targetTable) {
         List<String> tmpPartitionNames = Lists.newArrayList();
         if (insertStmt != null && job.getTxnId() > 0) {
             // Normal execution: get temp partition names from TransactionState
@@ -534,18 +586,31 @@ public class InsertOverwriteJobRunner {
         return tmpPartitionNames;
     }
 
-    private List<String> getTempPartitionNamesFromTxnState() throws InterruptedException {
+    // Wait until the load transaction of a dynamic overwrite job is no longer running,
+    // so that getCreatedPartitionNames() below returns the complete list. This polls
+    // with sleeps and only reads transaction state, so it must be called before the
+    // table lock is taken.
+    private void waitTransactionSettled() throws InterruptedException {
         int waitTimes = 10;
-        TransactionState txnState = null;
-        do {
-            txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+        while (true) {
+            TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
                     .getTransactionState(dbId, job.getTxnId());
             if (txnState == null) {
                 throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, job.getTxnId());
             }
+            if (!txnState.isRunning() || --waitTimes <= 0) {
+                return;
+            }
             Thread.sleep(200);
-        } while (txnState.isRunning() && --waitTimes > 0);
+        }
+    }
 
+    private List<String> getTempPartitionNamesFromTxnState() {
+        TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .getTransactionState(dbId, job.getTxnId());
+        if (txnState == null) {
+            throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, job.getTxnId());
+        }
         List<String> tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
         LOG.info("dynamic overwrite job {} drop tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
         return tmpPartitionNames;
@@ -595,18 +660,16 @@ public class InsertOverwriteJobRunner {
         if (db == null) {
             throw new DmlException("database id:%s does not exist", dbId);
         }
-        Locker locker = new Locker();
-        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
-            throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
-        }
         OlapTable tmpTargetTable = null;
         InsertOverwriteJobStats stats = new InsertOverwriteJobStats();
         stats.setSourcePartitionIds(job.getSourcePartitionIds());
         stats.setTargetPartitionIds(job.getTmpPartitionIds());
+        Set<Tablet> sourceTablets = Sets.newHashSet();
 
-        // Collect partition tablet row counts for statistics sampling
-        com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
-
+        Locker locker = new Locker();
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
+            throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
+        }
         try {
             // try exception to release write lock finally
             final OlapTable targetTable = checkAndGetTable(db, tableId);
@@ -636,7 +699,6 @@ public class InsertOverwriteJobRunner {
                         return partition.getName();
                     })
                     .collect(Collectors.toList());
-            Set<Tablet> sourceTablets = Sets.newHashSet();
             sourcePartitionNames.forEach(name -> {
                 Partition partition = targetTable.getPartition(name);
                 for (PhysicalPartition subPartition : partition.getSubPartitions()) {
@@ -714,6 +776,47 @@ public class InsertOverwriteJobRunner {
                 throw new DdlException("partition type " + partitionInfo.getType() + " is not supported");
             }
 
+            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
+                    InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
+                    job.getTmpPartitionIds(), job.getTxnId());
+            final List<String> finalSourcePartitionNames = sourcePartitionNames;
+            final List<String> finalTmpPartitionNames = tmpPartitionNames;
+            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {
+                replacePartition(targetTable, finalSourcePartitionNames, finalTmpPartitionNames);
+            });
+
+            targetTable.lastSchemaUpdateTime.set(System.nanoTime());
+        } catch (Exception e) {
+            LOG.warn("replace partitions failed when insert overwrite into dbId:{}, tableId:{}",
+                    job.getTargetDbId(), job.getTargetTableId(), e);
+            throw new DmlException("replace partitions failed", e);
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+        }
+
+        postCommit(tmpTargetTable, sourceTablets, stats);
+
+        // trigger listeners after insert overwrite committed, trigger listeners after
+        // write unlock to avoid holding lock too long
+        GlobalStateMgr.getCurrentState().getOperationListenerBus()
+                .onInsertOverwriteJobCommitFinish(db, tmpTargetTable, stats);
+    }
+
+    // Post-commit follow-up. The partition swap is already durable in the journal, so
+    // nothing here may fail the job: an exception escaping doCommit() at this point
+    // would route the job to gc(), which would drop the partitions that just became
+    // live. None of this work needs the table WRITE lock.
+    private void postCommit(OlapTable targetTable, Set<Tablet> sourceTablets, InsertOverwriteJobStats stats) {
+        // mark all source tablet ids force delete to drop it directly on BE, not to
+        // move it to trash. The marks are best-effort in-memory hints consumed by
+        // ReportHandler only after the recycle bin erases the swapped-out partitions,
+        // which happens far later than this point.
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().markTabletsForceDelete(sourceTablets);
+
+        // Collect partition tablet row counts for statistics sampling
+        com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
+        try (AutoCloseableLock ignore =
+                new AutoCloseableLock(new Locker(), dbId, Lists.newArrayList(tableId), LockType.READ)) {
             long sumTargetRows = 0;
             if (insertStmt != null) {
                 TransactionState txnState = GlobalStateMgr.getCurrentState()
@@ -765,40 +868,18 @@ public class InsertOverwriteJobRunner {
 
             stats.setTargetRows(sumTargetRows);
             stats.setPartitionTabletRowCounts(partitionTabletRowCounts);
-            // mark all source tablet ids force delete to drop it directly on BE,
-            // not to move it to trash
-            sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
 
-            InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
-                    InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
-                    job.getTmpPartitionIds(), job.getTxnId());
-            final List<String> finalSourcePartitionNames = sourcePartitionNames;
-            final List<String> finalTmpPartitionNames = tmpPartitionNames;
-            GlobalStateMgr.getCurrentState().getEditLog().logInsertOverwriteStateChange(info, wal -> {
-                replacePartition(targetTable, finalSourcePartitionNames, finalTmpPartitionNames);
-            });
-
-            try {
-                GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(targetTable,
-                        true /* isJoin */, null /* expectGroupId */);
-            } catch (DdlException e) {
-                // log an error if update colocation info failed, insert overwrite already succeeded
-                LOG.error("table {} update colocation info failed after insert overwrite, {}.", tableId, e.getMessage());
-            }
-
-            targetTable.lastSchemaUpdateTime.set(System.nanoTime());
+            // ColocateTableIndex self-protects with its own lock, and for lake tables this
+            // ends with a StarOS RPC, so it must not run under the table WRITE lock; the
+            // table READ lock is enough for the shard group reads (same locking as
+            // StarMgrMetaSyncer.syncTableColocationInfo).
+            GlobalStateMgr.getCurrentState().getColocateTableIndex().updateLakeTableColocationInfo(targetTable,
+                    true /* isJoin */, null /* expectGroupId */);
         } catch (Exception e) {
-            LOG.warn("replace partitions failed when insert overwrite into dbId:{}, tableId:{}",
-                    job.getTargetDbId(), job.getTargetTableId(), e);
-            throw new DmlException("replace partitions failed", e);
-        } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+            // log an error if post-commit work failed, insert overwrite already succeeded
+            LOG.error("insert overwrite post-commit work failed for dbId:{}, tableId:{}, the job still succeeds",
+                    dbId, tableId, e);
         }
-
-        // trigger listeners after insert overwrite committed, trigger listeners after
-        // write unlock to avoid holding lock too long
-        GlobalStateMgr.getCurrentState().getOperationListenerBus()
-                .onInsertOverwriteJobCommitFinish(db, tmpTargetTable, stats);
     }
 
     private void replacePartition(OlapTable targetTable,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3212,7 +3212,13 @@ public class StmtExecutor {
         InsertOverwriteJob job = new InsertOverwriteJob(GlobalStateMgr.getCurrentState().getNextId(),
                 insertStmt, db.getId(), olapTable.getId(), context.getCurrentWarehouseId(),
                 insertStmt.isDynamicOverwrite());
-        if (!locker.lockTableAndCheckDbExist(db, olapTable.getId(), LockType.WRITE)) {
+        // A READ lock is enough here: the job is fully built above and the critical
+        // section only writes the job-creation edit log; no table state is read or
+        // mutated. The lock merely keeps the table from being dropped until the job
+        // creation is durable, and InsertOverwriteJobRunner.prepare() re-validates the
+        // table after this. Note it provides NO exclusion between concurrent insert
+        // overwrite jobs on the same table (see InsertOverwriteJobRunner).
+        if (!locker.lockTableAndCheckDbExist(db, olapTable.getId(), LockType.READ)) {
             throw new DmlException("database:%s does not exist.", db.getFullName());
         }
         try {
@@ -3222,7 +3228,7 @@ public class StmtExecutor {
                     job.isDynamicOverwrite());
             GlobalStateMgr.getCurrentState().getEditLog().logCreateInsertOverwrite(info);
         } finally {
-            locker.unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), olapTable.getId(), LockType.READ);
         }
         insertStmt.setOverwriteJobId(job.getJobId());
         InsertOverwriteJobMgr manager = GlobalStateMgr.getCurrentState().getInsertOverwriteJobMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerEditLogTest.java
@@ -24,8 +24,10 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.persist.EditLog;
@@ -33,10 +35,13 @@ import com.starrocks.persist.InsertOverwriteStateChangeInfo;
 import com.starrocks.persist.OperationType;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -50,13 +55,19 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class InsertOverwriteJobRunnerEditLogTest {
     private static final String DB_NAME = "test_insert_overwrite_editlog";
     private static final String TABLE_NAME = "t1";
 
     private static final long INDEX_ID = 41007L;
+    // Backend id used by the single replica of every tablet built in this test. The
+    // replicas exist so that markTabletForceDelete has backend ids to record; they are
+    // deliberately NOT registered in the tablet inverted index.
+    private static final long BACKEND_ID = 20001L;
 
     private Database db;
     private OlapTable table;
@@ -156,6 +167,80 @@ public class InsertOverwriteJobRunnerEditLogTest {
     }
 
     @Test
+    public void testDoCommitMarksSourceTabletsForceDelete() {
+        InsertOverwriteJob job = new InsertOverwriteJob(2007L, db.getId(), table.getId(),
+                Lists.newArrayList(sourcePartitionId), false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+        job.setSourcePartitionNames(Lists.newArrayList(TABLE_NAME));
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        runner.doCommit();
+
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+        // the swapped-out source tablets must be marked so BE drops them directly
+        // instead of moving them to trash
+        Assertions.assertTrue(invertedIndex.tabletForceDelete(sourceTabletId, BACKEND_ID));
+        // the tablets of the new (previously temp) partition are live and must never
+        // be marked
+        Assertions.assertFalse(invertedIndex.tabletForceDelete(tempTabletId, BACKEND_ID));
+    }
+
+    @Test
+    public void testPostCommitFailureDoesNotFailCommittedJob() {
+        InsertStmt insertStmt = mock(InsertStmt.class);
+        when(insertStmt.getTargetPartitionIds()).thenReturn(Lists.newArrayList(sourcePartitionId));
+        // doCommit's critical section never touches insertStmt for a non-dynamic job,
+        // so this throws exactly inside postCommit's statistics collection
+        when(insertStmt.getTxnId()).thenThrow(new RuntimeException("injected post-commit failure"));
+
+        InsertOverwriteJob job = new InsertOverwriteJob(2008L, insertStmt, db.getId(), table.getId(),
+                0L, false);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_RUNNING);
+        job.setTmpPartitionIds(Lists.newArrayList(tempPartitionId));
+        job.setSourcePartitionNames(Lists.newArrayList(TABLE_NAME));
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job, null, null);
+        // the swap is journaled before post-commit work runs; a post-commit failure
+        // must not escape doCommit, otherwise the job would be routed to gc(), which
+        // would drop the partitions that just became live
+        Assertions.assertDoesNotThrow(runner::doCommit);
+
+        Partition replaced = table.getPartition(TABLE_NAME);
+        Assertions.assertNotNull(replaced);
+        Assertions.assertEquals(tempPartitionId, replaced.getId());
+        Assertions.assertFalse(table.existTempPartitions());
+        // marking precedes the failing statistics collection, so it must have happened
+        Assertions.assertTrue(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
+                .tabletForceDelete(sourceTabletId, BACKEND_ID));
+    }
+
+    @Test
+    public void testGcAbortsDynamicTxnWhenTableDropped() throws Exception {
+        long txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                dbId, Lists.newArrayList(tableId), "test_dynamic_overwrite_gc_abort",
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "127.0.0.1"),
+                TransactionState.LoadJobSourceType.INSERT_STREAMING, 600);
+
+        InsertOverwriteJob job = new InsertOverwriteJob(2009L, db.getId(), table.getId(), null, true);
+        job.setJobState(InsertOverwriteJobState.OVERWRITE_FAILED);
+        job.setTxnId(txnId);
+
+        // drop the target table so gc() hits the early table-not-exist exit
+        db.dropTable(TABLE_NAME);
+
+        InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(job);
+        Assertions.assertThrows(DmlException.class, runner::gc);
+
+        // the PREPARE transaction must not leak until the txn timeout checker reaps
+        // it: gc() aborts it even though the table is gone
+        TransactionState txnState = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                .getTransactionState(dbId, txnId);
+        Assertions.assertNotNull(txnState);
+        Assertions.assertEquals(TransactionStatus.ABORTED, txnState.getTransactionStatus());
+    }
+
+    @Test
     public void testDoCommitEditLogException() {
         InsertOverwriteJob job = new InsertOverwriteJob(2005L, db.getId(), table.getId(),
                 Lists.newArrayList(sourcePartitionId), false);
@@ -178,6 +263,13 @@ public class InsertOverwriteJobRunnerEditLogTest {
             Assertions.assertNotNull(sourcePartition);
             Assertions.assertEquals(sourcePartitionId, sourcePartition.getId());
             Assertions.assertTrue(table.existTempPartitions());
+
+            // a failed commit must leave no force-delete marks: the source tablets are
+            // still live, and a stale mark would make BE skip trash on a later
+            // legitimate drop of these tablets
+            TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+            Assertions.assertFalse(invertedIndex.tabletForceDelete(sourceTabletId, BACKEND_ID));
+            Assertions.assertFalse(invertedIndex.tabletForceDelete(tempTabletId, BACKEND_ID));
         } finally {
             GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
         }
@@ -221,6 +313,7 @@ public class InsertOverwriteJobRunnerEditLogTest {
 
         MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
         LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(new Replica(tabletId + 10000L, BACKEND_ID, Replica.ReplicaState.NORMAL, 1L, 0), false);
         TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, INDEX_ID, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
@@ -240,6 +333,7 @@ public class InsertOverwriteJobRunnerEditLogTest {
                                          long physicalPartitionId, long tabletId, String partitionName) {
         MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
         LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(new Replica(tabletId + 10000L, BACKEND_ID, Replica.ReplicaState.NORMAL, 1L, 0), false);
         TabletMeta tabletMeta = new TabletMeta(dbId, table.getId(), partitionId, INDEX_ID, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
@@ -273,6 +367,7 @@ public class InsertOverwriteJobRunnerEditLogTest {
                                             long tabletId, String partitionName) {
         MaterializedIndex baseIndex = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
         LocalTablet tablet = new LocalTablet(tabletId);
+        tablet.addReplica(new Replica(tabletId + 10000L, BACKEND_ID, Replica.ReplicaState.NORMAL, 1L, 0), false);
         TabletMeta tabletMeta = new TabletMeta(dbId, table.getId(), partitionId, INDEX_ID, TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
         DistributionInfo distributionInfo = table.getDefaultDistributionInfo();


### PR DESCRIPTION
Every phase of INSERT OVERWRITE held the db-IX + table-WRITE lock stronger or longer than the work inside required:

- handleInsertOverwrite: the job-creation edit log is written from a pre-built job object and touches no table state; relax the table WRITE lock to READ.
- prepare: the RUNNING state change only resolves partition ids to names and logs with an empty WAL applier, mutating no table state; relax WRITE to READ and begin the dynamic-overwrite transaction before taking the lock (it only touches transaction manager state, and gc() aborts it if prepare fails afterwards).
- doCommit: move force-delete marking (batched, lock-free inverted index writes), target-row statistics collection, and updateLakeTableColocationInfo (which ends with a StarOS RPC for lake tables) out of the WRITE section into a post-commit step; the stats and colocation update run under a table READ lock and are wrapped so a failure after the journaled swap can no longer route the committed job to gc(), which would drop the partitions that just became live.
- gc: hoist the dynamic-overwrite transaction-settle poll (sleeps up to 2s, and previously always at least 200ms) before the lock; move batched force-delete marking and abortTransaction after unlock.
- TempPartitions.dropPartition: delete tablets from the inverted index with one batched deleteTablets call instead of one call per tablet.

Also document on InsertOverwriteJobRunner that concurrent insert overwrite jobs on the same table/partitions have no mutual exclusion: disjoint partition sets run in parallel; overlapping jobs either fail on missing source partition ids or last-commit-wins, with no metadata corruption in any interleaving.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
