### PR TITLE
[Enhancement] Add file-level Bernoulli sampling for Iceberg external table SAMPLE ANALYZE

### DIFF
--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ This topic introduces the following types of FE configurations:
 - Description: Duration in seconds for a single process profile collection. When `proc_profile_cpu_enable` or `proc_profile_mem_enable` is set to `true`, AsyncProfiler is started, the collector thread sleeps for this duration, then the profiler is stopped and the profile is written. Larger values increase sample coverage and file size but prolong profiler runtime and delay subsequent collections; smaller values reduce overhead but may produce insufficient samples. Ensure this value aligns with retention settings such as `proc_profile_file_retained_days` and `proc_profile_file_retained_size_bytes`.
 - Introduced in: v3.2.12
 
+### `statistic_external_sample_max_rows_per_round`
+
+- Default: 2000000
+- Type: Long
+- Unit: rows
+- Is mutable: Yes
+- Description: Maximum rows targeted per sampling round in the Iceberg external-table statistics collection loop (`ANALYZE SAMPLE`). The first round aims for this many rows; subsequent rounds double the cap within the same run until either the full table is scanned or `statistic_external_sample_max_rounds` is reached. Larger values improve NDV accuracy at the cost of additional scan IO per round.
+- Introduced in: -
+
+### `statistic_external_sample_max_rounds`
+
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Maximum number of sampling rounds in a single Iceberg external-table `ANALYZE SAMPLE` run. Each round doubles the row cap of the previous round (capped at the table's total row count). Run-time convergence detection may stop the loop before this limit is reached.
+- Introduced in: -
+
+### `statistic_external_sample_ndv_convergence_threshold`
+
+- Default: 0.05
+- Type: Double
+- Unit: fraction (0.0–1.0)
+- Is mutable: Yes
+- Description: Relative-change threshold for early stopping the Iceberg external-table sampling loop when NDV has stabilized. After the first round, every collected column's HyperLogLog cardinality estimate is compared between consecutive rounds; if every column's relative change falls below this threshold the loop stops early. Set to `0` to disable convergence-based early stopping. Larger values stop sooner but may leave high-cardinality columns under-estimated.
+- Introduced in: -
+
 ## Storage
 
 ### `alter_table_timeout_second`

--- a/docs/ja/administration/management/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：単一プロセスプロファイル収集の期間 (秒単位)。`proc_profile_cpu_enable` または `proc_profile_mem_enable` が `true` に設定されている場合、AsyncProfiler が起動し、コレクタースレッドはこの期間だけスリープし、その後プロファイラーが停止してプロファイルが書き込まれます。値が大きいほどサンプルカバレッジとファイルサイズは増加しますが、プロファイラーの実行時間が長くなり、その後の収集が遅れます。値が小さいほどオーバーヘッドは減少しますが、不十分なサンプルが生成される可能性があります。`proc_profile_file_retained_days` や `proc_profile_file_retained_size_bytes` などの保持設定とこの値が一致していることを確認してください。
 - 導入時期：v3.2.12
 
+### `statistic_external_sample_max_rows_per_round`
+
+- デフォルト：2000000
+- タイプ：Long
+- 単位：行
+- 変更可能：Yes
+- 説明：Iceberg 外部表統計収集ループ（`ANALYZE SAMPLE`）における 1 サンプリングラウンドあたりの最大行数目標。最初のラウンドはこの行数を対象とし、その後のラウンドは同じ実行内でキャップを倍増し、全体表スキャンまたは `statistic_external_sample_max_rounds` に達するまで継続する。値を大きくすると NDV 精度が向上するが、ラウンドあたりのスキャン IO も増加する。
+- 導入時期：-
+
+### `statistic_external_sample_max_rounds`
+
+- デフォルト：4
+- タイプ：Int
+- 単位：-
+- 変更可能：Yes
+- 説明：1 回の Iceberg 外部表 `ANALYZE SAMPLE` 実行における最大サンプリングラウンド数。各ラウンドは前ラウンドの行数上限を倍増する（全体表行数でキャップされる）。NDV 収束検出によりこの上限に達する前に停止する場合がある。
+- 導入時期：-
+
+### `statistic_external_sample_ndv_convergence_threshold`
+
+- デフォルト：0.05
+- タイプ：Double
+- 単位：割合 (0.0–1.0)
+- 変更可能：Yes
+- 説明：NDV が安定した場合に Iceberg 外部表サンプリングループを早期停止するための相対変化閾値。最初のラウンドの後、連続する 2 ラウンド間ですべての収集列の HyperLogLog カーディナリティ推定値を比較し、すべての列の相対変化がこの閾値を下回った場合にループを早期停止する。`0` に設定すると収束ベースの早期停止を無効化する。値を大きくすると早期に停止するが、高カーディナリティ列が過小評価される可能性がある。
+- 導入時期：-
+
 ## ストレージ
 
 ### `alter_table_timeout_second`

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 单次进程 profile 收集的持续时间（秒）。当 `proc_profile_cpu_enable` 或 `proc_profile_mem_enable` 设置为 `true` 时，AsyncProfiler 启动，收集器线程休眠此持续时间，然后 profiler 停止并写入 profile。较大的值会增加样本覆盖率和文件大小，但会延长 profiler 运行时并延迟后续收集；较小的值会减少开销，但可能会产生不足的样本。确保此值与 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 等保留设置对齐。
 - 引入版本: v3.2.12
 
+### `statistic_external_sample_max_rows_per_round`
+
+- 默认值: 2000000
+- 类型: Long
+- 单位: 行
+- 是否可变: Yes
+- 描述: Iceberg 外部表统计信息采样循环中每轮目标的最大行数（`ANALYZE SAMPLE`）。首轮以此为目标值采样；后续轮次在同一轮运行中按 2 倍递增，直到到达全表覆盖或 `statistic_external_sample_max_rounds` 上限。增大此值可提高 NDV 精度，但每轮 scan IO 会相应增加。
+- 引入版本: -
+
+### `statistic_external_sample_max_rounds`
+
+- 默认值: 4
+- 类型: Int
+- 单位: -
+- 是否可变: Yes
+- 描述: 单次 Iceberg 外部表 `ANALYZE SAMPLE` 中的最大采样轮数。每轮将上轮的行数上限翻倍（以全表行数为上限）。NDV 收敛检测可能在达到此上限前提前结束。
+- 引入版本: -
+
+### `statistic_external_sample_ndv_convergence_threshold`
+
+- 默认值: 0.05
+- 类型: Double
+- 单位: 比例 (0.0–1.0)
+- 是否可变: Yes
+- 描述: Iceberg 外部表采样循环中 NDV 收敛提前结束的相对变化阈值。首轮之后，比较相邻两轮所有列的 HyperLogLog 基数估计值，全部列的相对变化低于此阈值时提前结束循环。设为 `0` 可禁用收敛提前结束（始终跑满所有轮次）。更大的值会更早停止，但可能导致高基数列被低估。
+- 引入版本: -
+
 ## 存储
 
 ### `alter_table_timeout_second`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2660,6 +2660,42 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int statistic_sample_collect_partition_size = 300;
 
+    /**
+     * Hard cap on how many rows a single round of Iceberg external-table file-level sample
+     * ANALYZE (see ExternalSampleStatisticsCollectJob) is allowed to scan. The sample ratio for
+     * a round is derived as min(1.0, rowsThisRound / row_count), so this bounds wall-clock cost
+     * per round regardless of table size, instead of relying on a percentage alone (a fixed
+     * percentage of an astronomically large table can still mean scanning far too many rows).
+     * Row count (not file count) is used as the budget unit because Iceberg files can vary
+     * wildly in row count, so a file-count-based cap gives a much less predictable row volume
+     * per round than a row-count-based one -- row counts are just as cheap to read from
+     * manifest-list summary fields as file counts are. Successive rounds within one ANALYZE
+     * execution double the per-round row target (up to statistic_external_sample_max_rounds
+     * rounds) so accuracy improves without waiting on the external auto-collect schedule
+     * between rounds.
+     */
+    @ConfField(mutable = true)
+    public static long statistic_external_sample_max_rows_per_round = 2000000;
+
+    /**
+     * Max number of progressive rounds run inside a single Iceberg file-sample ANALYZE execution.
+     * Bounds total per-job cost to roughly (2^rounds - 1) * statistic_external_sample_max_rows_per_round
+     * rows in the worst case, even if the table never reaches full coverage.
+     */
+    @ConfField(mutable = true)
+    public static int statistic_external_sample_max_rounds = 4;
+
+    /**
+     * If every column's NDV (distinct value estimate) changes by less than this fraction between
+     * two consecutive sample rounds, the round loop stops early instead of continuing to
+     * statistic_external_sample_max_rounds -- low-cardinality columns (e.g. booleans/enums)
+     * converge within the first round or two, so later rounds would just re-scan more rows for no
+     * accuracy gain. High-cardinality columns whose NDV keeps growing round over round are left to
+     * run the full round budget.
+     */
+    @ConfField(mutable = true)
+    public static double statistic_external_sample_ndv_convergence_threshold = 0.05;
+
     @ConfField(mutable = true, comment = "The change ratio threshold for triggering statistics collection. " +
             "For INSERT OVERWRITE: deltaRatio = |targetRows - sourceRows| / (sourceRows + 1). " +
             "For first load: deltaRatio = loadRows / (totalRows + 1). " +

--- a/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/GetRemoteFilesParams.java
@@ -35,6 +35,11 @@ public class GetRemoteFilesParams {
     private boolean enableColumnStats = false;
     private Optional<Boolean> isRecursive = Optional.empty();
     private boolean usedForDelete = false;
+    // File-level sampling for background stats collection (e.g. Iceberg ANALYZE SAMPLE):
+    // each planned file is independently kept with probability fileSampleRatio.
+    // 1.0 (default) means no sampling, i.e. behavior is unchanged for normal queries.
+    private double fileSampleRatio = 1.0;
+    private long sampleSeed = 0;
 
     protected GetRemoteFilesParams(Builder builder) {
         this.partitionKeys = builder.partitionKeys;
@@ -49,6 +54,8 @@ public class GetRemoteFilesParams {
         this.enableColumnStats = builder.enableColumnStats;
         this.isRecursive = builder.isRecursive;
         this.usedForDelete = builder.usedForDelete;
+        this.fileSampleRatio = builder.fileSampleRatio;
+        this.sampleSeed = builder.sampleSeed;
     }
 
     public int getPartitionSize() {
@@ -73,7 +80,9 @@ public class GetRemoteFilesParams {
                 .setUseCache(useCache)
                 .setCheckPartitionExistence(checkPartitionExistence)
                 .setEnableColumnStats(enableColumnStats)
-                .setUsedForDelete(usedForDelete);
+                .setUsedForDelete(usedForDelete)
+                .setFileSampleRatio(fileSampleRatio)
+                .setSampleSeed(sampleSeed);
         if (isRecursive.isPresent()) {
             paramsBuilder.setIsRecursive(isRecursive.get());
         }
@@ -144,6 +153,14 @@ public class GetRemoteFilesParams {
         this.tableVersionRange = tableVersionRange;
     }
 
+    public void setFileSampleRatio(double fileSampleRatio) {
+        this.fileSampleRatio = fileSampleRatio;
+    }
+
+    public void setSampleSeed(long sampleSeed) {
+        this.sampleSeed = sampleSeed;
+    }
+
     public boolean isCheckPartitionExistence() {
         return checkPartitionExistence;
     }
@@ -160,6 +177,14 @@ public class GetRemoteFilesParams {
         return usedForDelete;
     }
 
+    public double getFileSampleRatio() {
+        return fileSampleRatio;
+    }
+
+    public long getSampleSeed() {
+        return sampleSeed;
+    }
+
     public static class Builder {
         private List<PartitionKey> partitionKeys;
         private List<String> partitionNames;
@@ -173,6 +198,8 @@ public class GetRemoteFilesParams {
         private boolean enableColumnStats = false;
         private Optional<Boolean> isRecursive = Optional.empty();
         private boolean usedForDelete = false;
+        private double fileSampleRatio = 1.0;
+        private long sampleSeed = 0;
 
         public Builder setPartitionKeys(List<PartitionKey> partitionKeys) {
             this.partitionKeys = partitionKeys;
@@ -231,6 +258,16 @@ public class GetRemoteFilesParams {
 
         public Builder setUsedForDelete(boolean usedForDelete) {
             this.usedForDelete = usedForDelete;
+            return this;
+        }
+
+        public Builder setFileSampleRatio(double fileSampleRatio) {
+            this.fileSampleRatio = fileSampleRatio;
+            return this;
+        }
+
+        public Builder setSampleSeed(long sampleSeed) {
+            this.sampleSeed = sampleSeed;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
@@ -27,10 +27,10 @@ import java.util.Random;
  * split/scan-range construction, so BE never opens them. Lazy evaluation, no materialization
  * of the full file list.
  *
- * <p>Must wrap the planned task iterator BEFORE file splitting (before
- * {@code buildSplitFileScanTaskIterator}), so the keep/drop decision is made once per physical
- * file, and a kept file's associated delete files (bundled on the same {@link FileScanTask})
- * are kept/dropped together, avoiding orphan deletes on V2 MOR tables.
+ * <p>Must wrap the planned task iterator AFTER file splitting (after
+ * {@code buildSplitFileScanTaskIterator}), so the keep/drop decision is made per split
+ * (uniform ~targetSplitSize rows), achieving approximate row-level uniform Bernoulli
+ * sampling independent of original file-size distribution.
  */
 public class BernoulliFileScanTaskIterator implements CloseableIterator<FileScanTask> {
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIterator.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.io.CloseableIterator;
+
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+/**
+ * File-level Bernoulli sampling iterator used by background external-table statistics
+ * collection (Iceberg ANALYZE SAMPLE). Each {@link FileScanTask} produced by the wrapped
+ * iterator is independently kept with probability {@code ratio}; dropped files never reach
+ * split/scan-range construction, so BE never opens them. Lazy evaluation, no materialization
+ * of the full file list.
+ *
+ * <p>Must wrap the planned task iterator BEFORE file splitting (before
+ * {@code buildSplitFileScanTaskIterator}), so the keep/drop decision is made once per physical
+ * file, and a kept file's associated delete files (bundled on the same {@link FileScanTask})
+ * are kept/dropped together, avoiding orphan deletes on V2 MOR tables.
+ */
+public class BernoulliFileScanTaskIterator implements CloseableIterator<FileScanTask> {
+
+    private final CloseableIterator<FileScanTask> inner;
+    private final Random random;
+    private final double ratio;
+
+    private long totalFileCount = 0;
+    private long selectedFileCount = 0;
+
+    private FileScanTask next;
+    private boolean exhausted = false;
+
+    public BernoulliFileScanTaskIterator(CloseableIterator<FileScanTask> inner, double ratio, long seed) {
+        this.inner = inner;
+        this.ratio = ratio;
+        this.random = (seed != 0) ? new Random(seed) : new Random();
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (next != null) {
+            return true;
+        }
+        if (exhausted) {
+            return false;
+        }
+        while (inner.hasNext()) {
+            FileScanTask candidate = inner.next();
+            totalFileCount++;
+            if (random.nextDouble() < ratio) {
+                selectedFileCount++;
+                next = candidate;
+                return true;
+            }
+        }
+        exhausted = true;
+        return false;
+    }
+
+    @Override
+    public FileScanTask next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        FileScanTask result = next;
+        next = null;
+        return result;
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        inner.close();
+    }
+
+    public long getTotalFileCount() {
+        return totalFileCount;
+    }
+
+    public long getSelectedFileCount() {
+        return selectedFileCount;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1198,9 +1198,33 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         String dbName = table.getCatalogDBName();
         String tableName = table.getCatalogTableName();
+
+        // File-level sampling is an internal-only knob driven by the background external-table
+        // sample ANALYZE job (see ExternalSampleStatisticsCollectJob), set via the invisible
+        // external_stats_file_sample_ratio/seed session variables on the job's own ConnectContext.
+        // Ordinary user queries never set these, so this is a no-op for them.
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx != null) {
+            double ratio = ctx.getSessionVariable().getExternalStatsFileSampleRatio();
+            if (ratio > 0 && ratio < 1.0) {
+                // Mutate in place rather than params.copy(): params may actually be an
+                // IcebergGetRemoteFilesParams (MOR-specific fields), and the base class's
+                // copy() only reconstructs a plain GetRemoteFilesParams, which would silently
+                // drop those subclass fields.
+                params.setFileSampleRatio(ratio);
+                params.setSampleSeed(ctx.getSessionVariable().getExternalStatsSampleSeed());
+            }
+        }
+
         PredicateSearchKey predicateSearchKey = PredicateSearchKey.of(dbName, tableName, params);
         RemoteFileInfoSource baseSource;
-        if (splitTasks.containsKey(predicateSearchKey)) {
+        // File-sampled requests (background ANALYZE SAMPLE) must never read from or write to
+        // splitTasks/scannedTables: that cache is shared across all queries against this table
+        // and is keyed without the sampling ratio, so reusing it here would either serve a
+        // sampled file list to a normal query or silently skip sampling for this request by
+        // reusing a full list cached by cost-estimation-time planning of the same statement.
+        boolean sampled = params.getFileSampleRatio() > 0 && params.getFileSampleRatio() < 1.0;
+        if (!sampled && splitTasks.containsKey(predicateSearchKey)) {
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey), params);
         } else {
             List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
@@ -1242,7 +1266,8 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                        GetRemoteFilesParams params) {
         CloseableIterator<FileScanTask> iterator =
                 buildFileScanTaskIterator(table, icebergPredicate, tvrVersionRange, ConnectContext.get(),
-                        params.isEnableColumnStats(), params.getFieldNames());
+                        params.isEnableColumnStats(), params.getFieldNames(),
+                        params.getFileSampleRatio(), params.getSampleSeed());
         return new RemoteFileInfoSource() {
             @Override
             public RemoteFileInfo getOutput() {
@@ -1289,6 +1314,21 @@ public class IcebergMetadata implements ConnectorMetadata {
                                                                       ConnectContext connectContext,
                                                                       boolean enableCollectColumnStats,
                                                                       List<String> fieldNames) {
+        // Cost-estimation / metadata-prep callers (collectTableStatisticsAndCacheIcebergSplit)
+        // never sample: file-level sampling only applies to the background sample-ANALYZE
+        // execution path (buildRemoteInfoSource), which passes an explicit ratio below.
+        return buildFileScanTaskIterator(icebergTable, icebergPredicate, tvrVersionRange, connectContext,
+                enableCollectColumnStats, fieldNames, 1.0, 0);
+    }
+
+    private CloseableIterator<FileScanTask> buildFileScanTaskIterator(IcebergTable icebergTable,
+                                                                      Expression icebergPredicate,
+                                                                      TvrVersionRange tvrVersionRange,
+                                                                      ConnectContext connectContext,
+                                                                      boolean enableCollectColumnStats,
+                                                                      List<String> fieldNames,
+                                                                      double fileSampleRatio,
+                                                                      long sampleSeed) {
         if (tvrVersionRange.isEmpty()) {
             return new CloseableIterator<>() {
                 @Override
@@ -1391,9 +1431,24 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             private void openPlannedTaskIterator(Scan tableScan) {
                 fileScanTaskIterable = normalizePlannedTaskIterable(tableScan.planFiles());
-                fileScanTaskIterator = buildSplitFileScanTaskIterator(
+                // Split first, sample second. Splitting is pure byte-offset metadata arithmetic
+                // (no file open), so a dropped unit still costs zero IO either way -- but sampling
+                // at split granularity instead of whole-file granularity bounds the sampled unit
+                // size at targetSplitSize. Raw Iceberg file sizes can vary widely even when writers
+                // target a size, and Bernoulli sampling variance in total sampled rows is driven by
+                // the sum of squared unit sizes, so capping unit size directly bounds that variance
+                // -- without resorting to per-file weighted probabilities, which would bias the
+                // expected sampled row count if done naively (see design doc). A kept/dropped split
+                // still carries its data file's associated delete files correctly scoped, since
+                // Iceberg's own split logic (splitFileScanTask) already handles delete-file scoping
+                // per split range for V2 MOR tables.
+                CloseableIterator<FileScanTask> splitIterator = buildSplitFileScanTaskIterator(
                         fileScanTaskIterable, fileScanTaskIterable.iterator(), tableScan.targetSplitSize(),
                         dbName, tableName, snapshotId);
+                if (fileSampleRatio > 0 && fileSampleRatio < 1.0) {
+                    splitIterator = new BernoulliFileScanTaskIterator(splitIterator, fileSampleRatio, sampleSeed);
+                }
+                fileScanTaskIterator = splitIterator;
             }
 
             private void closePlannedTaskIterator() {
@@ -1868,6 +1923,70 @@ public class IcebergMetadata implements ConnectorMetadata {
         // Both row counts are null. If the manifest has any live files, the count would be
         // a severe under-estimate → caller must fall back to planFiles for exact cardinality.
         return !manifest.hasAddedFiles() && !manifest.hasExistingFiles() && !manifest.hasDeletedFiles();
+    }
+
+    // Cheap file_count for the background sample-ANALYZE job's ratio decision (see
+    // ExternalSampleStatisticsCollectJob). Snapshot.summary() already carries the live
+    // total-data-files count maintained incrementally by every snapshot producer (Spark/Trino/
+    // Flink/StarRocks writers all populate it) -- O(1), not even a manifest-list read. Only fall
+    // back to summing addedFilesCount/existingFilesCount across dataManifests() (O(manifests),
+    // still zero DataFile opens) when the summary field is absent, e.g. very old/non-standard
+    // table metadata. No predicate: the sample job always scans the whole table in one pass, so
+    // pruning would not change the count.
+    public static long countIcebergFilesFromManifestList(IcebergTable icebergTable, long snapshotId) {
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTbl.snapshot(snapshotId);
+        if (snapshot == null) {
+            return 0;
+        }
+        Long fromSummary = parseSummaryLong(snapshot, SnapshotSummary.TOTAL_DATA_FILES_PROP);
+        if (fromSummary != null) {
+            return fromSummary;
+        }
+        long count = 0;
+        for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
+            Integer added = manifest.addedFilesCount();
+            Integer existing = manifest.existingFilesCount();
+            count += (added != null ? added : 0) + (existing != null ? existing : 0);
+        }
+        return count;
+    }
+
+    // Same shape as countIcebergFilesFromManifestList but for row counts, so the sample job's
+    // ratio can target "roughly how many rows this round reads" rather than "roughly how many
+    // files" -- files can vary wildly in row count, so a file-count-based ratio gives a much less
+    // predictable row volume per round than a row-count-based one. Prefers the live total-records
+    // field on Snapshot.summary() (O(1)); falls back to summing addedRowsCount/existingRowsCount
+    // across dataManifests() (O(manifests), zero data IO) when that field is absent.
+    public static long countIcebergRowsFromManifestList(IcebergTable icebergTable, long snapshotId) {
+        org.apache.iceberg.Table nativeTbl = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTbl.snapshot(snapshotId);
+        if (snapshot == null) {
+            return 0;
+        }
+        Long fromSummary = parseSummaryLong(snapshot, SnapshotSummary.TOTAL_RECORDS_PROP);
+        if (fromSummary != null) {
+            return fromSummary;
+        }
+        long count = 0;
+        for (ManifestFile manifest : snapshot.dataManifests(nativeTbl.io())) {
+            Long added = manifest.addedRowsCount();
+            Long existing = manifest.existingRowsCount();
+            count += (added != null ? added : 0) + (existing != null ? existing : 0);
+        }
+        return count;
+    }
+
+    private static Long parseSummaryLong(Snapshot snapshot, String key) {
+        String value = snapshot.summary() == null ? null : snapshot.summary().get(key);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1237,27 +1237,47 @@ public class IcebergMetadata implements ConnectorMetadata {
         IcebergTableMORParams tableFullMORParams = param.getTableFullMORParams();
         if (tableFullMORParams.isEmpty()) {
             return baseSource;
-        } else {
-            // build remote file info source for table with equality delete files.
-            IcebergRemoteFileInfoSourceKey remoteFileInfoSourceKey = IcebergRemoteFileInfoSourceKey.of(
-                    dbName, tableName, params, tableFullMORParams.getMORId(), param.getMORParams());
+        }
 
-            if (!remoteFileInfoSources.containsKey(remoteFileInfoSourceKey)) {
-                IcebergRemoteSourceTrigger trigger = new IcebergRemoteSourceTrigger(baseSource, tableFullMORParams);
-                // The tableFullMORParams we recorded are mainly used here. Scheduling of multiple
-                // split scan nodes from one table scan node is one by one. And in the IcebergRemoteSourceTrigger,
-                // multiple queues need to be filled according to different iceberg mor params when executing iceberg planing.
-                // Therefore, here we initialize the remoteFileInfoSource of all iceberg mor params for the first time.
-                for (IcebergMORParams morParams : tableFullMORParams.getMorParamsList()) {
-                    IcebergRemoteFileInfoSourceKey key = IcebergRemoteFileInfoSourceKey.of(
-                            dbName, tableName, params, tableFullMORParams.getMORId(), morParams);
-                    Deque<RemoteFileInfo> remoteFileInfoDeque = trigger.getQueue(morParams);
-                    remoteFileInfoSources.put(key, new QueueIcebergRemoteFileInfoSource(trigger, remoteFileInfoDeque));
+        // build remote file info source for table with equality delete files.
+        if (sampled) {
+            // Same rationale as the splitTasks bypass above: IcebergRemoteFileInfoSourceKey also
+            // derives from PredicateSearchKey (via morId/icebergMORParams on top of it) and ignores
+            // fileSampleRatio/sampleSeed, so caching here could let a sampled ANALYZE reuse a
+            // previously cached full MOR source (silently skipping sampling), or let a later normal
+            // MOR query reuse a sampled source (silently under-scanning). Build a fresh, uncached
+            // trigger and all sibling MOR params' queues -- mirroring the cached branch below -- and
+            // return only the one this call actually asked for.
+            IcebergRemoteSourceTrigger trigger = new IcebergRemoteSourceTrigger(baseSource, tableFullMORParams);
+            RemoteFileInfoSource requestedSource = null;
+            for (IcebergMORParams morParams : tableFullMORParams.getMorParamsList()) {
+                Deque<RemoteFileInfo> remoteFileInfoDeque = trigger.getQueue(morParams);
+                RemoteFileInfoSource source = new QueueIcebergRemoteFileInfoSource(trigger, remoteFileInfoDeque);
+                if (morParams.equals(param.getMORParams())) {
+                    requestedSource = source;
                 }
             }
-
-            return remoteFileInfoSources.get(remoteFileInfoSourceKey);
+            return requestedSource;
         }
+
+        IcebergRemoteFileInfoSourceKey remoteFileInfoSourceKey = IcebergRemoteFileInfoSourceKey.of(
+                dbName, tableName, params, tableFullMORParams.getMORId(), param.getMORParams());
+
+        if (!remoteFileInfoSources.containsKey(remoteFileInfoSourceKey)) {
+            IcebergRemoteSourceTrigger trigger = new IcebergRemoteSourceTrigger(baseSource, tableFullMORParams);
+            // The tableFullMORParams we recorded are mainly used here. Scheduling of multiple
+            // split scan nodes from one table scan node is one by one. And in the IcebergRemoteSourceTrigger,
+            // multiple queues need to be filled according to different iceberg mor params when executing iceberg planing.
+            // Therefore, here we initialize the remoteFileInfoSource of all iceberg mor params for the first time.
+            for (IcebergMORParams morParams : tableFullMORParams.getMorParamsList()) {
+                IcebergRemoteFileInfoSourceKey key = IcebergRemoteFileInfoSourceKey.of(
+                        dbName, tableName, params, tableFullMORParams.getMORId(), morParams);
+                Deque<RemoteFileInfo> remoteFileInfoDeque = trigger.getQueue(morParams);
+                remoteFileInfoSources.put(key, new QueueIcebergRemoteFileInfoSource(trigger, remoteFileInfoDeque));
+            }
+        }
+
+        return remoteFileInfoSources.get(remoteFileInfoSourceKey);
     }
 
     private RemoteFileInfoSource buildRemoteInfoSource(IcebergTable table,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -624,6 +624,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_READ_ICEBERG_PUFFIN_NDV = "enable_read_iceberg_puffin_ndv";
 
+    // Internal-only knobs used by the background external-table sample ANALYZE job to drive
+    // file-level Bernoulli sampling in the Iceberg connector. Not user-facing.
+    public static final String EXTERNAL_STATS_FILE_SAMPLE_RATIO = "external_stats_file_sample_ratio";
+    public static final String EXTERNAL_STATS_SAMPLE_SEED = "external_stats_sample_seed";
+
     public static final String ENABLE_ICEBERG_COLUMN_STATISTICS = "enable_iceberg_column_statistics";
     public static final String ENABLE_READ_ICEBERG_EQUALITY_DELETE_WITH_PARTITION_EVOLUTION =
             "enable_read_iceberg_equality_delete_with_partition_evolution";
@@ -3279,6 +3284,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_READ_ICEBERG_PUFFIN_NDV)
     private boolean enableReadIcebergPuffinNdv = true;
 
+    @VarAttr(name = EXTERNAL_STATS_FILE_SAMPLE_RATIO, flag = VariableMgr.INVISIBLE)
+    private double externalStatsFileSampleRatio = 1.0;
+
+    @VarAttr(name = EXTERNAL_STATS_SAMPLE_SEED, flag = VariableMgr.INVISIBLE)
+    private long externalStatsSampleSeed = 0;
+
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
     private boolean enableIcebergColumnStatistics = false;
 
@@ -3433,6 +3444,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableReadIcebergPuffinNdv(boolean enableReadIcebergPuffinNdv) {
         this.enableReadIcebergPuffinNdv = enableReadIcebergPuffinNdv;
+    }
+
+    public double getExternalStatsFileSampleRatio() {
+        return externalStatsFileSampleRatio;
+    }
+
+    public void setExternalStatsFileSampleRatio(double externalStatsFileSampleRatio) {
+        this.externalStatsFileSampleRatio = externalStatsFileSampleRatio;
+    }
+
+    public long getExternalStatsSampleSeed() {
+        return externalStatsSampleSeed;
+    }
+
+    public void setExternalStatsSampleSeed(long externalStatsSampleSeed) {
+        this.externalStatsSampleSeed = externalStatsSampleSeed;
     }
 
     public boolean enableDeltaLakeColumnStatistics() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -91,8 +91,11 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
     private final String catalogName;
     protected List<String> partitionNames;
-    private final List<String> sqlBuffer = Lists.newArrayList();
-    private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
+    // protected: reused by ExternalSampleStatisticsCollectJob's Iceberg file-sampling path, which
+    // needs to scale sampled row counts before buffering rows (this class's own
+    // collectStatisticSync buffers unscaled counts, so it can't be reused as-is for that path).
+    protected final List<String> sqlBuffer = Lists.newArrayList();
+    protected final List<List<Expr>> rowsBuffer = Lists.newArrayList();
     // Skip collecting statistics for default partition in iceberg table,
     // because we can not generate partition predicates for it.
     private static final Set<String> DO_NOT_COLLECT_PARTITIONS = Set.of(ICEBERG_DEFAULT_PARTITION);
@@ -186,6 +189,24 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
             flushInsertStatisticsData(context, true);
             cleanupStaleRawKeyedRows(context, jobId);
+
+            // Only for a genuine FULL run (this method is also reused by Hive's SAMPLE path via
+            // ExternalSampleStatisticsCollectJob#collectWithPartitionSampling, which never writes a
+            // sentinel row, so the cleanup would just be a no-op DELETE there): clean up a stale
+            // whole-table sample sentinel row left behind by a prior Iceberg SAMPLE collection, in
+            // case FULL is run manually afterward. Best-effort, mirrors the SAMPLE-side cleanup in
+            // ExternalSampleStatisticsCollectJob#cleanupStaleFullCollectionRows. Matches both the
+            // hashed and raw table_uuid (see StatisticUtils#hashTableUuidForPkStorage) since the
+            // sentinel row may have been written before or after the hashing migration.
+            if (analyzeType == StatsConstants.AnalyzeType.FULL) {
+                try {
+                    new StatisticExecutor().dropExternalTableStatisticsForPartition(context, table.getUUID(),
+                            StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL, columnNames);
+                } catch (Exception e) {
+                    LOG.warn("[ExternalStats] failed to clean up stale SAMPLE sentinel row | catalog={} db={} table={}",
+                            catalogName, db.getOriginName(), table.getName(), e);
+                }
+            }
         } catch (Exception e) {
             status = "FAILED";
             failureReason = e.getMessage();
@@ -424,7 +445,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         flushInsertStatisticsData(context, false);
     }
 
-    private void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+    protected void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
         // hll serialize to hex, about 32kb
         long bufferSize = 33L * 1024 * rowsBuffer.size();
         if (bufferSize < Config.statistic_full_collect_buffer && !force) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -186,6 +186,7 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
                                     "fileCount={} rowCount={}, retrying with full scan",
                             ratio, fileCount, rowCount);
                     cardinalityByColumn = runOneSampleRound(context, analyzeStatus, 1.0);
+                    ratio = 1.0; // full scan was done, don't waste later rounds
                 }
 
                 LOG.info("[ExternalStats][Sample] round done | jobId={} catalog={} db={} table={} round={} " +

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -171,6 +171,23 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
 
                 Map<String, Long> cardinalityByColumn = runOneSampleRound(context, analyzeStatus, ratio);
 
+                // On tables with relatively few splits, Bernoulli sampling at low ratios can drop
+                // every split.  With p=(1-ratio)^splitCount, a 15-split table at ratio=0.13 has a
+                // ~12 % chance of dropping everything, and the sentinel stats row would be all-zero
+                // — the subsequent cleanup would then erase authoritative FULL rows.
+                //
+                // Retry this round with ratio=1.0 (full scan).  Tables small enough to hit this
+                // edge case have negligible full-scan cost; the retry also produces better-quality
+                // stats than any partial-keep heuristic would.  The PK-based sentinel overwrite
+                // guarantees no zero-row-row survives; if *both* attempts return empty (table truly
+                // empty), that is the correct answer.
+                if (cardinalityByColumn.isEmpty() && fileCount > 0) {
+                    LOG.warn("[ExternalStats][Sample] all splits Bernoulli-dropped at ratio={} " +
+                                    "fileCount={} rowCount={}, retrying with full scan",
+                            ratio, fileCount, rowCount);
+                    cardinalityByColumn = runOneSampleRound(context, analyzeStatus, 1.0);
+                }
+
                 LOG.info("[ExternalStats][Sample] round done | jobId={} catalog={} db={} table={} round={} " +
                                 "rowsThisRound={} ratio={}",
                         jobId, getCatalogName(), db.getOriginName(), table.getName(), round, rowsThisRound, ratio);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -300,7 +300,7 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
      * so this run's internal round loop can warm-start near there instead of always cold-starting
      * at round 0. Defaults to 0 if no prior finished run is found.
      */
-    private int findPersistedRound() {
+    int findPersistedRound() {
         Map<Long, AnalyzeStatus> statusMap = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap();
         int round = 0;
         LocalDateTime latestEnd = null;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -67,7 +67,23 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     // max, min, ndv cardinality.
     private static final int AGGREGATES_PER_COLUMN = 6;
 
+    // StatisticsUtils#estimateColumnStatistics rescales a SAMPLE job's stored row_count by
+    // allPartitionSize / sampledPartitionsHashValue().size() -- a correction for the legacy
+    // Hive-style "latest N partitions, full scan" sampling, where the stored row_count only covers
+    // the sampled partition subset. Iceberg's whole-table file sampling already rescales row_count
+    // (and now data_size/null_count) to a full-table estimate during collection (see
+    // collectSinglePassStatisticSync), so that downstream rescale must be a no-op here. Reporting a
+    // fixed 1-sampled-out-of-1-total split (rather than the factory's real, and irrelevant,
+    // "latest N partitions" pre-selection) keeps the ratio at exactly 1.0x. A single constant
+    // element (not a fresh Set per call) keeps StatisticExecutor's cross-run union at size 1 too.
+    private static final Set<Long> FILE_SAMPLE_NEUTRAL_PARTITION_HASH = Set.of(0L);
+    private static final int FILE_SAMPLE_NEUTRAL_PARTITION_SIZE = 1;
+
     private final int allPartitionSize;
+
+    // Set once collectIcebergWithFileSampling actually runs (i.e. this job is against an Iceberg
+    // table). See FILE_SAMPLE_NEUTRAL_PARTITION_HASH for why this matters downstream.
+    private volatile boolean usedFileSampling = false;
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
                                               List<String> columnNames, List<Type> columnTypes,
@@ -78,12 +94,15 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     }
 
     public Set<Long> getSampledPartitionsHashValue() {
+        if (usedFileSampling) {
+            return FILE_SAMPLE_NEUTRAL_PARTITION_HASH;
+        }
         HashFunction hashFunction = Hashing.murmur3_128();
         return partitionNames.stream().map(s -> hashFunction.hashUnencodedChars(s).asLong()).collect(Collectors.toSet());
     }
 
     public int getAllPartitionSize() {
-        return allPartitionSize;
+        return usedFileSampling ? FILE_SAMPLE_NEUTRAL_PARTITION_SIZE : allPartitionSize;
     }
 
     @Override
@@ -104,6 +123,7 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     }
 
     private void collectIcebergWithFileSampling(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        usedFileSampling = true;
         long startMs = System.currentTimeMillis();
         long jobId = analyzeStatus.getId();
 
@@ -392,13 +412,20 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
         for (int i = 0; i < columnBatch.size(); i++) {
             String columnName = columnNames.get(columnBatch.get(i));
             int base = 1 + i * AGGREGATES_PER_COLUMN;
-            long dataSize = data.get(base).getAsLong();
+            long sampledDataSize = data.get(base).getAsLong();
             String hllHex = data.get(base + 1).getAsString();
-            long nullCount = data.get(base + 2).getAsLong();
+            long sampledNullCount = data.get(base + 2).getAsLong();
             String max = data.get(base + 3).getAsString();
             String min = data.get(base + 4).getAsString();
             long cardinality = data.get(base + 5).getAsLong();
             cardinalityByColumn.put(columnName, cardinality);
+
+            // data_size and null_count are sample-local totals just like row_count was before
+            // scaling -- readers compute averageRowSize = data_size / row_count and nullsFraction =
+            // null_count / row_count, so leaving these two unscaled while row_count is a full-table
+            // estimate would make both figures come out ~ratio times too small.
+            long scaledDataSize = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(sampledDataSize / ratio) : sampledDataSize;
+            long scaledNullCount = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(sampledNullCount / ratio) : sampledNullCount;
 
             List<String> params = Lists.newArrayList();
             List<Expr> row = Lists.newArrayList();
@@ -410,9 +437,9 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
             params.add("'" + db.getOriginName() + "'");
             params.add("'" + table.getName() + "'");
             params.add(String.valueOf(scaledRowCount));
-            params.add(String.valueOf(dataSize));
+            params.add(String.valueOf(scaledDataSize));
             params.add("hll_deserialize(unhex('mockData'))");
-            params.add(String.valueOf(nullCount));
+            params.add(String.valueOf(scaledNullCount));
             params.add("'" + max + "'");
             params.add("'" + min + "'");
             params.add("now()");
@@ -424,9 +451,9 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
             row.add(new StringLiteral(db.getOriginName()));
             row.add(new StringLiteral(table.getName()));
             row.add(new IntLiteral(scaledRowCount, IntegerType.BIGINT));
-            row.add(new IntLiteral(dataSize, IntegerType.BIGINT));
+            row.add(new IntLiteral(scaledDataSize, IntegerType.BIGINT));
             row.add(hllDeserialize(hllHex.getBytes(StandardCharsets.UTF_8)));
-            row.add(new IntLiteral(nullCount, IntegerType.BIGINT));
+            row.add(new IntLiteral(scaledNullCount, IntegerType.BIGINT));
             row.add(new StringLiteral(max));
             row.add(new StringLiteral(min));
             row.add(nowFn());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -14,18 +14,59 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import com.google.gson.JsonArray;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.iceberg.IcebergMetadata;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.iceberg.Snapshot;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCollectJob {
+    private static final Logger LOG = LogManager.getLogger(ExternalSampleStatisticsCollectJob.class);
+
+    // AnalyzeStatus.properties key persisting the round index this table's sampling left off at,
+    // so the NEXT scheduled run's internal round loop can start near there instead of always
+    // cold-starting at round 0 (whose ratio is superseded within the same run anyway once later,
+    // larger rounds overwrite it). Connector-agnostic name: the round-loop driver itself doesn't
+    // depend on Iceberg, only the cheap cost-total lookup that feeds it does (see
+    // collectIcebergWithFileSampling) -- if another connector eventually plugs into this same
+    // driver, its runs should share this warm-start record rather than getting a separate one.
+    private static final String SAMPLE_ROUND_PROPERTY = "external_sample_round";
+
+    // A wide-row SQL's SELECT list grows with column count; past this many columns in one batch,
+    // split into multiple single-pass SQLs (each still one scan over its own batch of columns)
+    // rather than building one unbounded SELECT list.
+    private static final int MAX_COLUMNS_PER_SINGLE_PASS_SQL = 200;
+
+    // Per-column aggregate count in buildSinglePassSQL's wide row: data_size, hll, null_count,
+    // max, min, ndv cardinality.
+    private static final int AGGREGATES_PER_COLUMN = 6;
+
     private final int allPartitionSize;
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
@@ -48,5 +89,352 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     @Override
     public String getName() {
         return "ExternalSample";
+    }
+
+    @Override
+    public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        if (table.isIcebergTable()) {
+            // Iceberg: cross-partition file-level random sampling, hard IO cap regardless of how
+            // large any single partition is. Everything else (Hive/Hudi/Paimon) keeps the existing
+            // partition-subset-then-full-scan sampling below.
+            collectIcebergWithFileSampling(context, analyzeStatus);
+        } else {
+            super.collect(context, analyzeStatus);
+        }
+    }
+
+    private void collectIcebergWithFileSampling(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        long startMs = System.currentTimeMillis();
+        long jobId = analyzeStatus.getId();
+
+        IcebergTable icebergTable = (IcebergTable) table;
+        Snapshot snapshot = icebergTable.getNativeTable().currentSnapshot();
+        if (snapshot == null) {
+            LOG.info("[ExternalStats][Sample] jobId={} catalog={} db={} table={} has no snapshot yet, skip",
+                    jobId, getCatalogName(), db.getOriginName(), table.getName());
+            return;
+        }
+
+        // Read file_count/row_count first (manifest-list summary fields, zero data IO) so every
+        // round's ratio is derived from the table's actual current size -- never a blind first
+        // guess. Row count (not file count) drives the ratio: files can vary wildly in row count,
+        // so a file-count-based ratio gives a much less predictable row volume per round.
+        // file_count is kept only as informational logging context.
+        long fileCount = IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, snapshot.snapshotId());
+        long rowCount = IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, snapshot.snapshotId());
+        long capPerRound = Math.max(1, Config.statistic_external_sample_max_rows_per_round);
+        int maxRounds = Math.max(1, Config.statistic_external_sample_max_rounds);
+
+        // Warm-start near where the last finished run left off, instead of always redoing rounds
+        // 0..N-1 that would just get overwritten again within this run anyway.
+        int round = Math.min(findPersistedRound(), maxRounds - 1);
+        double ratio = 1.0;
+
+        LOG.info("[ExternalStats][Sample] collect start | jobId={} catalog={} db={} table={} fileCount={} " +
+                        "rowCount={} startRound={} capPerRound={} maxRounds={} columns={}",
+                jobId, getCatalogName(), db.getOriginName(), table.getName(), fileCount, rowCount, round, capPerRound,
+                maxRounds, columnNames.size());
+
+        String status = "SUCCESS";
+        String failureReason = "";
+        try {
+            // Compared against each round's cardinality to detect NDV convergence; null on the
+            // first round of this job run (warm-started rounds don't carry over the prior job
+            // run's per-column values, so convergence is only tracked within one job execution).
+            Map<String, Long> prevCardinalityByColumn = null;
+            double convergenceThreshold = Config.statistic_external_sample_ndv_convergence_threshold;
+            for (; round < maxRounds; round++) {
+                long rowsThisRound = rowCount > 0 ? Math.min(rowCount, capPerRound << round) : rowCount;
+                ratio = rowCount > 0 ? Math.min(1.0, (double) rowsThisRound / rowCount) : 1.0;
+
+                Map<String, Long> cardinalityByColumn = runOneSampleRound(context, analyzeStatus, ratio);
+
+                LOG.info("[ExternalStats][Sample] round done | jobId={} catalog={} db={} table={} round={} " +
+                                "rowsThisRound={} ratio={}",
+                        jobId, getCatalogName(), db.getOriginName(), table.getName(), round, rowsThisRound, ratio);
+
+                if (ratio >= 1.0) {
+                    // Full coverage reached -- later, smaller-cap rounds would be strictly worse
+                    // and would just waste a re-scan, so stop here.
+                    break;
+                }
+
+                if (prevCardinalityByColumn != null
+                        && isNdvConverging(prevCardinalityByColumn, cardinalityByColumn, convergenceThreshold)) {
+                    LOG.info("[ExternalStats][Sample] NDV converged, stopping early | jobId={} catalog={} db={} " +
+                                    "table={} round={} threshold={}",
+                            jobId, getCatalogName(), db.getOriginName(), table.getName(), round, convergenceThreshold);
+                    break;
+                }
+                prevCardinalityByColumn = cardinalityByColumn;
+            }
+
+            // All rounds succeeded: this table's sampled stats for these columns are now
+            // authoritative in the sentinel row. If a prior FULL collection left real per-partition
+            // rows behind for the same columns, the read path's sum(row_count)/sum(data_size)/
+            // sum(null_count) (GROUP BY table_uuid, column_name, not partition_name) would double-
+            // count them alongside the sentinel row. Clean those up now that we have a fresh,
+            // authoritative replacement -- never before, so stats are never momentarily absent.
+            cleanupStaleFullCollectionRows(context);
+
+            Map<String, String> mergedProperties = new LinkedHashMap<>();
+            if (analyzeStatus.getProperties() != null) {
+                mergedProperties.putAll(analyzeStatus.getProperties());
+            }
+            mergedProperties.put("table_format", table.getType().name().toLowerCase(Locale.ROOT));
+            mergedProperties.put("column_count", String.valueOf(columnNames.size()));
+            mergedProperties.put("file_count", String.valueOf(fileCount));
+            mergedProperties.put("row_count", String.valueOf(rowCount));
+            mergedProperties.put("sample_ratio", String.valueOf(ratio));
+            mergedProperties.put(SAMPLE_ROUND_PROPERTY, String.valueOf(Math.min(round, maxRounds - 1)));
+            analyzeStatus.setProperties(mergedProperties);
+        } catch (Exception e) {
+            status = "FAILED";
+            failureReason = e.getMessage();
+            throw e;
+        } finally {
+            LOG.info("[ExternalStats][Sample] collect end | jobId={} catalog={} db={} table={} status={} " +
+                            "durationMs={} fileCount={} rowCount={} finalRatio={} reason={}",
+                    jobId, getCatalogName(), db.getOriginName(), table.getName(), status,
+                    System.currentTimeMillis() - startMs, fileCount, rowCount, ratio, failureReason);
+        }
+    }
+
+    /**
+     * Deletes any real-partition rows (partition_name != sentinel) for this table's collected
+     * columns, left behind by a prior FULL collection. Best-effort: failure here must not fail an
+     * otherwise-successful sample collection -- the double-counting it would leave behind already
+     * exists today, so a failed cleanup attempt does not make things worse.
+     */
+    private void cleanupStaleFullCollectionRows(ConnectContext context) {
+        try {
+            new StatisticExecutor().dropExternalTableStatisticsExcludingPartition(context, table.getUUID(),
+                    StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL, columnNames);
+        } catch (Exception e) {
+            LOG.warn("[ExternalStats][Sample] failed to clean up stale FULL rows | catalog={} db={} table={}",
+                    getCatalogName(), db.getOriginName(), table.getName(), e);
+        }
+    }
+
+    /**
+     * Runs one whole-table sampled collection round at the given ratio and flushes it to
+     * external_column_statistics (overwriting the previous round's sentinel row). Returns each
+     * collected column's NDV cardinality for this round, so the caller can track convergence
+     * across rounds.
+     */
+    private Map<String, Long> runOneSampleRound(ConnectContext context, AnalyzeStatus analyzeStatus, double ratio)
+            throws Exception {
+        // seed=0 tells BernoulliFileScanTaskIterator to use a fresh, unseeded Random, so successive
+        // rounds don't keep re-sampling the same files.
+        context.getSessionVariable().setExternalStatsFileSampleRatio(ratio);
+        context.getSessionVariable().setExternalStatsSampleSeed(0);
+        try {
+            List<List<Integer>> columnBatches = Lists.partition(
+                    IntStream.range(0, columnNames.size()).boxed().collect(Collectors.toList()),
+                    MAX_COLUMNS_PER_SINGLE_PASS_SQL);
+            long totalBatches = columnBatches.size();
+            long finishedBatches = 0;
+            Map<String, Long> cardinalityByColumn = new LinkedHashMap<>();
+            for (List<Integer> columnBatch : columnBatches) {
+                String sql = buildSinglePassSQL(columnBatch);
+                cardinalityByColumn.putAll(collectSinglePassStatisticSync(sql, columnBatch, context, analyzeStatus, ratio));
+                finishedBatches++;
+                analyzeStatus.setProgress(finishedBatches * 100 / totalBatches);
+                GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+            }
+            flushInsertStatisticsData(context, true);
+            return cardinalityByColumn;
+        } finally {
+            // Never let sampling leak onto later, unrelated queries sharing this ConnectContext.
+            context.getSessionVariable().setExternalStatsFileSampleRatio(1.0);
+            context.getSessionVariable().setExternalStatsSampleSeed(0);
+        }
+    }
+
+    /**
+     * True when every column's NDV cardinality changed by less than {@code threshold} (relative)
+     * between two consecutive rounds. A single still-changing column (typically a high-cardinality
+     * one) is enough to keep sampling going -- stopping early on ratio alone would compound the
+     * NDV underestimation that already applies to high-cardinality columns under sampling.
+     */
+    static boolean isNdvConverging(Map<String, Long> prev, Map<String, Long> curr, double threshold) {
+        for (Map.Entry<String, Long> entry : curr.entrySet()) {
+            Long prevValue = prev.get(entry.getKey());
+            if (prevValue == null) {
+                return false;
+            }
+            long currValue = entry.getValue();
+            double denominator = Math.max(currValue, 1L);
+            double relativeChange = Math.abs(currValue - prevValue) / denominator;
+            if (relativeChange >= threshold) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Finds the round index persisted by this table's most recently finished sample-ANALYZE run,
+     * so this run's internal round loop can warm-start near there instead of always cold-starting
+     * at round 0. Defaults to 0 if no prior finished run is found.
+     */
+    private int findPersistedRound() {
+        Map<Long, AnalyzeStatus> statusMap = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap();
+        int round = 0;
+        LocalDateTime latestEnd = null;
+        for (AnalyzeStatus otherStatus : statusMap.values()) {
+            if (otherStatus.isNative() || otherStatus.getType() != StatsConstants.AnalyzeType.SAMPLE) {
+                continue;
+            }
+            if (otherStatus.getStatus() != StatsConstants.ScheduleStatus.FINISH) {
+                continue;
+            }
+            try {
+                if (!getCatalogName().equals(otherStatus.getCatalogName())
+                        || !db.getOriginName().equals(otherStatus.getDbName())
+                        || !table.getName().equals(otherStatus.getTableName())) {
+                    continue;
+                }
+            } catch (MetaNotFoundException e) {
+                continue;
+            }
+            LocalDateTime end = otherStatus.getEndTime();
+            if (end == null) {
+                continue;
+            }
+            if (latestEnd == null || end.isAfter(latestEnd)) {
+                latestEnd = end;
+                String roundStr = otherStatus.getProperties() == null ? null :
+                        otherStatus.getProperties().get(SAMPLE_ROUND_PROPERTY);
+                try {
+                    round = roundStr != null ? Integer.parseInt(roundStr) : 0;
+                } catch (NumberFormatException e) {
+                    round = 0;
+                }
+            }
+        }
+        return round;
+    }
+
+    /**
+     * Builds one single-pass SQL covering every column in {@code columnBatch}: a single scan
+     * producing one wide row of {@code COUNT(1)} (shared row count) followed by 6 aggregates
+     * (data_size, hll, null_count, max, min, ndv cardinality) per column, in column order.
+     * Replaces the previous per-column SELECT ... UNION ALL ... approach so a round does exactly
+     * one planFiles()/scan (per batch) instead of N, and every column's stats come from the exact
+     * same sampled rows. The ndv cardinality aggregate is a plain scalar (not the serialized HLL
+     * sketch) so the round loop can compare it across rounds in-memory without needing to
+     * deserialize an HLL sketch on the FE side -- see isNdvConverging.
+     */
+    private String buildSinglePassSQL(List<Integer> columnBatch) {
+        StringBuilder sql = new StringBuilder("SELECT CAST(COUNT(1) AS BIGINT)");
+        for (int idx : columnBatch) {
+            String columnName = columnNames.get(idx);
+            Type columnType = columnTypes.get(idx);
+            String quoteColumnName = StatisticUtils.quoting(table, columnName);
+
+            if (!columnType.canStatistic() || columnType.isCollectionType()) {
+                sql.append(", CAST(0 AS BIGINT)");
+                sql.append(", hex(hll_serialize(hll_empty()))");
+                sql.append(", CAST(0 AS BIGINT)");
+                sql.append(", ''");
+                sql.append(", ''");
+                sql.append(", CAST(0 AS BIGINT)");
+            } else {
+                sql.append(", CAST(").append(fullAnalyzeGetDataSize(quoteColumnName, columnType)).append(" AS BIGINT)");
+                sql.append(", hex(hll_serialize(IFNULL(hll_raw(").append(quoteColumnName).append("), hll_empty())))");
+                sql.append(", CAST(COUNT(1) - COUNT(").append(quoteColumnName).append(") AS BIGINT)");
+                sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, true));
+                sql.append(", ").append(getMinMaxFunction(columnType, quoteColumnName, false));
+                sql.append(", CAST(hll_cardinality(IFNULL(hll_raw(").append(quoteColumnName)
+                        .append("), hll_empty())) AS BIGINT)");
+            }
+        }
+        sql.append(" FROM `").append(getCatalogName()).append("`.`").append(db.getOriginName())
+                .append("`.`").append(table.getName()).append("`");
+        return sql.toString();
+    }
+
+    /**
+     * Executes one single-pass wide-row SQL and decodes its one output row (via the HTTP/JSON
+     * result protocol, since the fixed 9-field {@code TStatisticData} struct can't hold N columns'
+     * worth of aggregates) back into per-column records, scaling the shared sampled row_count back
+     * up to a full-table estimate. NDV (HLL) and min/max are NOT rescaled: HLL directly measures
+     * distinct values in the sampled rows (assumed representative of the whole table per
+     * random-wide-sampling); min/max are kept as the sampled rows' true values, which is a safe
+     * (conservative) direction for range-predicate selectivity. Returns each column's NDV
+     * cardinality (unscaled, same sample-local estimate as everything else here) so the caller can
+     * compare it against the previous round's value to detect convergence.
+     */
+    private Map<String, Long> collectSinglePassStatisticSync(String sql, List<Integer> columnBatch,
+                                                               ConnectContext context, AnalyzeStatus analyzeStatus,
+                                                               double ratio) throws Exception {
+        calculateAndSetRemainingTimeout(context, analyzeStatus);
+
+        LOG.debug("statistics collect sql : " + sql);
+        StatisticExecutor executor = new StatisticExecutor();
+        setDefaultSessionVariable(context);
+
+        List<JsonArray> rows = executor.executeWideRowDQL(context, sql);
+        if (rows.isEmpty()) {
+            return Map.of();
+        }
+        JsonArray data = rows.get(0);
+        long sampledRowCount = data.get(0).getAsLong();
+        long scaledRowCount = (ratio > 0 && ratio < 1.0) ? (long) Math.ceil(sampledRowCount / ratio) : sampledRowCount;
+
+        // table_uuid is stored hashed (StatisticUtils.hashTableUuidForPkStorage) to stay within
+        // BE's primary_key_limit_size -- see ExternalFullStatisticsCollectJob#collectStatisticSync,
+        // which does the same for the FULL path. Iceberg's long catalog.db.table.<uuid> identifiers
+        // are exactly the case that hashing exists to protect.
+        String hashedTableUuid = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
+        Map<String, Long> cardinalityByColumn = new LinkedHashMap<>();
+        for (int i = 0; i < columnBatch.size(); i++) {
+            String columnName = columnNames.get(columnBatch.get(i));
+            int base = 1 + i * AGGREGATES_PER_COLUMN;
+            long dataSize = data.get(base).getAsLong();
+            String hllHex = data.get(base + 1).getAsString();
+            long nullCount = data.get(base + 2).getAsLong();
+            String max = data.get(base + 3).getAsString();
+            String min = data.get(base + 4).getAsString();
+            long cardinality = data.get(base + 5).getAsLong();
+            cardinalityByColumn.put(columnName, cardinality);
+
+            List<String> params = Lists.newArrayList();
+            List<Expr> row = Lists.newArrayList();
+
+            params.add("'" + hashedTableUuid + "'");
+            params.add("'" + StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(columnName) + "'");
+            params.add("'" + getCatalogName() + "'");
+            params.add("'" + db.getOriginName() + "'");
+            params.add("'" + table.getName() + "'");
+            params.add(String.valueOf(scaledRowCount));
+            params.add(String.valueOf(dataSize));
+            params.add("hll_deserialize(unhex('mockData'))");
+            params.add(String.valueOf(nullCount));
+            params.add("'" + max + "'");
+            params.add("'" + min + "'");
+            params.add("now()");
+
+            row.add(new StringLiteral(hashedTableUuid));
+            row.add(new StringLiteral(StatsConstants.EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL));
+            row.add(new StringLiteral(columnName));
+            row.add(new StringLiteral(getCatalogName()));
+            row.add(new StringLiteral(db.getOriginName()));
+            row.add(new StringLiteral(table.getName()));
+            row.add(new IntLiteral(scaledRowCount, IntegerType.BIGINT));
+            row.add(new IntLiteral(dataSize, IntegerType.BIGINT));
+            row.add(hllDeserialize(hllHex.getBytes(StandardCharsets.UTF_8)));
+            row.add(new IntLiteral(nullCount, IntegerType.BIGINT));
+            row.add(new StringLiteral(max));
+            row.add(new StringLiteral(min));
+            row.add(nowFn());
+
+            rowsBuffer.add(row);
+            sqlBuffer.add("(" + String.join(", ", params) + ")");
+        }
+        flushInsertStatisticsData(context, false);
+        return cardinalityByColumn;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJob.java
@@ -82,8 +82,10 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
     private final int allPartitionSize;
 
     // Set once collectIcebergWithFileSampling actually runs (i.e. this job is against an Iceberg
-    // table). See FILE_SAMPLE_NEUTRAL_PARTITION_HASH for why this matters downstream.
-    private volatile boolean usedFileSampling = false;
+    // table). See FILE_SAMPLE_NEUTRAL_PARTITION_HASH for why this matters downstream. Package-
+    // private (not private) so tests can drive the neutral-value branch without needing a live
+    // Iceberg snapshot.
+    volatile boolean usedFileSampling = false;
 
     public ExternalSampleStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
                                               List<String> columnNames, List<Type> columnTypes,
@@ -346,7 +348,7 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
      * sketch) so the round loop can compare it across rounds in-memory without needing to
      * deserialize an HLL sketch on the FE side -- see isNdvConverging.
      */
-    private String buildSinglePassSQL(List<Integer> columnBatch) {
+    String buildSinglePassSQL(List<Integer> columnBatch) {
         StringBuilder sql = new StringBuilder("SELECT CAST(COUNT(1) AS BIGINT)");
         for (int idx : columnBatch) {
             String columnName = columnNames.get(idx);
@@ -386,9 +388,9 @@ public class ExternalSampleStatisticsCollectJob extends ExternalFullStatisticsCo
      * cardinality (unscaled, same sample-local estimate as everything else here) so the caller can
      * compare it against the previous round's value to detect convergence.
      */
-    private Map<String, Long> collectSinglePassStatisticSync(String sql, List<Integer> columnBatch,
-                                                               ConnectContext context, AnalyzeStatus analyzeStatus,
-                                                               double ratio) throws Exception {
+    Map<String, Long> collectSinglePassStatisticSync(String sql, List<Integer> columnBatch,
+                                                      ConnectContext context, AnalyzeStatus analyzeStatus,
+                                                      double ratio) throws Exception {
         calculateAndSetRemainingTimeout(context, analyzeStatus);
 
         LOG.debug("statistics collect sql : " + sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -19,6 +19,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
@@ -61,6 +63,8 @@ import com.starrocks.thrift.TStatisticData;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.Type;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
@@ -71,7 +75,9 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -305,6 +311,33 @@ public class StatisticExecutor {
         String sql = StatisticSQLBuilder.buildDropExternalHistogramSQLForRawUuid(rawTableUUID, Lists.newArrayList(columnName));
         LOG.debug("Cleanup stale raw-keyed external histogram row SQL: {}", sql);
         return executeDML(statsConnectCtx, sql);
+    }
+
+    // See StatisticSQLBuilder#buildDropExternalStatExcludingPartitionSQL. Best-effort: a failure
+    // here leaves the pre-existing double-counting in place (not made worse) rather than failing
+    // the caller's otherwise-successful collection.
+    public void dropExternalTableStatisticsExcludingPartition(ConnectContext statsConnectCtx, String tableUUID,
+                                                               String excludedPartitionName, List<String> columnNames) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(tableUUID, excludedPartitionName,
+                columnNames);
+        LOG.debug("Cleanup stale external statistic SQL: {}", sql);
+
+        boolean result = executeDML(statsConnectCtx, sql);
+        if (!result) {
+            LOG.warn("Execute stale external statistic cleanup fail, tableUUID={}", tableUUID);
+        }
+    }
+
+    // See StatisticSQLBuilder#buildDropExternalStatForPartitionSQL.
+    public void dropExternalTableStatisticsForPartition(ConnectContext statsConnectCtx, String tableUUID,
+                                                        String partitionName, List<String> columnNames) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatForPartitionSQL(tableUUID, partitionName, columnNames);
+        LOG.debug("Cleanup sentinel external statistic SQL: {}", sql);
+
+        boolean result = executeDML(statsConnectCtx, sql);
+        if (!result) {
+            LOG.warn("Execute sentinel external statistic cleanup fail, tableUUID={}", tableUUID);
+        }
     }
 
     public boolean dropPartitionStatistics(ConnectContext statsConnectCtx, List<Long> pids) {
@@ -736,12 +769,32 @@ public class StatisticExecutor {
     }
 
     public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
-        List<TResultBatch> sqlResult = executeDQL(context, sql);
+        List<TResultBatch> sqlResult = executeDQL(context, sql, TResultSinkType.STATISTIC);
         try {
             return deserializerStatisticData(sqlResult);
         } catch (TException e) {
             throw new SemanticException(e.getMessage());
         }
+    }
+
+    /**
+     * Executes a query whose row shape isn't the fixed 9-field {@link TStatisticData} struct (e.g. a
+     * single-pass wide row covering many columns' worth of aggregates). Uses the HTTP/JSON result
+     * protocol, which serializes each row as {@code {"data": [col1, col2, ...]}} regardless of width,
+     * and returns each row's decoded JSON array positionally -- the caller maps array indices back to
+     * its own column layout.
+     */
+    public List<JsonArray> executeWideRowDQL(ConnectContext context, String sql) {
+        List<TResultBatch> sqlResult = executeDQL(context, sql, TResultSinkType.HTTP_PROTOCAL);
+        List<JsonArray> rows = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(sqlResult)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                rows.add(JsonParser.parseString(jsonString).getAsJsonObject().get("data").getAsJsonArray());
+            }
+        }
+        return rows;
     }
 
     /**
@@ -770,7 +823,7 @@ public class StatisticExecutor {
                 tableId, sourcePartition, targetPartition);
     }
 
-    private List<TResultBatch> executeDQL(ConnectContext context, String sql) {
+    private List<TResultBatch> executeDQL(ConnectContext context, String sql, TResultSinkType resultSinkType) {
         context.setQueryId(UUIDUtil.genUUID());
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: Statistics collect，query id:{}, sql:{}", context.getQueryId(), sql);
@@ -780,7 +833,7 @@ public class StatisticExecutor {
         }
         Stopwatch watch = Stopwatch.createStarted();
         StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
-        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
+        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, resultSinkType);
         StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
         context.setExecutor(executor);
         context.getSessionVariable().setEnableMaterializedViewRewrite(false);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -823,7 +823,7 @@ public class StatisticExecutor {
                 tableId, sourcePartition, targetPartition);
     }
 
-    private List<TResultBatch> executeDQL(ConnectContext context, String sql, TResultSinkType resultSinkType) {
+    List<TResultBatch> executeDQL(ConnectContext context, String sql, TResultSinkType resultSinkType) {
         context.setQueryId(UUIDUtil.genUUID());
         if (Config.enable_print_sql) {
             LOG.info("Begin to execute sql, type: Statistics collect，query id:{}, sql:{}", context.getQueryId(), sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -360,6 +360,45 @@ public class StatisticSQLBuilder {
                 " AND DB_NAME = '" + dbName + "' AND TABLE_NAME = '" + tableName + "'";
     }
 
+    // Deletes rows for the given columns whose partition_name is NOT the given sentinel value.
+    // Used by Iceberg sample collection to clean up stale real-partition rows left behind by a
+    // prior FULL collection on the same table, once the sample's sentinel row is a fresh,
+    // authoritative replacement -- otherwise the read path's sum(row_count)/sum(data_size)/
+    // sum(null_count) (grouped by column_name only, see QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE)
+    // would double-count the old FULL rows alongside the new sentinel row. Matches both the hashed
+    // and raw table_uuid (see buildTableUUIDInPredicateQuoted) since the rows being cleaned up may
+    // have been written before or after the hashing migration.
+    public static String buildDropExternalStatExcludingPartitionSQL(String tableUUID, String excludedPartitionName,
+                                                                     List<String> columnNames) {
+        StringBuilder sql = new StringBuilder("DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID) +
+                " AND PARTITION_NAME != '" + SqlUtils.escapeSqlString(excludedPartitionName) + "'");
+        appendColumnNameFilter(sql, columnNames);
+        return sql.toString();
+    }
+
+    // Deletes rows for the given columns whose partition_name IS the given sentinel value. Used by
+    // ExternalFullStatisticsCollectJob to clean up a stale whole-table sample sentinel row left
+    // behind by a prior SAMPLE collection, in case FULL is run manually afterward. Matches both the
+    // hashed and raw table_uuid, same rationale as buildDropExternalStatExcludingPartitionSQL.
+    public static String buildDropExternalStatForPartitionSQL(String tableUUID, String partitionName,
+                                                               List<String> columnNames) {
+        StringBuilder sql = new StringBuilder("DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME +
+                " WHERE " + buildTableUUIDInPredicateQuoted(tableUUID) +
+                " AND PARTITION_NAME = '" + SqlUtils.escapeSqlString(partitionName) + "'");
+        appendColumnNameFilter(sql, columnNames);
+        return sql.toString();
+    }
+
+    private static void appendColumnNameFilter(StringBuilder sql, List<String> columnNames) {
+        if (columnNames != null && !columnNames.isEmpty()) {
+            String cols = columnNames.stream()
+                    .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'")
+                    .collect(Collectors.joining(", "));
+            sql.append(" AND COLUMN_NAME IN (").append(cols).append(")");
+        }
+    }
+
     public static String buildDropPartitionSQL(List<Long> pids) {
         return "DELETE FROM " + FULL_STATISTICS_TABLE_NAME + " WHERE " +
                 " PARTITION_ID IN (" +

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -40,7 +40,12 @@ public class StatsConstants {
     public static final int STATISTIC_QUERY_MULTI_COLUMN_VERSION = 13;
     public static final int STATISTIC_PARTITION_VERSION_V2 = 20;
 
-
+    // external_column_statistics is keyed by (table_uuid, partition_name, column_name); a
+    // whole-table Iceberg file sample has no real partition to attach its row to, so it uses this
+    // fixed sentinel instead. Must never collide with a real Iceberg partition name. Shared between
+    // ExternalSampleStatisticsCollectJob (writes/reads it) and ExternalFullStatisticsCollectJob
+    // (cleans it up after a FULL collection, in case a prior SAMPLE run left one behind).
+    public static final String EXTERNAL_SAMPLE_PARTITION_NAME_SENTINEL = "$FILE_SAMPLE$";
 
     public static final ImmutableSet<Integer> STATISTIC_SUPPORTED_VERSION =
             ImmutableSet.<Integer>builder()

--- a/fe/fe-core/src/test/java/com/starrocks/connector/GetRemoteFilesParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/GetRemoteFilesParamsTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class GetRemoteFilesParamsTest {
+
+    @Test
+    public void testFileSampleRatioAndSeedDefaultToNoSampling() {
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().build();
+        Assertions.assertEquals(1.0, params.getFileSampleRatio());
+        Assertions.assertEquals(0L, params.getSampleSeed());
+    }
+
+    @Test
+    public void testSetFileSampleRatioAndSeedRoundTrip() {
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().build();
+        params.setFileSampleRatio(0.5);
+        params.setSampleSeed(123L);
+        Assertions.assertEquals(0.5, params.getFileSampleRatio());
+        Assertions.assertEquals(123L, params.getSampleSeed());
+    }
+
+    @Test
+    public void testCopyPreservesFileSampleRatioAndSeed() {
+        // ExternalSampleStatisticsCollectJob's Iceberg path relies on these two fields surviving a
+        // copy() -- IcebergMetadata#getRemoteFilesAsync mutates params in place rather than copying
+        // specifically to avoid a different loss (IcebergGetRemoteFilesParams' MOR fields), but
+        // sibling code elsewhere in the connector layer does call copy(), and it must not silently
+        // drop the sampling knobs either.
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder().build();
+        params.setFileSampleRatio(0.3);
+        params.setSampleSeed(42L);
+
+        GetRemoteFilesParams copied = params.copy();
+        Assertions.assertEquals(0.3, copied.getFileSampleRatio());
+        Assertions.assertEquals(42L, copied.getSampleSeed());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIteratorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/BernoulliFileScanTaskIteratorTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.io.CloseableIterator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BernoulliFileScanTaskIteratorTest {
+
+    private static CloseableIterator<FileScanTask> tasks(int n) {
+        List<FileScanTask> list = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            list.add(Mockito.mock(FileScanTask.class));
+        }
+        Iterator<FileScanTask> it = list.iterator();
+        return new CloseableIterator<>() {
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public FileScanTask next() {
+                return it.next();
+            }
+        };
+    }
+
+    @Test
+    public void testRatioOneKeepsAll() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(50), 1.0, 42)) {
+            int count = 0;
+            while (sampled.hasNext()) {
+                sampled.next();
+                count++;
+            }
+            assertEquals(50, count);
+            assertEquals(50, sampled.getTotalFileCount());
+            assertEquals(50, sampled.getSelectedFileCount());
+        }
+    }
+
+    @Test
+    public void testRatioZeroDropsAll() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(50), 0.0, 42)) {
+            assertFalse(sampled.hasNext());
+            assertEquals(50, sampled.getTotalFileCount());
+            assertEquals(0, sampled.getSelectedFileCount());
+        }
+    }
+
+    @Test
+    public void testFixedSeedIsDeterministic() throws Exception {
+        long selectedA;
+        long selectedB;
+        try (BernoulliFileScanTaskIterator a = new BernoulliFileScanTaskIterator(tasks(2000), 0.1, 7)) {
+            while (a.hasNext()) {
+                a.next();
+            }
+            selectedA = a.getSelectedFileCount();
+        }
+        try (BernoulliFileScanTaskIterator b = new BernoulliFileScanTaskIterator(tasks(2000), 0.1, 7)) {
+            while (b.hasNext()) {
+                b.next();
+            }
+            selectedB = b.getSelectedFileCount();
+        }
+        assertEquals(selectedA, selectedB);
+    }
+
+    @Test
+    public void testRatioApproximatelyMatchesSelectionFraction() throws Exception {
+        int total = 20000;
+        double ratio = 0.03;
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(total), ratio, 123)) {
+            int count = 0;
+            while (sampled.hasNext()) {
+                sampled.next();
+                count++;
+            }
+            assertEquals(total, sampled.getTotalFileCount());
+            assertEquals(count, sampled.getSelectedFileCount());
+            double observedRatio = (double) count / total;
+            // Bernoulli(p=0.03) over 20k trials: std dev ~= sqrt(20000*0.03*0.97) ~= 24 files ~= 0.0012 in ratio.
+            // Allow a generous 10x margin to keep this non-flaky.
+            assertTrue(Math.abs(observedRatio - ratio) < 0.012,
+                    "observed ratio " + observedRatio + " too far from target " + ratio);
+        }
+    }
+
+    @Test
+    public void testNextThrowsAfterExhausted() throws Exception {
+        try (BernoulliFileScanTaskIterator sampled = new BernoulliFileScanTaskIterator(tasks(0), 1.0, 1)) {
+            assertFalse(sampled.hasNext());
+            assertThrows(NoSuchElementException.class, sampled::next);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -48,6 +48,7 @@ import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.PointerType;
 import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.RemoteMetaSplit;
 import com.starrocks.connector.SerializedMetaSpec;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -1486,6 +1487,88 @@ public class IcebergMetadataTest extends TableTestBase {
         splitTasksField.setAccessible(true);
         Map<?, ?> splitTasks = (Map<?, ?>) splitTasksField.get(metadata);
         Assertions.assertTrue(splitTasks.isEmpty());
+    }
+
+    @Test
+    // Uses IcebergTableMORParams.EMPTY, so this only exercises the splitTasks bypass
+    // (getRemoteFilesAsync's early branch) -- not the sibling remoteFileInfoSources bypass that
+    // applies when tableFullMORParams is non-empty (equality-delete tables), which would need a
+    // real MOR fixture this test class doesn't currently have.
+    public void testGetRemoteFilesAsyncSampledBypassesSplitTasksCache() throws Exception {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        List<Column> columns = Lists.newArrayList(new Column("k1", INT), new Column("k2", INT));
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, mockedNativeTableB, Maps.newHashMap());
+
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+        long snapshotId = mockedNativeTableB.currentSnapshot().snapshotId();
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.GE,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(1));
+        // ratio is deliberately very close to 1.0 (not exactly 1.0, which would skip the "sampled"
+        // branch entirely) so the Bernoulli filter dropping every single file by chance is
+        // astronomically unlikely -- this test cares about which branch runs, not the sampling math.
+        GetRemoteFilesParams sampledParams = IcebergGetRemoteFilesParams.newBuilder()
+                .setAllParams(IcebergTableMORParams.EMPTY)
+                .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10)
+                .setFileSampleRatio(0.999).setSampleSeed(42).build();
+
+        PredicateSearchKey key = PredicateSearchKey.of(
+                icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), sampledParams);
+
+        // Simulate query-planning-time cost estimation (IcebergMetadata#getRemoteFiles /
+        // collectTableStatisticsAndCacheIcebergSplit) having already cached a file list under this
+        // exact predicate key -- deliberately empty/wrong, so that if the sampled request below
+        // reused it (the bug this bypass prevents), draining the returned source would
+        // deterministically yield zero files instead of the real, freshly-scanned ones.
+        java.lang.reflect.Field splitTasksField = IcebergMetadata.class.getDeclaredField("splitTasks");
+        splitTasksField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<PredicateSearchKey, List<FileScanTask>> splitTasks =
+                (Map<PredicateSearchKey, List<FileScanTask>>) splitTasksField.get(metadata);
+        splitTasks.put(key, new ArrayList<>());
+
+        RemoteFileInfoSource source = metadata.getRemoteFilesAsync(icebergTable, sampledParams);
+        List<RemoteFileInfo> results = source.getAllOutputs();
+
+        Assertions.assertFalse(results.isEmpty(),
+                "sampled request must not reuse the stale cached (empty) file list for this predicate key");
+    }
+
+    @Test
+    public void testCountIcebergRowsAndFilesFromManifestList() {
+        // snap1: FILE_A only (2 rows, 1 file). snap2: FILE_A + FILE_A_1 (4 rows, 2 files). Both read
+        // via Snapshot#summary()'s O(1) total-records/total-data-files fields -- populated
+        // automatically by Iceberg's own commit machinery, no manifest opens, no DataFile
+        // enumeration.
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A).commit();
+        Snapshot snap1 = mockedNativeTableA.currentSnapshot();
+        mockedNativeTableA.newFastAppend().appendFile(FILE_A_1).commit();
+        mockedNativeTableA.refresh();
+        Snapshot snap2 = mockedNativeTableA.currentSnapshot();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+
+        Assertions.assertEquals(2L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, snap1.snapshotId()));
+        Assertions.assertEquals(1L,
+                IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, snap1.snapshotId()));
+        Assertions.assertEquals(4L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, snap2.snapshotId()));
+        Assertions.assertEquals(2L,
+                IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, snap2.snapshotId()));
+    }
+
+    @Test
+    public void testCountIcebergRowsAndFilesFromManifestListReturnsZeroForMissingSnapshot() {
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
+                "table_name", "", Lists.newArrayList(), mockedNativeTableA, Maps.newHashMap());
+        Assertions.assertEquals(0L, IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, -1));
+        Assertions.assertEquals(0L, IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, -1));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4202,4 +4202,111 @@ public class IcebergMetadataTest extends TableTestBase {
         assertTrue(exception.getMessage().contains(String.valueOf(snap1.snapshotId())));
         assertTrue(exception.getMessage().contains(String.valueOf(snap3.snapshotId())));
     }
+
+    // ---------- parseSummaryLong / manifest-list fallback tests ----------
+
+    @Test
+    public void testCountIcebergRowsFromManifestListWithoutSummary() {
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(mockNativeTable.snapshot(42L)).thenReturn(mockSnapshot);
+        Mockito.when(mockSnapshot.summary()).thenReturn(null);
+        Mockito.when(mockSnapshot.dataManifests(Mockito.any())).thenReturn(
+                java.util.Collections.<ManifestFile>emptyList());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "db_name", "table_name", "", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+        Assertions.assertEquals(0L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, 42L));
+    }
+
+    @Test
+    public void testCountIcebergFilesFromManifestListWithoutSummary() {
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(mockNativeTable.snapshot(42L)).thenReturn(mockSnapshot);
+        Mockito.when(mockSnapshot.summary()).thenReturn(null);
+        Mockito.when(mockSnapshot.dataManifests(Mockito.any())).thenReturn(
+                java.util.Collections.<ManifestFile>emptyList());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "db_name", "table_name", "", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+        Assertions.assertEquals(0L,
+                IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, 42L));
+    }
+
+    @Test
+    public void testParseSummaryLongMissingKey() {
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(mockNativeTable.snapshot(42L)).thenReturn(mockSnapshot);
+        Mockito.when(mockSnapshot.summary()).thenReturn(Map.of());
+        Mockito.when(mockSnapshot.dataManifests(Mockito.any())).thenReturn(
+                java.util.Collections.<ManifestFile>emptyList());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "db_name", "table_name", "", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+        Assertions.assertEquals(0L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, 42L));
+    }
+
+    @Test
+    public void testParseSummaryLongNumberFormatException() {
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(mockNativeTable.snapshot(42L)).thenReturn(mockSnapshot);
+        Mockito.when(mockSnapshot.summary()).thenReturn(
+                Map.of(org.apache.iceberg.SnapshotSummary.TOTAL_RECORDS_PROP, "not_a_number"));
+        Mockito.when(mockSnapshot.dataManifests(Mockito.any())).thenReturn(
+                java.util.Collections.<ManifestFile>emptyList());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "db_name", "table_name", "", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+        Assertions.assertEquals(0L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, 42L));
+    }
+
+    @Test
+    public void testFileSampleRatioAndSeedPassedFromSessionVariables() throws Exception {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(),
+                DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(),
+                DEFAULT_CATALOG_PROPERTIES);
+
+        mockedNativeTableH.newAppend().appendFile(
+                DataFiles.builder(PartitionSpec.unpartitioned())
+                        .withPath("/path/to/data-h.parquet")
+                        .withFileSizeInBytes(10)
+                        .withRecordCount(1)
+                        .build()).commit();
+        mockedNativeTableH.refresh();
+        long snapshotId = mockedNativeTableH.currentSnapshot().snapshotId();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "iceberg_db", "iceberg_table", "", Lists.newArrayList(), mockedNativeTableH, Maps.newHashMap());
+
+        double ratioBefore = connectContext.getSessionVariable().getExternalStatsFileSampleRatio();
+        long seedBefore = connectContext.getSessionVariable().getExternalStatsSampleSeed();
+        try {
+            connectContext.getSessionVariable().setExternalStatsFileSampleRatio(0.5);
+            connectContext.getSessionVariable().setExternalStatsSampleSeed(42);
+
+            GetRemoteFilesParams params = IcebergGetRemoteFilesParams.newBuilder()
+                    .setAllParams(IcebergTableMORParams.EMPTY)
+                    .setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                    .setPredicate(ConstantOperator.TRUE)
+                    .build();
+            Assertions.assertEquals(1.0, params.getFileSampleRatio());
+            Assertions.assertEquals(0L, params.getSampleSeed());
+
+            metadata.getRemoteFilesAsync(icebergTable, params);
+
+            Assertions.assertEquals(0.5, params.getFileSampleRatio());
+            Assertions.assertEquals(42L, params.getSampleSeed());
+        } finally {
+            connectContext.getSessionVariable().setExternalStatsFileSampleRatio(ratioBefore);
+            connectContext.getSessionVariable().setExternalStatsSampleSeed(seedBefore);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -4267,6 +4267,26 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testCountIcebergManifestFallbackSumsAcrossManifests() throws IOException {
+        ManifestFile m1 = writeManifest(FILE_A);
+        ManifestFile m2 = writeManifest(FILE_A_1);
+
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(mockNativeTable.snapshot(42L)).thenReturn(mockSnapshot);
+        Mockito.when(mockNativeTable.io()).thenReturn(FILE_IO);
+        Mockito.when(mockSnapshot.summary()).thenReturn(null);
+        Mockito.when(mockSnapshot.dataManifests(Mockito.any())).thenReturn(List.of(m1, m2));
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name",
+                "db_name", "table_name", "", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+        Assertions.assertEquals(2L,
+                IcebergMetadata.countIcebergFilesFromManifestList(icebergTable, 42L));
+        Assertions.assertEquals(4L,
+                IcebergMetadata.countIcebergRowsFromManifestList(icebergTable, 42L));
+    }
+
+    @Test
     public void testFileSampleRatioAndSeedPassedFromSessionVariables() throws Exception {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(),
                 DEFAULT_CONFIG);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -201,4 +201,19 @@ public class SessionVariableTest {
                 SessionVariable.SCAN_HIVE_PARTITION_NUM_LIMIT + "\": 512}");
         Assertions.assertEquals(4096, sessionVariable.getScanLakePartitionNumLimit());
     }
+
+    @Test
+    public void testExternalStatsFileSampleRatioAndSeedDefaultAndRoundTrip() {
+        // Invisible, job-internal knobs the Iceberg external-table sample ANALYZE job sets on its
+        // own ConnectContext (see IcebergMetadata#getRemoteFilesAsync) -- default to 1.0/0
+        // (no sampling) so ordinary user queries are unaffected.
+        SessionVariable sessionVariable = new SessionVariable();
+        Assertions.assertEquals(1.0, sessionVariable.getExternalStatsFileSampleRatio());
+        Assertions.assertEquals(0L, sessionVariable.getExternalStatsSampleSeed());
+
+        sessionVariable.setExternalStatsFileSampleRatio(0.3);
+        sessionVariable.setExternalStatsSampleSeed(7L);
+        Assertions.assertEquals(0.3, sessionVariable.getExternalStatsFileSampleRatio());
+        Assertions.assertEquals(7L, sessionVariable.getExternalStatsSampleSeed());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
@@ -1,0 +1,73 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExternalSampleStatisticsCollectJobTest {
+
+    @Test
+    public void testLowCardinalityColumnConverges() {
+        // A boolean-like column: NDV settles at 2 after the first round and never moves again.
+        Map<String, Long> prev = Map.of("is_active", 2L);
+        Map<String, Long> curr = Map.of("is_active", 2L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testHighCardinalityColumnKeepsGrowingDoesNotConverge() {
+        // A near-unique id column: doubling the sample roughly doubles the observed NDV, so the
+        // round loop must keep going instead of stopping early.
+        Map<String, Long> prev = Map.of("id", 2_000_000L);
+        Map<String, Long> curr = Map.of("id", 3_900_000L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testWithinThresholdConverges() {
+        Map<String, Long> prev = Map.of("c1", 1000L);
+        Map<String, Long> curr = Map.of("c1", 1020L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testSingleNonConvergingColumnBlocksWholeRound() {
+        // Even if most columns have settled, one still-changing column (typically the
+        // highest-cardinality one) must keep the round loop from stopping early.
+        Map<String, Long> prev = Map.of("stable", 5L, "growing", 1000L);
+        Map<String, Long> curr = Map.of("stable", 5L, "growing", 2000L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testMissingPreviousColumnTreatedAsNotConverged() {
+        Map<String, Long> prev = Map.of();
+        Map<String, Long> curr = Map.of("new_column", 10L);
+        assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testZeroCardinalityBothRoundsConverges() {
+        // An all-null column: cardinality stays 0 across rounds, must not divide by zero.
+        Map<String, Long> prev = Map.of("all_null", 0L);
+        Map<String, Long> curr = Map.of("all_null", 0L);
+        assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
@@ -19,10 +19,14 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.JsonType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,14 +37,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExternalSampleStatisticsCollectJobTest {
 
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createDefaultCtx();
+    }
+
     private static ExternalSampleStatisticsCollectJob newJob(List<String> partitionNames, List<String> columnNames,
-                                                              List<com.starrocks.type.Type> columnTypes,
-                                                              int allPartitionSize) {
+                                                               List<com.starrocks.type.Type> columnTypes,
+                                                               int allPartitionSize) {
         Database database = new Database(1, "test_db");
         Table table = HiveTable.builder().setTableName("test_table").build();
         return new ExternalSampleStatisticsCollectJob("test_catalog", database, table, partitionNames, columnNames,
                 columnTypes, StatsConstants.AnalyzeType.SAMPLE, StatsConstants.ScheduleType.ONCE,
                 Maps.newHashMap(), allPartitionSize);
+    }
+
+    private void clearAnalyzeStatusMap() {
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeStatusMap().clear();
     }
 
     @Test
@@ -155,5 +168,133 @@ public class ExternalSampleStatisticsCollectJobTest {
         assertTrue(sql.contains("hex(hll_serialize(hll_empty()))"), sql);
         // COUNT(1) + 6 placeholder aggregates => 7 SELECT items => 6 separating commas.
         assertEquals(6, sql.split(",").length - 1);
+    }
+
+    @Test
+    public void testFindPersistedRoundNoPriorRuns() {
+        clearAnalyzeStatusMap();
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundSkipsNativeStatus() {
+        clearAnalyzeStatusMap();
+        ExternalAnalyzeStatus nativeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        nativeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        nativeStatus.setEndTime(LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(nativeStatus);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundSkipsNonSampleType() {
+        clearAnalyzeStatusMap();
+        ExternalAnalyzeStatus fullStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.FULL,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        fullStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        fullStatus.setEndTime(LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(fullStatus);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundSkipsNonFinishedStatus() {
+        clearAnalyzeStatusMap();
+        ExternalAnalyzeStatus runningStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+        runningStatus.setStatus(StatsConstants.ScheduleStatus.RUNNING);
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(runningStatus);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundReturnsMostRecentRound() {
+        clearAnalyzeStatusMap();
+        Map<String, String> olderProps = Maps.newHashMap();
+        olderProps.put("external_sample_round", "2");
+        ExternalAnalyzeStatus older = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, olderProps, LocalDateTime.now().minusDays(1));
+        older.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        older.setEndTime(LocalDateTime.now().minusHours(1));
+
+        Map<String, String> newerProps = Maps.newHashMap();
+        newerProps.put("external_sample_round", "3");
+        ExternalAnalyzeStatus newer = new ExternalAnalyzeStatus(2, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, newerProps, LocalDateTime.now());
+        newer.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        newer.setEndTime(LocalDateTime.now());
+
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(older);
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(newer);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(3, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundMissingPropertyDefaultsZero() {
+        clearAnalyzeStatusMap();
+        ExternalAnalyzeStatus noProp = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, null, LocalDateTime.now());
+        noProp.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        noProp.setEndTime(LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(noProp);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundBadFormatDefaultsZero() {
+        clearAnalyzeStatusMap();
+        Map<String, String> props = Maps.newHashMap();
+        props.put("external_sample_round", "not_a_number");
+        ExternalAnalyzeStatus badRound = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, props, LocalDateTime.now());
+        badRound.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        badRound.setEndTime(LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(badRound);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
+    }
+
+    @Test
+    public void testFindPersistedRoundSkipsDifferentTable() {
+        clearAnalyzeStatusMap();
+        Map<String, String> props = Maps.newHashMap();
+        props.put("external_sample_round", "5");
+        ExternalAnalyzeStatus otherTable = new ExternalAnalyzeStatus(1, "other_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, props, LocalDateTime.now());
+        otherTable.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        otherTable.setEndTime(LocalDateTime.now());
+        GlobalStateMgr.getCurrentState().getAnalyzeMgr().replayAddAnalyzeStatus(otherTable);
+
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
+        assertEquals(0, job.findPersistedRound());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
@@ -18,18 +18,32 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.connector.iceberg.IcebergMetadata;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.StatsConstants.AnalyzeType;
+import com.starrocks.statistic.StatsConstants.ScheduleType;
+import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.JsonType;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.iceberg.Snapshot;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -75,6 +89,7 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testWithinThresholdConverges() {
+        // Within the default 5% threshold, NDV is considered stable.
         Map<String, Long> prev = Map.of("c1", 1000L);
         Map<String, Long> curr = Map.of("c1", 1020L);
         assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
@@ -91,6 +106,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testMissingPreviousColumnTreatedAsNotConverged() {
+        // A column that only appears in the current round (e.g. new column added mid-job)
+        // must be treated as not-converged since we have no prior value to compare against.
         Map<String, Long> prev = Map.of();
         Map<String, Long> curr = Map.of("new_column", 10L);
         assertFalse(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
@@ -141,13 +158,13 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testBuildSinglePassSQLEmitsSixAggregatesPerStatisticableColumn() {
+        // One data_size + hll + null_count + max + min + cardinality aggregate per column, in order.
         ExternalSampleStatisticsCollectJob job = newJob(List.of(),
                 Lists.newArrayList("c1", "c2"),
                 Lists.newArrayList(IntegerType.INT, IntegerType.BIGINT), 1);
         String sql = job.buildSinglePassSQL(List.of(0, 1));
 
         assertTrue(sql.startsWith("SELECT CAST(COUNT(1) AS BIGINT)"), sql);
-        // One data_size + hll + null_count + max + min + cardinality aggregate per column, in order.
         assertTrue(sql.contains("hll_serialize(IFNULL(hll_raw(`c1`), hll_empty()))"), sql);
         assertTrue(sql.contains("COUNT(1) - COUNT(`c1`)"), sql);
         assertTrue(sql.contains("hll_cardinality(IFNULL(hll_raw(`c1`), hll_empty()))"), sql);
@@ -166,12 +183,14 @@ public class ExternalSampleStatisticsCollectJobTest {
 
         assertFalse(sql.contains("hll_raw(`j1`)"), sql);
         assertTrue(sql.contains("hex(hll_serialize(hll_empty()))"), sql);
-        // COUNT(1) + 6 placeholder aggregates => 7 SELECT items => 6 separating commas.
         assertEquals(6, sql.split(",").length - 1);
     }
 
+    // ---------- findPersistedRound tests ----------
+
     @Test
     public void testFindPersistedRoundNoPriorRuns() {
+        // Empty AnalyzeMgr: no prior finished SAMPLE runs exist, default to round 0.
         clearAnalyzeStatusMap();
         ExternalSampleStatisticsCollectJob job = newJob(List.of(),
                 Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
@@ -180,6 +199,9 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundSkipsNativeStatus() {
+        // ExternalAnalyzeStatus.isNative() returns false, so it wouldn't normally be skipped by
+        // the native check. The test verifies that a standard SAMPLE + FINISHED + matching-table
+        // status IS found (but since properties are null, round defaults to 0).
         clearAnalyzeStatusMap();
         ExternalAnalyzeStatus nativeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
                 "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
@@ -195,6 +217,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundSkipsNonSampleType() {
+        // A FULL-type completed status on the same table must be ignored;
+        // only SAMPLE-type runs contribute to warm start.
         clearAnalyzeStatusMap();
         ExternalAnalyzeStatus fullStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
                 "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.FULL,
@@ -210,6 +234,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundSkipsNonFinishedStatus() {
+        // A RUNNING (or FAILED) status must not be used for warm start, even if it matches the
+        // same table — only FINISH runs are considered.
         clearAnalyzeStatusMap();
         ExternalAnalyzeStatus runningStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
                 "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
@@ -224,6 +250,7 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundReturnsMostRecentRound() {
+        // Two FINISHED SAMPLE runs exist for the same table; pick the one with the latest endTime.
         clearAnalyzeStatusMap();
         Map<String, String> olderProps = Maps.newHashMap();
         olderProps.put("external_sample_round", "2");
@@ -251,6 +278,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundMissingPropertyDefaultsZero() {
+        // A FINISHED SAMPLE run exists but has no "external_sample_round" property (or properties
+        // are null). Default to round 0.
         clearAnalyzeStatusMap();
         ExternalAnalyzeStatus noProp = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
                 "uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
@@ -266,6 +295,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundBadFormatDefaultsZero() {
+        // The "external_sample_round" property is present but contains a non-numeric string.
+        // Integer.parseInt throws NumberFormatException → round defaults to 0.
         clearAnalyzeStatusMap();
         Map<String, String> props = Maps.newHashMap();
         props.put("external_sample_round", "not_a_number");
@@ -283,6 +314,8 @@ public class ExternalSampleStatisticsCollectJobTest {
 
     @Test
     public void testFindPersistedRoundSkipsDifferentTable() {
+        // A FINISHED SAMPLE run exists but for a different catalog; must not match the current
+        // table and must not influence warm start.
         clearAnalyzeStatusMap();
         Map<String, String> props = Maps.newHashMap();
         props.put("external_sample_round", "5");
@@ -296,5 +329,182 @@ public class ExternalSampleStatisticsCollectJobTest {
         ExternalSampleStatisticsCollectJob job = newJob(List.of(),
                 Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 1);
         assertEquals(0, job.findPersistedRound());
+    }
+
+    // ---------- collectIcebergWithFileSampling tests ----------
+
+    private static IcebergTable createMockIcebergTable(boolean hasSnapshot) {
+        org.apache.iceberg.Table mockNativeTable = Mockito.mock(org.apache.iceberg.Table.class);
+        if (hasSnapshot) {
+            Snapshot mockSnapshot = Mockito.mock(Snapshot.class);
+            Mockito.when(mockNativeTable.currentSnapshot()).thenReturn(mockSnapshot);
+            Mockito.when(mockSnapshot.snapshotId()).thenReturn(42L);
+        } else {
+            Mockito.when(mockNativeTable.currentSnapshot()).thenReturn(null);
+        }
+        return new IcebergTable(1, "test_table", "test_catalog", "resource",
+                "test_db", "test_table", "uuid", Lists.newArrayList(), mockNativeTable, Maps.newHashMap());
+    }
+
+    private static TResultBatch wideRowBatch() {
+        TResultBatch batch = new TResultBatch();
+        batch.setRows(Lists.newArrayList(
+                ByteBuffer.wrap(JSON_RESULT.getBytes(StandardCharsets.UTF_8))));
+        batch.setIs_compressed(false);
+        batch.setPacket_seq(0);
+        return batch;
+    }
+
+    private static final String JSON_RESULT =
+            "{\"data\": [100, 500, \"00\", 0, \"100\", \"1\", 50," +
+                    " 500, \"00\", 0, \"200\", \"10\", 80]}";
+
+    private static long capturedFileCount = 0;
+    private static long capturedRowCount = 0;
+
+    @Test
+    public void testCollectIcebergWithFileSamplingNullSnapshot() throws Exception {
+        // Empty table with no snapshot: the method must return early without error.
+        IcebergTable icebergTable = createMockIcebergTable(false);
+
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getUUID() {
+                return "test_catalog.test_db.test_table.uuid";
+            }
+        };
+
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            protected void flushInsertStatisticsData(ConnectContext ctx, boolean all) { }
+        };
+
+        ExternalSampleStatisticsCollectJob job = new ExternalSampleStatisticsCollectJob("test_catalog",
+                new Database(1, "test_db"), icebergTable, List.of(), Lists.newArrayList("c1"),
+                Lists.newArrayList(IntegerType.INT),
+                AnalyzeType.SAMPLE, ScheduleType.ONCE, Maps.newHashMap(), 1);
+
+        ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1"), AnalyzeType.SAMPLE, ScheduleType.ONCE,
+                Maps.newHashMap(), LocalDateTime.now());
+
+        job.collect(UtFrameUtils.createDefaultCtx(), analyzeStatus);
+    }
+
+    @Test
+    public void testCollectIcebergWithFileSamplingFullScanSingleRound() throws Exception {
+        // Table with 1M rows (<= capPerRound=2M): first round reaches full coverage (ratio=1.0),
+        // round loop breaks, cleanup runs, analyzeStatus properties are populated.
+        IcebergTable icebergTable = createMockIcebergTable(true);
+        capturedFileCount = 5L;
+        capturedRowCount = 1_000_000L;
+
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getUUID() {
+                return "test_catalog.test_db.test_table.uuid";
+            }
+        };
+
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            protected void flushInsertStatisticsData(ConnectContext ctx, boolean all) { }
+        };
+
+        new MockUp<IcebergMetadata>() {
+            @Mock
+            public static long countIcebergFilesFromManifestList(IcebergTable t, long sid) {
+                return capturedFileCount;
+            }
+
+            @Mock
+            public static long countIcebergRowsFromManifestList(IcebergTable t, long sid) {
+                return capturedRowCount;
+            }
+        };
+
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TResultBatch> executeDQL(ConnectContext ctx, String sql, TResultSinkType st) {
+                return Lists.newArrayList(wideRowBatch());
+            }
+        };
+
+        ExternalSampleStatisticsCollectJob job = new ExternalSampleStatisticsCollectJob("test_catalog",
+                new Database(1, "test_db"), icebergTable, List.of(), Lists.newArrayList("c1", "c2"),
+                Lists.newArrayList(IntegerType.INT, IntegerType.INT),
+                AnalyzeType.SAMPLE, ScheduleType.ONCE, Maps.newHashMap(), 1);
+
+        ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1", "c2"), AnalyzeType.SAMPLE, ScheduleType.ONCE,
+                Maps.newHashMap(), LocalDateTime.now());
+        analyzeStatus.setStartTime(LocalDateTime.now());
+
+        job.collect(UtFrameUtils.createDefaultCtx(), analyzeStatus);
+
+        Map<String, String> props = analyzeStatus.getProperties();
+        assertTrue(props.containsKey("file_count"));
+        assertTrue(props.containsKey("row_count"));
+    }
+
+    @Test
+    public void testCollectIcebergWithFileSamplingAllDroppedRetry() throws Exception {
+        // Simulate the edge case where Bernoulli sampling at a low ratio drops every split.
+        // The first executeDQL call returns an empty list (all splits dropped); the method
+        // must detect this, log a warning, and retry the round with ratio=1.0.
+        IcebergTable icebergTable = createMockIcebergTable(true);
+        capturedFileCount = 10L;
+        capturedRowCount = 10_000_000L;
+
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getUUID() {
+                return "test_catalog.test_db.test_table.uuid";
+            }
+        };
+
+        new MockUp<ExternalFullStatisticsCollectJob>() {
+            @Mock
+            protected void flushInsertStatisticsData(ConnectContext ctx, boolean all) { }
+        };
+
+        new MockUp<IcebergMetadata>() {
+            @Mock
+            public static long countIcebergFilesFromManifestList(IcebergTable t, long sid) {
+                return capturedFileCount;
+            }
+
+            @Mock
+            public static long countIcebergRowsFromManifestList(IcebergTable t, long sid) {
+                return capturedRowCount;
+            }
+        };
+
+        AtomicInteger executeDqlCalls = new AtomicInteger(0);
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<TResultBatch> executeDQL(ConnectContext ctx, String sql, TResultSinkType st) {
+                int call = executeDqlCalls.getAndIncrement();
+                if (call == 0) {
+                    return List.of();
+                }
+                return Lists.newArrayList(wideRowBatch());
+            }
+        };
+
+        ExternalSampleStatisticsCollectJob job = new ExternalSampleStatisticsCollectJob("test_catalog",
+                new Database(1, "test_db"), icebergTable, List.of(), Lists.newArrayList("c1", "c2"),
+                Lists.newArrayList(IntegerType.INT, IntegerType.INT),
+                AnalyzeType.SAMPLE, ScheduleType.ONCE, Maps.newHashMap(), 1);
+
+        ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "uuid", Lists.newArrayList("c1", "c2"), AnalyzeType.SAMPLE, ScheduleType.ONCE,
+                Maps.newHashMap(), LocalDateTime.now());
+        analyzeStatus.setStartTime(LocalDateTime.now());
+
+        job.collect(UtFrameUtils.createDefaultCtx(), analyzeStatus);
+
+        // First call returned empty (simulated all-dropped), retry with ratio=1.0 succeeded.
+        assertEquals(2, executeDqlCalls.get());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/ExternalSampleStatisticsCollectJobTest.java
@@ -14,14 +14,34 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.JsonType;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExternalSampleStatisticsCollectJobTest {
+
+    private static ExternalSampleStatisticsCollectJob newJob(List<String> partitionNames, List<String> columnNames,
+                                                              List<com.starrocks.type.Type> columnTypes,
+                                                              int allPartitionSize) {
+        Database database = new Database(1, "test_db");
+        Table table = HiveTable.builder().setTableName("test_table").build();
+        return new ExternalSampleStatisticsCollectJob("test_catalog", database, table, partitionNames, columnNames,
+                columnTypes, StatsConstants.AnalyzeType.SAMPLE, StatsConstants.ScheduleType.ONCE,
+                Maps.newHashMap(), allPartitionSize);
+    }
 
     @Test
     public void testLowCardinalityColumnConverges() {
@@ -69,5 +89,71 @@ public class ExternalSampleStatisticsCollectJobTest {
         Map<String, Long> prev = Map.of("all_null", 0L);
         Map<String, Long> curr = Map.of("all_null", 0L);
         assertTrue(ExternalSampleStatisticsCollectJob.isNdvConverging(prev, curr, 0.05));
+    }
+
+    @Test
+    public void testGetSampledPartitionsHashValueAndAllPartitionSizeDefaultToLegacyPartitionSelection() {
+        // Before Iceberg file sampling has run (or for a non-Iceberg SAMPLE job that never sets
+        // usedFileSampling), these must report the factory's real partition pre-selection, since
+        // that's what Hive-style partition sampling actually depends on.
+        ExternalSampleStatisticsCollectJob job = newJob(Lists.newArrayList("p1", "p2"),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 5);
+        assertEquals(5, job.getAllPartitionSize());
+        assertEquals(2, job.getSampledPartitionsHashValue().size());
+    }
+
+    @Test
+    public void testGetSampledPartitionsHashValueAndAllPartitionSizeAreNeutralAfterFileSampling() {
+        // Once Iceberg's whole-table file sampling has run, row_count/data_size/null_count are
+        // already rescaled to a full-table estimate during collection (see
+        // collectSinglePassStatisticSync); StatisticsUtils#estimateColumnStatistics must not apply
+        // its own allPartitionSize / sampledPartitionsHashValue().size() rescale on top of that, or
+        // a partitioned Iceberg table's row count gets inflated a second time. Reporting a fixed
+        // 1-of-1 split keeps that downstream rescale a no-op.
+        ExternalSampleStatisticsCollectJob job = newJob(Lists.newArrayList("p1", "p2"),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 5);
+        job.usedFileSampling = true;
+        assertEquals(1, job.getAllPartitionSize());
+        Set<Long> sampled = job.getSampledPartitionsHashValue();
+        assertEquals(1, sampled.size());
+
+        // A second, independently-constructed job must report the exact same neutral hash value so
+        // StatisticExecutor's cross-run union (sampledPartitions.addAll(...)) never grows past size
+        // 1 -- growing past 1 would silently reintroduce the double-rescale this is meant to avoid.
+        ExternalSampleStatisticsCollectJob otherJob = newJob(Lists.newArrayList("p3"),
+                Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT), 9);
+        otherJob.usedFileSampling = true;
+        assertEquals(sampled, otherJob.getSampledPartitionsHashValue());
+    }
+
+    @Test
+    public void testBuildSinglePassSQLEmitsSixAggregatesPerStatisticableColumn() {
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("c1", "c2"),
+                Lists.newArrayList(IntegerType.INT, IntegerType.BIGINT), 1);
+        String sql = job.buildSinglePassSQL(List.of(0, 1));
+
+        assertTrue(sql.startsWith("SELECT CAST(COUNT(1) AS BIGINT)"), sql);
+        // One data_size + hll + null_count + max + min + cardinality aggregate per column, in order.
+        assertTrue(sql.contains("hll_serialize(IFNULL(hll_raw(`c1`), hll_empty()))"), sql);
+        assertTrue(sql.contains("COUNT(1) - COUNT(`c1`)"), sql);
+        assertTrue(sql.contains("hll_cardinality(IFNULL(hll_raw(`c1`), hll_empty()))"), sql);
+        assertTrue(sql.contains("hll_serialize(IFNULL(hll_raw(`c2`), hll_empty()))"), sql);
+        assertTrue(sql.endsWith("FROM `test_catalog`.`test_db`.`test_table`"), sql);
+    }
+
+    @Test
+    public void testBuildSinglePassSQLUsesConstantPlaceholdersForNonStatisticableColumns() {
+        // JSON columns can't be statistic'd (Type#canStatistic()); the wide row must still emit the
+        // same six aggregate slots (via constant placeholders) so the caller's fixed base-offset
+        // decoding (base, base+1, ..., base+5) lines up regardless of column type.
+        ExternalSampleStatisticsCollectJob job = newJob(List.of(),
+                Lists.newArrayList("j1"), Lists.newArrayList(JsonType.JSON), 1);
+        String sql = job.buildSinglePassSQL(List.of(0));
+
+        assertFalse(sql.contains("hll_raw(`j1`)"), sql);
+        assertTrue(sql.contains("hex(hll_serialize(hll_empty()))"), sql);
+        // COUNT(1) + 6 placeholder aggregates => 7 SELECT items => 6 separating commas.
+        assertEquals(6, sql.split(",").length - 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticExecutorTest.java
@@ -16,15 +16,23 @@ package com.starrocks.statistic;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.thrift.TStatisticData;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -58,5 +66,46 @@ public class StatisticExecutorTest extends PlanTestBase {
         List<TStatisticData> stats = statisticExecutor.queryStatisticSync(
                 StatisticUtils.buildConnectContext(), null, 1000L, Lists.newArrayList("foo", "bar"));
         Assertions.assertEquals(0, stats.size());
+    }
+
+    @Test
+    public void testExecuteWideRowDQL() {
+        String json1 = "{\"data\": [100, \"string_val\", 0, 10, 1]}";
+        String json2 = "{\"data\": [200, \"another\", 1, 20, 2]}";
+        TResultBatch batch = new TResultBatch();
+        batch.setRows(Lists.newArrayList(
+                ByteBuffer.wrap(json1.getBytes(StandardCharsets.UTF_8)),
+                ByteBuffer.wrap(json2.getBytes(StandardCharsets.UTF_8))));
+        batch.setIs_compressed(false);
+        batch.setPacket_seq(0);
+
+        List<TResultBatch> mockResult = Lists.newArrayList(batch);
+
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            List<TResultBatch> executeDQL(ConnectContext context, String sql,
+                                                    TResultSinkType sinkType) {
+                return mockResult;
+            }
+        };
+
+        StatisticExecutor executor = new StatisticExecutor();
+        List<JsonArray> rows = executor.executeWideRowDQL(
+                StatisticUtils.buildConnectContext(), "SELECT 1");
+
+        Assertions.assertEquals(2, rows.size());
+
+        JsonArray row0 = rows.get(0);
+        Assertions.assertEquals(5, row0.size());
+        Assertions.assertEquals(100, row0.get(0).getAsInt());
+        Assertions.assertEquals("string_val", row0.get(1).getAsString());
+        Assertions.assertEquals(0, row0.get(2).getAsInt());
+        Assertions.assertEquals(10, row0.get(3).getAsInt());
+        Assertions.assertEquals(1, row0.get(4).getAsInt());
+
+        JsonArray row1 = rows.get(1);
+        Assertions.assertEquals(5, row1.size());
+        Assertions.assertEquals(200, row1.get(0).getAsInt());
+        Assertions.assertEquals("another", row1.get(1).getAsString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticSQLBuilderTest.java
@@ -19,6 +19,7 @@ import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 // external_column_statistics / external_histogram_statistics store table_uuid hashed
@@ -144,5 +145,40 @@ class StatisticSQLBuilderTest {
         Assertions.assertTrue(sql.contains("TABLE_UUID = 'iceberg.db.o''brien\\\\table.uuid'"), sql);
         Assertions.assertTrue(sql.contains("PARTITION_NAME IN ('p''1')"), sql);
         Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c\\\\1')"), sql);
+    }
+
+    // --- Iceberg SAMPLE sentinel-row cleanup (FULL/SAMPLE double-counting fix) ---
+    // buildDropExternalStatExcludingPartitionSQL / buildDropExternalStatForPartitionSQL also match
+    // both the hashed and raw table_uuid (buildTableUUIDInPredicateQuoted), for the same reason as
+    // every other predicate in this class: the rows being cleaned up may have been written before
+    // or after the hashing migration.
+
+    @Test
+    void testBuildDropExternalStatExcludingPartitionSQL() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage("uuid-1");
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", List.of("c1", "c2"));
+        Assertions.assertTrue(sql.contains("DELETE FROM external_column_statistics"));
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', 'uuid-1')"));
+        Assertions.assertTrue(sql.contains("PARTITION_NAME != '$FILE_SAMPLE$'"));
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c1', 'c2')"));
+    }
+
+    @Test
+    void testBuildDropExternalStatExcludingPartitionSQLNoColumns() {
+        String sql = StatisticSQLBuilder.buildDropExternalStatExcludingPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", Collections.emptyList());
+        Assertions.assertTrue(sql.contains("PARTITION_NAME != '$FILE_SAMPLE$'"));
+        Assertions.assertFalse(sql.contains("COLUMN_NAME"));
+    }
+
+    @Test
+    void testBuildDropExternalStatForPartitionSQL() {
+        String hashed = StatisticUtils.hashTableUuidForPkStorage("uuid-1");
+        String sql = StatisticSQLBuilder.buildDropExternalStatForPartitionSQL(
+                "uuid-1", "$FILE_SAMPLE$", List.of("c1"));
+        Assertions.assertTrue(sql.contains("table_uuid in ('" + hashed + "', 'uuid-1')"));
+        Assertions.assertTrue(sql.contains("PARTITION_NAME = '$FILE_SAMPLE$'"));
+        Assertions.assertTrue(sql.contains("COLUMN_NAME IN ('c1')"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -17,6 +17,7 @@ package com.starrocks.statistic;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.OlapTable;
@@ -34,6 +35,8 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.AnalyzeStmt;
 import com.starrocks.sql.ast.DropHistogramStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -52,6 +55,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class StatisticsExecutorTest extends PlanTestBase {
@@ -278,6 +282,52 @@ public class StatisticsExecutorTest extends PlanTestBase {
                 getExternalTableBasicStatsMeta("test_catalog", "test_db", "test_table");
         Assertions.assertEquals(externalBasicStatsMeta.getColumns(), Lists.newArrayList("col1", "col3"));
         Assertions.assertEquals(externalBasicStatsMeta.getColumnStatsMetaMap().size(), 3);
+    }
+
+    @Test
+    public void testCollectSinglePassStatisticSyncScalesSampleLocalAggregatesToFullTableEstimate() throws Exception {
+        // Iceberg's single-pass wide-row sampling round: row_count is scaled by 1/ratio to a
+        // full-table estimate, and data_size/null_count must be scaled the exact same way -- readers
+        // compute averageRowSize = data_size / row_count and nullsFraction = null_count / row_count,
+        // so leaving those two sample-local while row_count is full-table would make both ~ratio
+        // times too small. NDV cardinality is returned unscaled (it's an in-memory convergence
+        // signal compared round-over-round, not a persisted column).
+        Database database = new Database(1, "test_db");
+        Table table = HiveTable.builder().setTableName("test_table").build();
+        ExternalSampleStatisticsCollectJob job = new ExternalSampleStatisticsCollectJob("test_catalog",
+                database, table, List.of(), Lists.newArrayList("c1"), Lists.newArrayList(IntegerType.INT),
+                StatsConstants.AnalyzeType.SAMPLE, StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), 1);
+
+        JsonArray sampledRow = new JsonArray();
+        sampledRow.add(100); // sampled row_count
+        sampledRow.add(500); // sampled data_size
+        sampledRow.add("deadbeef"); // hll hex
+        sampledRow.add(3); // sampled null_count
+        sampledRow.add("zmax"); // max
+        sampledRow.add("amin"); // min
+        sampledRow.add(42); // ndv cardinality (never scaled)
+
+        new MockUp<StatisticExecutor>() {
+            @Mock
+            public List<JsonArray> executeWideRowDQL(ConnectContext context, String sql) {
+                return List.of(sampledRow);
+            }
+        };
+
+        ExternalAnalyzeStatus analyzeStatus = new ExternalAnalyzeStatus(1, "test_catalog", "test_db", "test_table",
+                "test-uuid", Lists.newArrayList("c1"), StatsConstants.AnalyzeType.SAMPLE,
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.now());
+
+        Map<String, Long> cardinalityByColumn = job.collectSinglePassStatisticSync(
+                "SELECT ...", List.of(0), connectContext, analyzeStatus, 0.5);
+
+        Assertions.assertEquals(42L, cardinalityByColumn.get("c1"));
+
+        Assertions.assertEquals(1, job.rowsBuffer.size());
+        List<Expr> row = job.rowsBuffer.get(0);
+        Assertions.assertEquals(200L, ((IntLiteral) row.get(6)).getLongValue(), "row_count must be scaled by 1/ratio");
+        Assertions.assertEquals(1000L, ((IntLiteral) row.get(7)).getLongValue(), "data_size must scale the same way");
+        Assertions.assertEquals(6L, ((IntLiteral) row.get(9)).getLongValue(), "null_count must scale the same way");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
Today, `ANALYZE ... SAMPLE` on an Iceberg external table just picks the latest N partitions and does a **full scan** of them. Cost is unbounded whenever a single partition is large — a table with a few TB-scale partitions makes SAMPLE ANALYZE effectively as expensive as FULL, defeating the point of sampling. We want a sampling strategy that:

- Works at the file level across the whole table (not scoped to a handful of partitions),
- Has a hard, predictable cost cap regardless of table size,
- Gets more accurate over time without needing a separate full scan,
- Requires zero BE changes.


## What I'm doing:
Add a Bernoulli file-sampling layer that FE applies to the scan plan right after Iceberg's file list is split into scan units, before scan ranges are handed to BE. Each unit is independently kept/dropped by a probability `ratio`; dropped units cost zero IO and BE never knows sampling happened.


```
read total row_count (Iceberg manifest-list summary fields, zero data IO)
        │
        ▼
round loop (inside one ANALYZE execution, resumes from last run's round):
    rowsThisRound = min(row_count, cap << round)      // cap doubles each round
    ratio = min(1.0, rowsThisRound / row_count)
    → run one sampled collection pass, upsert into stats table
    → stop once ratio hits 1.0 (full coverage) or max rounds reached
        │
        ▼
planFiles() → split into scan units (existing parallelism logic, unchanged)
        → Bernoulli filter(ratio)   // FE-only, drops units before scan ranges are built
        → scan ranges → BE (scans only the kept units)
```

Key pieces:
- **Ratio is row-count calibrated, with an absolute cap**: `ratio = min(1.0, targetRows / totalRows)`, where `totalRows` comes from Iceberg manifest-list summary fields (no data files opened). This bounds a single round's cost by an absolute row budget instead of a bare percentage, so cost stays predictable even for astronomically large tables.
- **Progressive rounds, warm-started across scheduled runs**: within one ANALYZE execution, the target row budget doubles each round until it reaches full coverage or a max-round limit. The round index is persisted in `AnalyzeStatus` properties so the *next* scheduled run resumes from where the last one left off, instead of always restarting at the smallest ratio.
- **Sampling ratio flows through session variables, not SQL text**: the ANALYZE job sets two invisible session variables on its own connection; the Iceberg connector reads them when building the scan. A tricky gotcha worth flagging: the connector has a query-planning-time file-list cache keyed without the sampling ratio — if left alone, cost-estimation would populate that cache with the *unsampled* file list under the same key, and the sampled execution would silently hit that cache and skip sampling entirely. Sampled requests now bypass that cache.
- **Statistics computed from the same sampled pass**: row count is rescaled by `1/ratio`; NDV and min/max are used as-is from the sampled rows (a conservative, CBO-safe direction — no rescaling attempted).
- Hive, Delta, and other external table types are untouched; they keep the existing "latest N partitions, full scan" sampling behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5