### PR TITLE
[BugFix] Fix MV rewrite serving stale results after Iceberg rollback_to_snapshot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1252,8 +1252,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         long baseTableRefreshTimestamp = baseTableRefreshTimestampOpt.get();
         long mvStaleness = (baseTableRefreshTimestamp - mvRefreshTimestamp) / 1000;
+        ZoneId currentTimeZoneId = TimeUtils.getTimeZone().toZoneId();
+        if (mvStaleness < 0) {
+            // A base table's refresh timestamp regressed below the MV's own refresh timestamp, e.g. after an
+            // Iceberg `rollback_to_snapshot`/`rollback_to_timestamp`. Treat as outdated rather than trusting a
+            // negative staleness, otherwise the MV would be served as fresh without re-checking base tables.
+            LOG.debug("MV is outdated because base tables' lastRefreshTime {} is before MV's lastRefreshTime {}",
+                    DateUtils.formatTimeStampInMill(baseTableRefreshTimestamp, currentTimeZoneId),
+                    DateUtils.formatTimeStampInMill(mvRefreshTimestamp, currentTimeZoneId));
+            return false;
+        }
         if (mvStaleness > this.maxMVRewriteStaleness) {
-            ZoneId currentTimeZoneId = TimeUtils.getTimeZone().toZoneId();
             LOG.debug("MV is outdated because MV's staleness {} (baseTables' lastRefreshTime {} - " +
                             "MV's lastRefreshTime {}) is greater than the staleness config {}",
                     DateUtils.formatTimeStampInMill(baseTableRefreshTimestamp, currentTimeZoneId),

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -56,6 +56,8 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
@@ -1772,5 +1774,45 @@ public class MaterializedViewTest extends StarRocksTestBase {
         Assertions.assertEquals(
                 "{\"default_catalog.db.t_olap\":\"" + TimeUtils.longToTimeString(versionTimeMillis) + "\"}",
                 mv.getBaseTableRefreshVersionTimesJson());
+    }
+
+    /**
+     * Test that isStalenessSatisfied() treats a negative staleness (base table's refresh timestamp
+     * regressed below the MV's own refresh timestamp, e.g. after an Iceberg rollback_to_snapshot) as
+     * outdated rather than incorrectly falling through to "fresh".
+     */
+    @Test
+    public void testIsStalenessSatisfiedWithNegativeStaleness() {
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(2_000_000L);
+        MaterializedView mv = new MaterializedView(1000, 100, "mv_staleness_test", columns, KeysType.AGG_KEYS,
+                null, null, refreshScheme);
+        mv.setMaxMVRewriteStaleness(600);
+
+        new MockUp<MaterializedView>() {
+            @Mock
+            public Optional<Long> maxBaseTableRefreshTimestamp() {
+                // base table's refresh timestamp is before the MV's own refresh timestamp
+                return Optional.of(1_000_000L);
+            }
+        };
+        Assertions.assertFalse(mv.isStalenessSatisfied());
+    }
+
+    @Test
+    public void testIsStalenessSatisfiedWithPositiveStalenessWithinBudget() {
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(1_000_000L);
+        MaterializedView mv = new MaterializedView(1000, 100, "mv_staleness_test2", columns, KeysType.AGG_KEYS,
+                null, null, refreshScheme);
+        mv.setMaxMVRewriteStaleness(600);
+
+        new MockUp<MaterializedView>() {
+            @Mock
+            public Optional<Long> maxBaseTableRefreshTimestamp() {
+                return Optional.of(1_000_000L + 500 * 1000L);
+            }
+        };
+        Assertions.assertTrue(mv.isStalenessSatisfied());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

By default, StarRocks only rewrites a query against an async materialized view (MV) if every base table is unchanged since the MV's last refresh. `mv_rewrite_staleness_second` relaxes that: it lets the optimizer still use the MV as long as the elapsed time between the base tables' most recent refresh/modification and the MV's own last refresh is within the configured budget.

`isStalenessSatisfied()` computed `mvStaleness = (baseTableRefreshTimestamp - mvRefreshTimestamp) / 1000` and only rejected the MV as fresh when that value exceeded `mv_rewrite_staleness_second`. It never checked for the base table's refresh timestamp going *backwards* relative to the MV's own last refresh.

For Iceberg base tables, `IcebergPartitionTraits.maxPartitionRefreshTs()` returns the raw `currentSnapshot().timestampMillis()`. This is normally monotonically increasing, but Iceberg's `rollback_to_snapshot`/`rollback_to_timestamp` procedures can move a table's current snapshot - and therefore its timestamp - backwards in time. When that happens, `mvStaleness` goes negative, which always satisfies `mvStaleness > staleness_budget` as false, so the MV is treated as fresh and used for rewrite even though the underlying data has been rolled back to a different state than what the MV last captured.

Concretely, `getUpdatedPartitionNamesOfExternalTable()` / `getUpdatedPartitionNamesOfOlapTable()` short-circuit to "no partitions need checking" whenever `isStalenessSatisfied()` returns true, so the bug skips the actual per-partition staleness comparison entirely.

## What I'm doing:

Reject the MV outright whenever `mvStaleness < 0` instead of falling through to the budget comparison, so a rolled-back base table forces the planner to fall through to the normal per-partition comparison instead of blindly trusting a stale MV.

This only affects MVs that explicitly set `mv_rewrite_staleness_second` (default is `0`, i.e. disabled) and, in practice, is only reachable through Iceberg's `rollback_to_snapshot`/`rollback_to_timestamp` procedures, since other connectors' `maxPartitionRefreshTs()` implementations don't have a documented operation that moves their timestamp backwards.

Fixes #71977

## What type of PR is this:

- [x] BugFix

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.3

## Test plan
- [x] Added `MaterializedViewTest#testIsStalenessSatisfiedWithNegativeStaleness` and `#testIsStalenessSatisfiedWithPositiveStalenessWithinBudget`, exercising the new negative-staleness branch and confirming the existing positive-staleness-within-budget path is unaffected.
- [x] `mvn -pl fe-grammar,fe-parser,fe-core -am test-compile` clean.
- [x] `mvn -pl fe-core checkstyle:check` clean.
- [x] Both new tests pass: `Tests run: 2, Failures: 0, Errors: 0`.