### PR TITLE
[Tool] Upgrade toolchain JDK to 21 and streamline rocky9/ubuntu packages

### DIFF
--- a/docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile
@@ -1,12 +1,19 @@
 # Build toolchains on rockylinux9, dev-env image can be built based on this image for rocky9
 # NOTE: build context MUST be set to `docker/dockerfiles/toolchains/`
 #  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/toolchains-rocky9.Dockerfile -t toolchains-rocky9:latest docker/dockerfiles/toolchains/
+#
+# Key toolchain versions:
+#   gcc           14.3.0   built from source, pinned via GCC_DOWNLOAD_URL
+#   jdk           21       distro java-21-openjdk-devel (currently 21.0.11)
+#   cmake         3.31.x   distro cmake (currently 3.31.8)
+#   maven         3.6.3    distro maven-openjdk21 (maven 3.6.3 bound to jdk21)
+#   lld           21.1.8   distro lld (STARROCKS_LINKER=lld)
+#   clang-format  21.1.8   distro clang-tools-extra
+#   binutils      2.35.2   distro binutils (as/ld)
+#   glibc         2.34     distro glibc (glibc-langpack-en)
 
 ARG GCC_INSTALL_HOME=/opt/gcc-toolset-14
 ARG GCC_DOWNLOAD_URL=https://ftp.gnu.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.gz
-ARG CMAKE_INSTALL_HOME=/opt/cmake
-ARG MAVEN_VERSION=3.6.3
-ARG MAVEN_INSTALL_HOME=/opt/maven
 ARG COMMIT_ID=unset
 
 
@@ -36,9 +43,6 @@ RUN cd /workspace/gcc && mkdir -p /workspace/installed && make DESTDIR=/workspac
 FROM rockylinux:9
 
 ARG GCC_INSTALL_HOME
-ARG CMAKE_INSTALL_HOME
-ARG MAVEN_VERSION
-ARG MAVEN_INSTALL_HOME
 ARG COMMIT_ID
 
 LABEL org.opencontainers.image.source="https://github.com/StarRocks/starrocks"
@@ -46,31 +50,18 @@ LABEL com.starrocks.commit=${COMMIT_ID}
 
 # Note: these packages are not part of rocky9's minimal base image, but are required to build
 # StarRocks: xz for .tar.xz extraction, gettext for autotools, perl (FindBin and friends) for
-# OpenSSL's Configure script, and binutils-devel for libiberty.a needed when linking the backend.
+# OpenSSL's Configure script, and binutils for the assembler/linker (as/ld) used by gcc.
 RUN dnf install -y 'dnf-command(config-manager)' && \
         dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
         dnf install -y epel-release && \
-        dnf install -y gh wget unzip bzip2 xz patch bison byacc flex autoconf automake make \
-        gettext perl binutils-devel libtool which git ccache python3 java-17-openjdk-devel file less psmisc clang-tools-extra lld glibc-langpack-en && \
+        dnf install -y gh wget unzip bzip2 xz pigz patch bison byacc flex autoconf automake make cmake maven-openjdk21 \
+        gettext perl binutils libtool which git ccache python3 java-21-openjdk-devel file less psmisc clang-tools-extra lld glibc-langpack-en && \
         dnf clean all && rm -rf /var/cache/dnf
 
 # install gcc
 COPY --from=gcc-builder /workspace/installed/ /
-# install cmake
-RUN ARCH=`uname -m` && mkdir -p $CMAKE_INSTALL_HOME && cd $CMAKE_INSTALL_HOME && \
-    curl -s -k https://cmake.org/files/v3.31/cmake-3.31.9-linux-${ARCH}.tar.gz | tar -xzf - --strip-components=1 && \
-    ln -s $CMAKE_INSTALL_HOME/bin/cmake /usr/bin/cmake
-
-# jdk17 is provided by the distro `java-17-openjdk-devel` package (installed above), no external download needed
-
-# install maven
-RUN mkdir -p ${MAVEN_INSTALL_HOME} && cd ${MAVEN_INSTALL_HOME} && \
-    curl -s -k https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | tar -xzf - --strip-components=1 && \
-    ln -s ${MAVEN_INSTALL_HOME}/bin/mvn /usr/bin/mvn
-# clang-format is provided by the distro `clang-tools-extra` package (installed above), no external download needed
 
 ENV STARROCKS_GCC_HOME=${GCC_INSTALL_HOME}
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
-ENV MAVEN_HOME=${MAVEN_INSTALL_HOME}
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
 ENV STARROCKS_LINKER=lld
 ENV LANG=en_US.utf8

--- a/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
@@ -1,5 +1,15 @@
 # Build toolchains on ubuntu24.04, dev-env image can be built based on this image for ubuntu24
 #  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile -t toolchains-ubuntu:latest docker/dockerfiles/toolchains/
+#
+# Key toolchain versions:
+#   gcc           14.3.0   built from source, pinned via GCC_DOWNLOAD_URL
+#   jdk           21       apt openjdk-21-jdk (currently 21.0.11)
+#   cmake         3.31.9   pinned, downloaded from cmake.org
+#   maven         3.8.7    apt maven
+#   lld           18.1.3   apt lld (STARROCKS_LINKER=lld)
+#   clang-format  18.1.3   apt clang-format (rocky9 ships 21; ubuntu24.04 has no clang-format-21)
+#   binutils      2.42     apt binutils (as/ld)
+#   glibc         2.39     apt libc6
 
 ARG GCC_INSTALL_HOME=/opt/gcc-toolset-14
 ARG GCC_WORK_DIR=/workspace/gcc-14
@@ -36,7 +46,7 @@ LABEL com.starrocks.commit=${COMMIT_ID}
 # Install common libraries and tools that are needed for dev environment
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-    automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 make openjdk-17-jdk git patch lld bzip2 \
+    automake bison byacc ccache flex binutils libtool maven zip python3 python-is-python3 make openjdk-21-jdk git patch lld clang-format bzip2 pigz \
     wget unzip curl vim tree net-tools openssh-client xz-utils gh locales less && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
     locale-gen en_US.UTF-8 && \
@@ -61,11 +71,11 @@ RUN ARCH=`uname -m` && mkdir -p $CMAKE_INSTALL_HOME && cd $CMAKE_INSTALL_HOME &&
     curl -s -k https://cmake.org/files/v3.31/cmake-3.31.9-linux-${ARCH}.tar.gz | tar -xzf - --strip-components=1 && \
     ln -s $CMAKE_INSTALL_HOME/bin/cmake /usr/bin/cmake
 
-# Set the soft link to jvm; the build uses JAVA_HOME (set below) which points at JDK 17.
+# Set the soft link to jvm; the build uses JAVA_HOME (set below) which points at JDK 21.
 RUN ARCH=`uname -m` && \
     cd /lib/jvm && \
-    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
+    if [ "$ARCH" = "aarch64" ] ; then ln -s java-21-openjdk-arm64 java-21-openjdk ; else ln -s java-21-openjdk-amd64 java-21-openjdk  ; fi ;
 
-ENV JAVA_HOME=/lib/jvm/java-17-openjdk
+ENV JAVA_HOME=/lib/jvm/java-21-openjdk
 ENV STARROCKS_LINKER=lld
 ENV LANG=en_US.utf8


### PR DESCRIPTION
Bump the rocky9 and ubuntu24.04 build toolchains from JDK 17 to JDK 21 (java-21-openjdk-devel / openjdk-21-jdk, repointed jvm symlink and JAVA_HOME).

Rocky9:
- cmake and maven now come from distro packages instead of manual cmake.org / archive.apache.org tarballs: cmake (3.31.8) and maven-openjdk21 (maven 3.6.3 bound to JDK 21, so no JDK 17 is pulled in). Removed the now unused MAVEN_HOME / CMAKE_INSTALL_HOME / MAVEN_INSTALL_HOME plumbing; distro maven auto-detects /usr/share/maven.
- Dropped binutils-devel: only libiberty.a/BFD dev files came from it and nothing in the build references them; the assembler/linker (as/ld) stay via binutils, a hard dependency of gcc (pulled by clang-tools-extra).

Ubuntu keeps its manual cmake tarball and apt maven, and now also installs clang-format (18.1.3; 24.04 has no clang-format-21). Dropped libiberty-dev for the same reason as rocky9's binutils-devel.

Documented the resulting toolchain versions in a comment block at the head of each Dockerfile.

Verified by building both toolchain images locally and running a gcc-14 compile+link+run smoke test in each: java/javac 21.0.11, gcc 14.3.0, as/ld present, libiberty.a absent; rocky9 cmake 3.31.8 + mvn 3.6.3 (JDK 21 only), ubuntu cmake 3.31.9 + mvn 3.8.7.

## Why I'm doing:

## What I'm doing:

Refs #74519

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
