### PR TITLE
[Tool] Fix module-risk job skipped on every PR by author_association gate

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -230,15 +230,29 @@ jobs:
   # the GitHub REST API (GITHUB_TOKEN injected). --comment applies a strict confidence gate and emits
   # either a sticky-marked briefing or the sentinel "MODULE-RISK: none" (then we post nothing).
   #
+  # TRIGGER: every human-authored PR event (opened/reopened/synchronize/ready_for_review), minus
+  # mergify/ and *-sync-pr-* automation branches and Bot-typed authors. It intentionally does NOT
+  # restrict to org members / collaborators — external contributors are briefed too (deliberate; see
+  # the SECURITY note below for the accepted risk).
+  #
+  # Why no trusted-author gate: the prior `author_association in [OWNER,MEMBER,COLLABORATOR]` check
+  # silently skipped EVERY PR. In the pull_request_target payload `author_association` reflects only
+  # PUBLICLY-visible org membership, and StarRocks committers keep membership private, so they arrive
+  # as CONTRIBUTOR and the gate matched nobody (module-risk never ran once since it was added). The
+  # replacement `github.event.pull_request.user.type != 'Bot'` keeps automation (mergify[bot],
+  # dependabot, ...) out while briefing all human PRs.
+  #
   # SECURITY (pull_request_target): this job injects secrets (GITHUB_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)
   # into `claude --dangerously-skip-permissions`, which reads attacker-influenceable PR body/diff and
-  # whose output is posted back to the PR. An untrusted author could prompt-inject the model to run
-  # bash / emit secrets (e.g. after the marker) and have them published. So it is GATED to TRUSTED
-  # authors only (author_association OWNER/MEMBER/COLLABORATOR = write access); external / first-time
-  # contributors never reach the model. (assign-reviewer tolerates all authors because its host step
-  # extracts only login-shaped tokens — a strict whitelist; module-risk's output is free-form, so it
-  # needs the author gate. The marker-bounded extraction below is defense-in-depth, not the control.)
-  # For an external PR a maintainer can still run /github-pr-module-risk:review manually.
+  # posts output back to the PR. Untrusted authors now reach the model, so a malicious PR can attempt
+  # prompt-injection to run bash / emit secrets. This risk is ACCEPTED in exchange for briefing every
+  # human PR; residual mitigations (defense-in-depth, NOT a hard gate): the model runs inside the
+  # claude-cli container, the upsert step extracts only from the `<!-- module-risk-briefing -->` marker
+  # onward, and continue-on-error stops a hijacked run from failing checks. To re-restrict to write
+  # access, a preflight job can query repos/<repo>/collaborators/<author>/permission at runtime (the
+  # webhook author_association field cannot, per above). (assign-reviewer stays safe for any author
+  # because its host step extracts only login-shaped tokens — a strict whitelist; module-risk's output
+  # is free-form.)
   module-risk:
     runs-on: [self-hosted, normal]
     # Dedup rapid pushes for THIS job only (a new event cancels the in-flight briefing run).
@@ -253,7 +267,7 @@ jobs:
        github.event.action == 'synchronize' || github.event.action == 'ready_for_review') &&
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event.pull_request.user.type != 'Bot'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -242,17 +242,23 @@ jobs:
   # replacement `github.event.pull_request.user.type != 'Bot'` keeps automation (mergify[bot],
   # dependabot, ...) out while briefing all human PRs.
   #
-  # SECURITY (pull_request_target): this job injects secrets (GITHUB_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)
-  # into `claude --dangerously-skip-permissions`, which reads attacker-influenceable PR body/diff and
-  # posts output back to the PR. Untrusted authors now reach the model, so a malicious PR can attempt
-  # prompt-injection to run bash / emit secrets. This risk is ACCEPTED in exchange for briefing every
-  # human PR; residual mitigations (defense-in-depth, NOT a hard gate): the model runs inside the
-  # claude-cli container, the upsert step extracts only from the `<!-- module-risk-briefing -->` marker
-  # onward, and continue-on-error stops a hijacked run from failing checks. To re-restrict to write
-  # access, a preflight job can query repos/<repo>/collaborators/<author>/permission at runtime (the
-  # webhook author_association field cannot, per above). (assign-reviewer stays safe for any author
-  # because its host step extracts only login-shaped tokens — a strict whitelist; module-risk's output
-  # is free-form.)
+  # SECURITY (pull_request_target): the briefing runs attacker-influenceable PR body/diff through
+  # `claude --dangerously-skip-permissions` with secrets in env, so a malicious PR can prompt-inject
+  # the model to run bash and try to exfiltrate whatever the container holds. To bound the blast
+  # radius the work is SPLIT into two jobs:
+  #   * module-risk (runs the model): its GITHUB_TOKEN is scoped READ-only (job `permissions:` below),
+  #     so an injected run cannot write to the repo or steal a write-capable token. It never posts —
+  #     it only hands the briefing text to the next job via a job output.
+  #   * module-risk-comment (posts the comment): holds the pull-requests:write token, never runs the
+  #     model, and receives the untrusted body through env (never spliced into a command via ${{ }}),
+  #     so an injected body cannot inject shell. The body crosses the job boundary base64-encoded, so
+  #     it also cannot forge the job-output framing.
+  # Residual risk: CLAUDE_CODE_OAUTH_TOKEN still lives in the model container and a determined
+  # injection could exfiltrate it — that is a Claude billing/abuse exposure (rotatable), NOT repo
+  # write or supply-chain. Closing it fully needs container network-egress allowlisting
+  # (anthropic / github / context-base only); tracked separately. (assign-reviewer stays safe for any
+  # author because its host step extracts only login-shaped tokens — a strict whitelist; module-risk's
+  # output is free-form.)
   module-risk:
     runs-on: [self-hosted, normal]
     # Dedup rapid pushes for THIS job only (a new event cancels the in-flight briefing run).
@@ -262,57 +268,85 @@ jobs:
       group: ai-sr-skills-module-risk-${{ github.event.number }}
       cancel-in-progress: true
     continue-on-error: true
+    # READ-only token: this job runs the model on untrusted PR content, so it must NOT hold a
+    # write-capable token (see SECURITY above). The sibling module-risk-comment job does the posting.
+    permissions:
+      contents: read
+      pull-requests: read
     if: >
       (github.event.action == 'opened' || github.event.action == 'reopened' ||
        github.event.action == 'synchronize' || github.event.action == 'ready_for_review') &&
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-') &&
       github.event.pull_request.user.type != 'Bot'
+    outputs:
+      # base64 of the marker-to-EOF briefing (empty when there is nothing to post). base64 keeps the
+      # untrusted body to a single [A-Za-z0-9+/=] line so it can neither forge the job-output framing
+      # nor inject anything when the comment job consumes it.
+      body: ${{ steps.brief.outputs.body }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       PR_URL: ${{ github.event.pull_request.html_url }}
-      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Module-risk briefing (AI, read-only)
+        id: brief
         run: |
           # Namespaced plugin command (a bare /review would NOT resolve in headless -p — it would be
-          # treated as prompt text and silently no-op). tee captures stdout for the upsert step.
+          # treated as prompt text and silently no-op). tee captures stdout for extraction below.
           docker exec -i -u claudeuser \
             -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
             -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
             claude-cli claude --dangerously-skip-permissions \
             -p "/github-pr-module-risk:review ${PR_URL} --comment" 2>&1 | tee "${RUNNER_TEMP}/module_risk.txt" || true
-
-      - name: Upsert sticky comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.number }}
-          REPO: ${{ github.repository }}
-        run: |
+          # The skill emits the briefing starting at the marker line, or "MODULE-RISK: none" (no
+          # marker) when nothing clears the confidence gate. Take from the marker to EOF as the body
+          # (empty for no marker / sentinel / error => the comment job posts nothing); sed from the
+          # marker also strips any claude preamble before it. Hand it to the comment job base64-encoded
+          # on a single line (see the `outputs:` note above).
           out="${RUNNER_TEMP}/module_risk.txt"
           marker="<!-- module-risk-briefing -->"
-          [ -f "$out" ] || { echo "no skill output, skip"; exit 0; }
-          # The skill emits the briefing starting at the marker line, or "MODULE-RISK: none" (no
-          # marker) when nothing clears the confidence gate. Take from the marker to EOF as the body;
-          # empty (no marker / sentinel / error) => post nothing. sed from the marker also strips any
-          # claude preamble before it.
-          body="$(sed -n "/$marker/,\$p" "$out" 2>/dev/null || true)"
+          b64=""
+          [ -f "$out" ] && b64="$(sed -n "/$marker/,\$p" "$out" 2>/dev/null | base64 -w0 || true)"
+          echo "body=${b64}" >> "$GITHUB_OUTPUT"
+
+  module-risk-comment:
+    needs: module-risk
+    runs-on: [self-hosted, normal]
+    continue-on-error: true
+    # Holds the write token and does the posting; it never runs the model, so untrusted PR content
+    # never meets a write-capable token. Skipped when the brief produced no briefing (empty output),
+    # and (via `needs`) when the brief job itself was gated out.
+    permissions:
+      pull-requests: write
+    if: ${{ needs.module-risk.outputs.body != '' }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR: ${{ github.event.number }}
+      REPO: ${{ github.repository }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      # Untrusted (model-produced) body, base64. Passed via env, never spliced into a command via
+      # ${{ }}, so a prompt-injected body cannot inject shell.
+      BODY_B64: ${{ needs.module-risk.outputs.body }}
+    steps:
+      - name: Upsert sticky comment
+        run: |
+          marker="<!-- module-risk-briefing -->"
+          body="$(printf '%s' "$BODY_B64" | base64 -d 2>/dev/null || true)"
           if [ -z "$body" ]; then
             echo "no high-confidence, diff-aligned module risk — not commenting"
             exit 0
           fi
-          # Stamp the PR head SHA as line 2 (right after the marker, which sed guaranteed is line 1)
-          # so reviewers can detect a briefing that predates the latest push. awk avoids sed escaping
-          # pitfalls; the SHA is hex so it is injection-safe. Applies to both the real briefing and the
-          # incomplete-coverage caveat (both carry the marker as line 1).
+          # Stamp the PR head SHA as line 2 (right after the marker, which the brief job's sed
+          # guaranteed is line 1) so reviewers can detect a briefing that predates the latest push.
+          # awk avoids sed escaping pitfalls; the SHA is hex so it is injection-safe.
           sha_line="<!-- module-risk-head-sha: ${PR_HEAD_SHA} -->"
           printf '%s\n' "$body" \
             | awk -v s="$sha_line" 'NR==1{print; print s; next} {print}' \
             > "${RUNNER_TEMP}/mr_body.md"
           # Sticky: edit our existing marked comment if present, else create one. Idempotent across
-          # reopen / workflow rerun (the marker identifies our comment; gh is host-side, not in the
-          # container). PATCH body is JSON-built with jq so markdown is escaped correctly.
+          # reopen / workflow rerun (the marker identifies our comment). PATCH body is JSON-built with
+          # jq so markdown is escaped correctly.
           existing="$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
                         --jq ".[] | select(.body | contains(\"$marker\")) | .id" 2>/dev/null | head -1 || true)"
           if [ -n "$existing" ]; then


### PR DESCRIPTION
## Why I'm doing:

The `module-risk` briefing job in `.github/workflows/ai-sr-skills.yml` has been **silently skipped on every PR since it was introduced (#74716)**.

Root cause: on `pull_request_target`, `github.event.pull_request.author_association` only reflects **publicly-visible** org membership. StarRocks committers keep their org membership private, so the webhook payload reports them as `CONTRIBUTOR` (not `MEMBER`), and the gate `author_association ∈ ["OWNER","MEMBER","COLLABORATOR"]` matched nobody.

Evidence: across the last 30 workflow runs, `module-risk` = `skipped` **30/30**, while its sibling `assign-reviewer` (same workflow/event, no author gate) ran successfully on the same `opened` events. The PR authors resolve to `MEMBER` via the REST API but return `404` on `orgs/StarRocks/public_members/<user>`, confirming private membership as the trigger of the mismatch.

## What I'm doing:

**1. Fix the trigger (commit 1).** Replace the broken `author_association` gate with `github.event.pull_request.user.type != 'Bot'`, so **all human-authored PRs are briefed** (this is an OSS repo — external-contributor PRs are exactly where a historical module-risk briefing helps a reviewer most) while automation (`mergify[bot]`, `dependabot`, ...) stays excluded. The existing `mergify/` and `*-sync-pr-*` head-branch exclusions are unchanged.

**2. Harden the run instead of gating authors (commit 2).** Dropping the trusted-author restriction means untrusted PRs now reach `claude --dangerously-skip-permissions`. To bound the blast radius, `module-risk` is split into two jobs so the model never holds a write-capable token:

- `module-risk` (runs the model): `permissions:` scoped to `contents: read` + `pull-requests: read`. Reads the diff, emits the marker-to-EOF briefing as a **base64 job output**. Never posts.
- `module-risk-comment` (`needs: module-risk`): holds `pull-requests: write`, **never runs the model**, consumes the body via `env` (base64, never spliced into a command via `${{ }}`) and posts the sticky comment.

This removes the write-token / token-backed-PR-action exfiltration vector a prompt-injected briefing could otherwise abuse on a fork PR — directly addressing the `@codex` P1. (The workflow file is synced to a private repo, so the container still needs a *read* token to fetch the diff; dropping it entirely is not an option.) The residual `CLAUDE_CODE_OAUTH_TOKEN` exposure (Claude billing/abuse, rotatable — not repo write or supply-chain) is documented in the workflow comment; fully closing it needs container network-egress allowlisting, tracked separately.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

CI-only change (GitHub Actions job trigger + token scoping); no StarRocks product/interface/parameter behavior is affected.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
