### PR TITLE
[Enhancement] Trace the uncovered lake load publish-version paths

### DIFF
--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/transactions.h"
 
 #include "base/container/lru_cache.h"
+#include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "common/config_lake_fwd.h"
 #include "fs/fs_factory.h"
@@ -347,9 +348,13 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                                                txns.back().gtid());
     }
 
-    // Read base version metadata
-    auto base_metadata_or =
-            tablet_mgr->get_tablet_metadata(tablet_info.get_tablet_id_in_metadata(), base_version, false);
+    // Read base version metadata. This is an object-storage/metacache read that
+    // happens before the PublishTablet apply counters start, so time it here to
+    // keep it from hiding inside the overall publish cost.
+    auto base_metadata_or = [&] {
+        TRACE_COUNTER_SCOPE_LATENCY_US("get_base_metadata_latency_us");
+        return tablet_mgr->get_tablet_metadata(tablet_info.get_tablet_id_in_metadata(), base_version, false);
+    }();
     if (base_metadata_or.status().is_not_found()) {
         return new_version_metadata_or_error(base_metadata_or.status());
     }
@@ -408,7 +413,13 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
             }
             txn_log_st = std::vector<TxnLogVector>{{std::move(schema_change_log_or).value()}};
         } else {
-            txn_log_st = load_txn_log(tablet_mgr, tablet_info.get_tablet_ids_in_txn_logs(), txns[i]);
+            // Loading the txn log reads one or more log files from object storage
+            // and is otherwise untraced; a slow/throttled read here would hide in
+            // the total publish cost.
+            {
+                TRACE_COUNTER_SCOPE_LATENCY_US("load_txn_log_latency_us");
+                txn_log_st = load_txn_log(tablet_mgr, tablet_info.get_tablet_ids_in_txn_logs(), txns[i]);
+            }
 
             if (txn_log_st.status().is_not_found()) {
                 if (i == 0) {
@@ -627,8 +638,13 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
         new_metadata->set_vector_index_built_version(std::max(prev_bv, fe_built_version));
     }
 
-    // Save new metadata
-    RETURN_IF_ERROR(log_applier->finish());
+    // Save new metadata. finish() commits the primary index and writes the new
+    // tablet metadata (and delvecs) to object storage; that metadata write is not
+    // covered by the apply counters, so time the whole step here.
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("apply_finish_latency_us");
+        RETURN_IF_ERROR(log_applier->finish());
+    }
 
     delete_files_async(std::move(files_to_delete));
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -173,8 +173,14 @@ StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(
     auto index_entry = _index_cache.get_or_create(metadata->id());
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
-    // Fetch lock guard before `lake_load`
-    guard = index.fetch_guard();
+    // Fetch lock guard before `lake_load`. Acquiring this per-tablet index lock
+    // can block on a concurrent apply/compaction/point-lookup that already holds
+    // it; that wait happens before `lake_load` and is otherwise invisible in the
+    // publish trace, so time it separately from the load below.
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_lock_wait_us");
+        guard = index.fetch_guard();
+    }
     Status st = index.lake_load(_tablet_mgr, metadata, base_version, builder);
     _index_cache.update_object_size(index_entry, index.memory_usage());
     if (!st.ok()) {


### PR DESCRIPTION
## Why I'm doing:

When a shared-data (cloud-native) primary-key **load publish** is slow, the per-tablet
`PublishTablet` trace emitted by `lake_service.cpp` only instruments the apply work
inside `publish_primary_key_tablet` (segment IO, condition-update compare/upsert,
primary-index update/commit). The steps that run **before and after** the apply have no
trace counters, so a stall in one of them shows up only as a large overall
`publish rpc cost` while every child-trace timer is near-zero.

Real case that motivated this (a customer shared-data cluster):

```
Published txns=... tablets=...,X cost=36180170us   # 36.18s
trace: PublishTablet{ queuing_latency_us=2078,
                      condition_update_compare_phase_us=396,
                      update_index_latency_us=1400,
                      primary_index_load_latency_us=1,
                      upsert_rows=2, ... }           # every counter in the µs range
```

A `merge_commit` micro-batch of **2 rows** took **36.18s**, all child counters in the
microsecond range, node CPU idle — i.e. the 36s was an **uninstrumented wait** (an
object-storage read/write, or acquiring the per-tablet primary-index lock). The current
trace cannot say which.

## What I'm doing:

Adding `TRACE_COUNTER_SCOPE_LATENCY_US` around the previously-uncovered spots on the
**load publish** path so the next slow publish points directly at the culprit:

| counter | covers |
| --- | --- |
| `get_base_metadata_latency_us` | reading base-version tablet metadata (object storage / metacache) |
| `load_txn_log_latency_us` | loading the txn log(s) from object storage |
| `primary_index_lock_wait_us` | waiting for the per-tablet primary-index write lock in `prepare_primary_index`, **before** `lake_load` (existing `primary_index_load_latency_us` only times the load *after* the lock is held) |
| `apply_finish_latency_us` | `TxnLogApplier::finish()` — index commit + `MetaFileBuilder::finalize` writing the new tablet metadata/delvecs to object storage |

The load-apply segment reads are already covered (`get_each_segment_us`,
`load_segment_us`, `do_load_upserts_us`), so no counters were added there.

These are **pure instrumentation** — no control-flow or behavior change. All counters
attach to the same `PublishTablet` child trace as the existing ones, so they appear
inline in the existing slow-publish log line.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
