### PR TITLE
[UT]  Add shared weak getJNIEnv stub for test binaries linking Runtime without libhdfs

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -214,6 +214,10 @@ function(target_link_be_test_cxa_throw_wrap TEST_TARGET)
     target_link_libraries(${TEST_TARGET} be_test_cxa_throw_wrap)
 endfunction()
 
+# Weak getJNIEnv fallback shared by the focused test binaries that link Runtime
+# but not libhdfs (which provides the real symbol). See base/jni_env_stub.cpp.
+set(BE_TEST_JNI_ENV_STUB ${CMAKE_CURRENT_SOURCE_DIR}/base/jni_env_stub.cpp)
+
 add_subdirectory(base)
 add_subdirectory(common)
 add_subdirectory(column)

--- a/be/test/base/jni_env_stub.cpp
+++ b/be/test/base/jni_env_stub.cpp
@@ -1,0 +1,10 @@
+// Shared across the focused test binaries under be/test. These targets do not
+// exercise JVM integration, but the Runtime library they link references
+// getJNIEnv() (implemented by libhdfs, see be/src/runtime/java/jni_env.h), which
+// those binaries do not link. This weak fallback satisfies the reference; the
+// real libhdfs definition (a strong symbol) always wins wherever it is linked.
+#include <jni.h>
+
+extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
+    return nullptr;
+}

--- a/be/test/cache/CMakeLists.txt
+++ b/be/test/cache/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(CACHE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    ${BE_TEST_JNI_ENV_STUB}
     data_cache_hit_rate_counter_test.cpp
     datacache_metrics_test.cpp
     datacache_utils_test.cpp

--- a/be/test/compute_env/CMakeLists.txt
+++ b/be/test/compute_env/CMakeLists.txt
@@ -41,7 +41,7 @@ set(COMPUTE_ENV_WORKGROUP_TEST_FILES
 
 set(COMPUTE_ENV_SPILL_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     load_spill/load_chunk_spiller_test.cpp
     load_spill/load_spill_block_manager_test.cpp
     load_spill/load_spill_block_merge_executor_test.cpp
@@ -93,6 +93,7 @@ target_link_libraries(compute_env_test ${COMPUTE_ENV_TEST_LINK_LIBS})
 
 set(COMPUTE_ENV_SORTING_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    ${BE_TEST_JNI_ENV_STUB}
     sorting/sorted_chunks_merger_test.cpp
     sorting/sorting_test.cpp
 )

--- a/be/test/compute_env/jni_env_stub.cpp
+++ b/be/test/compute_env/jni_env_stub.cpp
@@ -1,7 +1,0 @@
-// The focused compute env tests do not exercise JVM integration, but Runtime
-// can pull Java helper objects into this test binary through filesystem paths.
-#include <jni.h>
-
-extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
-    return nullptr;
-}

--- a/be/test/connector/CMakeLists.txt
+++ b/be/test/connector/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CONNECTOR_CACHE_STATS_TEST_LINK_LIBS
 
 add_executable(connector_cache_stats_test
         ${BE_TEST_MACOS_LINK_STUBS}
+        ${BE_TEST_JNI_ENV_STUB}
         cache_stats/cache_stats_connector_test.cpp
 )
 target_link_libraries(connector_cache_stats_test ${CONNECTOR_CACHE_STATS_TEST_LINK_LIBS} gtest_main)
@@ -49,6 +50,7 @@ if (WITH_CONNECTOR_MYSQL)
 
     add_executable(connector_mysql_test
             ${BE_TEST_MACOS_LINK_STUBS}
+            ${BE_TEST_JNI_ENV_STUB}
             mysql/mysql_connector_test.cpp
     )
     target_link_libraries(connector_mysql_test ${CONNECTOR_MYSQL_TEST_LINK_LIBS} gtest_main)
@@ -69,6 +71,7 @@ if (WITH_CONNECTOR_BENCHMARK)
 
     add_executable(connector_benchmark_test
             ${BE_TEST_MACOS_LINK_STUBS}
+            ${BE_TEST_JNI_ENV_STUB}
             benchmark/benchmark_connector_test.cpp
             benchmark/benchmark_scanner_test.cpp
     )
@@ -114,6 +117,7 @@ if (WITH_CONNECTOR_ELASTICSEARCH)
 
     add_executable(connector_elasticsearch_test
             ${BE_TEST_MACOS_LINK_STUBS}
+            ${BE_TEST_JNI_ENV_STUB}
             ${SRC_DIR}/runtime/descriptors_ext.cpp
             elasticsearch/es_query_builder_test.cpp
             elasticsearch/es_scan_reader_test.cpp

--- a/be/test/connector_primitive/CMakeLists.txt
+++ b/be/test/connector_primitive/CMakeLists.txt
@@ -38,6 +38,6 @@ set(CONNECTOR_PRIMITIVE_TEST_LINK_LIBS
     ${WL_END_GROUP}
 )
 
-add_executable(connector_primitive_test ${BE_TEST_MACOS_LINK_STUBS} connector_primitive_test.cpp)
+add_executable(connector_primitive_test ${BE_TEST_MACOS_LINK_STUBS} ${BE_TEST_JNI_ENV_STUB} connector_primitive_test.cpp)
 target_link_libraries(connector_primitive_test ${CONNECTOR_PRIMITIVE_TEST_LINK_LIBS} gtest_main)
 set_target_properties(connector_primitive_test PROPERTIES COMPILE_FLAGS "-fno-access-control")

--- a/be/test/exec/CMakeLists.txt
+++ b/be/test/exec/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(EXEC_RUNTIME_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    jni_env_stub.cpp
     pipeline_driver_exec_runtime_test.cpp
     pipeline_event_scheduler_exec_runtime_test.cpp
     pipeline_execution_group_exec_runtime_test.cpp
@@ -63,6 +64,7 @@ target_link_libraries(exec_runtime_test ${EXEC_RUNTIME_TEST_LINK_LIBS} gtest_mai
 
 set(SCHEMA_SCANNER_CORE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    jni_env_stub.cpp
     schema_scanner/schema_scanner_core_test.cpp
 )
 
@@ -94,6 +96,7 @@ target_link_libraries(schema_scanner_core_test ${SCHEMA_SCANNER_CORE_TEST_LINK_L
 
 set(EXEC_SCHEMA_SCANNERS_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    jni_env_stub.cpp
     schema_scanner/exec_schema_scanners_test.cpp
 )
 
@@ -125,6 +128,7 @@ target_link_libraries(exec_schema_scanners_test ${EXEC_SCHEMA_SCANNERS_TEST_LINK
 
 set(JOIN_CORE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    jni_env_stub.cpp
     join_hash_map_test.cpp
 )
 

--- a/be/test/exec/CMakeLists.txt
+++ b/be/test/exec/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 set(EXEC_RUNTIME_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     pipeline_driver_exec_runtime_test.cpp
     pipeline_event_scheduler_exec_runtime_test.cpp
     pipeline_execution_group_exec_runtime_test.cpp
@@ -64,7 +64,7 @@ target_link_libraries(exec_runtime_test ${EXEC_RUNTIME_TEST_LINK_LIBS} gtest_mai
 
 set(SCHEMA_SCANNER_CORE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     schema_scanner/schema_scanner_core_test.cpp
 )
 
@@ -96,7 +96,7 @@ target_link_libraries(schema_scanner_core_test ${SCHEMA_SCANNER_CORE_TEST_LINK_L
 
 set(EXEC_SCHEMA_SCANNERS_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     schema_scanner/exec_schema_scanners_test.cpp
 )
 
@@ -128,7 +128,7 @@ target_link_libraries(exec_schema_scanners_test ${EXEC_SCHEMA_SCANNERS_TEST_LINK
 
 set(JOIN_CORE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     join_hash_map_test.cpp
 )
 

--- a/be/test/exec/jni_env_stub.cpp
+++ b/be/test/exec/jni_env_stub.cpp
@@ -1,0 +1,7 @@
+// The focused exec tests do not exercise JVM integration, but Runtime can pull
+// Java helper objects into these test binaries.
+#include <jni.h>
+
+extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
+    return nullptr;
+}

--- a/be/test/exec/jni_env_stub.cpp
+++ b/be/test/exec/jni_env_stub.cpp
@@ -1,7 +1,0 @@
-// The focused exec tests do not exercise JVM integration, but Runtime can pull
-// Java helper objects into these test binaries.
-#include <jni.h>
-
-extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
-    return nullptr;
-}

--- a/be/test/exec_primitive/CMakeLists.txt
+++ b/be/test/exec_primitive/CMakeLists.txt
@@ -21,7 +21,7 @@ set(EXEC_PRIMITIVE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
     data_sink/data_sink_core_test.cpp
     exec_node_exec_primitive_test.cpp
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     morsel_primitive_test.cpp
     pipeline_event_exec_primitive_test.cpp
     pipeline_metrics_exec_primitive_test.cpp

--- a/be/test/exec_primitive/jni_env_stub.cpp
+++ b/be/test/exec_primitive/jni_env_stub.cpp
@@ -1,7 +1,0 @@
-// The focused exec primitive tests do not exercise JVM integration, but
-// Runtime can pull Java helper objects into this test binary.
-#include <jni.h>
-
-extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
-    return nullptr;
-}

--- a/be/test/formats/CMakeLists.txt
+++ b/be/test/formats/CMakeLists.txt
@@ -17,7 +17,7 @@ set(FORMAT_CORE_TEST_FILES
     disk_range_test.cpp
     io/async_flush_output_stream_test.cpp
     io/formatted_output_stream_file_test.cpp
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
 )
 
 set(FORMAT_CSV_TEST_FILES

--- a/be/test/formats/jni_env_stub.cpp
+++ b/be/test/formats/jni_env_stub.cpp
@@ -1,7 +1,0 @@
-// The focused format tests do not exercise JVM integration, but Runtime can
-// pull Java helper objects into this test binary through RuntimeEnv paths.
-#include <jni.h>
-
-extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
-    return nullptr;
-}

--- a/be/test/storage_base/CMakeLists.txt
+++ b/be/test/storage_base/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(STORAGE_BASE_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
+    ${BE_TEST_JNI_ENV_STUB}
     short_key_index_test.cpp
 )
 

--- a/be/test/storage_primitive/CMakeLists.txt
+++ b/be/test/storage_primitive/CMakeLists.txt
@@ -28,7 +28,7 @@ set(STORAGE_PRIMITIVE_TEST_FILES
     column_value_range_test.cpp
     disjunctive_predicates_test.cpp
     key_coder_test.cpp
-    jni_env_stub.cpp
+    ${BE_TEST_JNI_ENV_STUB}
     lake_file_name_test.cpp
     predicate_tree_test.cpp
     projection_iterator_test.cpp

--- a/be/test/storage_primitive/jni_env_stub.cpp
+++ b/be/test/storage_primitive/jni_env_stub.cpp
@@ -1,7 +1,0 @@
-// The focused storage primitive tests do not exercise JVM integration, but
-// Runtime can pull Java helper objects into this test binary.
-#include <jni.h>
-
-extern "C" __attribute__((weak)) JNIEnv* getJNIEnv(void) {
-    return nullptr;
-}


### PR DESCRIPTION
## Why I'm doing:

  Several focused unit-test binaries under `be/test/` (e.g. `exec_*`, `compute_env_*`, `cache_test`, `storage_base_test`, `storage_primitive_test`, `connector_*`, `connector_primitive_test`, `format_test`) link the `Runtime` library
  — directly or transitively through libs like `ComputeEnv` / `Connector*` / `Formats` — but do **not** link `hdfs`. `Runtime` references `getJNIEnv()`, which is implemented by libhdfs (see `be/src/runtime/java/jni_env.h`), so
  linking these binaries fails with:

```
[ 66%] Building CXX object src/exec/CMakeFiles/ExecSchemaScanners.dir/schema_scanner/schema_events_scanner.cpp.o
ld.lld: error: undefined symbol: getJNIEnv
>>> referenced by jvm_helper.cpp:63 (/root/starrocks/be/src/runtime/java/jvm_helper.cpp:63)
>>>               CMakeFiles/Runtime.dir/java/jvm_helper.cpp.o:(starrocks::JVMHelper::getInstance()) in archive ../../src/runtime/libRuntime.a
>>> referenced by jvm_helper.cpp:63 (/root/starrocks/be/src/runtime/java/jvm_helper.cpp:63)
>>>               CMakeFiles/Runtime.dir/java/jvm_helper.cpp.o:(starrocks::JVMHelper::getInstanceWithEnv()) in archive ../../src/runtime/libRuntime.a
>>> referenced by jvm_helper.cpp:63 (/root/starrocks/be/src/runtime/java/jvm_helper.cpp:63)
>>>               CMakeFiles/Runtime.dir/java/jvm_helper.cpp.o:(std::_Function_handler<starrocks::Status (), starrocks::DirectByteBuffer::~DirectByteBuffer()::'lambda'()>::_M_invoke(std::_Any_data const&)) in archive ../../src/runtime/libRuntime.a
>>> referenced 26 more times
```

## What I'm doing:

  Add a single shared weak fallback for `getJNIEnv` and wire it into the affected test targets:
  
  - `be/test/base/jni_env_stub.cpp` — one `__attribute__((weak))` `getJNIEnv` returning `nullptr`. These tests do not exercise JVM integration, so `nullptr` is safe; wherever libhdfs *is* linked (`starrocks_be`, `starrocks_format`,
  ...), its strong symbol always overrides this weak one, so production behavior is unchanged.
  - `be/test/CMakeLists.txt` — define `BE_TEST_JNI_ENV_STUB` once so subdirectories can reference the shared source (consistent with the existing `BE_TEST_MACOS_LINK_STUBS` pattern), instead of duplicating a stub file per directory.
  - Add `${BE_TEST_JNI_ENV_STUB}` to the source lists of the test targets that link `Runtime` without `hdfs`. Targets that already link `hdfs` (e.g. `connector_jdbc_test`) are left untouched.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
