### PR TITLE
[Doc] Document ADD ROLLUP ORDER BY for shared-data range-distribution rollups

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -737,17 +737,31 @@ Syntax:
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP rollup_name (column_name1, column_name2, ...)
+[ORDER BY (column_name1, column_name2, ...)]
 [FROM from_index_name]
 [PROPERTIES ("key"="value", ...)]
 ```
 
 PROPERTIES: Support setting timeout time and the default timeout time is one day.
 
+`ORDER BY`: defines an independent sort key for the rollup that can differ from the base table's sort key. It is supported only for range-distribution tables in shared-data clusters (from v4.2 onwards), and lets queries that filter or aggregate on the rollup's leading sort-key columns be served by the rollup. The following limitations apply:
+
+- The table must be a Duplicate Key or Aggregate table. Primary Key tables are not supported.
+- The table must not be a colocate table and must not contain an AUTO_INCREMENT column.
+- The rollup can be added only when the table has no other rollup or synchronous materialized view.
+
 Example:
 
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP r1(col1,col2) from r0;
+```
+
+Example: create a rollup with an independent sort key on a range-distribution table in a shared-data cluster.
+
+```SQL
+ALTER TABLE example_db.my_table
+ADD ROLLUP r_reorder (k1, k2, v1) ORDER BY (k2, k1);
 ```
 
 #### Create rollups in batches

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -738,17 +738,31 @@ field_desc ::= <field_type> [ AFTER <prior_field_name> | FIRST ]
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP rollup_name (column_name1, column_name2, ...)
+[ORDER BY (column_name1, column_name2, ...)]
 [FROM from_index_name]
 [PROPERTIES ("key"="value", ...)]
 ```
 
 PROPERTIES: タイムアウト時間を設定することをサポートしています。デフォルトのタイムアウト時間は1日です。
 
+`ORDER BY`: ベーステーブルのソートキーとは異なる、ロールアップ独自のソートキーを定義します。共有データクラスタの Range 分散テーブルでのみサポートされます（v4.2 以降）。ロールアップの先頭ソートキー列でフィルタまたは集計を行うクエリがロールアップで処理されるようになります。以下の制限があります。
+
+- テーブルは重複キー（Duplicate Key）テーブルまたは集計（Aggregate）テーブルである必要があります。主キー（Primary Key）テーブルはサポートされません。
+- テーブルは Colocate テーブルであってはならず、AUTO_INCREMENT 列を含めることはできません。
+- ロールアップは、テーブルに他のロールアップまたは同期マテリアライズドビューが存在しない場合にのみ追加できます。
+
 例:
 
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP r1(col1,col2) from r0;
+```
+
+例: 共有データクラスタの Range 分散テーブルに、独立したソートキーを持つロールアップを作成します。
+
+```SQL
+ALTER TABLE example_db.my_table
+ADD ROLLUP r_reorder (k1, k2, v1) ORDER BY (k2, k1);
 ```
 
 #### バッチでロールアップを作成する

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -737,17 +737,31 @@ field_desc ::= <field_type> [ AFTER <prior_field_name> | FIRST ]
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP rollup_name (column_name1, column_name2, ...)
+[ORDER BY (column_name1, column_name2, ...)]
 [FROM from_index_name]
 [PROPERTIES ("key"="value", ...)]
 ```
 
 PROPERTIES：支持设置超时时间，默认超时时间为一天。
 
+`ORDER BY`：为 Rollup 定义独立于基表的排序键（可与基表排序键不同）。仅支持存算分离集群中的 Range 分布表（自 v4.2 起），可使按 Rollup 排序键前缀列进行过滤或聚合的查询命中该 Rollup。有以下限制：
+
+- 表必须为明细表（Duplicate Key）或聚合表（Aggregate），不支持主键表（Primary Key）。
+- 表不能为 Colocate 表，且不能包含 AUTO_INCREMENT 列。
+- 仅当表尚无其他 Rollup 或同步物化视图时，才能添加该 Rollup。
+
 示例：
 
 ```SQL
 ALTER TABLE [<db_name>.]<tbl_name> 
 ADD ROLLUP r1(col1,col2) from r0;
+```
+
+示例：在存算分离集群的 Range 分布表上创建一个具有独立排序键的 Rollup。
+
+```SQL
+ALTER TABLE example_db.my_table
+ADD ROLLUP r_reorder (k1, k2, v1) ORDER BY (k2, k1);
 ```
 
 #### 批量创建 Rollup


### PR DESCRIPTION
## Why I'm doing:

Shared-data range-distribution tables can now attach a rollup with an independent sort key via `ALTER TABLE ... ADD ROLLUP ... ORDER BY (...)` (shipped in #75618), but the ADD ROLLUP documentation did not cover the new `ORDER BY` clause.

## What I'm doing:

Document the optional `ORDER BY` clause of `ALTER TABLE ... ADD ROLLUP` in the "Create a rollup" section: the syntax, what it does (an independent sort key that can differ from the base table's), the supported table models and limitations (shared-data range-distribution Duplicate Key / Aggregate tables; not Primary Key, colocate, or AUTO_INCREMENT tables; only when the table has no other rollup or synchronous materialized view), and an example. Updated the English, Chinese, and Japanese pages.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)