### PR TITLE
[BugFix] Read Paimon TIMESTAMP (NTZ) INT96 without timezone shift

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -94,13 +94,14 @@ public:
     Int96ToDateTimeConverter() = default;
     ~Int96ToDateTimeConverter() override = default;
 
-    Status init(const std::string& timezone);
+    Status init(const std::string& timezone, bool as_timestamp_ntz);
     // convert column from int96 to timestamp
     Status convert(const Column* src, Column* dst) override;
 
 private:
     int _offset = 0;
     cctz::time_zone _ctz;
+    bool _as_timestamp_ntz = false;
 };
 
 class FixedLenByteArrayToUUIDConverter final : public ColumnConverter {
@@ -624,7 +625,7 @@ Status ColumnConverterFactory::create_converter(const ParquetField& field, const
         need_convert = true;
         if (col_type == LogicalType::TYPE_DATETIME) {
             auto _converter = std::make_unique<Int96ToDateTimeConverter>();
-            RETURN_IF_ERROR(_converter->init(timezone));
+            RETURN_IF_ERROR(_converter->init(timezone, typeDescriptor.datetime_is_ntz));
             *converter = std::move(_converter);
         }
         break;
@@ -779,7 +780,8 @@ Status parquet::Int32ToDateTimeConverter::convert(const Column* src, Column* dst
     return Status::OK();
 }
 
-Status Int96ToDateTimeConverter::init(const std::string& timezone) {
+Status Int96ToDateTimeConverter::init(const std::string& timezone, bool as_timestamp_ntz) {
+    _as_timestamp_ntz = as_timestamp_ntz;
     if (!TimezoneUtils::find_cctz_time_zone(timezone, _ctz)) {
         return Status::InternalError(strings::Substitute("can not find cctz time zone $0", timezone));
     }
@@ -812,6 +814,12 @@ Status Int96ToDateTimeConverter::convert(const Column* src, Column* dst) {
             if (!src_null_data[i]) {
                 Timestamp timestamp =
                         (static_cast<uint64_t>(src_data[i].hi) << TIMESTAMP_BITS) | (src_data[i].lo / 1000);
+                if (_as_timestamp_ntz) {
+                    // Paimon TIMESTAMP (NTZ): the INT96 stores the wall clock, so keep it as-is
+                    // instead of shifting by the session timezone the way Hive/Spark INT96 needs.
+                    dst_data[i].set_timestamp(timestamp);
+                    continue;
+                }
                 int offset = _offset;
                 if constexpr (!FAST_TZ) {
                     offset = timestamp::get_timezone_offset_by_timestamp(timestamp, _ctz);

--- a/be/src/types/type_descriptor.cpp
+++ b/be/src/types/type_descriptor.cpp
@@ -40,6 +40,7 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx) {
         len = (scalar_type.__isset.len) ? scalar_type.len : -1;
         scale = (scalar_type.__isset.scale) ? scalar_type.scale : -1;
         precision = (scalar_type.__isset.precision) ? scalar_type.precision : -1;
+        datetime_is_ntz = scalar_type.__isset.datetime_is_ntz && scalar_type.datetime_is_ntz;
 
         if (type == TYPE_DECIMAL || type == TYPE_DECIMALV2 || type == TYPE_DECIMAL32 || type == TYPE_DECIMAL64 ||
             type == TYPE_DECIMAL128 || type == TYPE_DECIMAL256) {
@@ -117,6 +118,9 @@ void TypeDescriptor::to_thrift(TTypeDesc* thrift_type) const {
         }
         if (precision != -1) {
             scalar_type.__set_precision(precision);
+        }
+        if (datetime_is_ntz) {
+            scalar_type.__set_datetime_is_ntz(true);
         }
     }
 }

--- a/be/src/types/type_descriptor.h
+++ b/be/src/types/type_descriptor.h
@@ -44,6 +44,13 @@ struct TypeDescriptor {
     int precision{-1};
     int scale{-1};
 
+    /// Only meaningful for TYPE_DATETIME read from lake formats that distinguish
+    /// timestamp-without-time-zone (NTZ) from timestamp-with-local-time-zone. Rides along
+    /// as metadata and does NOT participate in type identity (operator==, hashing, etc.).
+    /// Default false means "shift a UTC instant into the session timezone" (Hive / Iceberg /
+    /// Paimon LTZ); true means the value is a naive wall clock that must NOT be shifted.
+    bool datetime_is_ntz{false};
+
     /// Must be kept in sync with FE's max precision/scale.
     static const int MAX_PRECISION = 76;
     static const int MAX_SCALE = MAX_PRECISION;

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -22,6 +22,9 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "base/types/int96.h"
+#include "types/time_types.h"
+#include "types/timestamp_value.h"
 #include "common/config_exec_fwd.h"
 #include "formats/parquet/encoding_dict.h"
 #include "formats/parquet/encoding_plain.h"
@@ -786,5 +789,48 @@ TEST_F(ColumnConverterTest, Int64PreEpochTimestampSubSecond) {
         const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME);
         check(file_path, col_type, col_name, expected_value, expected_rows);
     }
+}
+
+// Paimon TIMESTAMP (NTZ) columns are written as INT96 for precision 7-9. Unlike Hive/Spark INT96
+// (which stores a UTC instant that must be shifted into the session/local timezone), a Paimon NTZ
+// value is a naive wall clock that must be kept as-is. The TypeDescriptor.datetime_is_ntz flag,
+// plumbed from FE via TScalarType, selects the behavior in Int96ToDateTimeConverter.
+TEST_F(ColumnConverterTest, Int96ReadAsTimestampNtz) {
+    // Encode wall clock 2024-01-15 12:30:45 into an INT96 the way Int96ToDateTimeConverter decodes it:
+    //   timestamp = (hi << TIMESTAMP_BITS) | (lo / 1000)
+    const Timestamp packed = timestamp::from_datetime(2024, 1, 15, 12, 30, 45, 0);
+    int96_t raw;
+    raw.hi = static_cast<uint32_t>(packed >> TIMESTAMP_BITS);
+    raw.lo = (packed & ((static_cast<uint64_t>(1) << TIMESTAMP_BITS) - 1)) * 1000;
+
+    ParquetField field;
+    field.physical_type = tparquet::Type::INT96;
+    const std::string timezone = "Asia/Shanghai";
+
+    auto read_back = [&](bool datetime_is_ntz) -> Timestamp {
+        auto src_data = FixedLengthColumn<int96_t>::create();
+        src_data->append(raw);
+        auto src_null = NullColumn::create();
+        src_null->append(0);
+        ColumnPtr src = NullableColumn::create(std::move(src_data), std::move(src_null));
+
+        TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME);
+        col_type.datetime_is_ntz = datetime_is_ntz;
+
+        std::unique_ptr<ColumnConverter> converter;
+        CHECK(ColumnConverterFactory::create_converter(field, col_type, timezone, &converter).ok());
+
+        auto dst = ColumnHelper::create_column(col_type, true);
+        CHECK(converter->convert(src.get(), dst.get()).ok());
+
+        auto* dst_nullable = down_cast<NullableColumn*>(dst.get());
+        const auto* ts_col = down_cast<const TimestampColumn*>(dst_nullable->data_column().get());
+        return ts_col->get_data()[0].timestamp();
+    };
+
+    // NTZ (Paimon TIMESTAMP): wall clock kept as-is, no session/local timezone shift.
+    EXPECT_EQ(packed, read_back(true));
+    // Default (Hive/Spark INT96): shifted into the local timezone (+8h for Asia/Shanghai).
+    EXPECT_EQ(timestamp::add<TimeUnit::SECOND>(packed, 8 * 3600), read_back(false));
 }
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -18,13 +18,11 @@
 
 #include <filesystem>
 
+#include "base/types/int96.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
-#include "base/types/int96.h"
-#include "types/time_types.h"
-#include "types/timestamp_value.h"
 #include "common/config_exec_fwd.h"
 #include "formats/parquet/encoding_dict.h"
 #include "formats/parquet/encoding_plain.h"
@@ -34,6 +32,8 @@
 #include "fs/fs.h"
 #include "parquet_test_util/util.h"
 #include "runtime/descriptor_helper.h"
+#include "types/time_types.h"
+#include "types/timestamp_value.h"
 
 namespace starrocks::parquet {
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -564,7 +564,10 @@ public class ColumnTypeConverter {
         }
 
         public Type visit(TimestampType timestampType) {
-            return DATETIME;
+            // Paimon TIMESTAMP is timezone-naive (NTZ): carry the flag so the BE reader keeps the
+            // wall clock unshifted. The flag rides along on the type (survives clone, ignored by
+            // equals) and is read at slot toThrift. TIMESTAMP_LTZ (below) is a UTC instant -> default.
+            return ScalarType.createDatetimeNtzType();
         }
 
         public Type visit(LocalZonedTimestampType timestampType) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeSerializer.java
@@ -202,6 +202,9 @@ public class TypeSerializer {
                 node.setType(TTypeNodeType.SCALAR);
                 TScalarType scalarType = new TScalarType();
                 scalarType.setType(TypeSerializer.toThrift(primitiveType));
+                if (type.isDatetimeNtz()) {
+                    scalarType.setDatetime_is_ntz(true);
+                }
                 node.setScalar_type(scalarType);
                 break;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.paimon;
 
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.type.AnyElementType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
@@ -25,10 +26,12 @@ import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.JsonType;
 import com.starrocks.type.MapType;
+import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
+import com.starrocks.type.TypeSerializer;
 import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
@@ -318,5 +321,34 @@ public class PaimonColumnConverterTest {
         Assertions.assertThrows(StarRocksConnectorException.class,
                 () -> ColumnTypeConverter.toPaimonDataType(AnyElementType.ANY_ELEMENT));
 
+    }
+
+    @Test
+    public void testConvertTimestampNtz() {
+        // Paimon TIMESTAMP is timezone-naive (NTZ): fromPaimonType flags it so the BE reader keeps
+        // the wall clock unshifted, while the flag stays invisible to type identity.
+        org.apache.paimon.types.TimestampType paimonType = new org.apache.paimon.types.TimestampType();
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assertions.assertTrue(result instanceof ScalarType);
+        ScalarType scalarType = (ScalarType) result;
+        Assertions.assertTrue(scalarType.isDatetimeNtz());
+        // The flag must NOT change type identity: it still equals a plain DATETIME.
+        Assertions.assertEquals(DateType.DATETIME, result);
+        // The flag must survive clone().
+        Assertions.assertTrue(((ScalarType) scalarType.clone()).isDatetimeNtz());
+        // It must serialize onto TScalarType.datetime_is_ntz for the BE reader.
+        TTypeDesc tTypeDesc = TypeSerializer.toThrift(result);
+        Assertions.assertTrue(tTypeDesc.getTypes().get(0).getScalar_type().isDatetime_is_ntz());
+    }
+
+    @Test
+    public void testConvertTimestampLtz() {
+        // Paimon TIMESTAMP_LTZ is a UTC instant: default behavior, not flagged NTZ.
+        org.apache.paimon.types.LocalZonedTimestampType paimonType =
+                new org.apache.paimon.types.LocalZonedTimestampType();
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assertions.assertTrue(result instanceof ScalarType);
+        Assertions.assertFalse(((ScalarType) result).isDatetimeNtz());
+        Assertions.assertEquals(DateType.DATETIME, result);
     }
 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
@@ -71,12 +71,31 @@ public class ScalarType extends Type implements Cloneable {
     @SerializedName(value = "scale")
     private int scale;
 
+    // Only meaningful for DATETIME read from lake formats that distinguish
+    // timestamp-without-time-zone (true) from timestamp-with-local-time-zone. Rides along as
+    // metadata and is intentionally excluded from equals()/hashCode() so it does NOT affect
+    // type identity; it only tells the BE reader to keep the naive wall clock unshifted.
+    private boolean datetimeIsNtz = false;
+
     public ScalarType(PrimitiveType type) {
         this.type = type;
     }
 
     public ScalarType() {
         this.type = PrimitiveType.INVALID_TYPE;
+    }
+
+    // A DATETIME whose source is a timezone-naive lake timestamp (e.g. Paimon TIMESTAMP). Returns a
+    // fresh instance (not a shared DATETIME singleton) carrying the datetime_is_ntz metadata flag,
+    // which rides along to the BE reader without affecting type identity.
+    public static ScalarType createDatetimeNtzType() {
+        ScalarType type = new ScalarType(PrimitiveType.DATETIME);
+        type.datetimeIsNtz = true;
+        return type;
+    }
+
+    public boolean isDatetimeNtz() {
+        return datetimeIsNtz;
     }
 
     public PrimitiveType getType() {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -124,6 +124,13 @@ struct TScalarType {
     // Only set for DECIMAL
     3: optional i32 precision
     4: optional i32 scale
+
+    // Only meaningful for DATETIME read from lake formats that distinguish
+    // timestamp-without-time-zone (NTZ) from timestamp-with-local-time-zone. Rides along
+    // as metadata and does NOT affect type identity. Default (false) means the value is a
+    // UTC instant that must be shifted into the session timezone (Hive/Iceberg/Paimon LTZ);
+    // Paimon TIMESTAMP sets it to true so the reader keeps the wall clock unshifted.
+    5: optional bool datetime_is_ntz
 }
 
 // Represents a field in a STRUCT type.


### PR DESCRIPTION
## Why I'm doing:
Paimon TIMESTAMP (timezone-naive, NTZ) columns of precision 7-9 are physically stored as parquet INT96, which carries no isAdjustedToUtc logical type. The parquet reader's Int96ToDateTimeConverter unconditionally shifts the value by the session/local timezone -- correct for Hive/Spark INT96 (a UTC instant), but wrong for a Paimon NTZ wall clock, which therefore reads back shifted (e.g. +8h in Asia/Shanghai). Precision 0-6 (INT64, which carries isAdjustedToUtc) is already correct.

## What I'm doing:
Carry a per-column datetime_is_ntz flag on the column type: ColumnTypeConverter.fromPaimonType maps a Paimon TIMESTAMP to a DATETIME ScalarType flagged NTZ; TIMESTAMP_LTZ stays default. The flag rides along as metadata -- excluded from equals()/hashCode() so type identity is unchanged, preserved through clone() -- and reaches BE via the slot's originType (TypeSerializer -> TScalarType.datetime_is_ntz -> TypeDescriptor). Int96ToDateTimeConverter keeps the wall clock unshifted when set. Default false, so Hive/Iceberg/Paimon LTZ INT96 keep shifting.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
