### PR TITLE
[BugFix] Remove useless per-rowid seeks in ArrayColumnIterator::fetch_values_by_rowid offsets-only path

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -236,9 +236,6 @@ Status ArrayColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t 
 
         size_t size_to_read = 0;
         for (size_t i = 0; i < size; ++i) {
-            RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(rowids[i]));
-            size_t element_ordinal = _array_size_iterator->element_ordinal();
-            RETURN_IF_ERROR(_element_iterator->seek_to_ordinal(element_ordinal));
             size_to_read += array_size.get_data()[i];
         }
 

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -44,6 +44,7 @@
 #include "column/binary_column.h"
 #include "column/chunk_factory.h"
 #include "column/column.h"
+#include "column/column_access_path.h"
 #include "column/column_helper.h"
 #include "column/datum_convert.h"
 #include "column/fixed_length_column.h"
@@ -694,6 +695,107 @@ TEST_F(ColumnReaderWriterTest, test_default_value) {
 TEST_F(ColumnReaderWriterTest, test_array_int) {
     test_int_array<2>();
     test_int_array<2>("1");
+}
+
+// Covers ArrayColumnIterator::fetch_values_by_rowid with an offsets-only access
+// path (_access_values == false): only array sizes are materialized, element
+// values are never read. This locks the semantics: returned offsets must match
+// the written array lengths, and the elements column stays a const default
+// column sized by the sum of the fetched array sizes.
+TEST_F(ColumnReaderWriterTest, test_array_fetch_by_rowid_offsets_only) {
+    TabletColumn array_column = create_array(0, true, sizeof(Collection));
+    TabletColumn int_column = create_int_value(0, STORAGE_AGGREGATE_NONE, true);
+    array_column.add_sub_column(int_column);
+
+    // Enough rows that the element data spans multiple 64KB pages, so scattered
+    // rowids land on different pages.
+    const size_t kNumRows = 20000;
+
+    auto src_offsets = UInt32Column::create();
+    auto src_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    auto src_column = ArrayColumn::create(src_elements, src_offsets);
+
+    // Row i holds i % 5 elements, so array lengths vary and are predictable.
+    uint32_t offset = 0;
+    for (size_t i = 0; i < kNumRows; ++i) {
+        size_t array_size = i % 5;
+        for (size_t j = 0; j < array_size; ++j) {
+            src_elements->append_datum(static_cast<int32_t>(i * 10 + j));
+        }
+        offset += array_size;
+        src_offsets->append(offset);
+    }
+
+    ColumnMetaPB meta;
+    const std::string fname = TEST_DIR + "/" + generate_uuid_string() + ".data";
+    auto segment = create_dummy_segment(fname);
+
+    // write data
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(fname));
+
+        ColumnWriterOptions writer_opts = make_writer_opts<TYPE_ARRAY, DEFAULT_ENCODING, 2>(&meta, false, false);
+
+        // init integer sub column
+        ColumnMetaPB* element_meta = writer_opts.meta->add_children_columns();
+        element_meta->set_column_id(0);
+        element_meta->set_unique_id(0);
+        element_meta->set_type(int_column.type());
+        element_meta->set_length(0);
+        element_meta->set_encoding(DEFAULT_ENCODING);
+        element_meta->set_compression(LZ4_FRAME);
+        element_meta->set_is_nullable(false);
+
+        ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &array_column, wfile.get()));
+        ASSERT_OK(writer->init());
+        ASSERT_OK(writer->append(*src_column));
+        flush_column_writer(writer.get());
+        ASSERT_OK(wfile->close());
+    }
+
+    // read back through an offsets-only access path (root with a single OFFSET
+    // child), which makes ArrayColumnIterator::init set _access_values = false.
+    {
+        ASSIGN_OR_ABORT(auto child_path, ColumnAccessPath::create(TAccessPathType::type::OFFSET, "offsets", 1));
+        ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::type::ROOT, "root", 0));
+        path->children().emplace_back(std::move(child_path));
+
+        ASSIGN_OR_ABORT(_reader, ColumnReader::create(&meta, segment.get(), nullptr));
+        ASSIGN_OR_ABORT(auto iter, _reader->new_iterator(path.get()));
+        ASSIGN_OR_ABORT(_read_file, _fs->new_random_access_file(fname));
+
+        ColumnIteratorOptions iter_opts;
+        iter_opts.stats = &_stats;
+        iter_opts.read_file = _read_file.get();
+        iter_opts.use_page_cache = true;
+        ASSERT_OK(iter->init(iter_opts));
+
+        // scattered rowids: first row, one every 997 rows, and the last row.
+        std::vector<rowid_t> rowids;
+        for (size_t i = 0; i < kNumRows; i += 997) {
+            rowids.push_back(i);
+        }
+        rowids.push_back(kNumRows - 1);
+
+        auto dst_offsets = UInt32Column::create();
+        auto dst_elements = NullableColumn::create(Int32Column::create(), NullColumn::create());
+        auto dst_column = ArrayColumn::create(std::move(dst_elements), std::move(dst_offsets));
+        ASSERT_OK(iter->fetch_values_by_rowid(rowids.data(), rowids.size(), dst_column.get()));
+        ASSERT_EQ(rowids.size(), dst_column->size());
+
+        // each fetched row must report the same array length as written.
+        size_t expected_element_rows = 0;
+        for (size_t i = 0; i < rowids.size(); ++i) {
+            size_t expected_size = rowids[i] % 5;
+            ASSERT_EQ(expected_size, dst_column->get_element_size(i)) << " row " << i << " rowid " << rowids[i];
+            expected_element_rows += expected_size;
+        }
+
+        // element values are not read: the elements column is a const default
+        // column whose row count equals the sum of the fetched array sizes.
+        ASSERT_TRUE(dst_column->elements_column()->is_constant());
+        ASSERT_EQ(expected_element_rows, dst_column->elements_column()->size());
+    }
 }
 
 TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {


### PR DESCRIPTION
## Why I'm doing:

When a query only uses `array_length()` / `cardinality()` on an array column, the FE pushes down an offsets-only `ColumnAccessPath` and `ArrayColumnIterator::init` sets `_access_values = false`. In this mode element data is never read. However, `fetch_values_by_rowid` (the late-materialization path) still performs a per-rowid `seek_to_ordinal_and_calc_element_ordinal` on the size iterator and a `seek_to_ordinal` on the element iterator in its offsets-only branch. Neither seek has any consumer: no `next_batch`/`next_dict_codes` follows (contrast with the `_access_values == true` branch), and the loop only needs the array sizes already fetched in bulk by `_array_size_iterator->fetch_values_by_rowid` at the top of the function. Each rowid pays one size-page prefix decode plus one element page load — a real page-cache miss / disk read whenever consecutive rowids fall on different pages.

Measured on a 2M-row table with 10K rows surviving the predicate (`SELECT SUM(array_length(tags)) FROM t_repro WHERE flag = 1`):

| Counter | Before | After |
|---|---|---|
| ReadPagesNum | 10238 | 185 |
| LateMaterialize | 57.45ms | 0.42ms |
| Hot query time | ~61ms | ~11ms |
| SUM result | 200000 | 200000 (unchanged) |

~98% of the pages read before the fix were element pages loaded by the dead seeks and thrown away.

## What I'm doing:

- Remove the three dead seek lines from the offsets-only branch of `ArrayColumnIterator::fetch_values_by_rowid`; the loop now only sums the already-fetched array sizes to size the const default elements column.
- Add `ColumnReaderWriterTest.test_array_fetch_by_rowid_offsets_only`: writes a 20000-row `ARRAY<INT>` column spanning multiple data pages, reads it back through an offsets-only access path with scattered rowids, and asserts the returned array lengths match what was written and the elements column stays a const default column sized by the sum of the fetched array sizes. The test locks semantics, not implementation, and passes both before and after the fix.

Fixes #75860

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
