### PR TITLE
[Tool] fix BE/FE UT Clean ECI and Upload log steps failing in ci-pipeline-branch.yml (backport #71464)

### DIFF
--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -254,14 +254,14 @@ jobs:
           ./bin/elastic-ut.sh --pr ${PR_NUMBER} --module be --branch ${{ steps.branch.outputs.branch }} --repository ${{ github.repository }}
 
       - name: clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID
         run: |
           echo ${{ steps.run_ut.outputs.ECI_ID }}
-          eci rm ${{ steps.run_ut.outputs.ECI_ID }}
+          eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Upload log
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.run_ut.outputs.BE_LOG
         with:
           name: BE UT LOG
           path: ${{ steps.run_ut.outputs.BE_LOG }}
@@ -407,15 +407,15 @@ jobs:
           ./bin/elastic-ut.sh --pr ${PR_NUMBER} --module fe --branch ${{steps.branch.outputs.branch}} --build Release --repository ${{ github.repository }}
 
       - name: Clean ECI
-        if: always()
+        if: always() && steps.run_ut.outputs.ECI_ID
         run: |
           echo ${{ steps.run_ut.outputs.ECI_ID }}
           echo ">>> Dmesg info:"
           eci exec ${{ steps.run_ut.outputs.ECI_ID }} bash -c "dmesg -T"
-          eci rm ${{ steps.run_ut.outputs.ECI_ID }}
+          eci rm ${{ steps.run_ut.outputs.ECI_ID }} || true
 
       - name: Upload log
-        if: always()
+        if: always() && steps.run_ut.outputs.RES_LOG
         uses: actions/upload-artifact@v4
         with:
           name: FE UT LOG


### PR DESCRIPTION
## Why I'm doing:
When `elastic-ut.sh` skips UT on version match (same commit already passed), it writes an empty `ECI_ID=` output and exits 0 without creating an ECI or log file. The unguarded `if: always()` cleanup steps then run `eci exec/rm` with an empty instance ID (`eci: The instanceId mismatch instance type.`, exit 255) and `upload-artifact` with an empty path, failing the whole BE/FE UT job even though UT itself succeeded. Example: https://github.com/StarRocks/starrocks/actions/runs/28762762465/job/85288448592?pr=75858

## What I'm doing:
Backport #71464 (merged to main in April) to this release branch: guard `Clean ECI` / `clean ECI` with `steps.run_ut.outputs.ECI_ID`, guard `Upload log` with `RES_LOG`/`BE_LOG`, and make `eci rm` tolerant with `|| true`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

