### PR TITLE
[Tool] harden pr-checker checkbox parsing and fix stale-payload label race

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -145,7 +145,9 @@ jobs:
           VERSION: ${{ matrix.version }}
         run: |
           body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
-          has_label=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --jq "[.[].name] | contains([\"${VERSION}\"])")
+          # any(. == $v), not contains(): jq array containment matches strings
+          # by substring, so labels like "4.1-merged" or "4.1.0" would count as "4.1"
+          has_label=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --jq "any(.[].name; . == \"${VERSION}\")")
           version_re=${VERSION//./\\.}
           if grep -qiE "^[[:space:]]*-[[:space:]]*\[x\][[:space:]]+${version_re}[[:space:]]*$" <<< "$body"; then
             if [[ "$has_label" == "false" ]]; then

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -133,24 +133,37 @@ jobs:
       fail-fast: false
       matrix:
         version: ["4.1", "4.0", "3.5", "3.4", "3.3"]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.number }}
     steps:
-      - name: add ${{ matrix.version }} label
-        if: contains(toJson(github.event.pull_request.body), format('[x] {0}', matrix.version))
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: ${{ matrix.version }}
-
-      - name: remove ${{ matrix.version }} label
-        if: contains(toJson(github.event.pull_request.body), format('[ ] {0}', matrix.version)) && contains(github.event.pull_request.labels.*.name, matrix.version)
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: ${{ matrix.version }}
+      # Rapid checkbox edits arrive as a burst of `edited` events whose runs can
+      # start out of order under cancel-in-progress, so the surviving run may
+      # hold a stale body snapshot. Read the live PR state instead of the payload.
+      - name: sync ${{ matrix.version }} label
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+          has_label=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --jq "[.[].name] | contains([\"${VERSION}\"])")
+          version_re=${VERSION//./\\.}
+          if grep -qiE "^[[:space:]]*-[[:space:]]*\[x\][[:space:]]+${version_re}[[:space:]]*$" <<< "$body"; then
+            if [[ "$has_label" == "false" ]]; then
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" -f "labels[]=${VERSION}"
+            fi
+          elif grep -qiE "^[[:space:]]*-[[:space:]]*\[[[:space:]]?\][[:space:]]+${version_re}[[:space:]]*$" <<< "$body"; then
+            if [[ "$has_label" == "true" ]]; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${VERSION}"
+            fi
+          fi
 
       - name: check-done
-        if: contains(toJson(github.event.pull_request.body), '[ ] I have checked the version labels')
         run: |
-          echo "::error::You must mark this checkbox - I have checked the version labels which the pr will be auto-backported to the target branch"
-          exit 1
+          body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+          if grep -qiE '^[[:space:]]*-[[:space:]]*\[[[:space:]]?\][[:space:]]+I have checked the version labels' <<< "$body"; then
+            echo "::error::You must mark this checkbox - I have checked the version labels which the pr will be auto-backported to the target branch"
+            exit 1
+          fi
 
   backport-check:
     runs-on: ubuntu-latest
@@ -169,50 +182,57 @@ jobs:
       !startsWith(github.event.pull_request.title, 'Revert ') &&
       (github.base_ref == 'main' || !startsWith(github.head_ref, 'mergify/bp/') || github.event.action != 'opened')
     steps:
+      # Parse checkbox lines with whitespace/case-tolerant regexes instead of
+      # exact-literal contains(): an extra space after `[ ]` or an uppercase `[X]`
+      # must not fail the check. Read the live body (see backport-check-subtask).
       - name: Format Check
         id: check
-        if: >
-          (!contains(toJson(github.event.pull_request.body), '[ ] Yes, this PR will result in a change in behavior') &&
-          !contains(toJson(github.event.pull_request.body), '[x] Yes, this PR will result in a change in behavior')) ||
-          (!contains(toJson(github.event.pull_request.body), '[ ] No, this PR will not result in a change in behavior') &&
-          !contains(toJson(github.event.pull_request.body), '[x] No, this PR will not result in a change in behavior')) ||
-          (contains(toJson(github.event.pull_request.body), '[x] Yes, this PR will result in a change in behavior') &&
-          contains(toJson(github.event.pull_request.body), '[x] No, this PR will not result in a change in behavior')) ||
-          (contains(toJson(github.event.pull_request.body), '[ ] Yes, this PR will result in a change in behavior') &&
-          contains(toJson(github.event.pull_request.body), '[ ] No, this PR will not result in a change in behavior'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          echo "::error::Please check the format of your pr body about the behavior change checkbox!"
-          exit 1
+          body=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
+          checkbox='^[[:space:]]*-[[:space:]]*\['
+          yes_text='Yes, this PR will result in a change in behavior'
+          no_text='No, this PR will not result in a change in behavior'
+          yes_line=false; yes_checked=false; no_line=false; no_checked=false
+          grep -qiE "${checkbox}[x[:space:]]?\][[:space:]]+${yes_text}" <<< "$body" && yes_line=true
+          grep -qiE "${checkbox}x\][[:space:]]+${yes_text}" <<< "$body" && yes_checked=true
+          grep -qiE "${checkbox}[x[:space:]]?\][[:space:]]+${no_text}" <<< "$body" && no_line=true
+          grep -qiE "${checkbox}x\][[:space:]]+${no_text}" <<< "$body" && no_checked=true
+          if [[ "$yes_line" == "false" || "$no_line" == "false" ]]; then
+            echo "::error::PR body is missing the behavior change template line(s) ('- [ ] Yes, this PR will result...' / '- [ ] No, this PR will not result...'). Please restore the section from the PR template."
+            exit 1
+          fi
+          if [[ "$yes_checked" == "true" && "$no_checked" == "true" ]]; then
+            echo "::error::Both Yes and No are checked in the behavior change section. Please check exactly one."
+            exit 1
+          fi
+          if [[ "$yes_checked" == "false" && "$no_checked" == "false" ]]; then
+            echo "::error::Neither Yes nor No is checked in the behavior change section. Please check exactly one."
+            exit 1
+          fi
+          if [[ "$yes_checked" == "true" ]]; then
+            type_checked=false
+            for change_type in 'Interface/UI changes' 'Parameter changes' 'Policy changes' 'Feature removed' 'Miscellaneous'; do
+              grep -qiE "${checkbox}x\][[:space:]]+${change_type}" <<< "$body" && type_checked=true
+            done
+            if [[ "$type_checked" == "false" ]]; then
+              echo "::error::You must specify the type of change!"
+              exit 1
+            fi
+          fi
+          echo "yes_checked=${yes_checked}" >> "$GITHUB_OUTPUT"
+          echo "no_checked=${no_checked}" >> "$GITHUB_OUTPUT"
 
       - name: Behavior Unchanged Label
-        id: unchanged
-        if: >
-          steps.check.outcome == 'skipped' &&
-          contains(toJson(github.event.pull_request.body), '[x] No, this PR will not result in a change in behavior')
+        if: steps.check.outputs.no_checked == 'true'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: "behavior_changed"
 
-      - name: Behavior Changed Check
-        id: changed_check
-        if: >
-          always() && steps.check.outcome == 'skipped' && steps.unchanged.outcome == 'skipped' &&
-          contains(toJson(github.event.pull_request.body), '[x] Yes, this PR will result in a change in behavior') &&
-          contains(toJson(github.event.pull_request.body), '[ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information') &&
-          contains(toJson(github.event.pull_request.body), '[ ] Parameter changes: default values, similar parameters but with different default values') &&
-          contains(toJson(github.event.pull_request.body), '[ ] Policy changes: use new policy to replace old one, functionality automatically enabled') &&
-          contains(toJson(github.event.pull_request.body), '[ ] Feature removed') &&
-          contains(toJson(github.event.pull_request.body), '[ ] Miscellaneous: upgrade & downgrade compatibility, etc')
-        run: |
-          echo "::error::You must specify the type of change!"
-          exit 1
-
       - name: Behavior Changed Label
-        if: >
-          always() &&
-          steps.check.outcome == 'skipped' &&
-          steps.unchanged.outcome == 'skipped' &&
-          steps.changed_check.outcome != 'failure'
+        if: steps.check.outputs.yes_checked == 'true'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: "behavior_changed"


### PR DESCRIPTION
## Why I'm doing:
Two related weaknesses in `pr-checker.yml` bit real PRs this week:

1. **Exact-literal checkbox matching.** behavior-check compares the body against exact strings via `contains()`, so an extra space after `[ ]` fails the format check no matter what the author ticks. #75888 / #75825 were blocked this way (`- [ ]  No, ...` with two spaces — checking the box in the UI keeps the double space, so the error is unrecoverable from the UI), and the error message gives no hint about what is wrong.
2. **Stale-payload label race.** Version labels are driven by the frozen `edited`-event payload under `cancel-in-progress: true`. Ticking checkboxes one by one fires a burst of events whose runs can start out of order; the surviving run may hold a stale body snapshot and *remove* freshly added version labels. #75861 lost its `4.1/4.0/3.5` labels this way (timeline: `4.1` labeled 05:00:30 → unlabeled 05:03:04 by the stale run) and merged with no labels, so auto-backport never triggered.

## What I'm doing:
- Parse the **live** PR body (`gh api .../pulls/N`) instead of the event payload in `behavior-check` and `backport-check-subtask`, eliminating the stale-snapshot race: whichever run survives cancellation now reads the current state.
- Replace exact-literal `contains()` with whitespace/case-tolerant line regexes (`- [x]` / `- [X]` / extra spaces all accepted; matching is line-anchored so prose mentions no longer count).
- Emit a specific error per failure mode (template line missing / both checked / neither checked / change type missing) instead of one generic "check the format" message.
- Keep job/matrix names unchanged so any required-check references stay valid.

**Validation (replay against 380 recent real PRs, running the actual new bash logic):**
- behavior-check: 379/380 identical outcomes. The single divergence is #75825 — checked Yes + double-space No line; old logic wrongly blocked it, new logic passes it. Zero previously-passing PRs regress.
- version-label add/remove decisions: 570/570 identical (114 eligible PRs × 5 versions).
- Synthetic edge cases (double space, uppercase X, CRLF, both/neither checked, template deleted, Yes without type, `4.1` vs `4.10`) all classified correctly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
