### PR TITLE
[Enhancement] Add QUARTER to TimestampArithmeticExpr.TimeUnit enum

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/TimestampArithmeticExprTimeUnitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/TimestampArithmeticExprTimeUnitTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.TimestampArithmeticExpr.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TimestampArithmeticExprTimeUnitTest {
+
+    @Test
+    public void testQuarterIsRecognized() {
+        // QUARTER is a valid interval unit in the grammar; the enum must expose it so that
+        // TimeUnit.fromName() can resolve it (used by partition analyzers and, going forward,
+        // by enum-based checks in the expression analyzer) instead of returning null.
+        Assertions.assertEquals(TimeUnit.QUARTER, TimeUnit.fromName("QUARTER"));
+        Assertions.assertEquals(TimeUnit.QUARTER, TimeUnit.fromName("quarter"));
+        Assertions.assertEquals(TimeUnit.QUARTER, TimeUnit.fromName("QuArTeR"));
+        Assertions.assertEquals("QUARTER", TimeUnit.QUARTER.toString());
+    }
+
+    @Test
+    public void testOtherDateGranularityUnitsStillResolve() {
+        // Adding QUARTER in the middle of the enum must not disturb the sibling date-granularity units.
+        Assertions.assertEquals(TimeUnit.YEAR, TimeUnit.fromName("year"));
+        Assertions.assertEquals(TimeUnit.MONTH, TimeUnit.fromName("month"));
+        Assertions.assertEquals(TimeUnit.WEEK, TimeUnit.fromName("week"));
+        Assertions.assertEquals(TimeUnit.DAY, TimeUnit.fromName("day"));
+        Assertions.assertEquals(TimeUnit.HOUR, TimeUnit.fromName("hour"));
+    }
+
+    @Test
+    public void testUnknownUnitReturnsNull() {
+        // MILLISECOND exists in the grammar but not in this enum; fromName must stay null-safe
+        // so enum-based callers fall through rather than throwing.
+        Assertions.assertNull(TimeUnit.fromName("millisecond"));
+        Assertions.assertNull(TimeUnit.fromName("not_a_unit"));
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/TimestampArithmeticExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/TimestampArithmeticExpr.java
@@ -115,6 +115,7 @@ public class TimestampArithmeticExpr extends Expr {
     // Time units supported in timestamp arithmetic.
     public enum TimeUnit {
         YEAR("YEAR"),                               // YEARS
+        QUARTER("QUARTER"),                         // QUARTERS
         MONTH("MONTH"),                             // MONTHS
         WEEK("WEEK"),                               // WEEKS
         DAY("DAY"),                                 // DAYS


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

QUARTER is already a valid interval unit in the grammar, but the `TimeUnit` enum lacked it, so `TimeUnit.fromName("quarter")` returned `null`. Add the constant (name-based, no ordinal serialization impact) so it resolves correctly, unblocking enum-based unit checks in the expression analyzer.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
