### PR TITLE
[BugFix] Batch tablet inverted-index writes in insert overwrite path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TempPartitions.java
@@ -83,13 +83,14 @@ public class TempPartitions implements Writable, GsonPostProcessable {
             idToPartition.remove(partition.getId());
             nameToPartition.remove(partitionName);
             if (!GlobalStateMgr.isCheckpointThread() && needDropTablet) {
-                TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
+                List<Long> tabletIds = Lists.newArrayList();
                 for (MaterializedIndex index :
                         partition.getDefaultPhysicalPartition().getMaterializedIndices(IndexExtState.ALL)) {
                     for (Tablet tablet : index.getTablets()) {
-                        invertedIndex.deleteTablet(tablet.getId());
+                        tabletIds.add(tablet.getId());
                     }
                 }
+                GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteTablets(tabletIds);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -450,13 +450,14 @@ public class InsertOverwriteJobRunner {
         Preconditions.checkState(table instanceof OlapTable);
         OlapTable targetTable = (OlapTable) table;
 
+        // Source tablets of the temp partitions being dropped. Declared outside the try
+        // so the force-delete marking can run after the table write lock is released.
+        Set<Tablet> sourceTablets = Sets.newHashSet();
         Locker locker = new Locker();
         if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
             throw new DmlException("insert overwrite commit failed because locking db:%s failed", dbId);
         }
         try {
-            Set<Tablet> sourceTablets = Sets.newHashSet();
-
             // Drop temp partitions by partition IDs (for non-dynamic overwrite)
             if (job.getTmpPartitionIds() != null) {
                 for (long pid : job.getTmpPartitionIds()) {
@@ -477,9 +478,6 @@ public class InsertOverwriteJobRunner {
             }
 
             if (!isReplay) {
-                // Mark all source tablet ids force delete to drop it directly on BE
-                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
-
                 // Abort the transaction if it was created in prepare()
                 if (job.isDynamicOverwrite() && job.getTxnId() > 0) {
                     try {
@@ -501,6 +499,13 @@ public class InsertOverwriteJobRunner {
             LOG.warn("exception when gc insert overwrite job.", e);
         } finally {
             locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
+        }
+
+        if (!isReplay) {
+            // Mark all source tablet ids force delete to drop it directly on BE. The marks
+            // are best-effort in-memory hints that need no table lock, so do it after the
+            // write unlock to shorten lock hold time.
+            GlobalStateMgr.getCurrentState().getTabletInvertedIndex().markTabletsForceDelete(sourceTablets);
         }
     }
 
@@ -602,6 +607,10 @@ public class InsertOverwriteJobRunner {
         
         // Collect partition tablet row counts for statistics sampling
         com.google.common.collect.Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
+
+        // Source tablets of the swapped-out partitions. Declared outside the try so the
+        // force-delete marking can run after the table write lock is released.
+        Set<Tablet> sourceTablets = Sets.newHashSet();
         
         try {
             // try exception to release write lock finally
@@ -632,7 +641,6 @@ public class InsertOverwriteJobRunner {
                         return partition.getName();
                     })
                     .collect(Collectors.toList());
-            Set<Tablet> sourceTablets = Sets.newHashSet();
             sourcePartitionNames.forEach(name -> {
                 Partition partition = targetTable.getPartition(name);
                 for (PhysicalPartition subPartition : partition.getSubPartitions()) {
@@ -763,10 +771,6 @@ public class InsertOverwriteJobRunner {
             stats.setTargetRows(sumTargetRows);
             stats.setPartitionTabletRowCounts(partitionTabletRowCounts);
             if (!isReplay) {
-                // mark all source tablet ids force delete to drop it directly on BE,
-                // not to move it to trash
-                sourceTablets.forEach(GlobalStateMgr.getCurrentState().getTabletInvertedIndex()::markTabletForceDelete);
-
                 InsertOverwriteStateChangeInfo info = new InsertOverwriteStateChangeInfo(job.getJobId(), job.getJobState(),
                         InsertOverwriteJobState.OVERWRITE_SUCCESS, job.getSourcePartitionIds(), job.getSourcePartitionNames(),
                         job.getTmpPartitionIds(), job.getTxnId());
@@ -791,6 +795,12 @@ public class InsertOverwriteJobRunner {
         }
 
         if (!isReplay) {
+            // mark all source tablet ids force delete to drop it directly on BE, not to
+            // move it to trash. The marks are best-effort in-memory hints that need no
+            // table lock, so do it after the write unlock to shorten lock hold time; the
+            // partition swap is already journaled at this point.
+            GlobalStateMgr.getCurrentState().getTabletInvertedIndex().markTabletsForceDelete(sourceTablets);
+
             // trigger listeners after insert overwrite committed, trigger listeners after
             // write unlock to avoid holding lock too long
             GlobalStateMgr.getCurrentState().getOperationListenerBus()


### PR DESCRIPTION
Backport the TabletInvertedIndex batch optimization from #75828 without its larger lock-contention refactor:

- TempPartitions.dropPartition: collect tablet ids and issue one batched deleteTablets call instead of deleteTablet per tablet.
- InsertOverwriteJobRunner gc/doCommit: replace the per-tablet markTabletForceDelete loop with a single markTabletsForceDelete call, and move the marking out of the table WRITE lock to after the unlock. The marks are best-effort in-memory hints that need no table lock; in doCommit this runs after the partition swap is journaled.

The batch methods already exist on this branch (backported via #70513 and #73995); this only wires the remaining insert-overwrite call sites to use them.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

