### PR TITLE
[Enhancement] Chunk the force-run of a deferred over-large lake PK compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1539,6 +1539,20 @@ CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 // Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
 // size are unaffected even when set).
 CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
+// When a compaction deferred by lake_pk_compaction_defer_large_result_bytes is finally
+// FORCE-RUN (its tablet read pressure crossed lake_pk_compaction_emergency_score), split
+// that one over-large compaction into bounded chunks of at most this many result bytes:
+// the picked input rowsets are truncated to the shortest prefix whose cumulative result
+// bytes reach this cap (at least one rowset), the remainder are left for the next round.
+// This turns a single ~O(GB) synchronous publish (~14s compact_mapper read + PK-index
+// apply) into several small publishes, each of which only briefly stalls the hot tablet's
+// serialized ingest version chain -> lower ingest P99 tail. It only ever engages inside
+// the defer branch (projected output > lake_pk_compaction_defer_large_result_bytes AND
+// emergency), so tablets whose compactions never reach the defer size (e.g. HASH-scattered
+// small tablets) are NEVER chunked -> no compaction churn on them, unlike the global
+// lake_pk_compaction_max_result_bytes. Default 0 = disabled (force-run the full compaction,
+// legacy defer behavior).
+CONF_mInt64(lake_pk_compaction_deferred_chunk_result_bytes, "0");
 // Enable cleanup of orphan delvec entries during compaction.
 // Orphan delvecs are leaked metadata entries from a historical bug that reference
 // non-existent segments and prevent delvec file garbage collection.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1523,6 +1523,22 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // level's compact_level which can be stale after pick_max_level merges levels.
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
 // Enable cleanup of orphan delvec entries during compaction.
 // Orphan delvecs are leaked metadata entries from a historical bug that reference
 // non-existent segments and prevent delvec file garbage collection.

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -236,6 +236,21 @@ CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 // size are unaffected even when set).
 CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
 
+// When a compaction deferred by lake_pk_compaction_defer_large_result_bytes is finally
+// FORCE-RUN (its tablet read pressure crossed lake_pk_compaction_emergency_score), split
+// that one over-large compaction into bounded chunks of at most this many result bytes:
+// the picked input rowsets are truncated to the shortest prefix whose cumulative result
+// bytes reach this cap (at least one rowset), the remainder are left for the next round.
+// This turns a single ~O(GB) synchronous publish (~14s compact_mapper read + PK-index
+// apply) into several small publishes, each of which only briefly stalls the hot tablet's
+// serialized ingest version chain -> lower ingest P99 tail. It only ever engages inside
+// the defer branch (projected output > lake_pk_compaction_defer_large_result_bytes AND
+// emergency), so tablets whose compactions never reach the defer size (e.g. HASH-scattered
+// small tablets) are NEVER chunked -> no compaction churn on them, unlike the global
+// lake_pk_compaction_max_result_bytes. Default 0 = disabled (force-run the full compaction,
+// legacy defer behavior).
+CONF_mInt64(lake_pk_compaction_deferred_chunk_result_bytes, "0");
+
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -219,6 +219,23 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
+
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -722,6 +722,7 @@
         "lake_pk_compaction_emergency_score",
         "lake_pk_compaction_delvec_benefit_weight",
         "lake_pk_compaction_size_overflow_ratio",
+        "lake_pk_compaction_defer_large_result_bytes",
         "enable_light_pk_compaction_publish",
         "enable_lake_compaction_use_partial_segments",
         "enable_lake_compaction_range_split",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -723,6 +723,7 @@
         "lake_pk_compaction_delvec_benefit_weight",
         "lake_pk_compaction_size_overflow_ratio",
         "lake_pk_compaction_defer_large_result_bytes",
+        "lake_pk_compaction_deferred_chunk_result_bytes",
         "enable_light_pk_compaction_publish",
         "enable_lake_compaction_use_partial_segments",
         "enable_lake_compaction_range_split",

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -398,6 +398,36 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         }
     }
 
+    // Defer an over-large compaction so its ~O(GB) synchronous publish (compact_mapper read +
+    // PK-index apply) does not stall the hot tablet's serialized ingest version chain. The
+    // compaction is kept full-size (no shrinking -> no churn); it is simply not submitted this
+    // round -> pick returns empty -> segment score 0 -> FE de-prioritizes it. Bounded by the
+    // read-pressure emergency valve (same signal as skip_sparse_low_score_level [D]) so rowsets
+    // cannot pile up unbounded: once the tablet's read pressure crosses emergency_score the
+    // large compaction proceeds. Cheap SST/index compaction is unaffected (independent path).
+    if (config::lake_pk_compaction_defer_large_result_bytes > 0 &&
+        static_cast<int64_t>(cur_compaction_result_bytes) > config::lake_pk_compaction_defer_large_result_bytes) {
+        double tablet_read_pressure = 0.0;
+        for (const auto& rc : rowset_vec) {
+            tablet_read_pressure += rc.score;
+        }
+        const bool emergency = config::lake_pk_compaction_emergency_score > 0.0 &&
+                               tablet_read_pressure >= config::lake_pk_compaction_emergency_score;
+        if (!emergency) {
+            VLOG(2) << strings::Substitute(
+                    "lake PK compaction deferred (large result): tablet=$0 result_bytes=$1 > defer=$2 "
+                    "read_pressure=$3 (em=$4)",
+                    tablet_metadata->id(), cur_compaction_result_bytes,
+                    config::lake_pk_compaction_defer_large_result_bytes, tablet_read_pressure,
+                    config::lake_pk_compaction_emergency_score);
+            rowset_indexes.clear();
+            if (has_dels != nullptr) {
+                has_dels->clear();
+            }
+            return rowset_indexes;
+        }
+    }
+
     return rowset_indexes;
 }
 

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -455,8 +455,8 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
                 VLOG(2) << strings::Substitute(
                         "lake PK compaction force-run chunked: tablet=$0 full_bytes=$1 chunk_bytes=$2 "
                         "kept=$3/$4 rowsets read_pressure=$5",
-                        tablet_metadata->id(), cur_compaction_result_bytes, acc, keep,
-                        rowset_indexes.size(), tablet_read_pressure);
+                        tablet_metadata->id(), cur_compaction_result_bytes, acc, keep, rowset_indexes.size(),
+                        tablet_read_pressure);
                 rowset_indexes.resize(keep);
                 if (has_dels != nullptr) {
                     has_dels->resize(keep);

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -358,10 +358,15 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
 
     // 3. pick input rowsets from level
     size_t cur_compaction_result_bytes = 0;
+    // Per-picked-rowset result bytes, parallel to rowset_indexes, so a force-run over-large
+    // compaction can be truncated to a bounded prefix (lake_pk_compaction_deferred_chunk_result_bytes).
+    std::vector<size_t> picked_read_bytes;
     bool reach_max_input_per_compaction = false;
     while (!pick_level_ptr->rowsets.empty()) {
         const auto& rowset_candidate = pick_level_ptr->rowsets.top();
-        cur_compaction_result_bytes += rowset_candidate.read_bytes();
+        const size_t rc_read_bytes = rowset_candidate.read_bytes();
+        cur_compaction_result_bytes += rc_read_bytes;
+        picked_read_bytes.push_back(rc_read_bytes);
         rowset_indexes.push_back(rowset_candidate.rowset_index);
         if (has_dels != nullptr) {
             has_dels->push_back(rowset_candidate.delete_bytes() > 0);
@@ -381,7 +386,9 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
     if (is_real_time && !reach_max_input_per_compaction) {
         for (int i = 0; i < pick_level_ptr->other_level_rowsets.size(); i++) {
             const auto& rowset_candidate = pick_level_ptr->other_level_rowsets[i];
-            cur_compaction_result_bytes += rowset_candidate.read_bytes();
+            const size_t rc_read_bytes = rowset_candidate.read_bytes();
+            cur_compaction_result_bytes += rc_read_bytes;
+            picked_read_bytes.push_back(rc_read_bytes);
             rowset_indexes.push_back(rowset_candidate.rowset_index);
             if (has_dels != nullptr) {
                 has_dels->push_back(rowset_candidate.delete_bytes() > 0);
@@ -425,6 +432,36 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
                 has_dels->clear();
             }
             return rowset_indexes;
+        }
+        // Emergency force-run of the deferred over-large compaction. Optionally split it into a
+        // bounded chunk so its synchronous publish stays short: truncate the picked rowsets to
+        // the shortest prefix whose cumulative result bytes reach the chunk cap (>= 1 rowset);
+        // the remainder is left for a later round (which defers again until the next emergency).
+        // This only ever runs inside the defer branch, so non-hot tablets (compactions never
+        // exceeding the defer size) are never chunked -> no churn on them.
+        if (config::lake_pk_compaction_deferred_chunk_result_bytes > 0 &&
+            static_cast<int64_t>(cur_compaction_result_bytes) >
+                    config::lake_pk_compaction_deferred_chunk_result_bytes) {
+            size_t acc = 0;
+            size_t keep = 0;
+            for (size_t k = 0; k < picked_read_bytes.size(); ++k) {
+                acc += picked_read_bytes[k];
+                keep = k + 1;
+                if (static_cast<int64_t>(acc) > config::lake_pk_compaction_deferred_chunk_result_bytes) {
+                    break;
+                }
+            }
+            if (keep < rowset_indexes.size()) {
+                VLOG(2) << strings::Substitute(
+                        "lake PK compaction force-run chunked: tablet=$0 full_bytes=$1 chunk_bytes=$2 "
+                        "kept=$3/$4 rowsets read_pressure=$5",
+                        tablet_metadata->id(), cur_compaction_result_bytes, acc, keep,
+                        rowset_indexes.size(), tablet_read_pressure);
+                rowset_indexes.resize(keep);
+                if (has_dels != nullptr) {
+                    has_dels->resize(keep);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Why
Stacks on `lake_pk_compaction_defer_large_result_bytes` (defer, #75816). With defer alone, a deferred over-large PK compaction is force-run at FULL size once the hot tablet's read pressure crosses `lake_pk_compaction_emergency_score` -> a single ~O(GB) synchronous publish (~14s compact_mapper read + PK-index apply) stalls every queued realtime-ingest publish on the tablet's strict per-tablet version chain -> residual ingest P99 tail under skew (one contiguous hot key-head on a single tablet).

Benchmark: with defer=1GB the range-skew ingest p99 dropped 31.5s -> ~6.7s but still misses HASH by ~7-40%; the residual is entirely one giant force-run compaction (range max ~25-29s vs hash ~8s; p50/p90 identical to hash). Sweeping emergency_score (30/50/300) only shuffles variance and does not shrink that single event.

## What
New mutable BE config `lake_pk_compaction_deferred_chunk_result_bytes` (default 0 = disabled = force-run full). When >0, the emergency force-run keeps only the shortest prefix of the already-picked input rowsets whose cumulative result bytes reach the cap (>=1 rowset); the remainder is left for a later round. One giant publish -> several small ones, each only briefly stalling the version chain.

Only engages inside the defer branch (projected output > `lake_pk_compaction_defer_large_result_bytes` AND emergency), so tablets whose compactions never reach the defer size (HASH-scattered small tablets) are never chunked -> no churn on them, unlike the global `lake_pk_compaction_max_result_bytes` (#75814, which regressed the HASH control 6.2s->118.6s).

## Files
- `be/src/common/config.h`, `config_compaction_fwd.h` (regenerated), `config_fwd_headers_manifest.json`
- `be/src/storage/lake/primary_key_compaction_policy.cpp`

Base commit chain: 4975de9 + defer (#75816) + this. BE-only, default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)