### PR TITLE
[DIAG] GLM POS scan_version correlation (not-for-merge)

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -49,6 +49,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/flat_json_metrics.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/predicate_parser.h"
@@ -490,7 +491,13 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
         auto* glm_ctx = (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(scan_node_id, creator);
         glm_ctx->set_scan_node(thrift_lake_scan_node);
         int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
-        glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
+        if (!_morsel->rowsets().empty()) {
+            glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
+        } else {
+            auto lake_rowsets = lake::Rowset::get_rowsets(_provider->tablet_manager(), _tablet.metadata());
+            std::vector<BaseRowsetSharedPtr> base_rowsets(lake_rowsets.begin(), lake_rowsets.end());
+            glm_ctx->capture_rowsets(_scan_range.tablet_id, version, base_rowsets);
+        }
     }
 
     RETURN_IF_ERROR(_extend_schema_by_access_paths());

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -18,6 +18,7 @@
 
 #include "base/string/string_parser.hpp"
 #include "base/testutil/sync_point.h"
+#include "base/uid_util.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/column_access_path.h"
@@ -491,6 +492,12 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
         auto* glm_ctx = (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(scan_node_id, creator);
         glm_ctx->set_scan_node(thrift_lake_scan_node);
         int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
+        // [GLM-DIAG POS] this GLM-enabled scan emits row locators (tablet, rssid, rowid) for the
+        // fetch phase. Log the version this position scan reads at, keyed by query_id, so it can be
+        // correlated against the fetch's captured_version in the [GLM-DIAG notfound] line to
+        // discriminate durable index damage (versions equal) from scan-vs-fetch skew (versions differ).
+        LOG(WARNING) << "[GLM-DIAG POS] query_id=" << print_id(runtime_state->query_id())
+                     << " tablet=" << _scan_range.tablet_id << " scan_version=" << version;
         if (!_morsel->rowsets().empty()) {
             glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
         } else {

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -339,6 +339,11 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     }
 
     if (target == nullptr) {
+        // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
+        // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
+        LOG(WARNING) << "[GLM-DIAG notfound] tablet=" << _tablet_id << " rssid=" << rssid << " "
+                     << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
+                     << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }
 

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -20,6 +20,7 @@
 #include "base/status.h"
 #include "base/status_fmt.hpp"
 #include "base/statusor.h"
+#include "base/uid_util.h"
 #include "common/config_lake_fwd.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "exec/exec_env.h"
@@ -169,6 +170,8 @@ private:
     LakeScanLazyMaterializationContext* _glm_ctx = nullptr;
     std::vector<lake::RowsetPtr> _rowsets;
     bool _use_page_cache = false;
+    // [GLM-DIAG] correlation key with the [GLM-DIAG POS] scan-side line.
+    std::string _query_id_str;
 };
 
 Status OlapScanTabletAdaptor::init(int64_t tablet_id) {
@@ -272,6 +275,7 @@ Status LakeScanTabletAdaptor::init(int64_t tablet_id) {
 
 Status LakeScanTabletAdaptor::init_schema(RuntimeState* state) {
     _use_page_cache = state->use_page_cache();
+    _query_id_str = print_id(state->query_id());
     auto* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
     const auto& lake_scan_node = _glm_ctx->scan_node();
 
@@ -341,7 +345,8 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     if (target == nullptr) {
         // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
         // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
-        LOG(WARNING) << "[GLM-DIAG notfound] tablet=" << _tablet_id << " rssid=" << rssid << " "
+        LOG(WARNING) << "[GLM-DIAG notfound] query_id=" << _query_id_str << " tablet=" << _tablet_id
+                     << " rssid=" << rssid << " "
                      << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
                      << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -346,8 +346,7 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
         // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
         // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
         LOG(WARNING) << "[GLM-DIAG notfound] query_id=" << _query_id_str << " tablet=" << _tablet_id
-                     << " rssid=" << rssid << " "
-                     << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
+                     << " rssid=" << rssid << " " << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
                      << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -870,12 +870,10 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
     auto accumulated = accumulator.pull();
     if (accumulated == nullptr) {
         // [GLM-DIAG] distinguish empty-batch (a) from located-but-materialized-nothing (b).
-        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id
-                     << " n_locators=" << row_locators.size()
-                     << (row_locators.empty()
-                                 ? std::string()
-                                 : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
-                                               std::get<1>(row_locators[0])));
+        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id << " n_locators=" << row_locators.size()
+                     << (row_locators.empty() ? std::string()
+                                              : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
+                                                            std::get<1>(row_locators[0])));
         // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
         // materialized. Previously this null was dereferenced unconditionally below
         // (accumulated->schema()), which crashes the CN with SIGSEGV.

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -869,6 +869,13 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
     accumulator.finalize();
     auto accumulated = accumulator.pull();
     if (accumulated == nullptr) {
+        // [GLM-DIAG] distinguish empty-batch (a) from located-but-materialized-nothing (b).
+        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id
+                     << " n_locators=" << row_locators.size()
+                     << (row_locators.empty()
+                                 ? std::string()
+                                 : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
+                                               std::get<1>(row_locators[0])));
         // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
         // materialized. Previously this null was dereferenced unconditionally below
         // (accumulated->schema()), which crashes the CN with SIGSEGV.

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -37,6 +37,7 @@
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
 #include "runtime/chunk_accumulator.h"
+#include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage_primitive/range.h"
@@ -867,6 +868,28 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
 
     accumulator.finalize();
     auto accumulated = accumulator.pull();
+    if (accumulated == nullptr) {
+        // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
+        // materialized. Previously this null was dereferenced unconditionally below
+        // (accumulated->schema()), which crashes the CN with SIGSEGV.
+        //
+        // There are two ways to get here:
+        //  - There were no row locators to look up (empty lookup request). _build_row_id_range
+        //    returns an empty locator set only when its input has 0 rows, so an empty chunk with
+        //    the requested slots is the correct result.
+        //  - Row locators existed but none could be materialized. Under a version-consistent read
+        //    a located row must be readable, so this indicates the tablet changed under us between
+        //    the position scan and this fetch (concurrent ingest/updates/deletes, or
+        //    compaction/GC). Fail loudly so the query retries on a consistent snapshot rather than
+        //    silently returning fewer rows. (A missing rowset already surfaces as an error earlier
+        //    via _tablet_adaptor->get_iterator -> "not found lake rssid".)
+        if (!row_locators.empty()) {
+            return Status::InternalError(
+                    "late materialization produced no rows for a non-empty set of row locators; "
+                    "the tablet changed between the position scan and the lookup fetch");
+        }
+        return ChunkPtr(RuntimeChunkHelper::new_chunk(slots, 0));
+    }
 
     for (const auto& slot : slots) {
         size_t column_index = accumulated->schema()->get_field_index_by_name(slot->col_name());

--- a/be/src/exec/pipeline/scan/glm_manager.cpp
+++ b/be/src/exec/pipeline/scan/glm_manager.cpp
@@ -125,6 +125,33 @@ void LakeScanLazyMaterializationContext::capture_rowsets(int32_t tablet_id, int6
     _versions[tablet_id] = version;
 }
 
+// [GLM-DIAG] diagnostic only. rssid range of a rowset is [id, id + segment_metas_size).
+std::string LakeScanLazyMaterializationContext::debug_dump_ranges(const std::vector<lake::RowsetPtr>& rowsets) const {
+    std::string s = "n=" + std::to_string(rowsets.size()) + " ranges=[";
+    for (const auto& rs : rowsets) {
+        const auto& m = rs->metadata();
+        uint32_t base = m.id();
+        s += std::to_string(base) + ":" + std::to_string(base + m.segment_metas_size()) + " ";
+    }
+    s += "]";
+    return s;
+}
+
+// [GLM-DIAG] diagnostic only.
+std::string LakeScanLazyMaterializationContext::debug_dump_ranges(int32_t tablet_id) const {
+    std::shared_lock lock(_mutex);
+    std::string s = "captured_version=";
+    auto vit = _versions.find(tablet_id);
+    s += (vit == _versions.end() ? std::string("MISSING") : std::to_string(vit->second));
+    auto it = _rowsets.find(tablet_id);
+    if (it == _rowsets.end()) {
+        s += " captured=ABSENT";
+        return s;
+    }
+    s += " captured_" + debug_dump_ranges(it->second);
+    return s;
+}
+
 void LakeScanLazyMaterializationContext::set_scan_node(const TLakeScanNode& node) {
     std::unique_lock lock(_mutex);
     if (!_thrift_lake_scan_node.has_value()) {

--- a/be/src/exec/pipeline/scan/glm_manager.h
+++ b/be/src/exec/pipeline/scan/glm_manager.h
@@ -99,6 +99,10 @@ public:
     const TLakeScanNode& scan_node() const { return *_thrift_lake_scan_node; }
     void set_scan_node(const TLakeScanNode& node);
 
+    // [GLM-DIAG] dump captured version + rowset id-ranges for a tablet (diagnostic only).
+    std::string debug_dump_ranges(int32_t tablet_id) const;
+    std::string debug_dump_ranges(const std::vector<lake::RowsetPtr>& rowsets) const;
+
 private:
     mutable std::shared_mutex _mutex;
     std::unordered_map<int32_t, std::vector<lake::RowsetPtr>> _rowsets;

--- a/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+++ b/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
@@ -17,10 +17,10 @@
 #include <string>
 #include <vector>
 
+#include "column/chunk.h"
 #include "common/config_exec_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
-#include "column/chunk.h"
 #include "exec/pipeline/lookup/tablet_adaptor.h"
 #include "exec/pipeline/scan/glm_manager.h"
 #include "exec/runtime/query_runtime_state.h"

--- a/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+++ b/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
@@ -20,9 +20,15 @@
 #include "common/config_exec_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "column/chunk.h"
 #include "exec/pipeline/lookup/tablet_adaptor.h"
 #include "exec/pipeline/scan/glm_manager.h"
+#include "exec/runtime/query_runtime_state.h"
 #include "gtest/gtest.h"
+// Access NativeLookUpTask's private _late_materialize_by_row_locators() and RowLocators.
+#define private public
+#include "exec/pipeline/lookup_request.h"
+#undef private
 #include "runtime/descriptor_helper.h"
 #include "runtime/runtime_state.h"
 #include "storage/lake/rowset.h"
@@ -367,6 +373,49 @@ TEST(LakeScanTabletAdaptorTest, InvalidRssid) {
     auto iter_or = adaptor->get_iterator(-1, std::move(rowids));
     ASSERT_FALSE(iter_or.ok());
     ASSERT_TRUE(iter_or.status().is_internal_error());
+}
+
+// Regression test for a CN SIGSEGV in NativeLookUpTask::_late_materialize_by_row_locators.
+// When the lookup has no row locators to materialize, the ChunkAccumulator stays empty and
+// ChunkAccumulator::pull() returns nullptr. The old code dereferenced it unconditionally
+// (accumulated->schema()), crashing the CN. The fix returns an empty chunk carrying the
+// requested slots for the empty-locators case.
+TEST(NativeLookUpTaskTest, EmptyRowLocatorsReturnsEmptyChunk) {
+    RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+
+    // The late-materialize path requires a non-null GLM context for the scan id.
+    constexpr int64_t kScanId = 42;
+    GlobalLateMaterilizationContextMgr glm_mgr;
+    auto* glm_ctx = glm_mgr.get_or_create_ctx(kScanId, []() { return new DummyGLMContext(); });
+    pipeline::QueryRuntimeState qrs;
+    qrs.set_global_late_materialization_ctx_mgr(&glm_mgr);
+    state.set_query_runtime_state(&qrs);
+
+    auto ctx = std::make_shared<pipeline::LookUpTaskContext>();
+    ctx->scan_id = kScanId;
+
+    auto adaptor_or = create_look_up_tablet_adaptor(RowPositionDescriptor::Type::LAKE_SCAN);
+    ASSERT_TRUE(adaptor_or.ok());
+    pipeline::NativeLookUpTask task(ctx, std::move(adaptor_or.value()));
+
+    ObjectPool pool;
+    auto slots = create_slots(&state, &pool, {"c0", "c1"});
+    ASSERT_EQ(2, slots.size());
+
+    auto request_chunk = std::make_shared<Chunk>();
+    pipeline::NativeLookUpTask::RowLocators empty_locators; // empty -> accumulator empty -> pull() == nullptr
+
+    auto result = task._late_materialize_by_row_locators(&state, slots, empty_locators, request_chunk);
+    ASSERT_TRUE(result.ok()) << result.status().to_string();
+    auto out = result.value();
+    ASSERT_NE(nullptr, out);
+    EXPECT_EQ(0, out->num_rows());
+    EXPECT_EQ(slots.size(), out->num_columns());
+    for (auto* slot : slots) {
+        EXPECT_NE(nullptr, out->get_column_by_slot_id(slot->id()));
+    }
+
+    delete glm_ctx;
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Throwaway diagnostic PR (NOT FOR MERGE) — instrumentation to discriminate the GLM
`not found lake rssid` root cause between durable PK-index damage and live
scan-vs-fetch version skew. Adds a `[GLM-DIAG POS]` scan-side log (query_id, tablet,
scan_version) and tags the fetch-side `[GLM-DIAG notfound]` line with query_id.
On top of the #75889 null-guard. Close after the diagnostic run completes.
