### PR TITLE
[Refactor] Rename the IVM row-id-strategy flag to hasComputedRowId

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -211,10 +211,10 @@ public class IVMAnalyzer {
 
         try {
             QueryRelation queryRelation = queryStatement.getQueryRelation();
-            // Retractable queries produce their own __ROW_ID__ (encode(group_by_keys)); non-retractable
-            // append-only scans rely on storage AUTO_INCREMENT.
-            boolean isRetractable = rewriteImpl(queryRelation);
-            RowIdStrategy strategy = isRetractable
+            // A query that computes its own __ROW_ID__ (e.g. an aggregate's encode(group_by_keys)) uses
+            // QUERY_COMPUTED; an append-only scan without one relies on storage AUTO_INCREMENT.
+            boolean hasComputedRowId = rewriteImpl(queryRelation);
+            RowIdStrategy strategy = hasComputedRowId
                     ? RowIdStrategy.QUERY_COMPUTED
                     : RowIdStrategy.AUTO_INCREMENT;
             // Trial-rewrite catches drift the analyzer-level checks can't: e.g. a new logical
@@ -260,8 +260,8 @@ public class IVMAnalyzer {
 
     private boolean checkSubqueryRelation(SubqueryRelation subqueryRelation) throws AnalysisException {
         QueryStatement subQueryStatement = subqueryRelation.getQueryStatement();
-        boolean isChildRetractable = rewriteImpl(subQueryStatement.getQueryRelation());
-        if (isChildRetractable) {
+        boolean childHasComputedRowId = rewriteImpl(subQueryStatement.getQueryRelation());
+        if (childHasComputedRowId) {
             throw new SemanticException("IVMAnalyzer does not support subquery relation, " +
                     "but got: %s", subqueryRelation.getClass().getSimpleName());
         }
@@ -291,8 +291,8 @@ public class IVMAnalyzer {
                 throw new SemanticException("UnionRelation in IVMAnalyzer should not have aggregate functions, " +
                         "but got: %s", aggregateExprs);
             }
-            boolean isChildRetractable = checkRelation(selectChild);
-            if (isChildRetractable) {
+            boolean childHasComputedRowId = checkRelation(selectChild);
+            if (childHasComputedRowId) {
                 throw new SemanticException("IVMAnalyzer does not support UnionRelation with retractable sink, " +
                         "but got: %s", unionRelation.getClass().getSimpleName());
             }
@@ -324,10 +324,10 @@ public class IVMAnalyzer {
             throw new SemanticException("IVMAnalyzer does not support %s for incremental view maintenance",
                     groupByClause.getGroupingType());
         }
-        boolean isRetractable = checkAggregate(selectRelation);
+        boolean hasComputedRowId = checkAggregate(selectRelation);
         Relation innerRelation = selectRelation.getRelation();
-        isRetractable |= checkRelation(innerRelation);
-        return isRetractable;
+        hasComputedRowId |= checkRelation(innerRelation);
+        return hasComputedRowId;
     }
 
     private boolean checkRelation(Relation relation) throws AnalysisException {


### PR DESCRIPTION
## Why I'm doing:

The boolean returned by `rewriteImpl` / `checkSelectRelation` in `IVMAnalyzer` was named `isRetractable`, but it does not mean the MV is retractable (delete/update-maintainable). It only means the query **computes its own `__ROW_ID__`** — so the row-id strategy is `QUERY_COMPUTED` rather than storage `AUTO_INCREMENT`. It is also `true` for append-only aggregate MVs (which are not retractable), so the name is misleading.

## What I'm doing:

Fixes #issue: N/A — naming/readability refactor, no behavior change.

Rename the flag (and its child variant) to `hasComputedRowId` / `childHasComputedRowId`, and reword the comment to describe the `QUERY_COMPUTED` vs `AUTO_INCREMENT` decision. This is a pure rename of local variables — `TvrChangeType.RETRACTABLE` and the user-facing error messages are left unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
