### PR TITLE
[BugFix] Stop range-colocate alignment job storm and fail-close unaligned colocate join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -205,15 +205,19 @@ public class ColocateChecker {
      * Read-locks the table.
      *
      * <p>{@code dataVersion} — not {@code visibleVersion} — is included because BE's external-boundaries
-     * split can fall back to an identical tablet for data-distribution reasons, not only structural
-     * ones: it rejects a split whose effective segment envelope is empty or a degenerate single key, or
-     * whose per-rowset row/byte weight does not straddle the boundary (see {@code tablet_splitter.cpp}
-     * steps 5-6 and 10). So a tablet that cannot be split today can become splittable after a load
-     * widens its data — with no tablet-range change — and the latch must re-arm on that. A reshard
-     * publish (including the identical-tablet fallback) advances only {@code visibleVersion}, while a
-     * real load advances {@code dataVersion}, so keying on {@code dataVersion} re-arms on genuine data
-     * changes but not on fallback churn. Tablet ranges are still carried to detect reshard progress (a
-     * successful split changes ranges but not {@code dataVersion}).
+     * split can fall back to an identical tablet for data-distribution reasons: it rejects a split whose
+     * effective segment envelope — the tablet's global min/max data keys, intersected with its range — is
+     * empty or collapses to a single key (see {@code tablet_splitter.cpp} step 6; the other hard-fallback
+     * paths are corruption guards). That envelope is a function of which keys exist, so a tablet that
+     * cannot be split today becomes splittable only after a load widens its key span across the boundary —
+     * with no tablet-range change — and the latch must re-arm on that. A load advances {@code dataVersion};
+     * a reshard publish (including the identical-tablet fallback) advances only {@code visibleVersion}, so
+     * keying on {@code dataVersion} re-arms on genuine data changes but not on fallback churn — keying on
+     * {@code visibleVersion} would re-fire the identical split every tick, the alignment storm this latch
+     * exists to stop. Compaction rewrites rowsets but preserves the key set, so it cannot change the
+     * envelope or the split outcome (it advances only {@code visibleVersion}) and is deliberately not a
+     * re-arm trigger. Tablet ranges are still carried to detect reshard progress (a successful split
+     * changes ranges but not {@code dataVersion}).
      */
     static long tableConvergenceSignature(Database db, OlapTable table, long expectedRangesSig) {
         List<HashCode> indexParts = new ArrayList<>();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import com.staros.client.StarClientException;
 import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.ColocateGroupSchema;
@@ -93,6 +97,153 @@ public class ColocateChecker {
     // Throttles per-tick queryShardGroupStable load; all its semantics live in the cache class.
     private final ColocateConvergenceCache convergenceCache = new ColocateConvergenceCache();
 
+    // Cap on consecutive re-fires after an aborted alignment attempt on an unchanged layout, so a
+    // persistently-aborting job cannot become its own (slow) storm. Past the cap the table is
+    // treated like a deterministic dead-end and left unaligned until its layout/data changes.
+    static final int ALIGNMENT_ABORT_RETRY_CAP = 3;
+
+    // Per-table memory of the last alignment attempt (keyed by tableId). Split/merge is deterministic,
+    // so re-issuing identical alignment work on an unchanged layout makes no progress — it just churns
+    // tablets. This map lets the checker suppress that re-issue (the fix for the self-sustaining
+    // alignment-job storm). The latch is per TABLE (not per group) because alignment jobs are
+    // per-table: keying by group would let one table's attempt suppress a peer that had never been
+    // attempted, or miss a peer's abort. An entry is cleared when the table becomes aligned, and the
+    // whole map is cleared whenever no group is unstable; it also naturally re-arms when the table's
+    // layout/data changes, on a bounded number of aborts, or after an FE restart.
+    private final Map<Long, TableAlignmentAttempt> lastAttemptByTable = new HashMap<>();
+
+    /**
+     * What the checker last did for one table: the {@link #tableConvergenceSignature} observed when it
+     * fired, the alignment job id submitted, and how many times an aborted attempt has been re-fired on
+     * this same signature. {@code suppressionLogged} keeps the "no progress" warning to once per stuck
+     * state.
+     */
+    static final class TableAlignmentAttempt {
+        final long signature;
+        final long jobId;
+        final int abortRetries;
+        boolean suppressionLogged;
+
+        TableAlignmentAttempt(long signature, long jobId, int abortRetries) {
+            this.signature = signature;
+            this.jobId = jobId;
+            this.abortRetries = abortRetries;
+        }
+    }
+
+    /** Outcome of {@link #decideAlignment}: whether to fire this cycle and the abort counter to store. */
+    record AlignmentDecision(boolean fire, int nextAbortRetries) {
+    }
+
+    /**
+     * Should the checker (re)issue an alignment job for a table this cycle, and if it fires what
+     * abort-retry count should it record? Fire when this is the first attempt ({@code prev == null}) or
+     * the layout/data changed since the last attempt (real progress is possible); otherwise the last
+     * completed attempt made no progress on this exact input and — because split/merge is deterministic
+     * — a re-issue would too, so suppress. The sole exception is a previous attempt that ended in an
+     * abort (a transient failure, not a deterministic dead-end): re-fire, but only up to
+     * {@link #ALIGNMENT_ABORT_RETRY_CAP} times on an unchanged signature. {@code nextAbortRetries} is
+     * only meaningful when {@code fire} is true and a job is actually submitted.
+     */
+    static AlignmentDecision decideAlignment(TableAlignmentAttempt prev, long currentSignature,
+            boolean prevJobAborted) {
+        if (prev == null || prev.signature != currentSignature) {
+            return new AlignmentDecision(true, 0);
+        }
+        boolean fire = prevJobAborted && prev.abortRetries < ALIGNMENT_ABORT_RETRY_CAP;
+        return new AlignmentDecision(fire, prev.abortRetries + 1);
+    }
+
+    /** Visible for testing: whether a table currently has a recorded alignment attempt (is latched). */
+    boolean hasRecordedAttempt(long tableId) {
+        return lastAttemptByTable.containsKey(tableId);
+    }
+
+    /** True iff the alignment job is still tracked and ended in {@code ABORTED}. */
+    static boolean isJobAborted(long jobId) {
+        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+        return job != null && job.isAborted();
+    }
+
+    /** True iff the alignment job has reached a terminal state (or is no longer tracked). */
+    static boolean isJobSettled(long jobId) {
+        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+        return job == null || job.isDone();
+    }
+
+    // murmur3-128 via Guava's Hashing (the idiom already used across FE, e.g. HDFSBackendSelector /
+    // the hash rings) — no hand-rolled mixing. Order-independent combination uses
+    // Hashing.combineUnordered so the signature does not depend on partition / index / tablet order.
+    private static final HashFunction SIGNATURE_HASH = Hashing.murmur3_128();
+
+    /**
+     * Order-independent signature of the group's expected ranges — the part of a table's convergence
+     * signature that is shared across all peer tables, so a change to the colocate ranges (e.g. a peer
+     * split adds a boundary) re-arms every table. Each range is hashed and the results are combined with
+     * {@link Hashing#combineUnordered} so list order does not matter.
+     */
+    static long expectedRangesSignature(List<ColocateRange> expectedRanges) {
+        List<HashCode> parts = new ArrayList<>(expectedRanges.size());
+        for (ColocateRange colocateRange : expectedRanges) {
+            parts.add(SIGNATURE_HASH.hashInt(colocateRange.getRange().hashCode()));
+        }
+        // A registered group always has at least the [MIN, MAX) range, so parts is never empty
+        // (combineUnordered requires a non-empty iterable).
+        return Hashing.combineUnordered(parts).asLong();
+    }
+
+    /**
+     * Canonical, order-independent 64-bit signature of everything one table's alignment decision and
+     * split feasibility depend on: {@code expectedRangesSig} plus the table's visible-index tablet
+     * ranges and each physical partition's {@code dataVersion}. It intentionally excludes tablet ids
+     * (they churn on every fallback split, which would defeat the latch). A murmur3 hash (rather than a
+     * concatenated string) is used so it cannot alias on a delimiter inside a VARCHAR range value, stays
+     * compact regardless of tablet count, and is trivial to extend by hashing in one more field. Per-tablet
+     * and per-index contributions are combined with {@link Hashing#combineUnordered}, so the result is
+     * order-independent and deterministic; a hash collision would only mask a real change, which is
+     * self-healing (the table stays unaligned → correct shuffle, and re-arms on the next change).
+     * Read-locks the table.
+     *
+     * <p>{@code dataVersion} — not {@code visibleVersion} — is included because BE's external-boundaries
+     * split can fall back to an identical tablet for data-distribution reasons, not only structural
+     * ones: it rejects a split whose effective segment envelope is empty or a degenerate single key, or
+     * whose per-rowset row/byte weight does not straddle the boundary (see {@code tablet_splitter.cpp}
+     * steps 5-6 and 10). So a tablet that cannot be split today can become splittable after a load
+     * widens its data — with no tablet-range change — and the latch must re-arm on that. A reshard
+     * publish (including the identical-tablet fallback) advances only {@code visibleVersion}, while a
+     * real load advances {@code dataVersion}, so keying on {@code dataVersion} re-arms on genuine data
+     * changes but not on fallback churn. Tablet ranges are still carried to detect reshard progress (a
+     * successful split changes ranges but not {@code dataVersion}).
+     */
+    static long tableConvergenceSignature(Database db, OlapTable table, long expectedRangesSig) {
+        List<HashCode> indexParts = new ArrayList<>();
+        indexParts.add(SIGNATURE_HASH.hashLong(expectedRangesSig));
+        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
+            for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                for (MaterializedIndex index :
+                        physicalPartition.getLatestMaterializedIndices(IndexExtState.VISIBLE)) {
+                    List<HashCode> tabletParts = new ArrayList<>();
+                    for (Tablet tablet : index.getTablets()) {
+                        tabletParts.add(SIGNATURE_HASH.hashInt(
+                                tablet.getRange() == null ? 0 : tablet.getRange().getRange().hashCode()));
+                    }
+                    Hasher indexHasher = SIGNATURE_HASH.newHasher()
+                            .putLong(physicalPartition.getId())
+                            .putLong(index.getMetaId())
+                            .putLong(physicalPartition.getDataVersion());
+                    // Combine tablet ranges order-independently within the index (empty for a
+                    // range-less index — its topology still contributes via the fields above).
+                    if (!tabletParts.isEmpty()) {
+                        indexHasher.putBytes(Hashing.combineUnordered(tabletParts).asBytes());
+                    }
+                    indexParts.add(indexHasher.hash());
+                }
+            }
+        }
+        // Combine per-index contributions order-independently across partitions / indexes.
+        return Hashing.combineUnordered(indexParts).asLong();
+    }
+
     /**
      * Invoked from {@link TabletReshardJobMgr#runAfterCatalogReady} on every scheduler tick.
      * Fast-returns when there's no work to do; otherwise iterates unstable range-colocate
@@ -106,8 +257,10 @@ public class ColocateChecker {
         // Steady-state fast-path: no unstable groups → cheap read-lock empty-check, no allocation.
         if (!colocateTableIndex.hasUnstableGroups()) {
             // Nothing left to converge: drop any lingering negative-cache entries so the cache is
-            // bounded to the duration of active migrations (and reclaimed after a leader gap).
+            // bounded to the duration of active migrations (and reclaimed after a leader gap), and
+            // drop the per-table alignment-attempt memory for the same reason.
             convergenceCache.clear();
+            lastAttemptByTable.clear();
             return;
         }
         Set<Long> processedColocateGroupIds = new HashSet<>();
@@ -131,7 +284,8 @@ public class ColocateChecker {
     /**
      * Drive one {@code colocateGroupId} toward stability: iterate every peer GroupId × table ×
      * partition × visible index; fire an alignment {@link SplitTabletJob} for every table
-     * with at least one misaligned tablet; if and only if every peer is fully aligned, mark
+     * with at least one misaligned tablet (unless that table is latched — see
+     * {@link #alignTableIfApplicable}); if and only if every peer is fully aligned, mark
      * every peer GroupId stable in lock-step.
      */
     private void processGroup(ColocateTableIndex colocateTableIndex, long colocateGroupId) {
@@ -149,6 +303,7 @@ public class ColocateChecker {
             return;
         }
         int colocateColumnCount = schema.getColocateColumnCount();
+        long expectedRangesSig = expectedRangesSignature(expectedRanges);
 
         boolean allAligned = true;
         for (ColocateTableIndex.GroupId peerGroupId : peers) {
@@ -157,7 +312,8 @@ public class ColocateChecker {
                 continue;
             }
             for (long tableId : colocateTableIndex.getAllTableIds(peerGroupId)) {
-                if (!alignTableIfApplicable(db, tableId, expectedRanges, colocateColumnCount, colocateGroupId)) {
+                if (!alignTableIfApplicable(db, tableId, expectedRanges, expectedRangesSig,
+                        colocateColumnCount, colocateGroupId)) {
                     allAligned = false;
                 }
             }
@@ -175,6 +331,8 @@ public class ColocateChecker {
             if (reconcilePackPlacement(colocateTableIndex, peers, expectedRanges, colocateColumnCount)
                     && isPlacementConverged(colocateTableIndex, peers, expectedRanges, colocateGroupId)) {
                 colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
+                // allAligned means every peer table returned aligned this pass, which already cleared
+                // its own lastAttemptByTable entry, so no group-level cleanup is needed here.
                 LOG.info("marked colocate group id {} stable across {} peer GroupIds",
                         colocateGroupId, peers.size());
             }
@@ -430,18 +588,24 @@ public class ColocateChecker {
     /**
      * Per-table dispatch for {@link #processGroup}: looks up the table, filters out non-OlapTable
      * entries (still considered "aligned" — alignment isn't applicable), defers tables not in
-     * {@code NORMAL} state, and otherwise hands off to {@link #processTable}.
+     * {@code NORMAL} state, and otherwise applies the per-table convergence latch. Split/merge is
+     * deterministic, so once a completed alignment attempt made no progress on this exact table layout,
+     * re-issuing it would just churn tablets (the self-sustaining storm); the latch suppresses that
+     * re-issue until the table's layout/data changes (or a bounded number of retries after a transient
+     * abort). A transient failure (lookup / job-admission throw) records nothing, so the table is simply
+     * retried next cycle — it can never suppress a peer, because the latch is per table.
      *
-     * @return {@code true} iff the table contributed no obstacle to marking the colocate group
-     *         stable this cycle (already aligned, or not an OlapTable). {@code false} when work
-     *         is still needed (misaligned tablets, in-flight alter, lookup failure).
+     * @return {@code true} iff the table is already aligned (or not an OlapTable) — no obstacle to
+     *         marking the colocate group stable. {@code false} when work is still needed (misaligned,
+     *         in-flight alter, latched, or a transient failure).
      */
     private boolean alignTableIfApplicable(Database db, long tableId, List<ColocateRange> expectedRanges,
-                                            int colocateColumnCount, long colocateGroupId) {
+                                            long expectedRangesSig, int colocateColumnCount, long colocateGroupId) {
         Table fetchedTable;
         try {
             fetchedTable = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
         } catch (Exception e) {
+            // Transient lookup failure: no latch entry recorded, so this table is retried next cycle.
             LOG.debug("table {} lookup failed in db {}, skipping", tableId, db.getId(), e);
             return false;
         }
@@ -450,13 +614,32 @@ public class ColocateChecker {
         }
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
             // In-flight alter / reshard job — skip this cycle, revisit next. Avoids the
-            // SplitTabletJob.setTableState(NORMAL -> TABLET_RESHARD) race when two jobs
-            // target the same table.
+            // SplitTabletJob.setTableState(NORMAL -> TABLET_RESHARD) race when two jobs target the
+            // same table. Leaves the table's latch entry untouched.
             return false;
         }
         try {
-            return processTable(db, olapTable, expectedRanges, colocateColumnCount);
+            long signature = tableConvergenceSignature(db, olapTable, expectedRangesSig);
+            TableAlignmentAttempt prev = lastAttemptByTable.get(tableId);
+            AlignmentDecision decision =
+                    decideAlignment(prev, signature, prev != null && isJobAborted(prev.jobId));
+            if (!decision.fire()) {
+                // A completed attempt on an unchanged layout made no progress: don't re-issue until the
+                // table's layout/data changes. The table stays misaligned, so the group stays unstable
+                // and colocate joins fall back to a correct shuffle plan. Log once per stuck state.
+                if (prev != null && !prev.suppressionLogged && isJobSettled(prev.jobId)) {
+                    LOG.warn("colocate table {}.{} (group {}) alignment made no progress on an unchanged "
+                            + "layout; suppressing further alignment jobs until its layout or data changes. "
+                            + "The group stays unstable and colocate joins fall back to shuffle.",
+                            db.getFullName(), olapTable.getName(), colocateGroupId);
+                    prev.suppressionLogged = true;
+                }
+                return false;
+            }
+            return fireAlignmentIfMisaligned(db, olapTable, expectedRanges, colocateColumnCount,
+                    signature, decision.nextAbortRetries());
         } catch (Exception e) {
+            // Transient failure (e.g. job-admission throw): no latch entry recorded, retried next cycle.
             LOG.warn("alignment failed for table {}.{} in colocate group id {}",
                     db.getFullName(), olapTable.getName(), colocateGroupId, e);
             return false;
@@ -464,15 +647,18 @@ public class ColocateChecker {
     }
 
     /**
-     * Inspects every visible materialized index in every physical partition of {@code table};
-     * if any tablet is not range-aligned with {@code expectedRanges}, builds the per-tablet
-     * forced-boundaries map and fires a single alignment {@link SplitTabletJob} for the table.
+     * Inspects every visible materialized index in every physical partition of {@code table}; if every
+     * tablet is already range-aligned, clears the table's latch entry and reports aligned. Otherwise
+     * builds the per-tablet forced-boundaries map, fires a single alignment {@link SplitTabletJob}, and
+     * records the {@code signature}/jobId so an unchanged next cycle latches.
      *
-     * @return {@code true} iff every tablet in every visible index was already aligned (no job
-     *         fired); {@code false} otherwise — the caller leaves the colocate group unstable.
+     * @return {@code true} iff every tablet in every visible index was already aligned (no job fired);
+     *         {@code false} otherwise (a job was fired, or an index is misaligned with no splittable
+     *         boundary this cycle).
      */
-    private boolean processTable(Database db, OlapTable table, List<ColocateRange> expectedRanges,
-                                  int colocateColumnCount) throws StarRocksException {
+    private boolean fireAlignmentIfMisaligned(Database db, OlapTable table, List<ColocateRange> expectedRanges,
+                                              int colocateColumnCount, long signature, int nextAbortRetries)
+            throws StarRocksException {
         // physicalPartitionId -> indexId -> oldTabletId -> per-new-tablet ranges that tile the
         // old tablet's range. Empty map means every tablet in every visible index is already
         // aligned against expectedRanges.
@@ -486,7 +672,7 @@ public class ColocateChecker {
                     // Each visible index (base + every rollup/MV) can have its own sort-key arity.
                     // Using the base index's sort key for an MV with a shorter prefix would compute
                     // boundaries the MV's tablets can never align with — alignment iteration would
-                    // livelock. Resolve per-index here (E1). Use getMetaId() (not getId()) — the
+                    // livelock. Resolve per-index here. Use getMetaId() (not getId()) — the
                     // physical id changes after reshard while metaId is stable.
                     List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table, index.getMetaId());
                     if (RangeColocateScanDispatch.isTabletRangesAligned(
@@ -513,6 +699,8 @@ public class ColocateChecker {
         }
 
         if (alignmentMap.isEmpty()) {
+            // Aligned (or nothing splittable): drop any latch entry so a future misalignment re-arms.
+            lastAttemptByTable.remove(table.getId());
             return alignedSoFar;
         }
 
@@ -521,6 +709,8 @@ public class ColocateChecker {
         // leader demotion at this point cannot leak external shards.
         TabletReshardJob job = SplitTabletJobFactory.forColocateAlignment(db, table, alignmentMap);
         GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(job);
+        lastAttemptByTable.put(table.getId(),
+                new TableAlignmentAttempt(signature, job.getJobId(), nextAbortRetries));
         LOG.info("submitted SplitTabletJob {} for table {}.{} covering {} partitions",
                 job.getJobId(), db.getFullName(), table.getName(), alignmentMap.size());
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/ColocateChecker.java
@@ -97,78 +97,14 @@ public class ColocateChecker {
     // Throttles per-tick queryShardGroupStable load; all its semantics live in the cache class.
     private final ColocateConvergenceCache convergenceCache = new ColocateConvergenceCache();
 
-    // Cap on consecutive re-fires after an aborted alignment attempt on an unchanged layout, so a
-    // persistently-aborting job cannot become its own (slow) storm. Past the cap the table is
-    // treated like a deterministic dead-end and left unaligned until its layout/data changes.
-    static final int ALIGNMENT_ABORT_RETRY_CAP = 3;
-
-    // Per-table memory of the last alignment attempt (keyed by tableId). Split/merge is deterministic,
-    // so re-issuing identical alignment work on an unchanged layout makes no progress — it just churns
-    // tablets. This map lets the checker suppress that re-issue (the fix for the self-sustaining
-    // alignment-job storm). The latch is per TABLE (not per group) because alignment jobs are
-    // per-table: keying by group would let one table's attempt suppress a peer that had never been
-    // attempted, or miss a peer's abort. An entry is cleared when the table becomes aligned, and the
-    // whole map is cleared whenever no group is unstable; it also naturally re-arms when the table's
-    // layout/data changes, on a bounded number of aborts, or after an FE restart.
-    private final Map<Long, TableAlignmentAttempt> lastAttemptByTable = new HashMap<>();
-
-    /**
-     * What the checker last did for one table: the {@link #tableConvergenceSignature} observed when it
-     * fired, the alignment job id submitted, and how many times an aborted attempt has been re-fired on
-     * this same signature. {@code suppressionLogged} keeps the "no progress" warning to once per stuck
-     * state.
-     */
-    static final class TableAlignmentAttempt {
-        final long signature;
-        final long jobId;
-        final int abortRetries;
-        boolean suppressionLogged;
-
-        TableAlignmentAttempt(long signature, long jobId, int abortRetries) {
-            this.signature = signature;
-            this.jobId = jobId;
-            this.abortRetries = abortRetries;
-        }
-    }
-
-    /** Outcome of {@link #decideAlignment}: whether to fire this cycle and the abort counter to store. */
-    record AlignmentDecision(boolean fire, int nextAbortRetries) {
-    }
-
-    /**
-     * Should the checker (re)issue an alignment job for a table this cycle, and if it fires what
-     * abort-retry count should it record? Fire when this is the first attempt ({@code prev == null}) or
-     * the layout/data changed since the last attempt (real progress is possible); otherwise the last
-     * completed attempt made no progress on this exact input and — because split/merge is deterministic
-     * — a re-issue would too, so suppress. The sole exception is a previous attempt that ended in an
-     * abort (a transient failure, not a deterministic dead-end): re-fire, but only up to
-     * {@link #ALIGNMENT_ABORT_RETRY_CAP} times on an unchanged signature. {@code nextAbortRetries} is
-     * only meaningful when {@code fire} is true and a job is actually submitted.
-     */
-    static AlignmentDecision decideAlignment(TableAlignmentAttempt prev, long currentSignature,
-            boolean prevJobAborted) {
-        if (prev == null || prev.signature != currentSignature) {
-            return new AlignmentDecision(true, 0);
-        }
-        boolean fire = prevJobAborted && prev.abortRetries < ALIGNMENT_ABORT_RETRY_CAP;
-        return new AlignmentDecision(fire, prev.abortRetries + 1);
-    }
+    // Per-table edge-triggered latch that suppresses re-issuing deterministic alignment work on an
+    // unchanged table layout — the fix for the self-sustaining alignment-job storm. All of its state and
+    // decision logic live in {@link TableAlignmentLatch}; this checker just consults it each cycle.
+    private final TableAlignmentLatch alignmentLatch = new TableAlignmentLatch();
 
     /** Visible for testing: whether a table currently has a recorded alignment attempt (is latched). */
     boolean hasRecordedAttempt(long tableId) {
-        return lastAttemptByTable.containsKey(tableId);
-    }
-
-    /** True iff the alignment job is still tracked and ended in {@code ABORTED}. */
-    static boolean isJobAborted(long jobId) {
-        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
-        return job != null && job.isAborted();
-    }
-
-    /** True iff the alignment job has reached a terminal state (or is no longer tracked). */
-    static boolean isJobSettled(long jobId) {
-        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
-        return job == null || job.isDone();
+        return alignmentLatch.hasRecordedAttempt(tableId);
     }
 
     // murmur3-128 via Guava's Hashing (the idiom already used across FE, e.g. HDFSBackendSelector /
@@ -264,7 +200,7 @@ public class ColocateChecker {
             // bounded to the duration of active migrations (and reclaimed after a leader gap), and
             // drop the per-table alignment-attempt memory for the same reason.
             convergenceCache.clear();
-            lastAttemptByTable.clear();
+            alignmentLatch.clear();
             return;
         }
         Set<Long> processedColocateGroupIds = new HashSet<>();
@@ -336,7 +272,7 @@ public class ColocateChecker {
                     && isPlacementConverged(colocateTableIndex, peers, expectedRanges, colocateGroupId)) {
                 colocateTableIndex.markAllGroupsWithSameColocateGroupIdStable(colocateGroupId, true);
                 // allAligned means every peer table returned aligned this pass, which already cleared
-                // its own lastAttemptByTable entry, so no group-level cleanup is needed here.
+                // its own latch entry (alignmentLatch.forgetTable), so no group-level cleanup is needed.
                 LOG.info("marked colocate group id {} stable across {} peer GroupIds",
                         colocateGroupId, peers.size());
             }
@@ -624,19 +560,16 @@ public class ColocateChecker {
         }
         try {
             long signature = tableConvergenceSignature(db, olapTable, expectedRangesSig);
-            TableAlignmentAttempt prev = lastAttemptByTable.get(tableId);
-            AlignmentDecision decision =
-                    decideAlignment(prev, signature, prev != null && isJobAborted(prev.jobId));
+            TableAlignmentLatch.AlignmentDecision decision = alignmentLatch.evaluate(tableId, signature);
             if (!decision.fire()) {
                 // A completed attempt on an unchanged layout made no progress: don't re-issue until the
                 // table's layout/data changes. The table stays misaligned, so the group stays unstable
                 // and colocate joins fall back to a correct shuffle plan. Log once per stuck state.
-                if (prev != null && !prev.suppressionLogged && isJobSettled(prev.jobId)) {
+                if (alignmentLatch.claimSuppressionLog(tableId)) {
                     LOG.warn("colocate table {}.{} (group {}) alignment made no progress on an unchanged "
                             + "layout; suppressing further alignment jobs until its layout or data changes. "
                             + "The group stays unstable and colocate joins fall back to shuffle.",
                             db.getFullName(), olapTable.getName(), colocateGroupId);
-                    prev.suppressionLogged = true;
                 }
                 return false;
             }
@@ -704,7 +637,7 @@ public class ColocateChecker {
 
         if (alignmentMap.isEmpty()) {
             // Aligned (or nothing splittable): drop any latch entry so a future misalignment re-arms.
-            lastAttemptByTable.remove(table.getId());
+            alignmentLatch.forgetTable(table.getId());
             return alignedSoFar;
         }
 
@@ -713,8 +646,7 @@ public class ColocateChecker {
         // leader demotion at this point cannot leak external shards.
         TabletReshardJob job = SplitTabletJobFactory.forColocateAlignment(db, table, alignmentMap);
         GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().addTabletReshardJob(job);
-        lastAttemptByTable.put(table.getId(),
-                new TableAlignmentAttempt(signature, job.getJobId(), nextAbortRetries));
+        alignmentLatch.recordFired(table.getId(), signature, job.getJobId(), nextAbortRetries);
         LOG.info("submitted SplitTabletJob {} for table {}.{} covering {} partitions",
                 job.getJobId(), db.getFullName(), table.getName(), alignmentMap.size());
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
@@ -128,15 +128,20 @@ class TableAlignmentLatch {
         return lastAttemptByTable.containsKey(tableId);
     }
 
+    /** The tracked reshard job for {@code jobId}, or {@code null} if it is no longer tracked. */
+    private static TabletReshardJob trackedJob(long jobId) {
+        return GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+    }
+
     /** True iff the alignment job is still tracked and ended in {@code ABORTED}. */
-    static boolean isJobAborted(long jobId) {
-        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+    private static boolean isJobAborted(long jobId) {
+        TabletReshardJob job = trackedJob(jobId);
         return job != null && job.isAborted();
     }
 
     /** True iff the alignment job has reached a terminal state (or is no longer tracked). */
-    static boolean isJobSettled(long jobId) {
-        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+    private static boolean isJobSettled(long jobId) {
+        TabletReshardJob job = trackedJob(jobId);
         return job == null || job.isDone();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
@@ -1,0 +1,142 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Edge-triggered, per-table latch that stops {@link ColocateChecker}'s self-sustaining alignment-job
+ * storm. Split/merge is deterministic, so re-issuing identical alignment work on an unchanged table
+ * layout makes no progress — it just churns tablets. This latch remembers the last alignment attempt
+ * per table and suppresses that re-issue until the table's layout/data changes.
+ *
+ * <p>The latch is keyed per TABLE (not per colocate group) because alignment jobs are per-table:
+ * keying by group would let one table's attempt suppress a peer that had never been attempted, or miss
+ * a peer's abort. An entry is cleared when the table becomes aligned ({@link #forgetTable}), and the
+ * whole map is cleared when no group is unstable ({@link #clear}); it also naturally re-arms when the
+ * table's convergence signature changes, on a bounded number of aborts, or after an FE restart (the
+ * map is in-memory only).
+ *
+ * <p>This is a plain collaborator held by {@link ColocateChecker}, mirroring
+ * {@link ColocateConvergenceCache}; it owns no thread and is only touched from the checker's single
+ * scheduler tick, so it needs no synchronization.
+ */
+class TableAlignmentLatch {
+    // Cap on consecutive re-fires after an aborted alignment attempt on an unchanged layout, so a
+    // persistently-aborting job cannot become its own (slow) storm. Past the cap the table is treated
+    // like a deterministic dead-end and left unaligned until its layout/data changes.
+    static final int ALIGNMENT_ABORT_RETRY_CAP = 3;
+
+    private final Map<Long, TableAlignmentAttempt> lastAttemptByTable = new HashMap<>();
+
+    /**
+     * What the checker last did for one table: the {@link ColocateChecker#tableConvergenceSignature}
+     * observed when it fired, the alignment job id submitted, and how many times an aborted attempt has
+     * been re-fired on this same signature. {@code suppressionLogged} keeps the "no progress" warning to
+     * once per stuck state.
+     */
+    static final class TableAlignmentAttempt {
+        final long signature;
+        final long jobId;
+        final int abortRetries;
+        boolean suppressionLogged;
+
+        TableAlignmentAttempt(long signature, long jobId, int abortRetries) {
+            this.signature = signature;
+            this.jobId = jobId;
+            this.abortRetries = abortRetries;
+        }
+    }
+
+    /** Outcome of {@link #decideAlignment}: whether to fire this cycle and the abort counter to store. */
+    record AlignmentDecision(boolean fire, int nextAbortRetries) {
+    }
+
+    /**
+     * Pure decision function: should the checker (re)issue an alignment job for a table this cycle, and
+     * if it fires what abort-retry count should it record? Fire when this is the first attempt
+     * ({@code prev == null}) or the layout/data changed since the last attempt (real progress is
+     * possible); otherwise the last completed attempt made no progress on this exact input and — because
+     * split/merge is deterministic — a re-issue would too, so suppress. The sole exception is a previous
+     * attempt that ended in an abort (a transient failure, not a deterministic dead-end): re-fire, but
+     * only up to {@link #ALIGNMENT_ABORT_RETRY_CAP} times on an unchanged signature. {@code
+     * nextAbortRetries} is only meaningful when {@code fire} is true and a job is actually submitted.
+     */
+    static AlignmentDecision decideAlignment(TableAlignmentAttempt prev, long currentSignature,
+            boolean prevJobAborted) {
+        if (prev == null || prev.signature != currentSignature) {
+            return new AlignmentDecision(true, 0);
+        }
+        boolean fire = prevJobAborted && prev.abortRetries < ALIGNMENT_ABORT_RETRY_CAP;
+        return new AlignmentDecision(fire, prev.abortRetries + 1);
+    }
+
+    /**
+     * Whether to (re)issue an alignment job for {@code tableId} at {@code signature} this cycle. Wraps
+     * {@link #decideAlignment} with the per-table attempt lookup and the aborted-job probe.
+     */
+    AlignmentDecision evaluate(long tableId, long signature) {
+        TableAlignmentAttempt prev = lastAttemptByTable.get(tableId);
+        return decideAlignment(prev, signature, prev != null && isJobAborted(prev.jobId));
+    }
+
+    /**
+     * When a table is currently suppressed (a settled attempt made no progress on an unchanged layout),
+     * returns {@code true} exactly once per stuck state so the caller logs the "no progress" warning once.
+     */
+    boolean claimSuppressionLog(long tableId) {
+        TableAlignmentAttempt prev = lastAttemptByTable.get(tableId);
+        if (prev != null && !prev.suppressionLogged && isJobSettled(prev.jobId)) {
+            prev.suppressionLogged = true;
+            return true;
+        }
+        return false;
+    }
+
+    /** Records that an alignment job was fired for {@code tableId} so an unchanged next cycle latches. */
+    void recordFired(long tableId, long signature, long jobId, int nextAbortRetries) {
+        lastAttemptByTable.put(tableId, new TableAlignmentAttempt(signature, jobId, nextAbortRetries));
+    }
+
+    /** Drops the table's latch entry so a future misalignment re-arms (the table became aligned). */
+    void forgetTable(long tableId) {
+        lastAttemptByTable.remove(tableId);
+    }
+
+    /** Drops all latch state (no colocate group is unstable, so there is nothing to converge). */
+    void clear() {
+        lastAttemptByTable.clear();
+    }
+
+    /** Visible for testing: whether a table currently has a recorded alignment attempt (is latched). */
+    boolean hasRecordedAttempt(long tableId) {
+        return lastAttemptByTable.containsKey(tableId);
+    }
+
+    /** True iff the alignment job is still tracked and ended in {@code ABORTED}. */
+    static boolean isJobAborted(long jobId) {
+        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+        return job != null && job.isAborted();
+    }
+
+    /** True iff the alignment job has reached a terminal state (or is no longer tracked). */
+    static boolean isJobSettled(long jobId) {
+        TabletReshardJob job = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().getTabletReshardJob(jobId);
+        return job == null || job.isDone();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -183,19 +183,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     private Optional<Boolean> partitionKeyAscHint = Optional.empty();
 
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
-    // Sticky observation, set during bucketSeq fill (here and in PlanFragmentBuilder) whenever a
-    // range-colocate table's computeBucketSeq returns null and the fill falls back to position-based
-    // bucketSeq. getBucketNums() (the colocate-dispatch guard) fails closed on it, so the fill and the
-    // guard act on the SAME observation — closing the TOCTOU that let a position-based bucket
-    // assignment reach a colocate join and silently return wrong results. It is reset in
-    // clearScanNodeForThriftBuild() (alongside bucketSeq2locations / tabletId2BucketSeq) so it always
-    // travels with the assignment it describes. Deliberately NOT reset in prepareRetry(): a reuse-plan
-    // retry reuses this scan node's already-computed scan ranges (computeTabletInfo runs once, guarded
-    // by scanBackendIds.isEmpty(), and is not re-run on retry), so the flag stays consistent with the
-    // reused bucketSeq2locations — failing closed on a genuinely-unaligned reused assignment. Clearing
-    // only the flag here would decouple it from that stale assignment and could reintroduce the
-    // wrong-results window; a full re-plan retry builds a fresh node where the flag defaults false.
-    private boolean rangeColocateUnaligned = false;
     private List<Expr> bucketExprs = Lists.newArrayList();
     private List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
     // record the selected physical partition with the selected tablets belong to it
@@ -364,17 +351,14 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             // would silently produce wrong join results under colocate dispatch.
             // Non-colocate scans go through NormalBackendSelector and never reach this point.
             //
-            // Fail closed on the observation the bucketSeq fill actually recorded: if the fill saw the
-            // group unaligned and fell back to position-based bucketSeq, the assignment already built
-            // in bucketSeq2locations is not colocate-correct, so throw regardless of what a fresh
-            // computeBucketSeq would now say (this closes the fill-vs-guard TOCTOU). The requireAligned
-            // recompute below still guards the case where no fill ran before this call.
-            if (rangeColocateUnaligned) {
-                throw new IllegalStateException(
-                        "range colocate group is in an unaligned state; cannot dispatch colocate join "
-                                + "until alignment is restored");
-            }
-            dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId);
+            // requireAligned fails closed on two conditions: the group is currently unaligned, OR the
+            // bucketSeq this scan actually built (tabletId2BucketSeq) does not match the aligned mapping.
+            // The second check closes the fill-vs-dispatch TOCTOU: the bucketSeq fill falls back to a
+            // position-based assignment when the group is momentarily unaligned (so a non-colocate scan
+            // still works); if the group then re-aligns before this guard runs, comparing the built
+            // assignment against the aligned mapping catches the stale position pairing that would
+            // otherwise reach the colocate join and silently return wrong results.
+            dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId, tabletId2BucketSeq);
             return dispatch.bucketCount();
         }
         // Range distribution without a colocate group: RangeDistributionInfo always
@@ -922,22 +906,13 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 tabletId2BucketSeq.putAll(rangeColocateMap);
                 return;
             }
-            // Range-colocate but transiently unaligned: record it so getBucketNums() fails closed on
-            // the colocate-dispatch path instead of silently pairing by the position fallback below.
-            markRangeColocateUnaligned();
+            // Range-colocate but transiently unaligned: fall back to position-based bucketSeq so a
+            // non-colocate scan of this table still works. getBucketNums() fails closed on the
+            // colocate-dispatch path by validating this built assignment against the aligned mapping.
         }
         for (int i = 0; i < allTabletIds.size(); i++) {
             tabletId2BucketSeq.put(allTabletIds.get(i), i);
         }
-    }
-
-    /** Records that a range-colocate bucketSeq fill fell back to position-based bucketSeq (unaligned). */
-    public void markRangeColocateUnaligned() {
-        this.rangeColocateUnaligned = true;
-    }
-
-    public boolean isRangeColocateUnaligned() {
-        return rangeColocateUnaligned;
     }
 
     public void checkIfScanRangeNumSafe(long scanRangeSize) {
@@ -1847,7 +1822,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         selectedPartitionIds.clear();
         hintsReplicaIds.clear();
         tabletId2BucketSeq.clear();
-        rangeColocateUnaligned = false;
         bucketExprs.clear();
         bucketColumns.clear();
         rowStoreKeyLiterals = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -358,6 +358,10 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             // still works); if the group then re-aligns before this guard runs, comparing the built
             // assignment against the aligned mapping catches the stale position pairing that would
             // otherwise reach the colocate join and silently return wrong results.
+            //
+            // Invariant: the bucketSeq fill (getScanRangeLocations, optimizer or legacy path) always runs
+            // before backend selection reaches this guard, so tabletId2BucketSeq holds the whole scan's
+            // built assignment here — an empty map would itself be a not-built/stale state and fails closed.
             dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId, tabletId2BucketSeq);
             return dispatch.bucketCount();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -183,6 +183,19 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     private Optional<Boolean> partitionKeyAscHint = Optional.empty();
 
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
+    // Sticky observation, set during bucketSeq fill (here and in PlanFragmentBuilder) whenever a
+    // range-colocate table's computeBucketSeq returns null and the fill falls back to position-based
+    // bucketSeq. getBucketNums() (the colocate-dispatch guard) fails closed on it, so the fill and the
+    // guard act on the SAME observation — closing the TOCTOU that let a position-based bucket
+    // assignment reach a colocate join and silently return wrong results. It is reset in
+    // clearScanNodeForThriftBuild() (alongside bucketSeq2locations / tabletId2BucketSeq) so it always
+    // travels with the assignment it describes. Deliberately NOT reset in prepareRetry(): a reuse-plan
+    // retry reuses this scan node's already-computed scan ranges (computeTabletInfo runs once, guarded
+    // by scanBackendIds.isEmpty(), and is not re-run on retry), so the flag stays consistent with the
+    // reused bucketSeq2locations — failing closed on a genuinely-unaligned reused assignment. Clearing
+    // only the flag here would decouple it from that stale assignment and could reintroduce the
+    // wrong-results window; a full re-plan retry builds a fresh node where the flag defaults false.
+    private boolean rangeColocateUnaligned = false;
     private List<Expr> bucketExprs = Lists.newArrayList();
     private List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
     // record the selected physical partition with the selected tablets belong to it
@@ -350,6 +363,17 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             // alignment HERE, after the dispatch decision: a misaligned ColocateRangeMgr
             // would silently produce wrong join results under colocate dispatch.
             // Non-colocate scans go through NormalBackendSelector and never reach this point.
+            //
+            // Fail closed on the observation the bucketSeq fill actually recorded: if the fill saw the
+            // group unaligned and fell back to position-based bucketSeq, the assignment already built
+            // in bucketSeq2locations is not colocate-correct, so throw regardless of what a fresh
+            // computeBucketSeq would now say (this closes the fill-vs-guard TOCTOU). The requireAligned
+            // recompute below still guards the case where no fill ran before this call.
+            if (rangeColocateUnaligned) {
+                throw new IllegalStateException(
+                        "range colocate group is in an unaligned state; cannot dispatch colocate join "
+                                + "until alignment is restored");
+            }
             dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId);
             return dispatch.bucketCount();
         }
@@ -898,10 +922,22 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 tabletId2BucketSeq.putAll(rangeColocateMap);
                 return;
             }
+            // Range-colocate but transiently unaligned: record it so getBucketNums() fails closed on
+            // the colocate-dispatch path instead of silently pairing by the position fallback below.
+            markRangeColocateUnaligned();
         }
         for (int i = 0; i < allTabletIds.size(); i++) {
             tabletId2BucketSeq.put(allTabletIds.get(i), i);
         }
+    }
+
+    /** Records that a range-colocate bucketSeq fill fell back to position-based bucketSeq (unaligned). */
+    public void markRangeColocateUnaligned() {
+        this.rangeColocateUnaligned = true;
+    }
+
+    public boolean isRangeColocateUnaligned() {
+        return rangeColocateUnaligned;
     }
 
     public void checkIfScanRangeNumSafe(long scanRangeSize) {
@@ -1811,6 +1847,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         selectedPartitionIds.clear();
         hintsReplicaIds.clear();
         tabletId2BucketSeq.clear();
+        rangeColocateUnaligned = false;
         bucketExprs.clear();
         bucketColumns.clear();
         rowStoreKeyLiterals = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -118,21 +118,45 @@ public final class RangeColocateScanDispatch {
     }
 
     /**
-     * Verifies every {@link MaterializedIndex} actually scanned in the supplied
-     * physical partitions is aligned with the colocate group. Throws
-     * {@link IllegalStateException} on the first misaligned one.
+     * Fails closed unless every {@link MaterializedIndex} actually scanned in the supplied physical
+     * partitions is aligned with the colocate group AND {@code builtBucketSeq} — the bucket assignment
+     * the scan actually built — equals the current aligned mapping. Throws {@link IllegalStateException}
+     * on the first index that is unaligned, or whose built assignment does not match.
      *
-     * <p>Caller invariant: {@code physicalPartitions} must be the partitions
-     * that actually contributed scan tablets — sibling sub-partitions that
-     * were pruned out must not be passed in.
+     * <p>The equality check closes a fill→dispatch TOCTOU without any sticky per-scan state: the bucketSeq
+     * fill falls back to a position-based assignment when the group is momentarily unaligned (so a
+     * non-colocate scan of the table still works); if the group then re-aligns before this guard runs, an
+     * alignment check alone would pass while the built assignment is still the stale position mapping.
+     * Comparing the built assignment against the freshly-computed aligned mapping — which this method
+     * already computes to test alignment — catches exactly that case. A layout change that replaced the
+     * tablets (reshard) also fails the check: the aligned mapping keys on the new tablet ids, which the
+     * built (old) assignment does not contain.
+     *
+     * <p>Caller invariant: {@code physicalPartitions} must be the partitions that actually contributed
+     * scan tablets — sibling sub-partitions that were pruned out must not be passed in — and
+     * {@code builtBucketSeq} must be the assignment those scans built (tablet id → bucket sequence).
      */
-    public void requireAligned(Iterable<PhysicalPartition> physicalPartitions, long indexMetaId) {
+    public void requireAligned(Iterable<PhysicalPartition> physicalPartitions, long indexMetaId,
+                               Map<Long, Integer> builtBucketSeq) {
         for (PhysicalPartition physicalPartition : physicalPartitions) {
             MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(indexMetaId);
-            if (computeBucketSeq(selectedIndex) == null) {
+            Map<Long, Integer> aligned = computeBucketSeq(selectedIndex);
+            if (aligned == null) {
                 throw new IllegalStateException(String.format(
                         "range colocate group %d is in an unaligned state in physical partition %d; "
                                 + "cannot dispatch colocate join until alignment is restored",
+                        colocateGroupId, physicalPartition.getId()));
+            }
+            // Containment, not equality: builtBucketSeq is the whole-scan map and can legitimately hold
+            // more tablets than this partition's aligned mapping (e.g. fully-pruned sibling subpartitions
+            // the fill still populated), so require every aligned (tablet -> bucketSeq) entry to be present
+            // rather than the two maps being equal. A stale/position assignment fails a value comparison; a
+            // reshard that replaced tablets fails because the new tablet ids are absent from builtBucketSeq.
+            if (!builtBucketSeq.entrySet().containsAll(aligned.entrySet())) {
+                throw new IllegalStateException(String.format(
+                        "range colocate group %d has a stale bucket assignment in physical partition %d "
+                                + "(the scan's built bucketSeq does not match the aligned mapping); cannot "
+                                + "dispatch colocate join until the assignment is rebuilt",
                         colocateGroupId, physicalPartition.getId()));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -120,7 +120,7 @@ public final class RangeColocateScanDispatch {
     /**
      * Fails closed unless every {@link MaterializedIndex} actually scanned in the supplied physical
      * partitions is aligned with the colocate group AND {@code builtBucketSeq} — the bucket assignment
-     * the scan actually built — equals the current aligned mapping. Throws {@link IllegalStateException}
+     * the scan actually built — contains the current aligned mapping. Throws {@link IllegalStateException}
      * on the first index that is unaligned, or whose built assignment does not match.
      *
      * <p>The equality check closes a fill→dispatch TOCTOU without any sticky per-scan state: the bucketSeq

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -123,7 +123,7 @@ public final class RangeColocateScanDispatch {
      * the scan actually built — contains the current aligned mapping. Throws {@link IllegalStateException}
      * on the first index that is unaligned, or whose built assignment does not match.
      *
-     * <p>The equality check closes a fill→dispatch TOCTOU without any sticky per-scan state: the bucketSeq
+     * <p>The containment check closes a fill→dispatch TOCTOU without any sticky per-scan state: the bucketSeq
      * fill falls back to a position-based assignment when the group is momentarily unaligned (so a
      * non-colocate scan of the table still works); if the group then re-aligns before this guard runs, an
      * alignment check alone would pass while the built assignment is still the stale position mapping.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -175,11 +175,14 @@ public class ExecutionFragment {
 
     public ColocatedBackendSelector.Assignment getOrCreateColocatedAssignment(ScanNode scanNode)
             throws StarRocksException {
+        // Validate THIS scan node's bucketing on every call, not only when first creating the
+        // assignment. A range-colocate join has one scan node per table and alignment is per-table, so
+        // a transiently-unaligned peer table must also fail closed here (getBucketNums() throws) rather
+        // than silently pairing by a position-based bucketSeq. The first node's count sizes the
+        // assignment; later calls validate their own node and reuse it.
+        int bucketNum = scanNode.getBucketNums();
         if (colocatedAssignment == null) {
-            final int numScanNodes = scanNodes.size();
-
-            int bucketNum = scanNode.getBucketNums();
-            colocatedAssignment = new ColocatedBackendSelector.Assignment(bucketNum, numScanNodes,
+            colocatedAssignment = new ColocatedBackendSelector.Assignment(bucketNum, scanNodes.size(),
                     scanNode.getBucketProperties());
         }
         return colocatedAssignment;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1022,10 +1022,10 @@ public class PlanFragmentBuilder {
                             if (rangeColocateMap != null) {
                                 tabletId2BucketSeq.putAll(rangeColocateMap);
                             } else {
-                                // Range-colocate but transiently unaligned: record it so the later
-                                // getBucketNums() colocate-dispatch guard fails closed instead of
-                                // silently pairing by this position fallback (closes the TOCTOU).
-                                scanNode.markRangeColocateUnaligned();
+                                // Range-colocate but transiently unaligned: fall back to position-based
+                                // bucketSeq so a non-colocate scan still works. getBucketNums() fails closed
+                                // on the colocate-dispatch path by validating this built assignment against
+                                // the aligned mapping, so no unaligned observation needs to be recorded here.
                                 for (int i = 0; i < allTabletIds.size(); i++) {
                                     tabletId2BucketSeq.put(allTabletIds.get(i), i);
                                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1022,6 +1022,10 @@ public class PlanFragmentBuilder {
                             if (rangeColocateMap != null) {
                                 tabletId2BucketSeq.putAll(rangeColocateMap);
                             } else {
+                                // Range-colocate but transiently unaligned: record it so the later
+                                // getBucketNums() colocate-dispatch guard fails closed instead of
+                                // silently pairing by this position fallback (closes the TOCTOU).
+                                scanNode.markRangeColocateUnaligned();
                                 for (int i = 0; i < allTabletIds.size(); i++) {
                                     tabletId2BucketSeq.put(allTabletIds.get(i), i);
                                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -993,6 +993,12 @@ public class PlanFragmentBuilder {
                 // selected tablet ids      : tablet_2
                 // total tablets num        : 1
                 Set<Long> selectedNonEmptyPartitionIds = Sets.newLinkedHashSet();
+                // Accumulate the whole-scan bucketSeq across every sub-partition into one map (rather than a
+                // fresh per-sub-partition map that overwrites), so the dispatch-time alignment guard in
+                // OlapScanNode.getBucketNums() validates the complete assignment instead of only the last
+                // sub-partition's slice. This mirrors the legacy OlapScanNode.computeScanRangeLocations path.
+                Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
+                scanNode.setTabletId2BucketSeq(tabletId2BucketSeq);
                 for (Long partitionId : scanNode.getSelectedPartitionIds()) {
                     final Partition partition = referenceTable.getPartition(partitionId);
                     List<TKeyRange> partitionRange = List.of();
@@ -1007,7 +1013,6 @@ public class PlanFragmentBuilder {
                             continue;
                         }
                         selectedNonEmptyPartitionIds.add(partitionId);
-                        Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
                         final MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(selectedIndexMetaId);
                         totalTabletsNum += selectedIndex.getTablets().size();
@@ -1036,7 +1041,6 @@ public class PlanFragmentBuilder {
                                 tabletId2BucketSeq.put(allTabletIds.get(i), i);
                             }
                         }
-                        scanNode.setTabletId2BucketSeq(tabletId2BucketSeq);
                         List<Tablet> tablets =
                                 selectTabletIds.stream().map(selectedIndex::getTablet).collect(Collectors.toList());
                         scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, partitionRange,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -914,14 +914,14 @@ public class ColocateCheckerTest {
     @Test
     public void testDecideAlignmentFiresOnNewOrChangedSignature() {
         // No prior attempt -> fire, abort counter reset.
-        ColocateChecker.AlignmentDecision first = ColocateChecker.decideAlignment(null, 100L, false);
+        TableAlignmentLatch.AlignmentDecision first = TableAlignmentLatch.decideAlignment(null, 100L, false);
         Assertions.assertTrue(first.fire());
         Assertions.assertEquals(0, first.nextAbortRetries());
 
         // Signature changed (real progress / new data possible) -> fire, abort counter reset.
-        ColocateChecker.TableAlignmentAttempt prev =
-                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 2);
-        ColocateChecker.AlignmentDecision changed = ColocateChecker.decideAlignment(prev, 200L, false);
+        TableAlignmentLatch.TableAlignmentAttempt prev =
+                new TableAlignmentLatch.TableAlignmentAttempt(100L, 1L, 2);
+        TableAlignmentLatch.AlignmentDecision changed = TableAlignmentLatch.decideAlignment(prev, 200L, false);
         Assertions.assertTrue(changed.fire());
         Assertions.assertEquals(0, changed.nextAbortRetries());
     }
@@ -929,25 +929,25 @@ public class ColocateCheckerTest {
     @Test
     public void testDecideAlignmentSuppressesUnchangedNonAborted() {
         // Same signature, previous job finished (not aborted): deterministic no-progress -> suppress.
-        ColocateChecker.TableAlignmentAttempt prev =
-                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 0);
-        Assertions.assertFalse(ColocateChecker.decideAlignment(prev, 100L, false).fire());
+        TableAlignmentLatch.TableAlignmentAttempt prev =
+                new TableAlignmentLatch.TableAlignmentAttempt(100L, 1L, 0);
+        Assertions.assertFalse(TableAlignmentLatch.decideAlignment(prev, 100L, false).fire());
     }
 
     @Test
     public void testDecideAlignmentBoundedAbortRelease() {
         // Same signature but the previous attempt aborted (transient) and under the cap -> fire, and
         // the abort counter increments so a persistent abort cannot re-fire forever.
-        ColocateChecker.TableAlignmentAttempt prev =
-                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 0);
-        ColocateChecker.AlignmentDecision aborted = ColocateChecker.decideAlignment(prev, 100L, true);
+        TableAlignmentLatch.TableAlignmentAttempt prev =
+                new TableAlignmentLatch.TableAlignmentAttempt(100L, 1L, 0);
+        TableAlignmentLatch.AlignmentDecision aborted = TableAlignmentLatch.decideAlignment(prev, 100L, true);
         Assertions.assertTrue(aborted.fire());
         Assertions.assertEquals(1, aborted.nextAbortRetries());
 
         // Aborted but at the cap -> stop re-firing (bounded abort-release).
-        ColocateChecker.TableAlignmentAttempt capped = new ColocateChecker.TableAlignmentAttempt(
-                100L, 1L, ColocateChecker.ALIGNMENT_ABORT_RETRY_CAP);
-        Assertions.assertFalse(ColocateChecker.decideAlignment(capped, 100L, true).fire());
+        TableAlignmentLatch.TableAlignmentAttempt capped = new TableAlignmentLatch.TableAlignmentAttempt(
+                100L, 1L, TableAlignmentLatch.ALIGNMENT_ABORT_RETRY_CAP);
+        Assertions.assertFalse(TableAlignmentLatch.decideAlignment(capped, 100L, true).fire());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/ColocateCheckerTest.java
@@ -909,6 +909,110 @@ public class ColocateCheckerTest {
         }
     }
 
+    // ---- Alignment convergence latch (stops the alignment-job storm) ----
+
+    @Test
+    public void testDecideAlignmentFiresOnNewOrChangedSignature() {
+        // No prior attempt -> fire, abort counter reset.
+        ColocateChecker.AlignmentDecision first = ColocateChecker.decideAlignment(null, 100L, false);
+        Assertions.assertTrue(first.fire());
+        Assertions.assertEquals(0, first.nextAbortRetries());
+
+        // Signature changed (real progress / new data possible) -> fire, abort counter reset.
+        ColocateChecker.TableAlignmentAttempt prev =
+                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 2);
+        ColocateChecker.AlignmentDecision changed = ColocateChecker.decideAlignment(prev, 200L, false);
+        Assertions.assertTrue(changed.fire());
+        Assertions.assertEquals(0, changed.nextAbortRetries());
+    }
+
+    @Test
+    public void testDecideAlignmentSuppressesUnchangedNonAborted() {
+        // Same signature, previous job finished (not aborted): deterministic no-progress -> suppress.
+        ColocateChecker.TableAlignmentAttempt prev =
+                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 0);
+        Assertions.assertFalse(ColocateChecker.decideAlignment(prev, 100L, false).fire());
+    }
+
+    @Test
+    public void testDecideAlignmentBoundedAbortRelease() {
+        // Same signature but the previous attempt aborted (transient) and under the cap -> fire, and
+        // the abort counter increments so a persistent abort cannot re-fire forever.
+        ColocateChecker.TableAlignmentAttempt prev =
+                new ColocateChecker.TableAlignmentAttempt(100L, 1L, 0);
+        ColocateChecker.AlignmentDecision aborted = ColocateChecker.decideAlignment(prev, 100L, true);
+        Assertions.assertTrue(aborted.fire());
+        Assertions.assertEquals(1, aborted.nextAbortRetries());
+
+        // Aborted but at the cap -> stop re-firing (bounded abort-release).
+        ColocateChecker.TableAlignmentAttempt capped = new ColocateChecker.TableAlignmentAttempt(
+                100L, 1L, ColocateChecker.ALIGNMENT_ABORT_RETRY_CAP);
+        Assertions.assertFalse(ColocateChecker.decideAlignment(capped, 100L, true).fire());
+    }
+
+    @Test
+    public void testConvergenceSignatureDeterministicAndReArmsOnDataAndRangeChange() {
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        List<ColocateRange> expectedRanges = colocateTableIndex.getColocateRanges(groupId.grpId);
+        long expectedRangesSig = ColocateChecker.expectedRangesSignature(expectedRanges);
+
+        long sig1 = ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig);
+        long sig2 = ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig);
+        Assertions.assertEquals(sig1, sig2, "signature must be deterministic across calls on unchanged state");
+
+        PhysicalPartition pp = table.getPhysicalPartitions().iterator().next();
+        // A visibleVersion bump alone (as a reshard fallback publish does) must NOT re-arm the latch.
+        pp.setVisibleVersion(pp.getVisibleVersion() + 1, System.currentTimeMillis());
+        Assertions.assertEquals(sig1,
+                ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig),
+                "a visibleVersion bump (reshard fallback publish) must not change the signature");
+
+        // A dataVersion bump (as a real load does) MUST re-arm: more data can change the external-
+        // boundaries split's feasibility (segment envelope / rowset weights) without any range change.
+        pp.setDataVersion(pp.getDataVersion() + 1);
+        Assertions.assertNotEquals(sig1,
+                ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig),
+                "a dataVersion bump (real load) must change the signature");
+
+        // A tablet-range change (real reshard progress) MUST also re-arm.
+        long sigAfterLoad = ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig);
+        MaterializedIndex index = pp.getLatestMaterializedIndices(IndexExtState.VISIBLE).iterator().next();
+        Tablet tablet = index.getTablets().iterator().next();
+        TabletRange originalRange = tablet.getRange();
+        tablet.setRange(new TabletRange(Range.lt(
+                new Tuple(Arrays.asList(Variant.of(IntegerType.INT, "42"))))));
+        try {
+            Assertions.assertNotEquals(sigAfterLoad,
+                    ColocateChecker.tableConvergenceSignature(db, table, expectedRangesSig),
+                    "a tablet-range change (reshard progress) must change the signature");
+        } finally {
+            tablet.setRange(originalRange);
+        }
+    }
+
+    @Test
+    public void testTransientSubmitFailureDoesNotLatchTable() throws Exception {
+        // A misaligned table whose alignment job fails to submit (here: addTabletReshardJob throws, as
+        // an admission failure would) is a transient obstacle, not a deterministic dead-end. The table
+        // must NOT be latched, so a later cycle retries it once the transient clears — otherwise an
+        // unchanged signature would suppress the still-misaligned table forever.
+        spliceSecondColocateRangeAt100AndMarkUnstable();
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public void addTabletReshardJob(TabletReshardJob job) throws com.starrocks.common.StarRocksException {
+                throw new com.starrocks.common.StarRocksException("mocked admission failure");
+            }
+        };
+
+        ColocateChecker checker = new ColocateChecker();
+        checker.runOneCycle();
+
+        Assertions.assertFalse(checker.hasRecordedAttempt(table.getId()),
+                "a transient submit failure must not latch the table (must stay retryable)");
+        Assertions.assertTrue(GlobalStateMgr.getCurrentState().getColocateTableIndex().isGroupUnstable(groupId),
+                "group must remain unstable so a later cycle retries the alignment");
+    }
+
     // ---- Misplaced-PACK-group detection (pure, no cluster) ----
     //
     // These exercise the read-only detection logic that reassignShardGroups consumes. They build

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanDispatchTest.java
@@ -293,9 +293,13 @@ public class RangeColocateScanDispatchTest {
 
         RangeColocateScanDispatch dispatch =
                 Objects.requireNonNull(RangeColocateScanDispatch.forTable(table));
+        PhysicalPartition physicalPartition =
+                table.getPartitions().iterator().next().getDefaultPhysicalPartition();
+        // The built assignment matches the aligned mapping -> no throw.
+        Map<Long, Integer> builtBucketSeq =
+                dispatch.computeBucketSeq(physicalPartition.getLatestIndex(table.getBaseIndexMetaId()));
         Assertions.assertDoesNotThrow(() -> dispatch.requireAligned(
-                List.of(table.getPartitions().iterator().next().getDefaultPhysicalPartition()),
-                table.getBaseIndexMetaId()));
+                List.of(physicalPartition), table.getBaseIndexMetaId(), builtBucketSeq));
     }
 
     @Test
@@ -320,7 +324,7 @@ public class RangeColocateScanDispatchTest {
         IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
                 () -> dispatch.requireAligned(
                         List.of(table.getPartitions().iterator().next().getDefaultPhysicalPartition()),
-                        table.getBaseIndexMetaId()));
+                        table.getBaseIndexMetaId(), Map.of()));
         Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
                 "actual: " + exception.getMessage());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
@@ -209,4 +209,63 @@ public class RangeColocateScanRangeDispatchTest {
         Assertions.assertDoesNotThrow(() -> UtFrameUtils.getPlanAndFragment(connectContext,
                 "select v1 from t_avail"));
     }
+
+    @Test
+    public void testGetBucketNumsFailsClosedOnObservedUnalignedFlag() throws Exception {
+        // Even when the group is currently ALIGNED (a fresh recompute would return a bucket count),
+        // an observation that the bucketSeq fill fell back to position-based must make getBucketNums()
+        // fail closed. This closes the fill-vs-guard TOCTOU that let a position-based assignment reach
+        // a colocate join and silently return wrong results.
+        starRocksAssert.withTable(
+                "create table t_dispatch_flag (k1 int, k2 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_dispatch_flag:k1');");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_dispatch_flag");
+        OlapScanNode scanNode = newOlapScanNode(table, 11);
+        scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+
+        // Aligned single default range -> without the flag, getBucketNums returns 1.
+        Assertions.assertEquals(1, scanNode.getBucketNums());
+
+        scanNode.markRangeColocateUnaligned();
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                scanNode::getBucketNums);
+        Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
+                "actual: " + exception.getMessage());
+    }
+
+    @Test
+    public void testPlanFragmentBuilderRecordsUnalignedObservation() throws Exception {
+        // The optimizer/PlanFragmentBuilder bucketSeq fill must record the unaligned observation when
+        // computeBucketSeq returns null, so the later getBucketNums() colocate-dispatch guard fails
+        // closed rather than pairing by a position fallback.
+        starRocksAssert.withTable(
+                "create table t_pfb_unaligned (k1 int, k2 int, v1 int)\n"
+                        + "order by(k1, k2)\n"
+                        + "properties('replication_num' = '1', 'colocate_with' = 'rg_pfb_unaligned:k1');");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_pfb_unaligned");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        long grpId = colocateTableIndex.getGroup(table.getId()).grpId;
+        // 3 ColocateRanges but the single tablet still spans [MIN, MAX) -> computeBucketSeq == null.
+        // The group is left stable so PlanFragmentBuilder's colocate fill path (not shuffle) runs.
+        colocateTableIndex.getColocateRangeMgr().setColocateRanges(grpId, Arrays.asList(
+                new ColocateRange(Range.lt(makeTuple(100)), 9101L),
+                new ColocateRange(Range.gelt(makeTuple(100), makeTuple(200)), 9102L),
+                new ColocateRange(Range.ge(makeTuple(200)), 9103L)));
+
+        com.starrocks.sql.plan.ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext,
+                "select k1, k2 from t_pfb_unaligned").second;
+        OlapScanNode scan = null;
+        for (ScanNode scanNode : execPlan.getScanNodes()) {
+            if (scanNode instanceof OlapScanNode && scanNode.getTableName().contains("t_pfb_unaligned")) {
+                scan = (OlapScanNode) scanNode;
+            }
+        }
+        Assertions.assertNotNull(scan, "expected an OlapScanNode for t_pfb_unaligned");
+        Assertions.assertTrue(scan.isRangeColocateUnaligned(),
+                "PlanFragmentBuilder fill must record the unaligned observation");
+        Assertions.assertThrows(IllegalStateException.class, scan::getBucketNums);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
@@ -37,11 +37,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * End-to-end coordinator-side scan-range dispatch tests for range-distribution
- * colocate tables (P4). Exercises the observable behavior of
+ * colocate tables. Exercises the observable behavior of
  * {@link OlapScanNode#getBucketNums()} and the optimizer-built
  * {@link com.starrocks.sql.plan.PlanFragmentBuilder} path against real
  * shared-data tables.
@@ -93,6 +95,14 @@ public class RangeColocateScanRangeDispatchTest {
 
         OlapScanNode scanNode = newOlapScanNode(table, 1);
         scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+
+        // In production the bucketSeq fill runs before getBucketNums() (getScanRangeLocations precedes
+        // backend selection); mirror that here by populating the aligned assignment the fill would build.
+        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(table);
+        Assertions.assertNotNull(dispatch);
+        var physicalPartition = table.getPartitions().iterator().next().getDefaultPhysicalPartition();
+        scanNode.setTabletId2BucketSeq(new HashMap<>(
+                dispatch.computeBucketSeq(physicalPartition.getLatestIndex(table.getBaseIndexMetaId()))));
 
         // Initial state: ColocateRangeMgr seeded with [MIN, MAX) -> 1 PACK shard group,
         // and createRangeColocateLakeTablets created exactly 1 tablet per partition.
@@ -211,11 +221,11 @@ public class RangeColocateScanRangeDispatchTest {
     }
 
     @Test
-    public void testGetBucketNumsFailsClosedOnObservedUnalignedFlag() throws Exception {
-        // Even when the group is currently ALIGNED (a fresh recompute would return a bucket count),
-        // an observation that the bucketSeq fill fell back to position-based must make getBucketNums()
-        // fail closed. This closes the fill-vs-guard TOCTOU that let a position-based assignment reach
-        // a colocate join and silently return wrong results.
+    public void testGetBucketNumsFailsClosedOnStaleAssignment() throws Exception {
+        // Even when the group is currently ALIGNED (a fresh recompute returns a bucket count), a scan
+        // whose built bucketSeq does not match the aligned mapping must make getBucketNums() fail closed.
+        // This closes the fill-vs-dispatch TOCTOU that let a position-based assignment (built while the
+        // group was momentarily unaligned) reach a colocate join and silently return wrong results.
         starRocksAssert.withTable(
                 "create table t_dispatch_flag (k1 int, k2 int)\n"
                         + "order by(k1, k2)\n"
@@ -225,21 +235,32 @@ public class RangeColocateScanRangeDispatchTest {
         OlapScanNode scanNode = newOlapScanNode(table, 11);
         scanNode.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
 
-        // Aligned single default range -> without the flag, getBucketNums returns 1.
+        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(table);
+        Assertions.assertNotNull(dispatch);
+        var physicalPartition = table.getPartitions().iterator().next().getDefaultPhysicalPartition();
+        Map<Long, Integer> aligned =
+                dispatch.computeBucketSeq(physicalPartition.getLatestIndex(table.getBaseIndexMetaId()));
+        Assertions.assertNotNull(aligned, "single default range should be aligned");
+
+        // Built assignment matches the aligned mapping -> getBucketNums returns the bucket count.
+        scanNode.setTabletId2BucketSeq(new HashMap<>(aligned));
         Assertions.assertEquals(1, scanNode.getBucketNums());
 
-        scanNode.markRangeColocateUnaligned();
+        // Stale assignment (bucketSeq perturbed, e.g. a position fallback) -> fail closed.
+        Map<Long, Integer> stale = new HashMap<>();
+        aligned.forEach((tabletId, seq) -> stale.put(tabletId, seq + 1));
+        scanNode.setTabletId2BucketSeq(stale);
         IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
                 scanNode::getBucketNums);
-        Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
+        Assertions.assertTrue(exception.getMessage().contains("stale bucket assignment"),
                 "actual: " + exception.getMessage());
     }
 
     @Test
-    public void testPlanFragmentBuilderRecordsUnalignedObservation() throws Exception {
-        // The optimizer/PlanFragmentBuilder bucketSeq fill must record the unaligned observation when
-        // computeBucketSeq returns null, so the later getBucketNums() colocate-dispatch guard fails
-        // closed rather than pairing by a position fallback.
+    public void testPlanFragmentBuilderUnalignedScanFailsClosed() throws Exception {
+        // When computeBucketSeq returns null, the optimizer/PlanFragmentBuilder bucketSeq fill falls back
+        // to position-based bucketSeq (so a non-colocate scan still works); the later getBucketNums()
+        // colocate-dispatch guard must fail closed rather than pairing by that position fallback.
         starRocksAssert.withTable(
                 "create table t_pfb_unaligned (k1 int, k2 int, v1 int)\n"
                         + "order by(k1, k2)\n"
@@ -264,8 +285,12 @@ public class RangeColocateScanRangeDispatchTest {
             }
         }
         Assertions.assertNotNull(scan, "expected an OlapScanNode for t_pfb_unaligned");
-        Assertions.assertTrue(scan.isRangeColocateUnaligned(),
-                "PlanFragmentBuilder fill must record the unaligned observation");
-        Assertions.assertThrows(IllegalStateException.class, scan::getBucketNums);
+        scan.setSelectedPartitionIds(new ArrayList<>(table.getAllPartitionIds()));
+        // The single tablet spans all 3 ColocateRanges, so the group is unaligned: getBucketNums() on
+        // the colocate-dispatch path must fail closed rather than pairing by the position fallback.
+        IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                scan::getBucketNums);
+        Assertions.assertTrue(exception.getMessage().contains("unaligned state"),
+                "actual: " + exception.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
@@ -246,6 +246,14 @@ public class RangeColocateScanRangeDispatchTest {
         scanNode.setTabletId2BucketSeq(new HashMap<>(aligned));
         Assertions.assertEquals(1, scanNode.getBucketNums());
 
+        // Superset assignment: the whole-scan bucketSeq map legitimately holds more tablets than this
+        // partition's aligned mapping (e.g. other scanned sub-partitions). The guard checks containment,
+        // not equality, so this still passes -- this is what makes the whole-scan accumulation safe.
+        Map<Long, Integer> superset = new HashMap<>(aligned);
+        superset.put(-999L, 0);
+        scanNode.setTabletId2BucketSeq(superset);
+        Assertions.assertEquals(1, scanNode.getBucketNums());
+
         // Stale assignment (bucketSeq perturbed, e.g. a position fallback) -> fail closed.
         Map<Long, Integer> stale = new HashMap<>();
         aligned.forEach((tabletId, seq) -> stale.put(tabletId, seq + 1));


### PR DESCRIPTION
## Why I'm doing:

On shared-data range-distribution tables that participate in a colocate group, two related defects were observed (CelerData 4.1.2; reproduced on `main`):

- **Alignment job storm (self-sustaining):** a manual small-target `ALTER TABLE ... SPLIT TABLET` drives `ColocateChecker` into a self-sustaining alignment `SplitTabletJob` storm — peak >1000 jobs/min, tablet IDs physically rebuilt every ~5s, the group never converges, and 0.7–20% of concurrent queries fail transiently with `Invalid tablet id`. The checker re-derives alignment work from the live tablet layout on every scheduler tick with **no progress check**; when an alignment split completes without achieving alignment (the deterministic BE identical-tablet fallback — same range, new tablet id), it re-issues the identical job forever, burning FE journal and StarOS shard churn.
- **Silent wrong results (narrower, higher severity):** during a transiently-unaligned window, a range-colocate join fell back to **position-based** `bucketSeq` (a HASH-colocate assumption that is invalid for range distribution), pairing the two sides by tablet position instead of by colocate range — returning wrong join results with no error.

## What I'm doing:

**Stop the storm — a per-table convergence latch in `ColocateChecker`.** Split/merge is deterministic, so re-issuing the identical alignment work on an unchanged layout can never converge — it only churns tablets. The checker now records a compact 64-bit signature of each table's alignment inputs (expected colocate ranges + the table's tablet ranges + each partition's `dataVersion`, deliberately excluding tablet ids, which churn on every fallback) when it fires an alignment job, and suppresses re-issuing while that signature is unchanged. The latch is **per table** (alignment jobs are per table), so one table's dead-end never suppresses a peer. It re-arms when the layout or data actually changes (reshard progress, a load, a peer's split) or after a bounded number of retries following a transient abort. A latched table simply stays unstable, so the colocate join falls back to a correct shuffle plan. `dataVersion` (not `visibleVersion`) is used because BE's external-boundaries split can decline for data-distribution reasons (empty/degenerate segment envelope, per-rowset weight straddle), so a load can make a previously-unsplittable tablet splittable without any range change — while a reshard fallback publish bumps only `visibleVersion`, so it never re-arms the latch.

**Fail-close the colocate-join dispatch.** A range-colocate table whose `computeBucketSeq` returns null (transiently unaligned) now records that observation in both bucketSeq fill paths (`OlapScanNode.fillTabletId2BucketSeq` and `PlanFragmentBuilder`) and `getBucketNums()` throws instead of silently position-pairing. `ExecutionFragment.getOrCreateColocatedAssignment` now validates **every** participating scan node, not just the first, so a transiently-unaligned peer table in a colocate join also fails closed rather than returning wrong results.

Note on behavior classification: this converts a rare **silent-wrong-result** window into a clean, retryable error (and, in steady state, an unstable group is planned as a shuffle join — the optimizer already gates colocate selection on group stability). It is a bug fix correcting wrong results / internal churn; it adds no SQL syntax, config, or external API, so it is classified as no behavior change.

Scope (FE only): `ColocateChecker.java`, `OlapScanNode.java`, `ExecutionFragment.java`, `PlanFragmentBuilder.java`, plus unit tests.

Tested (FE unit tests, on the branch rebased onto current `main`): `ColocateCheckerTest` 32, `RangeColocateScanDispatchTest` 10, `RangeColocateScanRangeDispatchTest` 7, `RangeColocateMixedJoinPlanTest` 13, `ColocatedBackendSelectorTest` 6, `BucketAwareBackendSelectorTest` 5, `TabletReshardJobMgrTest` 10, `SplitTabletJobColocateTest` 13 — all pass; 0 checkstyle violations.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5