### PR TITLE
[Enhancement] Route async vector index build to the table's warehouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -402,22 +402,40 @@ public class WarehouseManager implements Writable {
     }
 
     public ComputeResource getVectorIndexBuildComputeResource(long tableId) {
-        // Route async vector index build work to the warehouse named by
-        // lake_vector_index_build_warehouse so users can isolate it from query
-        // workload. Fall back to the default resource if the configured
-        // warehouse is unset, missing, or unavailable — building on the
-        // default warehouse is always preferable to dropping the build.
+        // Warehouse selection for async vector index build mirrors the load path:
+        // explicit config > the table's (loading session's) warehouse > default.
+        //   1. An explicit lake_vector_index_build_warehouse lets admins isolate all
+        //      async builds onto a dedicated warehouse, away from query/load workload.
+        //   2. Otherwise route to the warehouse the table is loaded into — its
+        //      background compute resource, the same one compaction and other
+        //      background tablet work use (recorded at load commit via
+        //      recordWarehouseInfoForTable). This keeps the build in the table's own
+        //      compute pool (data-cache locality + multi-warehouse isolation) instead
+        //      of piling every table's build onto the default warehouse. In OSS
+        //      single-warehouse mode this collapses to the default warehouse.
+        //   3. Fall back to the default resource as a last resort — building on the
+        //      default warehouse is always preferable to dropping the build.
         String warehouseName = Config.lake_vector_index_build_warehouse;
-        if (warehouseName == null || warehouseName.isEmpty()
-                || warehouseName.equalsIgnoreCase(DEFAULT_WAREHOUSE_NAME)) {
-            return DEFAULT_RESOURCE;
+        if (warehouseName != null && !warehouseName.isEmpty()
+                && !warehouseName.equalsIgnoreCase(DEFAULT_WAREHOUSE_NAME)) {
+            Warehouse wh = getWarehouseAllowNull(warehouseName);
+            if (wh != null) {
+                try {
+                    return acquireComputeResource(CRAcquireContext.of(wh.getId()));
+                } catch (Exception e) {
+                    LOG.warn("Configured vector index build warehouse {} is unavailable, " +
+                            "falling back to the table's warehouse", warehouseName, e);
+                }
+            } else {
+                LOG.warn("Configured vector index build warehouse {} does not exist, " +
+                        "falling back to the table's warehouse", warehouseName);
+            }
         }
-        Warehouse wh = getWarehouseAllowNull(warehouseName);
-        if (wh == null) {
-            return DEFAULT_RESOURCE;
-        }
+        // No usable explicit config warehouse: use the table's warehouse (its
+        // background compute resource). Falls back to the default resource if the
+        // table has no recorded warehouse or it is currently unavailable.
         try {
-            return acquireComputeResource(CRAcquireContext.of(wh.getId()));
+            return getBackgroundComputeResource(tableId);
         } catch (Exception e) {
             return DEFAULT_RESOURCE;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
@@ -431,6 +432,76 @@ public class WarehouseManagerTest {
         mgr.initDefaultWarehouse();
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, mgr.getBackgroundWarehouse(123).getId());
         Assertions.assertEquals(WarehouseManager.DEFAULT_WAREHOUSE_ID, mgr.getBackgroundComputeResource(123).getWarehouseId());
+    }
+
+    // ---- getVectorIndexBuildComputeResource: explicit config > table warehouse > default ----
+
+    @Test
+    public void testVectorIndexBuildComputeResourceUsesExplicitConfigWarehouse() {
+        new MockUp<RunMode>() {
+            @Mock
+            public boolean isSharedDataMode() {
+                return true;
+            }
+        };
+        new MockUp<WarehouseComputeResourceProvider>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
+            }
+        };
+        WarehouseManager mgr = new WarehouseManager();
+        mgr.initDefaultWarehouse();
+        mgr.addWarehouse(new DefaultWarehouse(1000L, "vi_build_wh"));
+        String saved = Config.lake_vector_index_build_warehouse;
+        try {
+            // An explicit non-default config warehouse takes priority over the table's warehouse.
+            Config.lake_vector_index_build_warehouse = "vi_build_wh";
+            Assertions.assertEquals(1000L, mgr.getVectorIndexBuildComputeResource(123).getWarehouseId());
+        } finally {
+            Config.lake_vector_index_build_warehouse = saved;
+        }
+    }
+
+    @Test
+    public void testVectorIndexBuildComputeResourceFallsBackToTableWarehouse() {
+        // No explicit config warehouse -> route to the table's background compute resource
+        // (table-aware in multi-warehouse mode) instead of blindly returning the default resource.
+        ComputeResource tableResource = WarehouseComputeResource.of(2000L);
+        WarehouseManager mgr = new WarehouseManager() {
+            @Override
+            public ComputeResource getBackgroundComputeResource(long tableId) {
+                return tableResource;
+            }
+        };
+        mgr.initDefaultWarehouse();
+        String saved = Config.lake_vector_index_build_warehouse;
+        try {
+            Config.lake_vector_index_build_warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+            Assertions.assertEquals(2000L, mgr.getVectorIndexBuildComputeResource(123).getWarehouseId());
+        } finally {
+            Config.lake_vector_index_build_warehouse = saved;
+        }
+    }
+
+    @Test
+    public void testVectorIndexBuildComputeResourceFallsThroughWhenConfigWarehouseMissing() {
+        // A configured-but-nonexistent warehouse falls through to the table's warehouse.
+        ComputeResource tableResource = WarehouseComputeResource.of(3000L);
+        WarehouseManager mgr = new WarehouseManager() {
+            @Override
+            public ComputeResource getBackgroundComputeResource(long tableId) {
+                return tableResource;
+            }
+        };
+        mgr.initDefaultWarehouse();
+        String saved = Config.lake_vector_index_build_warehouse;
+        try {
+            Config.lake_vector_index_build_warehouse = "nonexistent_wh";
+            Assertions.assertEquals(3000L, mgr.getVectorIndexBuildComputeResource(123).getWarehouseId());
+        } finally {
+            Config.lake_vector_index_build_warehouse = saved;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Async vector index build in shared-data mode picks its compute warehouse via
`WarehouseManager.getVectorIndexBuildComputeResource(tableId)`. Previously, unless
the `lake_vector_index_build_warehouse` config was explicitly set to a non-default
warehouse, the build always ran on the **default warehouse** — the `tableId`
argument was ignored.

In a multi-warehouse deployment this is undesirable:

- every table's build piles onto the default warehouse, making it a shared
  bottleneck and breaking workload isolation between warehouses;
- the build reads cold from object storage instead of reusing the data cache on
  the CNs that just loaded the segments;
- it diverges from how compaction / dynamic-partition / reshard already select
  their warehouse (`getCompactionComputeResource(tableId)` /
  `getBackgroundComputeResource(tableId)`), which route to the warehouse the table
  is loaded into.

## What I'm doing:

Make `getVectorIndexBuildComputeResource(tableId)` mirror the load path's priority
— **explicit config > table (loading session) warehouse > default**:

1. An explicit `lake_vector_index_build_warehouse` (non-empty, non-`default_warehouse`)
   still wins, so admins can isolate all builds onto a dedicated warehouse.
2. Otherwise route to the table's background compute resource
   (`getBackgroundComputeResource(tableId)`) — the same table-aware warehouse
   compaction and other background tablet work use, recorded at load commit via
   `recordWarehouseInfoForTable`. In OSS single-warehouse mode this collapses to
   the default warehouse (no behavior change).
3. Fall back to the default resource as a last resort — building on the default
   warehouse is always preferable to dropping the build. A configured-but-missing
   or unavailable warehouse now falls through to the table warehouse instead of
   jumping straight to default.

Added `WarehouseManagerTest` cases covering the full priority chain.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
