### PR TITLE
[diag][throwaway] SPLIT-DIAG protected_rssids gap runtime proof

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -49,6 +49,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/flat_json_metrics.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/predicate_parser.h"
@@ -490,7 +491,13 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
         auto* glm_ctx = (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(scan_node_id, creator);
         glm_ctx->set_scan_node(thrift_lake_scan_node);
         int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
-        glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
+        if (!_morsel->rowsets().empty()) {
+            glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
+        } else {
+            auto lake_rowsets = lake::Rowset::get_rowsets(_provider->tablet_manager(), _tablet.metadata());
+            std::vector<BaseRowsetSharedPtr> base_rowsets(lake_rowsets.begin(), lake_rowsets.end());
+            glm_ctx->capture_rowsets(_scan_range.tablet_id, version, base_rowsets);
+        }
     }
 
     RETURN_IF_ERROR(_extend_schema_by_access_paths());

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -18,6 +18,7 @@
 
 #include "base/string/string_parser.hpp"
 #include "base/testutil/sync_point.h"
+#include "base/uid_util.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/column_access_path.h"
@@ -491,6 +492,12 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
         auto* glm_ctx = (LakeScanLazyMaterializationContext*)glm_mgr->get_or_create_ctx(scan_node_id, creator);
         glm_ctx->set_scan_node(thrift_lake_scan_node);
         int64_t version = strtoul(_scan_range.version.c_str(), nullptr, 10);
+        // [GLM-DIAG POS] this GLM-enabled scan emits row locators (tablet, rssid, rowid) for the
+        // fetch phase. Log the version this position scan reads at, keyed by query_id, so it can be
+        // correlated against the fetch's captured_version in the [GLM-DIAG notfound] line to
+        // discriminate durable index damage (versions equal) from scan-vs-fetch skew (versions differ).
+        LOG(WARNING) << "[GLM-DIAG POS] query_id=" << print_id(runtime_state->query_id())
+                     << " tablet=" << _scan_range.tablet_id << " scan_version=" << version;
         if (!_morsel->rowsets().empty()) {
             glm_ctx->capture_rowsets(_scan_range.tablet_id, version, _morsel->rowsets());
         } else {

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -346,8 +346,7 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
         // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
         // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
         LOG(WARNING) << "[GLM-DIAG notfound] query_id=" << _query_id_str << " tablet=" << _tablet_id
-                     << " rssid=" << rssid << " "
-                     << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
+                     << " rssid=" << rssid << " " << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
                      << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         // [GLM-DIAG sstprov] Dump the tablet's PK-index SST filesets with split provenance, to pin
         // whether the failing rssid was served by a shared=1 (inherited-from-split-parent) SST vs a
@@ -388,8 +387,8 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
             }
             LOG(WARNING) << "[GLM-DIAG sstprov] query_id=" << _query_id_str << " tablet=" << _tablet_id
                          << " rssid=" << rssid << " meta_version=" << meta_version << " n_sst=" << n_sst
-                         << " n_shared=" << n_shared << " n_local=" << n_local
-                         << " shared_hit_idx=" << shared_hit_idx << dump;
+                         << " n_shared=" << n_shared << " n_local=" << n_local << " shared_hit_idx=" << shared_hit_idx
+                         << dump;
         }
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -339,6 +339,11 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     }
 
     if (target == nullptr) {
+        // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
+        // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
+        LOG(WARNING) << "[GLM-DIAG notfound] tablet=" << _tablet_id << " rssid=" << rssid << " "
+                     << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
+                     << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }
 

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -349,6 +349,48 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
                      << " rssid=" << rssid << " "
                      << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
                      << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
+        // [GLM-DIAG sstprov] Dump the tablet's PK-index SST filesets with split provenance, to pin
+        // whether the failing rssid was served by a shared=1 (inherited-from-split-parent) SST vs a
+        // shared=0 (locally-produced compaction) SST. A shared SST with shared_version>0 rewrites
+        // every key it serves to the single value (shared_rssid + rssid_offset) — see
+        // PersistentIndexSstable::multi_get. So `shared_hit_idx>=0` means the failing rssid was
+        // produced by that inherited SST => (S1) split-time handoff; a shared=0 SST that should cover
+        // the key yet lost to the inherited one => (S2) post-split compaction gap. See goal.
+        {
+            const auto& meta = _tablet.metadata();
+            std::string dump;
+            int shared_hit_idx = -1;
+            int n_shared = 0, n_local = 0, n_sst = 0;
+            int64_t meta_version = (meta != nullptr) ? meta->version() : -1;
+            if (meta != nullptr && meta->has_sstable_meta()) {
+                const auto& ssts = meta->sstable_meta().sstables();
+                n_sst = ssts.size();
+                for (int i = 0; i < ssts.size(); ++i) {
+                    const auto& s = ssts.Get(i);
+                    const bool is_shared = s.shared();
+                    if (is_shared) {
+                        ++n_shared;
+                    } else {
+                        ++n_local;
+                    }
+                    if (is_shared && s.has_shared_version() && s.shared_version() > 0) {
+                        const int64_t eff = static_cast<int64_t>(s.shared_rssid()) + s.rssid_offset();
+                        if (eff == rssid) {
+                            shared_hit_idx = i;
+                        }
+                    }
+                    dump += fmt::format(
+                            " sst[{}]{{shared={} shared_rssid={} shared_version={} rssid_offset={} "
+                            "has_range={} file={}}}",
+                            i, is_shared ? 1 : 0, s.shared_rssid(), s.shared_version(), s.rssid_offset(),
+                            s.has_range() ? 1 : 0, s.filename());
+                }
+            }
+            LOG(WARNING) << "[GLM-DIAG sstprov] query_id=" << _query_id_str << " tablet=" << _tablet_id
+                         << " rssid=" << rssid << " meta_version=" << meta_version << " n_sst=" << n_sst
+                         << " n_shared=" << n_shared << " n_local=" << n_local
+                         << " shared_hit_idx=" << shared_hit_idx << dump;
+        }
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));
     }
 

--- a/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
+++ b/be/src/exec/pipeline/lookup/tablet_adaptor.cpp
@@ -20,6 +20,7 @@
 #include "base/status.h"
 #include "base/status_fmt.hpp"
 #include "base/statusor.h"
+#include "base/uid_util.h"
 #include "common/config_lake_fwd.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "exec/exec_env.h"
@@ -169,6 +170,8 @@ private:
     LakeScanLazyMaterializationContext* _glm_ctx = nullptr;
     std::vector<lake::RowsetPtr> _rowsets;
     bool _use_page_cache = false;
+    // [GLM-DIAG] correlation key with the [GLM-DIAG POS] scan-side line.
+    std::string _query_id_str;
 };
 
 Status OlapScanTabletAdaptor::init(int64_t tablet_id) {
@@ -272,6 +275,7 @@ Status LakeScanTabletAdaptor::init(int64_t tablet_id) {
 
 Status LakeScanTabletAdaptor::init_schema(RuntimeState* state) {
     _use_page_cache = state->use_page_cache();
+    _query_id_str = print_id(state->query_id());
     auto* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
     const auto& lake_scan_node = _glm_ctx->scan_node();
 
@@ -341,7 +345,8 @@ auto LakeScanTabletAdaptor::get_iterator(int64_t rssid, SparseRange<rowid_t> row
     if (target == nullptr) {
         // [GLM-DIAG] dump captured vs live rowset ranges to expose the scan-vs-fetch snapshot
         // mismatch behind "not found lake rssid". All PB access lives in debug_dump_ranges.
-        LOG(WARNING) << "[GLM-DIAG notfound] tablet=" << _tablet_id << " rssid=" << rssid << " "
+        LOG(WARNING) << "[GLM-DIAG notfound] query_id=" << _query_id_str << " tablet=" << _tablet_id
+                     << " rssid=" << rssid << " "
                      << _glm_ctx->debug_dump_ranges(static_cast<int32_t>(_tablet_id))
                      << " live_" << _glm_ctx->debug_dump_ranges(_rowsets);
         return Status::InternalError(fmt::format("not found lake rssid:{} in tablet_id:{}", rssid, _tablet_id));

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -870,12 +870,10 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
     auto accumulated = accumulator.pull();
     if (accumulated == nullptr) {
         // [GLM-DIAG] distinguish empty-batch (a) from located-but-materialized-nothing (b).
-        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id
-                     << " n_locators=" << row_locators.size()
-                     << (row_locators.empty()
-                                 ? std::string()
-                                 : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
-                                               std::get<1>(row_locators[0])));
+        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id << " n_locators=" << row_locators.size()
+                     << (row_locators.empty() ? std::string()
+                                              : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
+                                                            std::get<1>(row_locators[0])));
         // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
         // materialized. Previously this null was dereferenced unconditionally below
         // (accumulated->schema()), which crashes the CN with SIGSEGV.

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -869,6 +869,13 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
     accumulator.finalize();
     auto accumulated = accumulator.pull();
     if (accumulated == nullptr) {
+        // [GLM-DIAG] distinguish empty-batch (a) from located-but-materialized-nothing (b).
+        LOG(WARNING) << "[GLM-DIAG empty-accum] scan_id=" << _ctx->scan_id
+                     << " n_locators=" << row_locators.size()
+                     << (row_locators.empty()
+                                 ? std::string()
+                                 : fmt::format(" first=(tablet={},rssid={})", std::get<0>(row_locators[0]),
+                                               std::get<1>(row_locators[0])));
         // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
         // materialized. Previously this null was dereferenced unconditionally below
         // (accumulated->schema()), which crashes the CN with SIGSEGV.

--- a/be/src/exec/pipeline/lookup_request.cpp
+++ b/be/src/exec/pipeline/lookup_request.cpp
@@ -37,6 +37,7 @@
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
 #include "runtime/chunk_accumulator.h"
+#include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage_primitive/range.h"
@@ -867,6 +868,28 @@ auto NativeLookUpTask::_late_materialize_by_row_locators(RuntimeState* state, co
 
     accumulator.finalize();
     auto accumulated = accumulator.pull();
+    if (accumulated == nullptr) {
+        // pull() returns nullptr when the accumulator produced no chunk, i.e. nothing was
+        // materialized. Previously this null was dereferenced unconditionally below
+        // (accumulated->schema()), which crashes the CN with SIGSEGV.
+        //
+        // There are two ways to get here:
+        //  - There were no row locators to look up (empty lookup request). _build_row_id_range
+        //    returns an empty locator set only when its input has 0 rows, so an empty chunk with
+        //    the requested slots is the correct result.
+        //  - Row locators existed but none could be materialized. Under a version-consistent read
+        //    a located row must be readable, so this indicates the tablet changed under us between
+        //    the position scan and this fetch (concurrent ingest/updates/deletes, or
+        //    compaction/GC). Fail loudly so the query retries on a consistent snapshot rather than
+        //    silently returning fewer rows. (A missing rowset already surfaces as an error earlier
+        //    via _tablet_adaptor->get_iterator -> "not found lake rssid".)
+        if (!row_locators.empty()) {
+            return Status::InternalError(
+                    "late materialization produced no rows for a non-empty set of row locators; "
+                    "the tablet changed between the position scan and the lookup fetch");
+        }
+        return ChunkPtr(RuntimeChunkHelper::new_chunk(slots, 0));
+    }
 
     for (const auto& slot : slots) {
         size_t column_index = accumulated->schema()->get_field_index_by_name(slot->col_name());

--- a/be/src/exec/pipeline/scan/glm_manager.cpp
+++ b/be/src/exec/pipeline/scan/glm_manager.cpp
@@ -125,6 +125,33 @@ void LakeScanLazyMaterializationContext::capture_rowsets(int32_t tablet_id, int6
     _versions[tablet_id] = version;
 }
 
+// [GLM-DIAG] diagnostic only. rssid range of a rowset is [id, id + segment_metas_size).
+std::string LakeScanLazyMaterializationContext::debug_dump_ranges(const std::vector<lake::RowsetPtr>& rowsets) const {
+    std::string s = "n=" + std::to_string(rowsets.size()) + " ranges=[";
+    for (const auto& rs : rowsets) {
+        const auto& m = rs->metadata();
+        uint32_t base = m.id();
+        s += std::to_string(base) + ":" + std::to_string(base + m.segment_metas_size()) + " ";
+    }
+    s += "]";
+    return s;
+}
+
+// [GLM-DIAG] diagnostic only.
+std::string LakeScanLazyMaterializationContext::debug_dump_ranges(int32_t tablet_id) const {
+    std::shared_lock lock(_mutex);
+    std::string s = "captured_version=";
+    auto vit = _versions.find(tablet_id);
+    s += (vit == _versions.end() ? std::string("MISSING") : std::to_string(vit->second));
+    auto it = _rowsets.find(tablet_id);
+    if (it == _rowsets.end()) {
+        s += " captured=ABSENT";
+        return s;
+    }
+    s += " captured_" + debug_dump_ranges(it->second);
+    return s;
+}
+
 void LakeScanLazyMaterializationContext::set_scan_node(const TLakeScanNode& node) {
     std::unique_lock lock(_mutex);
     if (!_thrift_lake_scan_node.has_value()) {

--- a/be/src/exec/pipeline/scan/glm_manager.h
+++ b/be/src/exec/pipeline/scan/glm_manager.h
@@ -99,6 +99,10 @@ public:
     const TLakeScanNode& scan_node() const { return *_thrift_lake_scan_node; }
     void set_scan_node(const TLakeScanNode& node);
 
+    // [GLM-DIAG] dump captured version + rowset id-ranges for a tablet (diagnostic only).
+    std::string debug_dump_ranges(int32_t tablet_id) const;
+    std::string debug_dump_ranges(const std::vector<lake::RowsetPtr>& rowsets) const;
+
 private:
     mutable std::shared_mutex _mutex;
     std::unordered_map<int32_t, std::vector<lake::RowsetPtr>> _rowsets;

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1344,9 +1344,8 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
                         }
                     }
                     LOG(WARNING) << "[SPLIT-DIAG removed] child=" << new_tablet_new_metadata->id()
-                                 << " rowset_id=" << split_diag_rssid_base << " rssid_range=["
-                                 << split_diag_rssid_base << ","
-                                 << (split_diag_rssid_base + split_diag_orig_seg_count) << ")"
+                                 << " rowset_id=" << split_diag_rssid_base << " rssid_range=[" << split_diag_rssid_base
+                                 << "," << (split_diag_rssid_base + split_diag_orig_seg_count) << ")"
                                  << " protected=" << (any_protected ? 1 : 0)
                                  << " removed=" << (keep_rowset[rowset_index] ? 0 : 1)
                                  << " has_pruned_protected=" << (has_pruned_protected_rssid ? 1 : 0);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1258,6 +1258,21 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
         }
     }
 
+    // [SPLIT-DIAG] Runtime proof of the protected_rssids gap: dump the protected set once
+    // per split so it can be correlated with per-rowset removal decisions and query-time
+    // [GLM-DIAG notfound] rssids. protected_rssids only holds each sstable's single
+    // shared_rssid, so a removed rowset whose rssid range is absent from this set but still
+    // referenced by a surviving sstable is the dangling seed we are hunting.
+    {
+        std::string prs;
+        for (uint32_t r : protected_rssids) {
+            prs += std::to_string(r);
+            prs += ",";
+        }
+        LOG(WARNING) << "[SPLIT-DIAG protected] old_tablet=" << old_tablet_metadata->id()
+                     << " n_protected=" << protected_rssids.size() << " protected_rssids=[" << prs << "]";
+    }
+
     for (int32_t i = 0; i < splitting_tablet.new_tablet_ids_size(); ++i) {
         auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
         new_tablet_new_metadata->set_id(splitting_tablet.new_tablet_ids(i));
@@ -1288,6 +1303,12 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
             // are then pruned to those overlapping this new tablet (shared=false where provably
             // exclusive+contained), or for non-pruneable / degraded rowsets stay all-shared.
             if (rowset_prunable[rowset_index]) {
+                // Capture the ORIGINAL rssid range before apply_segment_ownership_to_new_tablet_rowset
+                // prunes segment_metas away: base = rowset id, count = original segment count
+                // (rssid = id + segment_idx, per meta_file.cpp:get_rssid).
+                const uint32_t split_diag_rssid_base = rowset_metadata.id();
+                const int split_diag_orig_seg_count = rowset_metadata.segment_metas_size();
+
                 const bool has_pruned_protected_rssid = propagate_pruned_ownership_to_non_segment_files(
                         rowset_metadata, rowset_ownership[rowset_index], i, protected_rssids,
                         new_tablet_new_metadata.get());
@@ -1305,6 +1326,30 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
                     rowset_metadata.del_files_size() == 0 && !has_pruned_protected_rssid) {
                     keep_rowset[rowset_index] = false;
                     removed_rowset_ids.push_back(rowset_metadata.id());
+                }
+
+                // [SPLIT-DIAG] Log EVERY fully-pruned rowset on this child, with whether any rssid
+                // in its original range is protected and whether it was actually removed. A
+                // removed=1 protected=0 line whose rssid_range=[a,b) later matches a query-time
+                // [GLM-DIAG notfound] tablet=child rssid=r with a<=r<b is the direct runtime proof:
+                // the split dropped an unprotected rowset and the index still hands out a position
+                // in its now-gone rssid range. referenced_by_surviving_sstable is omitted (scanning
+                // sstable entries at split time is too heavy) — the query-time correlation supplies it.
+                if (rowset_metadata.segment_metas_size() == 0) {
+                    bool any_protected = false;
+                    for (int off = 0; off < split_diag_orig_seg_count; ++off) {
+                        if (protected_rssids.contains(split_diag_rssid_base + off)) {
+                            any_protected = true;
+                            break;
+                        }
+                    }
+                    LOG(WARNING) << "[SPLIT-DIAG removed] child=" << new_tablet_new_metadata->id()
+                                 << " rowset_id=" << split_diag_rssid_base << " rssid_range=["
+                                 << split_diag_rssid_base << ","
+                                 << (split_diag_rssid_base + split_diag_orig_seg_count) << ")"
+                                 << " protected=" << (any_protected ? 1 : 0)
+                                 << " removed=" << (keep_rowset[rowset_index] ? 0 : 1)
+                                 << " has_pruned_protected=" << (has_pruned_protected_rssid ? 1 : 0);
                 }
             } else {
                 tablet_reshard_helper::set_all_data_files_shared(&rowset_metadata);

--- a/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+++ b/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
@@ -17,10 +17,10 @@
 #include <string>
 #include <vector>
 
+#include "column/chunk.h"
 #include "common/config_exec_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
-#include "column/chunk.h"
 #include "exec/pipeline/lookup/tablet_adaptor.h"
 #include "exec/pipeline/scan/glm_manager.h"
 #include "exec/runtime/query_runtime_state.h"

--- a/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
+++ b/be/test/exec/pipeline/glm_manager_tablet_adaptor_test.cpp
@@ -20,9 +20,15 @@
 #include "common/config_exec_fwd.h"
 #include "common/object_pool.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "column/chunk.h"
 #include "exec/pipeline/lookup/tablet_adaptor.h"
 #include "exec/pipeline/scan/glm_manager.h"
+#include "exec/runtime/query_runtime_state.h"
 #include "gtest/gtest.h"
+// Access NativeLookUpTask's private _late_materialize_by_row_locators() and RowLocators.
+#define private public
+#include "exec/pipeline/lookup_request.h"
+#undef private
 #include "runtime/descriptor_helper.h"
 #include "runtime/runtime_state.h"
 #include "storage/lake/rowset.h"
@@ -367,6 +373,49 @@ TEST(LakeScanTabletAdaptorTest, InvalidRssid) {
     auto iter_or = adaptor->get_iterator(-1, std::move(rowids));
     ASSERT_FALSE(iter_or.ok());
     ASSERT_TRUE(iter_or.status().is_internal_error());
+}
+
+// Regression test for a CN SIGSEGV in NativeLookUpTask::_late_materialize_by_row_locators.
+// When the lookup has no row locators to materialize, the ChunkAccumulator stays empty and
+// ChunkAccumulator::pull() returns nullptr. The old code dereferenced it unconditionally
+// (accumulated->schema()), crashing the CN. The fix returns an empty chunk carrying the
+// requested slots for the empty-locators case.
+TEST(NativeLookUpTaskTest, EmptyRowLocatorsReturnsEmptyChunk) {
+    RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+
+    // The late-materialize path requires a non-null GLM context for the scan id.
+    constexpr int64_t kScanId = 42;
+    GlobalLateMaterilizationContextMgr glm_mgr;
+    auto* glm_ctx = glm_mgr.get_or_create_ctx(kScanId, []() { return new DummyGLMContext(); });
+    pipeline::QueryRuntimeState qrs;
+    qrs.set_global_late_materialization_ctx_mgr(&glm_mgr);
+    state.set_query_runtime_state(&qrs);
+
+    auto ctx = std::make_shared<pipeline::LookUpTaskContext>();
+    ctx->scan_id = kScanId;
+
+    auto adaptor_or = create_look_up_tablet_adaptor(RowPositionDescriptor::Type::LAKE_SCAN);
+    ASSERT_TRUE(adaptor_or.ok());
+    pipeline::NativeLookUpTask task(ctx, std::move(adaptor_or.value()));
+
+    ObjectPool pool;
+    auto slots = create_slots(&state, &pool, {"c0", "c1"});
+    ASSERT_EQ(2, slots.size());
+
+    auto request_chunk = std::make_shared<Chunk>();
+    pipeline::NativeLookUpTask::RowLocators empty_locators; // empty -> accumulator empty -> pull() == nullptr
+
+    auto result = task._late_materialize_by_row_locators(&state, slots, empty_locators, request_chunk);
+    ASSERT_TRUE(result.ok()) << result.status().to_string();
+    auto out = result.value();
+    ASSERT_NE(nullptr, out);
+    EXPECT_EQ(0, out->num_rows());
+    EXPECT_EQ(slots.size(), out->num_columns());
+    for (auto* slot : slots) {
+        EXPECT_NE(nullptr, out->get_column_by_slot_id(slot->id()));
+    }
+
+    delete glm_ctx;
 }
 
 } // namespace starrocks


### PR DESCRIPTION
THROWAWAY diagnostic build — do not merge, will be closed.

Adds two `[SPLIT-DIAG]` log lines to `tablet_splitter.cpp`'s split-apply path to
capture the `protected_rssids` gap at runtime:

- `[SPLIT-DIAG protected] old_tablet=<id> protected_rssids=[...]` once per split
  (protected_rssids only holds each sstable's single `shared_rssid`).
- `[SPLIT-DIAG removed] child=<new_id> rowset_id=<id> rssid_range=[base,base+segs)
  protected=<0/1> removed=<0/1> has_pruned_protected=<0/1>` for every fully-pruned
  rowset on each child.

Correlated with the existing `[GLM-DIAG notfound]` fetch-side log: a `removed=1
protected=0` range on child C that a later `[GLM-DIAG notfound] tablet=C rssid=r`
falls into (base<=r<base+segs) is the direct dangling-seed proof.

Based on `diag/glm-sst-provenance` (keeps the #75889 null-guard so CNs survive).
BE-only change.
