### PR TITLE
[UT] Fix flaky LakePersistentIndexTest.test_major_compaction

### DIFF
--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -400,7 +400,11 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
-        index->flush_memtable(true);
+        ASSERT_OK(index->flush_memtable(true));
+        // Wait for async flush to complete so every sstable is committed; otherwise a
+        // still-pending memtable would be dropped from the committed metadata and the
+        // compaction below would have nothing (or too few sstables) to merge.
+        ASSERT_OK(index->sync_flush_all_memtables(10000000)); // 10 seconds timeout
     }
     ASSERT_TRUE(index->memory_usage() > 0);
 


### PR DESCRIPTION
## Why I'm doing:

`LakePersistentIndexTest.test_major_compaction` is flaky (observed on branch-4.1
CI, and reproduced locally at ~1/40). It intermittently fails with:

```
lake_persistent_index_test.cpp:421: Failure
Value of: txn_log->op_compaction().input_sstables_size() > 0
  Actual: false
Expected: true
```

Root cause: the test issues `flush_memtable(true)` five times and then calls
`commit()` **without waiting for the asynchronous flushes to finish**.
`flush_memtable` submits the memtable to `pk_index_memtable_flush_thread_pool`
and only drains completed sstables into `_sstable_filesets` on a *subsequent*
`flush_memtable` / `sync_flush_all_memtables` call — `commit()` itself does not
drain `_inactive_memtables`. So a still-pending (or the last-submitted) memtable
is dropped from the committed `sstable_meta`, leaving `major_compact` with too
few sstables and failing `ASSERT_TRUE(input_sstables_size() > 0)`. Instrumented
runs also show a straggler flush thread outliving the test and hitting the
already-removed test directory (`opendir ... errno=2`).

This is a **test-only** issue: the production reshard path
(`update_manager.cpp`) already calls `sync_flush_persistent_index` before
`commit`, and every sibling test in this file
(`test_major_compaction_with_tablet_range`,
`test_range_single_int_pk_end_to_end`, `test_ingest_sst_*`) already calls
`sync_flush_all_memtables` after its flush loop. `test_major_compaction` was the
only one missing it — and the only flaky one.

## What I'm doing:

Add `ASSERT_OK(index->sync_flush_all_memtables(...))` after the flush in the
loop (matching the sibling tests), and check the return value of
`flush_memtable`, so every sstable is committed before compaction runs.

Verified in the shared-data dev-env container (RELEASE build): **300/300 passes**
after the fix (was ~1/40 failing before).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
