### PR TITLE
[Tool] fix format library link order for thirdparty deps

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -558,7 +558,19 @@ set(STARROCKS_LINK_LIBS
     ${WL_WHOLE_ARCHIVE_PREFIX} ${EXPR_EXTENSION_LIBS} ${WL_WHOLE_ARCHIVE_SUFFIX}
     ${WL_END_GROUP}
     Storage
+    # The concrete format libraries must be linked ahead of the thirdparty
+    # dependency group below (which owns avro/avrocpp/arrow/orc). Linking only
+    # the Formats aggregate lets CMake append its concrete members after that
+    # group as transitive deps, which leaves FormatAvro's avro/avrocpp
+    # references unresolved. List the members explicitly, with FormatCore last,
+    # to keep them ahead of their thirdparty archives.
     Formats
+    FormatParquet
+    FormatOrc
+    FormatAvro
+    FormatJson
+    FormatCsv
+    FormatCore
     ExecRuntime
     ComputeEnv
     ExecPrimitive

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -37,6 +37,7 @@
 #include "common/logging.h"
 #include "common/util/thrift_util.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/runtime_range_pruner.hpp"
 #include "exec/hdfs_scanner/hdfs_scanner.h"
 #include "exec_primitive/runtime_filter/runtime_filter_helper.h"
 #include "exprs/binary_predicate.h"


### PR DESCRIPTION
* List the concrete Format libraries (FormatParquet/Orc/Avro/Json/Csv/Core) explicitly ahead of the thirdparty dependency group so FormatAvro's avro/avrocpp references resolve at link time. Add the missing
* runtime_range_pruner.hpp include to the parquet file_reader test.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
