### PR TITLE
[Tool] Guard explain/trace assert helpers against failed SQL

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3406,6 +3406,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "explain %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             tools.assert_true(
                 str(res["result"]).find(expect) > 0,
@@ -3418,6 +3419,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "explain %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             tools.assert_true(str(res["result"]).find(expect) == -1, "assert expect %s is found in plan" % (expect))
 
@@ -3441,6 +3443,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "explain costs %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             plan_string = "\n".join(item[0] for item in res["result"])
             tools.assert_true(
@@ -3456,6 +3459,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "explain costs %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         plan_string = "\n".join(item[0] for item in res["result"])
         for line in plan_string.split("\n"):
             stripped = line.strip()
@@ -3469,6 +3473,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "show stats meta %s" % predicate
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             # Concatenate all tuples in res['result'] into a single string
             meta_string = "\n".join("\t".join(item) for item in res["result"])
@@ -3483,6 +3488,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "trace values %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             tools.assert_true(
                 str(res["result"]).find(expect) > 0,
@@ -3584,6 +3590,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         """
         sql = "trace times %s" % query
         res = self.execute_sql(sql, True)
+        tools.assert_true(res["status"], res["msg"])
         for expect in expects:
             tools.assert_true(
                 str(res["result"]).find(expect) > 0,


### PR DESCRIPTION
## Why I'm doing:

`assert_explain_contains` and its sibling helpers in `test/lib/sr_sql_lib.py` read `res["result"]` without first checking `res["status"]`. When the `explain` / `trace` / `show stats` statement itself errors, `execute_sql` returns `{"status": False, "msg": ...}` with **no** `"result"` key, so the helper crashes with `KeyError: 'result'` instead of failing with the real SQL error.

In CI this surfaces as an unparseable SQL-Tester check-run annotation (just `'result'`) that hides the actual cause and prevents the unstable-case reporter from recognizing the failing case.

## What I'm doing:

Add `tools.assert_true(res["status"], res["msg"])` right after `execute_sql(...)` in the helpers that were missing it, so a failed statement fails the test with the real error message (a normal assertion `<failure>`) instead of a raw `KeyError`. This matches the existing pattern already used by `assert_explain_verbose_contains`.

Functions guarded: `assert_explain_contains`, `assert_explain_not_contains`, `assert_explain_costs_contains`, `get_col_stats_from_explain_costs`, `assert_show_stats_meta_contains`, `assert_trace_values_contains`, `assert_trace_times_contains`.

The change is purely additive: when `status` is `True` (the normal path) the guard passes and behavior is unchanged; it only improves the error path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This is a backport pr