### PR TITLE
[Enhancement] Enable CHAR sort-key tablet pre-split (meta tier + range-router type fix)

### DIFF
--- a/be/src/exec/data_sinks/range_router.cpp
+++ b/be/src/exec/data_sinks/range_router.cpp
@@ -24,6 +24,7 @@
 #include "fmt/format.h"
 #include "runtime/descriptors.h"
 #include "storage/types.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -55,7 +56,12 @@ Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, const s
                 continue;
             }
             TypeDescriptor boundary_type = TypeDescriptor::from_thrift(boundary->type);
-            if (boundary_type.type != key_types[i].type) {
+            // CHAR and VARCHAR share one string domain: StarRocks normalizes CHAR to VARCHAR in
+            // expression typing, so a CHAR sort key surfaces here as a VARCHAR routing key while the
+            // tablet-range boundary keeps its declared CHAR type. Their routing comparison is the same
+            // raw-byte memcmp for either type, so accept a CHAR/VARCHAR pairing instead of rejecting it.
+            if (boundary_type.type != key_types[i].type &&
+                !(is_string_type(boundary_type.type) && is_string_type(key_types[i].type))) {
                 return Status::InternalError(fmt::format(
                         "routing key type mismatch at column {}: key type {} incompatible with boundary type {}", i,
                         key_types[i].debug_string(), boundary_type.debug_string()));

--- a/be/test/exec/data_sinks/range_router_test.cpp
+++ b/be/test/exec/data_sinks/range_router_test.cpp
@@ -61,6 +61,15 @@ protected:
         return tv;
     }
 
+    // A CHAR-typed boundary, as the FE emits it for a CHAR sort key (the routing key is VARCHAR
+    // because SlotRef normalizes CHAR to VARCHAR, so init() must accept this CHAR/VARCHAR pairing).
+    TVariant make_char_variant(const std::string& v) {
+        TVariant tv;
+        tv.__set_type(TYPE_CHAR_DESC.to_thrift());
+        tv.__set_value(v);
+        return tv;
+    }
+
     TVariant make_datetime_variant(const std::string& v) {
         TVariant tv;
         tv.__set_type(TYPE_DATETIME_DESC.to_thrift());
@@ -531,6 +540,49 @@ TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
     for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
         ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";
     }
+}
+
+// A CHAR sort-key emits CHAR-typed tablet-range boundaries, but its routing key is VARCHAR (SlotRef
+// normalizes CHAR -> VARCHAR). init() must accept that CHAR/VARCHAR pairing (before the fix it
+// failed with "routing key type mismatch"), and routing must place rows the same as VARCHAR.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, CharBoundaryVarcharKeyRoutingMatches) {
+    std::vector<TTabletRange> ranges;
+    {
+        TTabletRange r0; // (-inf, "m")
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{make_char_variant("m")});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+        ranges.emplace_back(r0);
+    }
+    {
+        TTabletRange r1; // ["m", +inf)
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{make_char_variant("m")});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+        ranges.emplace_back(r1);
+    }
+
+    std::vector<int64_t> tablet_ids{10, 20};
+
+    RangeRouter router;
+    // CHAR boundary vs VARCHAR routing key must be accepted.
+    ASSERT_TRUE(router.init(ranges, varchar_types(1)).ok());
+
+    std::vector<std::string> values = {"apple", "m", "zebra"};
+    Chunk chunk = make_varchar_chunk("s1", values);
+    SlotDescriptor slot_desc(0, "s1", TypeDescriptor::from_logical_type(TYPE_VARCHAR));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+    std::vector<uint16_t> row_indices{0, 1, 2};
+    std::vector<int64_t> routed_ids;
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    // "apple" -> R0 (10); "m" (== inclusive lower bound) and "zebra" -> R1 (20).
+    std::vector<int64_t> expected = {10, 20, 20};
+    ASSERT_EQ(expected, routed_ids);
 }
 
 // NULL_TYPE boundary values should be treated as NULL and route with NULL as minimum.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -66,11 +66,15 @@ import java.util.Objects;
  *       a pre-1970 sub-second — and packs the calendar date through the same proleptic conversion as
  *       the boundary parse). TIMESTAMP_INSTANT is deferred (the load applies a session-tz offset this
  *       reader cannot reproduce).</li>
- *   <li>ORC STRING/VARCHAR -> StarRocks VARCHAR, using the stripe min/max when ORC
+ *   <li>ORC STRING/VARCHAR -> StarRocks VARCHAR or CHAR, using the stripe min/max when ORC
  *       kept them exact (getMinimum()/getMaximum() non-null); a truncated bound (value
  *       > 1024 bytes -> getMinimum()/getMaximum() null) marks the stripe truncated -> data
- *       tier. StarRocks CHAR (the BE pads/truncates it to a fixed width before routing) and the
- *       ORC CHAR source category (space-padded) are both deferred -> data tier.</li>
+ *       tier. CHAR is safe even though the BE right-pads a CHAR routing key with '\0' to its
+ *       fixed width before routing: '\0'-padding to fixed width is order-preserving under the BE
+ *       unsigned memcmp + shorter-prefix tiebreak, and the boundary is stored stripped, so a
+ *       NUL-free CHAR boundary separates rows exactly as VARCHAR does; a CHAR min/max containing
+ *       a '\0' is rejected -> data tier (the BE truncates a CHAR boundary at the first NUL). The
+ *       ORC CHAR source category (space-padded in its own stats) stays deferred -> data tier.</li>
  * </ul>
  * Everything else -- BOOLEAN, FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this
  * reader cannot reproduce), non-matching-precision/scale DECIMAL, ORC CHAR, and any complex type --
@@ -161,8 +165,9 @@ public final class OrcStripeStatisticsReader {
      * back to data tier", not "fail the load". The supported window is the unannotated
      * integer categories, ORC DATE -> StarRocks DATE, ORC DECIMAL -> a same-precision/scale
      * StarRocks DECIMAL, ORC TIMESTAMP -> StarRocks DATETIME, and ORC STRING/VARCHAR ->
-     * StarRocks VARCHAR. Boolean, floating-point, TIMESTAMP_INSTANT, non-matching DECIMAL,
-     * a CHAR target, and complex types are deferred (fall back to data tier).
+     * StarRocks VARCHAR or CHAR. Boolean, floating-point, TIMESTAMP_INSTANT, non-matching DECIMAL,
+     * the ORC CHAR source category (space-padded in its own stats), and complex types are
+     * deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
             TypeDescription fieldType, Column sortKeyColumn) throws MetaTierUnavailableException {
@@ -178,12 +183,15 @@ public final class OrcStripeStatisticsReader {
             // Plain ORC TIMESTAMP is local (no timezone); the BE load stores its UTC wall clock
             // verbatim (no session-tz offset, unlike TIMESTAMP_INSTANT) → StarRocks DATETIME.
             case TIMESTAMP -> starRocksPrimitive == PrimitiveType.DATETIME;
-            // ORC STRING/VARCHAR categories are unpadded; their stripe min/max are
-            // unsigned-byte-ordered (Text/WritableComparator), matching BE VARCHAR routing.
-            // Target CHAR is excluded (the BE pads/truncates CHAR to its fixed width before
-            // routing, so raw stripe stats would not match the routed key), as is the ORC CHAR
-            // source category (space-padded) -> data tier.
-            case STRING, VARCHAR -> starRocksPrimitive == PrimitiveType.VARCHAR;
+            // ORC STRING/VARCHAR source categories are unpadded; their stripe min/max are
+            // unsigned-byte-ordered (Text/WritableComparator), matching BE routing. A CHAR target
+            // is safe too: the BE right-pads a CHAR routing key with '\0' to its fixed width before
+            // routing, but '\0'-padding to fixed width is order-preserving under the BE unsigned
+            // memcmp + shorter-prefix tiebreak, and a CHAR StringVariant is canonicalized (truncated
+            // at the first '\0') to match the BE's strnlen view of a CHAR value -- so a CHAR boundary
+            // separates rows exactly as a VARCHAR one does. The ORC CHAR *source category* stays
+            // excluded (falls through to default -> false): ORC space-pads CHAR in its own stats.
+            case STRING, VARCHAR -> starRocksPrimitive.isCharFamily();
             default -> false;
         };
         if (!compatible) {
@@ -329,6 +337,7 @@ public final class OrcStripeStatisticsReader {
         if (min == null || max == null) {
             return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ true);
         }
+        // A CHAR value is NUL-canonicalized in the StringVariant constructor; VARCHAR keeps raw bytes.
         Variant minVariant;
         Variant maxVariant;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -72,11 +72,15 @@ import java.util.Objects;
  *   <li>Parquet INT64 with TIMESTAMP annotation, {@code isAdjustedToUTC=false}
  *       (MILLIS/MICROS/NANOS) → StarRocks DATETIME. UTC-adjusted timestamps are
  *       deferred (the load applies a session-tz offset this reader cannot reproduce).</li>
- *   <li>Parquet BINARY with UTF8 (string) annotation -> StarRocks VARCHAR
+ *   <li>Parquet BINARY with UTF8 (string) annotation -> StarRocks VARCHAR or CHAR
  *       (footer min/max are decoded as UTF-8 and used directly; FE compares them in the
- *       same unsigned-byte order the BE uses to route rows). CHAR is deferred -> data tier:
- *       the BE pads/truncates a CHAR value to its fixed width before routing, so raw footer
- *       stats would not match the routed key.</li>
+ *       same unsigned-byte order the BE uses to route rows). CHAR is safe even though the BE
+ *       right-pads a CHAR routing key with '\0' to its fixed width before routing: '\0' is the
+ *       minimum byte, so fixed-width '\0'-padding is order-preserving under the BE unsigned
+ *       memcmp + shorter-prefix-is-smaller tiebreak, and the BE stores the boundary itself
+ *       stripped, so a NUL-free CHAR boundary separates rows exactly as VARCHAR does. A CHAR
+ *       min/max that contains a '\0' is the one exception (the BE truncates a CHAR boundary at
+ *       the first NUL while FE compares raw bytes) and is rejected -> data tier.</li>
  *   <li>Parquet INT32/INT64 with DECIMAL annotation → StarRocks DECIMAL of the SAME
  *       precision and scale (the unscaled integer's signed order equals the decimal order).</li>
  *   <li>Parquet FIXED_LEN_BYTE_ARRAY/BINARY with DECIMAL annotation → StarRocks DECIMAL of the
@@ -241,11 +245,13 @@ public final class ParquetRowGroupStatisticsReader {
             case BOOLEAN -> logicalAnnotation == null && starRocksPrimitive == PrimitiveType.BOOLEAN;
             case BINARY -> {
                 if (logicalAnnotation instanceof StringLogicalTypeAnnotation) {
-                    // VARCHAR only. A CHAR(N) load pads/truncates every value to the fixed width
-                    // before the BE routes the row (pad_char_values, be/src/exec/data_sinks/tablet_sink.cpp),
-                    // so the raw footer min/max would not match the routed key and could yield a
-                    // skewed split. CHAR falls back to the data tier, which samples the post-cast rows.
-                    yield starRocksPrimitive == PrimitiveType.VARCHAR;
+                    // VARCHAR and CHAR. The BE right-pads a CHAR routing key with '\0' to its fixed
+                    // width before routing (_padding_char_column, be/src/exec/data_sinks/tablet_sink.cpp),
+                    // but '\0' is the minimum byte, so fixed-width '\0'-padding is order-preserving under
+                    // the BE unsigned memcmp + shorter-prefix tiebreak, and a CHAR StringVariant is
+                    // canonicalized (truncated at the first '\0') to match the BE's strnlen view of a
+                    // CHAR value, so a CHAR boundary separates rows exactly as a VARCHAR one does.
+                    yield starRocksPrimitive.isCharFamily();
                 }
                 yield isSignedByteArrayDecimal(logicalAnnotation, sortKeyColumn, typeDefinedColumnOrder);
             }
@@ -350,6 +356,7 @@ public final class ParquetRowGroupStatisticsReader {
         String rendered = location.parquetTypeName == PrimitiveTypeName.BINARY
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
+        // A CHAR value is NUL-canonicalized in the StringVariant constructor; VARCHAR keeps raw bytes.
         return Variant.of(location.starRocksColumn.getType(), rendered);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.StringUtils;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
 
 /*
@@ -28,6 +29,17 @@ public class StringVariant extends Variant {
 
     public StringVariant(Type type, String value) {
         super(type);
+        // CHAR is defined only up to its first NUL in StarRocks: the BE strnlen-truncates a CHAR
+        // value on every storage read and when parsing a routing boundary (datum_from_string), so
+        // the bytes at/after the first '\0' are not part of the value. Canonicalize a CHAR variant
+        // the same way, so FE ordering and pre-split boundaries match what the BE stores and routes.
+        // VARCHAR/BINARY keep their raw bytes (the BE does not strnlen them).
+        if (value != null && type != null && type.getPrimitiveType() == PrimitiveType.CHAR) {
+            int nul = value.indexOf('\0');
+            if (nul >= 0) {
+                value = value.substring(0, nul);
+            }
+        }
         this.value = value;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -165,11 +165,44 @@ class OrcStripeStatisticsReaderTest {
     }
 
     @Test
-    void charSortKeyFallsBackToDataTier() throws Exception {
-        // A CHAR(N) sort key is padded/truncated to its fixed width by the BE before routing,
-        // so the raw stripe min/max cannot be trusted for a meta-tier split -- reject eagerly.
+    void readsCharTargetStatistics() throws Exception {
+        // A CHAR(N) sort key is meta-tier-eligible: the BE right-pads a CHAR routing key with '\0'
+        // to its fixed width before routing, but '\0'-padding is order-preserving under the BE
+        // unsigned memcmp + shorter-prefix tiebreak and the boundary is stored stripped, so a
+        // NUL-free CHAR boundary separates rows exactly as a VARCHAR one. Same ORC STRING source
+        // and stats as readsStringStatistics, just with a CHAR(16) target column.
         Path orcPath = writeOrc(
                 "struct<tenant:string>",
+                /*rowCount=*/ 8,
+                (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
+                        .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
+
+        List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("tenant", TypeFactory.createCharType(16)));
+
+        Assertions.assertFalse(stripeStatistics.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics stripe : stripeStatistics) {
+            Assertions.assertFalse(stripe.isTruncated());
+            String minValue = stripe.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = stripe.getMaxTuple().getValues().get(0).getStringValue();
+            Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("tenant-00", globalMin);
+        Assertions.assertEquals("tenant-07", globalMax);
+    }
+
+    @Test
+    void orcCharSourceCategoryFallsBackToDataTier() throws Exception {
+        // The ORC CHAR *source category* stays deferred even though the CHAR *target* is now
+        // accepted: ORC space-pads a CHAR column in its own stripe stats, a separate concern. A
+        // VARCHAR target isolates that this rejection is about the ORC source category, not the target.
+        Path orcPath = writeOrc(
+                "struct<tenant:char(16)>",
                 /*rowCount=*/ 4,
                 (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
                         .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
@@ -177,7 +210,38 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("tenant", TypeFactory.createCharType(16))));
+                        new Column("tenant", VarcharType.VARCHAR)));
+    }
+
+    @Test
+    void charSortKeyWithNulCanonicalizedToPrefix() throws Exception {
+        // A CHAR value is defined only up to its first '\0' (the BE strnlen-truncates it), so a CHAR
+        // StringVariant canonicalizes a boundary to the prefix; VARCHAR keeps the raw bytes.
+        // The NUL byte is built numerically (byte[]{...,0,...}) to keep the source ASCII-clean.
+        Path orcPath = writeOrc(
+                "struct<tenant:string>",
+                /*rowCount=*/ 4,
+                (batch, batchRow, rowIndex) -> ((BytesColumnVector) batch.cols[0])
+                        .setVal(batchRow, new byte[] {'a', 0, 'z', '-', (byte) ('0' + rowIndex)}));
+
+        // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
+        List<RowGroupStatistics> charStats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("tenant", TypeFactory.createCharType(16)));
+        Assertions.assertFalse(charStats.isEmpty());
+        for (RowGroupStatistics stripe : charStats) {
+            Assertions.assertEquals("a", stripe.getMinTuple().getValues().get(0).getStringValue());
+            Assertions.assertEquals("a", stripe.getMaxTuple().getValues().get(0).getStringValue());
+        }
+
+        // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
+        List<RowGroupStatistics> varcharStats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("tenant", VarcharType.VARCHAR));
+        Assertions.assertFalse(varcharStats.isEmpty());
+        for (RowGroupStatistics stripe : varcharStats) {
+            Assertions.assertTrue(stripe.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -108,18 +108,63 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
-    void charSortKeyFallsBackToDataTier() throws Exception {
-        // A CHAR(N) sort key is padded/truncated to its fixed width by the BE before routing,
-        // so the raw UTF8 footer min/max cannot be trusted for a meta-tier split -- reject eagerly.
+    void readsCharStatistics() throws Exception {
+        // A CHAR(N) sort key is meta-tier-eligible: the BE right-pads a CHAR routing key with '\0'
+        // to its fixed width before routing, but '\0'-padding is order-preserving under the BE
+        // unsigned memcmp + shorter-prefix tiebreak and the boundary is stored stripped, so a
+        // NUL-free CHAR boundary separates rows exactly as VARCHAR does. Same footer min/max as
+        // readsVarcharStatistics, just with a CHAR(16) target column.
+        Path parquetPath = writeParquet(
+                "message schema { required binary tenant (UTF8); }",
+                /*rowCount=*/ 16,
+                (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
+
+        List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("tenant", TypeFactory.createCharType(16)));
+
+        Assertions.assertFalse(rowGroupStatistics.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics rowGroup : rowGroupStatistics) {
+            Assertions.assertFalse(rowGroup.isTruncated());
+            String minValue = rowGroup.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = rowGroup.getMaxTuple().getValues().get(0).getStringValue();
+            Assertions.assertTrue(minValue.compareTo(maxValue) <= 0);
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("tenant-00", globalMin);
+        Assertions.assertEquals("tenant-15", globalMax);
+    }
+
+    @Test
+    void charSortKeyWithNulCanonicalizedToPrefix() throws Exception {
+        // A CHAR value is defined only up to its first '\0' (the BE strnlen-truncates it), so a CHAR
+        // StringVariant canonicalizes a boundary to the prefix; VARCHAR keeps the raw bytes.
         Path parquetPath = writeParquet(
                 "message schema { required binary tenant (UTF8); }",
                 /*rowCount=*/ 4,
-                (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
+                (group, rowIndex) -> group.append("tenant", "a\u0000z-" + rowIndex));
 
-        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
-                ParquetRowGroupStatisticsReader.read(
-                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("tenant", TypeFactory.createCharType(16))));
+        // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
+        List<RowGroupStatistics> charStats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("tenant", TypeFactory.createCharType(16)));
+        Assertions.assertFalse(charStats.isEmpty());
+        for (RowGroupStatistics rowGroup : charStats) {
+            Assertions.assertEquals("a", rowGroup.getMinTuple().getValues().get(0).getStringValue());
+            Assertions.assertEquals("a", rowGroup.getMaxTuple().getValues().get(0).getStringValue());
+        }
+
+        // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
+        List<RowGroupStatistics> varcharStats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("tenant", VarcharType.VARCHAR));
+        Assertions.assertFalse(varcharStats.isEmpty());
+        for (RowGroupStatistics rowGroup : varcharStats) {
+            Assertions.assertTrue(rowGroup.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -340,6 +341,25 @@ public class VariantTest {
         Assertions.assertEquals(TypeSerializer.toThrift(VarcharType.VARCHAR), tStr.getType());
         Assertions.assertTrue(tStr.isSetValue());
         Assertions.assertEquals("hello", tStr.getValue());
+    }
+
+    @Test
+    public void testCharVariantTruncatesAtFirstNul() {
+        // A CHAR value is canonicalized to its prefix before the first '\0', matching the BE's
+        // strnlen view of a CHAR value everywhere (storage read + routing-boundary parse). VARCHAR
+        // keeps the raw bytes. The NUL byte is built numerically to keep the source ASCII-clean.
+        String nulValue = new String(new byte[] {'a', 0, 'z'}, StandardCharsets.UTF_8);
+
+        Variant charVariant = Variant.of(TypeFactory.createCharType(16), nulValue);
+        Assertions.assertEquals("a", charVariant.getStringValue());
+        // The truncation flows into serialization too (the BE receives "a", not "a\0z").
+        Assertions.assertEquals("a", charVariant.toThrift().getValue());
+
+        // VARCHAR keeps the raw NUL-bearing value (the BE does not strnlen a VARCHAR value).
+        Assertions.assertEquals(nulValue, Variant.of(VarcharType.VARCHAR, nulValue).getStringValue());
+
+        // A NUL-free CHAR value is unchanged.
+        Assertions.assertEquals("abc", Variant.of(TypeFactory.createCharType(16), "abc").getStringValue());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A range-distribution table with a `CHAR(N)` sort key could not be tablet pre-split at all. The FE
builds a tablet-range boundary from the column's declared `CHAR` type, but the BE range router types
a `CHAR` routing key as `VARCHAR` (`SlotRef` normalizes CHAR to VARCHAR in expression typing), so
`RangeRouter::init` rejected the pair ("routing key type mismatch: key type VARCHAR incompatible with
boundary type CHAR") and the load failed, leaving the table unloadable — on **both** tiers. This PR
fixes the routing-key type check and enables the `CHAR` sort-key target for the meta tier.

## What I'm doing:

**BE (root fix)** — `RangeRouter::init` (`be/src/exec/data_sinks/range_router.cpp`) treats a `CHAR`
boundary vs a `VARCHAR` routing key as compatible (both `is_string_type`; the routing comparison is a
raw-byte `memcmp` identical for either). Any other type mismatch is still rejected. The BE tablet
splitter validates the proto boundary against the tablet's `CHAR` column schema and is unchanged.
Adds a `RangeRouter` unit test.

**FE (enablement)** — both footer readers admit a `CHAR` target on the string arm
(`== PrimitiveType.VARCHAR` -> `starRocksPrimitive.isCharFamily()`). CHAR is safe for a meta-tier
boundary: the BE right-pads a CHAR routing key with `'\0'` to its fixed width before routing, but
`'\0'`-padding is order-preserving under the BE unsigned `memcmp` + length tiebreak, so a CHAR
boundary separates rows exactly as a VARCHAR one does.

A `CHAR` value is defined only up to its first `'\0'` in StarRocks — the BE `strnlen`-truncates a
CHAR value on every storage read and when parsing a routing boundary (`datum_from_string`). The FE
now canonicalizes a `CHAR` `StringVariant` the same way (truncate at the first `'\0'` at
construction), so FE ordering, pre-split boundaries and query-time pruning all match what the BE
stores and routes. VARCHAR keeps its raw bytes. The ORC CHAR **source category** stays deferred (ORC
space-pads it in its own stats).

### Testing

- FE unit tests: `VariantTest` (CHAR canonicalization vs VARCHAR raw), `ParquetRowGroupStatisticsReaderTest`,
  `OrcStripeStatisticsReaderTest`, `BoundaryPlannerTest` (positive CHAR-target reads-meta-tier; CHAR
  NUL canonicalized-to-prefix in both readers; ORC CHAR-source-category fallback). No regression in
  `RangeDistributionPrunerTest` / `ColocateRange*Test` (the `StringVariant` blast radius).
- BE unit test: `RangeRouterTest.CharBoundaryVarcharKeyRoutingMatches`.
- **Cluster e2e (shared-data, 1 FE + 3 CN):** a `CHAR(16)` range-distribution table loaded from 3
  ordered non-overlapping bands, for both Parquet and ORC -> `tablet_pre_split_tier_used{tier="meta_tier"}`
  +1 per load, `tablet_reshard_split_external_boundaries_fallback_total` = 0 on all 3 CNs, partition
  split 1 -> 2 tablets, COUNT = 3,000,000 and MIN/MAX (`0000000000`/`0002999999`) preserved per table,
  query pruning consistent (exact-match and range queries return correct counts). This is the exact
  scenario that failed with a routing-key type mismatch before the fix.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
