### PR TITLE
[BugFix] Consolidate load-spill parallel merge results in flush order

### DIFF
--- a/be/src/compute_env/load_spill/load_chunk_spiller.cpp
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.cpp
@@ -402,6 +402,10 @@ StatusOr<LoadSpillMergeInputBatch> LoadChunkSpiller::generate_merge_input_batch(
     std::sort(groups.begin(), groups.end(),
               [](const BlockGroupPtrWithSlot& a, const BlockGroupPtrWithSlot& b) { return a.slot_idx < b.slot_idx; });
 
+    // This batch consumes a prefix of the (now slot-sorted) groups, so groups[0] is its smallest slot.
+    // Record it so the consolidation step can restore flush order regardless of task registration order.
+    result_batch.slot_idx = groups[0].slot_idx;
+
     // Tracks the last group index included in this task (used for cleanup at end)
     int64_t stop_idx = -1;
 

--- a/be/src/compute_env/load_spill/load_spill_merge_input_batch.h
+++ b/be/src/compute_env/load_spill/load_spill_merge_input_batch.h
@@ -42,6 +42,12 @@ struct LoadSpillMergeInputBatch {
     // sorted merge (for aggregation/ordering) and union (for DUP_KEYS tables).
     ChunkIteratorPtr merge_itr;
 
+    // Smallest slot_idx (original memtable flush order) among this batch's block groups. Batches are
+    // formed from a contiguous, monotonically increasing slot range, so this gives each batch a stable
+    // order key. The result-consolidation step sorts batches by it so segments/del files are merged in
+    // flush order regardless of the (concurrent, hence unordered) order in which tasks were registered.
+    int64_t slot_idx = -1;
+
     // Metrics for monitoring merge workload distribution across pipeline tasks.
     // Used to ensure roughly equal work distribution and for performance analysis.
     size_t total_block_groups = 0;

--- a/be/src/storage/lake/load_spill_pipeline_merge_context.cpp
+++ b/be/src/storage/lake/load_spill_pipeline_merge_context.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/load_spill_pipeline_merge_context.h"
 
+#include <algorithm>
+
 #include "common/thread/threadpool.h"
 #include "compute_env/load_spill/load_spill_block_merge_executor.h"
 #include "storage/lake/tablet_internal_parallel_merge_task.h"
@@ -68,6 +70,18 @@ Status LoadSpillPipelineMergeContext::merge_task_results() {
     if (_token != nullptr) {
         _token->wait();
     }
+
+    // Consolidate in flush (slot) order. Tasks are registered via add_merge_task() from concurrent eager
+    // merges (parallel flush) where generating a batch and registering its task are not atomic, so the
+    // registration order does NOT necessarily match the batch slot order. merge_other_writer() appends
+    // each task's segments/del files in the order iterated here and (for PK tables) derives del rssid /
+    // op_offset from the running segment count, so consolidating out of slot order would let an
+    // earlier-flush row/delete win over a later one. Sort by the batch's smallest slot_idx first.
+    std::stable_sort(_merge_tasks.begin(), _merge_tasks.end(),
+                     [](const std::shared_ptr<lake::TabletInternalParallelMergeTask>& a,
+                        const std::shared_ptr<lake::TabletInternalParallelMergeTask>& b) {
+                         return a->slot_idx() < b->slot_idx();
+                     });
 
     for (const auto& task : _merge_tasks) {
         // IMPORTANT: Check task status first to fail fast if any parallel merge task failed.

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -127,6 +127,10 @@ void TabletInternalParallelMergeTask::cancel() {
     update_status(Status::Cancelled("TabletInternalParallelMergeTask cancelled"));
 }
 
+int64_t TabletInternalParallelMergeTask::slot_idx() const {
+    return _task->slot_idx;
+}
+
 void TabletInternalParallelMergeTask::update_status(const Status& st) {
     // Update task's status (Status::update is idempotent - first error wins)
     _status.update(st);

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -83,6 +83,10 @@ public:
      */
     const std::unique_ptr<TabletWriter>& writer() const { return _writer; }
 
+    // Smallest slot_idx (memtable flush order) of this task's merge batch. Used to consolidate task
+    // results in flush order, since tasks may be registered out of order under concurrent eager merge.
+    int64_t slot_idx() const;
+
 private:
     // Owned writer clone for independent parallel writes
     std::unique_ptr<TabletWriter> _writer;

--- a/be/test/storage/lake/spill_mem_table_sink_test.cpp
+++ b/be/test/storage/lake/spill_mem_table_sink_test.cpp
@@ -29,6 +29,7 @@
 #include "common/logging.h"
 #include "common/runtime_profile.h"
 #include "compute_env/load_spill/load_spill_block_manager.h"
+#include "compute_env/load_spill/load_spill_merge_input_batch.h"
 #include "compute_env/spill/options.h"
 #include "compute_env/spill/serde.h"
 #include "compute_env/spill/spiller.h"
@@ -38,6 +39,7 @@
 #include "storage/lake/general_tablet_writer.h"
 #include "storage/lake/load_spill_pipeline_merge_context.h"
 #include "storage/lake/pk_tablet_writer.h"
+#include "storage/lake/tablet_internal_parallel_merge_task.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/test_util.h"
@@ -474,6 +476,44 @@ TEST_P(SpillMemTableSinkTest, test_merge_blocks_after_eager_merge_consumed_all) 
     // With the fix, merge_blocks_to_segments() calls merge_task_results() when spiller is empty,
     // instead of returning OK without collecting any results.
     ASSERT_OK(sink.merge_blocks_to_segments());
+}
+
+// merge_task_results() must consolidate task writers in flush (slot) order, even when tasks are
+// registered out of order -- which happens under concurrent eager merge, where generating a merge batch
+// and registering its task are not atomic. Register three tasks whose writers each hold one segment with
+// a distinct row count, in a scrambled order (2, 0, 1), and verify the parent writer's segments come out
+// in slot order (row counts 1x, 2x, 3x kChunkSize). Without the ordering fix the segments would follow
+// the registration order.
+TEST_P(SpillMemTableSinkTest, test_merge_task_results_orders_by_slot) {
+    int64_t tablet_id = 1;
+    auto parent =
+            std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), tablet_id, _tablet_schema, 1, false);
+    ASSERT_OK(parent->open());
+    LoadSpillPipelineMergeContext context(parent.get());
+
+    for (int64_t slot : {static_cast<int64_t>(2), static_cast<int64_t>(0), static_cast<int64_t>(1)}) {
+        auto writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr.get(), tablet_id, _tablet_schema,
+                                                                      100 + slot, false);
+        ASSERT_OK(writer->open());
+        auto chunk = gen_data(static_cast<int>((slot + 1) * kChunkSize), 0);
+        ASSERT_OK(writer->write(*chunk, nullptr));
+        ASSERT_OK(writer->flush());
+        ASSERT_OK(writer->finish());
+        ASSERT_EQ(1, writer->segments().size());
+
+        auto batch = std::make_unique<LoadSpillMergeInputBatch>();
+        batch->slot_idx = slot;
+        auto task = std::make_shared<TabletInternalParallelMergeTask>(std::move(writer), std::move(batch),
+                                                                      _schema.get(), nullptr, nullptr);
+        context.add_merge_task(task);
+    }
+
+    ASSERT_OK(context.merge_task_results());
+
+    ASSERT_EQ(3, parent->segments().size());
+    EXPECT_EQ(static_cast<int64_t>(1 * kChunkSize), static_cast<int64_t>(parent->segments()[0].num_rows));
+    EXPECT_EQ(static_cast<int64_t>(2 * kChunkSize), static_cast<int64_t>(parent->segments()[1].num_rows));
+    EXPECT_EQ(static_cast<int64_t>(3 * kChunkSize), static_cast<int64_t>(parent->segments()[2].num_rows));
 }
 
 INSTANTIATE_TEST_SUITE_P(SpillMemTableSinkTest, SpillMemTableSinkTest,


### PR DESCRIPTION
## Why I'm doing:

In the shared-data load-spill parallel merge, `LoadSpillPipelineMergeContext::merge_task_results()`
consolidates each merge task's cloned tablet writer into the parent writer **in the order tasks were
registered** via `add_merge_task()`.

Under **concurrent eager merge** (parallel flush), a flush thread generates a merge batch
(`LoadChunkSpiller::generate_merge_input_batch`, which pulls a slot-ordered, contiguous batch of block
groups under the block-groups lock) and then registers the task (`add_merge_task`, under a *different*
lock) — the two steps are **not atomic**. So two flush threads can register their tasks **out of slot
(memtable flush) order**: e.g. thread A pulls slots [0,1], is preempted, thread B pulls slots [2,3] and
registers first, then A registers.

`merge_other_writer()` appends each task's segments / del files in the iterated order and (for PK tables)
derives the delete rssid / `op_offset` from the running segment count. Consolidating out of flush order
therefore lets an **earlier-flush row win over a later one** — i.e. wrong last-writer-wins for upsert
dedup, and (once the op-aware PK delete path is in) wrong upsert/delete resolution.

## What I'm doing:

Give each merge batch a stable order key and sort by it before consolidating:

- Record the batch's smallest `slot_idx` on `LoadSpillMergeInputBatch` (batches cover a monotonic,
  contiguous slot range, so the min slot uniquely orders them), set in `generate_merge_input_batch`
  right after the block groups are slot-sorted.
- Expose it via `TabletInternalParallelMergeTask::slot_idx()`.
- `stable_sort` `_merge_tasks` by it in `merge_task_results()` before the consolidation loop.

This restores flush order regardless of registration order, without adding a lock on the flush hot path
(the actual merge still runs in parallel; only the final, already-serialized consolidation is ordered).
Only the concurrent eager-merge path was affected — the final merge generates and registers tasks
single-threaded and was already ordered.

BE UT `SpillMemTableSinkTest.test_merge_task_results_orders_by_slot`: registers three tasks (writers with
distinct segment row counts) in scrambled order and asserts the parent writer's segments come out in slot
order. Fails without the fix, passes with it.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
