### PR TITLE
[BugFix] Read durable metadata in cal_new_base_version to avoid dangling prev_garbage_version

### DIFF
--- a/be/src/storage/lake/options.h
+++ b/be/src/storage/lake/options.h
@@ -19,6 +19,10 @@ namespace starrocks::lake {
 struct CacheOptions {
     bool fill_meta_cache = true;
     bool fill_data_cache = true;
+    // When true, bypass the tablet-metadata metacache lookup and read straight from durable storage.
+    // Lets a caller tell "durably persisted in remote storage" apart from "only in the metacache"
+    // (cached during publish but not yet durably flushed).
+    bool skip_meta_cache = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -750,9 +750,11 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& path, const CacheOptions& cache_opts,
                                                                int64_t expected_gtid,
                                                                const std::shared_ptr<FileSystem>& fs) {
-    if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
-        TRACE("got cached tablet metadata");
-        return ptr;
+    if (!cache_opts.skip_meta_cache) {
+        if (auto ptr = _metacache->lookup_tablet_metadata(path); ptr != nullptr) {
+            TRACE("got cached tablet metadata");
+            return ptr;
+        }
     }
     StatusOr<TabletMetadataPtr> metadata_or;
     auto [tablet_id, version] = parse_tablet_metadata_filename(basename(path));
@@ -926,8 +928,10 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
                                                                       int64_t expected_gtid,
                                                                       const std::shared_ptr<FileSystem>& fs) {
     auto tablet_path = tablet_metadata_location(tablet_id, version);
-    if (auto ptr = _metacache->lookup_tablet_metadata(tablet_path); ptr != nullptr) {
-        return ptr;
+    if (!cache_opts.skip_meta_cache) {
+        if (auto ptr = _metacache->lookup_tablet_metadata(tablet_path); ptr != nullptr) {
+            return ptr;
+        }
     }
     if (version == kInitialVersion) {
         return Status::NotFound("Not found expected tablet metadata");

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -24,6 +24,7 @@
 #include "gutil/strings/join.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/metacache.h"
+#include "storage/lake/options.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -96,8 +97,16 @@ int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64
     if (index_version > version) {
         // There is a possibility that the index version is newer than the version in remote storage.
         // Check whether the index version exists in remote storage. If not, clear and rebuild the index.
+        // skip_meta_cache forces this to read DURABLE storage only: with file bundling a version can sit in
+        // the metacache (its metadata cached during publish) without a durable bundle written yet -- e.g. a
+        // batch publish advanced the primary index and cached the metadata but had not written the bundle,
+        // and is now being retried. A plain cache-hitting read would treat such a version as "exists in
+        // remote", adopt it as the base, and record it as prev_garbage_version, leaving a dangling reference
+        // (NotFound while vacuum walks the chain) once the cache is evicted.
         auto gtid = txns.size() == 1 ? txns[0].gtid() : txns[index_version - base_version - 1].gtid();
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, index_version, true, gtid);
+        auto res = tablet_mgr->get_tablet_metadata(
+                tablet_id, index_version,
+                CacheOptions{.fill_meta_cache = true, .fill_data_cache = true, .skip_meta_cache = true}, gtid);
         if (res.ok()) {
             version = index_version;
         } else {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1136,6 +1136,70 @@ TEST_F(LakeTabletManagerTest, get_tablet_metadata_cache_options) {
     EXPECT_TRUE(_tablet_manager->metacache()->lookup_tablet_metadata(path) == nullptr);
 }
 
+// skip_meta_cache=true must distinguish "durably persisted" from "only in the
+// metacache": a version whose metadata was cached (e.g. during an aggregate
+// publish) but never durably written reads as NotFound.
+TEST_F(LakeTabletManagerTest, get_tablet_metadata_skip_meta_cache_cache_only) {
+    auto metadata = std::make_shared<TabletMetadata>();
+    auto tablet_id = next_id();
+    metadata->set_id(tablet_id);
+    metadata->set_version(2);
+
+    // Cache-only: present in the metacache, no durable file.
+    auto path = _tablet_manager->tablet_metadata_location(tablet_id, 2);
+    _tablet_manager->metacache()->cache_tablet_metadata(path, metadata);
+
+    // A cache-hitting read sees it...
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 2, lake::CacheOptions{});
+    EXPECT_TRUE(res.ok());
+
+    // ...but a skip_meta_cache read reports NotFound.
+    lake::CacheOptions skip_cache_opts{.fill_meta_cache = true, .fill_data_cache = true, .skip_meta_cache = true};
+    res = _tablet_manager->get_tablet_metadata(tablet_id, 2, skip_cache_opts);
+    EXPECT_TRUE(res.status().is_not_found()) << res.status();
+
+    // Same contract on the single-tablet (bundle) read path.
+    res = _tablet_manager->get_single_tablet_metadata(tablet_id, 2, skip_cache_opts);
+    EXPECT_TRUE(res.status().is_not_found()) << res.status();
+}
+
+// With a durable copy present, skip_meta_cache reads it from storage (not the
+// cached copy) and, with fill_meta_cache=true, refreshes the cache with it.
+TEST_F(LakeTabletManagerTest, get_tablet_metadata_skip_meta_cache_reads_durable) {
+    constexpr int64_t kDurableCommitTime = 100;
+    constexpr int64_t kStaleCommitTime = 999999;
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    auto tablet_id = next_id();
+    metadata->set_id(tablet_id);
+    metadata->set_version(2);
+    metadata->set_commit_time(kDurableCommitTime);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    // Overwrite the cache entry with a deliberately-different stale copy.
+    auto path = _tablet_manager->tablet_metadata_location(tablet_id, 2);
+    auto stale = std::make_shared<TabletMetadata>(*metadata);
+    stale->set_commit_time(kStaleCommitTime);
+    _tablet_manager->metacache()->cache_tablet_metadata(path, stale);
+
+    // A cache-hitting read returns the stale copy.
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 2, lake::CacheOptions{});
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(kStaleCommitTime, res.value()->commit_time());
+
+    // skip_meta_cache returns the durable copy...
+    res = _tablet_manager->get_tablet_metadata(
+            tablet_id, 2,
+            lake::CacheOptions{.fill_meta_cache = true, .fill_data_cache = true, .skip_meta_cache = true});
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(kDurableCommitTime, res.value()->commit_time());
+
+    // ...and fill_meta_cache=true refreshed the cache with it.
+    auto cached = _tablet_manager->metacache()->lookup_tablet_metadata(path);
+    ASSERT_TRUE(cached != nullptr);
+    EXPECT_EQ(kDurableCommitTime, cached->commit_time());
+}
+
 TEST_F(LakeTabletManagerTest, parse_bundle_tablet_metadata_with_zero_size) {
     // Create a corrupted bundle metadata file with bundle_metadata_size = 0
     std::string serialized_string;

--- a/be/test/storage/lake/transactions_test.cpp
+++ b/be/test/storage/lake/transactions_test.cpp
@@ -519,4 +519,138 @@ TEST_F(NoOpPublishTest, mid_batch_missing_txnlog_without_force_publish_errors) {
     ASSERT_FALSE(result.ok());
 }
 
+// ===========================================================================
+// Tests for cal_new_base_version — the helper that decides which version a
+// (possibly retried) publish uses as its base when the in-memory primary
+// index is ahead of the durable base version.
+//
+// Regression scenario (file bundling): an aggregate publish caches each
+// tablet's metadata in the metacache and only writes one durable bundle at
+// the batch's final version. If a batch publish is retried after a prior
+// attempt advanced the primary index but before the bundle was written, the
+// index version exists ONLY in the metacache. cal_new_base_version must not
+// adopt such a cache-only version as the publish base — it would be recorded
+// as prev_garbage_version and dangle (NotFound) once the cache evicts,
+// permanently breaking the vacuum version walk below it.
+// ===========================================================================
+
+int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64_t base_version, int64_t new_version,
+                             const std::span<const TxnInfoPB>& txns);
+
+class CalNewBaseVersionTest : public TestBase {
+public:
+    CalNewBaseVersionTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        // Durable base: version 1.
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_cal_new_base_version";
+
+    // Simulate a prior publish attempt that advanced the primary index to |version|.
+    void set_primary_index_data_version(int64_t tablet_id, int64_t version) {
+        auto& index_cache = _update_mgr->index_cache();
+        auto* entry = index_cache.get_or_create(tablet_id);
+        entry->value().update_data_version(version);
+        index_cache.release(entry);
+    }
+
+    // Two-txn batch matching the base_version=1 -> new_version=3 retry scenario.
+    std::vector<TxnInfoPB> make_txns() {
+        return {TEST_txn_info(next_id(), time(nullptr)), TEST_txn_info(next_id(), time(nullptr))};
+    }
+
+    std::shared_ptr<TabletMetadataPB> _tablet_metadata;
+};
+
+// Core regression: the index version's metadata sits in the metacache but was
+// never durably written. cal_new_base_version must keep the durable base and
+// drop the stale index instead of adopting the cache-only version.
+TEST_F(CalNewBaseVersionTest, cache_only_version_not_adopted) {
+    const int64_t tablet_id = _tablet_metadata->id();
+
+    auto meta_v2 = std::make_shared<TabletMetadataPB>(*_tablet_metadata);
+    meta_v2->set_version(2);
+    _tablet_mgr->metacache()->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(tablet_id, 2), meta_v2);
+    set_primary_index_data_version(tablet_id, 2);
+
+    auto txns = make_txns();
+    ASSERT_EQ(1, cal_new_base_version(tablet_id, _tablet_mgr.get(), 1, 3, txns));
+    // The index referencing the non-durable version must have been removed so
+    // it gets rebuilt from the durable base.
+    ASSERT_EQ(0, _update_mgr->get_primary_index_data_version(tablet_id));
+}
+
+// Same as above but with the partition marked as an aggregation (file
+// bundling) partition, so the read goes through get_single_tablet_metadata
+// first — the exact metacache lookup the original bug hit.
+TEST_F(CalNewBaseVersionTest, cache_only_version_not_adopted_on_aggregation_partition) {
+    const int64_t tablet_id = _tablet_metadata->id();
+
+    auto meta_v2 = std::make_shared<TabletMetadataPB>(*_tablet_metadata);
+    meta_v2->set_version(2);
+    _tablet_mgr->metacache()->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(tablet_id, 2), meta_v2);
+    _tablet_mgr->metacache()->cache_aggregation_partition(_tablet_mgr->tablet_metadata_root_location(tablet_id), true);
+    set_primary_index_data_version(tablet_id, 2);
+
+    auto txns = make_txns();
+    ASSERT_EQ(1, cal_new_base_version(tablet_id, _tablet_mgr.get(), 1, 3, txns));
+    ASSERT_EQ(0, _update_mgr->get_primary_index_data_version(tablet_id));
+}
+
+// Counterpart: when the index version IS durably persisted (plain metadata
+// file), it remains a valid publish base and the index is kept.
+TEST_F(CalNewBaseVersionTest, durable_version_adopted) {
+    const int64_t tablet_id = _tablet_metadata->id();
+
+    auto meta_v2 = std::make_shared<TabletMetadataPB>(*_tablet_metadata);
+    meta_v2->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*meta_v2));
+    // Evict the metacache so only the durable copy can satisfy the read.
+    _tablet_mgr->metacache()->prune();
+    set_primary_index_data_version(tablet_id, 2);
+
+    auto txns = make_txns();
+    ASSERT_EQ(2, cal_new_base_version(tablet_id, _tablet_mgr.get(), 1, 3, txns));
+    ASSERT_EQ(2, _update_mgr->get_primary_index_data_version(tablet_id));
+}
+
+// Counterpart on the file-bundling path: a durable BUNDLE at the index
+// version must still be adopted with the metacache fully evicted — the
+// skip_meta_cache read reaches durable storage, not just the cache.
+TEST_F(CalNewBaseVersionTest, durable_bundle_version_adopted) {
+    const int64_t tablet_id = _tablet_metadata->id();
+
+    TabletMetadataPB meta_v2(*_tablet_metadata);
+    meta_v2.set_version(2);
+    std::map<int64_t, TabletMetadataPB> tablet_metas;
+    tablet_metas.emplace(tablet_id, meta_v2);
+    CHECK_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas));
+    _tablet_mgr->metacache()->prune();
+    _tablet_mgr->metacache()->cache_aggregation_partition(_tablet_mgr->tablet_metadata_root_location(tablet_id), true);
+    set_primary_index_data_version(tablet_id, 2);
+
+    auto txns = make_txns();
+    ASSERT_EQ(2, cal_new_base_version(tablet_id, _tablet_mgr.get(), 1, 3, txns));
+    ASSERT_EQ(2, _update_mgr->get_primary_index_data_version(tablet_id));
+}
+
+// Pre-existing contract: an index version beyond new_version is unusable for
+// this publish; the index is dropped and the base version kept.
+TEST_F(CalNewBaseVersionTest, index_version_beyond_new_version_unloads_index) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    set_primary_index_data_version(tablet_id, 5);
+
+    auto txns = make_txns();
+    ASSERT_EQ(1, cal_new_base_version(tablet_id, _tablet_mgr.get(), 1, 3, txns));
+    ASSERT_EQ(0, _update_mgr->get_primary_index_data_version(tablet_id));
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

For a Primary Key table with file bundling, aggregate publish caches each tablet's metadata (`skip_write_tablet_metadata`) and writes only one durable bundle at the batch's final version; the intermediate per-tablet versions are cache-only. When a batch publish is **retried** after a prior attempt advanced the primary index but before the durable bundle was written, `cal_new_base_version` probes remote storage for the primary-index version via `get_tablet_metadata` — which, for an aggregation partition, hits the metacache first and returns OK for a version that has **no durable bundle**. It then adopts that non-durable version as the publish base and records it as `prev_garbage_version`.

Once the metacache is evicted (or the BE restarts) that reference dangles: `get_tablet_metadata` now returns NotFound, the tablet-metadata vacuum walk (which descends `prev_garbage_version`) breaks at that point, and every older version below it is left permanently unreclaimed. This exists on main.

## What I'm doing:

- **`storage/lake/options.h`**: add `CacheOptions.skip_meta_cache` (default `false`). When true it bypasses the tablet-metadata metacache lookup and reads straight from durable storage, letting a caller tell "durably persisted in remote storage" apart from "only in the metacache".
- **`storage/lake/tablet_manager.cpp`**: honor `skip_meta_cache` in both metacache lookups on the read path — `get_tablet_metadata(path, ...)` and `get_single_tablet_metadata`. The durable bundle read path is unchanged, so a version that only exists as a cache entry now reads as NotFound.
- **`storage/lake/transactions.cpp`**: `cal_new_base_version` reads the index version with `CacheOptions{.skip_meta_cache = true}` (the `fill_meta_cache` / `fill_data_cache` flags stay `true`, so a durable read still warms the cache as before). A cache-only version now returns NotFound, so the primary index is rebuilt from the durable base instead of adopting a non-durable version — `prev_garbage_version` only ever references a durably persisted version.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
