### PR TITLE
[Enhancement] Make object storage client cache size runtime mutable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1262,6 +1262,12 @@ CONF_Int64(object_storage_rename_file_request_timeout_ms, "30000");
 CONF_Int64(object_storage_max_retries, "10");
 CONF_Int64(object_storage_retry_scale_factor, "25");
 
+// Maximum number of object storage clients (S3 and Azure Blob) cached per client factory.
+// Mutable at runtime: the value is snapshotted on each client creation, so a lowered value
+// takes effect as cached clients are evicted on subsequent creations. Values below 1 are
+// treated as 1.
+CONF_mInt64(object_storage_client_cache_size, "8");
+
 CONF_Strings(fallback_to_hadoop_fs_list, "");
 CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");
 CONF_mBool(s3_use_list_objects_v1, "false");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -595,6 +595,7 @@
         "object_storage_rename_file_request_timeout_ms",
         "object_storage_max_retries",
         "object_storage_retry_scale_factor",
+        "object_storage_client_cache_size",
         "fallback_to_hadoop_fs_list",
         "s3_compatible_fs_list",
         "s3_use_list_objects_v1",

--- a/be/src/common/config_object_storage_fwd.h
+++ b/be/src/common/config_object_storage_fwd.h
@@ -66,6 +66,12 @@ CONF_Int64(object_storage_max_retries, "10");
 
 CONF_Int64(object_storage_retry_scale_factor, "25");
 
+// Maximum number of object storage clients (S3 and Azure Blob) cached per client factory.
+// Mutable at runtime: the value is snapshotted on each client creation, so a lowered value
+// takes effect as cached clients are evicted on subsequent creations. Values below 1 are
+// treated as 1.
+CONF_mInt64(object_storage_client_cache_size, "8");
+
 CONF_Strings(fallback_to_hadoop_fs_list, "");
 
 CONF_Strings(s3_compatible_fs_list, "s3n://, s3a://, s3://, oss://, cos://, cosn://, obs://, ks3://, tos://");

--- a/be/src/fs/azure/fs_azblob.cpp
+++ b/be/src/fs/azure/fs_azblob.cpp
@@ -16,10 +16,9 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <azure/identity.hpp>
 #include <azure/storage/blobs.hpp>
-
-#include <algorithm>
 
 #include "base/concurrency/stopwatch.hpp"
 #include "base/random/random.h"

--- a/be/src/fs/azure/fs_azblob.cpp
+++ b/be/src/fs/azure/fs_azblob.cpp
@@ -19,8 +19,11 @@
 #include <azure/identity.hpp>
 #include <azure/storage/blobs.hpp>
 
+#include <algorithm>
+
 #include "base/concurrency/stopwatch.hpp"
 #include "base/random/random.h"
+#include "common/config_object_storage_fwd.h"
 #include "fs/azure/azblob_uri.h"
 #include "fs/azure/utils.h"
 #include "fs/credential/cloud_configuration_factory.h"
@@ -285,8 +288,6 @@ private:
     BlobContainerClientPtr create_blob_container_client(const AzureCloudCredential& azure_cloud_credential,
                                                         const AzBlobURI& blob_uri);
 
-    constexpr static int kMaxItems = 8;
-
     struct ClientCacheItem {
         AzureCloudCredential azure_cloud_credential;
         BlobContainerClientPtr blob_container_client;
@@ -321,8 +322,17 @@ BlobContainerClientPtr AzBlobClientFactory::new_blob_container_client(
             }
         }
 
-        auto& client = _client_cache.size() < kMaxItems ? _client_cache.emplace_back()
-                                                        : _client_cache[ThreadLocalRandomUniform(kMaxItems)];
+        // Snapshot the runtime-mutable cache capacity once for this creation. Random victims are
+        // evicted until the cache stays within capacity, so lowering object_storage_client_cache_size
+        // shrinks the cache instead of only overwriting entries.
+        const size_t max_items = std::max<int64_t>(1, config::object_storage_client_cache_size);
+        while (!_client_cache.empty() && _client_cache.size() >= max_items) {
+            int32_t idx = ThreadLocalRandomUniform(static_cast<int32_t>(_client_cache.size()));
+            std::swap(_client_cache[idx], _client_cache.back());
+            _client_cache.pop_back();
+        }
+
+        auto& client = _client_cache.emplace_back();
         client.azure_cloud_credential = azure_cloud_credential;
         client.blob_container_client = container_client;
     }

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -30,6 +30,7 @@
 #include <aws/sts/STSClient.h>
 #include <fmt/core.h>
 
+#include <algorithm>
 #include <ctime>
 #include <limits>
 
@@ -119,13 +120,23 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3ClientFactory::_get_aws_cre
 
 void S3ClientFactory::close() {
     std::lock_guard l(_lock);
-    for (auto& item : _clients) {
-        item.reset();
+    _clients.clear();
+    _client_cache_keys.clear();
+}
+
+void S3ClientFactory::_put_client(const ClientCacheKey& client_cache_key, const S3ClientPtr& client, size_t max_items) {
+    // caller holds _lock
+    // Honor the (possibly reduced) capacity by evicting random victims first, so that a lowered
+    // object_storage_client_cache_size shrinks the cache instead of only overwriting entries.
+    while (!_clients.empty() && _clients.size() >= max_items) {
+        int idx = _rand.Uniform(static_cast<int>(_clients.size()));
+        std::swap(_client_cache_keys[idx], _client_cache_keys.back());
+        std::swap(_clients[idx], _clients.back());
+        _client_cache_keys.pop_back();
+        _clients.pop_back();
     }
-    for (auto& key : _client_cache_keys) {
-        key = ClientCacheKey{};
-    }
-    _items = 0;
+    _client_cache_keys.push_back(client_cache_key);
+    _clients.push_back(client);
 }
 
 // clang-format: off
@@ -170,10 +181,12 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfigurati
     auto client_conf = std::make_shared<Aws::Client::ClientConfiguration>(config);
     auto aws_config = std::make_shared<AWSCloudConfiguration>(aws_cloud_configuration);
     ClientCacheKey client_cache_key{client_conf, aws_config};
+    // Snapshot the runtime-mutable cache capacity once for this creation.
+    const size_t max_items = std::max<int64_t>(1, config::object_storage_client_cache_size);
     {
         // Duplicate code for cache s3 client
         std::lock_guard l(_lock);
-        for (size_t i = 0; i < _items; i++) {
+        for (size_t i = 0; i < _client_cache_keys.size(); i++) {
             if (_client_cache_keys[i] == client_cache_key) return _clients[i];
         }
     }
@@ -187,24 +200,18 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfigurati
 
     {
         std::lock_guard l(_lock);
-        if (UNLIKELY(_items >= kMaxItems)) {
-            int idx = _rand.Uniform(kMaxItems);
-            _client_cache_keys[idx] = client_cache_key;
-            _clients[idx] = client;
-        } else {
-            _client_cache_keys[_items] = client_cache_key;
-            _clients[_items] = client;
-            _items++;
-        }
+        _put_client(client_cache_key, client, max_items);
     }
     return client;
 }
 
 S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfiguration& config, const FSOptions& opts) {
     std::lock_guard l(_lock);
+    // Snapshot the runtime-mutable cache capacity once for this creation.
+    const size_t max_items = std::max<int64_t>(1, config::object_storage_client_cache_size);
     auto client_conf = std::make_shared<Aws::Client::ClientConfiguration>(config);
     ClientCacheKey client_cache_key{client_conf, std::make_shared<AWSCloudConfiguration>()};
-    for (size_t i = 0; i < _items; i++) {
+    for (size_t i = 0; i < _client_cache_keys.size(); i++) {
         if (_client_cache_keys[i] == client_cache_key) return _clients[i];
     }
 
@@ -251,15 +258,7 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfigurati
                                                      !path_style_access);
     }
 
-    if (UNLIKELY(_items >= kMaxItems)) {
-        int idx = _rand.Uniform(kMaxItems);
-        _client_cache_keys[idx] = client_cache_key;
-        _clients[idx] = client;
-    } else {
-        _client_cache_keys[_items] = client_cache_key;
-        _clients[_items] = client;
-        _items++;
-    }
+    _put_client(client_cache_key, client, max_items);
     return client;
 }
 
@@ -268,7 +267,7 @@ bool S3ClientFactory::_find_client_cache_keys_by_config_TEST(const Aws::Client::
                                                              AWSCloudConfiguration* cloud_config) {
     std::lock_guard l(_lock);
     auto aws_config = cloud_config == nullptr ? AWSCloudConfiguration{} : *cloud_config;
-    for (size_t i = 0; i < _items; i++) {
+    for (size_t i = 0; i < _client_cache_keys.size(); i++) {
         if (_client_cache_keys[i] == ClientCacheKey{std::make_shared<Aws::Client::ClientConfiguration>(config),
                                                     std::make_shared<AWSCloudConfiguration>(aws_config)})
             return true;

--- a/be/src/fs/fs_s3.h
+++ b/be/src/fs/fs_s3.h
@@ -17,6 +17,10 @@
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
 
+#include <memory>
+#include <mutex>
+#include <vector>
+
 #include "base/random/random.h"
 #include "fs/credential/cloud_configuration.h"
 #include "fs/fs.h"
@@ -104,17 +108,20 @@ private:
         bool operator==(const ClientCacheKey& rhs) const;
     };
 
-    constexpr static int kMaxItems = 8;
-
     // Only use for UT
     bool _find_client_cache_keys_by_config_TEST(const Aws::Client::ClientConfiguration& config,
                                                 AWSCloudConfiguration* cloud_config = nullptr);
 
+    // Insert a newly created client into the cache. |max_items| is the runtime-mutable cache
+    // capacity snapshotted by the caller for the current creation. Random victims are evicted
+    // until the cache stays within capacity, so lowering the capacity shrinks the cache over
+    // subsequent insertions. Caller must hold |_lock|.
+    void _put_client(const ClientCacheKey& client_cache_key, const S3ClientPtr& client, size_t max_items);
+
     std::mutex _lock;
-    int _items{0};
-    // _client_cache_keys[i] is the client cache key of |_clients[i].
-    ClientCacheKey _client_cache_keys[kMaxItems];
-    S3ClientPtr _clients[kMaxItems];
+    // _client_cache_keys[i] is the client cache key of _clients[i]; the two vectors stay in sync.
+    std::vector<ClientCacheKey> _client_cache_keys;
+    std::vector<S3ClientPtr> _clients;
     Random _rand;
 };
 

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -640,6 +640,40 @@ TEST_F(S3FileSystemTest, test_s3_client_factory_close_idempotent_and_reusable) {
     ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(config));
 }
 
+TEST_F(S3FileSystemTest, test_s3_client_factory_cache_size_runtime_mutable) {
+    close_s3_clients();
+    int64_t old_cache_size = config::object_storage_client_cache_size;
+    // Lower the cache capacity at runtime so it holds at most 2 clients.
+    config::object_storage_client_cache_size = 2;
+
+    auto make_config = [](const std::string& endpoint) {
+        Aws::Client::ClientConfiguration config = S3ClientFactory::getClientConfig();
+        config.endpointOverride = endpoint;
+        config.region = "us-east-1";
+        return config;
+    };
+
+    auto c1 = make_config("s3-cache-size-ep-1");
+    auto c2 = make_config("s3-cache-size-ep-2");
+    auto c3 = make_config("s3-cache-size-ep-3");
+
+    ASSERT_NE(nullptr, S3ClientFactory::instance().new_client(c1, FSOptions()));
+    ASSERT_NE(nullptr, S3ClientFactory::instance().new_client(c2, FSOptions()));
+    ASSERT_NE(nullptr, S3ClientFactory::instance().new_client(c3, FSOptions()));
+
+    int present = 0;
+    present += S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(c1) ? 1 : 0;
+    present += S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(c2) ? 1 : 0;
+    present += S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(c3) ? 1 : 0;
+    // Capacity was lowered to 2 at runtime, so only 2 of the 3 distinct clients remain cached.
+    ASSERT_EQ(2, present);
+    // The most recently created client is always retained after eviction.
+    ASSERT_TRUE(S3ClientFactory::instance().find_client_cache_keys_by_config_TEST(c3));
+
+    config::object_storage_client_cache_size = old_cache_size;
+    close_s3_clients();
+}
+
 // Helper function to get object content type via HeadObject
 static std::string get_object_content_type(const std::string& uri) {
     S3URI s3_uri;

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -386,6 +386,15 @@ This topic introduces the following types of BE configurations:
 - Description: The minimum number of file descriptors in the BE process.
 - Introduced in: -
 
+### object_storage_client_cache_size
+
+- Default: 8
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of object storage clients (S3-compatible and Azure Blob) cached per client factory. The value is read on each client creation, so lowering it takes effect gradually as cached clients are evicted during subsequent creations. Values below `1` are treated as `1`.
+- Introduced in: v4.1.4, v4.0.14
+
 ### object_storage_connect_timeout_ms
 
 - Default: -1

--- a/docs/ja/administration/management/BE_parameters/query_loading.md
+++ b/docs/ja/administration/management/BE_parameters/query_loading.md
@@ -378,6 +378,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: BEプロセスにおけるファイルディスクリプタの最小数。
 - 導入バージョン: -
 
+### object_storage_client_cache_size
+
+- デフォルト: 8
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: クライアントファクトリーごとにキャッシュされるオブジェクトストレージクライアント（S3 互換および Azure Blob）の最大数。この値はクライアント作成のたびに読み取られるため、値を下げても即座には反映されず、以降の作成時にキャッシュされたクライアントが退避されるにつれて徐々に反映されます。`1` 未満の値は `1` として扱われます。
+- 導入バージョン: v4.1.4, v4.0.14
+
 ### object_storage_connect_timeout_ms
 
 - デフォルト: -1

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -374,6 +374,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BE 进程中文件描述符的最小数量。
 - 引入版本：-
 
+### object_storage_client_cache_size
+
+- 默认值：8
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：每个客户端工厂缓存的对象存储客户端（S3 兼容及 Azure Blob）的最大数量。该值在每次创建客户端时读取，因此调低该值不会立即生效，而是随着后续创建过程中缓存客户端被逐出而逐步生效。小于 `1` 的值按 `1` 处理。
+- 引入版本：v4.1.4, v4.0.14
+
 ### object_storage_connect_timeout_ms
 
 - 默认值：-1


### PR DESCRIPTION
The S3 and Azure Blob client factories in be/src/fs/ cached clients in fixed-size arrays hard-coded to 8 entries (kMaxItems). Introduce the mutable config object_storage_client_cache_size (default 8) and have both factories honor it: S3ClientFactory now stores clients in vectors and AzBlobClientFactory reads the capacity per creation. Each creation snapshots the value once and evicts random victims until the cache stays within capacity, so lowering the config shrinks the cache on subsequent creations instead of only overwriting entries.

Add a UT covering runtime capacity reduction and document the config in the en/zh/ja BE parameter references.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5