### PR TITLE
[BugFix] Make flat_json config reliable on the shared-data write path

### DIFF
--- a/be/src/data_sink/tablet/olap_table_sink.cpp
+++ b/be/src/data_sink/tablet/olap_table_sink.cpp
@@ -99,6 +99,10 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _merge_condition = table_sink.merge_condition;
     _encryption_meta = table_sink.encryption_meta;
     _partial_update_mode = table_sink.partial_update_mode;
+    if (table_sink.__isset.flat_json_config) {
+        _has_flat_json_config = true;
+        _flat_json_config = table_sink.flat_json_config;
+    }
     _load_id.set_hi(table_sink.load_id.hi);
     _load_id.set_lo(table_sink.load_id.lo);
     _txn_id = table_sink.txn_id;

--- a/be/src/data_sink/tablet/olap_table_sink.h
+++ b/be/src/data_sink/tablet/olap_table_sink.h
@@ -176,6 +176,10 @@ private:
     std::string _merge_condition;
     std::string _encryption_meta;
     TPartialUpdateMode::type _partial_update_mode;
+    // Table-level Flat JSON policy carried with the load plan (shared-data). Copied into
+    // each PTabletWriterOpenRequest so the target CN's segment writer uses the FE value.
+    bool _has_flat_json_config = false;
+    TFlatJsonConfig _flat_json_config;
 
     // this is tuple descriptor of destination OLAP table
     TupleDescriptor* _output_tuple_desc = nullptr;

--- a/be/src/data_sink/tablet/tablet_sink_index_channel.cpp
+++ b/be/src/data_sink/tablet/tablet_sink_index_channel.cpp
@@ -43,6 +43,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/serde/protobuf_chunk_serde.h"
 #include "runtime/service_contexts.h"
+#include "storage_primitive/flat_json_config.h"
 
 namespace starrocks {
 
@@ -242,6 +243,11 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
         request.set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE);
     } else if (_parent->_partial_update_mode == TPartialUpdateMode::type::COLUMN_UPDATE_MODE) {
         request.set_partial_update_mode(PartialUpdateMode::COLUMN_UPDATE_MODE);
+    }
+    if (_parent->_has_flat_json_config) {
+        FlatJsonConfig flat_json_config;
+        flat_json_config.update(_parent->_flat_json_config);
+        flat_json_config.to_pb(request.mutable_flat_json_config());
     }
     request.set_allocated_id(&_parent->_load_id);
     request.set_index_id(index_id);

--- a/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
+++ b/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
@@ -964,6 +964,14 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
             // already created for the tablet, usually in incremental open case
             continue;
         }
+        // Flat JSON policy carried with the load plan (FE-authoritative). When present, the
+        // segment writer uses it instead of the best-effort tablet-metadata cache. Same value
+        // for every tablet in this channel.
+        std::shared_ptr<FlatJsonConfig> flat_json_config;
+        if (params.has_flat_json_config()) {
+            flat_json_config = std::make_shared<FlatJsonConfig>();
+            flat_json_config->update(params.flat_json_config());
+        }
         ASSIGN_OR_RETURN(auto writer, lake::AsyncDeltaWriterBuilder()
                                               .set_tablet_manager(_tablet_manager)
                                               .set_tablet_id(tablet.tablet_id())
@@ -971,6 +979,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_partition_id(tablet.partition_id())
                                               .set_slot_descriptors(slots)
                                               .set_merge_condition(params.merge_condition())
+                                              .set_flat_json_config(flat_json_config)
                                               .set_miss_auto_increment_column(params.miss_auto_increment_column())
                                               .set_db_id(_schema->db_id())
                                               .set_table_id(params.table_id())

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -462,6 +462,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_partition_id(_partition_id)
                                           .set_slot_descriptors(_slots)
                                           .set_merge_condition(_merge_condition)
+                                          .set_flat_json_config(_flat_json_config)
                                           .set_mem_tracker(_mem_tracker)
                                           .set_immutable_tablet_size(_immutable_tablet_size)
                                           .set_miss_auto_increment_column(_miss_auto_increment_column)

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -30,6 +30,7 @@
 namespace starrocks {
 class MemTracker;
 class SlotDescriptor;
+class FlatJsonConfig;
 } // namespace starrocks
 
 namespace starrocks {
@@ -196,6 +197,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_flat_json_config(std::shared_ptr<FlatJsonConfig> flat_json_config) {
+        _flat_json_config = std::move(flat_json_config);
+        return *this;
+    }
+
     AsyncDeltaWriterBuilder& set_schema_id(int64_t schema_id) {
         _schema_id = schema_id;
         return *this;
@@ -250,6 +256,7 @@ private:
     int64_t _immutable_tablet_size{0};
     MemTracker* _mem_tracker{nullptr};
     std::string _merge_condition{};
+    std::shared_ptr<FlatJsonConfig> _flat_json_config;
     bool _miss_auto_increment_column{false};
     PartialUpdateMode _partial_update_mode{PartialUpdateMode::ROW_MODE};
     const std::map<std::string, std::string>* _column_to_expr_value{nullptr};

--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -140,10 +140,13 @@ StatusOr<std::unique_ptr<SegmentWriter>> ColumnModePartialUpdateHandler::_prepar
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     SegmentWriterOptions writer_options;
 
-    if (auto metadata = params.tablet->tablet_mgr()->get_latest_cached_tablet_metadata(params.tablet->id());
-        metadata && metadata->has_flat_json_config()) {
+    // Take flat_json from the exact version being written (params.metadata, already in scope and
+    // used just below for the DCG loader), not the best-effort latest-metadata cache. A cold-cache
+    // miss would otherwise silently drop the table's flat_json policy for delta-column writes,
+    // which is the same cache-reliability defect this change removes on the normal write path.
+    if (params.metadata != nullptr && params.metadata->has_flat_json_config()) {
         writer_options.flat_json_config = std::make_shared<FlatJsonConfig>();
-        writer_options.flat_json_config->update(metadata->flat_json_config());
+        writer_options.flat_json_config->update(params.metadata->flat_json_config());
     }
 
     if (config::enable_transparent_data_encryption) {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -125,7 +125,8 @@ public:
                              const std::map<string, string>* column_to_expr_value, PUniqueId load_id,
                              RuntimeProfile* profile, BundleWritableFileContext* bundle_writable_file_context,
                              GlobalDictByNameMaps* global_dicts, bool is_multi_statements_txn,
-                             std::shared_ptr<const TabletSchema> tablet_schema, bool force_build_vector_index_inline)
+                             std::shared_ptr<const TabletSchema> tablet_schema, bool force_build_vector_index_inline,
+                             std::shared_ptr<FlatJsonConfig> flat_json_config)
             : _tablet_manager(tablet_manager),
               _tablet_id(tablet_id),
               _txn_id(txn_id),
@@ -147,7 +148,8 @@ public:
               _bundle_writable_file_context(bundle_writable_file_context),
               _global_dicts(global_dicts),
               _is_multi_statements_txn(is_multi_statements_txn),
-              _force_build_vector_index_inline(force_build_vector_index_inline) {}
+              _force_build_vector_index_inline(force_build_vector_index_inline),
+              _flat_json_config(std::move(flat_json_config)) {}
 
     ~DeltaWriterImpl() = default;
 
@@ -335,6 +337,11 @@ private:
     // shadow tablet's existing data is fully indexed during the ALTER, matching DirectSchemaChange.
     bool _force_build_vector_index_inline = false;
 
+    // Table-level Flat JSON policy carried from the load plan (shared-data). When set, it is
+    // handed to the internal TabletWriter so the segment writer decides flattening from this
+    // FE-authoritative value instead of the best-effort tablet-metadata cache.
+    std::shared_ptr<FlatJsonConfig> _flat_json_config;
+
     // Record the time when DeltaWriter is opened
     int64_t _begin_time_ms = 0;
 
@@ -429,6 +436,9 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         }
         if (_force_build_vector_index_inline) {
             _tablet_writer->force_set_build_vector_index_inline();
+        }
+        if (_flat_json_config != nullptr) {
+            _tablet_writer->set_flat_json_config(_flat_json_config);
         }
         RETURN_IF_ERROR(_tablet_writer->open());
         if (should_enable_load_spill()) {
@@ -1311,7 +1321,7 @@ StatusOr<DeltaWriterBuilder::DeltaWriterPtr> DeltaWriterBuilder::build() {
             _tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition, _miss_auto_increment_column,
             _db_id, _table_id, _immutable_tablet_size, _mem_tracker, _max_buffer_size, _schema_id, _partial_update_mode,
             _column_to_expr_value, _load_id, _profile, _bundle_writable_file_context, _global_dicts,
-            _is_multi_statements_txn, _tablet_schema, _force_build_vector_index_inline);
+            _is_multi_statements_txn, _tablet_schema, _force_build_vector_index_inline, _flat_json_config);
     return std::make_unique<DeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -32,6 +32,7 @@ class MemTracker;
 class SlotDescriptor;
 class Chunk;
 class TabletSchema;
+class FlatJsonConfig;
 class ThreadPool;
 struct FileInfo;
 class TxnLogPB;
@@ -235,6 +236,13 @@ public:
         return *this;
     }
 
+    // Table-level Flat JSON policy carried from the load plan. When set, the internal
+    // TabletWriter uses it to decide JSON flattening instead of the tablet-metadata cache.
+    DeltaWriterBuilder& set_flat_json_config(std::shared_ptr<FlatJsonConfig> flat_json_config) {
+        _flat_json_config = std::move(flat_json_config);
+        return *this;
+    }
+
     DeltaWriterBuilder& set_immutable_tablet_size(int64_t immutable_tablet_size) {
         _immutable_tablet_size = immutable_tablet_size;
         return *this;
@@ -324,6 +332,7 @@ private:
     int64_t _tablet_id{0};
     const std::vector<SlotDescriptor*>* _slots{nullptr};
     std::string _merge_condition{};
+    std::shared_ptr<FlatJsonConfig> _flat_json_config;
     int64_t _immutable_tablet_size{0};
     MemTracker* _mem_tracker{nullptr};
     int64_t _max_buffer_size{0};

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -229,6 +229,12 @@ StatusOr<std::unique_ptr<TabletWriter>> HorizontalGeneralTabletWriter::clone() c
                                                             _flush_pool, _bundle_file_context, _global_dicts);
     RETURN_IF_ERROR(writer->open());
     writer->set_auto_flush(auto_flush());
+    // Propagate the plan-carried Flat JSON policy so spill-merged segments (built through cloned
+    // writers, see LoadSpillPipelineMergeIterator) keep using the FE-authoritative value instead of
+    // falling back to the best-effort tablet-metadata cache.
+    if (flat_json_config() != nullptr) {
+        writer->set_flat_json_config(flat_json_config());
+    }
     // Propagate the force-inline flag: spilled sorted schema changes merge through cloned writers
     // (LoadSpillPipelineMergeIterator). Without this, clones default to false and defer .vi building
     // even though the schema-change job stamped the shadow tablets' vibv as already built, so the
@@ -246,8 +252,13 @@ Status HorizontalGeneralTabletWriter::reset_segment_writer(bool eos) {
     opts.is_compaction = _is_compaction;
     opts.vector_index_build_threshold = get_vector_index_build_threshold(_schema);
 
-    if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
-        metadata && metadata->has_flat_json_config()) {
+    if (flat_json_config() != nullptr) {
+        // Plan-carried, FE-authoritative Flat JSON policy (shared-data). Preferred over the
+        // best-effort tablet-metadata cache so the flatten decision does not depend on cache
+        // warmth and honors the current table property (including after ALTER, via the plan).
+        opts.flat_json_config = flat_json_config();
+    } else if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
+               metadata && metadata->has_flat_json_config()) {
         opts.flat_json_config = std::make_shared<FlatJsonConfig>();
         opts.flat_json_config->update(metadata->flat_json_config());
     }
@@ -566,8 +577,13 @@ StatusOr<std::shared_ptr<SegmentWriter>> VerticalGeneralTabletWriter::create_seg
     opts.is_compaction = _is_compaction;
     opts.vector_index_build_threshold = get_vector_index_build_threshold(_schema);
 
-    if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
-        metadata && metadata->has_flat_json_config()) {
+    if (flat_json_config() != nullptr) {
+        // Plan-carried, FE-authoritative Flat JSON policy (shared-data). Preferred over the
+        // best-effort tablet-metadata cache so the flatten decision does not depend on cache
+        // warmth and honors the current table property (including after ALTER, via the plan).
+        opts.flat_json_config = flat_json_config();
+    } else if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
+               metadata && metadata->has_flat_json_config()) {
         opts.flat_json_config = std::make_shared<FlatJsonConfig>();
         opts.flat_json_config->update(metadata->flat_json_config());
     }

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -173,6 +173,12 @@ StatusOr<std::unique_ptr<TabletWriter>> HorizontalPkTabletWriter::clone() const 
         writer->force_set_enable_pk_index_eager_build();
     }
     writer->set_auto_flush(auto_flush());
+    // Propagate the plan-carried Flat JSON policy so spill-merged segments (built through cloned
+    // writers, see LoadSpillPipelineMergeIterator) keep using the FE-authoritative value instead of
+    // falling back to the best-effort tablet-metadata cache.
+    if (flat_json_config() != nullptr) {
+        writer->set_flat_json_config(flat_json_config());
+    }
     return writer;
 }
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -271,10 +271,15 @@ Status TabletReader::init_compaction_column_paths(const TabletReaderParams& read
             // must all be flat json type
             JsonPathDeriver deriver;
 
-            if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_metadata->id());
-                metadata && metadata->has_flat_json_config()) {
+            // Take flat_json from the exact version being compacted (_tablet_metadata, already in
+            // scope), not the best-effort latest-metadata cache. This keeps the compaction reader's
+            // path derivation consistent with the writer (VersionedTablet::new_writer_with_schema):
+            // on a cold-cache miss the cache returns null, so reading it here would fall back to
+            // default flatten factors while the writer uses the version's factors, and the two
+            // halves of the same compaction would disagree.
+            if (_tablet_metadata != nullptr && _tablet_metadata->has_flat_json_config()) {
                 auto flat_json_config = std::make_shared<FlatJsonConfig>();
-                flat_json_config->update(metadata->flat_json_config());
+                flat_json_config->update(_tablet_metadata->flat_json_config());
                 deriver.init_flat_json_config(flat_json_config.get());
             }
 

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -33,6 +33,7 @@ class Column;
 class TabletSchema;
 class ThreadPool;
 class SegmentWriter;
+class FlatJsonConfig;
 
 struct OlapWriterStatistics;
 
@@ -194,6 +195,13 @@ public:
     bool force_build_vector_index_inline() const { return _force_build_vector_index_inline; }
     void force_set_build_vector_index_inline() { _force_build_vector_index_inline = true; }
 
+    // Flat JSON policy delivered with the load plan (shared-data). When set, the segment writer
+    // uses it to decide JSON flattening instead of reading the best-effort tablet-metadata cache.
+    const std::shared_ptr<FlatJsonConfig>& flat_json_config() const { return _flat_json_config; }
+    void set_flat_json_config(std::shared_ptr<FlatJsonConfig> flat_json_config) {
+        _flat_json_config = std::move(flat_json_config);
+    }
+
     void check_global_dict(SegmentWriter* segment_writer);
 
     const FileInfo& lcrm_file() const { return _lcrm_file; }
@@ -226,6 +234,7 @@ protected:
     DictColumnsValidMap _global_dict_columns_valid_info;
     bool _enable_pk_index_eager_build = false;
     bool _force_build_vector_index_inline = false;
+    std::shared_ptr<FlatJsonConfig> _flat_json_config;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -20,6 +20,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/tablet_schema_map.h"
+#include "storage_primitive/flat_json_config.h"
 #include "storage_primitive/tablet_basic_info.h"
 
 namespace starrocks::lake {
@@ -45,25 +46,36 @@ StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer(WriterType t
 StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer_with_schema(
         WriterType type, int64_t txn_id, uint32_t max_rows_per_segment, ThreadPool* flush_pool, bool is_compaction,
         const std::shared_ptr<const TabletSchema>& tablet_schema) {
+    std::unique_ptr<TabletWriter> writer;
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id, flush_pool,
-                                                              is_compaction);
+            writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id, flush_pool,
+                                                                is_compaction);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                            max_rows_per_segment, flush_pool, is_compaction);
+            writer = std::make_unique<VerticalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+                                                              max_rows_per_segment, flush_pool, is_compaction);
         }
     } else {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                                   is_compaction, flush_pool);
+            writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+                                                                     is_compaction, flush_pool);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                                 max_rows_per_segment, is_compaction, flush_pool);
+            writer = std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+                                                                   max_rows_per_segment, is_compaction, flush_pool);
         }
     }
+    // Flat JSON policy for writers created off a specific metadata version (compaction / internal
+    // rewrites): take it from THIS version's metadata (_metadata), which we already hold, rather than
+    // the best-effort latest-metadata cache. This makes the flatten decision version-consistent (it
+    // uses the config of the exact version being read/compacted) and independent of cache warmth.
+    if (_metadata != nullptr && _metadata->has_flat_json_config()) {
+        auto flat_json_config = std::make_shared<FlatJsonConfig>();
+        flat_json_config->update(_metadata->flat_json_config());
+        writer->set_flat_json_config(std::move(flat_json_config));
+    }
+    return writer;
 }
 
 StatusOr<std::unique_ptr<TabletReader>> VersionedTablet::new_reader(Schema schema) {

--- a/be/src/storage_primitive/flat_json_config.h
+++ b/be/src/storage_primitive/flat_json_config.h
@@ -18,7 +18,8 @@
 
 #include <sstream>
 
-#include "gen_cpp/AgentService_types.h"
+// TFlatJsonConfig now lives in Types.thrift (shared by sink/agent paths).
+#include "gen_cpp/Types_types.h"
 
 namespace starrocks {
 class FlatJsonConfig {

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -25,6 +25,8 @@
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log_applier.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage_primitive/flat_json_config.h"
 #include "test_util.h"
 
 namespace starrocks::lake {
@@ -71,6 +73,55 @@ TEST_F(AlterTabletMetaTest, test_missing_txn_id) {
     auto status = handler.process_update_tablet_meta(update_tablet_meta_req);
     ASSERT_ERROR(status);
     ASSERT_EQ("txn_id not set in request", status.message());
+}
+
+// A compaction (or any writer created off a specific metadata version) must take flat_json from
+// THAT version's metadata (_metadata), not the best-effort latest-metadata cache -- so the flatten
+// decision is version-consistent and does not depend on cache warmth. Verifies
+// VersionedTablet::new_writer_with_schema wires the versioned config onto the writer.
+TEST_F(AlterTabletMetaTest, test_compaction_writer_uses_versioned_flat_json_config) {
+    // Version WITH flat_json_config: the compaction writer must carry it.
+    {
+        auto md = std::make_shared<TabletMetadata>(*_tablet_metadata);
+        md->mutable_flat_json_config()->set_flat_json_enable(true);
+        md->mutable_flat_json_config()->set_flat_json_max_column_max(80);
+        VersionedTablet tablet(_tablet_mgr.get(), md);
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer_with_schema(kHorizontal, next_id(), 0, nullptr,
+                                                                   /*is_compaction=*/true, _tablet_schema));
+        ASSERT_NE(nullptr, writer->flat_json_config());
+        ASSERT_TRUE(writer->flat_json_config()->is_flat_json_enabled());
+        ASSERT_EQ(80, writer->flat_json_config()->get_flat_json_max_column_max());
+    }
+    // Version WITHOUT flat_json_config: writer leaves it null (falls back to global at write time).
+    {
+        auto md = std::make_shared<TabletMetadata>(*_tablet_metadata);
+        md->clear_flat_json_config();
+        VersionedTablet tablet(_tablet_mgr.get(), md);
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer_with_schema(kHorizontal, next_id(), 0, nullptr,
+                                                                   /*is_compaction=*/true, _tablet_schema));
+        ASSERT_EQ(nullptr, writer->flat_json_config());
+    }
+}
+
+// Spill-merged loads build their final segments through cloned writers
+// (LoadSpillPipelineMergeIterator -> TabletWriter::clone()). The clone must inherit the
+// plan-carried flat_json config; otherwise a spilled load silently falls back to the
+// tablet-metadata cache / global config, recreating the nondeterminism this change removes.
+TEST_F(AlterTabletMetaTest, test_clone_writer_propagates_flat_json_config) {
+    auto md = std::make_shared<TabletMetadata>(*_tablet_metadata);
+    md->mutable_flat_json_config()->set_flat_json_enable(true);
+    md->mutable_flat_json_config()->set_flat_json_max_column_max(80);
+    VersionedTablet tablet(_tablet_mgr.get(), md);
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer_with_schema(kHorizontal, next_id(), 0, nullptr,
+                                                               /*is_compaction=*/false, _tablet_schema));
+    ASSERT_NE(nullptr, writer->flat_json_config());
+
+    ASSIGN_OR_ABORT(auto cloned, writer->clone());
+    ASSERT_NE(nullptr, cloned->flat_json_config());
+    ASSERT_TRUE(cloned->flat_json_config()->is_flat_json_enabled());
+    ASSERT_EQ(80, cloned->flat_json_config()->get_flat_json_max_column_max());
+    cloned->close();
+    writer->close();
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -235,6 +235,13 @@ public class OlapTableSink extends DataSink {
         tSink.setAutomatic_bucket_size(automaticBucketSize);
         tSink.setEncryption_meta(GlobalStateMgr.getCurrentState().getKeyMgr().getCurrentKEKAsEncryptionMeta());
         tSink.setEnable_data_file_bundling(dstTable.isFileBundling());
+        // Carry the table's Flat JSON policy with the load plan so the (shared-data) segment
+        // writer decides flattening from this FE-authoritative value instead of the best-effort
+        // tablet-metadata cache. Only set when the table has an explicit property; otherwise the
+        // writer falls back to the global config (unchanged behavior for property-less tables).
+        if (dstTable.containsFlatJsonConfig()) {
+            tSink.setFlat_json_config(dstTable.getFlatJsonConfig().toTFlatJsonConfig());
+        }
         tSink.setEnable_lake_per_partition_coordinator_txn_log(
                 Config.lake_enable_per_partition_coordinator_txn_log);
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -225,6 +225,11 @@ message PTabletWriterOpenRequest {
     // for multi olap table sink
     optional int64 sink_id = 36 [default = 0];
     optional bytes encryption_meta = 37;
+    // Table-level Flat JSON policy carried with the load, mirroring merge_condition /
+    // partial_update_mode. The (shared-data) segment writer uses this instead of the
+    // best-effort tablet-metadata cache. FlatJsonConfigPB comes from olap_file.proto
+    // (already imported).
+    optional FlatJsonConfigPB flat_json_config = 38;
 };
 
 message PTabletWriterOpenResult {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -85,13 +85,9 @@ struct TBinlogConfig {
     4: optional i64 binlog_max_size;
 }
 
-struct TFlatJsonConfig {
-    1: optional bool flat_json_enable;
-    2: optional double flat_json_null_factor;
-    3: optional double flat_json_sparsity_factor;
-    4: optional i64 flat_json_column_max;
-    5: optional i64 version;
-}
+// TFlatJsonConfig moved to Types.thrift so it can also be shared by DataSinks
+// (the load sink) without creating an include cycle. Referenced here as
+// Types.TFlatJsonConfig.
 
 // If you want to add types,
 // don't forget to also add type to PersistentIndexTypePB
@@ -138,7 +134,7 @@ struct TCreateTabletReq {
     23: optional i64 timeout_ms = -1;
     // Global transaction id
     24: optional i64 gtid = 0;
-    25: optional TFlatJsonConfig flat_json_config;
+    25: optional Types.TFlatJsonConfig flat_json_config;
     26: optional TCompactionStrategy compaction_strategy;
     27: optional Types.TTabletRange range;
 
@@ -555,7 +551,7 @@ struct TTabletMetaInfo {
     // |create_schema_file| only used when |tablet_schema| exists
     10: optional bool create_schema_file;
     11: optional TPersistentIndexType persistent_index_type;
-    12: optional TFlatJsonConfig flat_json_config;
+    12: optional Types.TFlatJsonConfig flat_json_config;
     13: optional bool bundle_tablet_metadata;
     14: optional TCompactionStrategy compaction_strategy;
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -248,6 +248,10 @@ struct TOlapTableSink {
     // legacy "sender_id == 0 collects all" rule. FE only sets this to true once
     // it knows every target CN supports the mode (rolling-upgrade interlock).
     35: optional bool enable_lake_per_partition_coordinator_txn_log
+    // Table-level Flat JSON policy, delivered with the load plan so the (shared-data)
+    // segment writer decides flattening from the FE-authoritative value rather than the
+    // best-effort tablet-metadata cache.
+    36: optional Types.TFlatJsonConfig flat_json_config
 }
 
 struct TSchemaTableSink {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2418,7 +2418,7 @@ struct TCloudTabletMeta {
     3: optional bool enable_persistent_index;
     4: optional AgentService.TPersistentIndexType persistent_index_type;
     5: optional AgentService.TCompactionStrategy compaction_strategy;
-    6: optional AgentService.TFlatJsonConfig flat_json_config;
+    6: optional Types.TFlatJsonConfig flat_json_config;
     7: optional map<i64, Types.TTabletRange> tablet_ranges;
     8: optional i64 gtid;
     9: optional Types.TCompressionType compression_type;

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -583,6 +583,18 @@ enum TPartialUpdateMode {
     COLUMN_UPDATE_MODE = 4;
 }
 
+// Table-level Flat JSON storage policy. Kept in the low-level Types thrift (like
+// TPartialUpdateMode) so it can be shared by the load sink (DataSinks.TOlapTableSink),
+// the tablet-create/meta-update agent path (AgentService), and FrontendService without
+// creating an include cycle.
+struct TFlatJsonConfig {
+    1: optional bool flat_json_enable;
+    2: optional double flat_json_null_factor;
+    3: optional double flat_json_sparsity_factor;
+    4: optional i64 flat_json_column_max;
+    5: optional i64 version;
+}
+
 enum TRunMode {
     SHARED_NOTHING = 0;
     SHARED_DATA = 1;


### PR DESCRIPTION
## Why I'm doing:

On shared-data clusters the table property `flat_json.*` was unreliable on the **write path**: the lake segment writer read `FlatJsonConfig` only from the in-memory tablet-metadata cache (`get_latest_cached_tablet_metadata`) and, on a miss, silently fell back to the global `config::enable_json_flat` (default `true`), ignoring the table property. With file-bundling on (the default) a brand-new table's first load hit this **deterministically**, so `flat_json.enable` and the sparsity/null/column factors were effectively ignored for that data.

## What I'm doing:

Fix the shared-data **write and compaction consumption paths** so the flatten decision honors the FE-authoritative table config instead of a best-effort cache.

- **Carry `FlatJsonConfig` in the load plan** (`TOlapTableSink` / `PTabletWriterOpenRequest`). The lake segment writer uses this FE-authoritative value and only falls back to the metadata cache / global config when it is absent (property-less table or rolling upgrade). Spill-merged loads build their final segments through cloned writers (`LoadSpillPipelineMergeIterator` → `TabletWriter::clone()`), so the clone propagates the config too.
- **Version-consistent compaction.** Compaction and version-specific rewrites now take flat_json from the exact metadata version being read (`VersionedTablet::new_writer_with_schema` uses the `_metadata` it already holds) instead of the best-effort latest cache, so the decision is version-consistent and independent of cache warmth.
- **Move `TFlatJsonConfig` into `Types.thrift`** so it can be shared by the load sink and the agent/create-tablet paths without an include cycle. The new sink/plan fields are optional and wire-compatible.

### Scope / relationship to #74747

Propagating an `ALTER TABLE ... SET("flat_json.*"=...)` change to the BE is a **separate problem** handled by #74747 (which covers both shared-nothing and shared-data). This PR **does not touch the ALTER path** — it focuses solely on the write-path/consumption defect that #74747 does not address (cache-miss fallback to the global config). The two PRs are complementary.

### Tests

- `AlterTabletMetaTest.test_compaction_writer_uses_versioned_flat_json_config` — a writer created off a specific metadata version (compaction / version-specific rewrite) picks up flat_json from *that* version's metadata, and is left null when the version has none.
- `AlterTabletMetaTest.test_clone_writer_propagates_flat_json_config` — `TabletWriter::clone()` (spill-merge path) inherits the plan-carried flat_json config, so spilled loads do not silently fall back to the cache/global config.

Both pass under ASAN (`AlterTabletMetaTest` 11/0). End-to-end on a shared-data cluster: a new table created with an explicit `flat_json.*` property has that property honored on its first load (with file-bundling on), instead of silently using the global default on a metadata-cache miss.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Rationale:
- **Policy change**: shared-data loads/compactions now honor the table's `flat_json.*` property for the flatten decision instead of silently using the global default on a metadata-cache miss.
- **Miscellaneous (compatibility)**: `TFlatJsonConfig` moved to `Types.thrift` and new optional `TOlapTableSink` / `PTabletWriterOpenRequest` fields. All additive/optional; mixed-version clusters fall back to prior behavior for property-less tables and during rolling upgrade.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
