### PR TITLE
[Enhancement] Track predicate column usage for external tables

### DIFF
--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ This topic introduces the following types of FE configurations:
 - Description: Duration in seconds for a single process profile collection. When `proc_profile_cpu_enable` or `proc_profile_mem_enable` is set to `true`, AsyncProfiler is started, the collector thread sleeps for this duration, then the profiler is stopped and the profile is written. Larger values increase sample coverage and file size but prolong profiler runtime and delay subsequent collections; smaller values reduce overhead but may produce insufficient samples. Ensure this value aligns with retention settings such as `proc_profile_file_retained_days` and `proc_profile_file_retained_size_bytes`.
 - Introduced in: v3.2.12
 
+### `enable_external_predicate_columns_collection`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to record predicate column usage (columns used in WHERE/JOIN/GROUP BY) for external (non-native) tables during query optimization. StarRocks uses this usage information to narrow down which columns ANALYZE collects statistics for on wide external tables. When disabled, external table predicate columns are not recorded, and ANALYZE falls back to collecting statistics for all columns.
+- Introduced in: v4.2.0
+
+### `statistic_external_predicate_columns_ttl_hours`
+
+- Default: 168
+- Type: Long
+- Unit: Hours
+- Is mutable: Yes
+- Description: The time-to-live (TTL) of recorded external table predicate column usage. Entries whose `last_used` timestamp is older than this value are removed by the periodic vacuum job. Set to a negative value (e.g. -1) to disable vacuum. Defaults to a week because external table ANALYZE runs far less frequently than for internal tables, so a short TTL (matching the internal table's 24-hour default) would evict usage information between two collections.
+- Introduced in: v4.2.0
+
+### `statistic_external_predicate_columns_cache_ttl_sec`
+
+- Default: 300
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The TTL of the in-memory cache that serves external table predicate column queries (for example, during automatic ANALYZE column selection). A shorter value makes newly recorded usage visible sooner but increases the query load on the underlying storage table; a longer value reduces that load at the cost of staleness.
+- Introduced in: v4.2.0
+
 ## Storage
 
 ### `alter_table_timeout_second`

--- a/docs/ja/administration/management/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：単一プロセスプロファイル収集の期間 (秒単位)。`proc_profile_cpu_enable` または `proc_profile_mem_enable` が `true` に設定されている場合、AsyncProfiler が起動し、コレクタースレッドはこの期間だけスリープし、その後プロファイラーが停止してプロファイルが書き込まれます。値が大きいほどサンプルカバレッジとファイルサイズは増加しますが、プロファイラーの実行時間が長くなり、その後の収集が遅れます。値が小さいほどオーバーヘッドは減少しますが、不十分なサンプルが生成される可能性があります。`proc_profile_file_retained_days` や `proc_profile_file_retained_size_bytes` などの保持設定とこの値が一致していることを確認してください。
 - 導入時期：v3.2.12
 
+### `enable_external_predicate_columns_collection`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：クエリ最適化時に外部（非ネイティブ）テーブルの述語列使用状況（WHERE/JOIN/GROUP BY で使用される列）を記録するかどうかを指定します。StarRocks はこの使用状況情報を利用して、幅の広い外部テーブルで ANALYZE が統計情報を収集する列の範囲を絞り込みます。無効にすると外部テーブルの述語列は記録されなくなり、ANALYZE はすべての列の統計情報を収集するようフォールバックします。
+- 導入時期：v4.2.0
+
+### `statistic_external_predicate_columns_ttl_hours`
+
+- デフォルト：168
+- タイプ：Long
+- 単位：Hours
+- 変更可能：Yes
+- 説明：記録された外部テーブルの述語列使用状況の有効期限 (TTL) です。`last_used` がこの値より古いエントリは、定期的な vacuum ジョブによって削除されます。vacuum を無効にするには負の値 (例: -1) を設定します。外部テーブルの ANALYZE は内部テーブルよりもはるかに低い頻度で実行されるため、デフォルトは 1 週間になっています。内部テーブルのデフォルトである 24 時間のような短い TTL では、2 回の収集の間に使用状況情報が削除されてしまいます。
+- 導入時期：v4.2.0
+
+### `statistic_external_predicate_columns_cache_ttl_sec`
+
+- デフォルト：300
+- タイプ：Long
+- 単位：Seconds
+- 変更可能：Yes
+- 説明：外部テーブルの述語列クエリ (自動 ANALYZE の列選択時など) に応答するためのインメモリキャッシュの TTL です。値を小さくすると新しく記録された使用状況がより早く反映されますが、基盤となるストレージテーブルへのクエリ負荷が増加します。値を大きくするとその負荷は減りますが、データが古くなります。
+- 導入時期：v4.2.0
+
 ## ストレージ
 
 ### `alter_table_timeout_second`

--- a/docs/zh/administration/management/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/management/FE_parameters/stats_storage.md
@@ -79,6 +79,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 单次进程 profile 收集的持续时间（秒）。当 `proc_profile_cpu_enable` 或 `proc_profile_mem_enable` 设置为 `true` 时，AsyncProfiler 启动，收集器线程休眠此持续时间，然后 profiler 停止并写入 profile。较大的值会增加样本覆盖率和文件大小，但会延长 profiler 运行时并延迟后续收集；较小的值会减少开销，但可能会产生不足的样本。确保此值与 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 等保留设置对齐。
 - 引入版本: v3.2.12
 
+### `enable_external_predicate_columns_collection`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否在查询优化过程中记录外部表（非原生表）的谓词列使用情况（WHERE/JOIN/GROUP BY 中用到的列）。StarRocks 利用这些使用信息缩小宽外部表 ANALYZE 时需要收集统计信息的列范围。禁用后不再记录外部表的谓词列，ANALYZE 会回退为收集所有列的统计信息。
+- 引入版本: v4.2.0
+
+### `statistic_external_predicate_columns_ttl_hours`
+
+- 默认值: 168
+- 类型: Long
+- 单位: 小时
+- 是否可变: Yes
+- 描述: 记录的外部表谓词列使用信息的存活时间（TTL）。`last_used` 时间早于该值的记录会被周期性的 vacuum 任务清除。设置为负值（例如 -1）可禁用 vacuum。默认值为一周，因为外部表 ANALYZE 的执行频率远低于内表，如果 TTL 太短（如内表默认的 24 小时），会导致两次收集之间使用信息被提前清除。
+- 引入版本: v4.2.0
+
+### `statistic_external_predicate_columns_cache_ttl_sec`
+
+- 默认值: 300
+- 类型: Long
+- 单位: 秒
+- 是否可变: Yes
+- 描述: 用于响应外部表谓词列查询（例如自动 ANALYZE 选列时）的内存缓存的 TTL。值越小，新记录的使用信息越快可见，但会增加对底层存储表的查询压力；值越大则降低该压力，但会增加数据的陈旧程度。
+- 引入版本: v4.2.0
+
 ## 存储
 
 ### `alter_table_timeout_second`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2492,6 +2492,20 @@ public class Config extends ConfigBase {
             "will not be recorded during query optimization")
     public static boolean enable_predicate_columns_collection = true;
 
+    @ConfField(mutable = true, comment = "Enable predicate columns collection for external (non-native) tables. " +
+            "If disabled, external table predicate columns will not be recorded during query optimization")
+    public static boolean enable_external_predicate_columns_collection = true;
+
+    @ConfField(mutable = true, comment = "The TTL of external table predicate columns in hours; entries older " +
+            "than this are removed by vacuum. A negative value (e.g. -1) disables vacuum. Defaults to a week " +
+            "since external table ANALYZE runs far less frequently than internal tables, so a short TTL " +
+            "(like the internal table's 24h default) would evict usage info between two collections.")
+    public static long statistic_external_predicate_columns_ttl_hours = 168;
+
+    @ConfField(mutable = true, comment = "The TTL of the in-memory cache used to serve external predicate " +
+            "columns queries (e.g. from auto ANALYZE column selection), in seconds")
+    public static long statistic_external_predicate_columns_cache_ttl_sec = 300;
+
     @ConfField(mutable = true, comment = "If enabled, FE will always collect optimizer timer traces during plan " +
             "generation and dump them to logs when plan generation fails (e.g. CBO timeout) for diagnosis.")
     public static boolean enable_dump_optimizer_trace_on_error = false;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -23,6 +23,7 @@ import com.starrocks.load.loadv2.LoadsHistorySyncer;
 import com.starrocks.load.rejected.RejectedRecordsTable;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.columns.ExternalPredicateColumnsStorage;
 import com.starrocks.statistic.columns.PredicateColumnsStorage;
 import jdk.jshell.spi.ExecutionControl;
 import org.apache.commons.lang3.StringUtils;
@@ -204,6 +205,7 @@ public class TableKeeper {
             keeperList.add(LoadsHistorySyncer.createKeeper());
             keeperList.add(com.starrocks.lake.TabletWriteLogHistorySyncer.createKeeper());
             keeperList.add(PredicateColumnsStorage.createKeeper());
+            keeperList.add(ExternalPredicateColumnsStorage.createKeeper());
             keeperList.add(RejectedRecordsTable.createKeeper());
             // TODO: add FileListPipeRepo
             // TODO: add statistic table

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.ast.StatisticsType;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.statistic.columns.ColumnUsage;
+import com.starrocks.statistic.columns.ExternalColumnUsage;
 import com.starrocks.statistic.columns.PredicateColumnsMgr;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
@@ -328,9 +329,30 @@ public class StatisticsCollectJobFactory {
         ExternalBasicStatsMeta basicStatsMeta = GlobalStateMgr.getCurrentState().getAnalyzeMgr().getExternalBasicStatsMetaMap()
                 .get(new AnalyzeMgr.StatsMetaKey(job.getCatalogName(), db.getFullName(), table.getName()));
 
+        boolean userSpecifiedColumns = CollectionUtils.isNotEmpty(columnNames);
         if (columnNames == null || columnNames.isEmpty()) {
             columnNames = StatisticUtils.getCollectibleColumns(table);
         }
+
+        // Use predicate columns if suitable: only when the user didn't pin down columns explicitly
+        // and the table is wide enough that collecting everything is wasteful. Falls back to the
+        // full column list when no predicate columns are known yet (e.g. table never queried).
+        if (!userSpecifiedColumns && Config.statistic_auto_collect_predicate_columns_threshold > 0
+                && columnNames.size() > Config.statistic_auto_collect_predicate_columns_threshold) {
+            List<ExternalColumnUsage> predicateColumns =
+                    PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table);
+            if (CollectionUtils.isNotEmpty(predicateColumns)) {
+                Set<String> predicateColumnNames = predicateColumns.stream()
+                        .map(ExternalColumnUsage::getColumnName)
+                        .collect(Collectors.toSet());
+                List<String> filtered =
+                        columnNames.stream().filter(predicateColumnNames::contains).collect(Collectors.toList());
+                if (!filtered.isEmpty()) {
+                    columnNames = filtered;
+                }
+            }
+        }
+
         List<String> needCollectStatsColumns;
         if (basicStatsMeta != null) {
             // check table row count

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -337,7 +337,10 @@ public class StatisticsCollectJobFactory {
         // Use predicate columns if suitable: only when the user didn't pin down columns explicitly
         // and the table is wide enough that collecting everything is wasteful. Falls back to the
         // full column list when no predicate columns are known yet (e.g. table never queried).
-        if (!userSpecifiedColumns && Config.statistic_auto_collect_predicate_columns_threshold > 0
+        // Also gated on the collection toggle itself: once disabled, operators must be able to force
+        // full-column collection immediately rather than waiting for stale rows to age out via TTL.
+        if (Config.enable_external_predicate_columns_collection && !userSpecifiedColumns
+                && Config.statistic_auto_collect_predicate_columns_threshold > 0
                 && columnNames.size() > Config.statistic_auto_collect_predicate_columns_threshold) {
             List<ExternalColumnUsage> predicateColumns =
                     PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
@@ -42,9 +42,12 @@ public class ExternalColumnUsage {
 
     private static final Logger LOG = LogManager.getLogger(ExternalColumnUsage.class);
 
-    // table_uuid is always the fixed-length hash (32 hex chars), so column_name is the only
-    // variable-length part of the PK; guard against pathological schemas blowing the PK size limit.
-    private static final int MAX_COLUMN_NAME_LENGTH = 96;
+    // BE's primary_key_limit_size defaults to 128 bytes (be/src/common/config_primary_key_fwd.h).
+    // PrimaryKeyEncoder::encode_exceed_limit adds a 2-byte separator per non-last VARCHAR PK field;
+    // our PK is (fe_id, table_uuid, column_name) with column_name last. Budget: fe_id up to 10 digits
+    // (+2) + table_uuid fixed 32 hex chars (+2) + column_name (no +2, last field) <= 128, i.e.
+    // column_name <= 82. Capped at 80 to leave a small margin.
+    private static final int MAX_COLUMN_NAME_LENGTH = 80;
 
     @SerializedName("tableUuidHash")
     private final String tableUuidHash;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.columns;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.statistic.StatisticUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Usage record for a column of an external (non-native) table.
+ * <p>
+ * Unlike {@link ColumnUsage}, the identity here is not a metastore-resolvable numeric id: external
+ * tables have no stable db/table/column id, so the row carries its own catalog/db/table/column names
+ * directly. table_uuid is always the fixed-length hash of {@link Table#getUUID()}
+ * ({@link StatisticUtils#hashTableUuidForPkStorage}), matching the PK scheme of
+ * {@code external_column_statistics} so both tables can be joined by table_uuid.
+ */
+public class ExternalColumnUsage {
+
+    private static final Logger LOG = LogManager.getLogger(ExternalColumnUsage.class);
+
+    // table_uuid is always the fixed-length hash (32 hex chars), so column_name is the only
+    // variable-length part of the PK; guard against pathological schemas blowing the PK size limit.
+    private static final int MAX_COLUMN_NAME_LENGTH = 96;
+
+    @SerializedName("tableUuidHash")
+    private final String tableUuidHash;
+
+    @SerializedName("catalogName")
+    private final String catalogName;
+
+    @SerializedName("dbName")
+    private final String dbName;
+
+    @SerializedName("tableName")
+    private final String tableName;
+
+    @SerializedName("columnName")
+    private final String columnName;
+
+    @SerializedName("useCase")
+    private final EnumSet<ColumnUsage.UseCase> useCase;
+
+    @SerializedName("lastUsed")
+    private LocalDateTime lastUsed;
+
+    @SerializedName("created")
+    private LocalDateTime created;
+
+    public ExternalColumnUsage(String tableUuidHash, String catalogName, String dbName, String tableName,
+                               String columnName, ColumnUsage.UseCase useCase) {
+        this(tableUuidHash, catalogName, dbName, tableName, columnName, EnumSet.of(useCase));
+    }
+
+    public ExternalColumnUsage(String tableUuidHash, String catalogName, String dbName, String tableName,
+                               String columnName, EnumSet<ColumnUsage.UseCase> useCase) {
+        this.tableUuidHash = tableUuidHash;
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.columnName = columnName;
+        this.useCase = useCase;
+        this.lastUsed = TimeUtils.getSystemNow();
+        this.created = TimeUtils.getSystemNow();
+    }
+
+    public static Optional<ExternalColumnUsage> build(Column column, Table table, ColumnUsage.UseCase useCase) {
+        String columnName = column.getName();
+        if (columnName.length() > MAX_COLUMN_NAME_LENGTH) {
+            LOG.warn("skip recording external predicate column usage, column name too long: {}.{}",
+                    table.getName(), columnName);
+            return Optional.empty();
+        }
+        String tableUuidHash = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
+        return Optional.of(new ExternalColumnUsage(tableUuidHash, table.getCatalogName(), table.getCatalogDBName(),
+                table.getCatalogTableName(), columnName, useCase));
+    }
+
+    public String getTableUuidHash() {
+        return tableUuidHash;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public EnumSet<ColumnUsage.UseCase> getUseCases() {
+        return useCase;
+    }
+
+    public String getUseCaseString() {
+        return useCase.stream().map(ColumnUsage.UseCase::toString).collect(Collectors.joining(","));
+    }
+
+    public void setLastUsed(LocalDateTime lastUsed) {
+        this.lastUsed = lastUsed;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+
+    public LocalDateTime getLastUsed() {
+        return lastUsed;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    // NOTE: mutable
+    public void useNow(ColumnUsage.UseCase useCase) {
+        this.lastUsed = LocalDateTime.now(TimeUtils.getSystemTimeZone().toZoneId());
+        this.useCase.add(useCase);
+    }
+
+    public boolean needPersist(LocalDateTime lastPersist) {
+        return this.lastUsed.isAfter(lastPersist);
+    }
+
+    public ExternalColumnUsage merge(ExternalColumnUsage other) {
+        Preconditions.checkArgument(other.equals(this));
+        ExternalColumnUsage merged = new ExternalColumnUsage(tableUuidHash, catalogName, dbName, tableName,
+                columnName, EnumSet.copyOf(this.useCase));
+        merged.useCase.addAll(other.useCase);
+        merged.lastUsed = this.lastUsed.isBefore(other.getLastUsed()) ? other.getLastUsed() : this.lastUsed;
+        return merged;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalColumnUsage that = (ExternalColumnUsage) o;
+        return Objects.equals(tableUuidHash, that.tableUuidHash) && Objects.equals(columnName, that.columnName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableUuidHash, columnName);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ExternalColumnUsage{catalog=%s, db=%s, table=%s, column=%s, useCase=%s}",
+                catalogName, dbName, tableName, columnName, getUseCaseString());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalColumnUsage.java
@@ -20,13 +20,10 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.statistic.StatisticUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.EnumSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -34,20 +31,15 @@ import java.util.stream.Collectors;
  * <p>
  * Unlike {@link ColumnUsage}, the identity here is not a metastore-resolvable numeric id: external
  * tables have no stable db/table/column id, so the row carries its own catalog/db/table/column names
- * directly. table_uuid is always the fixed-length hash of {@link Table#getUUID()}
- * ({@link StatisticUtils#hashTableUuidForPkStorage}), matching the PK scheme of
- * {@code external_column_statistics} so both tables can be joined by table_uuid.
+ * directly. table_uuid and column_name are both persisted as fixed-length hashes
+ * ({@link #getTableUuidHash()}, {@link #getColumnNameHash()}) so the PK never depends on the byte
+ * length of externally-supplied identifiers (multibyte column names would otherwise make a
+ * character-count guard unsafe, since BE's primary_key_limit_size is measured in encoded bytes).
+ * table_uuid hashing also matches the PK scheme of {@code external_column_statistics} so both tables
+ * can be joined by table_uuid. The raw column_name is kept as a plain (non-key) value column so it can
+ * be read back.
  */
 public class ExternalColumnUsage {
-
-    private static final Logger LOG = LogManager.getLogger(ExternalColumnUsage.class);
-
-    // BE's primary_key_limit_size defaults to 128 bytes (be/src/common/config_primary_key_fwd.h).
-    // PrimaryKeyEncoder::encode_exceed_limit adds a 2-byte separator per non-last VARCHAR PK field;
-    // our PK is (fe_id, table_uuid, column_name) with column_name last. Budget: fe_id up to 10 digits
-    // (+2) + table_uuid fixed 32 hex chars (+2) + column_name (no +2, last field) <= 128, i.e.
-    // column_name <= 82. Capped at 80 to leave a small margin.
-    private static final int MAX_COLUMN_NAME_LENGTH = 80;
 
     @SerializedName("tableUuidHash")
     private final String tableUuidHash;
@@ -90,20 +82,22 @@ public class ExternalColumnUsage {
         this.created = TimeUtils.getSystemNow();
     }
 
-    public static Optional<ExternalColumnUsage> build(Column column, Table table, ColumnUsage.UseCase useCase) {
+    public static ExternalColumnUsage build(Column column, Table table, ColumnUsage.UseCase useCase) {
         String columnName = column.getName();
-        if (columnName.length() > MAX_COLUMN_NAME_LENGTH) {
-            LOG.warn("skip recording external predicate column usage, column name too long: {}.{}",
-                    table.getName(), columnName);
-            return Optional.empty();
-        }
         String tableUuidHash = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
-        return Optional.of(new ExternalColumnUsage(tableUuidHash, table.getCatalogName(), table.getCatalogDBName(),
-                table.getCatalogTableName(), columnName, useCase));
+        return new ExternalColumnUsage(tableUuidHash, table.getCatalogName(), table.getCatalogDBName(),
+                table.getCatalogTableName(), columnName, useCase);
     }
 
     public String getTableUuidHash() {
         return tableUuidHash;
+    }
+
+    // Reuses the generic murmur3-based hasher (despite its table_uuid-oriented name/javadoc, the
+    // implementation is just a fixed-length hash of an arbitrary string) so column_name never affects
+    // the PK's byte size, regardless of length or encoding (see the class doc for why this matters).
+    public String getColumnNameHash() {
+        return StatisticUtils.hashTableUuidForPkStorage(columnName);
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
@@ -1,0 +1,340 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.columns;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.scheduler.history.TableKeeper;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TResultSinkType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Storage for {@code _statistics_.external_predicate_columns}, mirroring
+ * {@link PredicateColumnsStorage}'s persist/restore/vacuum lifecycle for external (non-native) table
+ * columns. See the class doc there for the general persistence/query/vacuum/restore model; the only
+ * structural difference is the identity columns (table_uuid hash + column_name instead of numeric
+ * db/table/column ids), since external tables have no metastore-resolvable numeric ids.
+ */
+public class ExternalPredicateColumnsStorage {
+
+    private static final Logger LOG = LogManager.getLogger(ExternalPredicateColumnsStorage.class);
+
+    public static final String DATABASE_NAME = StatsConstants.STATISTICS_DB_NAME;
+    public static final String TABLE_NAME = "external_predicate_columns";
+    public static final String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
+    private static final String TABLE_DDL = "CREATE TABLE " + TABLE_NAME + "( " +
+
+            // PRIMARY KEYS
+            "fe_id STRING NOT NULL," +
+            "table_uuid STRING NOT NULL," +
+            "column_name STRING NOT NULL," +
+
+            "catalog_name STRING NOT NULL," +
+            "db_name STRING NOT NULL," +
+            "table_name STRING NOT NULL," +
+            "usage STRING NOT NULL," +
+            "last_used DATETIME NOT NULL," +
+            "created DATETIME DEFAULT CURRENT_TIMESTAMP" +
+            ") " +
+            "PRIMARY KEY(fe_id, table_uuid, column_name) " +
+            "DISTRIBUTED BY HASH(fe_id, table_uuid, column_name) BUCKETS 8\n" +
+            "PROPERTIES('replication_num'='1')";
+
+    private static final TableKeeper KEEPER = new TableKeeper(DATABASE_NAME, TABLE_NAME, TABLE_DDL, null);
+
+    private static final VelocityEngine DEFAULT_VELOCITY_ENGINE;
+
+    static {
+        DEFAULT_VELOCITY_ENGINE = new VelocityEngine();
+        DEFAULT_VELOCITY_ENGINE.setProperty(VelocityEngine.RUNTIME_LOG_REFERENCE_LOG_INVALID, false);
+    }
+
+    private static final int INSERT_BATCH_SIZE = 1024;
+    private static final String SQL_COLUMN_LIST =
+            "fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used ";
+
+    private static final String ADD_RECORD = "INSERT INTO " + TABLE_FULL_NAME + "(" + SQL_COLUMN_LIST + ") VALUES ";
+    private static final String INSERT_VALUE =
+            "('$feId', '$tableUuidHash', '$columnName', '$catalogName', '$dbName', '$tableName', " +
+                    "'$usage', '$lastUsed')";
+
+    private static final String QUERY =
+            "SELECT fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used, created FROM "
+                    + TABLE_FULL_NAME + " WHERE true ";
+    private static final String WHERE_THIS_FE = "fe_id = '$feId'";
+
+    private static final String VACUUM = "DELETE FROM " + TABLE_FULL_NAME +
+            " WHERE fe_id='$feId' AND last_used < '$lastUsed'";
+
+    private static final ExternalPredicateColumnsStorage INSTANCE = new ExternalPredicateColumnsStorage();
+
+    /**
+     * MIN: the persisted state has not been restored, we cannot persist
+     */
+    private final LocalDateTime systemStartTime = TimeUtils.getSystemNow();
+    private volatile LocalDateTime lastPersist = LocalDateTime.MIN;
+
+    private final SimpleExecutor executor;
+
+    public static TableKeeper createKeeper() {
+        return KEEPER;
+    }
+
+    public static ExternalPredicateColumnsStorage getInstance() {
+        return INSTANCE;
+    }
+
+    public ExternalPredicateColumnsStorage() {
+        this.executor = new SimpleExecutor("external_predicate_column", TResultSinkType.HTTP_PROTOCAL);
+        // Set the DOP to 1 to reduce impact on normal queries
+        this.executor.setDop(1);
+    }
+
+    public ExternalPredicateColumnsStorage(SimpleExecutor executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * Query state from all FEs for a single table (identified by its hashed table_uuid)
+     */
+    public List<ExternalColumnUsage> queryGlobalState(String tableUuidHash, EnumSet<ColumnUsage.UseCase> useCases) {
+        StringBuilder sb = new StringBuilder(QUERY);
+        sb.append(" AND `table_uuid` = '").append(tableUuidHash).append("'");
+
+        if (!useCases.isEmpty()) {
+            String useCaseRegex = useCases.stream().map(ColumnUsage.UseCase::toString).collect(Collectors.joining("|"));
+            sb.append(String.format(" AND regexp(`usage`, '%s')", useCaseRegex));
+        }
+
+        String sql = sb.toString();
+        List<TResultBatch> tResultBatches = executor.executeDQL(sql);
+        List<ExternalColumnUsage> columnUsages = resultToColumnUsage(tResultBatches);
+        if (GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends().size() == 1) {
+            return columnUsages;
+        } else {
+            return deduplicateColumnUsages(columnUsages);
+        }
+    }
+
+    public List<ExternalColumnUsage> deduplicateColumnUsages(List<ExternalColumnUsage> columnUsages) {
+        Map<ExternalColumnUsage, ExternalColumnUsage> merged = columnUsages.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        Function.identity(),
+                        (existing, current) -> {
+                            existing.getUseCases().addAll(current.getUseCases());
+                            if (current.getLastUsed().isAfter(existing.getLastUsed())) {
+                                existing.setLastUsed(current.getLastUsed());
+                            }
+                            return existing;
+                        }
+                ));
+
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Persist changed records
+     */
+    public void persist(Collection<ExternalColumnUsage> columnUsageList) {
+        if (lastPersist == LocalDateTime.MIN) {
+            return;
+        }
+        LocalDateTime nextPersist = TimeUtils.getSystemNow();
+        Stopwatch watch = Stopwatch.createStarted();
+        List<ExternalColumnUsage> diff =
+                columnUsageList.stream().filter(x -> x.needPersist(lastPersist)).collect(Collectors.toList());
+        for (var batch : ListUtils.partition(diff, INSERT_BATCH_SIZE)) {
+            persistDiff(batch);
+        }
+        lastPersist = nextPersist;
+        String elapsed = watch.toString();
+        LOG.info("persist {} diffed external predicate columns elapsed {}, update lastPersist to {}", diff.size(),
+                elapsed, lastPersist);
+    }
+
+    private void persistDiff(List<ExternalColumnUsage> diff) {
+        StringBuilder insert = new StringBuilder(ADD_RECORD);
+        boolean first = true;
+        for (ExternalColumnUsage usage : diff) {
+            StringWriter sw = new StringWriter();
+
+            VelocityContext context = new VelocityContext();
+            context.put("feId", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid());
+            context.put("tableUuidHash", usage.getTableUuidHash());
+            context.put("columnName", usage.getColumnName());
+            context.put("catalogName", usage.getCatalogName());
+            context.put("dbName", usage.getDbName());
+            context.put("tableName", usage.getTableName());
+            context.put("usage", usage.getUseCaseString());
+            context.put("lastUsed", DateUtils.formatDateTimeUnix(usage.getLastUsed()));
+
+            DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", INSERT_VALUE);
+            if (!first) {
+                insert.append(", ");
+            }
+            insert.append(sw);
+            first = false;
+        }
+
+        String sql = insert.toString();
+        executor.executeDML(sql);
+    }
+
+    /**
+     * Restore this FE's own state
+     */
+    public List<ExternalColumnUsage> restore() {
+        String selfName = String.valueOf(GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid());
+
+        VelocityContext context = new VelocityContext();
+        context.put("feId", selfName);
+
+        String template = QUERY + " AND " + WHERE_THIS_FE;
+        StringWriter sw = new StringWriter();
+        DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", template);
+        String sql = sw.toString();
+
+        List<TResultBatch> tResultBatches = executor.executeDQL(sql);
+        return resultToColumnUsage(tResultBatches);
+    }
+
+    /**
+     * Remove this FE's own records if the lastUsed < ttlTime
+     */
+    public void vacuum(LocalDateTime ttlTime) {
+        String selfName = String.valueOf(GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid());
+
+        VelocityContext context = new VelocityContext();
+        context.put("feId", selfName);
+        context.put("lastUsed", DateUtils.formatDateTimeUnix(ttlTime));
+
+        StringWriter sw = new StringWriter();
+        DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", VACUUM);
+
+        String sql = sw.toString();
+        executor.executeDML(sql);
+
+        LOG.info("vacuum external column usage from storage before {}", ttlTime);
+    }
+
+    public boolean isSystemTableReady() {
+        return KEEPER.isReady();
+    }
+
+    public boolean isRestored() {
+        return lastPersist != LocalDateTime.MIN;
+    }
+
+    public void finishRestore() {
+        lastPersist = systemStartTime;
+        LOG.info("finish restore external predicate columns state, update lastPersist to {}", lastPersist);
+    }
+
+    @VisibleForTesting
+    protected void finishRestore(LocalDateTime lastPersistTime) {
+        lastPersist = lastPersistTime;
+    }
+
+    @VisibleForTesting
+    static class ExternalColumnUsageJsonRecord {
+
+        @SerializedName("data")
+        List<ExternalColumnUsage> data;
+
+        public ExternalColumnUsageJsonRecord() {
+            this.data = Lists.newArrayList();
+        }
+
+        /**
+         * {
+         * "data": [fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used, created]
+         * }
+         */
+        public static ExternalColumnUsageJsonRecord fromJson(String json) {
+            JsonElement object = JsonParser.parseString(json);
+            JsonArray data = object.getAsJsonObject().get("data").getAsJsonArray();
+            // String feId = data.get(0).getAsString();
+            String tableUuidHash = data.get(1).getAsString();
+            String columnName = data.get(2).getAsString();
+            String catalogName = data.get(3).getAsString();
+            String dbName = data.get(4).getAsString();
+            String tableName = data.get(5).getAsString();
+            String useCase = data.get(6).getAsString();
+            String lastUsed = data.get(7).getAsString();
+            String created = data.get(8).getAsString();
+
+            EnumSet<ColumnUsage.UseCase> useCases = ColumnUsage.fromUseCaseString(useCase);
+            ExternalColumnUsage usage =
+                    new ExternalColumnUsage(tableUuidHash, catalogName, dbName, tableName, columnName, useCases);
+            usage.setLastUsed(DateUtils.parseUnixDateTime(lastUsed));
+            usage.setCreated(DateUtils.parseUnixDateTime(created));
+
+            ExternalColumnUsageJsonRecord res = new ExternalColumnUsageJsonRecord();
+            res.data = List.of(usage);
+            return res;
+        }
+
+    }
+
+    @VisibleForTesting
+    protected static List<ExternalColumnUsage> resultToColumnUsage(List<TResultBatch> batches) {
+        List<ExternalColumnUsage> res = new ArrayList<>();
+        for (TResultBatch batch : ListUtils.emptyIfNull(batches)) {
+            for (ByteBuffer buffer : batch.getRows()) {
+                ByteBuf copied = Unpooled.copiedBuffer(buffer);
+                String jsonString = copied.toString(Charset.defaultCharset());
+                try {
+                    List<ExternalColumnUsage> records =
+                            ListUtils.emptyIfNull(ExternalColumnUsageJsonRecord.fromJson(jsonString).data);
+                    res.addAll(records);
+                } catch (Exception e) {
+                    LOG.warn("failed to deserialize ExternalColumnUsage record: {}", jsonString, e);
+                }
+            }
+        }
+        return res;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.SqlUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.history.TableKeeper;
@@ -140,7 +141,7 @@ public class ExternalPredicateColumnsStorage {
      */
     public List<ExternalColumnUsage> queryGlobalState(String tableUuidHash, EnumSet<ColumnUsage.UseCase> useCases) {
         StringBuilder sb = new StringBuilder(QUERY);
-        sb.append(" AND `table_uuid` = '").append(tableUuidHash).append("'");
+        sb.append(" AND `table_uuid` = '").append(SqlUtils.escapeSqlString(tableUuidHash)).append("'");
 
         if (!useCases.isEmpty()) {
             String useCaseRegex = useCases.stream().map(ColumnUsage.UseCase::toString).collect(Collectors.joining("|"));
@@ -200,14 +201,16 @@ public class ExternalPredicateColumnsStorage {
         for (ExternalColumnUsage usage : diff) {
             StringWriter sw = new StringWriter();
 
+            // catalog/db/table/column names come from external catalog metadata and are not trusted;
+            // escape before embedding them in the single-quoted SQL literals of INSERT_VALUE.
             VelocityContext context = new VelocityContext();
             context.put("feId", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid());
-            context.put("tableUuidHash", usage.getTableUuidHash());
-            context.put("columnName", usage.getColumnName());
-            context.put("catalogName", usage.getCatalogName());
-            context.put("dbName", usage.getDbName());
-            context.put("tableName", usage.getTableName());
-            context.put("usage", usage.getUseCaseString());
+            context.put("tableUuidHash", SqlUtils.escapeSqlString(usage.getTableUuidHash()));
+            context.put("columnName", SqlUtils.escapeSqlString(usage.getColumnName()));
+            context.put("catalogName", SqlUtils.escapeSqlString(usage.getCatalogName()));
+            context.put("dbName", SqlUtils.escapeSqlString(usage.getDbName()));
+            context.put("tableName", SqlUtils.escapeSqlString(usage.getTableName()));
+            context.put("usage", SqlUtils.escapeSqlString(usage.getUseCaseString()));
             context.put("lastUsed", DateUtils.formatDateTimeUnix(usage.getLastUsed()));
 
             DEFAULT_VELOCITY_ENGINE.evaluate(context, sw, "", INSERT_VALUE);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorage.java
@@ -54,8 +54,11 @@ import java.util.stream.Collectors;
  * Storage for {@code _statistics_.external_predicate_columns}, mirroring
  * {@link PredicateColumnsStorage}'s persist/restore/vacuum lifecycle for external (non-native) table
  * columns. See the class doc there for the general persistence/query/vacuum/restore model; the only
- * structural difference is the identity columns (table_uuid hash + column_name instead of numeric
- * db/table/column ids), since external tables have no metastore-resolvable numeric ids.
+ * structural difference is the identity columns: the PK is (fe_id, table_uuid hash, column_name hash)
+ * instead of numeric db/table/column ids, since external tables have no metastore-resolvable numeric
+ * ids and raw catalog-supplied names are unbounded in byte length. The raw column_name is kept as a
+ * plain value column (not part of the PK) so it can still be read back; see
+ * {@link ExternalColumnUsage}'s class doc for why both identity fields are hashed.
  */
 public class ExternalPredicateColumnsStorage {
 
@@ -66,20 +69,22 @@ public class ExternalPredicateColumnsStorage {
     public static final String TABLE_FULL_NAME = DATABASE_NAME + "." + TABLE_NAME;
     private static final String TABLE_DDL = "CREATE TABLE " + TABLE_NAME + "( " +
 
-            // PRIMARY KEYS
+            // PRIMARY KEYS: column_name_hash (not the raw column_name) keeps the PK's byte size
+            // fixed regardless of column name length/encoding; see ExternalColumnUsage's class doc.
             "fe_id STRING NOT NULL," +
             "table_uuid STRING NOT NULL," +
-            "column_name STRING NOT NULL," +
+            "column_name_hash STRING NOT NULL," +
 
             "catalog_name STRING NOT NULL," +
             "db_name STRING NOT NULL," +
             "table_name STRING NOT NULL," +
+            "column_name STRING NOT NULL," +
             "usage STRING NOT NULL," +
             "last_used DATETIME NOT NULL," +
             "created DATETIME DEFAULT CURRENT_TIMESTAMP" +
             ") " +
-            "PRIMARY KEY(fe_id, table_uuid, column_name) " +
-            "DISTRIBUTED BY HASH(fe_id, table_uuid, column_name) BUCKETS 8\n" +
+            "PRIMARY KEY(fe_id, table_uuid, column_name_hash) " +
+            "DISTRIBUTED BY HASH(fe_id, table_uuid, column_name_hash) BUCKETS 8\n" +
             "PROPERTIES('replication_num'='1')";
 
     private static final TableKeeper KEEPER = new TableKeeper(DATABASE_NAME, TABLE_NAME, TABLE_DDL, null);
@@ -93,12 +98,12 @@ public class ExternalPredicateColumnsStorage {
 
     private static final int INSERT_BATCH_SIZE = 1024;
     private static final String SQL_COLUMN_LIST =
-            "fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used ";
+            "fe_id, table_uuid, column_name_hash, catalog_name, db_name, table_name, column_name, usage, last_used ";
 
     private static final String ADD_RECORD = "INSERT INTO " + TABLE_FULL_NAME + "(" + SQL_COLUMN_LIST + ") VALUES ";
     private static final String INSERT_VALUE =
-            "('$feId', '$tableUuidHash', '$columnName', '$catalogName', '$dbName', '$tableName', " +
-                    "'$usage', '$lastUsed')";
+            "('$feId', '$tableUuidHash', '$columnNameHash', '$catalogName', '$dbName', '$tableName', " +
+                    "'$columnName', '$usage', '$lastUsed')";
 
     private static final String QUERY =
             "SELECT fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used, created FROM "
@@ -206,6 +211,7 @@ public class ExternalPredicateColumnsStorage {
             VelocityContext context = new VelocityContext();
             context.put("feId", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid());
             context.put("tableUuidHash", SqlUtils.escapeSqlString(usage.getTableUuidHash()));
+            context.put("columnNameHash", SqlUtils.escapeSqlString(usage.getColumnNameHash()));
             context.put("columnName", SqlUtils.escapeSqlString(usage.getColumnName()));
             context.put("catalogName", SqlUtils.escapeSqlString(usage.getCatalogName()));
             context.put("dbName", SqlUtils.escapeSqlString(usage.getDbName()));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.statistic.columns;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
@@ -24,6 +26,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -31,6 +34,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.statistic.StatisticUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.logging.log4j.LogManager;
@@ -41,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -51,6 +56,15 @@ public class PredicateColumnsMgr {
 
     // Why Map? To update the usage
     private final Map<ColumnUsage, ColumnUsage> id2columnUsage = Maps.newConcurrentMap();
+    private final Map<ExternalColumnUsage, ExternalColumnUsage> externalId2columnUsage = Maps.newConcurrentMap();
+
+    // Keyed by hashed table_uuid; negative results (empty list, e.g. a table never queried) are
+    // cached too, since a wide external table with no predicate columns yet would otherwise hit
+    // the storage table on every auto-analyze cycle.
+    private final Cache<String, List<ExternalColumnUsage>> externalQueryCache = Caffeine.newBuilder()
+            .expireAfterWrite(Config.statistic_external_predicate_columns_cache_ttl_sec, TimeUnit.SECONDS)
+            .maximumSize(10000)
+            .<String, List<ExternalColumnUsage>>build();
 
     public static PredicateColumnsMgr getInstance() {
         return INSTANCE;
@@ -130,10 +144,14 @@ public class PredicateColumnsMgr {
     }
 
     private void addOrUpdateColumnUsage(Table table, Column column, ColumnUsage.UseCase useCase) {
-        // only support OLAP table right now
-        if (!table.isNativeTableOrMaterializedView()) {
-            return;
+        if (table.isNativeTableOrMaterializedView()) {
+            addOrUpdateNativeColumnUsage(table, column, useCase);
+        } else {
+            addOrUpdateExternalColumnUsage(table, column, useCase);
         }
+    }
+
+    private void addOrUpdateNativeColumnUsage(Table table, Column column, ColumnUsage.UseCase useCase) {
         Optional<ColumnUsage> mayUsage = ColumnUsage.build(column, table, useCase);
         if (mayUsage.isEmpty()) {
             return;
@@ -143,6 +161,22 @@ public class PredicateColumnsMgr {
         }
         ColumnUsage usage = mayUsage.get();
         ColumnUsage oldValue = id2columnUsage.computeIfAbsent(usage, k -> usage);
+        oldValue.useNow(useCase);
+    }
+
+    private void addOrUpdateExternalColumnUsage(Table table, Column column, ColumnUsage.UseCase useCase) {
+        if (!Config.enable_external_predicate_columns_collection) {
+            return;
+        }
+        if (!CatalogMgr.isExternalCatalog(table.getCatalogName()) || table.isTemporaryTable()) {
+            return;
+        }
+        Optional<ExternalColumnUsage> mayUsage = ExternalColumnUsage.build(column, table, useCase);
+        if (mayUsage.isEmpty()) {
+            return;
+        }
+        ExternalColumnUsage usage = mayUsage.get();
+        ExternalColumnUsage oldValue = externalId2columnUsage.computeIfAbsent(usage, k -> usage);
         oldValue.useNow(useCase);
     }
 
@@ -167,9 +201,26 @@ public class PredicateColumnsMgr {
         }
     }
 
+    public List<ExternalColumnUsage> queryExternalPredicateColumns(Table table) {
+        EnumSet<ColumnUsage.UseCase> useCases = ColumnUsage.UseCase.getPredicateColumnUseCase();
+        String tableUuidHash = StatisticUtils.hashTableUuidForPkStorage(table.getUUID());
+        if (FeConstants.runningUnitTest) {
+            Predicate<ExternalColumnUsage> pred = c -> !SetUtils.intersection(c.getUseCases(), useCases).isEmpty();
+            return externalId2columnUsage.values().stream()
+                    .filter(x -> x.getTableUuidHash().equals(tableUuidHash))
+                    .filter(pred)
+                    .collect(Collectors.toList());
+        }
+        return externalQueryCache.get(tableUuidHash, key -> getExternalStorage().queryGlobalState(key, useCases));
+    }
+
     //==================================== Maintenance ============================================ //
     public void persist() {
         getStorage().persist(id2columnUsage.values());
+    }
+
+    public void persistExternal() {
+        getExternalStorage().persist(externalId2columnUsage.values());
     }
 
     public void vacuum() {
@@ -192,6 +243,24 @@ public class PredicateColumnsMgr {
         getStorage().vacuum(ttlTime);
     }
 
+    public void vacuumExternal() {
+        long ttlHour = Config.statistic_external_predicate_columns_ttl_hours;
+        if (ttlHour < 0) {
+            return;
+        }
+        LocalDateTime ttlTime = TimeUtils.getSystemNow().minusHours(ttlHour);
+        Predicate<ExternalColumnUsage> outdated = x -> x.getLastUsed().isBefore(ttlTime);
+
+        long before = externalId2columnUsage.size();
+        if (before > 0 && externalId2columnUsage.values().removeIf(outdated)) {
+            long after = externalId2columnUsage.size();
+            LOG.info("removed {} objects from external predicate columns because of ttl {}", before - after,
+                    Config.statistic_external_predicate_columns_ttl_hours);
+        }
+
+        getExternalStorage().vacuum(ttlTime);
+    }
+
     public void restore() {
         List<ColumnUsage> state = getStorage().restore();
         for (ColumnUsage usage : ListUtils.emptyIfNull(state)) {
@@ -199,13 +268,31 @@ public class PredicateColumnsMgr {
         }
     }
 
+    public void restoreExternal() {
+        List<ExternalColumnUsage> state = getExternalStorage().restore();
+        for (ExternalColumnUsage usage : ListUtils.emptyIfNull(state)) {
+            externalId2columnUsage.merge(usage, usage, ExternalColumnUsage::merge);
+        }
+    }
+
     private PredicateColumnsStorage getStorage() {
         return PredicateColumnsStorage.getInstance();
+    }
+
+    private ExternalPredicateColumnsStorage getExternalStorage() {
+        return ExternalPredicateColumnsStorage.getInstance();
     }
 
     @VisibleForTesting
     public void reset() {
         id2columnUsage.clear();
+        externalId2columnUsage.clear();
+        externalQueryCache.invalidateAll();
+    }
+
+    @VisibleForTesting
+    public void recordColumnUsageForTest(Table table, Column column, ColumnUsage.UseCase useCase) {
+        addOrUpdateColumnUsage(table, column, useCase);
     }
 
     public void startDaemon() {
@@ -229,19 +316,30 @@ public class PredicateColumnsMgr {
             setInterval(Config.statistic_predicate_columns_persist_interval_sec * 1000L);
 
             PredicateColumnsMgr mgr = PredicateColumnsMgr.getInstance();
-            PredicateColumnsStorage storage = PredicateColumnsStorage.getInstance();
 
+            // Native and external tables are tracked in separate in-memory maps and separate storage
+            // tables, each with its own restore-gating sentinel; drive them independently so one
+            // being un-restored (e.g. right after FE start) never blocks the other from persisting.
+            PredicateColumnsStorage storage = PredicateColumnsStorage.getInstance();
             if (!storage.isSystemTableReady()) {
                 LOG.warn("system table of predicate_columns is still not ready");
-                return;
-            }
-
-            if (!storage.isRestored()) {
+            } else if (!storage.isRestored()) {
                 mgr.restore();
                 storage.finishRestore();
             } else {
                 mgr.vacuum();
                 mgr.persist();
+            }
+
+            ExternalPredicateColumnsStorage externalStorage = ExternalPredicateColumnsStorage.getInstance();
+            if (!externalStorage.isSystemTableReady()) {
+                LOG.warn("system table of external_predicate_columns is still not ready");
+            } else if (!externalStorage.isRestored()) {
+                mgr.restoreExternal();
+                externalStorage.finishRestore();
+            } else {
+                mgr.vacuumExternal();
+                mgr.persistExternal();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
@@ -171,11 +171,7 @@ public class PredicateColumnsMgr {
         if (!CatalogMgr.isExternalCatalog(table.getCatalogName()) || table.isTemporaryTable()) {
             return;
         }
-        Optional<ExternalColumnUsage> mayUsage = ExternalColumnUsage.build(column, table, useCase);
-        if (mayUsage.isEmpty()) {
-            return;
-        }
-        ExternalColumnUsage usage = mayUsage.get();
+        ExternalColumnUsage usage = ExternalColumnUsage.build(column, table, useCase);
         ExternalColumnUsage oldValue = externalId2columnUsage.computeIfAbsent(usage, k -> usage);
         oldValue.useNow(useCase);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
@@ -68,6 +68,21 @@ class ExternalColumnUsageTest {
     }
 
     @Test
+    public void testColumnNameBoundaryStaysUnderBePrimaryKeyLimit() {
+        // BE's primary_key_limit_size defaults to 128 bytes; with a 3-field VARCHAR PK
+        // (fe_id, table_uuid, column_name) where column_name is last, the worst-case budget
+        // (10-digit fe_id + 2, 32-char table_uuid + 2, column_name with no separator) allows up
+        // to 82 bytes for column_name. MAX_COLUMN_NAME_LENGTH (80) must stay under that ceiling.
+        IcebergTable table = mockTable("catalog.db.t", "catalog", "db", "t");
+
+        Column atLimit = new Column("c".repeat(80), IntegerType.INT);
+        Assertions.assertTrue(ExternalColumnUsage.build(atLimit, table, ColumnUsage.UseCase.PREDICATE).isPresent());
+
+        Column overLimit = new Column("c".repeat(81), IntegerType.INT);
+        Assertions.assertTrue(ExternalColumnUsage.build(overLimit, table, ColumnUsage.UseCase.PREDICATE).isEmpty());
+    }
+
+    @Test
     public void testEqualityIsByTableUuidHashAndColumnName() {
         ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "catalogA", "dbA", "tA", "c1",
                 ColumnUsage.UseCase.PREDICATE);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
@@ -24,7 +24,6 @@ import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.EnumSet;
-import java.util.Optional;
 
 class ExternalColumnUsageTest {
 
@@ -43,10 +42,7 @@ class ExternalColumnUsageTest {
         IcebergTable table = mockTable("iceberg_catalog.db1.t1.uuid-1234", "iceberg_catalog", "db1", "t1");
         Column column = new Column("c1", IntegerType.INT);
 
-        Optional<ExternalColumnUsage> mayUsage =
-                ExternalColumnUsage.build(column, table, ColumnUsage.UseCase.PREDICATE);
-        Assertions.assertTrue(mayUsage.isPresent());
-        ExternalColumnUsage usage = mayUsage.get();
+        ExternalColumnUsage usage = ExternalColumnUsage.build(column, table, ColumnUsage.UseCase.PREDICATE);
         Assertions.assertEquals(StatisticUtils.hashTableUuidForPkStorage("iceberg_catalog.db1.t1.uuid-1234"),
                 usage.getTableUuidHash());
         Assertions.assertEquals("iceberg_catalog", usage.getCatalogName());
@@ -57,29 +53,35 @@ class ExternalColumnUsageTest {
     }
 
     @Test
-    public void testBuildSkipsOverlongColumnName() {
+    public void testBuildAcceptsLongAndMultibyteColumnNames() {
+        // column_name is never part of the persisted PK directly (only its hash is), so its length
+        // and encoding (e.g. multibyte CJK characters, where Java's String.length() undercounts the
+        // actual UTF-8 byte size) can never make the PK exceed BE's primary_key_limit_size.
         IcebergTable table = mockTable("catalog.db.t", "catalog", "db", "t");
-        String longName = "c".repeat(200);
-        Column column = new Column(longName, IntegerType.INT);
 
-        Optional<ExternalColumnUsage> mayUsage =
-                ExternalColumnUsage.build(column, table, ColumnUsage.UseCase.PREDICATE);
-        Assertions.assertTrue(mayUsage.isEmpty());
+        Column longName = new Column("c".repeat(200), IntegerType.INT);
+        ExternalColumnUsage longUsage = ExternalColumnUsage.build(longName, table, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertEquals(32, longUsage.getColumnNameHash().length());
+
+        Column multibyteName = new Column("列".repeat(50), IntegerType.INT);
+        ExternalColumnUsage multibyteUsage =
+                ExternalColumnUsage.build(multibyteName, table, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertEquals("列".repeat(50), multibyteUsage.getColumnName());
+        Assertions.assertEquals(32, multibyteUsage.getColumnNameHash().length());
     }
 
     @Test
-    public void testColumnNameBoundaryStaysUnderBePrimaryKeyLimit() {
-        // BE's primary_key_limit_size defaults to 128 bytes; with a 3-field VARCHAR PK
-        // (fe_id, table_uuid, column_name) where column_name is last, the worst-case budget
-        // (10-digit fe_id + 2, 32-char table_uuid + 2, column_name with no separator) allows up
-        // to 82 bytes for column_name. MAX_COLUMN_NAME_LENGTH (80) must stay under that ceiling.
-        IcebergTable table = mockTable("catalog.db.t", "catalog", "db", "t");
+    public void testColumnNameHashIsDeterministicAndDistinguishesNames() {
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        ExternalColumnUsage usage1Again = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c1",
+                ColumnUsage.UseCase.JOIN);
+        ExternalColumnUsage usage2 = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c2",
+                ColumnUsage.UseCase.PREDICATE);
 
-        Column atLimit = new Column("c".repeat(80), IntegerType.INT);
-        Assertions.assertTrue(ExternalColumnUsage.build(atLimit, table, ColumnUsage.UseCase.PREDICATE).isPresent());
-
-        Column overLimit = new Column("c".repeat(81), IntegerType.INT);
-        Assertions.assertTrue(ExternalColumnUsage.build(overLimit, table, ColumnUsage.UseCase.PREDICATE).isEmpty());
+        Assertions.assertEquals(usage1.getColumnNameHash(), usage1Again.getColumnNameHash());
+        Assertions.assertNotEquals(usage1.getColumnNameHash(), usage2.getColumnNameHash());
+        Assertions.assertEquals(32, usage1.getColumnNameHash().length());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalColumnUsageTest.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.columns;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Optional;
+
+class ExternalColumnUsageTest {
+
+    private IcebergTable mockTable(String uuid, String catalog, String db, String table) {
+        IcebergTable t = Mockito.mock(IcebergTable.class);
+        Mockito.when(t.getUUID()).thenReturn(uuid);
+        Mockito.when(t.getCatalogName()).thenReturn(catalog);
+        Mockito.when(t.getCatalogDBName()).thenReturn(db);
+        Mockito.when(t.getCatalogTableName()).thenReturn(table);
+        Mockito.when(t.getName()).thenReturn(table);
+        return t;
+    }
+
+    @Test
+    public void testBuild() {
+        IcebergTable table = mockTable("iceberg_catalog.db1.t1.uuid-1234", "iceberg_catalog", "db1", "t1");
+        Column column = new Column("c1", IntegerType.INT);
+
+        Optional<ExternalColumnUsage> mayUsage =
+                ExternalColumnUsage.build(column, table, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertTrue(mayUsage.isPresent());
+        ExternalColumnUsage usage = mayUsage.get();
+        Assertions.assertEquals(StatisticUtils.hashTableUuidForPkStorage("iceberg_catalog.db1.t1.uuid-1234"),
+                usage.getTableUuidHash());
+        Assertions.assertEquals("iceberg_catalog", usage.getCatalogName());
+        Assertions.assertEquals("db1", usage.getDbName());
+        Assertions.assertEquals("t1", usage.getTableName());
+        Assertions.assertEquals("c1", usage.getColumnName());
+        Assertions.assertEquals("predicate", usage.getUseCaseString());
+    }
+
+    @Test
+    public void testBuildSkipsOverlongColumnName() {
+        IcebergTable table = mockTable("catalog.db.t", "catalog", "db", "t");
+        String longName = "c".repeat(200);
+        Column column = new Column(longName, IntegerType.INT);
+
+        Optional<ExternalColumnUsage> mayUsage =
+                ExternalColumnUsage.build(column, table, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertTrue(mayUsage.isEmpty());
+    }
+
+    @Test
+    public void testEqualityIsByTableUuidHashAndColumnName() {
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "catalogA", "dbA", "tA", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        ExternalColumnUsage usage2 = new ExternalColumnUsage("hash1", "catalogB", "dbB", "tB", "c1",
+                ColumnUsage.UseCase.JOIN);
+        Assertions.assertEquals(usage1, usage2);
+
+        ExternalColumnUsage usage3 = new ExternalColumnUsage("hash1", "catalogA", "dbA", "tA", "c2",
+                ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertNotEquals(usage1, usage3);
+    }
+
+    @Test
+    public void testUseNowAndMerge() {
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        usage1.setLastUsed(LocalDateTime.parse("2025-01-01T00:00:00"));
+
+        ExternalColumnUsage usage2 = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c1",
+                EnumSet.of(ColumnUsage.UseCase.JOIN));
+        usage2.setLastUsed(LocalDateTime.parse("2025-01-02T00:00:00"));
+
+        ExternalColumnUsage merged = usage1.merge(usage2);
+        Assertions.assertEquals(EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN),
+                merged.getUseCases());
+        Assertions.assertEquals(LocalDateTime.parse("2025-01-02T00:00:00"), merged.getLastUsed());
+
+        usage1.useNow(ColumnUsage.UseCase.GROUP_BY);
+        Assertions.assertTrue(usage1.getUseCases().contains(ColumnUsage.UseCase.GROUP_BY));
+    }
+
+    @Test
+    public void testNeedPersist() {
+        ExternalColumnUsage usage = new ExternalColumnUsage("hash1", "catalog", "db", "t", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        usage.setLastUsed(LocalDateTime.parse("2025-01-02T00:00:00"));
+        Assertions.assertTrue(usage.needPersist(LocalDateTime.parse("2025-01-01T00:00:00")));
+        Assertions.assertFalse(usage.needPersist(LocalDateTime.parse("2025-01-03T00:00:00")));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
@@ -76,10 +76,11 @@ class ExternalPredicateColumnsStorageTest extends PlanTestBase {
         instance.persist(List.of(usage1));
 
         Mockito.verify(repo).executeDML(String.format(
-                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name, catalog_name, "
-                        + "db_name, table_name, usage, last_used ) VALUES "
-                        + "('%s', 'hash1', 'c1', 'iceberg_catalog', 'db1', 't1', 'predicate', '2024-11-20 01:02:03')",
-                feName));
+                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name_hash, "
+                        + "catalog_name, db_name, table_name, column_name, usage, last_used ) VALUES "
+                        + "('%s', 'hash1', '%s', 'iceberg_catalog', 'db1', 't1', 'c1', 'predicate', "
+                        + "'2024-11-20 01:02:03')",
+                feName, usage1.getColumnNameHash()));
 
         // query
         instance.queryGlobalState("hash1", EnumSet.noneOf(ColumnUsage.UseCase.class));
@@ -115,10 +116,11 @@ class ExternalPredicateColumnsStorageTest extends PlanTestBase {
         instance.persist(List.of(usage));
 
         Mockito.verify(repo).executeDML(String.format(
-                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name, catalog_name, "
-                        + "db_name, table_name, usage, last_used ) VALUES "
-                        + "('%s', 'hash1', 'c''1', 'cat''alog', 'db\\\\name', 't1', 'predicate', '2024-11-20 01:02:03')",
-                feName));
+                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name_hash, "
+                        + "catalog_name, db_name, table_name, column_name, usage, last_used ) VALUES "
+                        + "('%s', 'hash1', '%s', 'cat''alog', 'db\\\\name', 't1', 'c''1', 'predicate', "
+                        + "'2024-11-20 01:02:03')",
+                feName, usage.getColumnNameHash()));
 
         guard.close();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
@@ -97,6 +97,33 @@ class ExternalPredicateColumnsStorageTest extends PlanTestBase {
     }
 
     @Test
+    public void testPersistEscapesSpecialCharacters() {
+        // catalog/db/table/column names originate from external catalog metadata and must not be
+        // trusted; a quote or backslash in one of them must not break out of the SQL string literal.
+        TableKeeper keeper = ExternalPredicateColumnsStorage.createKeeper();
+        keeper.run();
+        ConnectContext.ScopeGuard guard = connectContext.bindScope();
+
+        SimpleExecutor repo = Mockito.mock(SimpleExecutor.class);
+        ExternalPredicateColumnsStorage instance = new ExternalPredicateColumnsStorage(repo);
+        instance.restore();
+        instance.finishRestore(LocalDateTime.parse("2024-11-10T01:00:00"));
+
+        ExternalColumnUsage usage = new ExternalColumnUsage("hash1", "cat'alog", "db\\name", "t1", "c'1",
+                ColumnUsage.UseCase.PREDICATE);
+        usage.setLastUsed(LocalDateTime.parse("2024-11-20T01:02:03"));
+        instance.persist(List.of(usage));
+
+        Mockito.verify(repo).executeDML(String.format(
+                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name, catalog_name, "
+                        + "db_name, table_name, usage, last_used ) VALUES "
+                        + "('%s', 'hash1', 'c''1', 'cat''alog', 'db\\\\name', 't1', 'predicate', '2024-11-20 01:02:03')",
+                feName));
+
+        guard.close();
+    }
+
+    @Test
     public void testSerialization() {
         ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c1",
                 ColumnUsage.UseCase.PREDICATE);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/ExternalPredicateColumnsStorageTest.java
@@ -1,0 +1,164 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.columns;
+
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.scheduler.history.TableKeeper;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.thrift.TResultBatch;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+class ExternalPredicateColumnsStorageTest extends PlanTestBase {
+
+    private static int feName;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        StatisticsMetaManager m = new StatisticsMetaManager();
+        m.createStatisticsTablesForTest();
+        feName = GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFid();
+    }
+
+    @Test
+    public void lifecycle() {
+        // create table
+        TableKeeper keeper = ExternalPredicateColumnsStorage.createKeeper();
+        keeper.run();
+        Assertions.assertNotNull(starRocksAssert.getTable(ExternalPredicateColumnsStorage.DATABASE_NAME,
+                ExternalPredicateColumnsStorage.TABLE_NAME));
+        ConnectContext.ScopeGuard guard = connectContext.bindScope();
+
+        SimpleExecutor repo = Mockito.mock(SimpleExecutor.class);
+        ExternalPredicateColumnsStorage instance = new ExternalPredicateColumnsStorage(repo);
+
+        // restore
+        LocalDateTime lastPersist = LocalDateTime.parse("2024-11-10T01:00:00");
+        Assertions.assertFalse(instance.isRestored());
+        instance.restore();
+        instance.finishRestore();
+        instance.finishRestore(lastPersist);
+        Assertions.assertTrue(instance.isRestored());
+        Mockito.verify(repo).executeDQL(
+                "SELECT fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used, created "
+                        + "FROM _statistics_.external_predicate_columns WHERE true  AND fe_id = '" + feName + "'");
+
+        // persist
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        usage1.setCreated(LocalDateTime.parse("2024-11-20T01:02:03"));
+        usage1.setLastUsed(LocalDateTime.parse("2024-11-20T01:02:03"));
+        instance.persist(List.of(usage1));
+
+        Mockito.verify(repo).executeDML(String.format(
+                "INSERT INTO _statistics_.external_predicate_columns(fe_id, table_uuid, column_name, catalog_name, "
+                        + "db_name, table_name, usage, last_used ) VALUES "
+                        + "('%s', 'hash1', 'c1', 'iceberg_catalog', 'db1', 't1', 'predicate', '2024-11-20 01:02:03')",
+                feName));
+
+        // query
+        instance.queryGlobalState("hash1", EnumSet.noneOf(ColumnUsage.UseCase.class));
+        Mockito.verify(repo).executeDQL(
+                "SELECT fe_id, table_uuid, column_name, catalog_name, db_name, table_name, usage, last_used, created "
+                        + "FROM _statistics_.external_predicate_columns WHERE true  AND `table_uuid` = 'hash1'");
+
+        // vacuum
+        instance.vacuum(lastPersist);
+        Mockito.verify(repo).executeDML("DELETE FROM _statistics_.external_predicate_columns " +
+                "WHERE fe_id=" + Strings.quote(Integer.toString(feName)) +
+                " AND last_used < '2024-11-10 01:00:00'");
+
+        guard.close();
+    }
+
+    @Test
+    public void testSerialization() {
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c1",
+                ColumnUsage.UseCase.PREDICATE);
+        ExternalColumnUsage usage2 = new ExternalColumnUsage("hash2", "iceberg_catalog", "db1", "t1", "c2",
+                EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN));
+
+        String row1 = String.format("{\"data\": ['%s','%s','%s','%s','%s','%s','%s','%s','%s']}",
+                feName, "hash1", "c1", "iceberg_catalog", "db1", "t1", usage1.getUseCaseString(),
+                DateUtils.formatDateTimeUnix(usage1.getLastUsed()), DateUtils.formatDateTimeUnix(usage1.getCreated()));
+        String row2 = String.format("{\"data\": ['%s','%s','%s','%s','%s','%s','%s','%s','%s']}",
+                feName, "hash2", "c2", "iceberg_catalog", "db1", "t1", usage2.getUseCaseString(),
+                DateUtils.formatDateTimeUnix(usage2.getLastUsed()), DateUtils.formatDateTimeUnix(usage2.getCreated()));
+
+        TResultBatch batch = new TResultBatch();
+        batch.setRows(List.of(ByteBuffer.wrap(row1.getBytes()), ByteBuffer.wrap(row2.getBytes())));
+        List<ExternalColumnUsage> result = ExternalPredicateColumnsStorage.resultToColumnUsage(List.of(batch));
+
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertEquals(usage1, result.get(0));
+        Assertions.assertEquals(usage2, result.get(1));
+
+        // corrupted json is skipped, valid rows around it still parse
+        String corruptedJson = "{\"data\": [invalid json}";
+        TResultBatch batchWithCorrupted = new TResultBatch();
+        batchWithCorrupted.setRows(List.of(ByteBuffer.wrap(row1.getBytes()), ByteBuffer.wrap(corruptedJson.getBytes()),
+                ByteBuffer.wrap(row2.getBytes())));
+        List<ExternalColumnUsage> resultWithCorrupted =
+                ExternalPredicateColumnsStorage.resultToColumnUsage(List.of(batchWithCorrupted));
+        Assertions.assertEquals(2, resultWithCorrupted.size());
+        Assertions.assertEquals(usage1, resultWithCorrupted.get(0));
+        Assertions.assertEquals(usage2, resultWithCorrupted.get(1));
+    }
+
+    @Test
+    public void testDeduplicateColumnUsages() {
+        List<ExternalColumnUsage> duplicated = new ArrayList<>();
+
+        ExternalColumnUsage usage1 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c1",
+                EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.DISTINCT));
+        usage1.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage1.setLastUsed(LocalDateTime.parse("2025-01-02T01:02:03"));
+        duplicated.add(usage1);
+
+        ExternalColumnUsage usage2 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c1",
+                EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN));
+        usage2.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage2.setLastUsed(LocalDateTime.parse("2025-01-02T02:02:03"));
+        duplicated.add(usage2);
+
+        ExternalColumnUsage usage3 = new ExternalColumnUsage("hash1", "iceberg_catalog", "db1", "t1", "c2",
+                EnumSet.of(ColumnUsage.UseCase.GROUP_BY, ColumnUsage.UseCase.JOIN));
+        usage3.setCreated(LocalDateTime.parse("2025-01-01T01:02:03"));
+        usage3.setLastUsed(LocalDateTime.parse("2025-01-02T03:02:03"));
+        duplicated.add(usage3);
+
+        List<ExternalColumnUsage> result =
+                ExternalPredicateColumnsStorage.getInstance().deduplicateColumnUsages(duplicated);
+
+        Assertions.assertEquals(2, result.size());
+        ExternalColumnUsage merged = result.stream().filter(x -> x.getColumnName().equals("c1")).findFirst().get();
+        Assertions.assertEquals(EnumSet.of(ColumnUsage.UseCase.PREDICATE, ColumnUsage.UseCase.JOIN,
+                ColumnUsage.UseCase.DISTINCT), merged.getUseCases());
+        Assertions.assertEquals(LocalDateTime.parse("2025-01-02T02:02:03"), merged.getLastUsed());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsMgrTest.java
@@ -108,13 +108,17 @@ class PredicateColumnsMgrTest extends PlanTestBase {
     }
 
     @Test
-    public void testOverlongColumnNameSkipped() {
+    public void testLongOrMultibyteColumnNameStillRecordedAndQueryable() {
+        // column_name is only ever hashed for PK storage, never truncated/rejected by length, so
+        // long or multibyte (e.g. CJK) column names round-trip through record -> query normally.
         IcebergTable table = mockExternalTable("iceberg_catalog.db1.t3.uuid-3", "iceberg_catalog", "db1", "t3");
-        Column column = new Column("c".repeat(200), IntegerType.INT);
+        Column column = new Column("列".repeat(50), IntegerType.INT);
 
         PredicateColumnsMgr.getInstance().recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
 
-        Assertions.assertTrue(PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table).isEmpty());
+        List<ExternalColumnUsage> result = PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("列".repeat(50), result.get(0).getColumnName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/columns/PredicateColumnsMgrTest.java
@@ -1,0 +1,150 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic.columns;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableName;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.scheduler.history.TableKeeper;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+class PredicateColumnsMgrTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StatisticsMetaManager statistic = new StatisticsMetaManager();
+        statistic.createStatisticsTablesForTest();
+        TableKeeper keeper = ExternalPredicateColumnsStorage.createKeeper();
+        keeper.run();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @BeforeEach
+    public void before() {
+        PredicateColumnsMgr.getInstance().reset();
+    }
+
+    private IcebergTable mockExternalTable(String uuid, String catalog, String db, String table) {
+        IcebergTable t = Mockito.mock(IcebergTable.class);
+        Mockito.when(t.getUUID()).thenReturn(uuid);
+        Mockito.when(t.getCatalogName()).thenReturn(catalog);
+        Mockito.when(t.getCatalogDBName()).thenReturn(db);
+        Mockito.when(t.getCatalogTableName()).thenReturn(table);
+        Mockito.when(t.getName()).thenReturn(table);
+        Mockito.when(t.isNativeTableOrMaterializedView()).thenReturn(false);
+        Mockito.when(t.isTemporaryTable()).thenReturn(false);
+        return t;
+    }
+
+    @Test
+    public void testExternalColumnRecordedAndQueryable() {
+        IcebergTable table = mockExternalTable("iceberg_catalog.db1.t1.uuid-1", "iceberg_catalog", "db1", "t1");
+        Column column = new Column("c1", IntegerType.INT);
+        PredicateColumnsMgr mgr = PredicateColumnsMgr.getInstance();
+
+        mgr.recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
+
+        List<ExternalColumnUsage> result = mgr.queryExternalPredicateColumns(table);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals("c1", result.get(0).getColumnName());
+        Assertions.assertEquals("iceberg_catalog", result.get(0).getCatalogName());
+    }
+
+    @Test
+    public void testNativeTableStillRecordsIntoInternalPath() {
+        PredicateColumnsMgr mgr = PredicateColumnsMgr.getInstance();
+        Table t0 = starRocksAssert.getTable(connectContext.getDatabase(), "t0");
+        Column v1 = t0.getColumn("v1");
+
+        mgr.recordColumnUsageForTest(t0, v1, ColumnUsage.UseCase.PREDICATE);
+
+        TableName tableName = new TableName(connectContext.getDatabase(), "t0");
+        List<ColumnUsage> result = mgr.queryPredicateColumns(tableName);
+        Assertions.assertEquals(1, result.size());
+
+        // and must not leak into the external map
+        IcebergTable unrelated = mockExternalTable("catalog.db.other", "catalog", "db", "other");
+        Assertions.assertTrue(mgr.queryExternalPredicateColumns(unrelated).isEmpty());
+    }
+
+    @Test
+    public void testExternalCollectionDisabledByConfig() {
+        boolean defaultValue = Config.enable_external_predicate_columns_collection;
+        Config.enable_external_predicate_columns_collection = false;
+        try {
+            IcebergTable table = mockExternalTable("iceberg_catalog.db1.t2.uuid-2", "iceberg_catalog", "db1", "t2");
+            Column column = new Column("c1", IntegerType.INT);
+            PredicateColumnsMgr.getInstance().recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
+
+            Assertions.assertTrue(PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table).isEmpty());
+        } finally {
+            Config.enable_external_predicate_columns_collection = defaultValue;
+        }
+    }
+
+    @Test
+    public void testOverlongColumnNameSkipped() {
+        IcebergTable table = mockExternalTable("iceberg_catalog.db1.t3.uuid-3", "iceberg_catalog", "db1", "t3");
+        Column column = new Column("c".repeat(200), IntegerType.INT);
+
+        PredicateColumnsMgr.getInstance().recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
+
+        Assertions.assertTrue(PredicateColumnsMgr.getInstance().queryExternalPredicateColumns(table).isEmpty());
+    }
+
+    @Test
+    public void testResetClearsExternalState() {
+        IcebergTable table = mockExternalTable("iceberg_catalog.db1.t4.uuid-4", "iceberg_catalog", "db1", "t4");
+        Column column = new Column("c1", IntegerType.INT);
+        PredicateColumnsMgr mgr = PredicateColumnsMgr.getInstance();
+
+        mgr.recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertEquals(1, mgr.queryExternalPredicateColumns(table).size());
+
+        mgr.reset();
+        Assertions.assertTrue(mgr.queryExternalPredicateColumns(table).isEmpty());
+    }
+
+    @Test
+    public void testVacuumExternalSkipsWhenTtlDisabled() {
+        IcebergTable table = mockExternalTable("iceberg_catalog.db1.t5.uuid-5", "iceberg_catalog", "db1", "t5");
+        Column column = new Column("c1", IntegerType.INT);
+        PredicateColumnsMgr mgr = PredicateColumnsMgr.getInstance();
+        mgr.recordColumnUsageForTest(table, column, ColumnUsage.UseCase.PREDICATE);
+        Assertions.assertEquals(1, mgr.queryExternalPredicateColumns(table).size());
+
+        long beforeValue = Config.statistic_external_predicate_columns_ttl_hours;
+        Config.statistic_external_predicate_columns_ttl_hours = -1;
+        try {
+            mgr.vacuumExternal();
+            Assertions.assertEquals(1, mgr.queryExternalPredicateColumns(table).size());
+        } finally {
+            Config.statistic_external_predicate_columns_ttl_hours = beforeValue;
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
External table ANALYZE (Iceberg/Hive/etc.) always collects statistics for every column, which wastes scan cost on wide tables. StarRocks already tracks which columns are actually used in WHERE/JOIN/GROUP BY for native tables (`_statistics_.predicate_columns`) and uses that to narrow down ANALYZE's column list, but this tracking has always hard-excluded external tables. This change extends the same mechanism to external tables so their ANALYZE jobs can skip columns nobody queries.

## What I'm doing:
- Add a new system table `_statistics_.external_predicate_columns` and its storage class `ExternalPredicateColumnsStorage`, mirroring the existing `predicate_columns`/`PredicateColumnsStorage` persist → restore → vacuum lifecycle (per-FE ownership, batched inserts, TTL-based cleanup).
- Add `ExternalColumnUsage`, the external-table counterpart of `ColumnUsage`. Since external tables have no stable numeric db/table/column id, identity is `(hash(table_uuid), column_name)` instead — the same hashing scheme already used by `external_column_statistics`, so both tables can be cross-referenced by `table_uuid`.
- Extend `PredicateColumnsMgr` to dispatch column-usage recording to either the native or the external path depending on table type, and drive both storages independently from the same background daemon tick.
- Wire the collected usage into `StatisticsCollectJobFactory`: when a user doesn't pin down columns explicitly and the table is wide enough, ANALYZE now narrows its column list to known predicate columns, falling back to all columns when nothing is known yet.
- Add a small in-memory read cache in front of the external query path, since it's expected to be queried far more often (many more external tables, auto-ANALYZE column selection) than the native path.

```
query optimizer
     │
     ▼
PredicateColumnsMgr.record*()
     │
     ├─ native table  → id2columnUsage            (existing)
     └─ external table → externalId2columnUsage   (new)
                              │
                    daemon (persist/restore/vacuum)
                              │
                              ▼
              _statistics_.external_predicate_columns
                              │
                    query (cached) ──► StatisticsCollectJobFactory
                                        picks narrower column list for ANALYZE
```

New configs: `enable_external_predicate_columns_collection`, `statistic_external_predicate_columns_ttl_hours` (default 7 days — external ANALYZE runs far less often than native, so a short TTL would evict usage between two collections), `statistic_external_predicate_columns_cache_ttl_sec`.

```
+-------+----------------------------------+----------------------------------+--------------+-------------------------------------------+------------+---------------+----------------+---------------------+---------------------+
| fe_id | table_uuid                       | column_name_hash                 | catalog_name | db_name                                   | table_name | column_name   | usage          | last_used           | created             |
+-------+----------------------------------+----------------------------------+--------------+-------------------------------------------+------------+---------------+----------------+---------------------+---------------------+
| 3     | 605ecd7315769756b9fa87ad356810a4 | 96c8d29de82a42c15c830d32d0c7754c | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | region     | r_name        | predicate      | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 665087eb9b67778652915b6825550bae | 0c7fe05562e41e971c42a6721ac0ec87 | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | part       | p_size        | predicate      | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | fddeb7f6fcb44095e6004d678b5a305f | 8ca789b6327a823cd28d58e8e4d970ff | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | nation     | n_regionkey   | join           | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 605ecd7315769756b9fa87ad356810a4 | 3a4792f5bf7a776aa14284ebb40ff4dc | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | region     | r_regionkey   | join           | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 665087eb9b67778652915b6825550bae | fdffa0c9ca13247c7808fcd9762b5a02 | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | part       | p_type        | predicate      | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 666490b1489fc3e0518f3f854e51c949 | 695a561cdebb361d90a4b7ca555fbc6d | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | partsupp   | ps_suppkey    | predicate,join | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 666490b1489fc3e0518f3f854e51c949 | e1dc9de93bb1abc983dcd0114e4d6908 | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | partsupp   | ps_supplycost | predicate      | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 763e1eee9c1fa16c1c85fbc65a94d024 | 2f4132f6c80042bef03a6f41ef15ce1d | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | supplier   | s_nationkey   | join           | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | fddeb7f6fcb44095e6004d678b5a305f | fad556ad16264916b74d5e1e5deb8230 | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | nation     | n_nationkey   | predicate,join | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 665087eb9b67778652915b6825550bae | 5b5102f92ebf8b974af05b4af5c090e8 | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | part       | p_partkey     | join,group_by  | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 666490b1489fc3e0518f3f854e51c949 | 6407777b49d21d19188b7d6e52521cbd | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | partsupp   | ps_partkey    | predicate,join | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
| 3     | 763e1eee9c1fa16c1c85fbc65a94d024 | 7de3760cf46fd960034c3b3f5c49c3cb | iceberg      | zz_iceberg_tpch_sf100_iceberg_parquet_lz4 | supplier   | s_suppkey     | join           | 2026-07-07 19:49:06 | 2026-07-07 19:49:17 |
+-------+----------------------------------+----------------------------------+--------------+-------------------------------------------+------------+---------------+----------------+---------------------+---------------------+
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
