### PR TITLE
[Refactor] Split cache stats connector into BE module

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -279,8 +279,8 @@ Read-side connector contracts, DataSource, and DataSourceProvider default mechan
 ### ConnectorBootstrap (`connectorbootstrap`)
 Connector-layer bootstrap for split connector libraries that install into the default registry without depending on the legacy built-in registry.
 - Targets: `ConnectorBootstrap`
-- Allowed internal include prefixes: `connector/connector_bootstrap.h`, `connector/benchmark/`, `connector/jdbc/`, `connector/elasticsearch/`, `connector/mysql/`, `connector/connector.h`, `connector/connector_registry.h`, `common/`, `base/`, `gutil/`, `gen_cpp/`
-- Allowed target deps: `Connector`, `ConnectorBenchmark`, `ConnectorJDBC`, `ConnectorElasticsearch`, `ConnectorMySQL`, `ConnectorPrimitive`, `Common`, `Base`, `Gutil`, `StarRocksGen`
+- Allowed internal include prefixes: `connector/connector_bootstrap.h`, `connector/benchmark/`, `connector/cache_stats/`, `connector/jdbc/`, `connector/elasticsearch/`, `connector/mysql/`, `connector/connector.h`, `connector/connector_registry.h`, `common/`, `base/`, `gutil/`, `gen_cpp/`
+- Allowed target deps: `Connector`, `ConnectorBenchmark`, `ConnectorCacheStats`, `ConnectorJDBC`, `ConnectorElasticsearch`, `ConnectorMySQL`, `ConnectorPrimitive`, `Common`, `Base`, `Gutil`, `StarRocksGen`
 - Remediation: Keep split connector bootstrap independent from ConnectorBuiltinRegistry; add newly split connector libraries here and let service-level startup compose legacy registry plus this bootstrap.
 
 ### ConnectorBuiltinRegistry (`connectorbuiltinregistry`)
@@ -333,7 +333,7 @@ Orchestration layer below Service for query, fragment, and ingestion lifecycle e
 Diagnostic script execution and command dispatch layer below Service, HttpService, Tools, and AgentServer, and above the remaining reusable BE modules.
 - Targets: `Script`
 - Allowed internal include prefixes: `script/`, `base/`, `cache/`, `column/`, `common/`, `connector/`, `compute_env/`, `data_workflows/`, `exec/`, `exprs/`, `formats/`, `fs/`, `gen_cpp/`, `geo/`, `gutil/`, `io/`, `orchestration/`, `platform/`, `runtime/`, `storage/`, `types/`
-- Allowed target deps: `Base`, `Gutil`, `Common`, `Cache`, `IO`, `FileSystem`, `Platform`, `Types`, `ColumnCore`, `ChunkCore`, `ColumnSortCore`, `Runtime`, `Runtime`, `Runtime`, `Formats`, `StoragePrimitive`, `StorageBase`, `Storage`, `ComputeEnv`, `DataWorkflows`, `Expr`, `ExprDict`, `ExprTableFunction`, `ExprUtility`, `ExecPrimitive`, `ExecRuntime`, `ExecSchemaScannerCore`, `ExecSchemaScanners`, `ExecJoinCore`, `Exec`, `ConnectorPrimitive`, `Connector`, `ConnectorBenchmark`, `ConnectorElasticsearch`, `ConnectorMySQL`, `ConnectorBootstrap`, `ConnectorBuiltinRegistry`, `Orchestration`, `Geo`, `StarRocksGen`
+- Allowed target deps: `Base`, `Gutil`, `Common`, `Cache`, `IO`, `FileSystem`, `Platform`, `Types`, `ColumnCore`, `ChunkCore`, `ColumnSortCore`, `Runtime`, `Runtime`, `Runtime`, `Formats`, `StoragePrimitive`, `StorageBase`, `Storage`, `ComputeEnv`, `DataWorkflows`, `Expr`, `ExprDict`, `ExprTableFunction`, `ExprUtility`, `ExecPrimitive`, `ExecRuntime`, `ExecSchemaScannerCore`, `ExecSchemaScanners`, `ExecJoinCore`, `Exec`, `ConnectorPrimitive`, `Connector`, `ConnectorBenchmark`, `ConnectorCacheStats`, `ConnectorElasticsearch`, `ConnectorMySQL`, `ConnectorBootstrap`, `ConnectorBuiltinRegistry`, `Orchestration`, `Geo`, `StarRocksGen`
 - Core tests: `script_test`
 - Remediation: Keep Script below Service, HttpService, Tools, and AgentServer; lower reusable behavior can live in lower BE modules that Script is allowed to depend on.
 

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -901,6 +901,37 @@
       "remediation": "Keep ConnectorBenchmark limited to the benchgen connector implementation; move registration into ConnectorBootstrap and avoid pulling Connector, storage, service, or full Exec code into the connector library."
     },
     {
+      "id": "connectorcachestats",
+      "doc_label": "ConnectorCacheStats",
+      "summary": "Cache-stats connector implementation above connector contracts with storage access, without registry composition, service, cache, or full Exec coupling.",
+      "agents_path": "be/src/connector/cache_stats/AGENTS.md",
+      "owned_targets": ["ConnectorCacheStats"],
+      "allowed_include_prefixes": [
+        "connector/cache_stats/",
+        "connector/connector.h",
+        "connector/data_source.h",
+        "connector/data_source_provider.h",
+        "storage/",
+        "exprs/",
+        "runtime/",
+        "column/",
+        "types/",
+        "common/",
+        "base/",
+        "gutil/",
+        "gen_cpp/"
+      ],
+      "forbidden_include_prefixes": ["exec/", "service/", "http/", "cache/", "util/"],
+      "forbidden_includes": [
+        "connector/connector_registry.h",
+        "exec/exec_env.h"
+      ],
+      "allowed_target_deps": ["ConnectorPrimitive", "Storage", "Expr", "Runtime", "ChunkCore", "ColumnCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_test_targets": ["connector_cache_stats_test"],
+      "allowed_test_link_deps": ["ConnectorCacheStats", "ConnectorPrimitive", "Storage", "Expr", "Runtime", "ChunkCore", "ColumnCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
+      "remediation": "Keep ConnectorCacheStats limited to the cache-stats connector and scanner implementation over Storage; move registration into ConnectorBootstrap and avoid pulling Connector, service, cache, or full Exec code into the connector library."
+    },
+    {
       "id": "connectorjdbc",
       "doc_label": "ConnectorJDBC",
       "summary": "JDBC connector implementation, scanner, driver manager, and type checker above connector contracts without registry composition, storage, service, or full Exec coupling.",
@@ -1002,6 +1033,7 @@
       "allowed_include_prefixes": [
         "connector/connector_bootstrap.h",
         "connector/benchmark/",
+        "connector/cache_stats/",
         "connector/jdbc/",
         "connector/elasticsearch/",
         "connector/mysql/",
@@ -1017,7 +1049,7 @@
         "connector/builtin_connector_registry.h",
         "exec/exec_env.h"
       ],
-      "allowed_target_deps": ["Connector", "ConnectorBenchmark", "ConnectorJDBC", "ConnectorElasticsearch", "ConnectorMySQL", "ConnectorPrimitive", "Common", "Base", "Gutil", "StarRocksGen"],
+      "allowed_target_deps": ["Connector", "ConnectorBenchmark", "ConnectorCacheStats", "ConnectorJDBC", "ConnectorElasticsearch", "ConnectorMySQL", "ConnectorPrimitive", "Common", "Base", "Gutil", "StarRocksGen"],
       "remediation": "Keep split connector bootstrap independent from ConnectorBuiltinRegistry; add newly split connector libraries here and let service-level startup compose legacy registry plus this bootstrap."
     },
     {
@@ -1214,6 +1246,7 @@
         "ConnectorPrimitive",
         "Connector",
         "ConnectorBenchmark",
+        "ConnectorCacheStats",
         "ConnectorElasticsearch",
         "ConnectorMySQL",
         "ConnectorBootstrap",

--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -37,7 +37,6 @@ ADD_BE_LIB(Connector
         connector_registry.cpp
         hive_connector.cpp
         lake_connector.cpp
-        cache_stats_connector.cpp
         file_connector.cpp
         file_scan_metrics.cpp
         iceberg_connector.cpp
@@ -57,6 +56,25 @@ ADD_BE_LIB(Connector
 
 target_link_libraries(Connector PUBLIC ConnectorPrimitive ComputeEnv Cache)
 target_link_libraries(Connector PRIVATE Platform)
+
+ADD_BE_LIB(ConnectorCacheStats
+        cache_stats/cache_stats_connector.cpp
+        cache_stats/cache_stats_scanner.cpp
+)
+
+target_link_libraries(ConnectorCacheStats PUBLIC
+        ConnectorPrimitive
+        Storage
+        Expr
+        Runtime
+        ChunkCore
+        ColumnCore
+        Types
+        Common
+        Base
+        Gutil
+        StarRocksGen
+)
 
 if (WITH_CONNECTOR_ELASTICSEARCH)
     ADD_BE_LIB(ConnectorElasticsearch
@@ -172,6 +190,7 @@ target_link_libraries(ConnectorBootstrap PUBLIC
 
 target_link_libraries(ConnectorBootstrap PRIVATE
         Connector
+        ConnectorCacheStats
         Base
         Gutil
         StarRocksGen

--- a/be/src/connector/cache_stats/AGENTS.md
+++ b/be/src/connector/cache_stats/AGENTS.md
@@ -1,0 +1,15 @@
+<!-- BEGIN GENERATED: BE MODULE HARNESSES -->
+## Module Harness
+
+This section is generated from `be/module_boundary_manifest.json`.
+Run `python3 build-support/render_be_agents.py --write` after changing the manifest.
+Run `python3 build-support/check_be_module_boundaries.py --mode full` to validate the same rules mechanically.
+
+### ConnectorCacheStats (`connectorcachestats`)
+Cache-stats connector implementation above connector contracts with storage access, without registry composition, service, cache, or full Exec coupling.
+- Targets: `ConnectorCacheStats`
+- Allowed internal include prefixes: `connector/cache_stats/`, `connector/connector.h`, `connector/data_source.h`, `connector/data_source_provider.h`, `storage/`, `exprs/`, `runtime/`, `column/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
+- Allowed target deps: `ConnectorPrimitive`, `Storage`, `Expr`, `Runtime`, `ChunkCore`, `ColumnCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
+- Core tests: `connector_cache_stats_test`
+- Remediation: Keep ConnectorCacheStats limited to the cache-stats connector and scanner implementation over Storage; move registration into ConnectorBootstrap and avoid pulling Connector, service, cache, or full Exec code into the connector library.
+<!-- END GENERATED: BE MODULE HARNESSES -->

--- a/be/src/connector/cache_stats/cache_stats_connector.cpp
+++ b/be/src/connector/cache_stats/cache_stats_connector.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "connector/cache_stats_connector.h"
+#include "connector/cache_stats/cache_stats_connector.h"
 
 #include "connector/connector.h"
-#include "exec/cache_stats_scanner.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 
@@ -51,7 +50,7 @@ Status CacheStatsDataSource::open(RuntimeState* state) {
         return Status::InternalError("Failed to get tuple descriptor for cache stats scan");
     }
 
-    _scanner = std::make_unique<starrocks::CacheStatsScanner>(_tuple_desc);
+    _scanner = std::make_unique<CacheStatsScanner>(_tuple_desc);
     RETURN_IF_ERROR(_scanner->init(state, _scan_range));
     RETURN_IF_ERROR(_scanner->open(state));
     return Status::OK();

--- a/be/src/connector/cache_stats/cache_stats_connector.h
+++ b/be/src/connector/cache_stats/cache_stats_connector.h
@@ -14,11 +14,8 @@
 
 #pragma once
 
+#include "connector/cache_stats/cache_stats_scanner.h"
 #include "connector/connector.h"
-
-namespace starrocks {
-class CacheStatsScanner;
-} // namespace starrocks
 
 namespace starrocks::connector {
 
@@ -68,7 +65,7 @@ public:
 private:
     const CacheStatsDataSourceProvider* _provider;
     TInternalScanRange _scan_range;
-    std::unique_ptr<starrocks::CacheStatsScanner> _scanner;
+    std::unique_ptr<CacheStatsScanner> _scanner;
     int64_t _rows_read = 0;
     int64_t _bytes_read = 0;
 };

--- a/be/src/connector/cache_stats/cache_stats_scanner.cpp
+++ b/be/src/connector/cache_stats/cache_stats_scanner.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "exec/cache_stats_scanner.h"
+#include "connector/cache_stats/cache_stats_scanner.h"
 
 #include "base/string/string_parser.hpp"
 
-namespace starrocks {
+namespace starrocks::connector {
 
 CacheStatsScanner::CacheStatsScanner(const TupleDescriptor* tuple_desc) {
     (void)tuple_desc;
@@ -52,4 +52,4 @@ Status CacheStatsScanner::get_chunk(RuntimeState* state, ChunkPtr* chunk, bool* 
     return Status::NotSupported("_CACHE_STATS_ is not implemented in BE");
 }
 
-} // namespace starrocks
+} // namespace starrocks::connector

--- a/be/src/connector/cache_stats/cache_stats_scanner.h
+++ b/be/src/connector/cache_stats/cache_stats_scanner.h
@@ -14,17 +14,16 @@
 
 #pragma once
 
-#include <memory>
-
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "gen_cpp/InternalService_types.h"
+#include "runtime/descriptors.h"
 
 namespace starrocks {
 
-class Chunk;
 class RuntimeState;
-class TupleDescriptor;
-using ChunkPtr = std::shared_ptr<Chunk>;
+
+namespace connector {
 
 class CacheStatsScanner {
 public:
@@ -41,4 +40,5 @@ private:
     int64_t _version = 0;
 };
 
+} // namespace connector
 } // namespace starrocks

--- a/be/src/connector/connector_bootstrap.cpp
+++ b/be/src/connector/connector_bootstrap.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 
+#include "connector/cache_stats/cache_stats_connector.h"
 #include "connector/connector.h"
 #include "connector/connector_registry.h"
 
@@ -53,6 +54,7 @@ void install_if_absent(ConnectorRegistry* registry, const std::string& name) {
 Status bootstrap_builtin_connectors() {
     auto* registry = ConnectorRegistry::default_instance();
     DCHECK(registry != nullptr);
+    install_if_absent<CacheStatsConnector>(registry, Connector::CACHE_STATS);
 #ifdef STARROCKS_WITH_CONNECTOR_BENCHMARK
     install_if_absent<BenchmarkConnector>(registry, Connector::BENCHMARK);
 #endif

--- a/be/src/connector/connector_registry_init.cpp
+++ b/be/src/connector/connector_registry_init.cpp
@@ -16,7 +16,6 @@
 #include <string>
 
 #include "connector/builtin_connector_registry.h"
-#include "connector/cache_stats_connector.h"
 #include "connector/connector_registry.h"
 #include "connector/file_connector.h"
 #include "connector/hive_connector.h"
@@ -41,7 +40,6 @@ void install_if_absent(ConnectorRegistry* registry, const std::string& name) {
 Status install_builtin_connectors(ConnectorRegistry* registry) {
     DCHECK(registry != nullptr);
     install_if_absent<HiveConnector>(registry, Connector::HIVE);
-    install_if_absent<CacheStatsConnector>(registry, Connector::CACHE_STATS);
     install_if_absent<FileConnector>(registry, Connector::FILE);
     install_if_absent<LakeConnector>(registry, Connector::LAKE);
 #ifndef __APPLE__

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -306,7 +306,6 @@ set(EXEC_NON_PIPELINE_FILES
     short_circuit_hybrid.cpp
     olap_common.cpp
     write_combined_txn_log.cpp
-    cache_stats_scanner.cpp
     local_file_writer.cpp
     plain_text_builder.cpp
     agg_runtime_filter_builder.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -81,7 +81,6 @@ set(EXEC_FILES
         ./exec/file_scan_node_test.cpp
         ./exec/hdfs_scan_node_test.cpp
         ./exec/json_parser_test.cpp
-        ./exec/cache_stats_scanner_test.cpp
         ./exec/lake_meta_scanner_test.cpp
         ./exec/data_sinks/multi_olap_table_sink_test.cpp
         ./exec/parquet_schema_builder_test.cpp

--- a/be/test/connector/CMakeLists.txt
+++ b/be/test/connector/CMakeLists.txt
@@ -42,6 +42,24 @@ add_executable(connector_primitive_test ${BE_TEST_MACOS_LINK_STUBS} connector_pr
 target_link_libraries(connector_primitive_test ${CONNECTOR_PRIMITIVE_TEST_LINK_LIBS} gtest_main)
 set_target_properties(connector_primitive_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
+set(CONNECTOR_CACHE_STATS_TEST_LINK_LIBS
+    ConnectorCacheStats
+    ${STARROCKS_DEPENDENCIES}
+    ${STARROCKS_STATIC_LINK_LIBS}
+    ${WL_LINK_DYNAMIC} ${STARROCKS_SYSTEM_LINK_LIBS} ${WRAP_LINKER_FLAGS}
+    ${WL_START_GROUP}
+    gmock
+    gtest
+    ${WL_END_GROUP}
+)
+
+add_executable(connector_cache_stats_test
+        ${BE_TEST_MACOS_LINK_STUBS}
+        cache_stats/cache_stats_connector_test.cpp
+)
+target_link_libraries(connector_cache_stats_test ${CONNECTOR_CACHE_STATS_TEST_LINK_LIBS} gtest_main)
+set_target_properties(connector_cache_stats_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
+
 if (WITH_CONNECTOR_MYSQL)
     set(CONNECTOR_MYSQL_TEST_LINK_LIBS
         ConnectorMySQL

--- a/be/test/connector/cache_stats/cache_stats_connector_test.cpp
+++ b/be/test/connector/cache_stats/cache_stats_connector_test.cpp
@@ -12,63 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BE_TEST
-#define BE_TEST
-#endif
-
-#include "exec/cache_stats_scanner.h"
+#include "connector/cache_stats/cache_stats_connector.h"
 
 #include <gtest/gtest.h>
 
-#include "base/testutil/assert.h"
-#include "base/testutil/id_generator.h"
+#include <memory>
+#include <string>
+
 #include "common/config_exec_fwd.h"
-#include "common/status.h"
-#include "connector/cache_stats_connector.h"
-#include "exec/exec_env.h"
-#include "fs/fs_util.h"
+#include "connector/cache_stats/cache_stats_scanner.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "storage/lake/fixed_location_provider.h"
-#include "storage/lake/join_path.h"
-#include "storage/lake/location_provider.h"
-#include "storage/lake/tablet_manager.h"
-#include "storage/storage_env.h"
 
-namespace starrocks {
+namespace starrocks::connector {
 
-class CacheStatsScannerTest : public ::testing::Test {
+class CacheStatsConnectorTest : public ::testing::Test {
 public:
-    CacheStatsScannerTest() : _tablet_id(next_id()) {
-        _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
-        _tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
-        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
-
-        CHECK(FileSystem::Default()
-                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName))
-                      .ok());
-        CHECK(FileSystem::Default()
-                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName))
-                      .ok());
-        CHECK(FileSystem::Default()
-                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName))
-                      .ok());
-
-        TUniqueId query_id;
+    void SetUp() override {
+        TUniqueId fragment_id;
         TQueryOptions query_options;
         TQueryGlobals query_globals;
-        TUniqueId fragment_id;
-        auto* exec_env = ExecEnv::GetInstance();
-        _state = _pool.add(new RuntimeState(query_id, fragment_id, query_options, query_globals,
-                                            &exec_env->query_execution_services(), exec_env));
-        _state->init_mem_trackers(query_id);
-    }
-
-    ~CacheStatsScannerTest() override {
-        (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
-        (void)fs::remove_all(kRootLocation);
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals,
+                                                        static_cast<const QueryExecutionServices*>(nullptr), nullptr);
+        TUniqueId query_id;
+        _runtime_state->init_mem_trackers(query_id);
+        _pool = _runtime_state->obj_pool();
     }
 
 protected:
@@ -109,26 +79,21 @@ protected:
         }
         tuple_desc_builder.build(&table_desc_builder);
 
-        CHECK(DescriptorTbl::create(_state, &_pool, table_desc_builder.desc_tbl(), &_desc_tbl,
-                                    config::vector_chunk_size)
-                      .ok());
-        _state->set_desc_tbl(_desc_tbl);
+        auto status = DescriptorTbl::create(_runtime_state.get(), _pool, table_desc_builder.desc_tbl(), &_desc_tbl,
+                                            config::vector_chunk_size);
+        ASSERT_TRUE(status.ok()) << status.to_string();
+        _runtime_state->set_desc_tbl(_desc_tbl);
     }
 
     const TupleDescriptor* tuple_desc() { return _desc_tbl->get_tuple_descriptor(0); }
 
-    constexpr static const char* const kRootLocation = "./CacheStatsScannerTest";
-    lake::TabletManager* _tablet_mgr;
-    std::shared_ptr<lake::LocationProvider> _location_provider;
-    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
-    int64_t _tablet_id;
-
-    ObjectPool _pool;
-    RuntimeState* _state = nullptr;
+    std::shared_ptr<RuntimeState> _runtime_state = nullptr;
+    ObjectPool* _pool = nullptr;
     DescriptorTbl* _desc_tbl = nullptr;
+    int64_t _tablet_id = 12345;
 };
 
-TEST_F(CacheStatsScannerTest, test_init_invalid_version) {
+TEST_F(CacheStatsConnectorTest, InitInvalidVersion) {
     build_desc_tbl();
     CacheStatsScanner scanner(tuple_desc());
 
@@ -136,12 +101,12 @@ TEST_F(CacheStatsScannerTest, test_init_invalid_version) {
     scan_range.tablet_id = _tablet_id;
     scan_range.version = "abc";
 
-    auto st = scanner.init(nullptr, scan_range);
-    ASSERT_FALSE(st.ok());
-    ASSERT_TRUE(st.message().find("Invalid") != std::string::npos) << st.message();
+    auto status = scanner.init(nullptr, scan_range);
+    ASSERT_FALSE(status.ok());
+    ASSERT_NE(status.message().find("Invalid"), std::string::npos) << status.message();
 }
 
-TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported) {
+TEST_F(CacheStatsConnectorTest, GetChunkNotSupported) {
     build_desc_tbl();
     CacheStatsScanner scanner(tuple_desc());
 
@@ -154,13 +119,13 @@ TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported) {
 
     ChunkPtr chunk;
     bool eos = false;
-    auto st = scanner.get_chunk(nullptr, &chunk, &eos);
-    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    auto status = scanner.get_chunk(nullptr, &chunk, &eos);
+    ASSERT_TRUE(status.is_not_supported()) << status.to_string();
     ASSERT_FALSE(eos);
     ASSERT_EQ(chunk, nullptr);
 }
 
-TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported_with_unknown_slot) {
+TEST_F(CacheStatsConnectorTest, GetChunkNotSupportedWithUnknownSlot) {
     build_desc_tbl(true);
     CacheStatsScanner scanner(tuple_desc());
 
@@ -173,20 +138,20 @@ TEST_F(CacheStatsScannerTest, test_get_chunk_not_supported_with_unknown_slot) {
 
     ChunkPtr chunk;
     bool eos = false;
-    auto st = scanner.get_chunk(nullptr, &chunk, &eos);
-    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    auto status = scanner.get_chunk(nullptr, &chunk, &eos);
+    ASSERT_TRUE(status.is_not_supported()) << status.to_string();
     ASSERT_FALSE(eos);
     ASSERT_EQ(chunk, nullptr);
 
     scanner.close(nullptr);
 }
 
-TEST_F(CacheStatsScannerTest, test_connector_data_source) {
+TEST_F(CacheStatsConnectorTest, ConnectorDataSource) {
     const int64_t version = 4;
     build_desc_tbl();
 
-    connector::CacheStatsConnector connector;
-    ASSERT_EQ(connector.connector_type(), connector::ConnectorType::CACHE_STATS);
+    CacheStatsConnector connector;
+    ASSERT_EQ(connector.connector_type(), ConnectorType::CACHE_STATS);
 
     TCacheStatsScanNode scan_node;
     scan_node.__set_tuple_id(0);
@@ -198,7 +163,7 @@ TEST_F(CacheStatsScannerTest, test_connector_data_source) {
     ASSERT_NE(provider, nullptr);
     ASSERT_FALSE(provider->insert_local_exchange_operator());
     ASSERT_FALSE(provider->accept_empty_scan_ranges());
-    ASSERT_EQ(provider->tuple_descriptor(_state), _state->desc_tbl().get_tuple_descriptor(0));
+    ASSERT_EQ(provider->tuple_descriptor(_runtime_state.get()), _runtime_state->desc_tbl().get_tuple_descriptor(0));
 
     TInternalScanRange internal_scan_range;
     internal_scan_range.tablet_id = _tablet_id;
@@ -210,18 +175,18 @@ TEST_F(CacheStatsScannerTest, test_connector_data_source) {
     auto data_source = provider->create_data_source(scan_range);
     ASSERT_NE(data_source, nullptr);
     ASSERT_EQ(data_source->name(), "CacheStatsDataSource");
-    ASSERT_TRUE(data_source->open(_state).ok());
+    ASSERT_TRUE(data_source->open(_runtime_state.get()).ok());
 
     ChunkPtr chunk;
-    auto st = data_source->get_next(_state, &chunk);
-    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+    auto status = data_source->get_next(_runtime_state.get(), &chunk);
+    ASSERT_TRUE(status.is_not_supported()) << status.to_string();
     ASSERT_EQ(chunk, nullptr);
     ASSERT_EQ(data_source->raw_rows_read(), 0);
     ASSERT_EQ(data_source->num_rows_read(), 0);
     ASSERT_EQ(data_source->num_bytes_read(), 0);
     ASSERT_EQ(data_source->cpu_time_spent(), 0);
 
-    data_source->close(_state);
+    data_source->close(_runtime_state.get());
 }
 
-} // namespace starrocks
+} // namespace starrocks::connector


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
