### PR TITLE
[BugFix] bm25: gate score() LIMIT pushdown on MATCH-only predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -851,6 +851,12 @@ public class OlapScanNode extends ScanNode {
             }
         }
 
+        // BM25 score() pushdown: topk=0 means every matched row is scored (no LIMIT
+        // pushdown, e.g. when a post-scan predicate follows the MATCH).
+        if (bm25ScoreSlotId >= 0) {
+            output.append(prefix).append("BM25SCORE: ON, topk=").append(bm25ScoreLimit).append("\n");
+        }
+
         if (detailLevel != TExplainLevel.VERBOSE) {
             if (isPreAggregation) {
                 output.append(prefix).append("PREAGGREGATION: ON").append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToBm25ScorePlanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteToBm25ScorePlanRule.java
@@ -126,9 +126,11 @@ public class RewriteToBm25ScorePlanRule extends TransformationRule {
         newScanOp.setBm25ScoreSlotId(scoreColRef.getId());
         // 5. Push the LIMIT into the scored GIN query so tantivy returns only the
         // top-k rows by score (WAND pruning), mirroring the vector ANN top-k path.
-        // Only valid for ORDER BY score() DESC (TopDocs keeps highest scores); for
-        // ASC, leave the limit at 0 so the BE scores every matched row.
-        if (!ordering.isAscending()) {
+        // Requires ORDER BY score() DESC (TopDocs keeps the highest scores) and MATCH
+        // as the whole filter: a post-scan predicate would drop rows after the top-k
+        // and could shrink the result below the limit. Otherwise the BE scores every
+        // matched row and the TopN above applies the limit.
+        if (!ordering.isAscending() && scanOp.getPredicate() instanceof MatchExprOperator) {
             newScanOp.setBm25ScoreLimit(topNOp.getLimit() + Math.max(0L, topNOp.getOffset()));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/Bm25ScoreLimitPushdownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/Bm25ScoreLimitPushdownTest.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the BM25 score() top-k pushdown in {@code RewriteToBm25ScorePlanRule}:
+ * the LIMIT reaches the scored GIN scan only when MATCH is the whole filter, so a
+ * post-scan predicate can't shrink the result below the limit.
+ */
+public class Bm25ScoreLimitPushdownTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        Config.enable_experimental_gin = true;
+        PlanTestBase.beforeClass();
+        starRocksAssert.withTable("CREATE TABLE test.bm25_docs ("
+                + " id INT,"
+                + " request VARCHAR(1024),"
+                + " status INT,"
+                + " INDEX idx_request (request) USING GIN ('imp_lib' = 'tantivy', 'parser' = 'english')"
+                + ") DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');");
+    }
+
+    @Test
+    public void pushesLimitWhenMatchIsSoleFilter() throws Exception {
+        String plan = getFragmentPlan("SELECT score() s FROM bm25_docs "
+                + "WHERE request MATCH 'fox' ORDER BY s DESC LIMIT 10");
+        assertContains(plan, "BM25SCORE: ON, topk=10");
+    }
+
+    @Test
+    public void skipsLimitWithPostScanPredicate() throws Exception {
+        String plan = getFragmentPlan("SELECT score() s FROM bm25_docs "
+                + "WHERE request MATCH 'fox' AND status = 200 ORDER BY s DESC LIMIT 10");
+        assertContains(plan, "BM25SCORE: ON, topk=0");
+    }
+
+    @Test
+    public void skipsLimitForAscendingOrder() throws Exception {
+        String plan = getFragmentPlan("SELECT score() s FROM bm25_docs "
+                + "WHERE request MATCH 'fox' ORDER BY s ASC LIMIT 10");
+        assertContains(plan, "BM25SCORE: ON, topk=0");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`RewriteToBm25ScorePlanRule` pushed the SQL `LIMIT` into the scored GIN search
(`TopDocs::with_limit`) for any `ORDER BY score() DESC`, without checking for
other predicates. With a post-scan scalar filter, e.g.

```sql
SELECT score() s FROM t WHERE request MATCH 'gif' AND status = 200
ORDER BY s DESC LIMIT N
```

tantivy returns the top-N rows by score *before* the `status` filter runs, so the
filter can drop the result below `N` — an under-return.

## What I'm doing:

Only push the limit when MATCH is the whole filter (predicate is a single
`MatchExprOperator`). Otherwise leave it at 0 so the BE scores every matched row
and the `TopN` operator applies the limit after the scalar predicate.

Also surface the pushdown in the scan explain (`BM25SCORE: ON, topk=N`), which the
new plan test asserts.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Tests

`Bm25ScoreLimitPushdownTest` (3 cases): limit pushed when MATCH is sole filter;
not pushed with a post-scan scalar predicate; not pushed for `ORDER BY score() ASC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
