### PR TITLE
[Doc] Note that shared-data primary key tables no longer support the LOCAL persistent index

### DIFF
--- a/docs/en/table_design/table_types/primary_key_table.md
+++ b/docs/en/table_design/table_types/primary_key_table.md
@@ -158,6 +158,12 @@ If the disk is an SSD, it is recommended to set it to `true`. If the disk is an 
 
 Since v3.1.4, Primary Key tables created in StarRocks shared-data clusters support index persistence onto local disks. And from v3.3.2 onwards, StarRocks shared-data clusters further support index persistence onto object storage. You can enable this feature by setting the table property `persistent_index_type` to `CLOUD_NATIVE`.
 
+:::note
+
+In shared-data clusters, Primary Key tables now support only the cloud-native persistent index (`persistent_index_type = CLOUD_NATIVE`). Setting `persistent_index_type` to `LOCAL` is no longer supported when you create or alter a table. Existing tables that use a `LOCAL` persistent index are not affected.
+
+:::
+
 </TabItem>
 
 <TabItem value="example2" label="Fully in-memory primary key index">

--- a/docs/ja/table_design/table_types/primary_key_table.md
+++ b/docs/ja/table_design/table_types/primary_key_table.md
@@ -159,6 +159,12 @@ PROPERTIES (
 
 v3.1.4 以降、StarRocks 共有データクラスタで作成された主キーテーブルは、ローカルディスクへのインデックス永続化をサポートしています。そして、v3.3.2 以降、StarRocks 共有データクラスタは、オブジェクトストレージへのインデックス永続化もサポートしています。この機能を有効にするには、テーブルプロパティ `persistent_index_type` を `CLOUD_NATIVE` に設定します。
 
+:::note
+
+共有データクラスタでは、主キーテーブルはクラウドネイティブ永続性インデックス（`persistent_index_type = CLOUD_NATIVE`）のみをサポートするようになりました。テーブルの作成または変更時に `persistent_index_type` を `LOCAL` に設定することはサポートされなくなりました。既に `LOCAL` 永続性インデックスを使用しているテーブルには影響しません。
+
+:::
+
 </TabItem>
 
 <TabItem value="example2" label="完全にメモリ内の主キーインデックス">

--- a/docs/zh/table_design/table_types/primary_key_table.md
+++ b/docs/zh/table_design/table_types/primary_key_table.md
@@ -157,6 +157,12 @@ PROPERTIES (
 
 自 3.1.4 版本起，StarRocks 存算分离集群支持基于本地磁盘上的持久化索引。自 3.3.2 版本起，存算分离集群进一步支持基于对象存储上的持久化索引。您可以通过将主键表 Property `persistent_index_type` 设置为 `CLOUD_NATIVE` 启用该功能。
 
+:::note
+
+在存算分离集群中，主键表现仅支持云原生持久化索引（`persistent_index_type = CLOUD_NATIVE`）。创建或修改表时，不再支持将 `persistent_index_type` 设置为 `LOCAL`。已使用 `LOCAL` 持久化索引的存量表不受影响。
+
+:::
+
 </TabItem>
 <TabItem value="example2" label="全内存主键索引">
 


### PR DESCRIPTION
## Why I'm doing:

Follow-up documentation for #75940, which restricts shared-data (cloud-native) primary key
tables to the cloud-native persistent index. The user-facing docs still described the `LOCAL`
persistent-index option for shared-data clusters, so users could follow documented SQL that now
fails on CREATE/ALTER.

## What I'm doing:

Document that in shared-data clusters, primary key tables only support the cloud-native persistent
index (`persistent_index_type = CLOUD_NATIVE`). Setting `persistent_index_type` to `LOCAL` is no
longer supported when creating or altering a table; existing tables that already use a `LOCAL`
persistent index are unaffected.

Updated `table_design/table_types/primary_key_table.md` in all three languages:

- `docs/en/table_design/table_types/primary_key_table.md`
- `docs/zh/table_design/table_types/primary_key_table.md`
- `docs/ja/table_design/table_types/primary_key_table.md`

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)