### PR TITLE
[Refactor] Remove dead TopN ordering in IVM appendPkLoadOpColumn

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -33,16 +33,13 @@ import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
-import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.Operator;
-import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalDeltaOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
@@ -206,60 +203,7 @@ public class IvmRewriter {
         requiredColumns.union(loadOpColumn);
         rootTaskContext.getRequiredColumns().union(loadOpColumn);
 
-        OptExpression projectExpr = OptExpression.create(new LogicalProjectOperator(projectMap), root);
-        // TopN orders DELETEs before UPSERTs for same-PK batches. Skip it when __ACTION__
-        // is provably constant (e.g. append-only Iceberg) — there are no DELETEs to order.
-        if (isActionColumnConstant(root, actionColumn)) {
-            return projectExpr;
-        }
-        List<Ordering> orderings = List.of(new Ordering(loadOpColumn, false, false));
-        LogicalTopNOperator.Builder topNBuilder = LogicalTopNOperator.builder()
-                .withOperator(
-                        new LogicalTopNOperator(orderings, Operator.DEFAULT_LIMIT, Operator.DEFAULT_OFFSET,
-                                SortPhase.PARTIAL))
-                .setOrderByElements(orderings)
-                .setPerPipeline(true);
-        LogicalTopNOperator topN = topNBuilder.build();
-        return OptExpression.create(topN, projectExpr);
-    }
-
-    /**
-     * Walks down the plan tracing {@code target} through aliasing projections (including
-     * projections attached to non-Project operators like Filter). Returns true if the trace
-     * lands on a {@link ConstantOperator}; bails at multi-input operators (join/union/set op)
-     * or any non-constant, non-alias expression.
-     */
-    private static boolean isActionColumnConstant(OptExpression root, ColumnRefOperator actionColumn) {
-        OptExpression current = root;
-        ColumnRefOperator target = actionColumn;
-        for (int i = 0; current != null && i < 64; i++) {
-            Map<ColumnRefOperator, ScalarOperator> colMap = extractColumnRefMap(current.getOp());
-            if (colMap != null && colMap.containsKey(target)) {
-                ScalarOperator expr = colMap.get(target);
-                if (expr instanceof ConstantOperator) {
-                    return true;
-                }
-                if (!(expr instanceof ColumnRefOperator)) {
-                    return false;
-                }
-                target = (ColumnRefOperator) expr;
-            }
-            if (current.getInputs().size() != 1) {
-                return false;
-            }
-            current = current.inputAt(0);
-        }
-        return false;
-    }
-
-    private static Map<ColumnRefOperator, ScalarOperator> extractColumnRefMap(Operator op) {
-        if (op instanceof LogicalProjectOperator) {
-            return ((LogicalProjectOperator) op).getColumnRefMap();
-        }
-        if (op.getProjection() != null) {
-            return op.getProjection().getColumnRefMap();
-        }
-        return null;
+        return OptExpression.create(new LogicalProjectOperator(projectMap), root);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriterTest.java
@@ -31,13 +31,10 @@ import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
-import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.ivm.common.IvmRuleUtils;
 import com.starrocks.sql.optimizer.task.TaskContext;
@@ -56,7 +53,7 @@ import java.util.Map;
  * - Gate: skip when {@code enable_ivm_refresh} is off
  * - Convergence success: Delta markers eliminated for supported patterns
  * - Convergence failure: throw SemanticException for unsupported patterns
- * - appendPkLoadOpColumn: __op column + TopN for PK MVs
+ * - appendPkLoadOpColumn: __op column for PK MVs
  * - isPrimaryKeyTargetMv: various statement types
  */
 public class IvmRewriterTest {
@@ -240,9 +237,7 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // Append-only Iceberg → constant __ACTION__ → TopN is skipped. Top is Project(__op).
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator);
         Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalProjectOperator);
         LogicalProjectOperator opProjectOp = (LogicalProjectOperator) rewrittenChild.getOp();
         // Should contain __op column
@@ -298,10 +293,7 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // Append-only Iceberg → constant __ACTION__ → TopN is skipped. Top is Project(__op).
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator,
-                "No TopN expected for append-only Iceberg (constant __ACTION__)");
         Assertions.assertTrue(rewrittenChild.getOp() instanceof LogicalProjectOperator);
         LogicalProjectOperator opProjectOp = (LogicalProjectOperator) rewrittenChild.getOp();
         boolean hasOpColumn = opProjectOp.getColumnRefMap().keySet().stream()
@@ -357,101 +349,6 @@ public class IvmRewriterTest {
                 "__op must reference __ACTION__ directly");
     }
 
-    /** TopN is skipped when {@code __ACTION__} is provably constant (no DELETEs to order). */
-    @Test
-    public void testTopNSkippedWhenActionConstant(@Mocked IcebergTable table,
-                                                   @Mocked MaterializedView targetMv,
-                                                   @Mocked InsertStmt insertStmt) {
-        mockIcebergTable(table);
-        new Expectations() {
-            {
-                insertStmt.getTargetTable();
-                result = targetMv;
-                minTimes = 0;
-
-                targetMv.getKeysType();
-                result = KeysType.PRIMARY_KEYS;
-                minTimes = 0;
-            }
-        };
-
-        ColumnRefFactory factory = new ColumnRefFactory();
-        OptimizerContext context = OptimizerFactory.mockContext(factory);
-        context.getSessionVariable().setEnableIVMRefresh(true);
-        context.setStatement(insertStmt);
-
-        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
-        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
-        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
-                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
-
-        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), scan);
-        deriveLogicalProperty(root);
-        IvmRewriter.rewrite(root, newTaskContext(context), new TaskScheduler(), new ColumnRefSet());
-
-        OptExpression top = root.inputAt(0);
-        Assertions.assertTrue(top.getOp() instanceof LogicalProjectOperator,
-                "top operator must be Project when __ACTION__ is constant; no TopN expected");
-        Assertions.assertFalse(top.getOp() instanceof LogicalTopNOperator);
-    }
-
-    /**
-     * Regression: when {@code __ACTION__} is forwarded through an aliasing projection
-     * (e.g., {@code IvmDeltaFilterRule} attaches {@code action → action}), the constant
-     * produced at the scan must still be detected — TopN is skipped.
-     */
-    @Test
-    public void testTopNSkippedAcrossAliasForwardingProjection(@Mocked IcebergTable table,
-                                                                @Mocked MaterializedView targetMv,
-                                                                @Mocked InsertStmt insertStmt) {
-        mockIcebergTable(table);
-        new Expectations() {
-            {
-                insertStmt.getTargetTable();
-                result = targetMv;
-                minTimes = 0;
-
-                targetMv.getKeysType();
-                result = KeysType.PRIMARY_KEYS;
-                minTimes = 0;
-            }
-        };
-
-        ColumnRefFactory factory = new ColumnRefFactory();
-        OptimizerContext context = OptimizerFactory.mockContext(factory);
-        context.getSessionVariable().setEnableIVMRefresh(true);
-        context.setStatement(insertStmt);
-
-        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, false);
-        ColumnRefOperator dataRef = factory.create("data", StringType.STRING, true);
-        OptExpression scan = newIcebergScan(factory, table, idRef, dataRef,
-                TvrTableDelta.of(TvrVersion.of(100L), TvrVersion.of(200L)));
-        // Filter above scan → IvmDeltaFilterRule attaches a passthrough Projection carrying
-        // `actionColumn → actionColumn` on the Filter operator. Without alias-chain walking,
-        // isActionColumnConstant would miss the constant and keep the TopN.
-        OptExpression filter = OptExpression.create(
-                new LogicalFilterOperator(ConstantOperator.createBoolean(true)), scan);
-        OptExpression root = OptExpression.create(new LogicalTreeAnchorOperator(), filter);
-        deriveLogicalProperty(root);
-
-        IvmRewriter.rewrite(root, newTaskContext(context), new TaskScheduler(), new ColumnRefSet());
-
-        Assertions.assertFalse(containsTopN(root.inputAt(0)),
-                "TopN must be skipped when __ACTION__ is constant, even through alias forwarding");
-    }
-
-    private static boolean containsTopN(OptExpression expr) {
-        if (expr.getOp() instanceof LogicalTopNOperator) {
-            return true;
-        }
-        for (OptExpression child : expr.getInputs()) {
-            if (containsTopN(child)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     @Test
     public void testNoPkLoadOpColumnForDupKeysMv(@Mocked IcebergTable table,
                                                   @Mocked MaterializedView targetMv,
@@ -488,10 +385,11 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // For DUP_KEYS MV, no TopN or __op should be added
+        // DUP_KEYS MV is not a PK target → appendPkLoadOpColumn does not run → no __op column.
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator,
-                "DUP_KEYS MV should NOT have TopN");
+        boolean hasOpColumn = rewrittenChild.getOutputColumns().getColumnRefOperators(factory).stream()
+                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        Assertions.assertFalse(hasOpColumn, "DUP_KEYS MV should NOT have a __op column");
     }
 
     @Test
@@ -516,9 +414,11 @@ public class IvmRewriterTest {
 
         IvmRewriter.rewrite(root, taskContext, scheduler, requiredColumns);
 
-        // No statement → no __op, no TopN
+        // No statement → isPrimaryKeyTargetMv false → appendPkLoadOpColumn does not run → no __op column.
         OptExpression rewrittenChild = root.inputAt(0);
-        Assertions.assertFalse(rewrittenChild.getOp() instanceof LogicalTopNOperator);
+        boolean hasOpColumn = rewrittenChild.getOutputColumns().getColumnRefOperators(factory).stream()
+                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        Assertions.assertFalse(hasOpColumn, "no-statement MV should NOT have a __op column");
     }
 
     // ==================== Helpers ====================


### PR DESCRIPTION
## Why I'm doing:

`IvmRewriter.appendPkLoadOpColumn` wraps the `__op` projection in a `TopN` that
orders same-PK `DELETE`-before-`UPSERT` so the primary-key sink applies them in
order. But the IVM CHANGES delta is append-only: `__ACTION__` is provably
constant (`UPSERT`), so `isActionColumnConstant` is always true and the `TopN`
branch is never emitted. It is dead code, together with the helpers only it uses.

## What I'm doing:

Remove the unreachable `TopN` branch from `appendPkLoadOpColumn`, plus the
now-unused `isActionColumnConstant` / `extractColumnRefMap` helpers. Drop the
tests that only exercised the `TopN` path; the two negative tests
(`testNoPkLoadOpColumnForDupKeysMv`, `testNoStatementIsNotPkMv`) now assert the
absence of the `__op` column directly instead of using "no TopN" as a proxy.

Fixes #issue: N/A — internal IVM cleanup, no user-facing issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
