### PR TITLE
[BugFix] Truncate CAST(x AS CHAR(N)) to N characters (MySQL-compatible)

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "base/string/utf8.h"
 #include "base/time/date_func.h"
 #include "base/types/int128.h"
 #include "base/types/numeric_types.h"
@@ -1519,6 +1520,16 @@ class VectorizedCastToStringExpr final : public Expr {
 public:
     DEFINE_CAST_CONSTRUCT(VectorizedCastToStringExpr);
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr result, _evaluate_to_string(context, ptr));
+        // MySQL semantics: CAST(x AS CHAR(N)) truncates to N characters. Only bounded CHAR(N)
+        // (len >= 0) is affected; VARCHAR(N) and wildcard CHAR keep the full value.
+        if (type().type == TYPE_CHAR && type().len >= 0) {
+            return _truncate_to_char_len(std::move(result), type().len);
+        }
+        return result;
+    }
+
+    StatusOr<ColumnPtr> _evaluate_to_string(ExprContext* context, Chunk* ptr) {
         ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(column) == column->size() && column->size() != 0) {
             return ColumnHelper::create_const_null_column(column->size());
@@ -1622,6 +1633,33 @@ private:
     // In SR, behaviors of both cast(string as varchar(n)) and cast(string as char(n)) keep the same: neglect
     // of the length of char/varchar and return input column directly.
     ColumnPtr _evaluate_string(ExprContext* context, ColumnPtr&& column) { return Column::mutate(std::move(column)); }
+
+    // Truncate each non-null value to its first `len` UTF-8 characters (MySQL CHAR(N) semantics).
+    // Nulls stay null; const-ness is preserved.
+    static ColumnPtr _truncate_to_char_len(ColumnPtr column, int len) {
+        if (column->only_null()) {
+            return column;
+        }
+        ColumnViewer<TYPE_VARCHAR> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(viewer.size());
+        for (int row = 0; row < viewer.size(); ++row) {
+            if (viewer.is_null(row)) {
+                builder.append_null();
+                continue;
+            }
+            Slice s = viewer.value(row);
+            // Byte length is an upper bound on the character count: <= len bytes already fits.
+            if (s.size <= static_cast<size_t>(len)) {
+                builder.append(s);
+                continue;
+            }
+            const char* begin = s.data;
+            const char* end = s.data + s.size;
+            const char* truncated_end = skip_leading_utf8(begin, end, static_cast<size_t>(len));
+            builder.append(Slice(begin, truncated_end - begin));
+        }
+        return builder.build(column->is_constant());
+    }
 
     ColumnPtr _evaluate_time(ExprContext* context, const ColumnPtr& column) {
         ColumnViewer<TYPE_TIME> viewer(column);

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1656,6 +1656,12 @@ private:
             const char* begin = s.data;
             const char* end = s.data + s.size;
             const char* truncated_end = skip_leading_utf8(begin, end, static_cast<size_t>(len));
+            // skip_leading_utf8 advances by the UTF-8 lead-byte width, which can step past `end`
+            // for a truncated multi-byte char, invalid UTF-8, or raw VARBINARY bytes. Clamp so we
+            // never read beyond the slice.
+            if (truncated_end > end) {
+                truncated_end = end;
+            }
             builder.append(Slice(begin, truncated_end - begin));
         }
         return builder.build(column->is_constant());

--- a/be/src/exprs/cast_expr_tpl.hpp
+++ b/be/src/exprs/cast_expr_tpl.hpp
@@ -33,6 +33,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "base/string/utf8.h"
 #include "base/time/date_func.h"
 #include "base/types/int128.h"
 #include "base/types/numeric_types.h"
@@ -1521,6 +1522,16 @@ class VectorizedCastToStringExpr final : public Expr {
 public:
     DEFINE_CAST_CONSTRUCT(VectorizedCastToStringExpr);
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        ASSIGN_OR_RETURN(ColumnPtr result, _evaluate_to_string(context, ptr));
+        // MySQL semantics: CAST(x AS CHAR(N)) truncates to N characters. Only bounded CHAR(N)
+        // (len >= 0) is affected; VARCHAR(N) and wildcard CHAR keep the full value.
+        if (type().type == TYPE_CHAR && type().len >= 0) {
+            return _truncate_to_char_len(std::move(result), type().len);
+        }
+        return result;
+    }
+
+    StatusOr<ColumnPtr> _evaluate_to_string(ExprContext* context, Chunk* ptr) {
         ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, ptr));
         if (ColumnHelper::count_nulls(column) == column->size() && column->size() != 0) {
             return ColumnHelper::create_const_null_column(column->size());
@@ -1624,6 +1635,33 @@ private:
     // In SR, behaviors of both cast(string as varchar(n)) and cast(string as char(n)) keep the same: neglect
     // of the length of char/varchar and return input column directly.
     ColumnPtr _evaluate_string(ExprContext* context, ColumnPtr&& column) { return Column::mutate(std::move(column)); }
+
+    // Truncate each non-null value to its first `len` UTF-8 characters (MySQL CHAR(N) semantics).
+    // Nulls stay null; const-ness is preserved.
+    static ColumnPtr _truncate_to_char_len(ColumnPtr column, int len) {
+        if (column->only_null()) {
+            return column;
+        }
+        ColumnViewer<TYPE_VARCHAR> viewer(column);
+        ColumnBuilder<TYPE_VARCHAR> builder(viewer.size());
+        for (int row = 0; row < viewer.size(); ++row) {
+            if (viewer.is_null(row)) {
+                builder.append_null();
+                continue;
+            }
+            Slice s = viewer.value(row);
+            // Byte length is an upper bound on the character count: <= len bytes already fits.
+            if (s.size <= static_cast<size_t>(len)) {
+                builder.append(s);
+                continue;
+            }
+            const char* begin = s.data;
+            const char* end = s.data + s.size;
+            const char* truncated_end = skip_leading_utf8(begin, end, static_cast<size_t>(len));
+            builder.append(Slice(begin, truncated_end - begin));
+        }
+        return builder.build(column->is_constant());
+    }
 
     ColumnPtr _evaluate_time(ExprContext* context, const ColumnPtr& column) {
         ColumnViewer<TYPE_TIME> viewer(column);

--- a/be/src/exprs/cast_expr_tpl.hpp
+++ b/be/src/exprs/cast_expr_tpl.hpp
@@ -1658,6 +1658,12 @@ private:
             const char* begin = s.data;
             const char* end = s.data + s.size;
             const char* truncated_end = skip_leading_utf8(begin, end, static_cast<size_t>(len));
+            // skip_leading_utf8 advances by the UTF-8 lead-byte width, which can step past `end`
+            // for a truncated multi-byte char, invalid UTF-8, or raw VARBINARY bytes. Clamp so we
+            // never read beyond the slice.
+            if (truncated_end > end) {
+                truncated_end = end;
+            }
             builder.append(Slice(begin, truncated_end - begin));
         }
         return builder.build(column->is_constant());

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -676,6 +676,89 @@ TEST_F(VectorizedCastExprTest, intCastString) {
     }
 }
 
+TEST_F(VectorizedCastExprTest, bigintCastCharTruncate) {
+    expr_node.child_type = TPrimitiveType::BIGINT;
+    expr_node.type = gen_type_desc(TPrimitiveType::CHAR);
+    expr_node.type.types[0].scalar_type.__set_len(10);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 4, (int64_t)1775580223839LL);
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    ASSERT_TRUE(ptr->is_binary());
+    auto v = BinaryColumn::static_pointer_cast(ptr);
+    ASSERT_EQ(4, v->size());
+    for (int j = 0; j < v->size(); ++j) {
+        ASSERT_EQ(std::string("1775580223"), v->get_slice(j));
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastCharTruncate) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::CHAR);
+    expr_node.type.types[0].scalar_type.__set_len(5);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::string s = "hello world";
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 4, Slice(s));
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    ASSERT_TRUE(ptr->is_binary());
+    auto v = BinaryColumn::static_pointer_cast(ptr);
+    ASSERT_EQ(4, v->size());
+    for (int j = 0; j < v->size(); ++j) {
+        ASSERT_EQ(std::string("hello"), v->get_slice(j));
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastVarcharNoTruncate) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::VARCHAR);
+    expr_node.type.types[0].scalar_type.__set_len(5);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::string s = "hello world";
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 4, Slice(s));
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    ASSERT_TRUE(ptr->is_binary());
+    auto v = BinaryColumn::static_pointer_cast(ptr);
+    ASSERT_EQ(4, v->size());
+    for (int j = 0; j < v->size(); ++j) {
+        ASSERT_EQ(std::string("hello world"), v->get_slice(j));
+    }
+}
+
+TEST_F(VectorizedCastExprTest, stringCastWildcardCharNoTruncate) {
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::CHAR);
+    expr_node.type.types[0].scalar_type.__set_len(-1); // wildcard CHAR: no truncation
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::string s = "hello world";
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 4, Slice(s));
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    ASSERT_TRUE(ptr->is_binary());
+    auto v = BinaryColumn::static_pointer_cast(ptr);
+    ASSERT_EQ(4, v->size());
+    for (int j = 0; j < v->size(); ++j) {
+        ASSERT_EQ(std::string("hello world"), v->get_slice(j));
+    }
+}
+
 TEST_F(VectorizedCastExprTest, booleanCastString) {
     expr_node.child_type = TPrimitiveType::BOOLEAN;
     expr_node.type = gen_type_desc(TPrimitiveType::VARCHAR);

--- a/be/test/exprs/cast_expr_test.cpp
+++ b/be/test/exprs/cast_expr_test.cpp
@@ -759,6 +759,30 @@ TEST_F(VectorizedCastExprTest, stringCastWildcardCharNoTruncate) {
     }
 }
 
+TEST_F(VectorizedCastExprTest, charTruncateHandlesInvalidUtf8WithoutOverrun) {
+    // Truncating invalid UTF-8 / raw VARBINARY bytes to CHAR(N) must not read past the slice end.
+    // 0xE4 advertises a 3-byte UTF-8 char, but only 2 bytes are present.
+    expr_node.child_type = TPrimitiveType::VARCHAR;
+    expr_node.type = gen_type_desc(TPrimitiveType::CHAR);
+    expr_node.type.types[0].scalar_type.__set_len(1);
+
+    std::unique_ptr<Expr> expr(VectorizedCastExprFactory::from_thrift(expr_node));
+
+    std::string bytes = "\xE4\xB8";
+    expr_node.type = gen_type_desc(expr_node.child_type);
+    MockVectorizedExpr<TYPE_VARCHAR> col1(expr_node, 2, Slice(bytes));
+    expr->_children.push_back(&col1);
+
+    ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+    ASSERT_TRUE(ptr->is_binary());
+    auto v = BinaryColumn::static_pointer_cast(ptr);
+    ASSERT_EQ(2, v->size());
+    for (int j = 0; j < v->size(); ++j) {
+        // Clamped to the slice end: never longer than the available bytes.
+        ASSERT_LE(v->get_slice(j).size, bytes.size());
+    }
+}
+
 TEST_F(VectorizedCastExprTest, booleanCastString) {
     expr_node.child_type = TPrimitiveType::BOOLEAN;
     expr_node.type = gen_type_desc(TPrimitiveType::VARCHAR);

--- a/docs/en/sql-reference/sql-functions/cast.md
+++ b/docs/en/sql-reference/sql-functions/cast.md
@@ -12,6 +12,12 @@ Converts an input into the specified type. For example, `cast (input as BIGINT)`
 
 From v2.4, StarRocks supports conversion to the ARRAY type.
 
+:::note
+
+`CAST(input AS CHAR(N))` truncates the result to the first `N` characters, consistent with MySQL. For example, `CAST(1775580223839 AS CHAR(10))` returns `1775580223`. `CAST(input AS CHAR)` without a length and `CAST(input AS VARCHAR(N))` are not truncated.
+
+:::
+
 ## Syntax
 
 ```Haskell

--- a/docs/ja/sql-reference/sql-functions/cast.md
+++ b/docs/ja/sql-reference/sql-functions/cast.md
@@ -10,6 +10,12 @@ sidebar_position: 0.9
 
 バージョン 2.4 から、StarRocks は ARRAY 型への変換をサポートしています。
 
+:::note
+
+`CAST(input AS CHAR(N))` は、MySQL と同様に結果を先頭 `N` 文字に切り詰めます。例えば `CAST(1775580223839 AS CHAR(10))` は `1775580223` を返します。長さを指定しない `CAST(input AS CHAR)` および `CAST(input AS VARCHAR(N))` は切り詰められません。
+
+:::
+
 ## 構文
 
 ```Haskell

--- a/docs/zh/sql-reference/sql-functions/cast.md
+++ b/docs/zh/sql-reference/sql-functions/cast.md
@@ -11,6 +11,12 @@ description: "将输入转换为指定的数据类型。"
 
 从 2.4 版本开始支持将 Array 字符串 和 JSON array 转换为 ARRAY 类型。
 
+:::note
+
+`CAST(input AS CHAR(N))` 会将结果截断为前 `N` 个字符，与 MySQL 一致。例如 `CAST(1775580223839 AS CHAR(10))` 返回 `1775580223`。不带长度的 `CAST(input AS CHAR)` 以及 `CAST(input AS VARCHAR(N))` 不会被截断。
+
+:::
+
 ## 语法
 
 ```Haskell

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -615,7 +615,16 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                 }
 
             } else if (desc.isChar() || desc.isVarchar()) {
-                res =  ConstantOperator.createChar(childString, desc);
+                String charValue = childString;
+                if (desc.isChar()) {
+                    int declaredLen = ((ScalarType) desc).getLength();
+                    // MySQL semantics: CAST(x AS CHAR(N)) truncates to the first N characters.
+                    // Wildcard CHAR (len < 0) and VARCHAR keep the full value.
+                    if (declaredLen >= 0) {
+                        charValue = truncateToCodePoints(childString, declaredLen);
+                    }
+                }
+                res = ConstantOperator.createChar(charValue, desc);
             } else if (desc.isScalarType(PrimitiveType.BINARY) || desc.isScalarType(PrimitiveType.VARBINARY)) {
                 res = ConstantOperator.createBinary(childString.getBytes(), desc);
             }
@@ -624,6 +633,23 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         }
         
         return Optional.ofNullable(res);
+    }
+
+    // Truncate to the first maxChars Unicode code points (MySQL CHAR(N) semantics). ASCII fast paths first.
+    private static String truncateToCodePoints(String value, int maxChars) {
+        if (maxChars <= 0) {
+            return "";
+        }
+        if (value.length() <= maxChars) {
+            // UTF-16 length is an upper bound on the code-point count, so the value already fits.
+            return value;
+        }
+        int codePointCount = value.codePointCount(0, value.length());
+        if (codePointCount <= maxChars) {
+            return value;
+        }
+        int endIndex = value.offsetByCodePoints(0, maxChars);
+        return value.substring(0, endIndex);
     }
 
     public Optional<ConstantOperator> successor() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -85,7 +85,8 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
                     && operator.getType().equals(operator.getChild(0).getType())) {
                 return inheritVarcharLengthAfterReduceCast(operator);
             }
-        } else if (operator.getType().matchesType(operator.getChild(0).getType())) {
+        } else if (operator.getType().matchesType(operator.getChild(0).getType())
+                && !isTruncatingCharCast(operator.getType(), operator.getChild(0).getType())) {
             return inheritVarcharLengthAfterReduceCast(operator);
         }
 
@@ -168,6 +169,21 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         Type childCompatibleType = TypeManager.getAssignmentCompatibleType(grandChild, child, true);
         Type parentCompatibleType = TypeManager.getAssignmentCompatibleType(child, parent, true);
         return childCompatibleType != InvalidType.INVALID && parentCompatibleType != InvalidType.INVALID;
+    }
+
+    // A cast to a bounded CHAR(N) truncates its input to the first N characters (MySQL semantics),
+    // so it is not a no-op and must not be reduced away when the source string could exceed N.
+    private static boolean isTruncatingCharCast(Type target, Type source) {
+        if (!target.isChar() || !source.isStringType()) {
+            return false;
+        }
+        int targetLen = ((ScalarType) target).getLength();
+        if (targetLen < 0) {
+            return false; // wildcard CHAR: no truncation
+        }
+        int sourceLen = ((ScalarType) source).getLength();
+        // A source no longer than N can never be truncated, so the cast is still a no-op.
+        return sourceLen < 0 || sourceLen > targetLen;
     }
 
     private ScalarOperator inheritVarcharLengthAfterReduceCast(CastOperator operator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -172,18 +172,20 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
     }
 
     // A cast to a bounded CHAR(N) truncates its input to the first N characters (MySQL semantics),
-    // so it is not a no-op and must not be reduced away when the source string could exceed N.
+    // so it is not a no-op and must not be reduced away.
+    //
+    // The source type's declared length is deliberately not consulted: it is not an upper bound on
+    // the runtime value. A cast to VARCHAR(N) does not enforce N (string-to-string cast returns the
+    // input column unchanged), so CAST(CAST(x AS VARCHAR(10)) AS CHAR(10)) carries a value that may
+    // exceed 10 characters even though the source type says otherwise. Deciding which producers do
+    // honour their declared length would be an open-ended audit, so every bounded CHAR(N) cast over
+    // a string source is kept and the truncation is left to constant folding or the BE.
     private static boolean isTruncatingCharCast(Type target, Type source) {
         if (!target.isChar() || !source.isStringType()) {
             return false;
         }
-        int targetLen = ((ScalarType) target).getLength();
-        if (targetLen < 0) {
-            return false; // wildcard CHAR: no truncation
-        }
-        int sourceLen = ((ScalarType) source).getLength();
-        // A source no longer than N can never be truncated, so the cast is still a no-op.
-        return sourceLen < 0 || sourceLen > targetLen;
+        // A wildcard CHAR (no declared length) does not truncate, so that cast is still a no-op.
+        return ((ScalarType) target).getLength() >= 0;
     }
 
     private ScalarOperator inheritVarcharLengthAfterReduceCast(CastOperator operator) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/operator/ConstantOperatorTest.java
@@ -15,9 +15,12 @@
 package com.starrocks.sql.optimizer.operator.operator;
 
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.type.CharType;
 import com.starrocks.type.DateType;
+import com.starrocks.type.DecimalType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +28,32 @@ import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 public class ConstantOperatorTest {
+    @Test
+    public void testCastToCharTruncatesToLength() {
+        // POST-1335 / QuickSight: CAST(1775580223839 AS CHAR(10)) -> "1775580223" (first 10 chars).
+        ConstantOperator bigint = ConstantOperator.createBigint(1775580223839L);
+        ConstantOperator asChar10 = bigint.castTo(new CharType(10)).get();
+        Assertions.assertEquals("1775580223", asChar10.getVarchar());
+        Assertions.assertEquals(10, asChar10.getVarchar().length());
+
+        // Chained: CAST(CAST(1775580223839 AS CHAR(10)) AS DECIMAL) -> 1775580223.
+        ConstantOperator asDecimal = asChar10.castTo(DecimalType.DEFAULT_DECIMAL128).get();
+        Assertions.assertEquals(1775580223L, asDecimal.getDecimal().longValue());
+
+        // String source truncates too.
+        Assertions.assertEquals("hello",
+                ConstantOperator.createVarchar("hello world").castTo(new CharType(5)).get().getVarchar());
+    }
+
+    @Test
+    public void testCastToVarcharAndWildcardCharDoNotTruncate() {
+        ConstantOperator bigint = ConstantOperator.createBigint(1775580223839L);
+        // VARCHAR(N) is not truncated.
+        Assertions.assertEquals("1775580223839", bigint.castTo(new VarcharType(10)).get().getVarchar());
+        // Wildcard CHAR (no length, len == -1) is not truncated.
+        Assertions.assertEquals("1775580223839", bigint.castTo(CharType.CHAR).get().getVarchar());
+    }
+
     @Test
     public void testCastToDateValid() throws Exception {
         String[][] testCases = {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -116,6 +116,29 @@ public class ReduceCastRuleTest {
     }
 
     @Test
+    public void testBoundedCharCastIsNotReducedWhenTruncating() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // CAST(varchar(20) AS CHAR(5)) truncates to 5 chars (MySQL semantics) -> must NOT be reduced away.
+        ScalarOperator truncating = new CastOperator(new CharType(5),
+                new ColumnRefOperator(0, TypeFactory.createVarcharType(20), "s", false));
+        ScalarOperator kept = rule.apply(truncating, null);
+        assertTrue(kept instanceof CastOperator);
+        assertTrue(kept.getType().isChar());
+        assertEquals(5, ((ScalarType) kept.getType()).getLength());
+
+        // Wildcard CHAR (no length) does not truncate -> still reducible.
+        ScalarOperator wildcard = new CastOperator(CharType.CHAR,
+                new ColumnRefOperator(1, TypeFactory.createVarcharType(20), "s2", false));
+        Assertions.assertFalse(rule.apply(wildcard, null) instanceof CastOperator);
+
+        // Source no longer than the target can never be truncated -> still reducible.
+        ScalarOperator noTrunc = new CastOperator(new CharType(10),
+                new ColumnRefOperator(2, TypeFactory.createVarcharType(3), "s3", false));
+        Assertions.assertFalse(rule.apply(noTrunc, null) instanceof CastOperator);
+    }
+
+    @Test
     public void testVarcharLengthIsNotInheritedByDefault() {
         ScalarOperatorRewriteRule rule = new ReduceCastRule();
         ScalarOperator child =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -132,10 +132,38 @@ public class ReduceCastRuleTest {
                 new ColumnRefOperator(1, TypeFactory.createVarcharType(20), "s2", false));
         Assertions.assertFalse(rule.apply(wildcard, null) instanceof CastOperator);
 
-        // Source no longer than the target can never be truncated -> still reducible.
-        ScalarOperator noTrunc = new CastOperator(new CharType(10),
+        // A source whose declared length fits in N is still kept: the declared length is not an
+        // upper bound on the runtime value, so it cannot be used to prove the cast is a no-op.
+        ScalarOperator shorterSource = new CastOperator(new CharType(10),
                 new ColumnRefOperator(2, TypeFactory.createVarcharType(3), "s3", false));
-        Assertions.assertFalse(rule.apply(noTrunc, null) instanceof CastOperator);
+        ScalarOperator keptShorter = rule.apply(shorterSource, null);
+        assertTrue(keptShorter instanceof CastOperator);
+        assertEquals(10, ((ScalarType) keptShorter.getType()).getLength());
+    }
+
+    @Test
+    public void testBoundedCharCastIsNotReducedOverNonTruncatingVarcharCast() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // CAST(CAST(s AS VARCHAR(10)) AS CHAR(10)): the inner VARCHAR cast does not enforce its
+        // length, so the outer CHAR(10) cast is the only thing that truncates and must survive.
+        ScalarOperator nested = new CastOperator(new CharType(10),
+                new CastOperator(TypeFactory.createVarcharType(10),
+                        new ColumnRefOperator(3, TypeFactory.createVarcharType(50), "s", false)));
+        ScalarOperator kept = rule.apply(nested, null);
+        assertTrue(kept instanceof CastOperator);
+        assertTrue(kept.getType().isChar());
+        assertEquals(10, ((ScalarType) kept.getType()).getLength());
+
+        // Same shape with a non-string leaf: CAST(CAST(n AS VARCHAR(10)) AS CHAR(10)) where a BIGINT
+        // formats to up to 20 characters.
+        ScalarOperator nestedNumeric = new CastOperator(new CharType(10),
+                new CastOperator(TypeFactory.createVarcharType(10),
+                        new ColumnRefOperator(4, IntegerType.BIGINT, "n", false)));
+        ScalarOperator keptNumeric = rule.apply(nestedNumeric, null);
+        assertTrue(keptNumeric instanceof CastOperator);
+        assertTrue(keptNumeric.getType().isChar());
+        assertEquals(10, ((ScalarType) keptNumeric.getType()).getLength());
     }
 
     @Test

--- a/test/sql/test_cast/R/test_cast_char_truncate
+++ b/test/sql/test_cast/R/test_cast_char_truncate
@@ -1,0 +1,21 @@
+-- name: test_cast_char_truncate
+select cast(1775580223839 as char(10));
+-- result:
+1775580223
+-- !result
+select cast(cast(1775580223839 as char(10)) as decimal);
+-- result:
+1775580223
+-- !result
+select cast('hello world' as char(5));
+-- result:
+hello
+-- !result
+select cast(1775580223839 as varchar(10));
+-- result:
+1775580223839
+-- !result
+select cast('hello world' as char);
+-- result:
+hello world
+-- !result

--- a/test/sql/test_cast/T/test_cast_char_truncate
+++ b/test/sql/test_cast/T/test_cast_char_truncate
@@ -1,0 +1,6 @@
+-- name: test_cast_char_truncate
+select cast(1775580223839 as char(10));
+select cast(cast(1775580223839 as char(10)) as decimal);
+select cast('hello world' as char(5));
+select cast(1775580223839 as varchar(10));
+select cast('hello world' as char);


### PR DESCRIPTION
## Why I'm doing:

`CAST(x AS CHAR(N))` did not truncate its result to N characters, unlike MySQL. Amazon QuickSight SPICE incremental refresh emits MySQL-style SQL such as `cast(cast(1775580223839 as char(10)) as decimal)`, expecting the 13-digit millisecond epoch to be truncated to a 10-digit second epoch (`1775580223`). StarRocks returned the full `1775580223839`, which then overflowed downstream `FROM_UNIXTIME` / `DATE_ADD` and broke the incremental-refresh filter. (Jira POST-1335)

## What I'm doing:

Make `CAST(x AS CHAR(N))` truncate to the first N characters (MySQL-compatible), consistently on both the FE constant-folding path and the BE execution path. Scoped to **bounded `CHAR(N)` only** — `VARCHAR(N)` and unbounded `CHAR` are left unchanged, because StarRocks uses `VARCHAR(N)` pervasively for implicit casts / type unification and MySQL has no `VARCHAR` cast target, so truncating it would risk silent data corruption in existing plans.

- **FE constant folding** (`ConstantOperator.castTo`): truncate to N code points for bounded `CHAR(N)`.
- **FE cast reduction** (`ReduceCastRule`): stop eliminating `CAST(string AS CHAR(N))` when the source string may exceed N. `matchesType()` treats all string types as identical, so the rule previously dropped the cast before `FoldConstantsRule` / the BE could truncate.
- **BE execution** (`VectorizedCastToStringExpr`): truncate the result to N UTF-8 characters for bounded `CHAR(N)` across all source types (via `skip_leading_utf8`). The common `VARCHAR` path is unchanged and has zero added overhead.

Examples:

```
CAST(1775580223839 AS CHAR(10))                    -> 1775580223
CAST(CAST(1775580223839 AS CHAR(10)) AS DECIMAL)   -> 1775580223
CAST('hello world' AS CHAR(5))                     -> hello
CAST(1775580223839 AS VARCHAR(10))                 -> 1775580223839   (unchanged)
CAST('hello world' AS CHAR)                        -> hello world     (unchanged)
```

Jira: POST-1335

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5