### PR TITLE
[BugFix] Keep runtime filter local and singleton for range-colocate joins

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -93,6 +93,10 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;
+    // True for a colocate join whose colocate columns are range-distributed. Such
+    // joins bucket data by range, which no hash-partitioned runtime-filter layout
+    // can match, so their runtime filters must stay singleton.
+    protected boolean colocateWithRangeDistribution = false;
     protected boolean canLocalShuffle = false;
     protected Map<SlotId, Expr> commonSlotMap;
 
@@ -152,6 +156,14 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         return this.probePartitionByExprs;
     }
 
+    public void setColocateWithRangeDistribution(boolean colocateWithRangeDistribution) {
+        this.colocateWithRangeDistribution = colocateWithRangeDistribution;
+    }
+
+    public boolean isColocateWithRangeDistribution() {
+        return this.colocateWithRangeDistribution;
+    }
+
     @Override
     public void buildRuntimeFilters(IdGenerator<RuntimeFilterId> runtimeFilterIdIdGenerator, DescriptorTable descTbl,
                                     ExecGroupSets execGroupSets) {
@@ -208,6 +220,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
             rf.setBuildPlanNode(this);
             rf.setExprOrder(i);
             rf.setJoinMode(distrMode);
+            rf.setColocateWithRangeDistribution(colocateWithRangeDistribution);
             rf.setEqualCount(eqJoinConjuncts.size());
             rf.setBuildCardinality(inner.getCardinality());
             rf.setEqualForNull(BinaryPredicate.IS_EQ_NULL_PREDICATE.apply(joinConjunct));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -74,6 +74,15 @@ public class RuntimeFilterDescription {
     private boolean hasRemoteTargets;
     private final List<TNetworkAddress> mergeNodes;
     private JoinNode.DistributionMode joinMode;
+    // Range-distributed colocate joins bucket their data by range containment,
+    // but every partitioned/global runtime-filter layout routes probe rows to a
+    // bloom filter by hashing the key. A hash layout over range-bucketed data
+    // would test rows against the wrong partition and silently drop join matches.
+    // Such joins therefore keep their runtime filters local and singleton: the
+    // local layout is forced to SINGLETON, and the filter is never pushed across
+    // an exchange (a global RF is merged as disjoint per-instance partitions that
+    // no singleton layout can probe correctly).
+    private boolean colocateWithRangeDistribution;
     private TUniqueId senderFragmentInstanceId;
 
     private Set<TUniqueId> broadcastGRFSenders;
@@ -367,6 +376,10 @@ public class RuntimeFilterDescription {
         joinMode = mode;
     }
 
+    public void setColocateWithRangeDistribution(boolean colocateWithRangeDistribution) {
+        this.colocateWithRangeDistribution = colocateWithRangeDistribution;
+    }
+
     public boolean isColocateOrBucketShuffle() {
         return joinMode.equals(COLOCATE) ||
                 joinMode.equals(LOCAL_HASH_BUCKET);
@@ -447,7 +460,10 @@ public class RuntimeFilterDescription {
     }
 
     public boolean canPushAcrossExchangeNode() {
-        if (onlyLocal) {
+        // A range-colocate RF must stay local: a global (remote) RF is merged as
+        // disjoint per-instance partitions, and no singleton/hash layout can probe
+        // those correctly over range-bucketed data (rows would be silently dropped).
+        if (onlyLocal || colocateWithRangeDistribution) {
             return false;
         }
         // skew join's broadcast join rf can not be pushed across exchange node
@@ -521,6 +537,9 @@ public class RuntimeFilterDescription {
     }
 
     private TRuntimeFilterLayoutMode computeLocalLayout() {
+        if (colocateWithRangeDistribution) {
+            return TRuntimeFilterLayoutMode.SINGLETON;
+        }
         if (sessionVariable.isEnablePipelineLevelMultiPartitionedRf()) {
             if (joinMode == BROADCAST || joinMode == REPLICATED) {
                 return TRuntimeFilterLayoutMode.SINGLETON;
@@ -573,7 +592,8 @@ public class RuntimeFilterDescription {
         layout.setFilter_id(filterId);
         layout.setLocal_layout(computeLocalLayout());
         layout.setGlobal_layout(computeGlobalLayout());
-        layout.setPipeline_level_multi_partitioned(sessionVariable.isEnablePipelineLevelMultiPartitionedRf());
+        layout.setPipeline_level_multi_partitioned(
+                !colocateWithRangeDistribution && sessionVariable.isEnablePipelineLevelMultiPartitionedRf());
         layout.setNum_instances(numInstances);
         layout.setNum_drivers_per_instance(numDriversPerInstance);
         if (bucketSeqToInstance != null && !bucketSeqToInstance.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3327,6 +3327,17 @@ public class PlanFragmentBuilder {
             fillSlotsInfo(node.getProjection(), joinNode, optExpr);
 
             joinNode.setDistributionMode(distributionMode);
+            // A range-distributed colocate join buckets its data by range, which no
+            // hash-partitioned runtime-filter layout can match; flag it so its
+            // runtime filters stay singleton (a hash layout would silently drop rows).
+            // A range colocate join has both sides range; the check stays fail-closed
+            // (either side range) so a hash-partitioned RF can never be applied over a
+            // range-bucketed side.
+            if (distributionMode == JoinNode.DistributionMode.COLOCATE &&
+                    (leftDistributionSpec instanceof RangeDistributionSpec ||
+                            rightDistributionSpec instanceof RangeDistributionSpec)) {
+                joinNode.setColocateWithRangeDistribution(true);
+            }
             joinNode.getConjuncts().addAll(conjuncts);
             joinNode.setLimit(node.getLimit());
             joinNode.computeStatistics(optExpr.getStatistics());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
@@ -33,6 +33,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * F2 follow-up (colocate.md): mixed range-colocate × hash JOIN must not surface
  * as MySQL "Unknown error" — the optimizer should plan a shuffle/bucket join.
@@ -244,5 +247,64 @@ public class RangeColocateMixedJoinPlanTest {
             count = checkNoRangeSpecOnJoinChildren(node.inputAt(i), count);
         }
         return count;
+    }
+
+    /**
+     * A range × range colocate join must be flagged so its runtime filters fall
+     * back to a singleton layout; a hash-partitioned runtime-filter layout over
+     * range-bucketed data would route probe rows by hash and silently drop
+     * matching rows. The mixed range × hash bucket-shuffle join must NOT be
+     * flagged — its probe side is hash-distributed, so hash routing is correct.
+     */
+    @Test
+    public void rangeColocateJoinIsFlaggedForRuntimeFilterSingleton() throws Exception {
+        ExecPlan rangePlan = UtFrameUtils.getPlanAndFragment(connectContext,
+                "select count(*) from cd a join cd2 b on a.k1 = b.k1").second;
+        List<JoinNode> rangeJoins = collectJoinNodes(rangePlan);
+        Assertions.assertFalse(rangeJoins.isEmpty(), "expected a join node in the range colocate plan");
+
+        boolean sawFlaggedJoin = false;
+        for (JoinNode joinNode : rangeJoins) {
+            if (!joinNode.isColocateWithRangeDistribution()) {
+                continue;
+            }
+            sawFlaggedJoin = true;
+            // The flag must reach every runtime filter the join builds, so each one
+            // stays local and can never be pushed across an exchange into a
+            // hash-partitioned global filter (which would silently drop rows).
+            List<RuntimeFilterDescription> runtimeFilters = joinNode.getBuildRuntimeFilters();
+            Assertions.assertFalse(runtimeFilters.isEmpty(),
+                    "flagged range colocate join must build a runtime filter");
+            for (RuntimeFilterDescription rf : runtimeFilters) {
+                Assertions.assertFalse(rf.canPushAcrossExchangeNode(),
+                        "range colocate runtime filter must stay local");
+            }
+        }
+        Assertions.assertTrue(sawFlaggedJoin,
+                "range colocate join must be flagged colocateWithRangeDistribution");
+
+        ExecPlan mixedPlan = UtFrameUtils.getPlanAndFragment(connectContext,
+                "select count(*) from cd join dim on cd.k1 = dim.k1").second;
+        List<JoinNode> mixedJoins = collectJoinNodes(mixedPlan);
+        Assertions.assertFalse(mixedJoins.isEmpty(), "expected a join node in the mixed plan");
+        Assertions.assertTrue(mixedJoins.stream().noneMatch(JoinNode::isColocateWithRangeDistribution),
+                "mixed bucket-shuffle join must not be flagged colocateWithRangeDistribution");
+    }
+
+    private static List<JoinNode> collectJoinNodes(ExecPlan execPlan) {
+        List<JoinNode> result = new ArrayList<>();
+        for (PlanFragment fragment : execPlan.getFragments()) {
+            collectJoinNodes(fragment.getPlanRoot(), result);
+        }
+        return result;
+    }
+
+    private static void collectJoinNodes(PlanNode node, List<JoinNode> result) {
+        if (node instanceof JoinNode) {
+            result.add((JoinNode) node);
+        }
+        for (PlanNode child : node.getChildren()) {
+            collectJoinNodes(child, result);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RuntimeFilterLayoutTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RuntimeFilterLayoutTest.java
@@ -107,4 +107,36 @@ public class RuntimeFilterLayoutTest {
             Assertions.assertEquals(layout.local_layout, TRuntimeFilterLayoutMode.SINGLETON);
         }
     }
+
+    @Test
+    public void testLayoutForRangeColocateJoin() {
+        SessionVariable sv = new SessionVariable();
+        sv.setEnablePipelineEngine(true);
+        sv.setEnablePipelineLevelMultiPartitionedRf(true);
+        RuntimeFilterDescription desc = new RuntimeFilterDescription(sv);
+        desc.setFilterId(1);
+        desc.setJoinMode(JoinNode.DistributionMode.COLOCATE);
+        desc.setBucketSeqToInstance(Arrays.asList(1, 1, 1, 2, 2, 2, 2, 2, 2));
+        desc.setBucketSeqToDriverSeq(Arrays.asList(0, 1, 2, 0, 1, 2, 0, 1, 2));
+        desc.setBucketSeqToPartition(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8));
+
+        // Control: a hash-colocate join keeps the partitioned bucket layout and
+        // may push its runtime filter across an exchange.
+        TRuntimeFilterLayout hashColocate = desc.toLayout();
+        Assertions.assertEquals(TRuntimeFilterLayoutMode.PIPELINE_BUCKET, hashColocate.local_layout);
+        Assertions.assertEquals(TRuntimeFilterLayoutMode.GLOBAL_BUCKET_2L, hashColocate.global_layout);
+        Assertions.assertTrue(hashColocate.pipeline_level_multi_partitioned);
+        Assertions.assertTrue(desc.canPushAcrossExchangeNode());
+
+        // Range colocate: data is bucketed by range containment, which no
+        // hash-partitioned runtime-filter layout can match. The filter must stay
+        // local and singleton: SINGLETON local layout, not multi-partitioned, and
+        // never pushed across an exchange (a global RF would be merged as disjoint
+        // per-instance partitions that a singleton layout cannot probe correctly).
+        desc.setColocateWithRangeDistribution(true);
+        TRuntimeFilterLayout rangeColocate = desc.toLayout();
+        Assertions.assertEquals(TRuntimeFilterLayoutMode.SINGLETON, rangeColocate.local_layout);
+        Assertions.assertFalse(rangeColocate.pipeline_level_multi_partitioned);
+        Assertions.assertFalse(desc.canPushAcrossExchangeNode());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

A range-distributed colocate join buckets its data by range containment, but the BE selects a runtime-filter partition by hashing the join key. With the session variable `enable_pipeline_level_multi_partitioned_rf` enabled, the planner emitted a hash-partitioned runtime-filter layout for such a join, so the BE routed probe rows into partitions that had been assigned by range. The wrong partitioned bloom filter was then tested and matching rows were silently dropped, returning incomplete join results.

The default configuration is unaffected: with `enable_pipeline_level_multi_partitioned_rf` off (the default) the local layout is already `SINGLETON`, so the bug does not fire. The hole is reachable only with that non-default session variable, and only after a colocate group has more than one range.

## What I'm doing:

Keep a range-colocate join's runtime filter local and singleton, so the BE never hash-routes probe rows over range-bucketed data:

- force the local layout to `SINGLETON`;
- clear `pipeline_level_multi_partitioned` so the build side merges a single filter (`num_hash_partitions() == 0`) and the probe skips partition selection;
- never push the filter across an exchange, because a global runtime filter is merged by concatenating each build instance's disjoint partition and no singleton or hash layout can probe that correctly over range-bucketed data.

The range-colocate join is detected in `PlanFragmentBuilder` (where the child distribution specs are available) and the flag is propagated to every `RuntimeFilterDescription` the join builds. Non-range-colocate joins (classic hash colocate, bucket-shuffle) are unaffected. FE-only; no BE or thrift change.

Tests:
- `RuntimeFilterLayoutTest#testLayoutForRangeColocateJoin` — a flagged runtime filter uses `SINGLETON` local layout, is not multi-partitioned, and cannot be pushed across an exchange; a hash-colocate filter keeps its partitioned bucket layout (control).
- `RangeColocateMixedJoinPlanTest#rangeColocateJoinIsFlaggedForRuntimeFilterSingleton` — a range × range colocate join is flagged and each runtime filter it builds stays local; a mixed range × hash bucket-shuffle join is not flagged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
