### PR TITLE
[BugFix] Rebuild the MV query for the PCT fallback in AUTO refresh mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -384,7 +384,13 @@ public class MaterializedViewAnalyzer {
                     statement.setRowIdStrategy(result.rowIdStrategy());
                     statement.setCurrentRefreshMode(result.currentRefreshMode());
                 } else {
-                    // if not ivm, set query statement directly
+                    // AUTO mode swallows the IVM SemanticException and falls back to PCT, but the trial may
+                    // have prepended __ROW_ID__ to the query in place before bailing. Re-parse the pre-trial
+                    // SQL so the PCT MV is built from the original query, not the half-rewritten one.
+                    queryStatement = (QueryStatement) SqlParser.parse(statement.getInlineViewDef(),
+                            context.getSessionVariable()).get(0);
+                    Analyzer.analyze(queryStatement, context);
+                    statement.setQueryStatement(queryStatement);
                     statement.setCurrentRefreshMode(MaterializedView.RefreshMode.PCT);
                 }
             } else {


### PR DESCRIPTION
## Why I'm doing:

When an incremental-or-auto materialized view is analyzed, the IVM rewrite runs against the query AST **in place**. An aggregate block prepends `__ROW_ID__ = encode(group keys)` to the select list before the rest of the shape is validated. In `AUTO` refresh mode, if a later check rejects an unsupported shape, the `SemanticException` is caught and swallowed and the MV falls back to `PCT` — but the query AST has already been mutated, so the `PCT` MV is built from the half-rewritten query and carries a spurious hidden `__ROW_ID__` column.

`INCREMENTAL` mode is unaffected: it rethrows the exception (CREATE fails) instead of falling back, so the fallback branch is only reachable under `AUTO`.

## What I'm doing:

Fixes #issue: N/A — internal robustness fix for the IVM AUTO-mode PCT fallback.

In `MaterializedViewAnalyzer`, the `AUTO` fallback branch now re-parses the pre-trial query SQL — captured in `inlineViewDef` before the IVM trial runs — and rebuilds the `PCT` MV from that original query instead of the mutated one. This covers every shape whose IVM trial mutates the AST before bailing (aggregate / sub-query / union over an unsupported inner relation).

Note on testing: `AUTO` refresh mode is disabled in my environment and I do not have a cluster to exercise it, so this is not covered by a new end-to-end test. The change is confined to the `AUTO` fallback branch, which is unreachable under `INCREMENTAL` (that path rethrows rather than falling back), so existing IVM tests are unaffected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
