### PR TITLE
[Enhancement] Restrict shared-data primary key tables to the cloud-native persistent index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2646,6 +2646,22 @@ public class SchemaChangeHandler extends AlterHandler {
                         PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, false);
                 persistentIndexType = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                         TableProperty.CLOUD_NATIVE_INDEX_TYPE);
+                // Shared-data primary key tables only support the cloud-native persistent index.
+                // The local-disk persistent index and the in-memory index are deprecated: disabling
+                // the persistent index or switching to LOCAL is no longer allowed (migrating an
+                // existing LOCAL table to CLOUD_NATIVE is still permitted). These restrictions only
+                // apply to primary key tables; enable_persistent_index is a no-op for other key types.
+                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
+                    if (!enablePersistentIndex) {
+                        throw new DdlException("The persistent index can not be disabled for shared-data primary key " +
+                                "tables, the in-memory index is no longer supported");
+                    }
+                    if (!TableProperty.CLOUD_NATIVE_INDEX_TYPE.equalsIgnoreCase(persistentIndexType)) {
+                        throw new DdlException("Only cloud native persistent index (persistent_index_type = " +
+                                "CLOUD_NATIVE) is supported for shared-data primary key tables, but got: " +
+                                persistentIndexType);
+                    }
+                }
                 boolean oldEnablePersistentIndex = olapTable.enablePersistentIndex();
                 String oldPersistentIndexType = olapTable.getPersistentIndexType() == TPersistentIndexType.LOCAL ?
                         TableProperty.LOCAL_INDEX_TYPE : TableProperty.CLOUD_NATIVE_INDEX_TYPE;
@@ -2654,10 +2670,6 @@ public class SchemaChangeHandler extends AlterHandler {
                     LOG.info(String.format("table: %s enable_persistent_index is %s persistent_index_type is %s, "
                             + "nothing need to do", olapTable.getName(), enablePersistentIndex, persistentIndexType));
                     return null;
-                }
-                if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
-                        && !enablePersistentIndex) {
-                    throw new DdlException("enable_persistent_index is false, can not set persistent_index_type");
                 }
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)) {
                 // only support set persistent_index_type when enable_persistent_index is true
@@ -2669,6 +2681,14 @@ public class SchemaChangeHandler extends AlterHandler {
                         TableProperty.LOCAL_INDEX_TYPE : TableProperty.CLOUD_NATIVE_INDEX_TYPE;
                 persistentIndexType = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                         TableProperty.CLOUD_NATIVE_INDEX_TYPE);
+                // Shared-data primary key tables only support the cloud-native persistent index; switching
+                // to LOCAL is deprecated (migrating an existing LOCAL table to CLOUD_NATIVE is still allowed).
+                if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS
+                        && !TableProperty.CLOUD_NATIVE_INDEX_TYPE.equalsIgnoreCase(persistentIndexType)) {
+                    throw new DdlException("Only cloud native persistent index (persistent_index_type = " +
+                            "CLOUD_NATIVE) is supported for shared-data primary key tables, but got: " +
+                            persistentIndexType);
+                }
                 if (oldPersistentIndexType.equals(persistentIndexType)) {
                     LOG.info(String.format("table: %s persistent_index_type is %s, nothing need to do",
                             olapTable.getName(), persistentIndexType));

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -93,7 +93,6 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
-import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
@@ -1681,22 +1680,6 @@ public class PropertyAnalyzer {
 
     public static boolean analyzeDataCacheEnable(Map<String, String> properties) throws AnalysisException {
         return analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, true);
-    }
-
-    public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {
-        if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
-            String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);
-            properties.remove(PROPERTIES_PERSISTENT_INDEX_TYPE);
-            if (type.equalsIgnoreCase(TableProperty.LOCAL_INDEX_TYPE)) {
-                return TPersistentIndexType.LOCAL;
-            } else if (type.equalsIgnoreCase(TableProperty.CLOUD_NATIVE_INDEX_TYPE)) {
-                return TPersistentIndexType.CLOUD_NATIVE;
-            } else {
-                throw new AnalysisException("Invalid persistent index type: " + type);
-            }
-        }
-        return Config.enable_cloud_native_persistent_index_by_default ? TPersistentIndexType.CLOUD_NATIVE
-                : TPersistentIndexType.LOCAL;
     }
 
     public static TCompactionStrategy analyzecompactionStrategy(Map<String, String> properties) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableIndexes;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
@@ -382,25 +383,18 @@ public class OlapTableFactory implements AbstractTableFactory {
                 }
             }
             if (table.isCloudNativeTable() && table.getKeysType() == KeysType.PRIMARY_KEYS) {
-                TPersistentIndexType persistentIndexType;
-                try {
-                    persistentIndexType = PropertyAnalyzer.analyzePersistentIndexType(properties);
-                } catch (AnalysisException e) {
-                    throw new DdlException(e.getMessage());
+                // Shared-data primary key tables only support the cloud-native persistent index.
+                // The local-disk persistent index and the in-memory index are deprecated: reject an
+                // explicit LOCAL (or any non-CLOUD_NATIVE) request, and force CLOUD_NATIVE regardless
+                // of enable_cloud_native_persistent_index_by_default. Consume the property from the map
+                // so it is not later flagged as an unknown property.
+                String specifiedType = properties == null ? null :
+                        properties.remove(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE);
+                if (specifiedType != null && !TableProperty.CLOUD_NATIVE_INDEX_TYPE.equalsIgnoreCase(specifiedType)) {
+                    throw new DdlException("Only cloud native persistent index (persistent_index_type = " +
+                            "CLOUD_NATIVE) is supported for shared-data primary key tables, but got: " + specifiedType);
                 }
-                // Judge there are whether compute nodes without storagePath or not.
-                // Cannot create cloud native table with persistent_index = true when ComputeNode without storagePath
-                Set<Long> cnUnSetStoragePath =
-                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodeIds().
-                                stream()
-                                .filter(id -> !GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(id).
-                                        isSetStoragePath()).collect(Collectors.toSet());
-                if (cnUnSetStoragePath.size() != 0 && persistentIndexType == TPersistentIndexType.LOCAL) {
-                    // Check CN storage path when using local persistent index
-                    throw new DdlException("Cannot create cloud native table with local persistent index" +
-                            "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
-                }
-                table.setPersistentIndexType(persistentIndexType);
+                table.setPersistentIndexType(TPersistentIndexType.CLOUD_NATIVE);
             }
 
             if (table.isCloudNativeTable()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -377,7 +377,10 @@ public class LakeTableAlterMetaJobTest {
     public void testSetDisblePersistentIndex() throws Exception {
         LakeTable table2 = createTable(connectContext,
                     "CREATE TABLE t1(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
-                                "PROPERTIES('enable_persistent_index'='true', 'persistent_index_type'='LOCAL')");
+                                "PROPERTIES('enable_persistent_index'='true')");
+        // Simulate a legacy LOCAL persistent index table: creating one with LOCAL is no longer
+        // allowed, but existing tables must still be handled by the alter-meta job path.
+        table2.setPersistentIndexType(TPersistentIndexType.LOCAL);
         LakeTableAlterMetaJob job2 = new LakeTableAlterMetaJob(GlobalStateMgr.getCurrentState().getNextId(),
                     db.getId(), table2.getId(), table2.getName(), 60 * 1000,
                     TTabletMetaType.ENABLE_PERSISTENT_INDEX, false, "LOCAL");
@@ -565,7 +568,9 @@ public class LakeTableAlterMetaJobTest {
     public void testModifyPropertyWithIndexType() throws Exception {
         LakeTable table2 = createTable(connectContext,
                     "CREATE TABLE t11(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
-                                "PROPERTIES('enable_persistent_index'='true', 'persistent_index_type'='LOCAL')");
+                                "PROPERTIES('enable_persistent_index'='true')");
+        // Simulate a legacy LOCAL persistent index table; migrating it to CLOUD_NATIVE must succeed.
+        table2.setPersistentIndexType(TPersistentIndexType.LOCAL);
         Map<String, String> properties = new HashMap<>();
         properties.put("persistent_index_type", "CLOUD_NATIVE");
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
@@ -580,16 +585,43 @@ public class LakeTableAlterMetaJobTest {
     public void testModifyPropertyWithIndexTypeFailure() throws Exception {
         LakeTable table2 = createTable(connectContext,
                     "CREATE TABLE t11(c0 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
-                                "PROPERTIES('enable_persistent_index'='true', 'persistent_index_type'='LOCAL')");
+                                "PROPERTIES('enable_persistent_index'='true')");
         Map<String, String> properties = new HashMap<>();
         properties.put("enable_persistent_index", "false");
         properties.put("persistent_index_type", "CLOUD_NATIVE");
         ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
         SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
-        // should throw exception
+        // disabling the persistent index is no longer supported for shared-data primary key tables
         ExceptionChecker.expectThrows(DdlException.class,
                 () -> schemaChangeHandler.createAlterMetaJob(modify, db, table2));
 
+    }
+
+    @Test
+    public void testModifyEnablePersistentIndexOnNonPkTableNoop() throws Exception {
+        LakeTable dupTable = createTable(connectContext,
+                    "CREATE TABLE t_dup(c0 INT, c1 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1");
+        Map<String, String> properties = new HashMap<>();
+        properties.put("enable_persistent_index", "false");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+        // enable_persistent_index is a no-op for non-primary-key tables and must not be rejected by the
+        // shared-data primary key restriction.
+        AlterJobV2 job2 = schemaChangeHandler.createAlterMetaJob(modify, db, dupTable);
+        Assertions.assertNull(job2);
+
+        db.dropTable(dupTable.getName());
+    }
+
+    @Test
+    public void testModifyPropertyToLocalIndexRejected() {
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        // switching persistent_index_type to LOCAL is deprecated for shared-data primary key tables
+        Map<String, String> typeProps = new HashMap<>();
+        typeProps.put("persistent_index_type", "LOCAL");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Only cloud native persistent index",
+                () -> schemaChangeHandler.createAlterMetaJob(new ModifyTablePropertiesClause(typeProps), db, table));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableDropPersistentIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableDropPersistentIndexTest.java
@@ -69,8 +69,10 @@ public class LakeTableDropPersistentIndexTest {
     @Test
     public void test() throws Exception {
         LakeTable table = createTable(connectContext, "CREATE TABLE t0(c0 INT, c1 INT) PRIMARY KEY(c0) DISTRIBUTED BY HASH(c0) " +
-                    "BUCKETS 2 PROPERTIES('persistent_index_type'='LOCAL')");
-        
+                    "BUCKETS 2 PROPERTIES('enable_persistent_index'='true')");
+        // Simulate a legacy LOCAL persistent index table: creating one with LOCAL is no longer allowed.
+        table.setPersistentIndexType(TPersistentIndexType.LOCAL);
+
         List<Tablet> tablets = Lists.newArrayList();
         List<Partition> partitions = Lists.newArrayList();
         List<PhysicalPartition> physicalPartitions = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -49,7 +49,6 @@ import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.expression.DateLiteral;
 import com.starrocks.thrift.TCompactionStrategy;
 import com.starrocks.thrift.TCompressionType;
-import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
@@ -281,29 +280,6 @@ public class PropertyAnalyzerTest {
         Map<String, String> property = new HashMap<>();
         property.put(PropertyAnalyzer.PROPERTIES_COMPRESSION, "zlib");
         Assertions.assertEquals(TCompressionType.ZLIB, (PropertyAnalyzer.analyzeCompressionType(property).first));
-    }
-
-    @Test
-    public void testPersistentIndexType() throws AnalysisException {
-        // empty property
-        Map<String, String> property = new HashMap<>();
-        Assertions.assertEquals(TPersistentIndexType.CLOUD_NATIVE, PropertyAnalyzer.analyzePersistentIndexType(property));
-
-        Map<String, String> property2 = new HashMap<>();
-        property2.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");
-        Assertions.assertEquals(TPersistentIndexType.LOCAL, PropertyAnalyzer.analyzePersistentIndexType(property2));
-
-        Map<String, String> property3 = new HashMap<>();
-        property3.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "local");
-        Assertions.assertEquals(TPersistentIndexType.LOCAL, PropertyAnalyzer.analyzePersistentIndexType(property3));
-
-        try {
-            Map<String, String> property4 = new HashMap<>();
-            property4.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL2");
-            TPersistentIndexType type = PropertyAnalyzer.analyzePersistentIndexType(property4);
-        } catch (AnalysisException e) {
-            Assertions.assertTrue(e.getMessage().contains("Invalid persistent index type: LOCAL2"));
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -271,8 +271,10 @@ public class CreateLakeTableTest {
         }
 
         UtFrameUtils.addMockComputeNode(50001);
+        // LOCAL persistent index is deprecated for shared-data primary key tables and is now
+        // rejected outright, regardless of whether a compute node has a storage path.
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "Cannot create cloud native table with local persistent index",
+                "Only cloud native persistent index",
                 () -> createTable(
                 "create table lake_test.table_with_persistent_index2\n" +
                         "(c0 int, c1 string, c2 int, c3 bigint)\n" +


### PR DESCRIPTION
## Why I'm doing:

For shared-data (cloud-native) primary key tables, the table-level index configuration
(`enable_persistent_index` / `persistent_index_type`) that still allows the in-memory index
and the local-disk (`LOCAL`) persistent index is being deprecated. Going forward these tables
should only use the cloud-native persistent index, which is the only index type that supports
the full feature set (parallel publish, SST-based apply, parallel upsert, major compaction, etc.).

## What I'm doing:

Add FE-side restrictions so that shared-data primary key tables can only use the cloud-native
persistent index. This is intentionally FE-only: the BE code paths are left untouched, so existing
tables that were created with a `LOCAL` or in-memory index keep working, and migrating an existing
`LOCAL` table to `CLOUD_NATIVE` via `ALTER` is still allowed.

- CREATE: for cloud-native primary key tables, reject an explicit non-`CLOUD_NATIVE`
  `persistent_index_type`, and force `CLOUD_NATIVE` regardless of
  `enable_cloud_native_persistent_index_by_default`. (The in-memory index was already rejected
  for all primary key tables at CREATE.) The old "LOCAL requires a compute node with storage_path"
  check becomes unreachable and is removed.
- ALTER: reject disabling the persistent index (`enable_persistent_index = false`) and reject
  switching `persistent_index_type` to `LOCAL`. Migration to `CLOUD_NATIVE` is still permitted.
- Remove the now-unused `PropertyAnalyzer.analyzePersistentIndexType` helper (its only remaining
  caller was CREATE, which no longer needs it) and its dedicated unit test.

Backward compatibility: existing `LOCAL`/in-memory shared-data PK tables are still loaded and
served by the unchanged BE; only new CREATE/ALTER requests are restricted.

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
