### PR TITLE
[BugFix] Fix nullsFraction clamp in LargeOrCalculatingVisitor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -549,7 +549,9 @@ public class PredicateStatisticsCalculator {
                 columnBuilder.setMaxValue(Math.max(columnStatistic.getMaxValue(), rightColumnStatistic.getMaxValue()));
                 double distinct = Math.max(1,
                         (columnStatistic.getDistinctValuesCount() + rightColumnStatistic.getDistinctValuesCount()) / 2);
-                double nulls = Math.max(1,
+                // nullsFraction is a ratio, not a count like distinct/NDV above it - cap at 1
+                // instead of flooring at 1, which forced every merge to the constant 1.0.
+                double nulls = Math.min(1.0,
                         (columnStatistic.getNullsFraction() + rightColumnStatistic.getNullsFraction()) / 2);
                 columnBuilder.setDistinctValuesCount(distinct);
                 columnBuilder.setNullsFraction(nulls);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -24,6 +24,8 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
@@ -586,5 +588,38 @@ public class PredicateStatisticsCalculatorTest {
 
         result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
         Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
+    }
+
+    @Test
+    public void testLargeOrNullsFractionIsAveragedNotFloored() {
+        // GIVEN a column with no nulls
+        final var aColumn = new ColumnRefOperator(0, VarcharType.VARCHAR, "a", true);
+        final var statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(aColumn, ColumnStatistic.builder()
+                        .setNullsFraction(0.0)
+                        .setDistinctValuesCount(100)
+                        .setAverageRowSize(10)
+                        .build())
+                .build();
+
+        // (a IS NULL) OR (a IS NOT NULL), ANDed together more than
+        // StatisticsEstimateCoefficient.DEFAULT_OR_OPERATOR_LIMIT (16) times so the estimator
+        // routes through LargeOrCalculatingVisitor's averaging heuristic instead of the
+        // inclusion-exclusion path.
+        ScalarOperator group = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                new IsNullPredicateOperator(false, aColumn), new IsNullPredicateOperator(true, aColumn));
+        ScalarOperator predicate = group;
+        for (int i = 0; i < StatisticsEstimateCoefficient.DEFAULT_OR_OPERATOR_LIMIT; i++) {
+            predicate = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, predicate, group);
+        }
+
+        // WHEN
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(predicate, statistics);
+
+        // THEN
+        // Each OR arm hard-sets nullsFraction to 1.0 (IS NULL) and 0.0 (IS NOT NULL), so the
+        // averaging heuristic should land on 0.5, not be floored up to 1.0.
+        Assertions.assertEquals(0.5, result.getColumnStatistic(aColumn).getNullsFraction(), 0.001);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

In `PredicateStatisticsCalculator.LargeOrCalculatingVisitor.computeOrPredicateStatistics` (the averaging-heuristic path used when an OR predicate has more than `DEFAULT_OR_OPERATOR_LIMIT` (16) disjuncts), the merged `nullsFraction` for a column was computed as:

```java
double nulls = Math.max(1,
        (columnStatistic.getNullsFraction() + rightColumnStatistic.getNullsFraction()) / 2);
```

`nullsFraction` is always a ratio in `[0, 1]`, so the average of two such ratios can never exceed `1`. This means `Math.max(1, avg)` always evaluates to the constant `1.0`, regardless of the actual inputs — it looks like a copy-paste of the NDV floor on the line above (`Math.max(1, ...)` is correct there since a distinct-value count must be at least 1, but the same floor doesn't make sense for a fraction).

In effect, any OR predicate with more than 16 disjuncts forces `nullsFraction` to 100% for every column touched by more than one arm, regardless of actual null content, which can badly skew downstream selectivity/cardinality estimates.

## What I'm doing:

Changes the incorrect `Math.max(1, ...)` floor to `Math.min(1.0, ...)`, since a ratio needs an upper cap, not a floor of 1 (the merged value is normally already the plain average of the two arms - the cap only guards against an out-of-range input, since `nullsFraction` isn't type-enforced to stay within `[0, 1]`). Added a regression test that ANDs 17 `(a IS NULL) OR (a IS NOT NULL)` groups together (to route through this visitor) and asserts the merged `nullsFraction` is `0.5`, not `1.0`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

