### PR TITLE
[Enhancement] Cancel in-flight exchange sink RPCs on fragment cancellation (backport #75613)

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -16,6 +16,7 @@
 
 #include <bthread/bthread.h>
 
+#include <cerrno>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -216,6 +217,20 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
     auto notify = this->defer_notify();
     if (--_num_uncancelled_sinkers == 0) {
         _is_finishing = true;
+        // Cancel all in-flight RPCs. Without this, a cancelled fragment keeps waiting until these RPCs drain.
+        // bthread_id_list_reset() may call on_error() callback of valid call ids, which may lead to deadlock if the
+        // thread is still holding the lock. So the lock-and-swap idiom is used. See bRPC comments (id.h) for more
+        // details.
+        for (auto& [_, sink_context] : _sink_ctxs) {
+            bthread_id_list_t tmplist;
+            bthread_id_list_init(&tmplist, 0, 0);
+            {
+                std::lock_guard cids_guard(sink_context->in_flight_rpc_cids_mutex);
+                bthread_id_list_swap(&tmplist, &sink_context->in_flight_rpc_cids);
+            }
+            bthread_id_list_reset(&tmplist, ECANCELED);
+            bthread_id_list_destroy(&tmplist);
+        }
     }
     if (state != nullptr && state->query_ctx() && state->query_ctx()->is_query_expired()) {
         // check how many cancel operations are issued, and show the state of that time.
@@ -421,6 +436,16 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
         SET_IGNORE_OVERCROWDED(closure->cntl, query);
+
+        // The call id must be obtained before launching the RPC, as per bRPC doc.
+        const auto call_id = closure->cntl.call_id();
+        {
+            std::lock_guard cids_guard(context.in_flight_rpc_cids_mutex);
+            // Do not cancel eos request, because eos request is the last request to be sent, and it must be sent to the destination.
+            if (!request.params->eos()) {
+                bthread_id_list_add(&context.in_flight_rpc_cids, call_id);
+            }
+        }
 
         Status st;
         if (bthread_self()) {

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <bthread/id.h>
 #include <bthread/mutex.h>
 
 #include <algorithm>
@@ -154,6 +155,9 @@ private:
     /// because TUniqueId::hi is exactly the same in one query
 
     struct SinkContext {
+        SinkContext() { bthread_id_list_init(&in_flight_rpc_cids, 0, 0); }
+        ~SinkContext() { bthread_id_list_destroy(&in_flight_rpc_cids); }
+
         // num eos per instance
         int64_t num_sinker;
         int64_t request_seq;
@@ -176,6 +180,10 @@ private:
         TimeTrace network_time;
 
         Mutex mutex;
+
+        // call_ids of each in-flight RPC. Used to actively cancel outstanding RPCs when the fragment is cancelled.
+        bthread_id_list_t in_flight_rpc_cids;
+        Mutex in_flight_rpc_cids_mutex;
 
         TNetworkAddress dest_addrs;
     };

--- a/be/test/exec/pipeline/exchange_sink_operator_test.cpp
+++ b/be/test/exec/pipeline/exchange_sink_operator_test.cpp
@@ -14,22 +14,31 @@
 
 #include "exec/pipeline/exchange/exchange_sink_operator.h"
 
+#include <brpc/server.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include "column/chunk.h"
+#include "exec/pipeline/exchange/sink_buffer.h"
 #include "exec/pipeline/fragment_context.h"
 #include "gen_cpp/DataSinks_types.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Partitions_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/data.pb.h"
+#include "gen_cpp/internal_service.pb.h"
 #include "gutil/casts.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "service/backend_options.h"
 #include "testutil/assert.h"
 #include "testutil/column_test_helper.h"
 #include "util/compression/block_compression.h"
+#include "util/countdown_latch.h"
 #include "util/defer_op.h"
+#include "util/internal_service_recoverable_stub.h"
 
 namespace starrocks::pipeline {
 
@@ -64,6 +73,9 @@ public:
         _query_context->init_mem_tracker(-1, GlobalEnv::GetInstance()->process_mem_tracker());
 
         TQueryOptions query_options;
+        // Use a large query timeout so an in-flight RPC does not complete on its own during the
+        // cancellation test; the test relies on cancel_one_sinker() to abort it promptly instead.
+        query_options.__set_query_timeout(300);
         TQueryGlobals query_globals;
         _runtime_state = std::make_shared<RuntimeState>(_fragment_id, query_options, query_globals, _exec_env);
         _runtime_state->set_query_ctx(_query_context.get());
@@ -161,6 +173,125 @@ TEST_F(ExchangeSinkOperatorTest, serialize_chunk_overflow_skip_disabled) {
     EXPECT_TRUE(st.is_internal_error()) << st.to_string();
 
     op->close(_runtime_state.get());
+}
+
+// A brpc PInternalService whose transmit_chunk blocks until explicitly released, so the client-side
+// RPC stays in-flight. This lets us assert that cancel_one_sinker() aborts outstanding RPCs actively
+// rather than waiting for them to drain (which would otherwise take until the RPC timeout).
+class HangingInternalService : public starrocks::PInternalService {
+public:
+    using Latch = CountDownLatch;
+
+    void transmit_chunk(google::protobuf::RpcController* /*controller*/,
+                        const starrocks::PTransmitChunkParams* /*request*/, starrocks::PTransmitChunkResult* response,
+                        google::protobuf::Closure* done) override {
+        received.count_down();
+        // Block the handler until the test tears down, keeping the client RPC pending.
+        release.wait();
+        if (response != nullptr) {
+            response->mutable_status()->set_status_code(0);
+        }
+        done->Run();
+    }
+
+    Latch received{1};
+    Latch release{1};
+};
+
+class SinkBufferCancelTest : public ExchangeSinkOperatorTest {
+protected:
+    // Build a SinkBuffer with a single real remote destination pointing at the given brpc port.
+    std::shared_ptr<SinkBuffer> make_remote_sink_buffer(int port, const TUniqueId& dest_id) {
+        TNetworkAddress addr;
+        addr.__set_hostname("127.0.0.1");
+        addr.__set_port(port);
+
+        TPlanFragmentDestination dest;
+        dest.__set_fragment_instance_id(dest_id);
+        dest.__set_brpc_server(addr);
+
+        std::vector<TPlanFragmentDestination> destinations{dest};
+        return std::make_shared<SinkBuffer>(_fragment_context.get(), destinations, /*is_dest_merge*/ false);
+    }
+
+    static TUniqueId make_dest_id(int64_t lo) {
+        TUniqueId id;
+        id.__set_hi(0);
+        id.__set_lo(lo);
+        return id;
+    }
+
+    static TransmitChunkInfo make_request(const TUniqueId& dest_id, int port,
+                                          std::shared_ptr<PInternalService_RecoverableStub> stub) {
+        TNetworkAddress addr;
+        addr.__set_hostname("127.0.0.1");
+        addr.__set_port(port);
+
+        auto params = std::make_shared<PTransmitChunkParams>();
+        params->set_eos(false);
+        return TransmitChunkInfo{dest_id,        std::move(stub),         std::move(params),
+                                 butil::IOBuf(), /*request_byte_size*/ 0, addr};
+    }
+};
+
+// cancel_one_sinker() must actively cancel in-flight RPCs. We launch an RPC against a server that
+// never responds, then cancel and assert the buffer reaches the finished state quickly (i.e. the
+// failure callback fired with ECANCELED) rather than blocking until the RPC timeout.
+TEST_F(SinkBufferCancelTest, cancel_aborts_inflight_rpc) {
+    brpc::Server server;
+    HangingInternalService service;
+    brpc::ServerOptions options;
+    options.num_threads = 2;
+    ASSERT_EQ(server.AddService(&service, brpc::SERVER_DOESNT_OWN_SERVICE), 0);
+    ASSERT_EQ(server.Start(0, &options), 0);
+    const int port = server.listen_address().port;
+    DeferOp stop_server([&] {
+        // Release the blocked handler and shut down the server.
+        service.release.count_down();
+        server.Stop(0);
+        server.Join();
+    });
+
+    auto dest_id = make_dest_id(/*lo*/ 987654321);
+    auto buffer = make_remote_sink_buffer(port, dest_id);
+    buffer->incr_sinker(_runtime_state.get());
+
+    auto stub = std::make_shared<PInternalService_RecoverableStub>(server.listen_address(), "");
+    ASSERT_OK(stub->reset_channel());
+
+    auto request = make_request(dest_id, port, stub);
+    ASSERT_OK(buffer->add_request(request));
+
+    // Wait until the server has actually received the RPC, guaranteeing it is in-flight.
+    ASSERT_TRUE(service.received.wait_for(std::chrono::seconds(10)));
+    EXPECT_FALSE(buffer->is_finished());
+
+    const auto cancel_start = std::chrono::steady_clock::now();
+    buffer->cancel_one_sinker(_runtime_state.get());
+
+    // The in-flight RPC should be aborted promptly. The query timeout is 300s, so if cancellation
+    // did not work this loop would time out here and fail rather than hanging for the full timeout.
+    const auto deadline = cancel_start + std::chrono::seconds(30);
+    while (!buffer->is_finished() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(buffer->is_finished());
+
+    const auto elapsed =
+            std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - cancel_start);
+    EXPECT_LT(elapsed.count(), 30) << "cancellation did not abort the in-flight RPC promptly";
+}
+
+// cancel_one_sinker() must be safe when there are no in-flight RPCs registered (the swap-and-reset
+// runs against a freshly initialized, empty bthread_id_list).
+TEST_F(SinkBufferCancelTest, cancel_with_no_inflight_rpc_is_safe) {
+    auto dest_id = make_dest_id(/*lo*/ 123456789);
+    // Any port works; no RPC is ever sent in this test.
+    auto buffer = make_remote_sink_buffer(/*port*/ 1, dest_id);
+    buffer->incr_sinker(_runtime_state.get());
+
+    buffer->cancel_one_sinker(_runtime_state.get());
+    EXPECT_TRUE(buffer->is_finished());
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
Backporting https://github.com/StarRocks/starrocks/pull/75613 to `branch-3.5-cc`

## Why I'm doing:

Fix for https://github.com/StarRocks/starrocks/issues/75612 on the BE side.

## What I'm doing:

Cancel in-flight exchange sink RPCs on fragment cancellation

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

cc @hagonzal 

