### PR TITLE
[Enhancement] Enlarge lake PK-index block cache to hold hot contiguous index base (draft/benchmark)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1551,7 +1551,15 @@ CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 // When the ratio of cumulative level to base level is greater than this config, use base merge.
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
-CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
+// Percentage of the lake update-memory budget used for the persistent-index block cache.
+// Raised from 10 to 40: under a skewed (zipf) realtime-ingest workload with a contiguous
+// PK layout (e.g. RANGE-distributed tables), the hot key head funnels ~half the writes onto
+// one tablet, whose persistent-index base level grows to several GB. At 10% the block cache
+// cannot hold that hot base, so every cold multi_get re-reads the base sstables from object
+// storage (observed multiget_t3 ~4s/publish), and those publishes serialize on the tablet
+// version chain into an ingest-latency tail. 40% keeps the hot base resident. Non-hot / HASH
+// tablets have small indexes that fit regardless, so this is a no-op for them.
+CONF_Int32(lake_pk_index_block_cache_limit_percent, "40");
 // When true, shared-data (lake) tablet metadata and txn log files are written with an
 // Adler-32 checksum (a FixedFileHeader for single files, a footer crc for bundle files), so
 // corruption can be detected on read. Readers always auto-detect and verify the checksum when

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1523,6 +1523,22 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // level's compact_level which can be stale after pick_max_level merges levels.
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
 // Enable cleanup of orphan delvec entries during compaction.
 // Orphan delvecs are leaked metadata entries from a historical bug that reference
 // non-existent segments and prevent delvec file garbage collection.

--- a/be/src/common/config_compaction_fwd.h
+++ b/be/src/common/config_compaction_fwd.h
@@ -219,6 +219,23 @@ CONF_mDouble(lake_pk_compaction_delvec_benefit_weight, "12.0");
 // Set to 0 to disable the override (no size cap).
 CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 
+// Defer (do NOT submit) a lake primary-key compaction whose projected output exceeds this
+// many bytes, to keep its synchronous publish off the hot tablet's serialized ingest
+// version chain. A lake PK compaction publishes in strict per-tablet version order (see
+// lake::publish_version / acquire_publish_tablet in storage/lake/transactions.cpp): a
+// multi-GB compaction's publish (compact_mapper read + PK-index apply, ~14s for a 2GB
+// output rowset) blocks every queued realtime-ingest publish behind it on the same tablet,
+// producing a large ingest P99 tail under skew workloads where one contiguous hot key-head
+// funnels onto a single tablet. Unlike lake_pk_compaction_max_result_bytes (which SHRINKS
+// each compaction and causes churn/pileup), this DEFERS an over-large compaction WITHOUT
+// shrinking it, so compactions stay full-size but rare on hot tablets. The deferral is
+// bounded by lake_pk_compaction_emergency_score: once the tablet's read pressure crosses
+// that valve the large compaction proceeds anyway, so rowsets can't accumulate unbounded.
+// Cheap SST/index compaction is unaffected (it runs independently of the picked rowsets).
+// Default 0 = disabled (legacy behavior; non-hot tablets whose compactions never reach this
+// size are unaffected even when set).
+CONF_mInt64(lake_pk_compaction_defer_large_result_bytes, "0");
+
 // Skip get from pk index when light pk compaction publish is enabled
 CONF_mBool(enable_light_pk_compaction_publish, "true");
 

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -722,6 +722,7 @@
         "lake_pk_compaction_emergency_score",
         "lake_pk_compaction_delvec_benefit_weight",
         "lake_pk_compaction_size_overflow_ratio",
+        "lake_pk_compaction_defer_large_result_bytes",
         "enable_light_pk_compaction_publish",
         "enable_lake_compaction_use_partial_segments",
         "enable_lake_compaction_range_split",

--- a/be/src/common/config_primary_key_fwd.h
+++ b/be/src/common/config_primary_key_fwd.h
@@ -161,7 +161,15 @@ CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 // When the ratio of cumulative level to base level is greater than this config, use base merge.
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 
-CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");
+// Percentage of the lake update-memory budget used for the persistent-index block cache.
+// Raised from 10 to 40: under a skewed (zipf) realtime-ingest workload with a contiguous
+// PK layout (e.g. RANGE-distributed tables), the hot key head funnels ~half the writes onto
+// one tablet, whose persistent-index base level grows to several GB. At 10% the block cache
+// cannot hold that hot base, so every cold multi_get re-reads the base sstables from object
+// storage (observed multiget_t3 ~4s/publish), and those publishes serialize on the tablet
+// version chain into an ingest-latency tail. 40% keeps the hot base resident. Non-hot / HASH
+// tablets have small indexes that fit regardless, so this is a no-op for them.
+CONF_Int32(lake_pk_index_block_cache_limit_percent, "40");
 
 // The maximum number of files which need to rebuilt in cloud native pk index.
 // If files which need to rebuilt larger than this, we will flush memtable immediately.

--- a/be/src/storage/lake/primary_key_compaction_policy.cpp
+++ b/be/src/storage/lake/primary_key_compaction_policy.cpp
@@ -398,6 +398,36 @@ StatusOr<std::vector<int64_t>> PrimaryCompactionPolicy::pick_rowset_indexes(
         }
     }
 
+    // Defer an over-large compaction so its ~O(GB) synchronous publish (compact_mapper read +
+    // PK-index apply) does not stall the hot tablet's serialized ingest version chain. The
+    // compaction is kept full-size (no shrinking -> no churn); it is simply not submitted this
+    // round -> pick returns empty -> segment score 0 -> FE de-prioritizes it. Bounded by the
+    // read-pressure emergency valve (same signal as skip_sparse_low_score_level [D]) so rowsets
+    // cannot pile up unbounded: once the tablet's read pressure crosses emergency_score the
+    // large compaction proceeds. Cheap SST/index compaction is unaffected (independent path).
+    if (config::lake_pk_compaction_defer_large_result_bytes > 0 &&
+        static_cast<int64_t>(cur_compaction_result_bytes) > config::lake_pk_compaction_defer_large_result_bytes) {
+        double tablet_read_pressure = 0.0;
+        for (const auto& rc : rowset_vec) {
+            tablet_read_pressure += rc.score;
+        }
+        const bool emergency = config::lake_pk_compaction_emergency_score > 0.0 &&
+                               tablet_read_pressure >= config::lake_pk_compaction_emergency_score;
+        if (!emergency) {
+            VLOG(2) << strings::Substitute(
+                    "lake PK compaction deferred (large result): tablet=$0 result_bytes=$1 > defer=$2 "
+                    "read_pressure=$3 (em=$4)",
+                    tablet_metadata->id(), cur_compaction_result_bytes,
+                    config::lake_pk_compaction_defer_large_result_bytes, tablet_read_pressure,
+                    config::lake_pk_compaction_emergency_score);
+            rowset_indexes.clear();
+            if (has_dels != nullptr) {
+                has_dels->clear();
+            }
+            return rowset_indexes;
+        }
+    }
+
     return rowset_indexes;
 }
 


### PR DESCRIPTION
## Why

Draft for a realtime-ingest benchmark (skewed/zipf, RANGE PK-range distribution). Stacks on the OPT-4 defer change (#75816); the block-cache change is the last commit.

Under skewed realtime ingest with a **contiguous PK layout**, the hot key head funnels ~half the writes onto one tablet whose **persistent-index base level grows to several GB**. At the default `lake_pk_index_block_cache_limit_percent=10` (10% of the lake update-memory budget, ~2.9GB here) the block cache cannot hold that hot base, so every cold `multi_get` re-reads the base sstables from object storage — measured `multiget_t3 ~3.8-4.2s` per publish, ~110MB remote IO/publish — and those publishes serialize on the tablet version chain into an ingest-latency tail (p99).

## Change

Raise the compiled default of `lake_pk_index_block_cache_limit_percent` from 10 to 40 so the hot base stays resident in memory across DataCache eviction. HASH / non-hot tablets have small persistent indexes that fit regardless, so this is a no-op for them.

Regenerated `config_primary_key_fwd.h` via `build-support/gen_config_fwd_headers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)