### PR TITLE
[Enhancement] Reassign colocate-boundary split children to the new PACK group immediately

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -348,7 +348,33 @@ public class ColocateChecker {
         if (tabletIdToRange.isEmpty()) {
             return true;
         }
+        return reconcileTabletPackPlacement(tabletIdToRange, expectedRanges, colocateColumnCount,
+                db.getFullName() + "." + table.getName());
+    }
 
+    /**
+     * Reads the actual PACK shard-group membership of the given tablets from StarOS in bounded
+     * batches, finds the ones whose membership disagrees with the {@link ColocateRange} their range
+     * belongs to, and reassigns each into its expected PACK shard group with the minimal add/remove
+     * delta. Shared by the placement backstop ({@link #reconcileTablePackPlacement}) and the
+     * post-publish split path ({@code SplitTabletJob}).
+     *
+     * <p>Best-effort per tablet. Catches the expected StarOS checked failures — the batched
+     * {@link StarOSAgent#getShardInfo} {@link StarClientException} and the per-tablet
+     * {@link StarOSAgent#reassignShardGroups} {@link DdlException} — but is intentionally not
+     * blanket-wrapped, so an unexpected bug still surfaces in the caller's diagnostics. Membership
+     * ({@code group_ids}) is central StarMgr state, independent of the worker group, so the read uses
+     * {@link StarOSAgent#DEFAULT_WORKER_GROUP_ID}.
+     *
+     * @return {@code true} iff nothing needed repair: the membership read covered every tablet and no
+     *         tablet was misplaced. A StarOS query failure, an incomplete response (a requested tablet
+     *         missing from the result — treated as an unread membership, never as "no groups", so it
+     *         cannot turn into a bogus add-only reassignment), or any misplaced tablet (reassignment
+     *         issued, confirmed by a re-read) ⇒ {@code false}.
+     */
+    static boolean reconcileTabletPackPlacement(Map<Long, Range<Tuple>> tabletIdToRange,
+                                                List<ColocateRange> expectedRanges, int colocateColumnCount,
+                                                String logContext) {
         StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
         List<Long> tabletIds = new ArrayList<>(tabletIdToRange.keySet());
         Map<Long, List<Long>> tabletIdToGroupIds = new HashMap<>();
@@ -362,16 +388,15 @@ public class ColocateChecker {
                     tabletIdToGroupIds.put(shardInfo.getShardId(), shardInfo.getGroupIdsList());
                 }
             } catch (StarClientException e) {
-                LOG.warn("failed to query shard membership for PACK reconcile of table {}.{}: {}",
-                        db.getFullName(), table.getName(), e.getMessage());
+                LOG.warn("failed to query shard membership for PACK reconcile of {}: {}",
+                        logContext, e.getMessage());
                 return false;
             }
         }
         // An incomplete response is an unread membership, not "tablet has no groups": treat it as a
         // failed read and retry next cycle, so a missing StarOS entry cannot become a bogus repair.
         if (!tabletIdToGroupIds.keySet().containsAll(tabletIdToRange.keySet())) {
-            LOG.warn("incomplete shard membership response during PACK reconcile of table {}.{}; retrying",
-                    db.getFullName(), table.getName());
+            LOG.warn("incomplete shard membership response during PACK reconcile of {}; retrying", logContext);
             return false;
         }
 
@@ -389,13 +414,12 @@ public class ColocateChecker {
                     : List.of(misplaced.currentPackGroupId());
             try {
                 starOSAgent.reassignShardGroups(misplaced.tabletId(), addGroupIds, removeGroupIds);
-                LOG.info("reassigned tablet {} from PACK shard group {} to {} in table {}.{}",
+                LOG.info("reassigned tablet {} from PACK shard group {} to {} in {}",
                         misplaced.tabletId(), misplaced.currentPackGroupId(), misplaced.expectedPackGroupId(),
-                        db.getFullName(), table.getName());
+                        logContext);
             } catch (DdlException e) {
-                LOG.warn("failed to reassign tablet {} to PACK shard group {} in table {}.{}: {}",
-                        misplaced.tabletId(), misplaced.expectedPackGroupId(),
-                        db.getFullName(), table.getName(), e.getMessage());
+                LOG.warn("failed to reassign tablet {} to PACK shard group {} in {}: {}",
+                        misplaced.tabletId(), misplaced.expectedPackGroupId(), logContext, e.getMessage());
             }
         }
         // Settled only when nothing needed repair; if reassignments were issued, stay unstable so

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -618,10 +618,15 @@ public class SplitTabletJob extends TabletReshardJob {
         Set<Tuple> canonicalLowers = new LinkedHashSet<>();
         boolean oldStradlesBoundary = false;
         boolean nonCanonicalCrossing = false;
+        // New child ranges captured during the walk below, reused after the splice for the best-effort
+        // immediate PACK reassignment. sortKeyColumns is hoisted out of the lock so that same reassign
+        // can reuse it (it is immutable schema, always assigned inside the lock before the walk).
+        Map<Long, Range<Tuple>> newChildRanges = new HashMap<>();
+        List<Column> sortKeyColumns = null;
 
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.READ)) {
             OlapTable olapTable = lockedTable.get();
-            List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
+            sortKeyColumns = MetaUtils.getRangeDistributionColumns(olapTable);
 
             for (ReshardingPhysicalPartition reshardingPhysicalPartition : reshardingPhysicalPartitions.values()) {
                 PhysicalPartition physicalPartition = olapTable
@@ -652,6 +657,7 @@ public class SplitTabletJob extends TabletReshardJob {
                                 continue;
                             }
                             Range<Tuple> newRange = newTablet.getRange().getRange();
+                            newChildRanges.put(newTabletId, newRange);
                             boolean canonicalLow = ColocateRangeUtils.hasCanonicalLowerBound(
                                     newRange, sortKeyColumns, colocateColumnCount);
                             if (canonicalLow) {
@@ -682,6 +688,31 @@ public class SplitTabletJob extends TabletReshardJob {
         } catch (DdlException e) {
             throw new TabletReshardException(
                     "Failed to apply range split result for grpId " + grpId + ": " + e.getMessage(), e);
+        }
+
+        // Best-effort: immediately move this split's originating-partition children that now belong in a
+        // newly-created PACK shard group, removing the cross-tick delay before the colocate checker
+        // backstop would reconcile them. Correctness does not depend on this — the backstop reaches the
+        // same terminal state — so a failure here must never abort the split (already published). The
+        // outer catch is what guarantees best-effort: the shared helper catches expected StarOS checked
+        // failures but is intentionally not blanket-wrapped, so an unexpected bug still surfaces here.
+        try {
+            List<ColocateRange> updatedRanges = colocateTableIndex.getColocateRanges(grpId);
+            // Only reconcile children that map cleanly into exactly one post-split ColocateRange. A child
+            // whose range straddles a boundary (legacy/mismatched BE, or a multi-way split with a
+            // non-canonical crossing) has no single well-defined PACK group; leave it to the backstop.
+            Map<Long, Range<Tuple>> containedChildRanges = new HashMap<>();
+            for (Map.Entry<Long, Range<Tuple>> entry : newChildRanges.entrySet()) {
+                if (ColocateRangeUtils.isContainedInOwningColocateRange(
+                        entry.getValue(), updatedRanges, sortKeyColumns, colocateColumnCount)) {
+                    containedChildRanges.put(entry.getKey(), entry.getValue());
+                }
+            }
+            ColocateChecker.reconcileTabletPackPlacement(containedChildRanges, updatedRanges,
+                    colocateColumnCount, "split of table " + tableId);
+        } catch (Exception e) {
+            LOG.warn("best-effort immediate PACK reassignment after split of table {} failed; "
+                    + "leaving convergence to the colocate checker: {}", tableId, e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -15,7 +15,9 @@
 package com.starrocks.alter.reshard;
 
 import com.google.common.collect.Multimap;
+import com.staros.client.StarClientException;
 import com.staros.proto.PlacementPolicy;
+import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.ColocateGroupSchema;
 import com.starrocks.catalog.ColocateRange;
 import com.starrocks.catalog.ColocateRangeMgr;
@@ -29,10 +31,12 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.StarOSAgent;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
@@ -57,6 +61,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -151,6 +156,13 @@ public class SplitTabletJobColocateTest {
                     new TabletRange(Range.ge(makeTwoColTuple(100, 50))).toProto());
             return result;
         });
+        boolean[] reassignCalled = {false};
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignCalled[0] = true;
+            }
+        };
 
         runSplitJob();
 
@@ -158,6 +170,8 @@ public class SplitTabletJobColocateTest {
                 "Level 2 split must not add a ColocateRange entry");
         Assertions.assertFalse(GlobalStateMgr.getCurrentState().getColocateTableIndex().isGroupUnstable(groupId),
                 "Level 2 split must leave the group stable");
+        Assertions.assertFalse(reassignCalled[0],
+                "no boundary spliced -> no immediate PACK reassignment");
     }
 
     @Test
@@ -345,6 +359,217 @@ public class SplitTabletJobColocateTest {
                 "non-canonical range crossing existing boundary must mark unstable");
         Assertions.assertEquals(2, rangeMgr.getColocateRanges(grpId).size(),
                 "non-canonical crossing must not add a ColocateRange entry");
+    }
+
+    /**
+     * A Level 1 boundary split must immediately reassign the boundary child (whose range now belongs
+     * in the newly-spliced PACK group) from the old PACK group to the new one, without waiting for the
+     * ColocateChecker backstop. The below-boundary child stays put.
+     */
+    @Test
+    public void testLevelOneSplitImmediatelyReassignsBoundaryChild() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long oldPackGroup = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        // The table's real SPREAD shard group id: a distinct StarMgr-allocated id that can never
+        // collide with a PACK group id, so findMisplacedTablets correctly ignores it.
+        long spreadGroup = table.getAllPhysicalPartitions().iterator().next()
+                .getLatestBaseIndex().getShardGroupId();
+
+        List<Long> orderedNewTabletIds = new ArrayList<>();
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            orderedNewTabletIds.clear();
+            orderedNewTabletIds.addAll(newTabletIds);
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1), new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        Map<Long, List<Long>> reassignedRemove = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> infos = new ArrayList<>();
+                for (long id : shardIds) {
+                    // Every child was created in the OLD PACK group (plus the SPREAD group).
+                    infos.add(ShardInfo.newBuilder().setShardId(id)
+                            .addGroupIds(spreadGroup).addGroupIds(oldPackGroup).build());
+                }
+                return infos;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+                reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
+            }
+        };
+
+        runSplitJob();
+
+        List<ColocateRange> ranges = rangeMgr.getColocateRanges(groupId.grpId);
+        Assertions.assertEquals(2, ranges.size());
+        long newPackGroup = ranges.get(1).getShardGroupId();       // right part of the boundary
+        Assertions.assertEquals(oldPackGroup, ranges.get(0).getShardGroupId());
+
+        long boundaryChild = orderedNewTabletIds.get(1);           // lower == canonical (100, NULL)
+        long belowChild = orderedNewTabletIds.get(0);              // stays in the old range
+        Assertions.assertEquals(List.of(newPackGroup), reassignedAdd.get(boundaryChild),
+                "boundary child must be added to the new PACK group at split time");
+        Assertions.assertEquals(List.of(oldPackGroup), reassignedRemove.get(boundaryChild),
+                "boundary child must be removed from the old PACK group at split time");
+        Assertions.assertFalse(reassignedAdd.containsKey(belowChild),
+                "the below-boundary child stays in the old PACK group; no reassignment");
+    }
+
+    /**
+     * The immediate reassignment is a best-effort optimization: a reassignShardGroups failure must not
+     * abort the already-published split. The group stays unstable so the backstop reconciles later.
+     */
+    @Test
+    public void testImmediateReassignFailureDoesNotAbortSplit() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long oldPackGroup = idx.getColocateRangeMgr().getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long spreadGroup = table.getAllPhysicalPartitions().iterator().next()
+                .getLatestBaseIndex().getShardGroupId();
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1), new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> infos = new ArrayList<>();
+                for (long id : shardIds) {
+                    infos.add(ShardInfo.newBuilder().setShardId(id)
+                            .addGroupIds(spreadGroup).addGroupIds(oldPackGroup).build());
+                }
+                return infos;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds)
+                    throws DdlException {
+                throw new DdlException("mocked reassign failure");
+            }
+        };
+
+        TabletReshardJob job = createTabletReshardJob(-2);
+        job.init();
+        job.run();
+        for (int i = 0; i < 6 && job.getJobState() != TabletReshardJob.JobState.FINISHED; i++) {
+            job.run();
+        }
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, job.getJobState(),
+                "a reassign failure must not abort the published split");
+        Assertions.assertEquals(2, idx.getColocateRangeMgr().getColocateRanges(groupId.grpId).size());
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "group stays unstable so the backstop reconciles the still-misplaced child");
+    }
+
+    /**
+     * A membership-read (getShardInfo) failure must also fail closed: no reassignment is issued and the
+     * published split still completes.
+     */
+    @Test
+    public void testImmediateReassignMembershipReadFailureDoesNotAbortSplit() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        boolean[] reassignCalled = {false};
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1), new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) throws StarClientException {
+                throw new StarClientException(com.staros.proto.StatusCode.INVALID_ARGUMENT, "mocked read failure");
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignCalled[0] = true;
+            }
+        };
+
+        TabletReshardJob job = createTabletReshardJob(-2);
+        job.init();
+        job.run();
+        for (int i = 0; i < 6 && job.getJobState() != TabletReshardJob.JobState.FINISHED; i++) {
+            job.run();
+        }
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, job.getJobState(),
+                "a membership-read failure must not abort the published split");
+        Assertions.assertFalse(reassignCalled[0],
+                "fail closed: no reassignment is issued when membership cannot be read");
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "group stays unstable so the backstop reconciles later");
+    }
+
+    /**
+     * A child whose range straddles a pre-existing colocate boundary has no single well-defined PACK
+     * group; the immediate reassignment must skip it (leaving it to the backstop) even though its
+     * lower-prefix expectation differs from its actual membership. The contained sibling is already
+     * correctly placed, so nothing is reassigned.
+     */
+    @Test
+    public void testBoundaryCrossingChildIsNotReassigned() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long grpId = groupId.grpId;
+        StarOSAgent agent = GlobalStateMgr.getCurrentState().getStarOSAgent();
+        long spreadGroup = table.getAllPhysicalPartitions().iterator().next()
+                .getLatestBaseIndex().getShardGroupId();
+
+        // Seed a boundary at colocate-prefix 100: [-inf,100) -> packLow, [100,+inf) -> packHigh.
+        long packLow = rangeMgr.getColocateRanges(grpId).get(0).getShardGroupId();
+        long packHigh = agent.createShardGroup(db.getId(), table.getId(), 0L, 0L, PlacementPolicy.PACK);
+        Tuple boundary = new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "100")));
+        rangeMgr.setColocateRanges(grpId, Arrays.asList(
+                new ColocateRange(Range.lt(boundary), packLow),
+                new ColocateRange(Range.ge(boundary), packHigh)));
+
+        // Legacy/mismatched BE: a child [(50,0),(150,0)) straddling the boundary at 100, plus a
+        // contained high child [(150,0),+inf). Both are reported in packHigh by the mock:
+        //   - crossing child is NOT contained -> the filter must skip it (its lower prefix 50 maps to
+        //     packLow, so an UNFILTERED reconcile would wrongly reassign it packHigh -> packLow);
+        //   - high child is contained in packHigh and already there -> correctly placed.
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.gelt(makeTwoColTuple(50, 0), makeTwoColTuple(150, 0))).toProto());
+            result.put(newTabletIds.get(1),
+                    new TabletRange(Range.ge(makeTwoColTuple(150, 0))).toProto());
+            return result;
+        });
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> infos = new ArrayList<>();
+                for (long id : shardIds) {
+                    infos.add(ShardInfo.newBuilder().setShardId(id)
+                            .addGroupIds(spreadGroup).addGroupIds(packHigh).build());
+                }
+                return infos;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+            }
+        };
+
+        runSplitJob();
+
+        Assertions.assertTrue(reassignedAdd.isEmpty(),
+                "a boundary-crossing child must not be reassigned; leave it to the backstop");
     }
 
     private static Tuple makeCanonicalTuple(int k1) {


### PR DESCRIPTION
## Why I'm doing:

On shared-data range-colocate tables, a user-driven colocate-boundary tablet split splices a new
`ColocateRange` and creates a new PACK shard group for the right side of the boundary. The split's
child tablets are created *before* the boundary is known, so they all join the **old** PACK group.
The child whose range now belongs to the new PACK group therefore stays in the old one until the
background reconciler (`ColocateChecker`) migrates it — one to two scheduler ticks later. During that
window the colocate-join optimization degrades on that single bucket (a network hop), and the group
stays unstable so the optimizer will not pick the colocate plan for the group.

Query correctness is never at stake (scan routing depends on the tablet range, not on PACK
membership), and the background reconciler already converges to the correct placement. This change
simply removes the cross-tick delay for the originating split.

## What I'm doing:

- Extract the reconcile primitive — read a set of tablets' actual PACK-group membership from StarOS,
  detect the ones whose membership no longer matches the `ColocateRange` their range belongs to, and
  reassign each with the minimal add/remove delta — into a shared package-static helper
  `ColocateChecker.reconcileTabletPackPlacement(...)`. The background reconciler now delegates to it;
  its behavior is unchanged.
- In `SplitTabletJob.applyColocateRangeSplitResult`, right after the range splice creates the new PACK
  shard group, call that helper on this split's child tablets so the mis-placed child is moved into the
  new PACK group immediately instead of on the next reconcile tick. Only children that map cleanly into
  exactly one post-split `ColocateRange` are reconciled; a child whose range straddles a boundary has no
  single well-defined PACK group and is left to the background reconciler.
- The immediate reassignment is **best-effort**: the split is already published, so a membership-read
  or reassign failure is caught and logged and never aborts the job. Membership is not journaled
  (StarOS persists it); on leader switch or mid-failure the background reconciler re-converges to the
  same terminal placement. Actual membership is re-read via `getShardInfo` (ground truth) rather than
  derived, because concurrent split jobs on the same group can change the range-to-PACK mapping between
  shard creation and this step.

This does not change SQL, configuration, or any external interface. It only changes *when* the
reassignment RPC is issued — the background reconciler already reaches the same terminal placement — so
behavior change is marked **No**.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
