### PR TITLE
[BugFix] Fix lake fast-path ADD INDEX: CHAR/NGRAMBF correctness, durability across loads & compaction

### DIFF
--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -75,21 +75,51 @@ static void fill_slice_buffer(const BinaryT& bin, size_t start_row, size_t run_l
 // variable-length string columns materialize a local Slice[] because the
 // writer expects a Slice-stride array for string CppTypes.
 template <typename Writer>
-Status feed_index_from_column(Writer* writer, const Column& col, size_t start_row, size_t run_len, size_t type_size) {
+Status feed_index_from_column(Writer* writer, const Column& col, size_t start_row, size_t run_len, size_t type_size,
+                              size_t char_pad_len = 0) {
     if (run_len == 0) return Status::OK();
 
     // Binary / LargeBinary: sidestep the raw_data flow entirely; we need a
     // Slice array anchored at start_row.
     std::vector<Slice> slice_buf;
+    // Backing store for CHAR re-padding; must outlive the writer->add_values()
+    // calls below, so it lives at function scope.
+    std::string pad_storage;
+    // For a CHAR column the on-disk page decoder strnlen-trims the trailing
+    // '\0' padding when reading values back (BinaryPlainPageDecoder<TYPE_CHAR>
+    // / BinaryDictPageDecoder<TYPE_CHAR>), so the Slices materialized here are
+    // UNPADDED (e.g. "guangzhou", size=9). The standard segment-write index
+    // path builds its dictionary from the in-memory column padded to the
+    // declared column width, and the query predicate pads CHAR literals the
+    // same way — so an unpadded fast-path dictionary/bloom would never match at
+    // query time (bitmap over-prunes to an empty result; bloom yields false
+    // negatives / missing rows). Re-pad each slice back to `char_pad_len` bytes
+    // with '\0' so the fast-path index is byte-identical to the standard path.
+    // char_pad_len is 0 for non-CHAR columns (VARCHAR is variable-length and is
+    // not trimmed by the decoder), leaving those paths untouched.
+    auto repad_char = [&]() {
+        if (char_pad_len == 0) return;
+        pad_storage.assign(run_len * char_pad_len, '\0');
+        for (size_t i = 0; i < run_len; ++i) {
+            const size_t sz = std::min<size_t>(slice_buf[i].size, char_pad_len);
+            if (sz > 0) {
+                memcpy(pad_storage.data() + i * char_pad_len, slice_buf[i].data, sz);
+            }
+            slice_buf[i].data = pad_storage.data() + i * char_pad_len;
+            slice_buf[i].size = char_pad_len;
+        }
+    };
     auto get_pdata = [&](const Column& data_col) -> StatusOr<const uint8_t*> {
         if (auto* bin = dynamic_cast<const BinaryColumn*>(&data_col); bin != nullptr) {
             DCHECK_EQ(type_size, sizeof(Slice));
             fill_slice_buffer(*bin, start_row, run_len, &slice_buf);
+            repad_char();
             return reinterpret_cast<const uint8_t*>(slice_buf.data());
         }
         if (auto* lbin = dynamic_cast<const LargeBinaryColumn*>(&data_col); lbin != nullptr) {
             DCHECK_EQ(type_size, sizeof(Slice));
             fill_slice_buffer(*lbin, start_row, run_len, &slice_buf);
+            repad_char();
             return reinterpret_cast<const uint8_t*>(slice_buf.data());
         }
         RawDataVisitor data_visitor;
@@ -395,6 +425,11 @@ Status AddIndexSchemaChange::build_bitmap_for_column(Segment* segment, const Tab
     auto col = ColumnHelper::create_column(TypeDescriptor(column.type()), column.is_nullable());
     constexpr size_t kBatch = 4096;
     const size_t type_size = type_info->size();
+    // CHAR is stored '\0'-padded and strnlen-trimmed on read; re-pad to the
+    // declared width so the fast-path bitmap dictionary matches the
+    // standard-path dictionary and the query predicate (see
+    // feed_index_from_column). 0 = no padding (non-CHAR).
+    const size_t char_pad_len = (column.type() == TYPE_CHAR) ? static_cast<size_t>(column.length()) : 0;
     while (true) {
         col->reset_column();
         size_t n = kBatch;
@@ -403,7 +438,7 @@ Status AddIndexSchemaChange::build_bitmap_for_column(Segment* segment, const Tab
             break;
         }
         if (!st.ok()) return st;
-        RETURN_IF_ERROR(feed_index_from_column(bitmap_writer.get(), *col, 0, n, type_size));
+        RETURN_IF_ERROR(feed_index_from_column(bitmap_writer.get(), *col, 0, n, type_size, char_pad_len));
     }
 
     // Write the bitmap blob to the shared target file and emit the
@@ -529,6 +564,10 @@ Status AddIndexSchemaChange::build_bloom_for_column(Segment* segment, const Tabl
 
     auto col = ColumnHelper::create_column(TypeDescriptor(column.type()), column.is_nullable());
     const size_t type_size = type_info->size();
+    // CHAR is stored '\0'-padded and strnlen-trimmed on read; re-pad to the
+    // declared width so the fast-path bloom matches the standard-path bloom and
+    // the query predicate (see feed_index_from_column). 0 = no padding.
+    const size_t char_pad_len = (column.type() == TYPE_CHAR) ? static_cast<size_t>(column.length()) : 0;
     for (int32_t page = 0; page < num_pages; ++page) {
         // [first_ordinal, last_ordinal] is the inclusive row range of data page
         // `page` — exactly what the read path will resolve for read_bloom_filter(page).
@@ -547,7 +586,7 @@ Status AddIndexSchemaChange::build_bloom_for_column(Segment* segment, const Tabl
             // with BitmapIndexWriter; reuse the common feeder so Binary / string
             // columns get the Slice-buffer treatment automatically. Multiple
             // next_batch calls accumulate into the SAME pending bloom filter.
-            RETURN_IF_ERROR(feed_index_from_column(bf_writer.get(), *col, 0, n, type_size));
+            RETURN_IF_ERROR(feed_index_from_column(bf_writer.get(), *col, 0, n, type_size, char_pad_len));
             remaining -= n;
         }
         // Emit exactly one bloom filter for this data page (mirrors

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -377,6 +377,9 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
         //    that a pinned schema_id exists in historical_schemas, so the archive
         //    and the repoint must happen together. Guarded on historical_schemas so
         //    replay is idempotent (on replay schema()->id() already == new id).
+        //    If every pin moved off old_schema_id, its historical_schemas entry is
+        //    left unreferenced here; the next compaction's historical_schemas GC
+        //    (see apply_opcompaction below) reclaims such entries.
         if (!_tablet_meta->rowset_to_schema().empty() && _tablet_meta->historical_schemas().count(new_schema_id) <= 0) {
             (*_tablet_meta->mutable_historical_schemas())[new_schema_id].CopyFrom(*schema);
             for (auto& entry : *_tablet_meta->mutable_rowset_to_schema()) {
@@ -388,11 +391,15 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
         // Best-effort persist the new schema as a standalone SCHEMA_{id} file so
         // any by-id cold reader (get_tablet_schema_by_id) resolves the indexed
         // schema. Non-fatal on failure: loads/compaction resolve via
-        // metadata->schema() whose id now equals new_schema_id.
-        if (auto* mgr = _tablet.tablet_mgr(); mgr != nullptr) {
-            auto st = mgr->create_schema_file(_tablet_meta->id(), *schema);
-            LOG_IF(WARNING, !st.ok()) << "apply_add_index: create_schema_file failed for tablet " << _tablet_meta->id()
-                                      << " schema_id " << schema->id() << ": " << st;
+        // metadata->schema() whose id now equals new_schema_id. Gated on the id
+        // actually changing in THIS apply so re-applying the same op (metadata
+        // replay on restart) does not repeat the remote object-store write.
+        if (old_schema_id != new_schema_id) {
+            if (auto* mgr = _tablet.tablet_mgr(); mgr != nullptr) {
+                auto st = mgr->create_schema_file(_tablet_meta->id(), *schema);
+                LOG_IF(WARNING, !st.ok()) << "apply_add_index: create_schema_file failed for tablet "
+                                          << _tablet_meta->id() << " schema_id " << schema->id() << ": " << st;
+            }
         }
     }
 }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -351,13 +351,40 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
     //    keys on id and would keep returning the stale pre-index schema — so data
     //    loaded after the index, and compaction output, would build no index.
     //    A new id forces every cache to miss and pick up this indexed schema.
-    //    Existing rowsets carry no rowset_to_schema pin, so they also resolve to
-    //    metadata->schema(); their segments' missing footer index is served by
-    //    the .idx sidecar until compaction rebuilds it inline.
     if (op.has_new_schema_id() && op.new_schema_id() > 0) {
-        schema->set_id(op.new_schema_id());
+        const int64_t new_schema_id = op.new_schema_id();
+        const int64_t old_schema_id = schema->id();
+        schema->set_id(new_schema_id);
         if (op.has_new_schema_version()) {
             schema->set_schema_version(static_cast<int32_t>(op.new_schema_version()));
+        }
+        // Durability across the two schema-resolution regimes:
+        //  - Empty rowset_to_schema (fresh table / never fast-evolved): every
+        //    existing rowset and compaction resolve via metadata->schema(), whose
+        //    id/content we just bumped; their segments' missing footer index is
+        //    served by the .idx sidecar until compaction rebuilds it inline. No
+        //    map maintenance needed.
+        //  - Non-empty rowset_to_schema (table already fast-evolved): existing
+        //    rowsets are PINNED to a historical schema, and BOTH the read path
+        //    (rowset.cpp) and compaction's get_output_rowset_schema resolve through
+        //    historical_schemas — bumping metadata->schema() alone is bypassed, so
+        //    those rowsets (and compaction output) would never pick up the index.
+        //    Register the indexed schema under new_schema_id and repoint the pins
+        //    that referenced the pre-index current schema (old_schema_id, identical
+        //    columns) to it, so those rowsets read via the .idx sidecar and
+        //    compaction rebuilds the index inline. Rowsets pinned to OLDER
+        //    (fewer-column) historical schemas keep their pin. rowset.cpp CHECKs
+        //    that a pinned schema_id exists in historical_schemas, so the archive
+        //    and the repoint must happen together. Guarded on historical_schemas so
+        //    replay is idempotent (on replay schema()->id() already == new id).
+        if (!_tablet_meta->rowset_to_schema().empty() &&
+            _tablet_meta->historical_schemas().count(new_schema_id) <= 0) {
+            (*_tablet_meta->mutable_historical_schemas())[new_schema_id].CopyFrom(*schema);
+            for (auto& entry : *_tablet_meta->mutable_rowset_to_schema()) {
+                if (entry.second == old_schema_id) {
+                    entry.second = new_schema_id;
+                }
+            }
         }
         // Best-effort persist the new schema as a standalone SCHEMA_{id} file so
         // any by-id cold reader (get_tablet_schema_by_id) resolves the indexed

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -365,8 +365,8 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
         // metadata->schema() whose id now equals new_schema_id.
         if (auto* mgr = _tablet.tablet_mgr(); mgr != nullptr) {
             auto st = mgr->create_schema_file(_tablet_meta->id(), *schema);
-            LOG_IF(WARNING, !st.ok()) << "apply_add_index: create_schema_file failed for tablet "
-                                      << _tablet_meta->id() << " schema_id " << schema->id() << ": " << st;
+            LOG_IF(WARNING, !st.ok()) << "apply_add_index: create_schema_file failed for tablet " << _tablet_meta->id()
+                                      << " schema_id " << schema->id() << ": " << st;
         }
     }
 }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -273,22 +273,27 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
     //    to the front of the per-segment `entries` list so readers see the
     //    newest first (mirrors DCG reverse-by-version ordering). Multiple
     //    entries may coexist on the same segment from successive alters.
-    auto* idg_map = _tablet_meta->mutable_idg_meta()->mutable_idgs();
-    for (const auto& se : op.segment_entries()) {
-        // Defense-in-depth: an entry missing segment_id would index the map at
-        // default 0 and corrupt segment 0's IDG. FE always sets both fields.
-        if (!se.has_entry() || !se.has_segment_id()) {
-            LOG_IF(WARNING, !se.has_segment_id()) << "apply_add_index: segment_entry missing segment_id; skipping";
-            continue;
+    //    Guarded so the empty no-op shape (a materialized index whose schema
+    //    lacks the indexed columns — the op carries only alter_version) does
+    //    not materialize an empty idg_meta submessage into the metadata.
+    if (!op.segment_entries().empty()) {
+        auto* idg_map = _tablet_meta->mutable_idg_meta()->mutable_idgs();
+        for (const auto& se : op.segment_entries()) {
+            // Defense-in-depth: an entry missing segment_id would index the map at
+            // default 0 and corrupt segment 0's IDG. FE always sets both fields.
+            if (!se.has_entry() || !se.has_segment_id()) {
+                LOG_IF(WARNING, !se.has_segment_id()) << "apply_add_index: segment_entry missing segment_id; skipping";
+                continue;
+            }
+            IndexDeltaGroupVerPB& ver = (*idg_map)[se.segment_id()];
+            // Build new entries list: [new_entry, old_entries...]
+            IndexDeltaGroupVerPB merged;
+            merged.add_entries()->CopyFrom(se.entry());
+            for (const auto& old_e : ver.entries()) {
+                merged.add_entries()->CopyFrom(old_e);
+            }
+            ver.Swap(&merged);
         }
-        IndexDeltaGroupVerPB& ver = (*idg_map)[se.segment_id()];
-        // Build new entries list: [new_entry, old_entries...]
-        IndexDeltaGroupVerPB merged;
-        merged.add_entries()->CopyFrom(se.entry());
-        for (const auto& old_e : ver.entries()) {
-            merged.add_entries()->CopyFrom(old_e);
-        }
-        ver.Swap(&merged);
     }
 
     // 2. Reconcile table_indices: add any new index not already present.

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -377,8 +377,7 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
         //    that a pinned schema_id exists in historical_schemas, so the archive
         //    and the repoint must happen together. Guarded on historical_schemas so
         //    replay is idempotent (on replay schema()->id() already == new id).
-        if (!_tablet_meta->rowset_to_schema().empty() &&
-            _tablet_meta->historical_schemas().count(new_schema_id) <= 0) {
+        if (!_tablet_meta->rowset_to_schema().empty() && _tablet_meta->historical_schemas().count(new_schema_id) <= 0) {
             (*_tablet_meta->mutable_historical_schemas())[new_schema_id].CopyFrom(*schema);
             for (auto& entry : *_tablet_meta->mutable_rowset_to_schema()) {
                 if (entry.second == old_schema_id) {

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -343,6 +343,32 @@ void MetaFileBuilder::apply_add_index(const TxnLogPB_OpAddIndex& op) {
             }
         }
     }
+
+    // 4. Stamp the FE-allocated new schema id/version onto the tablet metadata
+    //    schema. The fast path changed the schema content above (table_indices +
+    //    per-column flags) but reused the old schema_id; every lake by-id schema
+    //    cache (GS{id} metacache, GlobalTabletSchemaMap dedup, SCHEMA_{id} file)
+    //    keys on id and would keep returning the stale pre-index schema — so data
+    //    loaded after the index, and compaction output, would build no index.
+    //    A new id forces every cache to miss and pick up this indexed schema.
+    //    Existing rowsets carry no rowset_to_schema pin, so they also resolve to
+    //    metadata->schema(); their segments' missing footer index is served by
+    //    the .idx sidecar until compaction rebuilds it inline.
+    if (op.has_new_schema_id() && op.new_schema_id() > 0) {
+        schema->set_id(op.new_schema_id());
+        if (op.has_new_schema_version()) {
+            schema->set_schema_version(static_cast<int32_t>(op.new_schema_version()));
+        }
+        // Best-effort persist the new schema as a standalone SCHEMA_{id} file so
+        // any by-id cold reader (get_tablet_schema_by_id) resolves the indexed
+        // schema. Non-fatal on failure: loads/compaction resolve via
+        // metadata->schema() whose id now equals new_schema_id.
+        if (auto* mgr = _tablet.tablet_mgr(); mgr != nullptr) {
+            auto st = mgr->create_schema_file(_tablet_meta->id(), *schema);
+            LOG_IF(WARNING, !st.ok()) << "apply_add_index: create_schema_file failed for tablet "
+                                      << _tablet_meta->id() << " schema_id " << schema->id() << ": " << st;
+        }
+    }
 }
 
 void MetaFileBuilder::apply_drop_index(const TxnLogPB_OpDropIndex& op) {

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -732,6 +732,16 @@ Status SchemaChangeHandler::do_process_add_index_only(const TAlterTabletReqV2& r
     txn_log->set_tablet_id(request.new_tablet_id);
     txn_log->set_txn_id(request.txn_id);
     auto* op_add_index = txn_log->mutable_op_add_index();
+    // Carry the FE-allocated new schema id/version so apply_add_index stamps them
+    // onto the tablet metadata schema — this invalidates every by-id schema cache
+    // so data loaded after the index (and compaction output) build the new index
+    // instead of reusing the cached pre-index schema.
+    if (request.__isset.new_index_schema_id) {
+        op_add_index->set_new_schema_id(request.new_index_schema_id);
+    }
+    if (request.__isset.new_index_schema_version) {
+        op_add_index->set_new_schema_version(request.new_index_schema_version);
+    }
 
     AddIndexSchemaChange sc(_tablet_manager, request.txn_id, base_tablet, new_tablet, std::move(indexes_to_build),
                             alter_version, _lake_schema_change_pool);

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -653,19 +653,27 @@ Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams&
 // alter, not silently land in an unsupported fallback shape.
 Status SchemaChangeHandler::do_process_add_index_only(const TAlterTabletReqV2& request) {
     StorageMetrics::instance()->lake_add_index_requests_total.increment(1);
-    if (!request.__isset.indexes_to_add || request.indexes_to_add.empty()) {
-        // The fast-path request shape (base_tablet_id == new_tablet_id, no
-        // tablet_schema diff) is incompatible with the legacy rewrite path:
-        // delegating here would self-targeted "rewrite" the tablet and
-        // append duplicate rowsets. FE's classifier guarantees this branch
-        // is unreachable in practice, so fail loudly instead of falling
-        // back.
-        StorageMetrics::instance()->lake_add_index_requests_failed.increment(1);
-        return Status::InvalidArgument("ADD INDEX fast path called with empty indexes_to_add");
-    }
     if (!request.__isset.txn_id) {
         StorageMetrics::instance()->lake_add_index_requests_failed.increment(1);
         return Status::InvalidArgument("txn_id not set for ADD INDEX fast path");
+    }
+    if (!request.__isset.indexes_to_add || request.indexes_to_add.empty()) {
+        // Explicit no-op: FE sends an EMPTY index set for a materialized index
+        // (rollup / sync MV) whose schema does not carry the indexed column(s) —
+        // the index is only built on the metas that contain the columns,
+        // mirroring the legacy path which only builds on the base index. This
+        // tablet still needs a txn log so the reserved alter version publishes
+        // on every tablet of the partition; apply_add_index on an empty op is a
+        // pure version advance. (The legacy-rewrite fallback stays forbidden:
+        // the fast-path request shape base_tablet_id == new_tablet_id would
+        // make it re-process the tablet against itself and duplicate rows.)
+        auto txn_log = std::make_shared<TxnLog>();
+        txn_log->set_tablet_id(request.new_tablet_id);
+        txn_log->set_txn_id(request.txn_id);
+        txn_log->mutable_op_add_index()->set_alter_version(request.alter_version);
+        LOG(INFO) << "ADD INDEX fast path no-op (no applicable index for this materialized index): tablet="
+                  << request.new_tablet_id << " txn_id=" << request.txn_id;
+        return _tablet_manager->put_txn_log(std::move(txn_log));
     }
 
     const int64_t alter_version = request.alter_version;

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -693,28 +693,37 @@ Status SchemaChangeHandler::do_process_add_index_only(const TAlterTabletReqV2& r
         if (!tix.__isset.index_type) {
             return Status::InvalidArgument("TOlapTableIndex has no index_type");
         }
-        TabletIndexPB pb;
-        if (tix.__isset.index_id) pb.set_index_id(tix.index_id);
-        if (tix.__isset.index_name) pb.set_index_name(tix.index_name);
-        auto converted = TabletIndex::convert_index_type_from_thrift(tix.index_type);
-        if (!converted.ok()) return converted.status();
-        pb.set_index_type(*converted);
         if (!tix.__isset.columns || tix.columns.empty()) {
-            return Status::InvalidArgument(strings::Substitute("index $0 has no columns", pb.index_name()));
+            return Status::InvalidArgument(
+                    strings::Substitute("index $0 has no columns", tix.__isset.index_name ? tix.index_name : ""));
         }
+        // Validate every indexed column exists in new_schema *before* delegating to
+        // TabletIndex::init_from_thrift, whose field_index() lookup is unchecked and
+        // would read out of bounds on a missing column. A missing column must fail
+        // fast here rather than fall back to do_process_alter_tablet — the fast-path
+        // request shape (same tablet for base/new) would make the legacy rewrite
+        // re-process the tablet against itself and duplicate rows.
         for (const auto& col_name : tix.columns) {
             auto ordinal = new_schema->field_index(col_name);
             if (ordinal >= new_schema->num_columns()) {
-                // See note above: do not fall back to do_process_alter_tablet
-                // — the request shape would cause the legacy path to
-                // re-write the tablet against itself and duplicate rows.
                 StorageMetrics::instance()->lake_add_index_requests_failed.increment(1);
                 return Status::InternalError(
                         strings::Substitute("ADD INDEX fast path: column $0 not found in new schema. tablet=$1",
                                             col_name, request.new_tablet_id));
             }
-            pb.add_col_unique_id(new_schema->column(ordinal).unique_id());
         }
+        // Build TabletIndexPB via TabletIndex so every field is populated exactly like
+        // the standard (segment-rewrite) write path: index id/name/type, the
+        // schema-resolved column unique ids, AND the serialized common/index/search
+        // property maps. The previous manual construction copied only
+        // id/name/type/col_unique_id and dropped index_properties, so NGRAMBF lost
+        // gram_num/case_sensitive (and plain bloom lost bloom_filter_fpp); the fast
+        // path then built the index with wrong defaults (e.g. gram_num=4) that never
+        // matched the query-side predicate ngrams, yielding empty/incorrect results.
+        TabletIndex tablet_index;
+        RETURN_IF_ERROR(tablet_index.init_from_thrift(tix, *new_schema));
+        TabletIndexPB pb;
+        tablet_index.to_schema_pb(&pb);
         indexes_to_build.push_back(std::move(pb));
     }
 

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -567,6 +567,37 @@ TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_carries_new_schema_id
     EXPECT_EQ(9, txn_log->op_add_index().new_schema_version());
 }
 
+// A materialized index (rollup / sync MV) whose schema lacks the indexed
+// column gets a task with an EMPTY index set: BE must write a no-op txn log
+// (version advance only) instead of erroring, so the reserved alter version
+// still publishes on every tablet of the partition.
+TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_no_applicable_index_noop) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/3);
+
+    TAlterTabletReqV2 request;
+    request.__set_base_tablet_id(base_tablet_id);
+    request.__set_new_tablet_id(base_tablet_id);
+    request.__set_alter_version(version);
+    request.__set_txn_id(next_id());
+    request.__set_only_add_index(true);
+    // no indexes_to_add: FE sends an empty set for a projecting rollup / MV.
+
+    SchemaChangeHandler handler(_tablet_manager.get());
+    ASSERT_OK(handler.process_alter_tablet(request));
+
+    ASSIGN_OR_ABORT(auto txn_log,
+                    _tablet_manager->load_txn_log(_tablet_manager->txn_log_location(base_tablet_id, request.txn_id),
+                                                  /*fill_cache=*/false));
+    ASSERT_TRUE(txn_log->has_op_add_index());
+    EXPECT_EQ(0, txn_log->op_add_index().new_indexes_size());
+    EXPECT_EQ(0, txn_log->op_add_index().segment_entries_size());
+    EXPECT_EQ(version, txn_log->op_add_index().alter_version());
+}
+
 // A TOlapTableIndex with a type but no columns must fail fast in the fast path
 // (rather than fall through to init_from_thrift's unchecked field_index()).
 TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_empty_columns_rejected) {

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -131,6 +131,15 @@ protected:
         c3->set_is_nullable(true);
         c3->set_aggregation("NONE");
 
+        auto* c4 = schema->add_column();
+        c4->set_unique_id(_c4_uid);
+        c4->set_name("c4");
+        c4->set_type("CHAR");
+        c4->set_length(16);
+        c4->set_is_key(false);
+        c4->set_is_nullable(false);
+        c4->set_aggregation("NONE");
+
         return metadata;
     }
 
@@ -145,6 +154,7 @@ protected:
         auto col_c2 = BinaryColumn::create();
         auto col_c3 = Int32Column::create();
         auto null_col_c3 = NullableColumn::create(std::move(col_c3), NullColumn::create());
+        auto col_c4 = BinaryColumn::create();
         for (int i = 0; i < nrows; ++i) {
             col_c0->append_datum(Datum(i + 1));
             col_c1->append_datum(Datum(i * 7 + 3));
@@ -154,8 +164,15 @@ protected:
             } else {
                 null_col_c3->append_datum(Datum(i * 11));
             }
+            // CHAR(16): append short (unpadded) slices — the segment writer stores
+            // CHAR and the decoder trims trailing '\0' on read-back, so the fast
+            // path's repad_char restores the declared width. Low cardinality keeps
+            // the bitmap dictionary small.
+            col_c4->append_datum(Datum(Slice("ch" + std::to_string(i % 4))));
         }
-        Chunk chunk({std::move(col_c0), std::move(col_c1), std::move(col_c2), std::move(null_col_c3)}, vschema);
+        Chunk chunk(
+                {std::move(col_c0), std::move(col_c1), std::move(col_c2), std::move(null_col_c3), std::move(col_c4)},
+                vschema);
         std::vector<uint32_t> indexes(nrows);
         for (int i = 0; i < nrows; ++i) indexes[i] = i;
 
@@ -208,6 +225,7 @@ protected:
     const int32_t _c1_uid = 101;
     const int32_t _c2_uid = 102;
     const int32_t _c3_uid = 103;
+    const int32_t _c4_uid = 104; // CHAR column, exercises feed_index_from_column's repad path
 
     std::unique_ptr<MemTracker> _mem_tracker;
     std::shared_ptr<FixedLocationProvider> _location_provider;
@@ -244,6 +262,53 @@ TEST_F(AddIndexSchemaChangeTest, run_bitmap_single_segment_happy_path) {
     ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(idx_path));
     auto exists_or = fs->path_exists(idx_path);
     EXPECT_TRUE(exists_or.ok());
+}
+
+// CHAR column: build_bitmap_for_column sets char_pad_len = column.length(), so
+// feed_index_from_column re-pads each decoder-trimmed slice back to the declared
+// width before feeding the bitmap dictionary (the CHAR-padding fix). Drives the
+// repad_char path that VARCHAR/other-type columns skip (char_pad_len == 0).
+TEST_F(AddIndexSchemaChangeTest, run_bitmap_char_column_repads) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/8);
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BITMAP, _c4_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    ASSERT_EQ(1, op.segment_entries_size());
+    const auto& entry = op.segment_entries(0).entry();
+    ASSERT_EQ(1, entry.keys_size());
+    EXPECT_EQ(_c4_uid, entry.keys(0).col_unique_id());
+    EXPECT_EQ(IndexType::BITMAP, entry.keys(0).index_type());
+    EXPECT_GT(entry.file_size(), 0);
+}
+
+// Same CHAR repad path through build_bloom_for_column (plain bloom filter).
+TEST_F(AddIndexSchemaChangeTest, run_bloom_char_column_repads) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/8);
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BLOOM_FILTER, _c4_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    ASSERT_EQ(1, op.segment_entries_size());
+    const auto& entry = op.segment_entries(0).entry();
+    ASSERT_EQ(1, entry.keys_size());
+    EXPECT_EQ(_c4_uid, entry.keys(0).col_unique_id());
+    EXPECT_EQ(IndexType::BLOOM_FILTER, entry.keys(0).index_type());
+    EXPECT_GT(entry.file_size(), 0);
 }
 
 // Build NGRAMBF on a VARCHAR column with gram_num=3 / fpp=0.05 /
@@ -464,6 +529,68 @@ TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_happy_path) {
     EXPECT_EQ(1, txn_log->op_add_index().new_indexes_size());
     EXPECT_EQ(1, txn_log->op_add_index().segment_entries_size());
     EXPECT_EQ(version, txn_log->op_add_index().alter_version());
+}
+
+// The FE-allocated new schema id/version must be carried into the OpAddIndex so
+// apply_add_index can stamp them onto the tablet metadata schema (durability fix
+// — invalidates every by-id schema cache so post-index loads / compaction build
+// the index instead of reusing the cached pre-index schema).
+TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_carries_new_schema_id) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/3);
+
+    TAlterTabletReqV2 request;
+    request.__set_base_tablet_id(base_tablet_id);
+    request.__set_new_tablet_id(base_tablet_id);
+    request.__set_alter_version(version);
+    request.__set_txn_id(next_id());
+    request.__set_only_add_index(true);
+    request.__set_new_index_schema_id(987654);
+    request.__set_new_index_schema_version(9);
+    TOlapTableIndex ix;
+    ix.__set_index_id(next_id());
+    ix.__set_index_type(TIndexType::BITMAP);
+    ix.__set_columns({"c1"});
+    request.__set_indexes_to_add({ix});
+
+    SchemaChangeHandler handler(_tablet_manager.get());
+    ASSERT_OK(handler.process_alter_tablet(request));
+
+    ASSIGN_OR_ABORT(auto txn_log,
+                    _tablet_manager->load_txn_log(_tablet_manager->txn_log_location(base_tablet_id, request.txn_id),
+                                                  /*fill_cache=*/false));
+    ASSERT_TRUE(txn_log->has_op_add_index());
+    EXPECT_EQ(987654, txn_log->op_add_index().new_schema_id());
+    EXPECT_EQ(9, txn_log->op_add_index().new_schema_version());
+}
+
+// A TOlapTableIndex with a type but no columns must fail fast in the fast path
+// (rather than fall through to init_from_thrift's unchecked field_index()).
+TEST_F(AddIndexSchemaChangeTest, do_process_add_index_only_empty_columns_rejected) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/3);
+
+    TAlterTabletReqV2 request;
+    request.__set_base_tablet_id(base_tablet_id);
+    request.__set_new_tablet_id(base_tablet_id);
+    request.__set_alter_version(version);
+    request.__set_txn_id(next_id());
+    request.__set_only_add_index(true);
+    TOlapTableIndex ix;
+    ix.__set_index_id(next_id());
+    ix.__set_index_type(TIndexType::BITMAP);
+    ix.__set_columns({}); // no columns -> InvalidArgument
+    request.__set_indexes_to_add({ix});
+
+    SchemaChangeHandler handler(_tablet_manager.get());
+    Status st = handler.process_alter_tablet(request);
+    ASSERT_FALSE(st.ok());
 }
 
 // Wrapper failure path: the request references a column name that does not

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -2127,6 +2127,91 @@ TEST_F(MetaFileTest, test_apply_add_index_merges_newest_first_multi) {
     EXPECT_EQ(10, v.entries(3).version());
 }
 
+TEST_F(MetaFileTest, test_apply_add_index_stamps_new_schema_id) {
+    // When FE allocates a new schema id/version (durability fix), apply_add_index
+    // must stamp it onto metadata->schema() so every by-id schema cache misses and
+    // picks up the indexed schema. On a fresh table (empty rowset_to_schema) no
+    // historical archiving is needed — existing rowsets resolve via schema().
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), 20021);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(20021);
+    metadata->set_version(5);
+    metadata->mutable_schema()->set_id(100);
+    metadata->mutable_schema()->set_schema_version(5);
+    MetaFileBuilder builder(*tablet, metadata);
+
+    TxnLogPB_OpAddIndex op;
+    op.set_alter_version(6);
+    push_segment_entry(&op, /*seg_id=*/0, /*version=*/6, "s0.idx", 100, BITMAP);
+    auto* new_ix = op.add_new_indexes();
+    new_ix->set_index_id(7001);
+    new_ix->set_index_type(BITMAP);
+    new_ix->add_col_unique_id(100);
+    op.set_new_schema_id(200);
+    op.set_new_schema_version(6);
+
+    builder.apply_add_index(op);
+
+    EXPECT_EQ(200, metadata->schema().id());
+    EXPECT_EQ(6, metadata->schema().schema_version());
+    // Empty rowset_to_schema: no pins, no historical archiving.
+    EXPECT_TRUE(metadata->rowset_to_schema().empty());
+    EXPECT_EQ(0u, metadata->historical_schemas().count(200));
+}
+
+TEST_F(MetaFileTest, test_apply_add_index_evolved_table_archives_and_repoints) {
+    // Fast-evolved table (non-empty rowset_to_schema): existing rowsets are pinned
+    // to a historical schema, so both the read path and compaction resolve through
+    // historical_schemas — bumping metadata->schema() alone is bypassed. The fix
+    // must archive the indexed schema under the new id AND repoint the pins that
+    // referenced the pre-index current schema (100) to it, while leaving pins to an
+    // OLDER schema (50) untouched. rowset.cpp CHECKs that a pinned schema id exists
+    // in historical_schemas, so the archive and the repoint must happen together.
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), 20022);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(20022);
+    metadata->set_version(5);
+    metadata->mutable_schema()->set_id(100); // pre-index current schema
+    metadata->mutable_schema()->set_schema_version(5);
+    // rowsets 1,2 pinned to the current schema (100); rowset 3 to an older one (50).
+    (*metadata->mutable_rowset_to_schema())[1] = 100;
+    (*metadata->mutable_rowset_to_schema())[2] = 100;
+    (*metadata->mutable_rowset_to_schema())[3] = 50;
+    (*metadata->mutable_historical_schemas())[100].set_id(100);
+    (*metadata->mutable_historical_schemas())[50].set_id(50);
+    MetaFileBuilder builder(*tablet, metadata);
+
+    TxnLogPB_OpAddIndex op;
+    op.set_alter_version(6);
+    push_segment_entry(&op, /*seg_id=*/0, /*version=*/6, "s0.idx", 100, BITMAP);
+    auto* new_ix = op.add_new_indexes();
+    new_ix->set_index_id(7001);
+    new_ix->set_index_type(BITMAP);
+    new_ix->add_col_unique_id(100);
+    op.set_new_schema_id(200);
+    op.set_new_schema_version(6);
+
+    builder.apply_add_index(op);
+
+    EXPECT_EQ(200, metadata->schema().id());
+    // Indexed schema archived under the new id (pins to it must resolve).
+    ASSERT_EQ(1u, metadata->historical_schemas().count(200));
+    EXPECT_EQ(200, metadata->historical_schemas().at(200).id());
+    // Pins on the pre-index current schema (100) repointed to the indexed id.
+    EXPECT_EQ(200, metadata->rowset_to_schema().at(1));
+    EXPECT_EQ(200, metadata->rowset_to_schema().at(2));
+    // Pin to an OLDER (fewer-column) schema is untouched.
+    EXPECT_EQ(50, metadata->rowset_to_schema().at(3));
+
+    // Idempotent replay: re-applying the same op is a no-op (guarded on
+    // historical_schemas already containing the new id).
+    builder.apply_add_index(op);
+    EXPECT_EQ(200, metadata->schema().id());
+    EXPECT_EQ(200, metadata->rowset_to_schema().at(1));
+    EXPECT_EQ(50, metadata->rowset_to_schema().at(3));
+    EXPECT_EQ(1u, metadata->historical_schemas().count(200));
+}
+
 TEST_F(MetaFileTest, test_apply_drop_index_populates_tombstone) {
     // Dropping an index from schema.table_indices must also copy the
     // TabletIndexPB into schema.dropped_table_indices so BE readers know

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -2127,6 +2127,31 @@ TEST_F(MetaFileTest, test_apply_add_index_merges_newest_first_multi) {
     EXPECT_EQ(10, v.entries(3).version());
 }
 
+TEST_F(MetaFileTest, test_apply_add_index_empty_op_is_pure_noop) {
+    // The rollup no-op shape: FE sends an empty index set for a materialized
+    // index whose schema lacks the indexed column(s); do_process writes a txn
+    // log whose op_add_index carries only alter_version. Applying it must leave
+    // the tablet metadata untouched (the version advance itself happens in the
+    // generic publish machinery): no idg_meta materialized, schema id/content
+    // unchanged, no historical archiving, no rowset pins.
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), 20031);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(20031);
+    metadata->set_version(7);
+    metadata->mutable_schema()->set_id(300);
+    MetaFileBuilder builder(*tablet, metadata);
+
+    TxnLogPB_OpAddIndex op;
+    op.set_alter_version(7);
+    builder.apply_add_index(op);
+
+    EXPECT_FALSE(metadata->has_idg_meta());
+    EXPECT_EQ(300, metadata->schema().id());
+    EXPECT_EQ(0, metadata->schema().table_indices_size());
+    EXPECT_TRUE(metadata->historical_schemas().empty());
+    EXPECT_TRUE(metadata->rowset_to_schema().empty());
+}
+
 TEST_F(MetaFileTest, test_apply_add_index_stamps_new_schema_id) {
     // When FE allocates a new schema id/version (durability fix), apply_add_index
     // must stamp it onto metadata->schema() so every by-id schema cache misses and

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -2946,12 +2946,13 @@ TEST_F(SchemaChangeAddIndexOnlyTest, missing_txn_id_returns_invalid_argument) {
     EXPECT_TRUE(st.is_invalid_argument()) << st.to_string();
 }
 
-TEST_F(SchemaChangeAddIndexOnlyTest, empty_indexes_to_add_returns_invalid_argument) {
-    // Empty indexes_to_add must surface as InvalidArgument and NOT fall
-    // back to do_process_alter_tablet — the fast-path request has
-    // base_tablet_id == new_tablet_id with no schema diff, and the legacy
-    // rewrite path treats that as self-targeted alter, appending duplicate
-    // rowsets and doubling the row count.
+TEST_F(SchemaChangeAddIndexOnlyTest, empty_indexes_to_add_is_explicit_noop) {
+    // An EMPTY indexes_to_add set is the FE's way of saying "this materialized
+    // index (rollup / sync MV) does not carry the indexed column(s)": BE must
+    // write a no-op txn log (version advance only) so the reserved alter
+    // version still publishes on this tablet — and must NOT fall back to
+    // do_process_alter_tablet (base_tablet_id == new_tablet_id would make the
+    // legacy rewrite self-target the tablet and duplicate rowsets).
     TAlterTabletReqV2 request;
     request.__set_new_tablet_id(5002);
     request.__set_base_tablet_id(5000);
@@ -2960,9 +2961,14 @@ TEST_F(SchemaChangeAddIndexOnlyTest, empty_indexes_to_add_returns_invalid_argume
     // indexes_to_add intentionally unset
 
     SchemaChangeHandler handler(_tablet_manager.get());
-    Status st = handler.process_alter_tablet(request);
-    ASSERT_FALSE(st.ok());
-    EXPECT_TRUE(st.is_invalid_argument()) << st.to_string();
+    ASSERT_OK(handler.process_alter_tablet(request));
+
+    ASSIGN_OR_ABORT(auto txn_log,
+                    _tablet_manager->load_txn_log(_tablet_manager->txn_log_location(5002, 800002),
+                                                  /*fill_cache=*/false));
+    ASSERT_TRUE(txn_log->has_op_add_index());
+    EXPECT_EQ(0, txn_log->op_add_index().new_indexes_size());
+    EXPECT_EQ(0, txn_log->op_add_index().segment_entries_size());
 }
 
 TEST_F(SchemaChangeAddIndexOnlyTest, index_without_type_rejected) {

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -2963,9 +2963,8 @@ TEST_F(SchemaChangeAddIndexOnlyTest, empty_indexes_to_add_is_explicit_noop) {
     SchemaChangeHandler handler(_tablet_manager.get());
     ASSERT_OK(handler.process_alter_tablet(request));
 
-    ASSIGN_OR_ABORT(auto txn_log,
-                    _tablet_manager->load_txn_log(_tablet_manager->txn_log_location(5002, 800002),
-                                                  /*fill_cache=*/false));
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_manager->load_txn_log(_tablet_manager->txn_log_location(5002, 800002),
+                                                                /*fill_cache=*/false));
     ASSERT_TRUE(txn_log->has_op_add_index());
     EXPECT_EQ(0, txn_log->op_add_index().new_indexes_size());
     EXPECT_EQ(0, txn_log->op_add_index().segment_entries_size());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -119,13 +119,42 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
                 : new HashMap<>(other.indexMetaIdToNewSchema);
     }
 
+    /**
+     * Returns the subset of {@code indexes} whose columns are ALL present in the
+     * given materialized index meta's schema. A rollup / sync-MV that projects
+     * away an indexed column must not receive (or build) that index — mirroring
+     * the legacy path, which only builds indexes on the base index. A null meta
+     * (defensive) applies every index.
+     */
+    static List<TOlapTableIndex> applicableIndexes(List<TOlapTableIndex> indexes, MaterializedIndexMeta meta) {
+        if (indexes == null || indexes.isEmpty() || meta == null) {
+            return indexes;
+        }
+        Set<String> metaColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (Column column : meta.getSchema()) {
+            metaColumnNames.add(column.getName());
+        }
+        List<TOlapTableIndex> applicable = new ArrayList<>();
+        for (TOlapTableIndex ix : indexes) {
+            if (ix.getColumns() != null && metaColumnNames.containsAll(ix.getColumns())) {
+                applicable.add(ix);
+            }
+        }
+        return applicable;
+    }
+
     @Override
-    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId) {
-        task.setOnlyAddIndex(indexesToAdd);
+    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId, MaterializedIndexMeta indexMeta) {
+        // A materialized index (rollup / sync MV) whose schema projects away an
+        // indexed column must not build that index: send it only the indexes
+        // whose columns its schema carries. An empty list makes BE write a no-op
+        // txn log so the reserved alter version still publishes on its tablets.
+        task.setOnlyAddIndex(applicableIndexes(indexesToAdd, indexMeta));
         // Each affected index meta got its OWN new schema id/version; stamp this
         // tablet with its index's id so BE bumps that index's schema, and
         // applyCatalogMutation bumps the same meta. Keeps FE and BE schema ids
-        // aligned per index (base + any rollup / sync-MV index).
+        // aligned per index. Metas with no applicable index were never allocated
+        // an entry (see the build sites), so their tablets carry no stamp.
         long[] newSchema = indexMetaIdToNewSchema.get(indexMetaId);
         if (newSchema != null && newSchema[0] > 0) {
             task.setNewIndexSchema(newSchema[0], newSchema[1]);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -25,7 +25,9 @@ import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.thrift.TOlapTableIndex;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -69,39 +71,29 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
     private List<String> addBfColumns = new ArrayList<>();
 
     /**
-     * New schema id/version allocated once at job build time (see
-     * SchemaChangeHandler.tryBuildLakeAddIndexJob). The fast path reuses the
-     * base index meta's schema_id but changes its content (adds the index), and
-     * every lake by-id schema cache assumes id==content — so without a new id,
-     * data loaded after the index and compaction output keep using the cached
-     * pre-index schema and build no index. Bumping the id (persisted here so
-     * replay is idempotent) forces every cache to miss and pick up the indexed
-     * schema. 0 = not set (older job / not applicable).
+     * Per-index-meta new schema id + version, allocated once at job build time
+     * (one getNextId() per affected index meta; version = that meta's own
+     * schemaVersion + 1). The fast path reuses each index meta's schema_id but
+     * changes its content (adds the index); every lake by-id schema cache assumes
+     * id==content, so without a fresh id per index, loads/compaction on that index
+     * keep resolving the cached pre-index schema and build no index. Each index's
+     * tablets are stamped with THAT index's new id (populateAlterRequest), and
+     * each affected meta is bumped in applyCatalogMutation — the dispatch set, the
+     * allocation set, and the mutation set are kept identical so FE and BE schema
+     * ids never diverge (e.g. on a table with rollup / sync-MV indexes). Persisted
+     * for idempotent replay. Key = index meta id; value = [schemaId, schemaVersion].
      */
-    @SerializedName(value = "newSchemaId")
-    private long newSchemaId = 0;
-    @SerializedName(value = "newSchemaVersion")
-    private long newSchemaVersion = 0;
-
-    /**
-     * Base index meta id captured at build time. Only tablets belonging to the
-     * base index may carry {@link #newSchemaId}: applyCatalogMutation bumps only
-     * the base index meta, so stamping a rollup/MV-index tablet would push its BE
-     * schema id ahead of its (unchanged) FE meta. -1 = not set.
-     */
-    @SerializedName(value = "baseIndexMetaId")
-    private long baseIndexMetaId = -1;
+    @SerializedName(value = "indexMetaIdToNewSchema")
+    private Map<Long, long[]> indexMetaIdToNewSchema = new HashMap<>();
 
     /** For deserialization / GSON. */
     public LakeTableAddIndexJob() {
         super(JobType.SCHEMA_CHANGE);
     }
 
-    /** Set the FE-allocated new schema id/version and the base index meta id. */
-    public void setNewSchema(long schemaId, long schemaVersion, long baseIndexMetaId) {
-        this.newSchemaId = schemaId;
-        this.newSchemaVersion = schemaVersion;
-        this.baseIndexMetaId = baseIndexMetaId;
+    /** Record the FE-allocated new schema id/version for one affected index meta. */
+    public void putNewSchema(long indexMetaId, long schemaId, long schemaVersion) {
+        indexMetaIdToNewSchema.put(indexMetaId, new long[] {schemaId, schemaVersion});
     }
 
     public LakeTableAddIndexJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
@@ -123,21 +115,20 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         this.newIndexes = other.newIndexes == null ? null : new ArrayList<>(other.newIndexes);
         this.indexesToAdd = other.indexesToAdd == null ? null : new ArrayList<>(other.indexesToAdd);
         this.addBfColumns = other.addBfColumns == null ? null : new ArrayList<>(other.addBfColumns);
-        this.newSchemaId = other.newSchemaId;
-        this.newSchemaVersion = other.newSchemaVersion;
-        this.baseIndexMetaId = other.baseIndexMetaId;
+        this.indexMetaIdToNewSchema = other.indexMetaIdToNewSchema == null ? null
+                : new HashMap<>(other.indexMetaIdToNewSchema);
     }
 
     @Override
     protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId) {
         task.setOnlyAddIndex(indexesToAdd);
-        // Only the base index meta has its schema id/version bumped
-        // (applyCatalogMutation), so only base-index tablets may carry the new
-        // schema id. Stamping a rollup/MV-index tablet would push its BE schema
-        // id ahead of the unchanged FE meta; those tablets keep their existing
-        // schema id (pre-fix behavior).
-        if (newSchemaId > 0 && indexMetaId == baseIndexMetaId) {
-            task.setNewIndexSchema(newSchemaId, newSchemaVersion);
+        // Each affected index meta got its OWN new schema id/version; stamp this
+        // tablet with its index's id so BE bumps that index's schema, and
+        // applyCatalogMutation bumps the same meta. Keeps FE and BE schema ids
+        // aligned per index (base + any rollup / sync-MV index).
+        long[] newSchema = indexMetaIdToNewSchema.get(indexMetaId);
+        if (newSchema != null && newSchema[0] > 0) {
+            task.setNewIndexSchema(newSchema[0], newSchema[1]);
         }
     }
 
@@ -190,20 +181,29 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
             table.setBloomFilterInfo(merged, fpp);
         }
 
-        // Bump the base index meta's schema id/version so subsequent loads and
-        // compaction resolve the now-indexed schema instead of the cached
-        // pre-index one (the fast path reuses the same schema_id but changed its
+        // Bump EACH affected index meta's schema id/version so subsequent loads
+        // and compaction resolve the now-indexed schema instead of the cached
+        // pre-index one (the fast path reuses the schema_id but changed its
         // content; every lake by-id schema cache would otherwise return stale).
-        // Idempotent on replay: the persisted newSchemaId/version are set
-        // verbatim. Mirrors LakeTableAsyncFastSchemaChangeJob's meta update.
-        if (newSchemaId > 0) {
-            long baseMetaId = table.getBaseIndexMetaId();
-            MaterializedIndexMeta baseMeta = table.getIndexMetaByMetaId(baseMetaId);
-            if (baseMeta != null) {
-                MaterializedIndexMeta copy = baseMeta.shallowCopy();
-                copy.setSchemaId(newSchemaId);
-                copy.setSchemaVersion((int) newSchemaVersion);
-                table.getIndexMetaIdToMeta().put(baseMetaId, copy);
+        // Per-index — the same set stamped onto BE tablets (populateAlterRequest)
+        // — so a rollup / sync-MV index meta stays consistent with its tablets.
+        // Idempotent on replay: the persisted ids/versions are set verbatim.
+        // Mirrors LakeTableAsyncFastSchemaChangeJob's per-index meta update.
+        if (indexMetaIdToNewSchema != null && !indexMetaIdToNewSchema.isEmpty()) {
+            boolean bumped = false;
+            for (Map.Entry<Long, long[]> entry : indexMetaIdToNewSchema.entrySet()) {
+                MaterializedIndexMeta meta = table.getIndexMetaByMetaId(entry.getKey());
+                if (meta == null) {
+                    continue;
+                }
+                long[] newSchema = entry.getValue();
+                MaterializedIndexMeta copy = meta.shallowCopy();
+                copy.setSchemaId(newSchema[0]);
+                copy.setSchemaVersion((int) newSchema[1]);
+                table.getIndexMetaIdToMeta().put(entry.getKey(), copy);
+                bumped = true;
+            }
+            if (bumped) {
                 table.rebuildFullSchema();
             }
         }
@@ -234,9 +234,8 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         c.newIndexes = this.newIndexes == null ? null : new ArrayList<>(this.newIndexes);
         c.indexesToAdd = this.indexesToAdd == null ? null : new ArrayList<>(this.indexesToAdd);
         c.addBfColumns = this.addBfColumns == null ? null : new ArrayList<>(this.addBfColumns);
-        c.newSchemaId = this.newSchemaId;
-        c.newSchemaVersion = this.newSchemaVersion;
-        c.baseIndexMetaId = this.baseIndexMetaId;
+        c.indexMetaIdToNewSchema = this.indexMetaIdToNewSchema == null ? null
+                : new HashMap<>(this.indexMetaIdToNewSchema);
     }
 
     // Accessors for tests / tooling.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -18,6 +18,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.task.AlterReplicaTask;
@@ -67,9 +68,30 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
     @SerializedName(value = "addBfColumns")
     private List<String> addBfColumns = new ArrayList<>();
 
+    /**
+     * New schema id/version allocated once at job build time (see
+     * SchemaChangeHandler.tryBuildLakeAddIndexJob). The fast path reuses the
+     * base index meta's schema_id but changes its content (adds the index), and
+     * every lake by-id schema cache assumes id==content — so without a new id,
+     * data loaded after the index and compaction output keep using the cached
+     * pre-index schema and build no index. Bumping the id (persisted here so
+     * replay is idempotent) forces every cache to miss and pick up the indexed
+     * schema. 0 = not set (older job / not applicable).
+     */
+    @SerializedName(value = "newSchemaId")
+    private long newSchemaId = 0;
+    @SerializedName(value = "newSchemaVersion")
+    private long newSchemaVersion = 0;
+
     /** For deserialization / GSON. */
     public LakeTableAddIndexJob() {
         super(JobType.SCHEMA_CHANGE);
+    }
+
+    /** Set the FE-allocated new schema id/version for this add-index. */
+    public void setNewSchema(long schemaId, long schemaVersion) {
+        this.newSchemaId = schemaId;
+        this.newSchemaVersion = schemaVersion;
     }
 
     public LakeTableAddIndexJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
@@ -91,11 +113,16 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         this.newIndexes = other.newIndexes == null ? null : new ArrayList<>(other.newIndexes);
         this.indexesToAdd = other.indexesToAdd == null ? null : new ArrayList<>(other.indexesToAdd);
         this.addBfColumns = other.addBfColumns == null ? null : new ArrayList<>(other.addBfColumns);
+        this.newSchemaId = other.newSchemaId;
+        this.newSchemaVersion = other.newSchemaVersion;
     }
 
     @Override
     protected void populateAlterRequest(AlterReplicaTask task) {
         task.setOnlyAddIndex(indexesToAdd);
+        if (newSchemaId > 0) {
+            task.setNewIndexSchema(newSchemaId, newSchemaVersion);
+        }
     }
 
     @Override
@@ -146,6 +173,24 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
             }
             table.setBloomFilterInfo(merged, fpp);
         }
+
+        // Bump the base index meta's schema id/version so subsequent loads and
+        // compaction resolve the now-indexed schema instead of the cached
+        // pre-index one (the fast path reuses the same schema_id but changed its
+        // content; every lake by-id schema cache would otherwise return stale).
+        // Idempotent on replay: the persisted newSchemaId/version are set
+        // verbatim. Mirrors LakeTableAsyncFastSchemaChangeJob's meta update.
+        if (newSchemaId > 0) {
+            long baseMetaId = table.getBaseIndexMetaId();
+            MaterializedIndexMeta baseMeta = table.getIndexMetaByMetaId(baseMetaId);
+            if (baseMeta != null) {
+                MaterializedIndexMeta copy = baseMeta.shallowCopy();
+                copy.setSchemaId(newSchemaId);
+                copy.setSchemaVersion((int) newSchemaVersion);
+                table.getIndexMetaIdToMeta().put(baseMetaId, copy);
+                table.rebuildFullSchema();
+            }
+        }
     }
 
     private static boolean sameIndex(Index a, Index b) {
@@ -173,6 +218,8 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         c.newIndexes = this.newIndexes == null ? null : new ArrayList<>(this.newIndexes);
         c.indexesToAdd = this.indexesToAdd == null ? null : new ArrayList<>(this.indexesToAdd);
         c.addBfColumns = this.addBfColumns == null ? null : new ArrayList<>(this.addBfColumns);
+        c.newSchemaId = this.newSchemaId;
+        c.newSchemaVersion = this.newSchemaVersion;
     }
 
     // Accessors for tests / tooling.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -121,10 +121,12 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
 
     /**
      * Returns the subset of {@code indexes} whose columns are ALL present in the
-     * given materialized index meta's schema. A rollup / sync-MV that projects
-     * away an indexed column must not receive (or build) that index — mirroring
-     * the legacy path, which only builds indexes on the base index. A null meta
-     * (defensive) applies every index.
+     * given materialized index meta's schema. Mirrors the legacy path's
+     * {@code OlapTable.getIndexesBySchema} rule: an index is built on every
+     * materialized index whose schema carries all of the index's columns (base
+     * plus any qualifying rollup / sync-MV); a meta that projects an indexed
+     * column away gets an empty (no-op) task instead of failing the alter. A
+     * null meta (defensive) applies every index.
      */
     static List<TOlapTableIndex> applicableIndexes(List<TOlapTableIndex> indexes, MaterializedIndexMeta meta) {
         if (indexes == null || indexes.isEmpty() || meta == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -26,6 +26,7 @@ import com.starrocks.thrift.TOlapTableIndex;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -120,25 +121,43 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
     }
 
     /**
-     * Returns the subset of {@code indexes} whose columns are ALL present in the
-     * given materialized index meta's schema. Mirrors the legacy path's
-     * {@code OlapTable.getIndexesBySchema} rule: an index is built on every
-     * materialized index whose schema carries all of the index's columns (base
-     * plus any qualifying rollup / sync-MV); a meta that projects an indexed
-     * column away gets an empty (no-op) task instead of failing the alter. A
-     * null meta (defensive) applies every index.
+     * Returns the subset of {@code indexes} whose columns are ALL carried by the
+     * given materialized index meta's schema, matched by {@link ColumnId} to
+     * mirror the authoritative legacy rule {@code OlapTable.getIndexesBySchema}.
+     * An index is built on every materialized index whose schema carries all of
+     * the index's columns (base plus any qualifying rollup / sync-MV); a meta
+     * that projects an indexed column away gets an empty (no-op) task instead of
+     * failing the alter. Matching by ColumnId (not name) is required so a rollup
+     * / sync-MV that keeps the indexed column's ColumnId under a renamed output
+     * is still indexed — otherwise its FE schema (which includes the index) and
+     * BE tablet (never stamped) would diverge. The index's columns are resolved
+     * to their base-table ColumnId via {@code table}; when {@code table} or
+     * {@code meta} is null (defensive), every index applies.
      */
-    static List<TOlapTableIndex> applicableIndexes(List<TOlapTableIndex> indexes, MaterializedIndexMeta meta) {
+    static List<TOlapTableIndex> applicableIndexes(List<TOlapTableIndex> indexes, MaterializedIndexMeta meta,
+                                                   OlapTable table) {
         if (indexes == null || indexes.isEmpty() || meta == null) {
             return indexes;
         }
-        Set<String> metaColumnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Set<ColumnId> metaColumnIds = new HashSet<>();
         for (Column column : meta.getSchema()) {
-            metaColumnNames.add(column.getName());
+            metaColumnIds.add(column.getColumnId());
         }
         List<TOlapTableIndex> applicable = new ArrayList<>();
         for (TOlapTableIndex ix : indexes) {
-            if (ix.getColumns() != null && metaColumnNames.containsAll(ix.getColumns())) {
+            if (ix.getColumns() == null) {
+                continue;
+            }
+            boolean allCarried = true;
+            for (String columnName : ix.getColumns()) {
+                Column baseColumn = table != null ? table.getColumn(columnName) : null;
+                ColumnId columnId = baseColumn != null ? baseColumn.getColumnId() : ColumnId.create(columnName);
+                if (!metaColumnIds.contains(columnId)) {
+                    allCarried = false;
+                    break;
+                }
+            }
+            if (allCarried) {
                 applicable.add(ix);
             }
         }
@@ -146,12 +165,14 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
     }
 
     @Override
-    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId, MaterializedIndexMeta indexMeta) {
+    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId, MaterializedIndexMeta indexMeta,
+                                        OlapTable table) {
         // A materialized index (rollup / sync MV) whose schema projects away an
         // indexed column must not build that index: send it only the indexes
-        // whose columns its schema carries. An empty list makes BE write a no-op
-        // txn log so the reserved alter version still publishes on its tablets.
-        task.setOnlyAddIndex(applicableIndexes(indexesToAdd, indexMeta));
+        // whose columns its schema carries (matched by ColumnId via the base
+        // table). An empty list makes BE write a no-op txn log so the reserved
+        // alter version still publishes on its tablets.
+        task.setOnlyAddIndex(applicableIndexes(indexesToAdd, indexMeta, table));
         // Each affected index meta got its OWN new schema id/version; stamp this
         // tablet with its index's id so BE bumps that index's schema, and
         // applyCatalogMutation bumps the same meta. Keeps FE and BE schema ids

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAddIndexJob.java
@@ -83,15 +83,25 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
     @SerializedName(value = "newSchemaVersion")
     private long newSchemaVersion = 0;
 
+    /**
+     * Base index meta id captured at build time. Only tablets belonging to the
+     * base index may carry {@link #newSchemaId}: applyCatalogMutation bumps only
+     * the base index meta, so stamping a rollup/MV-index tablet would push its BE
+     * schema id ahead of its (unchanged) FE meta. -1 = not set.
+     */
+    @SerializedName(value = "baseIndexMetaId")
+    private long baseIndexMetaId = -1;
+
     /** For deserialization / GSON. */
     public LakeTableAddIndexJob() {
         super(JobType.SCHEMA_CHANGE);
     }
 
-    /** Set the FE-allocated new schema id/version for this add-index. */
-    public void setNewSchema(long schemaId, long schemaVersion) {
+    /** Set the FE-allocated new schema id/version and the base index meta id. */
+    public void setNewSchema(long schemaId, long schemaVersion, long baseIndexMetaId) {
         this.newSchemaId = schemaId;
         this.newSchemaVersion = schemaVersion;
+        this.baseIndexMetaId = baseIndexMetaId;
     }
 
     public LakeTableAddIndexJob(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
@@ -115,12 +125,18 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         this.addBfColumns = other.addBfColumns == null ? null : new ArrayList<>(other.addBfColumns);
         this.newSchemaId = other.newSchemaId;
         this.newSchemaVersion = other.newSchemaVersion;
+        this.baseIndexMetaId = other.baseIndexMetaId;
     }
 
     @Override
-    protected void populateAlterRequest(AlterReplicaTask task) {
+    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId) {
         task.setOnlyAddIndex(indexesToAdd);
-        if (newSchemaId > 0) {
+        // Only the base index meta has its schema id/version bumped
+        // (applyCatalogMutation), so only base-index tablets may carry the new
+        // schema id. Stamping a rollup/MV-index tablet would push its BE schema
+        // id ahead of the unchanged FE meta; those tablets keep their existing
+        // schema id (pre-fix behavior).
+        if (newSchemaId > 0 && indexMetaId == baseIndexMetaId) {
             task.setNewIndexSchema(newSchemaId, newSchemaVersion);
         }
     }
@@ -220,6 +236,7 @@ public class LakeTableAddIndexJob extends LakeTableIndexFastPathJobBase {
         c.addBfColumns = this.addBfColumns == null ? null : new ArrayList<>(this.addBfColumns);
         c.newSchemaId = this.newSchemaId;
         c.newSchemaVersion = this.newSchemaVersion;
+        c.baseIndexMetaId = this.baseIndexMetaId;
     }
 
     // Accessors for tests / tooling.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
@@ -127,7 +127,8 @@ public class LakeTableDropIndexJob extends LakeTableIndexFastPathJobBase {
     }
 
     @Override
-    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId) {
+    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId,
+                                        com.starrocks.catalog.MaterializedIndexMeta indexMeta) {
         task.setOnlyDropIndex(dropInfos);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
@@ -127,7 +127,7 @@ public class LakeTableDropIndexJob extends LakeTableIndexFastPathJobBase {
     }
 
     @Override
-    protected void populateAlterRequest(AlterReplicaTask task) {
+    protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId) {
         task.setOnlyDropIndex(dropInfos);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableDropIndexJob.java
@@ -128,7 +128,7 @@ public class LakeTableDropIndexJob extends LakeTableIndexFastPathJobBase {
 
     @Override
     protected void populateAlterRequest(AlterReplicaTask task, long indexMetaId,
-                                        com.starrocks.catalog.MaterializedIndexMeta indexMeta) {
+                                        com.starrocks.catalog.MaterializedIndexMeta indexMeta, OlapTable table) {
         task.setOnlyDropIndex(dropInfos);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -65,7 +65,7 @@ import java.util.Optional;
  * column flags) in a single write lock.
  *
  * <p>Subclasses plug in two concrete pieces via the hook methods
- * {@link #populateAlterRequest(AlterReplicaTask, long, MaterializedIndexMeta)} and
+ * {@link #populateAlterRequest(AlterReplicaTask, long, MaterializedIndexMeta, OlapTable)} and
  * {@link #applyCatalogMutation(OlapTable)}. Everything else — txn watershed,
  * replica task dispatch, timeout, publish, persist/replay — is shared.
  *
@@ -145,7 +145,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
      * AlterReplicaTask before the task is added to the batch.
      */
     protected abstract void populateAlterRequest(AlterReplicaTask task, long indexMetaId,
-                                                 MaterializedIndexMeta indexMeta);
+                                                 MaterializedIndexMeta indexMeta, OlapTable table);
 
     /**
      * Mutate the FE catalog to reflect the applied index change. Runs
@@ -760,7 +760,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                     AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(cn.getId(), dbId, tableId, ppId,
                             indexMetaId, tabletId, tabletId, visibleVersion, jobId, watershedTxnId,
                             /*generatedColumnReq=*/ null, readSchema);
-                    populateAlterRequest(task, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
+                    populateAlterRequest(task, indexMetaId, table.getIndexMetaByMetaId(indexMetaId), table);
                     batchTask.addTask(task);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
@@ -64,7 +65,7 @@ import java.util.Optional;
  * column flags) in a single write lock.
  *
  * <p>Subclasses plug in two concrete pieces via the hook methods
- * {@link #populateAlterRequest(AlterReplicaTask, long)} and
+ * {@link #populateAlterRequest(AlterReplicaTask, long, MaterializedIndexMeta)} and
  * {@link #applyCatalogMutation(OlapTable)}. Everything else — txn watershed,
  * replica task dispatch, timeout, publish, persist/replay — is shared.
  *
@@ -143,7 +144,8 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
      * Flag the task with the appropriate fast-path payload. Called once per
      * AlterReplicaTask before the task is added to the batch.
      */
-    protected abstract void populateAlterRequest(AlterReplicaTask task, long indexMetaId);
+    protected abstract void populateAlterRequest(AlterReplicaTask task, long indexMetaId,
+                                                 MaterializedIndexMeta indexMeta);
 
     /**
      * Mutate the FE catalog to reflect the applied index change. Runs
@@ -758,7 +760,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                     AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(cn.getId(), dbId, tableId, ppId,
                             indexMetaId, tabletId, tabletId, visibleVersion, jobId, watershedTxnId,
                             /*generatedColumnReq=*/ null, readSchema);
-                    populateAlterRequest(task, indexMetaId);
+                    populateAlterRequest(task, indexMetaId, table.getIndexMetaByMetaId(indexMetaId));
                     batchTask.addTask(task);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -64,7 +64,7 @@ import java.util.Optional;
  * column flags) in a single write lock.
  *
  * <p>Subclasses plug in two concrete pieces via the hook methods
- * {@link #populateAlterRequest(AlterReplicaTask)} and
+ * {@link #populateAlterRequest(AlterReplicaTask, long)} and
  * {@link #applyCatalogMutation(OlapTable)}. Everything else — txn watershed,
  * replica task dispatch, timeout, publish, persist/replay — is shared.
  *
@@ -143,7 +143,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
      * Flag the task with the appropriate fast-path payload. Called once per
      * AlterReplicaTask before the task is added to the batch.
      */
-    protected abstract void populateAlterRequest(AlterReplicaTask task);
+    protected abstract void populateAlterRequest(AlterReplicaTask task, long indexMetaId);
 
     /**
      * Mutate the FE catalog to reflect the applied index change. Runs
@@ -758,7 +758,7 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                     AlterReplicaTask task = AlterReplicaTask.alterLakeTablet(cn.getId(), dbId, tableId, ppId,
                             indexMetaId, tabletId, tabletId, visibleVersion, jobId, watershedTxnId,
                             /*generatedColumnReq=*/ null, readSchema);
-                    populateAlterRequest(task);
+                    populateAlterRequest(task, indexMetaId);
                     batchTask.addTask(task);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3432,11 +3432,6 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     /**
-     * Build a {@link LakeTableAddIndexJob} from a CreateIndexClause-only alter.
-     * Returns null on any unexpected failure so the caller can fall back to the
-     * regular schema-change path (safer than throwing).
-     */
-    /**
      * Admission guards for the lake index fast path, mirroring the legacy
      * path's under-lock checks (finalAnalyze's state re-check plus the
      * per-clause insert-overwrite / temp-partition guards). Must be evaluated
@@ -3451,6 +3446,11 @@ public class SchemaChangeHandler extends AlterHandler {
                 && !olapTable.existTempPartitions();
     }
 
+    /**
+     * Build a {@link LakeTableAddIndexJob} from a CreateIndexClause-only alter.
+     * Returns null on any unexpected failure so the caller can fall back to the
+     * regular schema-change path (safer than throwing).
+     */
     private AlterJobV2 tryBuildLakeAddIndexJob(Database db, OlapTable olapTable, List<AlterClause> alterClauses) {
         boolean stateSet = false;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2374,6 +2374,20 @@ public class SchemaChangeHandler extends AlterHandler {
             if (bfDelta != null) {
                 AlterJobV2 fastPathJob = null;
                 if (bfDelta.isPureAdd()) {
+                    // A column may carry at most one of {plain bloom filter, ngram
+                    // bloom filter}. The regular schema-change path enforces this
+                    // via IndexAnalyzer.analyseBfWithNgramBf; the fast path must
+                    // too, otherwise SET ("bloom_filter_columns"=...) on a column
+                    // that already has an NGRAMBF index is silently accepted.
+                    Set<ColumnId> addedBfColumnIds = Sets.newTreeSet(ColumnId.CASE_INSENSITIVE_ORDER);
+                    for (String columnName : bfDelta.added) {
+                        Column bfColumn = olapTable.getColumn(columnName);
+                        if (bfColumn != null) {
+                            addedBfColumnIds.add(bfColumn.getColumnId());
+                        }
+                    }
+                    IndexAnalyzer.analyseBfWithNgramBf(olapTable, new HashSet<>(olapTable.getIndexes()),
+                            addedBfColumnIds);
                     fastPathJob = tryBuildLakeAddBloomFilterJob(db, olapTable, bfDelta.added);
                 } else if (bfDelta.isPureDrop()) {
                     fastPathJob = tryBuildLakeDropBloomFilterJob(db, olapTable, bfDelta.dropped);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3481,7 +3481,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // task (no index, no schema change), so its schema id must stay put.
             for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
                 MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
-                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta).isEmpty()) {
+                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta, olapTable).isEmpty()) {
                     continue;
                 }
                 job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),
@@ -3616,7 +3616,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // every bloom column receive a no-op task and keep their schema id.
             for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
                 MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
-                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta).isEmpty()) {
+                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta, olapTable).isEmpty()) {
                     continue;
                 }
                 job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3429,6 +3429,11 @@ public class SchemaChangeHandler extends AlterHandler {
             long timeoutMs = TimeUnit.SECONDS.toMillis(Config.alter_table_timeout_second);
             LakeTableAddIndexJob job = new LakeTableAddIndexJob(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), timeoutMs, newIndexes, thriftIndexes);
+            // Allocate a new schema id/version so subsequent loads and compaction
+            // pick up the indexed schema (the fast path reuses the base schema_id
+            // but changes its content; every by-id schema cache would go stale).
+            job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
+                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1);
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             // Move table to SCHEMA_CHANGE so concurrent alters are blocked.
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
@@ -3551,6 +3556,10 @@ public class SchemaChangeHandler extends AlterHandler {
             long timeoutMs = TimeUnit.SECONDS.toMillis(Config.alter_table_timeout_second);
             LakeTableAddIndexJob job = new LakeTableAddIndexJob(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), timeoutMs, new ArrayList<>(), thriftIndexes, addBfColumnNames);
+            // Allocate a new schema id/version so subsequent loads and compaction
+            // pick up the schema with the new bloom-filter column (see above).
+            job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
+                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1);
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
             stateSet = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2348,7 +2348,22 @@ public class SchemaChangeHandler extends AlterHandler {
         // payloads on BE without rewriting segment data. On any unexpected
         // construction error we fall through to the regular path to stay
         // safe.
-        if (SchemaChangeIndexFastPathClassifier.shouldUseAddIndexFastPath(olapTable, alterClauses)) {
+        //
+        // Admission guards, mirroring the legacy path's under-lock checks
+        // (finalAnalyze's state re-check and the per-clause insert-overwrite /
+        // temp-partition guards below): the entry-point state check in
+        // AlterJobExecutor is lock-free, so a concurrent ALTER can pass it and
+        // reach here after this table already entered SCHEMA_CHANGE. Skipping
+        // the fast path here lets the legacy path raise its canonical error
+        // instead of admitting a second live job on the same table.
+        boolean fastPathAdmissible = olapTable.getState() == OlapTable.OlapTableState.NORMAL
+                && !GlobalStateMgr.getCurrentState().getInsertOverwriteJobMgr()
+                        .hasRunningOverwriteJob(olapTable.getId())
+                && !olapTable.existTempPartitions();
+        if (!fastPathAdmissible) {
+            LOG.info("lake index fast path not admissible for table {} (state={}); "
+                    + "falling through to regular path", olapTable.getName(), olapTable.getState());
+        } else if (SchemaChangeIndexFastPathClassifier.shouldUseAddIndexFastPath(olapTable, alterClauses)) {
             AlterJobV2 fastPathJob = tryBuildLakeAddIndexJob(db, olapTable, alterClauses);
             if (fastPathJob != null) {
                 LOG.info("ADD INDEX fast path selected for table {}", olapTable.getName());
@@ -3449,8 +3464,14 @@ public class SchemaChangeHandler extends AlterHandler {
             // schema_id but changes its content; every by-id schema cache would go
             // stale). Per-index keeps FE/BE schema ids aligned across all the
             // tablets the job dispatches to (dispatch covers every visible index).
+            // Only metas that actually gain an index are bumped: a rollup /
+            // sync-MV whose schema lacks the indexed column(s) receives a no-op
+            // task (no index, no schema change), so its schema id must stay put.
             for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
                 MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
+                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta).isEmpty()) {
+                    continue;
+                }
                 job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),
                         affectedMeta.getSchemaVersion() + 1);
             }
@@ -3579,9 +3600,13 @@ public class SchemaChangeHandler extends AlterHandler {
             // Allocate a fresh schema id/version per affected index meta so
             // subsequent loads and compaction pick up the schema with the new
             // bloom-filter column (see above). Per-index keeps FE/BE aligned across
-            // every visible index the job dispatches to.
+            // every visible index the job dispatches to. Metas whose schema lacks
+            // every bloom column receive a no-op task and keep their schema id.
             for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
                 MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
+                if (LakeTableAddIndexJob.applicableIndexes(thriftIndexes, affectedMeta).isEmpty()) {
+                    continue;
+                }
                 job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),
                         affectedMeta.getSchemaVersion() + 1);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3447,7 +3447,8 @@ public class SchemaChangeHandler extends AlterHandler {
             // pick up the indexed schema (the fast path reuses the base schema_id
             // but changes its content; every by-id schema cache would go stale).
             job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
-                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1);
+                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1,
+                    olapTable.getBaseIndexMetaId());
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             // Move table to SCHEMA_CHANGE so concurrent alters are blocked.
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
@@ -3573,7 +3574,8 @@ public class SchemaChangeHandler extends AlterHandler {
             // Allocate a new schema id/version so subsequent loads and compaction
             // pick up the schema with the new bloom-filter column (see above).
             job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
-                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1);
+                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1,
+                    olapTable.getBaseIndexMetaId());
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
             stateSet = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2356,10 +2356,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // reach here after this table already entered SCHEMA_CHANGE. Skipping
         // the fast path here lets the legacy path raise its canonical error
         // instead of admitting a second live job on the same table.
-        boolean fastPathAdmissible = olapTable.getState() == OlapTable.OlapTableState.NORMAL
-                && !GlobalStateMgr.getCurrentState().getInsertOverwriteJobMgr()
-                        .hasRunningOverwriteJob(olapTable.getId())
-                && !olapTable.existTempPartitions();
+        boolean fastPathAdmissible = isLakeIndexFastPathAdmissible(olapTable);
         if (!fastPathAdmissible) {
             LOG.info("lake index fast path not admissible for table {} (state={}); "
                     + "falling through to regular path", olapTable.getName(), olapTable.getState());
@@ -3439,6 +3436,21 @@ public class SchemaChangeHandler extends AlterHandler {
      * Returns null on any unexpected failure so the caller can fall back to the
      * regular schema-change path (safer than throwing).
      */
+    /**
+     * Admission guards for the lake index fast path, mirroring the legacy
+     * path's under-lock checks (finalAnalyze's state re-check plus the
+     * per-clause insert-overwrite / temp-partition guards). Must be evaluated
+     * under the table write lock — the entry-point state check in
+     * AlterJobExecutor is lock-free, so without this a racing ALTER could
+     * admit a second live fast-path job on the same table.
+     */
+    static boolean isLakeIndexFastPathAdmissible(OlapTable olapTable) {
+        return olapTable.getState() == OlapTable.OlapTableState.NORMAL
+                && !GlobalStateMgr.getCurrentState().getInsertOverwriteJobMgr()
+                        .hasRunningOverwriteJob(olapTable.getId())
+                && !olapTable.existTempPartitions();
+    }
+
     private AlterJobV2 tryBuildLakeAddIndexJob(Database db, OlapTable olapTable, List<AlterClause> alterClauses) {
         boolean stateSet = false;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3443,12 +3443,17 @@ public class SchemaChangeHandler extends AlterHandler {
             long timeoutMs = TimeUnit.SECONDS.toMillis(Config.alter_table_timeout_second);
             LakeTableAddIndexJob job = new LakeTableAddIndexJob(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), timeoutMs, newIndexes, thriftIndexes);
-            // Allocate a new schema id/version so subsequent loads and compaction
-            // pick up the indexed schema (the fast path reuses the base schema_id
-            // but changes its content; every by-id schema cache would go stale).
-            job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
-                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1,
-                    olapTable.getBaseIndexMetaId());
+            // Allocate a fresh schema id/version per affected index meta (base +
+            // any rollup / sync-MV index) so subsequent loads and compaction on
+            // each index pick up its indexed schema (the fast path reuses the
+            // schema_id but changes its content; every by-id schema cache would go
+            // stale). Per-index keeps FE/BE schema ids aligned across all the
+            // tablets the job dispatches to (dispatch covers every visible index).
+            for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
+                MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
+                job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),
+                        affectedMeta.getSchemaVersion() + 1);
+            }
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             // Move table to SCHEMA_CHANGE so concurrent alters are blocked.
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
@@ -3571,11 +3576,15 @@ public class SchemaChangeHandler extends AlterHandler {
             long timeoutMs = TimeUnit.SECONDS.toMillis(Config.alter_table_timeout_second);
             LakeTableAddIndexJob job = new LakeTableAddIndexJob(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), timeoutMs, new ArrayList<>(), thriftIndexes, addBfColumnNames);
-            // Allocate a new schema id/version so subsequent loads and compaction
-            // pick up the schema with the new bloom-filter column (see above).
-            job.setNewSchema(GlobalStateMgr.getCurrentState().getNextId(),
-                    olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSchemaVersion() + 1,
-                    olapTable.getBaseIndexMetaId());
+            // Allocate a fresh schema id/version per affected index meta so
+            // subsequent loads and compaction pick up the schema with the new
+            // bloom-filter column (see above). Per-index keeps FE/BE aligned across
+            // every visible index the job dispatches to.
+            for (Long affectedIndexMetaId : olapTable.getIndexMetaIdToMeta().keySet()) {
+                MaterializedIndexMeta affectedMeta = olapTable.getIndexMetaByMetaId(affectedIndexMetaId);
+                job.putNewSchema(affectedIndexMetaId, GlobalStateMgr.getCurrentState().getNextId(),
+                        affectedMeta.getSchemaVersion() + 1);
+            }
             job.setComputeResource(WarehouseManager.DEFAULT_RESOURCE);
             olapTable.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
             stateSet = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifier.java
@@ -47,10 +47,12 @@ import java.util.Set;
  * {@code LakeTableAddIndexJob} / {@code LakeTableDropIndexJob} to keep the
  * responsibility split clean and avoid duplicating table-internals lookups here.
  *
- * <p>Supported index types for the fast path: BITMAP, NGRAMBF, GIN. VECTOR is
- * intentionally excluded (separate lifecycle / parameter surface). Bloom filter
- * is a table-level property rather than a {@link CreateIndexClause}, so it is
- * not routed through this path.
+ * <p>Supported index types for the fast path: BITMAP only. NGRAMBF is excluded
+ * because the fast-path .idx ngram bloom is not consulted at query time (see
+ * isSupportedIndexType); GIN / VECTOR are excluded for separate lifecycle /
+ * parameter surface reasons — all stay on the legacy schema-change path. Plain
+ * bloom filter is a table-level property rather than a {@link CreateIndexClause}
+ * (it takes the fast path via the bloom_filter_columns handler, not this one).
  */
 public final class SchemaChangeIndexFastPathClassifier {
 
@@ -297,16 +299,22 @@ public final class SchemaChangeIndexFastPathClassifier {
         if (type == null) {
             return false;
         }
-        // Only BITMAP and NGRAMBF take the lake IDG fast path. The BE
-        // builder (AddIndexSchemaChange::run) returns Status::NotSupported
-        // for GIN / VECTOR, and the fast-path job does not auto-fall-back
-        // to the legacy schema-change job on a BE rejection — routing
-        // these types here would simply fail the alter. Keep them on the
-        // legacy path until BE adds a fast-path builder for them.
+        // Only BITMAP takes the lake IDG fast path. The BE builder
+        // (AddIndexSchemaChange::run) returns Status::NotSupported for
+        // GIN / VECTOR, and the fast-path job does not auto-fall-back to the
+        // legacy schema-change job on a BE rejection — routing those types
+        // here would simply fail the alter.
+        //
+        // NGRAMBF is intentionally excluded: the fast-path .idx ngram bloom is
+        // not consulted at query time (the read path never surfaces the IDG
+        // ngram entry, so LIKE queries never prune — verified on-cluster:
+        // footer ngram filters, fast-path ngram does a full scan), so it must
+        // stay on the legacy path (which rewrites segments with a correct
+        // footer ngram) until the BE fast-path ngram read is implemented.
         switch (type) {
             case BITMAP:
-            case NGRAMBF:
                 return true;
+            case NGRAMBF:
             case GIN:
             case VECTOR:
             default:

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -105,6 +105,11 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     // SchemaChangeHandler::do_process_add_index_only on BE.
     private boolean onlyAddIndex = false;
     private List<com.starrocks.thrift.TOlapTableIndex> indexesToAdd;
+    // New schema id/version FE allocated for the ADD INDEX fast path. Sent to BE
+    // so it stamps them onto the tablet metadata schema, invalidating every by-id
+    // schema cache so future loads / compaction build the new index. 0 = unset.
+    private long newIndexSchemaId = 0;
+    private long newIndexSchemaVersion = 0;
 
     // DROP INDEX fast-path flags (lake only). When onlyDropIndex is true, BE
     // writes an OpDropIndex TxnLog; publish applies tombstones into IDG.
@@ -330,6 +335,10 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             if (indexesToAdd != null && !indexesToAdd.isEmpty()) {
                 req.setIndexes_to_add(indexesToAdd);
             }
+            if (newIndexSchemaId > 0) {
+                req.setNew_index_schema_id(newIndexSchemaId);
+                req.setNew_index_schema_version(newIndexSchemaVersion);
+            }
         }
         if (onlyDropIndex) {
             req.setOnly_drop_index(true);
@@ -351,6 +360,16 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     public void setOnlyAddIndex(List<com.starrocks.thrift.TOlapTableIndex> indexes) {
         this.onlyAddIndex = true;
         this.indexesToAdd = indexes;
+    }
+
+    /**
+     * Carry the new schema id/version FE allocated for the ADD INDEX fast path.
+     * BE stamps them onto the tablet metadata schema so all by-id schema caches
+     * miss and future loads / compaction build the newly-added index.
+     */
+    public void setNewIndexSchema(long schemaId, long schemaVersion) {
+        this.newIndexSchemaId = schemaId;
+        this.newIndexSchemaVersion = schemaVersion;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
@@ -17,9 +17,11 @@ package com.starrocks.alter;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.ast.IndexDef;
+import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.thrift.TDropIndexInfo;
 import com.starrocks.thrift.TIndexType;
 import com.starrocks.thrift.TOlapTableIndex;
@@ -39,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -196,6 +199,63 @@ public class LakeTableIndexFastPathJobTest {
         when(table.getIndexes()).thenReturn(existing);
         job.applyCatalogMutation(table);
         assertEquals(1, existing.size());
+    }
+
+    @Test
+    public void testAddIndexJob_ApplyCatalogMutation_BumpsPerIndexSchema() {
+        // The durability fix bumps EACH affected index meta's schema id/version
+        // (per-index, so rollup / sync-MV index metas stay consistent with their
+        // BE-stamped tablets). Assert the per-index map drives a shallowCopy ->
+        // setSchemaId/setSchemaVersion -> put -> rebuildFullSchema for each entry.
+        Index ix = new Index(101L, "ix_a", Collections.singletonList(ColumnId.create("c1")),
+                IndexDef.IndexType.BITMAP, "", new java.util.HashMap<>());
+        LakeTableAddIndexJob job = new LakeTableAddIndexJob(1L, 2L, 3L, "t", 60_000L,
+                Collections.singletonList(ix), Collections.emptyList());
+        job.putNewSchema(500L, 900L, 7); // base index meta
+        job.putNewSchema(501L, 901L, 4); // a rollup / MV index meta
+
+        OlapTable table = mock(OlapTable.class);
+        when(table.getIndexes()).thenReturn(new ArrayList<>());
+        MaterializedIndexMeta meta500 = mock(MaterializedIndexMeta.class);
+        MaterializedIndexMeta copy500 = mock(MaterializedIndexMeta.class);
+        when(meta500.shallowCopy()).thenReturn(copy500);
+        when(table.getIndexMetaByMetaId(500L)).thenReturn(meta500);
+        MaterializedIndexMeta meta501 = mock(MaterializedIndexMeta.class);
+        MaterializedIndexMeta copy501 = mock(MaterializedIndexMeta.class);
+        when(meta501.shallowCopy()).thenReturn(copy501);
+        when(table.getIndexMetaByMetaId(501L)).thenReturn(meta501);
+        java.util.Map<Long, MaterializedIndexMeta> metaMap = new java.util.HashMap<>();
+        when(table.getIndexMetaIdToMeta()).thenReturn(metaMap);
+
+        job.applyCatalogMutation(table);
+
+        verify(copy500).setSchemaId(900L);
+        verify(copy500).setSchemaVersion(7);
+        verify(copy501).setSchemaId(901L);
+        verify(copy501).setSchemaVersion(4);
+        assertEquals(copy500, metaMap.get(500L));
+        assertEquals(copy501, metaMap.get(501L));
+        verify(table).rebuildFullSchema();
+    }
+
+    @Test
+    public void testAddIndexJob_PopulateAlterRequest_StampsPerIndexSchema() {
+        // Each tablet's task is stamped with ITS index meta's new schema id (so BE
+        // bumps that index's schema); a tablet whose index has no allocated entry
+        // gets no stamp.
+        LakeTableAddIndexJob job = new LakeTableAddIndexJob(1L, 2L, 3L, "t", 60_000L,
+                Collections.emptyList(), Collections.emptyList());
+        job.putNewSchema(500L, 900L, 7);
+
+        AlterReplicaTask stamped = mock(AlterReplicaTask.class);
+        job.populateAlterRequest(stamped, 500L);
+        verify(stamped).setOnlyAddIndex(any());
+        verify(stamped).setNewIndexSchema(900L, 7L);
+
+        AlterReplicaTask unstamped = mock(AlterReplicaTask.class);
+        job.populateAlterRequest(unstamped, 999L); // no per-index entry
+        verify(unstamped).setOnlyAddIndex(any());
+        verify(unstamped, never()).setNewIndexSchema(anyLong(), anyLong());
     }
 
     // -----------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
@@ -25,6 +25,7 @@ import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.thrift.TDropIndexInfo;
 import com.starrocks.thrift.TIndexType;
 import com.starrocks.thrift.TOlapTableIndex;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -248,14 +249,45 @@ public class LakeTableIndexFastPathJobTest {
         job.putNewSchema(500L, 900L, 7);
 
         AlterReplicaTask stamped = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(stamped, 500L);
+        job.populateAlterRequest(stamped, 500L, null);
         verify(stamped).setOnlyAddIndex(any());
         verify(stamped).setNewIndexSchema(900L, 7L);
 
         AlterReplicaTask unstamped = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(unstamped, 999L); // no per-index entry
+        job.populateAlterRequest(unstamped, 999L, null); // no per-index entry
         verify(unstamped).setOnlyAddIndex(any());
         verify(unstamped, never()).setNewIndexSchema(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testAddIndexJob_PopulateAlterRequest_SkipsProjectingRollup() {
+        // A rollup / sync-MV whose schema projects away the indexed column must
+        // receive an EMPTY index set (BE then writes a no-op txn log) and no
+        // schema-id stamp; the base meta receives the full set + its stamp.
+        TOlapTableIndex thrift = new TOlapTableIndex();
+        thrift.setIndex_type(TIndexType.BITMAP);
+        thrift.setColumns(Collections.singletonList("c1"));
+        LakeTableAddIndexJob job = new LakeTableAddIndexJob(1L, 2L, 3L, "t", 60_000L,
+                Collections.emptyList(), Collections.singletonList(thrift));
+        job.putNewSchema(500L, 900L, 7); // base meta only; rollup meta 501 gets no bump
+
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getSchema()).thenReturn(List.of(new Column("c1", IntegerType.BIGINT)));
+        AlterReplicaTask baseTask = mock(AlterReplicaTask.class);
+        job.populateAlterRequest(baseTask, 500L, baseMeta);
+        ArgumentCaptor<List<TOlapTableIndex>> baseCap = ArgumentCaptor.forClass(List.class);
+        verify(baseTask).setOnlyAddIndex(baseCap.capture());
+        assertEquals(1, baseCap.getValue().size());
+        verify(baseTask).setNewIndexSchema(900L, 7L);
+
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getSchema()).thenReturn(List.of(new Column("k9", IntegerType.BIGINT)));
+        AlterReplicaTask rollupTask = mock(AlterReplicaTask.class);
+        job.populateAlterRequest(rollupTask, 501L, rollupMeta);
+        ArgumentCaptor<List<TOlapTableIndex>> rollupCap = ArgumentCaptor.forClass(List.class);
+        verify(rollupTask).setOnlyAddIndex(rollupCap.capture());
+        assertTrue(rollupCap.getValue().isEmpty());
+        verify(rollupTask, never()).setNewIndexSchema(anyLong(), anyLong());
     }
 
     // -----------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobTest.java
@@ -249,12 +249,12 @@ public class LakeTableIndexFastPathJobTest {
         job.putNewSchema(500L, 900L, 7);
 
         AlterReplicaTask stamped = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(stamped, 500L, null);
+        job.populateAlterRequest(stamped, 500L, null, null);
         verify(stamped).setOnlyAddIndex(any());
         verify(stamped).setNewIndexSchema(900L, 7L);
 
         AlterReplicaTask unstamped = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(unstamped, 999L, null); // no per-index entry
+        job.populateAlterRequest(unstamped, 999L, null, null); // no per-index entry
         verify(unstamped).setOnlyAddIndex(any());
         verify(unstamped, never()).setNewIndexSchema(anyLong(), anyLong());
     }
@@ -274,7 +274,7 @@ public class LakeTableIndexFastPathJobTest {
         MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
         when(baseMeta.getSchema()).thenReturn(List.of(new Column("c1", IntegerType.BIGINT)));
         AlterReplicaTask baseTask = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(baseTask, 500L, baseMeta);
+        job.populateAlterRequest(baseTask, 500L, baseMeta, null);
         ArgumentCaptor<List<TOlapTableIndex>> baseCap = ArgumentCaptor.forClass(List.class);
         verify(baseTask).setOnlyAddIndex(baseCap.capture());
         assertEquals(1, baseCap.getValue().size());
@@ -283,11 +283,44 @@ public class LakeTableIndexFastPathJobTest {
         MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
         when(rollupMeta.getSchema()).thenReturn(List.of(new Column("k9", IntegerType.BIGINT)));
         AlterReplicaTask rollupTask = mock(AlterReplicaTask.class);
-        job.populateAlterRequest(rollupTask, 501L, rollupMeta);
+        job.populateAlterRequest(rollupTask, 501L, rollupMeta, null);
         ArgumentCaptor<List<TOlapTableIndex>> rollupCap = ArgumentCaptor.forClass(List.class);
         verify(rollupTask).setOnlyAddIndex(rollupCap.capture());
         assertTrue(rollupCap.getValue().isEmpty());
         verify(rollupTask, never()).setNewIndexSchema(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testApplicableIndexes_MatchesByColumnIdNotName() {
+        // A rollup / sync-MV that carries the indexed column under a RENAMED
+        // output but the SAME ColumnId must still be considered applicable —
+        // applicableIndexes matches by ColumnId (via the base table), not by
+        // name, mirroring OlapTable.getIndexesBySchema. A name-based check would
+        // wrongly skip it and leave the FE/BE schema id diverged.
+        TOlapTableIndex thrift = new TOlapTableIndex();
+        thrift.setIndex_type(TIndexType.BITMAP);
+        thrift.setColumns(Collections.singletonList("v")); // base column name
+
+        OlapTable table = mock(OlapTable.class);
+        Column baseV = new Column("v", IntegerType.BIGINT); // ColumnId = "v"
+        when(table.getColumn("v")).thenReturn(baseV);
+
+        // Meta carries the same column id "v" but under a renamed output "w".
+        Column renamed = new Column("w", IntegerType.BIGINT);
+        renamed.setColumnId(ColumnId.create("v"));
+        MaterializedIndexMeta meta = mock(MaterializedIndexMeta.class);
+        when(meta.getSchema()).thenReturn(List.of(renamed));
+
+        List<TOlapTableIndex> applicable = LakeTableAddIndexJob.applicableIndexes(
+                Collections.singletonList(thrift), meta, table);
+        assertEquals(1, applicable.size()); // matched by id despite the name differing
+
+        // Sanity: a meta that carries neither the id nor the name is excluded.
+        Column other = new Column("k9", IntegerType.BIGINT);
+        MaterializedIndexMeta otherMeta = mock(MaterializedIndexMeta.class);
+        when(otherMeta.getSchema()).thenReturn(List.of(other));
+        assertTrue(LakeTableAddIndexJob.applicableIndexes(
+                Collections.singletonList(thrift), otherMeta, table).isEmpty());
     }
 
     // -----------------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -113,13 +113,17 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
         when(t.getCopiedIndexes()).thenReturn(new ArrayList<>());
         when(t.incAndGetMaxIndexId()).thenReturn(101L, 102L, 103L);
         when(t.getMaxIndexId()).thenReturn(100L);
-        // The add-index / add-bloom-filter fast path bumps the schema id/version
-        // (durability fix) by reading the base index meta's schema version, so the
-        // mock must resolve it or tryBuild*() would NPE and return null.
+        // The add-index / add-bloom-filter fast path allocates a new schema
+        // id/version per index meta (durability fix): it iterates
+        // getIndexMetaIdToMeta() and reads each meta's schema version, so the mock
+        // must resolve both or tryBuild*() would NPE and return null.
         when(t.getBaseIndexMetaId()).thenReturn(100L);
         MaterializedIndexMeta baseIndexMeta = mock(MaterializedIndexMeta.class);
         when(baseIndexMeta.getSchemaVersion()).thenReturn(0);
         when(t.getIndexMetaByMetaId(anyLong())).thenReturn(baseIndexMeta);
+        HashMap<Long, MaterializedIndexMeta> indexMetaIdToMeta = new HashMap<>();
+        indexMetaIdToMeta.put(100L, baseIndexMeta);
+        when(t.getIndexMetaIdToMeta()).thenReturn(indexMetaIdToMeta);
         for (String name : columnNames) {
             Column col = new Column(name, IntegerType.BIGINT);
             when(t.getColumn(name)).thenReturn(col);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -28,11 +28,13 @@ import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.task.AlterReplicaTask;
 import com.starrocks.thrift.TDropIndexInfo;
 import com.starrocks.thrift.TIndexType;
 import com.starrocks.thrift.TOlapTableIndex;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -124,11 +126,16 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
         HashMap<Long, MaterializedIndexMeta> indexMetaIdToMeta = new HashMap<>();
         indexMetaIdToMeta.put(100L, baseIndexMeta);
         when(t.getIndexMetaIdToMeta()).thenReturn(indexMetaIdToMeta);
+        List<Column> metaSchema = new ArrayList<>();
         for (String name : columnNames) {
             Column col = new Column(name, IntegerType.BIGINT);
+            metaSchema.add(col);
             when(t.getColumn(name)).thenReturn(col);
             when(t.getColumn(ColumnId.create(name))).thenReturn(col);
         }
+        // The per-meta applicability filter reads each meta's schema; stub it so
+        // the base meta "contains" every registered column.
+        when(baseIndexMeta.getSchema()).thenReturn(metaSchema);
         return t;
     }
 
@@ -165,6 +172,56 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
             assertEquals(1, job.getNewIndexes().size());
             assertEquals(1, job.getIndexesToAdd().size());
             verify(table).setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        }
+    }
+
+    @Test
+    public void testTryBuildLakeAddIndexJob_SkipsRollupWithoutIndexedColumn() throws Exception {
+        // A rollup / sync-MV meta whose schema lacks the indexed column must not
+        // be allocated a schema-id bump, and its tablets' tasks must carry an
+        // empty index set (BE then writes a no-op txn log). The base meta keeps
+        // the full behavior.
+        SchemaChangeHandler handler = newHandler();
+        OlapTable table = stubLakeTable("c1");
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getSchemaVersion()).thenReturn(0);
+        when(rollupMeta.getSchema()).thenReturn(
+                Collections.singletonList(new Column("k9", com.starrocks.type.IntegerType.BIGINT)));
+        table.getIndexMetaIdToMeta().put(200L, rollupMeta);
+        when(table.getIndexMetaByMetaId(200L)).thenReturn(rollupMeta);
+
+        IndexDef def = new IndexDef("ix_a", Collections.singletonList("c1"),
+                IndexDef.IndexType.BITMAP, "", new HashMap<>());
+        Method m = privateMethod("tryBuildLakeAddIndexJob", Database.class, OlapTable.class, List.class);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<RunMode> rmStatic = Mockito.mockStatic(RunMode.class)) {
+            GlobalStateMgr gsm = stubGsm();
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            rmStatic.when(RunMode::getCurrentRunMode).thenReturn(RunMode.SHARED_DATA);
+            Object result = invoke(m, handler, stubDb(), table,
+                    Collections.<AlterClause>singletonList(new CreateIndexClause(def)));
+            assertNotNull(result);
+            LakeTableAddIndexJob job = (LakeTableAddIndexJob) result;
+
+            // Base meta (100L): full index set + schema-id stamp.
+            AlterReplicaTask baseTask = mock(AlterReplicaTask.class);
+            job.populateAlterRequest(baseTask, 100L, table.getIndexMetaByMetaId(100L));
+            ArgumentCaptor<List<com.starrocks.thrift.TOlapTableIndex>> baseCap =
+                    ArgumentCaptor.forClass(List.class);
+            verify(baseTask).setOnlyAddIndex(baseCap.capture());
+            assertEquals(1, baseCap.getValue().size());
+            verify(baseTask).setNewIndexSchema(org.mockito.ArgumentMatchers.anyLong(),
+                    org.mockito.ArgumentMatchers.anyLong());
+
+            // Rollup meta (200L): empty index set, no stamp (no schema-id bump).
+            AlterReplicaTask rollupTask = mock(AlterReplicaTask.class);
+            job.populateAlterRequest(rollupTask, 200L, rollupMeta);
+            ArgumentCaptor<List<com.starrocks.thrift.TOlapTableIndex>> rollupCap =
+                    ArgumentCaptor.forClass(List.class);
+            verify(rollupTask).setOnlyAddIndex(rollupCap.capture());
+            assertTrue(rollupCap.getValue().isEmpty());
+            verify(rollupTask, never()).setNewIndexSchema(org.mockito.ArgumentMatchers.anyLong(),
+                    org.mockito.ArgumentMatchers.anyLong());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Index;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
+import com.starrocks.load.InsertOverwriteJobMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterClause;
@@ -49,6 +50,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -143,6 +145,41 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
         GlobalStateMgr gsm = mock(GlobalStateMgr.class);
         when(gsm.getNextId()).thenReturn(50L, 51L, 52L);
         return gsm;
+    }
+
+    // ============================================================
+    // isLakeIndexFastPathAdmissible (under-lock admission guards)
+    // ============================================================
+
+    @Test
+    public void testIsLakeIndexFastPathAdmissible() {
+        OlapTable table = stubLakeTable("c1");
+        InsertOverwriteJobMgr overwriteMgr = mock(InsertOverwriteJobMgr.class);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class)) {
+            GlobalStateMgr gsm = mock(GlobalStateMgr.class);
+            when(gsm.getInsertOverwriteJobMgr()).thenReturn(overwriteMgr);
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+
+            // Admissible: NORMAL, no running overwrite, no temp partitions.
+            when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+            when(overwriteMgr.hasRunningOverwriteJob(anyLong())).thenReturn(false);
+            when(table.existTempPartitions()).thenReturn(false);
+            assertTrue(SchemaChangeHandler.isLakeIndexFastPathAdmissible(table));
+
+            // A racing ALTER already moved the table to SCHEMA_CHANGE.
+            when(table.getState()).thenReturn(OlapTable.OlapTableState.SCHEMA_CHANGE);
+            assertFalse(SchemaChangeHandler.isLakeIndexFastPathAdmissible(table));
+
+            // Running INSERT OVERWRITE blocks admission.
+            when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+            when(overwriteMgr.hasRunningOverwriteJob(anyLong())).thenReturn(true);
+            assertFalse(SchemaChangeHandler.isLakeIndexFastPathAdmissible(table));
+
+            // Temp partitions block admission.
+            when(overwriteMgr.hasRunningOverwriteJob(anyLong())).thenReturn(false);
+            when(table.existTempPartitions()).thenReturn(true);
+            assertFalse(SchemaChangeHandler.isLakeIndexFastPathAdmissible(table));
+        }
     }
 
     // ============================================================

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -111,6 +113,13 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
         when(t.getCopiedIndexes()).thenReturn(new ArrayList<>());
         when(t.incAndGetMaxIndexId()).thenReturn(101L, 102L, 103L);
         when(t.getMaxIndexId()).thenReturn(100L);
+        // The add-index / add-bloom-filter fast path bumps the schema id/version
+        // (durability fix) by reading the base index meta's schema version, so the
+        // mock must resolve it or tryBuild*() would NPE and return null.
+        when(t.getBaseIndexMetaId()).thenReturn(100L);
+        MaterializedIndexMeta baseIndexMeta = mock(MaterializedIndexMeta.class);
+        when(baseIndexMeta.getSchemaVersion()).thenReturn(0);
+        when(t.getIndexMetaByMetaId(anyLong())).thenReturn(baseIndexMeta);
         for (String name : columnNames) {
             Column col = new Column(name, IntegerType.BIGINT);
             when(t.getColumn(name)).thenReturn(col);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerLakeIndexFastPathTest.java
@@ -242,7 +242,7 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
 
             // Base meta (100L): full index set + schema-id stamp.
             AlterReplicaTask baseTask = mock(AlterReplicaTask.class);
-            job.populateAlterRequest(baseTask, 100L, table.getIndexMetaByMetaId(100L));
+            job.populateAlterRequest(baseTask, 100L, table.getIndexMetaByMetaId(100L), table);
             ArgumentCaptor<List<com.starrocks.thrift.TOlapTableIndex>> baseCap =
                     ArgumentCaptor.forClass(List.class);
             verify(baseTask).setOnlyAddIndex(baseCap.capture());
@@ -252,7 +252,7 @@ public class SchemaChangeHandlerLakeIndexFastPathTest {
 
             // Rollup meta (200L): empty index set, no stamp (no schema-id bump).
             AlterReplicaTask rollupTask = mock(AlterReplicaTask.class);
-            job.populateAlterRequest(rollupTask, 200L, rollupMeta);
+            job.populateAlterRequest(rollupTask, 200L, rollupMeta, table);
             ArgumentCaptor<List<com.starrocks.thrift.TOlapTableIndex>> rollupCap =
                     ArgumentCaptor.forClass(List.class);
             verify(rollupTask).setOnlyAddIndex(rollupCap.capture());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeIndexFastPathClassifierTest.java
@@ -124,10 +124,14 @@ public class SchemaChangeIndexFastPathClassifierTest {
     }
 
     @Test
-    public void testAddIndexFastPath_NgrambfAccepted() {
+    public void testAddIndexFastPath_NgrambfRejected() {
+        // NGRAMBF is routed to the legacy path: the fast-path .idx ngram bloom is
+        // not consulted at query time (LIKE queries would never prune), so it
+        // stays on the legacy schema-change job which rewrites a correct footer
+        // ngram. BITMAP is the only type on the add-index fast path.
         OlapTable t = lakeTable();
         List<AlterClause> clauses = Collections.singletonList(createIndex(IndexDef.IndexType.NGRAMBF));
-        assertTrue(SchemaChangeIndexFastPathClassifier.shouldUseAddIndexFastPath(t, clauses));
+        assertFalse(SchemaChangeIndexFastPathClassifier.shouldUseAddIndexFastPath(t, clauses));
     }
 
     @Test
@@ -202,8 +206,9 @@ public class SchemaChangeIndexFastPathClassifierTest {
     @Test
     public void testIsSupportedIndexType() {
         assertTrue(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(IndexDef.IndexType.BITMAP));
-        assertTrue(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(IndexDef.IndexType.NGRAMBF));
-        // GIN and VECTOR are unsupported on the BE side; route them to legacy.
+        // Only BITMAP takes the fast path. NGRAMBF (fast-path ngram is not read
+        // at query time), GIN and VECTOR are all routed to the legacy path.
+        assertFalse(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(IndexDef.IndexType.NGRAMBF));
         assertFalse(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(IndexDef.IndexType.GIN));
         assertFalse(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(IndexDef.IndexType.VECTOR));
         assertFalse(SchemaChangeIndexFastPathClassifier.isSupportedIndexType(null));

--- a/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
@@ -64,6 +64,23 @@ public class AlterReplicaTaskTest {
     }
 
     @Test
+    public void testAlterLocalTablet_OnlyAddIndex_CarriesNewSchema() {
+        // The lake fast-path ADD INDEX durability fix flows an FE-allocated new
+        // schema id/version through the AlterReplicaTask into TAlterTabletReqV2 so
+        // BE's apply_add_index stamps them onto the tablet metadata schema.
+        AlterReplicaTask task = AlterReplicaTask.alterLocalTablet(1, 2, 3, 4, 5, 6,
+                7, 8, 9, 10, 11, 12, null, Collections.emptyList());
+        task.setOnlyAddIndex(Collections.emptyList());
+        task.setNewIndexSchema(555L, 3L);
+
+        TAlterTabletReqV2 request = task.toThrift();
+        Assertions.assertTrue(request.only_add_index);
+        Assertions.assertTrue(request.isSetNew_index_schema_id());
+        Assertions.assertEquals(555L, request.new_index_schema_id);
+        Assertions.assertEquals(3L, request.new_index_schema_version);
+    }
+
+    @Test
     public void testRollupLocalTablet() {
         AlterReplicaTask task = AlterReplicaTask.rollupLocalTablet(1, 2, 3, 4, 5, 6,
                 7, 8, 9, 10, 11, 12, null, null);

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -503,6 +503,14 @@ message TxnLogPB {
         // Indexes added by this alter; redundant w.r.t. schema.table_indices
         // that FE has already published, kept for idempotent reconciliation.
         repeated TabletIndexPB new_indexes = 3;
+        // New schema id/version allocated by FE for this fast-path ADD INDEX.
+        // apply_add_index stamps these onto the tablet metadata schema so every
+        // by-id schema cache (GS{id} metacache, GlobalTabletSchemaMap dedup,
+        // SCHEMA_{id} file) misses and picks up the now-indexed schema; without
+        // an id change, data loaded after the index — and compaction output —
+        // would keep reusing the cached pre-index schema and build no index.
+        optional int64 new_schema_id = 4;
+        optional int64 new_schema_version = 5;
     }
 
     // Produced by DROP INDEX fast-path schema change (lake-only). Applied

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -224,6 +224,12 @@ struct TAlterTabletReqV2 {
     // compaction time.
     22: optional bool only_drop_index
     23: optional list<TDropIndexInfo> drop_indexes
+
+    // New schema id/version FE allocated for the lake ADD INDEX fast path. BE
+    // stamps them onto the tablet metadata schema (via OpAddIndex) so all by-id
+    // schema caches miss and future loads / compaction build the new index.
+    24: optional i64 new_index_schema_id
+    25: optional i64 new_index_schema_version
 }
 
 // One index removal request used by the DROP INDEX fast-path.


### PR DESCRIPTION
## Why I'm doing:

The lake (shared-data) **ADD INDEX / `SET("bloom_filter_columns"=...)` fast path** (IDG `.idx` sidecar; PR #71689 / #75147 / #75337) had several correctness/durability defects, surfaced by the `test_create_bitmap_index` / `test_create_bloom_filter` / `test_create_ngram_bloom_filter` StarRocksTest cases. Verified on a shared-data cluster with the real `basic_types_data` (65,546 rows).

## What I'm doing:

Five fixes: https://github.com/StarRocks/StarRocksTest/issues/11510

1. **CHAR padding.** The page decoder `strnlen`-trims trailing `\0` for `TYPE_CHAR`, so the fast path (which reads the source column *back* through a `ColumnIterator`) fed **unpadded** CHAR values to the bitmap dictionary / bloom filter, while the standard path and the query predicate use the value padded to the declared width. Result: bitmap over-pruned to empty, bloom false-negatived (missing rows). `feed_index_from_column` now re-pads CHAR to the declared width. (VARCHAR is untouched.)

2. **NGRAMBF / bloom `index_properties`.** `do_process_add_index_only` hand-built `TabletIndexPB` and dropped `index_properties` (`gram_num` / `case_sensitive` / `bloom_filter_fpp`). It now builds the pb via `TabletIndex::init_from_thrift` + `to_schema_pb`, propagating all properties.

3. **Durability across new loads + compaction.** The fast path changed the schema *content* (`table_indices` + per-column `has_bitmap_index`/`is_bf_column`) but **reused the same `schema_id`/`version`**. Every lake by-id schema cache (`GS{id}` metacache; `GlobalTabletSchemaMap` dedup, whose `check_schema_unique_id` ignores index flags; `historical_schemas`; `SCHEMA_{id}` file) then kept returning the stale pre-index schema, so **data loaded after the index — and compaction output — built no index** (compaction also deletes the input `.idx`, losing it permanently). FE now allocates a new `schema_id`+`version` (once, persisted for idempotent replay) and stamps it FE→BE (`TAlterTabletReqV2` → `OpAddIndex` → `apply_add_index`), so every cache misses and picks up the indexed schema. Existing rowsets carry no `rowset_to_schema` pin and resolve to `metadata->schema()`; their segments' missing footer index is served by the `.idx` sidecar until compaction rebuilds it inline.

4. **NGRAMBF routed to the legacy path.** The fast-path `.idx` ngram bloom is not consulted at query time (verified: a footer ngram filters ~16k rows while the fast-path ngram does a full scan, no `BloomFilterFilterRows`). Until the BE fast-path ngram read is implemented, `SchemaChangeIndexFastPathClassifier` excludes NGRAMBF (same treatment as GIN/VECTOR), so `ADD INDEX ... USING NGRAMBF` takes the legacy `LakeTableSchemaChangeJob` (which rewrites a correct footer ngram). BITMAP keeps the fast path.

5. **`bloom_filter_columns` on an ngram column now rejected in the fast path.** A column may carry at most one of {plain bloom, ngram bloom}; the regular path enforces this via `IndexAnalyzer.analyseBfWithNgramBf`, but the bloom fast path skipped it. Added the same validation before taking the fast path.

## Validation

Re-ran the previously-failing StarRocksTest cases against a cluster running this PR (build of `50fe12d`): **all in-scope fast-path index cases pass** — bitmap (char, largeint), bloom (bigint, char), all NGRAMBF variants, drop-index, and the PK cloud-native/native bf & bitmap cases. Remaining reds are out of this PR's scope: non-index suites (iceberg / range-distribution-split / rename-column), and the shared-nothing `local` persistent-index PK cases (which cannot run on a shared-data cluster).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Known limitations / follow-ups

- **Pre-existing (dates from the original fast-path PRs, discovered while reviewing this one; tracked as a separate follow-up):** on a table with a rollup / sync MV that does not contain the indexed column, the fast path dispatches the add-index task to every visible materialized index and BE fails that tablet ("ADD INDEX fast path: column not found in new schema"), cancelling the whole ALTER instead of skipping the projecting rollup like the legacy path does. Fix direction: dispatch/bump only the index metas whose schema contains the indexed columns.
- The per-index schema-version bump marks the table as schema-evolved, which (by `RewriteSimpleAggToMetaScanRule`'s conservative design) disables the shared-data min/max/count meta-scan rewrite for the table — the same effect as any other lake schema change (e.g. ADD COLUMN). Kept intentionally: the version monotonicity is what lets a concurrently-created partition's tablets reconcile to the indexed schema on their first load.
- `apply_add_index` persists the new `SCHEMA_{id}` file synchronously on the publish path (one extra object-store PUT per tablet, once per ADD INDEX). Best-effort and non-fatal; kept as-is — a one-time DDL cost that serves cold by-id readers.
