### PR TITLE
[Enhancement] Support Arrow (vectorized) input for Java UDFs

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -639,8 +639,9 @@ Status Aggregator::_create_aggregate_function(starrocks::RuntimeState* state, co
             TypeDescriptor serde_type = TypeDescriptor::from_thrift(fn.aggregate_fn.intermediate_type);
             DCHECK_LE(1, fn.arg_types.size());
             const TypeDescriptor& arg_type = arg_types[0];
+            bool is_arrow_input = fn.__isset.input_type && fn.input_type == "arrow";
             auto* func = get_aggregate_function(func_name, return_type, arg_types, is_result_nullable, fn.binary_type,
-                                                state->func_version());
+                                                state->func_version(), is_arrow_input);
             if (func == nullptr) {
                 return Status::InternalError(strings::Substitute(
                         "Invalid agg function plan: $0 with (arg type $1, serde type $2, result type $3, nullable $4)",

--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -92,7 +92,9 @@ Status TableFunctionOperator::prepare(RuntimeState* state) {
     if (table_function_name == "unnest" && arg_types.size() > 1) {
         _table_function = get_table_function(table_function_name, {}, {}, table_fn.binary_type);
     } else {
-        _table_function = get_table_function(table_function_name, arg_types, return_types, table_fn.binary_type);
+        bool is_arrow_input = table_fn.__isset.input_type && table_fn.input_type == "arrow";
+        _table_function =
+                get_table_function(table_function_name, arg_types, return_types, table_fn.binary_type, is_arrow_input);
     }
 
     if (_table_function == nullptr) {

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -60,7 +60,9 @@ Status TableFunctionNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (table_function_name == "unnest" && arg_types.size() > 1) {
         _table_function = get_table_function(table_function_name, {}, {}, table_fn.binary_type);
     } else {
-        _table_function = get_table_function(table_function_name, arg_types, return_types, table_fn.binary_type);
+        bool is_arrow_input = table_fn.__isset.input_type && table_fn.input_type == "arrow";
+        _table_function =
+                get_table_function(table_function_name, arg_types, return_types, table_fn.binary_type, is_arrow_input);
     }
 
     if (_table_function == nullptr) {

--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -112,6 +112,8 @@ set(EXPR_FILES
   udf/java/java_udf_context.cpp
   udf/java/java_udf_reflection.cpp
   udf/java/java_data_converter.cpp
+  udf/java/arrow_udf_jni.cpp
+  udf/java/jni_arrow_func_call_stub.cpp
   udf/python/env.cpp
   udf/python/callstub.cpp
   udf/udf_call_stub.cpp

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -33,7 +33,8 @@ const AggregateFunction* get_window_function(const std::string& name, LogicalTyp
 
 const AggregateFunction* get_aggregate_function(const std::string& agg_func_name, const TypeDescriptor& return_type,
                                                 const std::vector<TypeDescriptor>& arg_types, bool is_input_nullable,
-                                                TFunctionBinaryType::type binary_type, int func_version = 1);
+                                                TFunctionBinaryType::type binary_type, int func_version = 1,
+                                                bool is_arrow_input = false);
 
 const AggregateFunction* get_aggregate_function(const AggStateDesc& agg_state_desc);
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -32,12 +32,17 @@ DEFINE_FAIL_POINT(not_exist_agg_function);
 namespace {
 
 AggregateFunctionPtr resolve_non_builtin_aggregate_function(TFunctionBinaryType::type binary_type,
-                                                            bool is_window_function, bool is_input_nullable) {
+                                                            bool is_window_function, bool is_input_nullable,
+                                                            bool is_arrow_input) {
     if (binary_type != TFunctionBinaryType::SRJAR) {
         return nullptr;
     }
     if (is_window_function) {
         return getJavaWindowFunction();
+    }
+    if (is_arrow_input) {
+        // Vectorized ("input"="arrow") Java UDAF.
+        return getArrowJavaUDAFFunction();
     }
     return getJavaUDAFFunction(is_input_nullable);
 }
@@ -139,7 +144,7 @@ AggregateFunctionPtr AggregateFactory::MakeNtileWindowFunction() {
 
 static AggregateFunctionPtr get_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
                                          bool is_window_function, bool is_null, TFunctionBinaryType::type binary_type,
-                                         int func_version) {
+                                         int func_version, bool is_arrow_input = false) {
     std::string func_name = name;
     if (func_version > 1) {
         if (name == "multi_distinct_sum") {
@@ -182,7 +187,7 @@ static AggregateFunctionPtr get_function(const std::string& name, LogicalType ar
         }
         return AggregateFuncResolver::instance()->get_general_info(func_name, is_window_function, is_null);
     }
-    return resolve_non_builtin_aggregate_function(binary_type, is_window_function, is_null);
+    return resolve_non_builtin_aggregate_function(binary_type, is_window_function, is_null, is_arrow_input);
 }
 
 AggregateFunctionPtr get_aggregate_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
@@ -198,7 +203,8 @@ AggregateFunctionPtr get_window_function(const std::string& name, LogicalType ar
 
 AggregateFunctionPtr get_aggregate_function(const std::string& agg_func_name, const TypeDescriptor& return_type,
                                             const std::vector<TypeDescriptor>& arg_types, bool is_result_nullable,
-                                            TFunctionBinaryType::type binary_type, int func_version) {
+                                            TFunctionBinaryType::type binary_type, int func_version,
+                                            bool is_arrow_input) {
     // get function
     if (agg_func_name == "count") {
         return get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, is_result_nullable);
@@ -245,6 +251,11 @@ AggregateFunctionPtr get_aggregate_function(const std::string& agg_func_name, co
             arg_type = arg_type.children[0];
         }
 
+        if (is_arrow_input) {
+            // Vectorized ("input"="arrow") Java UDAF: route to the arrow function impl.
+            return get_function(agg_func_name, arg_type.type, ret_type.type, false, is_result_nullable, binary_type,
+                                func_version, /*is_arrow_input=*/true);
+        }
         return get_aggregate_function(agg_func_name, arg_type.type, ret_type.type, is_result_nullable, binary_type,
                                       func_version);
     }

--- a/be/src/exprs/agg/java_udaf_function.cpp
+++ b/be/src/exprs/agg/java_udaf_function.cpp
@@ -34,6 +34,11 @@ const AggregateFunction* getJavaUDAFFunction(bool input_nullable) {
     return &no_nullable_udaf_func;
 }
 
+const AggregateFunction* getArrowJavaUDAFFunction() {
+    static ArrowJavaUDAFAggregateFunction arrow_udaf_func;
+    return &arrow_udaf_func;
+}
+
 // Build a JavaUDAFSharedContext (class-level, shareable/cacheable).
 // This is the expensive part: class loading, method introspection, and stub class generation.
 // The UDAF object instance is NOT created here — it is per-aggregator (see build_udaf_unique_context).
@@ -76,7 +81,9 @@ static StatusOr<std::shared_ptr<JavaUDAFSharedContext>> build_udaf_shared_contex
     RETURN_IF_ERROR(add_method("serialize", udaf_ctx->udaf_class.clazz(), &udaf_ctx->serialize));
     RETURN_IF_ERROR(add_method("serializeLength", udaf_ctx->udaf_state_class.clazz(), &udaf_ctx->serialize_size));
 
-    // Generate and store the stub class/method — each unique context creates its own AggBatchCallStub from these
+    // Generate and store the stub class/method — each unique context creates its own AggBatchCallStub from these.
+    // Also generated for vectorized ("input"="arrow") UDAFs: the stub generator accepts FieldVector params
+    // (only primitives are rejected) and the arrow update path simply does not use the stub.
     const char* stub_clazz_name = AggBatchCallStub::stub_clazz_name;
     const char* stub_method_name = AggBatchCallStub::batch_update_method_name;
     jclass udaf_clazz = udaf_ctx->udaf_class.clazz();

--- a/be/src/exprs/agg/java_udaf_function.h
+++ b/be/src/exprs/agg/java_udaf_function.h
@@ -29,6 +29,7 @@
 #include "common/status.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/function_context.h"
+#include "exprs/udf/java/arrow_udf_jni.h"
 #include "exprs/udf/java/java_data_converter.h"
 #include "exprs/udf/java/java_udf.h"
 #include "exprs/udf/java/java_udf_context.h"
@@ -36,6 +37,7 @@
 #include "gutil/casts.h"
 #include "jni.h"
 #include "types/logical_type.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
 
@@ -118,7 +120,7 @@ public:
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t batch_size,
-                                     MutableColumnPtr& dst) const final {
+                                     MutableColumnPtr& dst) const override {
         auto& helper = JVMFunctionHelper::getInstance();
         auto* env = JVMHelper::getInstance().getEnv();
         auto* udf_ctxs = get_java_udaf_context(ctx);
@@ -517,5 +519,66 @@ public:
     }
 
     std::string get_name() const override { return "java_udaf"; }
+};
+
+// Vectorized ("input"="arrow") Java UDAF. Isolates the arrow calling convention from the shared
+// JavaUDAFAggregateFunction: it reuses the base for create/merge/serialize/finalize (which don't
+// touch raw input columns) and overrides only the update paths. Arrow input fits only the
+// single-state path (whole batch -> one state), i.e. global / sorted aggregation; the interleaved
+// hash GROUP BY paths are rejected. Selected at the factory when input="arrow".
+class ArrowJavaUDAFAggregateFunction final : public JavaUDAFAggregateFunction {
+public:
+    static constexpr const char* kGroupByUnsupported =
+            "arrow-input UDAF is only supported for global / sorted aggregation, not GROUP BY";
+
+    // Single-state update: convert the whole batch to Arrow and invoke update(State, FieldVector...)
+    // via com.starrocks.udf.ArrowUDFHelper.batchUpdateSingle over the C Data Interface.
+    void update_batch_single_state(FunctionContext* ctx, size_t batch_size, const Column** columns,
+                                   AggDataPtr __restrict state) const override {
+        auto& helper = JVMFunctionHelper::getInstance();
+        auto* udf_ctxs = get_java_udaf_context(ctx);
+        DCHECK(udf_ctxs != nullptr);
+        auto* env = JVMHelper::getInstance().getEnv();
+        env->PushLocalFrame(16);
+        auto defer = DeferOp([env]() { env->PopLocalFrame(nullptr); });
+
+        int num_cols = ctx->get_num_args();
+        std::vector<TypeDescriptor> arg_types(num_cols);
+        for (int i = 0; i < num_cols; ++i) {
+            arg_types[i] = *ctx->get_arg_type(i);
+        }
+
+        ExportedArrowBatch input;
+        auto st = input.export_columns(batch_size, columns, num_cols, arg_types.data());
+        SET_FUNCTION_CONTEXT_ERR(st, ctx);
+        RETURN_IF_UNLIKELY(!st.ok(), (void)0);
+
+        auto helper_cls = arrow_udf_helper_class();
+        SET_FUNCTION_CONTEXT_ERR(helper_cls.status(), ctx);
+        RETURN_IF_UNLIKELY(!helper_cls.ok(), (void)0);
+        jmethodID mid = env->GetStaticMethodID(helper_cls.value(), "batchUpdateSingle",
+                                               "(Ljava/lang/Object;Ljava/lang/reflect/Method;Ljava/lang/Object;JJ)V");
+        CHECK_UDF_CALL_EXCEPTION(env, ctx);
+
+        jobject state_obj = helper.convert_handle_to_jobject(ctx, this->data(state).handle);
+        env->CallStaticVoidMethod(helper_cls.value(), mid, udf_ctxs->handle.handle(),
+                                  udf_ctxs->ctx->update->method.handle(), state_obj, input.schema_addr(),
+                                  input.array_addr());
+        CHECK_UDF_CALL_EXCEPTION(env, ctx);
+    }
+
+    // Interleaved (per-row group routing) paths cannot hand a whole-batch FieldVector to one state.
+    void update_batch(FunctionContext* ctx, size_t, size_t, const Column**, AggDataPtr*) const override {
+        ctx->set_error(kGroupByUnsupported);
+    }
+    void update_batch_selectively(FunctionContext* ctx, size_t, size_t, const Column**, AggDataPtr*,
+                                  const Filter&) const override {
+        ctx->set_error(kGroupByUnsupported);
+    }
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns&, size_t, MutableColumnPtr&) const override {
+        ctx->set_error(kGroupByUnsupported);
+    }
+
+    std::string get_name() const override { return "arrow_java_udaf"; }
 };
 } // namespace starrocks

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -26,10 +26,12 @@
 #include "common/constexpr.h"
 #include "exprs/expr_context.h"
 #include "exprs/function_context.h"
+#include "exprs/udf/java/jni_arrow_func_call_stub.h"
 #include "exprs/udf/python/callstub.h"
 #include "gen_cpp/Types_types.h"
 #include "platform/user_function_cache.h"
 #include "runtime/current_thread.h"
+#include "runtime/java/java_runtime.h"
 
 namespace starrocks {
 
@@ -90,6 +92,10 @@ Status ArrowFunctionCallExpr::prepare(RuntimeState* state, ExprContext* context)
 Status ArrowFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
                                    FunctionContext::FunctionStateScope scope) {
     RETURN_IF_ERROR(Expr::open(state, context, scope));
+    // Arrow-input Java UDFs run their evaluate() in the JVM; make sure the JVM is up.
+    if (_fn.binary_type == TFunctionBinaryType::SRJAR) {
+        RETURN_IF_ERROR(detect_java_runtime());
+    }
     FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
     Columns const_columns;
     if (scope == FunctionContext::FRAGMENT_LOCAL) {
@@ -125,6 +131,9 @@ bool ArrowFunctionCallExpr::is_constant() const {
 
 std::unique_ptr<UDFCallStub> ArrowFunctionCallExpr::_build_stub(int32_t driver_id, FunctionContext* context) {
     auto binary_type = _fn.binary_type;
+    if (binary_type == TFunctionBinaryType::SRJAR) {
+        return create_jni_arrow_call_stub(context, _runtime_state, _lib_path, _fn.scalar_fn.symbol);
+    }
     if (binary_type == TFunctionBinaryType::PYTHON) {
         PyFunctionDescriptor py_func_desc;
         py_func_desc.symbol = _fn.scalar_fn.symbol;

--- a/be/src/exprs/expr_factory.cpp
+++ b/be/src/exprs/expr_factory.cpp
@@ -128,7 +128,13 @@ Status create_vectorized_expr(ObjectPool* pool, const TExprNode& texpr_node, Exp
     case TExprNodeType::COMPUTE_FUNCTION_CALL:
     case TExprNodeType::FUNCTION_CALL: {
         if (texpr_node.fn.binary_type == TFunctionBinaryType::SRJAR) {
-            *expr = pool->add(new JavaFunctionCallExpr(texpr_node));
+            // Vectorized ("input"="arrow") Java UDFs share the Arrow call path; the boxed
+            // per-row path stays on JavaFunctionCallExpr.
+            if (texpr_node.fn.__isset.input_type && texpr_node.fn.input_type == "arrow") {
+                *expr = pool->add(new ArrowFunctionCallExpr(texpr_node));
+            } else {
+                *expr = pool->add(new JavaFunctionCallExpr(texpr_node));
+            }
         } else if (texpr_node.fn.binary_type == TFunctionBinaryType::PYTHON) {
             *expr = pool->add(new ArrowFunctionCallExpr(texpr_node));
         }

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -25,6 +25,7 @@
 #include "common/compiler_util.h"
 #include "exprs/function_context.h"
 #include "exprs/table_function/table_function.h"
+#include "exprs/udf/java/arrow_udf_jni.h"
 #include "exprs/udf/java/java_data_converter.h"
 #include "exprs/udf/java/java_udf.h"
 #include "exprs/udf/java/java_udf_reflection.h"
@@ -171,16 +172,58 @@ Status JavaUDTFFunction::close(RuntimeState* runtime_state, TableFunctionState* 
     return Status::OK();
 }
 
+// Drain the per-input-row output arrays (rets[i] = T[] for input row i) into the output column and
+// build the row-expansion offsets. Shared by the per-row (boxed) and vectorized (arrow) UDTF paths,
+// which differ only in how they produce `rets`.
+static std::pair<Columns, UInt32Column::Ptr> emit_udtf_rows(JNIEnv* env, RuntimeState* runtime_state,
+                                                            JavaUDTFState* stateUDTF, const std::vector<jobject>& rets,
+                                                            size_t num_rows) {
+    Columns res;
+    auto offsets_col = UInt32Column::create();
+    auto& offsets = offsets_col->get_data();
+    offsets.resize(num_rows + 1);
+
+    auto col = ColumnHelper::create_column(stateUDTF->type_desc(), true);
+    col->reserve(num_rows);
+
+    for (int i = 0; i < num_rows; ++i) {
+        int len = rets[i] != nullptr ? env->GetArrayLength((jarray)rets[i]) : 0;
+        offsets[i + 1] = offsets[i] + len;
+        for (int j = 0; j < len; ++j) {
+            jobject vi = env->GetObjectArrayElement((jobjectArray)rets[i], j);
+            LOCAL_REF_GUARD_ENV(env, vi);
+            auto st = check_type_matched(stateUDTF->type_desc(), vi, stateUDTF->return_type_desc_handle());
+            if (UNLIKELY(!st.ok())) {
+                stateUDTF->set_status(st);
+                return {};
+            }
+            auto ares = append_jvalue(stateUDTF->type_desc(), true, col.get(), {.l = vi},
+                                      runtime_state != nullptr && runtime_state->error_if_overflow(),
+                                      stateUDTF->return_type_desc_handle());
+            if (UNLIKELY(!ares.ok())) {
+                stateUDTF->set_status(Status::InternalError(ares.to_string()));
+                return {};
+            }
+        }
+    }
+
+    res.emplace_back(std::move(col));
+
+    if (auto jthr = env->ExceptionOccurred(); jthr != nullptr) {
+        std::string err = fmt::format("execute UDF Function meet Exception:{}",
+                                      JVMHelper::getInstance().dumpExceptionString(jthr));
+        LOG(WARNING) << err;
+        env->ExceptionClear();
+    }
+    return std::make_pair(std::move(res), std::move(offsets_col));
+}
+
 std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* runtime_state,
                                                                 TableFunctionState* state) const {
-    Columns res;
     const Columns& cols = state->get_columns();
     auto* stateUDTF = down_cast<JavaUDTFState*>(state);
 
     JNIEnv* env = JVMHelper::getInstance().getEnv();
-
-    jmethodID methodID = env->GetMethodID(stateUDTF->get_udtf_clazz(), stateUDTF->method_process()->name.c_str(),
-                                          stateUDTF->method_process()->signature.c_str());
 
     std::vector<jvalue> call_stack;
     std::vector<jobject> rets;
@@ -197,6 +240,9 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
         env->PopLocalFrame(nullptr);
     });
     env->PushLocalFrame(num_cols * num_rows + 16);
+
+    jmethodID methodID = env->GetMethodID(stateUDTF->get_udtf_clazz(), stateUDTF->method_process()->name.c_str(),
+                                          stateUDTF->method_process()->signature.c_str());
 
     // Boundary check: method_desc must have at least num_cols + 1 elements
     // (index 0 is return type, indices 1..num_cols are parameter types)
@@ -238,46 +284,68 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* ru
         }
     }
 
-    // Build Return Type
-    auto offsets_col = UInt32Column::create();
-    auto& offsets = offsets_col->get_data();
-    offsets.resize(num_rows + 1);
+    return emit_udtf_rows(env, runtime_state, stateUDTF, rets, num_rows);
+}
 
-    auto col = ColumnHelper::create_column(stateUDTF->type_desc(), true);
-    col->reserve(num_rows);
+// Vectorized ("input"="arrow") Java UDTF. Isolates the arrow calling convention from the per-row
+// JavaUDTFFunction: it reuses init/open/close (class + process-method loading) and overrides only
+// process(), invoking process(FieldVector...) once per batch over the Arrow C Data Interface. The
+// output stays boxed (T[][]), so the row-expansion drain (emit_udtf_rows) is shared.
+class ArrowJavaUDTFFunction final : public JavaUDTFFunction {
+public:
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override {
+        const Columns& cols = state->get_columns();
+        auto* stateUDTF = down_cast<JavaUDTFState*>(state);
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
 
-    for (int i = 0; i < num_rows; ++i) {
-        int len = rets[i] != nullptr ? env->GetArrayLength((jarray)rets[i]) : 0;
-        offsets[i + 1] = offsets[i] + len;
-        // update for col
-        for (int j = 0; j < len; ++j) {
-            jobject vi = env->GetObjectArrayElement((jobjectArray)rets[i], j);
-            LOCAL_REF_GUARD_ENV(env, vi);
-            auto st = check_type_matched(stateUDTF->type_desc(), vi, stateUDTF->return_type_desc_handle());
-            if (UNLIKELY(!st.ok())) {
-                state->set_status(st);
-                return {};
-            }
-            auto res = append_jvalue(stateUDTF->type_desc(), true, col.get(), {.l = vi},
-                                     runtime_state != nullptr && runtime_state->error_if_overflow(),
-                                     stateUDTF->return_type_desc_handle());
-            if (UNLIKELY(!res.ok())) {
-                state->set_status(Status::InternalError(res.to_string()));
-                return {};
-            }
+        size_t num_rows = cols[0]->size();
+        std::vector<jobject> rets;
+        rets.resize(num_rows);
+        state->set_processed_rows(num_rows);
+
+        DeferOp defer = DeferOp([&]() { env->PopLocalFrame(nullptr); });
+        env->PushLocalFrame(static_cast<int>(num_rows) + 16);
+
+        ExportedArrowBatch input;
+        Status st = input.export_columns(num_rows, cols, stateUDTF->arg_type_descs().data());
+        if (!st.ok()) {
+            state->set_status(st);
+            return {};
         }
+        auto helper_cls = arrow_udf_helper_class();
+        if (!helper_cls.ok()) {
+            state->set_status(helper_cls.status());
+            return {};
+        }
+        jmethodID mid = env->GetStaticMethodID(helper_cls.value(), "evaluateUDTF",
+                                               "(Ljava/lang/Object;Ljava/lang/reflect/Method;JJ)[[Ljava/lang/Object;");
+        auto result = (jobjectArray)env->CallStaticObjectMethod(helper_cls.value(), mid, stateUDTF->handle(),
+                                                                stateUDTF->method_process()->method.handle(),
+                                                                input.schema_addr(), input.array_addr());
+        if (auto jthr = env->ExceptionOccurred(); jthr != nullptr) {
+            std::string err = fmt::format("execute arrow UDTF meet Exception:{}",
+                                          JVMHelper::getInstance().dumpExceptionString(jthr));
+            LOG(WARNING) << err;
+            env->ExceptionClear();
+            state->set_status(Status::InternalError(err));
+            return {};
+        }
+        int result_len = result != nullptr ? env->GetArrayLength(result) : 0;
+        if (result_len != static_cast<int>(num_rows)) {
+            state->set_status(Status::InternalError(
+                    fmt::format("arrow UDTF process() returned {} rows, expected {}", result_len, num_rows)));
+            return {};
+        }
+        for (int i = 0; i < num_rows; ++i) {
+            rets[i] = env->GetObjectArrayElement(result, i);
+        }
+        return emit_udtf_rows(env, runtime_state, stateUDTF, rets, num_rows);
     }
+};
 
-    res.emplace_back(std::move(col));
-
-    // TODO: add error msg to Function State
-    if (auto jthr = env->ExceptionOccurred(); jthr != nullptr) {
-        std::string err = fmt::format("execute UDF Function meet Exception:{}",
-                                      JVMHelper::getInstance().dumpExceptionString(jthr));
-        LOG(WARNING) << err;
-        env->ExceptionClear();
-    }
-
-    return std::make_pair(std::move(res), std::move(offsets_col));
+const TableFunction* getArrowJavaUDTFFunction() {
+    static ArrowJavaUDTFFunction arrow_java_table_function;
+    return &arrow_java_table_function;
 }
 } // namespace starrocks

--- a/be/src/exprs/table_function/java_udtf_function.h
+++ b/be/src/exprs/table_function/java_udtf_function.h
@@ -19,7 +19,7 @@
 namespace starrocks {
 
 // Now UDTF only support one column return
-class JavaUDTFFunction final : public TableFunction {
+class JavaUDTFFunction : public TableFunction {
 public:
     JavaUDTFFunction() = default;
     ~JavaUDTFFunction() override = default;

--- a/be/src/exprs/table_function/table_function_factory.cpp
+++ b/be/src/exprs/table_function/table_function_factory.cpp
@@ -137,11 +137,11 @@ void register_builtin_table_function(std::string name, const std::vector<Logical
 
 const TableFunction* get_table_function(const std::string& name, const std::vector<LogicalType>& arg_type,
                                         const std::vector<LogicalType>& return_type,
-                                        TFunctionBinaryType::type binary_type) {
+                                        TFunctionBinaryType::type binary_type, bool is_arrow_input) {
     if (binary_type == TFunctionBinaryType::BUILTIN) {
         return TableFunctionResolver::instance()->get_table_function(name, arg_type, return_type);
     } else if (binary_type == TFunctionBinaryType::SRJAR) {
-        return getJavaUDTFFunction();
+        return is_arrow_input ? getArrowJavaUDTFFunction() : getJavaUDTFFunction();
     }
     return nullptr;
 }

--- a/be/src/exprs/table_function/table_function_factory.h
+++ b/be/src/exprs/table_function/table_function_factory.h
@@ -25,7 +25,8 @@ public:
 
 extern const TableFunction* get_table_function(const std::string& name, const std::vector<LogicalType>& arg_type,
                                                const std::vector<LogicalType>& return_type,
-                                               TFunctionBinaryType::type binary_type = TFunctionBinaryType::BUILTIN);
+                                               TFunctionBinaryType::type binary_type = TFunctionBinaryType::BUILTIN,
+                                               bool is_arrow_input = false);
 extern void register_builtin_table_function(std::string name, const std::vector<LogicalType>& arg_type,
                                             const std::vector<LogicalType>& return_type,
                                             const TableFunctionPtr& table_func);

--- a/be/src/exprs/udf/java/arrow_udf_jni.cpp
+++ b/be/src/exprs/udf/java/arrow_udf_jni.cpp
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/udf/java/arrow_udf_jni.h"
+
+#include <arrow/c/bridge.h>
+#include <arrow/memory_pool.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "base/utility/arrow_utils.h"
+#include "column/arrow/record_batch_converter.h"
+#include "column/arrow/type_to_arrow_converter.h"
+#include "jni.h"
+#include "runtime/java/jvm_helper.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+ExportedArrowBatch::~ExportedArrowBatch() {
+    if (_array.release != nullptr) {
+        _array.release(&_array);
+    }
+    if (_schema.release != nullptr) {
+        _schema.release(&_schema);
+    }
+}
+
+Status ExportedArrowBatch::export_record_batch(const arrow::RecordBatch& batch) {
+    return to_status(arrow::ExportRecordBatch(batch, &_array, &_schema));
+}
+
+Status ExportedArrowBatch::export_columns(size_t num_rows, const Columns& columns, const TypeDescriptor* arg_types) {
+    arrow::SchemaBuilder schema_builder;
+    for (size_t i = 0; i < columns.size(); ++i) {
+        std::shared_ptr<arrow::Field> field;
+        RETURN_IF_ERROR(convert_to_arrow_field(arg_types[i], std::to_string(i), columns[i]->is_nullable(), &field));
+        RETURN_IF_ERROR(to_status(schema_builder.AddField(field)));
+    }
+    std::shared_ptr<arrow::Schema> schema;
+    auto finished = schema_builder.Finish();
+    RETURN_IF_ERROR(to_status(std::move(finished).Value(&schema)));
+
+    std::shared_ptr<arrow::RecordBatch> record_batch;
+    RETURN_IF_ERROR(convert_columns_to_arrow_batch(num_rows, columns, arrow::default_memory_pool(), arg_types, schema,
+                                                   &record_batch));
+    return export_record_batch(*record_batch);
+}
+
+Status ExportedArrowBatch::export_columns(size_t num_rows, const Column* const* columns, size_t num_cols,
+                                          const TypeDescriptor* arg_types) {
+    // Non-owning views over the raw input columns (owned by the caller for the duration of the
+    // export) so we can reuse the Columns-based converter without copying column data.
+    Columns view(num_cols);
+    for (size_t i = 0; i < num_cols; ++i) {
+        view[i] = ColumnPtr(const_cast<Column*>(columns[i]), [](Column*) {});
+    }
+    return export_columns(num_rows, view, arg_types);
+}
+
+StatusOr<jclass> arrow_udf_helper_class() {
+    static std::mutex mtx;
+    static JavaGlobalRef cached_class = nullptr;
+    std::lock_guard<std::mutex> guard(mtx);
+    if (cached_class.handle() == nullptr) {
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
+        std::string cls_name = JVMHelper::to_jni_class_name("com.starrocks.udf.ArrowUDFHelper");
+        jclass local = env->FindClass(cls_name.c_str());
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+        if (local == nullptr) {
+            return Status::InternalError("cannot find class com.starrocks.udf.ArrowUDFHelper");
+        }
+        cached_class = JavaGlobalRef(env->NewGlobalRef(local));
+        env->DeleteLocalRef(local);
+    }
+    return reinterpret_cast<jclass>(cached_class.handle());
+}
+
+} // namespace starrocks

--- a/be/src/exprs/udf/java/arrow_udf_jni.h
+++ b/be/src/exprs/udf/java/arrow_udf_jni.h
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <arrow/c/abi.h>
+
+#include "column/column.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "jni.h"
+#include "runtime/java/java_global_ref.h"
+
+namespace arrow {
+class RecordBatch;
+}
+
+namespace starrocks {
+struct TypeDescriptor;
+
+// Neutral low-level helpers for the vectorized ("input"="arrow") Java UDF paths, shared by the
+// scalar / UDTF / UDAF implementations but living in their own translation unit so none of those
+// paths depend on each other.
+
+// RAII holder for a StarRocks column batch exported to the Arrow C Data Interface. Exporting fills
+// the owned ArrowArray/ArrowSchema C structs with a release callback; the destructor invokes those
+// callbacks unless the Java importer already consumed (moved) the structs — importVectorSchemaRoot
+// nulls the source release on success, so this is a no-op on the happy path and a leak-guard on
+// error. Move/copy are disabled: the struct addresses handed to JNI must stay stable, so it is only
+// ever used as a local.
+class ExportedArrowBatch {
+public:
+    ExportedArrowBatch() = default;
+    ~ExportedArrowBatch();
+    ExportedArrowBatch(const ExportedArrowBatch&) = delete;
+    ExportedArrowBatch& operator=(const ExportedArrowBatch&) = delete;
+
+    // Export an already-built RecordBatch (scalar path: the base class builds it).
+    Status export_record_batch(const arrow::RecordBatch& batch);
+    // Build a RecordBatch from StarRocks columns and export it (UDTF path).
+    Status export_columns(size_t num_rows, const Columns& columns, const TypeDescriptor* arg_types);
+    // Same, from raw column pointers (UDAF path, where the agg framework passes const Column**).
+    Status export_columns(size_t num_rows, const Column* const* columns, size_t num_cols,
+                          const TypeDescriptor* arg_types);
+
+    jlong schema_addr() { return reinterpret_cast<jlong>(&_schema); }
+    jlong array_addr() { return reinterpret_cast<jlong>(&_array); }
+
+private:
+    ArrowArray _array{};
+    ArrowSchema _schema{};
+};
+
+// The process-global com.starrocks.udf.ArrowUDFHelper class, resolved and cached on first use
+// (thread-safe). Returned as a borrowed global jclass owned by the cache. Callers then
+// GetStaticMethodID the entry point they need (evaluateArrow / evaluateUDTF / batchUpdateSingle) —
+// GetStaticMethodID is cheap and jmethodIDs are process-stable, so per-batch resolution is fine.
+// Must be called on a JNI-capable thread.
+StatusOr<jclass> arrow_udf_helper_class();
+
+} // namespace starrocks

--- a/be/src/exprs/udf/java/java_function_fwd.h
+++ b/be/src/exprs/udf/java/java_function_fwd.h
@@ -18,6 +18,8 @@ namespace starrocks {
 class AggregateFunction;
 class TableFunction;
 const AggregateFunction* getJavaUDAFFunction(bool input_nullable);
+const AggregateFunction* getArrowJavaUDAFFunction();
 const AggregateFunction* getJavaWindowFunction();
 const TableFunction* getJavaUDTFFunction();
+const TableFunction* getArrowJavaUDTFFunction();
 } // namespace starrocks

--- a/be/src/exprs/udf/java/jni_arrow_func_call_stub.cpp
+++ b/be/src/exprs/udf/java/jni_arrow_func_call_stub.cpp
@@ -1,0 +1,174 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/udf/java/jni_arrow_func_call_stub.h"
+
+#include <arrow/array.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <fmt/format.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "base/utility/arrow_utils.h"
+#include "exprs/udf/java/arrow_udf_jni.h"
+#include "exprs/udf/java/java_udf_reflection.h"
+#include "jni.h"
+#include "runtime/java/java_env.h"
+#include "runtime/java/java_global_ref.h"
+#include "runtime/java/jvm_class.h"
+#include "runtime/java/jvm_helper.h"
+
+namespace starrocks {
+
+// Per-driver JNI state for one arrow scalar UDF: the loaded UDF class + instance, the resolved
+// `evaluate` reflect Method, and the com.starrocks.udf.ArrowUDFHelper entry points plus the
+// per-stub Arrow BufferAllocator handle. Global refs self-clean on a JNI thread (JavaGlobalRef);
+// the allocator is closed on a JNI pthread in the destructor (its leak check doubles as a guard).
+struct JniArrowUDFContext {
+    std::unique_ptr<JavaUdfClassLoader> classloader;
+    std::unique_ptr<JavaUdfClassAnalyzer> analyzer;
+    JVMClass udf_class{nullptr};
+    JavaGlobalRef udf_handle{nullptr};
+    JavaGlobalRef evaluate_method{nullptr};
+    jclass arrow_helper_class = nullptr; // borrowed from the process-global cache (not owned)
+    jmethodID evaluate_arrow_mid = nullptr;
+    jmethodID close_allocator_mid = nullptr;
+    jlong allocator_handle = 0;
+
+    ~JniArrowUDFContext() {
+        if (allocator_handle == 0 || close_allocator_mid == nullptr) {
+            return;
+        }
+        jclass klass = arrow_helper_class;
+        jmethodID mid = close_allocator_mid;
+        jlong handle = allocator_handle;
+        (void)JavaEnv::GetInstance()->call_function_in_pthread([klass, mid, handle]() -> Status {
+            JNIEnv* env = JVMHelper::getInstance().getEnv();
+            env->CallStaticVoidMethod(klass, mid, handle);
+            RETURN_ERROR_IF_JNI_EXCEPTION(env);
+            return Status::OK();
+        });
+    }
+};
+
+namespace {
+
+class JniArrowFuncCallStub final : public AbstractArrowFuncCallStub {
+public:
+    JniArrowFuncCallStub(FunctionContext* ctx, RuntimeState* state, std::shared_ptr<JniArrowUDFContext> jni_ctx)
+            : AbstractArrowFuncCallStub(ctx), _state(state), _ctx(std::move(jni_ctx)) {}
+
+protected:
+    StatusOr<std::shared_ptr<RecordBatch>> do_evaluate(RecordBatch&& batch) override;
+
+private:
+    RuntimeState* _state;
+    std::shared_ptr<JniArrowUDFContext> _ctx;
+};
+
+StatusOr<std::shared_ptr<arrow::RecordBatch>> JniArrowFuncCallStub::do_evaluate(RecordBatch&& batch) {
+    const int64_t num_rows = batch.num_rows();
+    std::shared_ptr<arrow::Array> result_array;
+
+    auto call = [&]() -> Status {
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
+
+        // Export the input batch to the Arrow C Data Interface. ExportedArrowBatch releases the
+        // exported buffers on scope exit unless Java consumed (moved) them.
+        ExportedArrowBatch input;
+        RETURN_IF_ERROR(input.export_record_batch(batch));
+
+        // BE-owned output structs; Java exports the result FieldVector into them and transfers
+        // buffer ownership back to us (freed when the imported arrow::Array is destroyed).
+        ArrowSchema out_schema{};
+        ArrowArray out_array{};
+
+        env->CallStaticVoidMethod(_ctx->arrow_helper_class, _ctx->evaluate_arrow_mid, _ctx->udf_handle.handle(),
+                                  _ctx->evaluate_method.handle(), _ctx->allocator_handle, input.schema_addr(),
+                                  input.array_addr(), reinterpret_cast<jlong>(&out_schema),
+                                  reinterpret_cast<jlong>(&out_array));
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+
+        auto imported = arrow::ImportArray(&out_array, &out_schema);
+        if (!imported.ok()) {
+            if (out_array.release != nullptr) {
+                out_array.release(&out_array);
+            }
+            if (out_schema.release != nullptr) {
+                out_schema.release(&out_schema);
+            }
+            return to_status(imported.status());
+        }
+        result_array = *imported;
+        return Status::OK();
+    };
+
+    RETURN_IF_ERROR(JavaEnv::GetInstance()->submit_java_udf_call(_state, call)->get_future().get());
+
+    if (result_array->length() != num_rows) {
+        return Status::InternalError(fmt::format("arrow UDF result length {} does not match input row count {}",
+                                                 result_array->length(), num_rows));
+    }
+    auto result_schema = arrow::schema({arrow::field("result", result_array->type(), /*nullable=*/true)});
+    return arrow::RecordBatch::Make(result_schema, result_array->length(), {result_array});
+}
+
+} // namespace
+
+std::unique_ptr<UDFCallStub> create_jni_arrow_call_stub(FunctionContext* ctx, RuntimeState* state,
+                                                        const std::string& libpath, const std::string& symbol) {
+    auto jni_ctx = std::make_shared<JniArrowUDFContext>();
+
+    auto build = [&]() -> Status {
+        JNIEnv* env = JVMHelper::getInstance().getEnv();
+
+        jni_ctx->classloader = std::make_unique<JavaUdfClassLoader>(libpath);
+        RETURN_IF_ERROR(jni_ctx->classloader->init());
+        jni_ctx->analyzer = std::make_unique<JavaUdfClassAnalyzer>();
+        ASSIGN_OR_RETURN(jni_ctx->udf_class, jni_ctx->classloader->getClass(symbol));
+        ASSIGN_OR_RETURN(jni_ctx->udf_handle, jni_ctx->udf_class.newInstance());
+        ASSIGN_OR_RETURN(auto evaluate_obj,
+                         jni_ctx->analyzer->get_method_object(jni_ctx->udf_class.clazz(), "evaluate"));
+        jni_ctx->evaluate_method = JavaGlobalRef(evaluate_obj);
+
+        // Resolve com.starrocks.udf.ArrowUDFHelper (bundled in udf-extensions.jar, same as UDFHelper).
+        ASSIGN_OR_RETURN(jni_ctx->arrow_helper_class, arrow_udf_helper_class());
+        jclass helper = jni_ctx->arrow_helper_class;
+
+        jmethodID create_mid = env->GetStaticMethodID(helper, "createAllocator", "()J");
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+        jni_ctx->close_allocator_mid = env->GetStaticMethodID(helper, "closeAllocator", "(J)V");
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+        jni_ctx->evaluate_arrow_mid =
+                env->GetStaticMethodID(helper, "evaluateArrow", "(Ljava/lang/Object;Ljava/lang/reflect/Method;JJJJJ)V");
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+
+        jni_ctx->allocator_handle = env->CallStaticLongMethod(helper, create_mid);
+        RETURN_ERROR_IF_JNI_EXCEPTION(env);
+        return Status::OK();
+    };
+
+    Status build_status = JavaEnv::GetInstance()->submit_java_udf_call(state, build)->get_future().get();
+    if (!build_status.ok()) {
+        return create_error_call_stub(build_status);
+    }
+    return std::make_unique<JniArrowFuncCallStub>(ctx, state, std::move(jni_ctx));
+}
+
+} // namespace starrocks

--- a/be/src/exprs/udf/java/jni_arrow_func_call_stub.h
+++ b/be/src/exprs/udf/java/jni_arrow_func_call_stub.h
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "exprs/function_context.h"
+#include "exprs/udf/udf_call_stub.h"
+
+namespace starrocks {
+class RuntimeState;
+
+// Build a UDFCallStub for a vectorized ("input"="arrow") scalar Java UDF. Input columns are
+// converted to an Arrow RecordBatch by AbstractArrowFuncCallStub and handed to the Java side
+// zero-copy over the Arrow C Data Interface (com.starrocks.udf.ArrowUDFHelper.evaluateArrow),
+// which invokes the user's evaluate(FieldVector...) and returns a FieldVector.
+//
+// On any JNI/classloading failure the returned stub is an error stub whose evaluate() surfaces
+// the failure Status (mirrors the Python path).
+std::unique_ptr<UDFCallStub> create_jni_arrow_call_stub(FunctionContext* ctx, RuntimeState* state,
+                                                        const std::string& libpath, const std::string& symbol);
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -117,6 +117,7 @@ set(EXEC_FILES
         ./exprs/runtime_filter_test.cpp
         ./exprs/variant_functions_test.cpp
         ./exprs/table_function/test_list_rowsets.cpp
+        ./exprs/table_function/java_udtf_factory_test.cpp
         ./exprs/dict_expr_test.cpp
         ./formats/json/binary_column_test.cpp
         ./formats/json/numeric_column_test.cpp

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -106,6 +106,7 @@ set(EXPR_JAVA_TEST_FILES
     # Keep them out of expr_test so --without-java-ext remains a valid fast loop.
     udf/java/java_data_converter_test.cpp
     udf/java/java_udf_test.cpp
+    udf/java/arrow_udf_jni_test.cpp
 )
 
 set(EXPR_TEST_LINK_LIBS

--- a/be/test/exprs/agg/aggregate_factory_extension_test.cpp
+++ b/be/test/exprs/agg/aggregate_factory_extension_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "exprs/agg/aggregate_factory.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
 
@@ -30,6 +31,15 @@ TEST(AggregateFactoryExtensionTest, srjarAggregateUsesExprsExtension) {
 
     ASSERT_NE(nullptr, func);
     EXPECT_EQ("java_udaf", func->get_name());
+}
+
+TEST(AggregateFactoryExtensionTest, srjarArrowAggregateUsesArrowVariant) {
+    TypeDescriptor bigint(TYPE_BIGINT);
+    const auto* func = get_aggregate_function("java_udaf", bigint, std::vector<TypeDescriptor>{bigint}, false,
+                                              TFunctionBinaryType::SRJAR, /*func_version=*/1, /*is_arrow_input=*/true);
+
+    ASSERT_NE(nullptr, func);
+    EXPECT_EQ("arrow_java_udaf", func->get_name());
 }
 
 TEST(AggregateFactoryExtensionTest, srjarWindowUsesExprsExtension) {

--- a/be/test/exprs/expr_factory_core_test.cpp
+++ b/be/test/exprs/expr_factory_core_test.cpp
@@ -123,6 +123,26 @@ TEST_F(ExprFactoryCoreTest, SrjarFunctionCallHasPriorityOverCoreCondition) {
     ASSERT_NE(nullptr, dynamic_cast<JavaFunctionCallExpr*>(root_expr));
 }
 
+TEST_F(ExprFactoryCoreTest, SrjarArrowInputUsesArrowFunctionCallExpr) {
+    reset_hook_counters();
+    ExprFactory::set_non_core_create_post_hook(post_hook_handle_all);
+
+    auto node = make_function_call_node("if", TFunctionBinaryType::SRJAR);
+    node.fn.__set_input_type("arrow");
+    TExpr texpr;
+    texpr.nodes.emplace_back(node);
+
+    ObjectPool pool;
+    RuntimeState state;
+    Expr* root_expr = nullptr;
+    ASSERT_TRUE(ExprFactory::create_expr_tree(&pool, texpr, &root_expr, &state).ok());
+    ASSERT_EQ(0, g_post_hook_calls);
+
+    // SRJAR + input=arrow routes to the Arrow call path, not the boxed JavaFunctionCallExpr.
+    ASSERT_NE(nullptr, dynamic_cast<ArrowFunctionCallExpr*>(root_expr));
+    ASSERT_EQ(nullptr, dynamic_cast<JavaFunctionCallExpr*>(root_expr));
+}
+
 TEST_F(ExprFactoryCoreTest, PythonFunctionCallHasPriorityOverCoreCondition) {
     reset_hook_counters();
     ExprFactory::set_non_core_create_post_hook(post_hook_handle_all);

--- a/be/test/exprs/table_function/java_udtf_factory_test.cpp
+++ b/be/test/exprs/table_function/java_udtf_factory_test.cpp
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "exprs/table_function/table_function_factory.h"
+
+namespace starrocks {
+
+// A SRJAR table function resolves to the boxed JavaUDTF by default, and to the vectorized
+// ("input"="arrow") variant when is_arrow_input is set — two distinct singletons.
+TEST(JavaUDTFFactoryTest, SrjarBoxedVsArrowDistinct) {
+    const auto* boxed = get_table_function("f", {TYPE_INT}, {TYPE_INT}, TFunctionBinaryType::SRJAR,
+                                           /*is_arrow_input=*/false);
+    const auto* arrow = get_table_function("f", {TYPE_INT}, {TYPE_INT}, TFunctionBinaryType::SRJAR,
+                                           /*is_arrow_input=*/true);
+    ASSERT_NE(nullptr, boxed);
+    ASSERT_NE(nullptr, arrow);
+    EXPECT_NE(boxed, arrow);
+}
+
+TEST(JavaUDTFFactoryTest, NonSrjarReturnsNull) {
+    EXPECT_EQ(nullptr, get_table_function("f", {TYPE_INT}, {TYPE_INT}, TFunctionBinaryType::PYTHON,
+                                          /*is_arrow_input=*/true));
+}
+
+} // namespace starrocks

--- a/be/test/exprs/udf/java/arrow_udf_jni_test.cpp
+++ b/be/test/exprs/udf/java/arrow_udf_jni_test.cpp
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/udf/java/arrow_udf_jni.h"
+
+#include <arrow/c/abi.h>
+#include <gtest/gtest.h>
+
+#include "base/testutil/assert.h"
+#include "column/fixed_length_column.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// ExportedArrowBatch exports StarRocks columns to the Arrow C Data Interface without needing a JVM,
+// so the export side of the vectorized UDF path is unit-testable directly.
+TEST(ExportedArrowBatchTest, ExportColumnsPopulatesCStructs) {
+    auto column = Int32Column::create();
+    column->append(1);
+    column->append(2);
+    column->append(3);
+    Columns columns;
+    columns.emplace_back(std::move(column));
+    TypeDescriptor type_descs[] = {TypeDescriptor(TYPE_INT)};
+
+    ExportedArrowBatch batch;
+    ASSERT_OK(batch.export_columns(3, columns, type_descs));
+
+    auto* array = reinterpret_cast<ArrowArray*>(batch.array_addr());
+    auto* schema = reinterpret_cast<ArrowSchema*>(batch.schema_addr());
+    EXPECT_EQ(3, array->length);
+    // The exporter installs release callbacks; the destructor invokes them (leak-guard).
+    EXPECT_NE(nullptr, array->release);
+    EXPECT_NE(nullptr, schema->release);
+}
+
+// The raw-pointer overload (used by the UDAF path, which receives const Column**) builds a
+// non-owning view internally and delegates to the Columns overload.
+TEST(ExportedArrowBatchTest, ExportRawColumnPointers) {
+    auto column = Int32Column::create();
+    column->append(7);
+    column->append(8);
+    TypeDescriptor type_descs[] = {TypeDescriptor(TYPE_INT)};
+    const Column* raw[] = {column.get()};
+
+    ExportedArrowBatch batch;
+    ASSERT_OK(batch.export_columns(2, raw, 1, type_descs));
+    EXPECT_EQ(2, reinterpret_cast<ArrowArray*>(batch.array_addr())->length);
+}
+
+} // namespace starrocks

--- a/be/test/exprs/udf/java/java_udf_test.cpp
+++ b/be/test/exprs/udf/java/java_udf_test.cpp
@@ -21,6 +21,7 @@
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "exprs/function_context.h"
+#include "exprs/udf/java/arrow_udf_jni.h"
 #include "exprs/udf/java/java_udf_reflection.h"
 #include "gutil/casts.h"
 #include "runtime/java/jni_env.h"
@@ -127,6 +128,18 @@ double JavaUDFTest::_expected_time_seconds(jobject time_obj) {
         seconds += 24 * 3600;
     }
     return static_cast<double>(seconds);
+}
+
+// The process-global com.starrocks.udf.ArrowUDFHelper class (used by the vectorized UDF paths)
+// resolves via JNI and is cached — the second call returns the same borrowed jclass.
+TEST_F(JavaUDFTest, arrow_udf_helper_class_resolves_and_caches) {
+    auto first = arrow_udf_helper_class();
+    ASSERT_TRUE(first.ok());
+    ASSERT_NE(nullptr, first.value());
+
+    auto second = arrow_udf_helper_class();
+    ASSERT_TRUE(second.ok());
+    EXPECT_EQ(first.value(), second.value());
 }
 
 TEST_F(JavaUDFTest, test_time_convert) {

--- a/docs/en/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/en/sql-reference/sql-functions/JAVA_UDF.md
@@ -405,6 +405,114 @@ PROPERTIES (
 | type      | The type of the UDF. Set the value to `StarrocksJar`, which specifies that the UDF is a Java-based function. |
 | file      | The HTTP URL from which you can download the JAR file that contains the code for the UDF. The value of this parameter is in the `http://<http_server_ip>:<http_server_port>/<jar_package_name>` format. |
 | isolation | (Optional) To share function instances across UDF executions and support static variables, set this to "shared". |
+| input     | (Optional) Input format. Valid values: `scalar` (default, one boxed Java object per row) and `arrow` (vectorized — one Apache Arrow `FieldVector` per argument for the whole batch). See [Vectorized (Arrow) input](#vectorized-arrow-input). |
+
+#### Vectorized (Arrow) input
+
+Setting `"input" = "arrow"` switches a Java UDF from the per-row boxed calling convention to a
+**vectorized** one: your method receives one Apache Arrow
+`FieldVector` per argument covering the whole batch, and
+(for scalar/UDTF) returns a `FieldVector`. Columns are exchanged with the backend zero-copy over the
+[Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html), avoiding the
+per-row boxing/unboxing of the default path.
+
+Add the Arrow dependency to your Maven project (the version must match the one bundled with your
+StarRocks release), scoped `provided` since the BE already ships it:
+
+```xml
+<dependency>
+    <groupId>org.apache.arrow</groupId>
+    <artifactId>arrow-vector</artifactId>
+    <version>17.0.0</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+Allocate result vectors from the framework-managed allocator via `arg.getAllocator()` so the engine
+owns their lifecycle.
+
+:::note
+The BE runs the UDF in an embedded JVM that must expose `java.nio` to Arrow's off-heap memory
+layer. The shipped `conf/be.conf` already sets this via
+`JAVA_OPTS="... --add-opens=java.base/java.nio=ALL-UNNAMED ..."`; if you customize `JAVA_OPTS`,
+keep that flag or arrow-input UDFs fail to initialize.
+:::
+
+**Scalar** — `evaluate(FieldVector...)` returns a `FieldVector`:
+
+```java
+public class ArrowAdd {
+    public IntVector evaluate(IntVector a, IntVector b) {
+        IntVector out = new IntVector("result", a.getAllocator());
+        int n = a.getValueCount();
+        out.allocateNew(n);
+        for (int i = 0; i < n; i++) {
+            if (a.isNull(i) || b.isNull(i)) {
+                out.setNull(i);
+            } else {
+                out.set(i, a.get(i) + b.get(i));
+            }
+        }
+        out.setValueCount(n);
+        return out;
+    }
+}
+```
+
+```SQL
+CREATE FUNCTION arrow_add(INT, INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.udf.sample.ArrowAdd",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "http://http_host:http_port/udf-1.0-SNAPSHOT-jar-with-dependencies.jar"
+);
+```
+
+**UDTF** — `process(FieldVector...)` returns `T[][]` (one `T[]` of output rows per input row; only the
+input is vectorized):
+
+```java
+public class ArrowRepeat {
+    public Integer[][] process(IntVector v) {
+        Integer[][] out = new Integer[v.getValueCount()][];
+        for (int i = 0; i < v.getValueCount(); i++) {
+            out[i] = v.isNull(i) ? new Integer[0] : new Integer[] {v.get(i), v.get(i)};
+        }
+        return out;
+    }
+}
+```
+
+**UDAF** — `update(State, FieldVector...)` receives the whole batch destined for one state;
+`create`/`merge`/`serialize`/`finalize` keep their normal (boxed) signatures.
+
+> **LIMITATIONS**
+>
+> - Arrow-input UDAFs are supported only for **global aggregation** and **sorted-streaming
+>   aggregation** (a whole batch belongs to one state). A query that routes an arrow UDAF through a
+>   hash `GROUP BY` fails with a clear error — use the default (boxed) input for `GROUP BY` UDAFs.
+> - Arrow input is **not** supported for window functions (`analytic = "true"`) yet.
+
+Mapping between SQL types and the Arrow `FieldVector` your method receives:
+
+| SQL type   | Arrow FieldVector          |
+| ---------- | -------------------------- |
+| BOOLEAN    | `BitVector`                |
+| TINYINT    | `TinyIntVector`            |
+| SMALLINT   | `SmallIntVector`           |
+| INT        | `IntVector`                |
+| BIGINT     | `BigIntVector`             |
+| FLOAT      | `Float4Vector`             |
+| DOUBLE     | `Float8Vector`             |
+| VARCHAR    | `VarCharVector`            |
+| DECIMAL    | `DecimalVector`            |
+| DATE       | `DateDayVector`            |
+| DATETIME   | `TimeStampMicroVector`     |
+| ARRAY      | `ListVector`               |
+| MAP        | `MapVector`                |
+| STRUCT     | `StructVector`             |
 
 #### Create a UDAF
 

--- a/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
+++ b/docs/zh/sql-reference/sql-functions/JAVA_UDF.md
@@ -412,6 +412,89 @@ PROPERTIES (
 |type|用于标记所创建的 UDF 类型。取值为 `StarrocksJar`，表示基于 Java 的 UDF。|
 |file|UDF 所在 Jar 包的 HTTP 路径。格式为`http://<http_server_ip>:<http_server_port>/<jar_package_name>`。|
 |isolation|(可选）如需在 UDF 执行中共享函数实例并支持静态变量，请将其设置为 "shared"。|
+|input|（可选）输入格式。取值：`scalar`（默认，每行一个装箱的 Java 对象）和 `arrow`（向量化，每个参数一个覆盖整批数据的 Apache Arrow `FieldVector`）。参见[向量化（Arrow）输入](#向量化arrow输入)。|
+
+#### 向量化（Arrow）输入
+
+设置 `"input" = "arrow"` 可将 Java UDF 从逐行装箱的调用方式切换为**向量化**方式：您的方法为每个参数接收一个覆盖整批数据的 Apache Arrow `FieldVector`，并（对 scalar / UDTF）返回一个 `FieldVector`。列数据通过 [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html) 与 BE 零拷贝交换，避免了默认路径逐行装箱/拆箱的开销。
+
+在 Maven 项目中添加 Arrow 依赖（版本需与 StarRocks 发行版内置版本一致）；因 BE 已内置该库，使用 `provided` 作用域：
+
+```xml
+<dependency>
+    <groupId>org.apache.arrow</groupId>
+    <artifactId>arrow-vector</artifactId>
+    <version>17.0.0</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+请通过 `arg.getAllocator()` 从框架管理的分配器分配结果向量，以便引擎管理其生命周期。
+
+:::note
+BE 在内置 JVM 中执行 UDF，该 JVM 必须向 Arrow 的堆外内存层开放 `java.nio`。发行版自带的 `conf/be.conf` 已通过
+`JAVA_OPTS="... --add-opens=java.base/java.nio=ALL-UNNAMED ..."` 设置；若自定义 `JAVA_OPTS`，请保留该参数，否则 arrow 输入的 UDF 无法初始化。
+:::
+
+**Scalar** —— `evaluate(FieldVector...)` 返回 `FieldVector`：
+
+```java
+public class ArrowAdd {
+    public IntVector evaluate(IntVector a, IntVector b) {
+        IntVector out = new IntVector("result", a.getAllocator());
+        int n = a.getValueCount();
+        out.allocateNew(n);
+        for (int i = 0; i < n; i++) {
+            if (a.isNull(i) || b.isNull(i)) {
+                out.setNull(i);
+            } else {
+                out.set(i, a.get(i) + b.get(i));
+            }
+        }
+        out.setValueCount(n);
+        return out;
+    }
+}
+```
+
+```SQL
+CREATE FUNCTION arrow_add(INT, INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.udf.sample.ArrowAdd",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "http://http_host:http_port/udf-1.0-SNAPSHOT-jar-with-dependencies.jar"
+);
+```
+
+**UDTF** —— `process(FieldVector...)` 返回 `T[][]`（每个输入行对应一个输出行数组 `T[]`，仅输入向量化）。
+
+**UDAF** —— `update(State, FieldVector...)` 接收发往同一个 state 的整批数据；`create`/`merge`/`serialize`/`finalize` 保持常规（装箱）签名。
+
+> **限制**
+>
+> - Arrow 输入的 UDAF 仅支持**全局聚合**和**有序流式聚合**（整批数据属于同一个 state）。将 Arrow UDAF 用于哈希 `GROUP BY` 的查询会返回明确错误——`GROUP BY` 的 UDAF 请使用默认（装箱）输入。
+> - 暂不支持窗口函数（`analytic = "true"`）的 Arrow 输入。
+
+SQL 类型与方法接收到的 Arrow `FieldVector` 的映射：
+
+| SQL 类型   | Arrow FieldVector          |
+| ---------- | -------------------------- |
+| BOOLEAN    | `BitVector`                |
+| TINYINT    | `TinyIntVector`            |
+| SMALLINT   | `SmallIntVector`           |
+| INT        | `IntVector`                |
+| BIGINT     | `BigIntVector`             |
+| FLOAT      | `Float4Vector`             |
+| DOUBLE     | `Float8Vector`             |
+| VARCHAR    | `VarCharVector`            |
+| DECIMAL    | `DecimalVector`            |
+| DATE       | `DateDayVector`            |
+| DATETIME   | `TimeStampMicroVector`     |
+| ARRAY      | `ListVector`               |
+| MAP        | `MapVector`                |
+| STRUCT     | `StructVector`             |
 
 #### 创建 UDAF
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -257,6 +257,7 @@ public class AggregateFunction extends Function {
         String symbolName;
         CloudConfiguration cloudConfiguration;
         private boolean isolationType = true;
+        private String inputType;
 
         private AggregateFunctionBuilder(TFunctionBinaryType binaryType) {
             this.binaryType = binaryType;
@@ -316,6 +317,11 @@ public class AggregateFunction extends Function {
             return this;
         }
 
+        public AggregateFunctionBuilder inputType(String inputType) {
+            this.inputType = inputType;
+            return this;
+        }
+
         public void setIntermediateType(Type intermediateType) {
             this.intermediateType = intermediateType;
         }
@@ -329,6 +335,7 @@ public class AggregateFunction extends Function {
             fn.setLocation(new HdfsURI(objectFile));
             fn.setCloudConfiguration(cloudConfiguration);
             fn.setIsolationType(isolationType);
+            fn.setInputType(inputType);
             return fn;
         }
     }
@@ -398,6 +405,9 @@ public class AggregateFunction extends Function {
         }
         if (isAnalyticFn) {
             props.put(CreateFunctionStmt.IS_ANALYTIC_NAME, "true");
+        }
+        if (!Strings.isEmpty(getInputType())) {
+            props.put(CreateFunctionStmt.INPUT_TYPE, getInputType());
         }
         return props;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -171,6 +171,11 @@ public class Function implements Writable {
     @SerializedName(value = "cloud_configuration")
     private CloudConfiguration cloudConfiguration;
 
+    // Input format passed to the BE ("arrow" for vectorized UDFs; null = the default per-row path).
+    // See TFunction.input_type and CreateFunctionStmt.INPUT_TYPE.
+    @SerializedName(value = "inputType")
+    private String inputType;
+
     // Only used for serialization
     protected Function() {
     }
@@ -248,6 +253,15 @@ public class Function implements Writable {
         isNullable = other.isNullable;
         isMetaFunction = other.isMetaFunction;
         aggStateDesc = other.aggStateDesc;
+        inputType = other.inputType;
+    }
+
+    public void setInputType(String inputType) {
+        this.inputType = inputType;
+    }
+
+    public String getInputType() {
+        return inputType;
     }
 
     public FunctionName getFunctionName() {
@@ -789,6 +803,9 @@ public class Function implements Writable {
         }
         if (aggStateDesc != null) {
             fn.setAgg_state_desc(TypeSerializer.toThrift(aggStateDesc));
+        }
+        if (inputType != null) {
+            fn.setInput_type(inputType);
         }
         fn.setCould_apply_dict_optimize(couldApplyDictOptimize);
         return fn;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -66,8 +66,6 @@ public class ScalarFunction extends Function {
     // isolated/shared
     @SerializedName(value = "isolated")
     private boolean isolationType = true;
-    @SerializedName(value = "inputType")
-    private String inputType;
     @SerializedName(value = "content")
     private String content;
 
@@ -105,7 +103,6 @@ public class ScalarFunction extends Function {
         prepareFnSymbol = other.prepareFnSymbol;
         closeFnSymbol = other.closeFnSymbol;
         isolationType = other.isolationType;
-        inputType = other.inputType;
         content = other.content;
     }
 
@@ -223,10 +220,6 @@ public class ScalarFunction extends Function {
         this.isolationType = isolationType;
     }
 
-    public void setInputType(String inputType) {
-        this.inputType = inputType;
-    }
-
     public void setContent(String content) {
         this.content = content;
     }
@@ -261,8 +254,8 @@ public class ScalarFunction extends Function {
         if (!Strings.isEmpty(getSymbolName())) {
             props.put(CreateFunctionStmt.SYMBOL_KEY, getSymbolName());
         }
-        if (!Strings.isEmpty(inputType)) {
-            props.put(CreateFunctionStmt.INPUT_TYPE, inputType);
+        if (!Strings.isEmpty(getInputType())) {
+            props.put(CreateFunctionStmt.INPUT_TYPE, getInputType());
         }
         // Default isolation is isolated (true); only emit the property when explicitly shared.
         if (!isolationType) {
@@ -284,9 +277,6 @@ public class ScalarFunction extends Function {
         }
         fn.setScalar_fn(scalarFunction);
         fn.setIsolated(isolationType);
-        if (inputType != null) {
-            fn.setInput_type(inputType);
-        }
         if (content != null) {
             fn.setContent(content);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -210,6 +210,9 @@ public class TableFunction extends Function {
         if (symbolName != null && !symbolName.isEmpty()) {
             props.put(CreateFunctionStmt.SYMBOL_KEY, symbolName);
         }
+        if (getInputType() != null && !getInputType().isEmpty()) {
+            props.put(CreateFunctionStmt.INPUT_TYPE, getInputType());
+        }
         return props;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -331,6 +331,66 @@ public class CreateFunctionAnalyzer {
         }
     }
 
+    private static final String ARROW_FIELD_VECTOR = "org.apache.arrow.vector.FieldVector";
+
+    /** Read and validate the {@code input} property ("scalar" default, or "arrow"). */
+    private static String getAndCheckInputType(CreateFunctionStmt stmt) {
+        String inputType = stmt.getProperties().getOrDefault(CreateFunctionStmt.INPUT_TYPE,
+                CreateFunctionStmt.INPUT_TYPE_SCALAR);
+        if (!inputType.equalsIgnoreCase(CreateFunctionStmt.INPUT_TYPE_ARROW) &&
+                !inputType.equalsIgnoreCase(CreateFunctionStmt.INPUT_TYPE_SCALAR)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown input type:" + inputType);
+        }
+        return inputType.toLowerCase();
+    }
+
+    private static boolean isArrowInput(String inputType) {
+        return CreateFunctionStmt.INPUT_TYPE_ARROW.equals(inputType);
+    }
+
+    /** True if {@code c} is (or implements/extends) org.apache.arrow.vector.FieldVector, by name. */
+    private static boolean isArrowFieldVector(Class<?> c) {
+        if (c == null || c.isPrimitive()) {
+            return false;
+        }
+        if (ARROW_FIELD_VECTOR.equals(c.getName())) {
+            return true;
+        }
+        for (Class<?> iface : c.getInterfaces()) {
+            if (isArrowFieldVector(iface)) {
+                return true;
+            }
+        }
+        return isArrowFieldVector(c.getSuperclass());
+    }
+
+    /**
+     * Require every parameter (varargs component included) and the return type of {@code method}
+     * to be an Apache Arrow {@code FieldVector}. Shared by scalar / UDAF / UDTF arrow validation.
+     */
+    private void checkArrowFieldVectorSignature(JavaUDFInternalClass owner, Method method,
+                                                int paramOffset, boolean checkReturn) {
+        if (checkReturn && !isArrowFieldVector(method.getReturnType())) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, String.format(
+                    "arrow-input UDF class '%s' method '%s' must return an %s",
+                    owner.getCanonicalName(), method.getName(), ARROW_FIELD_VECTOR));
+        }
+        Parameter[] params = method.getParameters();
+        for (int i = paramOffset; i < params.length; i++) {
+            Class<?> ptype = params[i].getType();
+            Class<?> effective = ptype.isArray() ? ptype.getComponentType() : ptype;
+            if (!isArrowFieldVector(effective)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, String.format(
+                        "arrow-input UDF class '%s' method '%s' parameter '%s' must be an %s",
+                        owner.getCanonicalName(), method.getName(), params[i].getName(), ARROW_FIELD_VECTOR));
+            }
+        }
+    }
+
+    private void checkArrowFieldVectorSignature(JavaUDFInternalClass owner, Method method) {
+        checkArrowFieldVectorSignature(owner, method, 0, true);
+    }
+
     private void checkStarrocksJarUdfClass(CreateFunctionStmt stmt, JavaUDFInternalClass mainClass) {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
@@ -352,9 +412,28 @@ public class CreateFunctionAnalyzer {
         }
     }
 
+    /**
+     * Validate the {@code evaluate} signature of a vectorized ("input"="arrow") scalar UDF: every
+     * argument and the return value must be an Apache Arrow {@code FieldVector}. The SQL&lt;-&gt;Java
+     * scalar-type mapping enforced for boxed UDFs is intentionally skipped here — arrow columns
+     * carry their own type, and the BE builds the arrow schema from the declared SQL arg types.
+     */
+    private void checkStarrocksArrowJarUdfClass(CreateFunctionStmt stmt, JavaUDFInternalClass mainClass) {
+        FunctionArgsDef argsDef = stmt.getArgsDef();
+        Method method = mainClass.getMethod(CreateFunctionStmt.EVAL_METHOD_NAME, true);
+        mainClass.checkMethodNonStaticAndPublic(method);
+        mainClass.checkArgumentCount(method, argsDef.getArgTypes().length, argsDef.isVariadic());
+        checkArrowFieldVectorSignature(mainClass, method);
+    }
+
     private Function analyzeStarrocksJarUdf(CreateFunctionStmt stmt, String checksum,
                                             JavaUDFInternalClass handleClass, ConnectContext context) {
-        checkStarrocksJarUdfClass(stmt, handleClass);
+        String inputType = getAndCheckInputType(stmt);
+        if (isArrowInput(inputType)) {
+            checkStarrocksArrowJarUdfClass(stmt, handleClass);
+        } else {
+            checkStarrocksJarUdfClass(stmt, handleClass);
+        }
 
         FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(
                 stmt.getFunctionRef(),
@@ -363,13 +442,16 @@ public class CreateFunctionAnalyzer {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
-        Function function = ScalarFunction.createUdf(
+        ScalarFunction function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
                 returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
                 objectFile, handleClass.getCanonicalName(), "", "",
                 !CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation),
                 cloudConfiguration);
         function.setChecksum(checksum);
+        if (isArrowInput(inputType)) {
+            function.setInputType(inputType);
+        }
         return function;
     }
 
@@ -394,7 +476,7 @@ public class CreateFunctionAnalyzer {
     }
 
     private void checkStarrocksJarUdafClass(CreateFunctionStmt stmt, JavaUDFInternalClass mainClass,
-                                            JavaUDFInternalClass udafStateClass) {
+                                            JavaUDFInternalClass udafStateClass, boolean arrowInput) {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         Map<String, String> properties = stmt.getProperties();
@@ -422,9 +504,12 @@ public class CreateFunctionAnalyzer {
             mainClass.checkReturnJavaType(method, void.class);
             mainClass.checkArgumentCount(method, argsDef.getArgTypes().length + 1, argsDef.isVariadic());
             mainClass.checkParamJavaType(method, udafStateClass.clazz, method.getParameters()[0]);
-            
+
             // Validate parameter types
-            if (argsDef.isVariadic()) {
+            if (arrowInput) {
+                // arrow UDAF: value args after the State are Apache Arrow FieldVectors (whole batch).
+                checkArrowFieldVectorSignature(mainClass, method, 1, false);
+            } else if (argsDef.isVariadic()) {
                 mainClass.checkVarargsParameters(method, argsDef.getArgTypes(), 1);
             } else {
                 for (int i = 0; i < argsDef.getArgTypes().length; i++) {
@@ -482,9 +567,16 @@ public class CreateFunctionAnalyzer {
 
         Map<String, String> properties = stmt.getProperties();
         boolean isAnalyticFn = "true".equalsIgnoreCase(properties.get(CreateFunctionStmt.IS_ANALYTIC_NAME));
+        String inputType = getAndCheckInputType(stmt);
+        if (isArrowInput(inputType) && isAnalyticFn) {
+            // Window (analytic) UDFs use the frame-based update path, which does not yet support
+            // arrow input. Aggregate arrow UDFs are supported for global / sorted aggregation.
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    "arrow input is not supported for window functions (analytic=true) yet");
+        }
 
         checkStarrocksJarUdafStateClass(stmt, mainClass, udafStateClass);
-        checkStarrocksJarUdafClass(stmt, mainClass, udafStateClass);
+        checkStarrocksJarUdafClass(stmt, mainClass, udafStateClass, isArrowInput(inputType));
         AggregateFunction.AggregateFunctionBuilder builder =
                 AggregateFunction.AggregateFunctionBuilder.createUdfBuilder(TFunctionBinaryType.SRJAR);
         builder.name(functionName).argsType(argsDef.getArgTypes()).retType(returnType.getType()).
@@ -493,6 +585,9 @@ public class CreateFunctionAnalyzer {
                 .symbolName(mainClass.getCanonicalName())
                 .cloudConfiguration(cloudConfiguration)
                 .setIsolationType(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation));
+        if (isArrowInput(inputType)) {
+            builder.inputType(inputType);
+        }
         Function function = builder.build();
         function.setChecksum(checksum);
         return function;
@@ -508,16 +603,27 @@ public class CreateFunctionAnalyzer {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
+        String inputType = getAndCheckInputType(stmt);
         {
-            // TYPE[] process(INPUT)
+            // TYPE[] process(INPUT)  (arrow: TYPE[][] process(FieldVector...))
             Method method = mainClass.getMethod(CreateFunctionStmt.PROCESS_METHOD_NAME, true);
             mainClass.checkMethodNonStaticAndPublic(method);
             mainClass.checkArgumentCount(method, argsDef.getArgTypes().length, argsDef.isVariadic());
-            
-            // Validate parameter types — STRUCT support requires threading the Parameter's
-            // parameterized type for nested record-class binding, so use the recursive
-            // scalar-style validator.
-            if (argsDef.isVariadic()) {
+
+            if (isArrowInput(inputType)) {
+                // arrow UDTF: every argument is an Apache Arrow FieldVector (whole batch); the
+                // per-row output stays boxed, so process must return T[][] (one T[] per input row).
+                checkArrowFieldVectorSignature(mainClass, method, 0, false);
+                Class<?> ret = method.getReturnType();
+                if (!ret.isArray() || !ret.getComponentType().isArray()) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, String.format(
+                            "arrow-input UDTF class '%s' method '%s' must return a 2-D array (T[][])",
+                            mainClass.getCanonicalName(), method.getName()));
+                }
+            } else if (argsDef.isVariadic()) {
+                // Validate parameter types — STRUCT support requires threading the Parameter's
+                // parameterized type for nested record-class binding, so use the recursive
+                // scalar-style validator.
                 mainClass.checkVarargsParameters(method, argsDef.getArgTypes(), 0);
             } else {
                 for (int i = 0; i < method.getParameters().length; i++) {
@@ -536,6 +642,9 @@ public class CreateFunctionAnalyzer {
         tableFunction.setLocation(new HdfsURI(objectFile));
         tableFunction.setSymbolName(mainClass.getCanonicalName());
         tableFunction.setCloudConfiguration(cloudConfiguration);
+        if (isArrowInput(inputType)) {
+            tableFunction.setInputType(inputType);
+        }
         return tableFunction;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -51,6 +51,9 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String IS_ANALYTIC_NAME = "analytic";
     public static final String PROCESS_METHOD_NAME = "process";
     public static final String INPUT_TYPE = "input";
+    // Values for the INPUT_TYPE property.
+    public static final String INPUT_TYPE_SCALAR = "scalar";
+    public static final String INPUT_TYPE_ARROW = "arrow";
 
     private final FunctionRef functionRef;
     private final boolean isAggregate;

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -535,6 +535,12 @@
                 <artifactId>arrow-compression</artifactId>
                 <version>${arrow.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-c-data</artifactId>
+                <version>${arrow.version}</version>
+            </dependency>
             <!-- apache arrow -->
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/java-extensions/udf-examples/pom.xml
+++ b/java-extensions/udf-examples/pom.xml
@@ -20,6 +20,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- For vectorized ("input"="arrow") UDF examples. Provided at runtime by the
+             udf-extensions jar on the BE classpath, so scope it provided. -->
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/ArrowSum.java
+++ b/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/ArrowSum.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.example.udf;
+
+import org.apache.arrow.vector.IntVector;
+
+import java.nio.ByteBuffer;
+
+// Vectorized ("input"="arrow") UDAF: SUM over INT. Only update() receives the whole-batch
+// FieldVector; create/merge/serialize/finalize keep the normal boxed signatures. Supported for
+// global / sorted aggregation (a whole batch belongs to one state); hash GROUP BY is rejected.
+public class ArrowSum {
+    public static class State {
+        long sum = 0;
+
+        public int serializeLength() {
+            return 8;
+        }
+    }
+
+    public State create() {
+        return new State();
+    }
+
+    public void destroy(State state) {}
+
+    public void update(State state, IntVector v) {
+        for (int i = 0; i < v.getValueCount(); i++) {
+            if (!v.isNull(i)) {
+                state.sum += v.get(i);
+            }
+        }
+    }
+
+    public void serialize(State state, ByteBuffer buf) {
+        buf.putLong(state.sum);
+    }
+
+    public void merge(State state, ByteBuffer buf) {
+        state.sum += buf.getLong();
+    }
+
+    public Long finalize(State state) {
+        return state.sum;
+    }
+}

--- a/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/UDFArrowAdd.java
+++ b/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/UDFArrowAdd.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.example.udf;
+
+import org.apache.arrow.vector.IntVector;
+
+// Vectorized ("input"="arrow") scalar UDF: element-wise a + b + 1 over the whole batch.
+// Allocate the result from the framework-managed allocator via arg.getAllocator().
+public class UDFArrowAdd {
+    public IntVector evaluate(IntVector a, IntVector b) {
+        IntVector out = new IntVector("result", a.getAllocator());
+        int n = a.getValueCount();
+        out.allocateNew(n);
+        for (int i = 0; i < n; i++) {
+            if (a.isNull(i) || b.isNull(i)) {
+                out.setNull(i);
+            } else {
+                out.set(i, a.get(i) + b.get(i) + 1);
+            }
+        }
+        out.setValueCount(n);
+        return out;
+    }
+}

--- a/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/UDTFArrowRepeat.java
+++ b/java-extensions/udf-examples/src/main/java/com/starrocks/example/udf/UDTFArrowRepeat.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.example.udf;
+
+import org.apache.arrow.vector.IntVector;
+
+// Vectorized ("input"="arrow") UDTF: for each input row emit two rows {x, x*10}.
+// Input is a whole-batch FieldVector; output stays boxed T[][] (one T[] per input row).
+public class UDTFArrowRepeat {
+    public Integer[][] process(IntVector v) {
+        Integer[][] out = new Integer[v.getValueCount()][];
+        for (int i = 0; i < v.getValueCount(); i++) {
+            if (v.isNull(i)) {
+                out[i] = new Integer[0];
+            } else {
+                int x = v.get(i);
+                out[i] = new Integer[] {x, x * 10};
+            }
+        }
+        return out;
+    }
+}

--- a/java-extensions/udf-extensions/pom.xml
+++ b/java-extensions/udf-extensions/pom.xml
@@ -45,6 +45,22 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>
         </dependency>
+
+        <!-- Apache Arrow: vectorized ("input"="arrow") Java UDF support.
+             arrow-c-data provides the C Data Interface (org.apache.arrow.c.Data)
+             used to exchange columns with the BE zero-copy over JNI. -->
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-c-data</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/ArrowUDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/ArrowUDFHelper.java
@@ -1,0 +1,240 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.udf;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.CDataDictionaryProvider;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Java-side entry point for vectorized ("input"="arrow") Java UDFs.
+ *
+ * <p>Columns are exchanged with the BE using the Apache Arrow C Data Interface
+ * ({@link org.apache.arrow.c.Data}): the BE exports an {@code arrow::RecordBatch}
+ * into a pair of C structs ({@code ArrowSchema}/{@code ArrowArray}) whose addresses
+ * are passed here as {@code long}s. We import them zero-copy, hand one
+ * {@link FieldVector} per SQL argument to the user's {@code evaluate}/{@code process}/
+ * {@code update} method, and export the result back into a BE-owned pair of C structs.
+ *
+ * <p>Memory ownership contract:
+ * <ul>
+ *   <li>Input: the BE owns the input C structs and their release callback; we
+ *       {@link ArrowArray#wrap wrap} them, {@code import} (which moves the release
+ *       callback into the returned root), and {@code close} the root when done —
+ *       that fires the BE-side release callback, freeing the exported input buffers.</li>
+ *   <li>Output: the user allocates the result vector from the framework-managed
+ *       allocator (obtainable via {@code arg.getAllocator()}). We
+ *       {@link Data#exportVector export} it into the BE-owned output C structs, which
+ *       <em>retains</em> a reference on the buffers; we then drop our own reference by
+ *       closing the result vector. The BE frees the buffers when it releases the
+ *       imported array. The output C-struct wrappers are NOT closed here — ownership
+ *       has transferred to the BE.</li>
+ *   <li>The {@link BufferAllocator} is per-stub (per driver) and outlives every
+ *       in-flight batch; it is closed only at stub teardown, where its non-zero
+ *       outstanding-allocation check doubles as a leak assertion.</li>
+ * </ul>
+ *
+ * <p>All methods are invoked from the BE on a dedicated JNI pthread.
+ */
+public class ArrowUDFHelper {
+    // long handle -> allocator, so the BE call sites stay jlong-only (mirrors NativeMethodHelper).
+    private static final ConcurrentHashMap<Long, BufferAllocator> ALLOCATORS = new ConcurrentHashMap<>();
+    private static final AtomicLong NEXT_HANDLE = new AtomicLong(1);
+
+    private ArrowUDFHelper() {
+    }
+
+    /** Create a per-stub allocator and return its handle. */
+    public static long createAllocator() {
+        long handle = NEXT_HANDLE.getAndIncrement();
+        ALLOCATORS.put(handle, new RootAllocator());
+        return handle;
+    }
+
+    /** Close and drop the per-stub allocator. Throws if any buffer is still outstanding (leak). */
+    public static void closeAllocator(long handle) {
+        BufferAllocator allocator = ALLOCATORS.remove(handle);
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    /**
+     * Scalar arrow UDF: invoke {@code evaluate(FieldVector...)} on the whole batch.
+     *
+     * @param udf         the user UDF instance
+     * @param evaluate    the resolved {@code evaluate} method
+     * @param allocHandle handle returned by {@link #createAllocator()}
+     * @param inSchemaAddr address of the input {@code ArrowSchema} C struct
+     * @param inArrayAddr  address of the input {@code ArrowArray} C struct
+     * @param outSchemaAddr address of the (BE-owned) output {@code ArrowSchema} C struct
+     * @param outArrayAddr  address of the (BE-owned) output {@code ArrowArray} C struct
+     */
+    public static void evaluateArrow(Object udf, Method evaluate, long allocHandle,
+                                     long inSchemaAddr, long inArrayAddr,
+                                     long outSchemaAddr, long outArrayAddr) throws Exception {
+        BufferAllocator allocator = getAllocator(allocHandle);
+        CDataDictionaryProvider provider = new CDataDictionaryProvider();
+        VectorSchemaRoot root = importRoot(allocator, provider, inArrayAddr, inSchemaAddr);
+        try {
+            List<FieldVector> args = root.getFieldVectors();
+            Object result = invokeVectorized(udf, evaluate, args, 0);
+            if (!(result instanceof FieldVector)) {
+                throw new RuntimeException("arrow UDF '" + evaluate.getName()
+                        + "' must return an org.apache.arrow.vector.FieldVector, got "
+                        + (result == null ? "null" : result.getClass().getName()));
+            }
+            FieldVector resultVector = (FieldVector) result;
+            exportResult(allocator, provider, resultVector, outArrayAddr, outSchemaAddr);
+            // Drop our producer reference now that the export holds its own — but not if the UDF
+            // returned one of the input vectors unchanged (identity), which the root owns/closes.
+            if (!aliasesInput(args, resultVector)) {
+                resultVector.close();
+            }
+        } finally {
+            root.close();
+            provider.close();
+        }
+    }
+
+    /**
+     * Arrow UDTF: invoke {@code process(FieldVector...)} on the whole batch and return the boxed
+     * per-input-row output arrays ({@code T[][]}). The BE drains these into the output column and
+     * builds the row-expansion offsets. Input is imported/released within this call (output is
+     * boxed, so no arrow buffers outlive it — a per-call allocator suffices).
+     */
+    public static Object[][] evaluateUDTF(Object udtf, Method process, long inSchemaAddr, long inArrayAddr)
+            throws Exception {
+        try (BufferAllocator allocator = new RootAllocator();
+                CDataDictionaryProvider provider = new CDataDictionaryProvider();
+                VectorSchemaRoot root = importRoot(allocator, provider, inArrayAddr, inSchemaAddr)) {
+            Object result = invokeVectorized(udtf, process, root.getFieldVectors(), 0);
+            if (result != null && !(result instanceof Object[][])) {
+                throw new RuntimeException("arrow UDTF '" + process.getName()
+                        + "' must return a 2-D array (T[][]), got " + result.getClass().getName());
+            }
+            return (Object[][]) result;
+        }
+    }
+
+    /**
+     * Arrow UDAF single-state update: invoke {@code update(State, FieldVector...)} on the whole
+     * batch destined for {@code state}. State/merge/serialize/finalize stay on the boxed path, so
+     * only input columns are arrow and a per-call allocator suffices.
+     */
+    public static void batchUpdateSingle(Object udaf, Method update, Object state, long inSchemaAddr, long inArrayAddr)
+            throws Exception {
+        try (BufferAllocator allocator = new RootAllocator();
+                CDataDictionaryProvider provider = new CDataDictionaryProvider();
+                VectorSchemaRoot root = importRoot(allocator, provider, inArrayAddr, inSchemaAddr)) {
+            invokeVectorized(udaf, update, root.getFieldVectors(), 1, state);
+        }
+    }
+
+    // True if the UDF returned one of its input vectors unchanged (identity); such a vector is
+    // owned by the input root, so the caller must not close it a second time.
+    private static boolean aliasesInput(List<FieldVector> inputs, FieldVector result) {
+        for (FieldVector in : inputs) {
+            if (in == result) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static BufferAllocator getAllocator(long handle) {
+        BufferAllocator allocator = ALLOCATORS.get(handle);
+        if (allocator == null) {
+            throw new IllegalStateException("arrow UDF allocator handle not found: " + handle);
+        }
+        return allocator;
+    }
+
+    /** Import a BE-exported RecordBatch (moves the release callback into the returned root). */
+    static VectorSchemaRoot importRoot(BufferAllocator allocator, CDataDictionaryProvider provider,
+                                       long arrayAddr, long schemaAddr) {
+        try (ArrowArray inArray = ArrowArray.wrap(arrayAddr);
+                ArrowSchema inSchema = ArrowSchema.wrap(schemaAddr)) {
+            return Data.importVectorSchemaRoot(allocator, inArray, inSchema, provider);
+        }
+    }
+
+    /**
+     * Export the user's result vector into the BE-owned output C structs. exportVector retains its
+     * own reference on the buffers (freed when the BE releases the imported array), so the caller
+     * still owns {@code result} afterwards and is responsible for closing it.
+     */
+    static void exportResult(BufferAllocator allocator, CDataDictionaryProvider provider,
+                             FieldVector result, long outArrayAddr, long outSchemaAddr) {
+        // Wrap, but do NOT close, the output structs: the BE owns them and will invoke release.
+        ArrowArray outArray = ArrowArray.wrap(outArrayAddr);
+        ArrowSchema outSchema = ArrowSchema.wrap(outSchemaAddr);
+        Data.exportVector(allocator, result, provider, outArray, outSchema);
+    }
+
+    /**
+     * Invoke a method whose value arguments are all {@link FieldVector}s, starting at
+     * {@code argOffset} of {@code prefix} (used by UDAF to prepend the state object).
+     */
+    static Object invokeVectorized(Object target, Method method, List<FieldVector> vectors,
+                                   int prefixCount, Object... prefix) throws Exception {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        int total = prefixCount + vectors.size();
+        if (method.isVarArgs()) {
+            int fixed = paramTypes.length - 1;
+            Object[] callArgs = new Object[paramTypes.length];
+            for (int i = 0; i < prefixCount; i++) {
+                callArgs[i] = prefix[i];
+            }
+            // Fixed FieldVector params after the prefix.
+            int vecIdx = 0;
+            for (int i = prefixCount; i < fixed; i++) {
+                callArgs[i] = vectors.get(vecIdx++);
+            }
+            // Remaining vectors packed into the varargs FieldVector[] component.
+            Class<?> compType = paramTypes[paramTypes.length - 1].getComponentType();
+            int restCount = vectors.size() - vecIdx;
+            Object varArr = Array.newInstance(compType, restCount);
+            for (int i = 0; i < restCount; i++) {
+                Array.set(varArr, i, vectors.get(vecIdx++));
+            }
+            callArgs[paramTypes.length - 1] = varArr;
+            return method.invoke(target, callArgs);
+        }
+        if (paramTypes.length != total) {
+            throw new RuntimeException("arrow UDF '" + method.getName() + "' expects " + paramTypes.length
+                    + " arguments but received " + total);
+        }
+        Object[] callArgs = new Object[total];
+        for (int i = 0; i < prefixCount; i++) {
+            callArgs[i] = prefix[i];
+        }
+        for (int i = 0; i < vectors.size(); i++) {
+            callArgs[prefixCount + i] = vectors.get(i);
+        }
+        return method.invoke(target, callArgs);
+    }
+}

--- a/test/sql/test_udf/R/test_jvm_arrow_udf
+++ b/test/sql/test_udf/R/test_jvm_arrow_udf
@@ -1,0 +1,80 @@
+-- name: test_jvm_arrow_udf @no_arrow_flight_sql
+CREATE FUNCTION arrow_add(INT, INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.UDFArrowAdd",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+-- result:
+-- !result
+CREATE TABLE FUNCTION arrow_repeat(INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.UDTFArrowRepeat",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+-- result:
+-- !result
+CREATE AGGREGATE FUNCTION arrow_sum(INT)
+RETURNS BIGINT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.ArrowSum",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+-- result:
+-- !result
+CREATE TABLE t_arrow (id INT, a INT, b INT)
+ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_arrow VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, NULL, 5), (5, 7, NULL);
+-- result:
+-- !result
+SELECT id, arrow_add(a, b) AS r FROM t_arrow ORDER BY id;
+-- result:
+1	12
+2	23
+3	34
+4	None
+5	None
+-- !result
+SELECT a, arrow_repeat AS r FROM t_arrow, arrow_repeat(a) ORDER BY a, r;
+-- result:
+1	1
+1	10
+2	2
+2	20
+3	3
+3	30
+7	7
+7	70
+-- !result
+SELECT arrow_sum(a) AS s FROM t_arrow;
+-- result:
+13
+-- !result
+SELECT b, arrow_sum(a) AS s FROM t_arrow GROUP BY b ORDER BY b;
+-- result:
+[REGEX].*arrow-input UDAF is only supported for global / sorted aggregation, not GROUP BY.*
+-- !result
+DROP FUNCTION arrow_add(INT, INT);
+-- result:
+-- !result
+DROP FUNCTION arrow_repeat(INT);
+-- result:
+-- !result
+DROP FUNCTION arrow_sum(INT);
+-- result:
+-- !result
+DROP TABLE t_arrow;
+-- result:
+-- !result

--- a/test/sql/test_udf/T/test_jvm_arrow_udf
+++ b/test/sql/test_udf/T/test_jvm_arrow_udf
@@ -1,0 +1,59 @@
+-- name: test_jvm_arrow_udf @no_arrow_flight_sql
+
+-- Vectorized ("input"="arrow") Java UDFs: scalar / UDTF / UDAF receive one Apache Arrow
+-- FieldVector per argument for the whole batch, exchanged over the Arrow C Data Interface.
+
+-- Scalar: IntVector evaluate(IntVector, IntVector) -> a + b + 1
+CREATE FUNCTION arrow_add(INT, INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.UDFArrowAdd",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+
+-- UDTF: Integer[][] process(IntVector) -> each row emits {x, x*10}
+CREATE TABLE FUNCTION arrow_repeat(INT)
+RETURNS INT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.UDTFArrowRepeat",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+
+-- UDAF (single-state): void update(State, IntVector) -> SUM(INT)
+CREATE AGGREGATE FUNCTION arrow_sum(INT)
+RETURNS BIGINT
+PROPERTIES (
+    "symbol" = "com.starrocks.example.udf.ArrowSum",
+    "type" = "StarrocksJar",
+    "input" = "arrow",
+    "file" = "${udf_url}/starrocks-jdbc/arrow.jar"
+);
+
+CREATE TABLE t_arrow (id INT, a INT, b INT)
+ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_arrow VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, NULL, 5), (5, 7, NULL);
+
+-- Scalar: a + b + 1, NULL when any argument is NULL
+SELECT id, arrow_add(a, b) AS r FROM t_arrow ORDER BY id;
+
+-- UDTF: each input row -> two output rows {a, a*10}; a NULL row emits no rows
+SELECT a, arrow_repeat AS r FROM t_arrow, arrow_repeat(a) ORDER BY a, r;
+
+-- UDAF global aggregation (no GROUP BY): SUM of non-null a = 13
+SELECT arrow_sum(a) AS s FROM t_arrow;
+
+-- Arrow UDAF is only supported for global / sorted aggregation; hash GROUP BY is rejected
+SELECT b, arrow_sum(a) AS s FROM t_arrow GROUP BY b ORDER BY b;
+
+DROP FUNCTION arrow_add(INT, INT);
+DROP FUNCTION arrow_repeat(INT);
+DROP FUNCTION arrow_sum(INT);
+DROP TABLE t_arrow;


### PR DESCRIPTION
## Why I'm doing:

Add a vectorized input mode for Java UDFs: PROPERTIES("type"="StarrocksJar", "input"="arrow") makes the user method receive one Apache Arrow FieldVector per argument (whole batch) instead of per-row boxed objects, mirroring the existing Python arrow-input mode. Columns are exchanged with the BE zero-copy over the Arrow C Data Interface (not Flight/IPC). Scope: scalar, UDTF, UDAF (single-state).

Arrow logic is isolated in dedicated classes selected at the factories, so the shared UDF execution paths are not branched on input type:
- Scalar: ArrowFunctionCallExpr + JniArrowFuncCallStub (reuses AbstractArrowFuncCallStub).
- UDTF: ArrowJavaUDTFFunction overrides process(); row-expansion drain shared via emit_udtf_rows.
- UDAF: ArrowJavaUDAFAggregateFunction overrides update_batch_single_state, rejects the interleaved GROUP BY paths; reuses the base for create/merge/serialize/finalize.
- Neutral udf/java/arrow_udf_jni.* holds the shared C-Data helpers (RAII ExportedArrowBatch, process-global ArrowUDFHelper class).

FE: inputType lives on the base Function (emitted once in Function.toThrift via TFunction.input_type, no thrift change); CreateFunctionAnalyzer validates the arrow FieldVector signatures. java-extensions: com.starrocks.udf.ArrowUDFHelper using org.apache.arrow.c.Data; add arrow-vector/-memory-netty/-c-data deps.

Note: arrow-memory needs --add-opens=java.base/java.nio=ALL-UNNAMED in the BE UDF JVM; the shipped conf/be.conf already sets it.

Docs: JAVA_UDF.md (en + zh). Tests: test/sql/test_udf/{T,R}/test_jvm_arrow_udf + udf-examples classes (UDFArrowAdd / UDTFArrowRepeat / ArrowSum), passing in SQLTest.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5