### PR TITLE
[Enhancement] Add (DATE, INT) -> DATE overloads for date-arithmetic functions

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1012,8 +1012,8 @@ DateValue date_value_add(DateValue dv, int count) {
     return dv.add<UNIT>(count);
 }
 
-#define DEFINE_DATE_ADD_FN(FN, UNIT)                                                                       \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, date, value) { return date_value_add<UNIT>(date, value); }  \
+#define DEFINE_DATE_ADD_FN(FN, UNIT)                                                                      \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, date, value) { return date_value_add<UNIT>(date, value); } \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATE, TYPE_INT, TYPE_DATE);
 
 #define DEFINE_DATE_SUB_FN(FN, UNIT)                                                                       \

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1003,6 +1003,46 @@ DEFINE_TIME_ADD_AND_SUB_FN(micros, TimeUnit::MICROSECOND);
 #undef DEFINE_TIME_SUB_FN
 #undef DEFINE_TIME_ADD_AND_SUB_FN
 
+// DATE-typed add/sub: DATE input -> DATE output (only meaningful for date-granularity units).
+// Keeps the result in the DATE domain so a folded `current_date() - interval '1' day` stays
+// '2026-07-05' instead of the DATETIME '2026-07-05 00:00:00', which lets connector push-down
+// and partition pruning match string date columns / partition values correctly.
+template <TimeUnit UNIT>
+DateValue date_value_add(DateValue dv, int count) {
+    return dv.add<UNIT>(count);
+}
+
+#define DEFINE_DATE_ADD_FN(FN, UNIT)                                                                       \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, date, value) { return date_value_add<UNIT>(date, value); }  \
+    DEFINE_TIME_CALC_FN(FN, TYPE_DATE, TYPE_INT, TYPE_DATE);
+
+#define DEFINE_DATE_SUB_FN(FN, UNIT)                                                                       \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, date, value) { return date_value_add<UNIT>(date, -value); } \
+    DEFINE_TIME_CALC_FN(FN, TYPE_DATE, TYPE_INT, TYPE_DATE);
+
+// days_add / days_sub for DATE input
+DEFINE_DATE_ADD_FN(days_add_date, TimeUnit::DAY);
+DEFINE_DATE_SUB_FN(days_sub_date, TimeUnit::DAY);
+
+// months_add / months_sub for DATE input
+DEFINE_DATE_ADD_FN(months_add_date, TimeUnit::MONTH);
+DEFINE_DATE_SUB_FN(months_sub_date, TimeUnit::MONTH);
+
+// years_add / years_sub for DATE input
+DEFINE_DATE_ADD_FN(years_add_date, TimeUnit::YEAR);
+DEFINE_DATE_SUB_FN(years_sub_date, TimeUnit::YEAR);
+
+// weeks_add / weeks_sub for DATE input
+DEFINE_DATE_ADD_FN(weeks_add_date, TimeUnit::WEEK);
+DEFINE_DATE_SUB_FN(weeks_sub_date, TimeUnit::WEEK);
+
+// quarters_add / quarters_sub for DATE input
+DEFINE_DATE_ADD_FN(quarters_add_date, TimeUnit::QUARTER);
+DEFINE_DATE_SUB_FN(quarters_sub_date, TimeUnit::QUARTER);
+
+#undef DEFINE_DATE_ADD_FN
+#undef DEFINE_DATE_SUB_FN
+
 Status TimeFunctions::time_slice_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
     if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -454,12 +454,28 @@ public:
     DEFINE_VECTORIZED_FN(years_sub);
 
     /**
+     * @param: [date, year]
+     * @paramType columns: [DateColumn, IntColumn]
+     * @return DateColumn
+     */
+    DEFINE_VECTORIZED_FN(years_add_date);
+    DEFINE_VECTORIZED_FN(years_sub_date);
+
+    /**
      * @param: [timestmap, quarter]
      * @paramType columns: [TimestampColumn, IntColumn]
      * @return TimestampColumn
      */
     DEFINE_VECTORIZED_FN(quarters_add);
     DEFINE_VECTORIZED_FN(quarters_sub);
+
+    /**
+     * @param: [date, quarter]
+     * @paramType columns: [DateColumn, IntColumn]
+     * @return DateColumn
+     */
+    DEFINE_VECTORIZED_FN(quarters_add_date);
+    DEFINE_VECTORIZED_FN(quarters_sub_date);
 
     /**
      * @param: [timestmap, month]
@@ -470,6 +486,14 @@ public:
     DEFINE_VECTORIZED_FN(months_sub);
 
     /**
+     * @param: [date, month]
+     * @paramType columns: [DateColumn, IntColumn]
+     * @return DateColumn
+     */
+    DEFINE_VECTORIZED_FN(months_add_date);
+    DEFINE_VECTORIZED_FN(months_sub_date);
+
+    /**
      * @param: [timestmap, month]
      * @paramType columns: [TimestampColumn, IntColumn]
      * @return TimestampColumn
@@ -478,12 +502,30 @@ public:
     DEFINE_VECTORIZED_FN(weeks_sub);
 
     /**
+     * @param: [date, week]
+     * @paramType columns: [DateColumn, IntColumn]
+     * @return DateColumn
+     */
+    DEFINE_VECTORIZED_FN(weeks_add_date);
+    DEFINE_VECTORIZED_FN(weeks_sub_date);
+
+    /**
      * @param: [timestmap, days]
      * @paramType columns: [TimestampColumn, IntColumn]
      * @return TimestampColumn
      */
     DEFINE_VECTORIZED_FN(days_add);
     DEFINE_VECTORIZED_FN(days_sub);
+
+    /**
+     * @param: [date, days]
+     * @paramType columns: [DateColumn, IntColumn]
+     * @return DateColumn
+     * DATE input keeps DATE result (no promotion to DATETIME), so lexicographic/temporal
+     * order is preserved for downstream connector push-down and partition pruning.
+     */
+    DEFINE_VECTORIZED_FN(days_add_date);
+    DEFINE_VECTORIZED_FN(days_sub_date);
 
     /**
      * @param: [timestmap, hours]

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -142,6 +142,391 @@ TEST_F(TimeFunctionsTest, yearAddTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, yearsAddDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto year = Int32Column::create();
+    for (int j = 0; j < 20; ++j) {
+        tc->append(DateValue::create(2000, 1, 1));
+        year->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(year);
+
+    ColumnPtr result = TimeFunctions::years_add_date(_utils->get_fn_ctx(), columns).value();
+
+    // DATE input keeps a DATE result (no promotion to DATETIME).
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 20; ++k) {
+        ASSERT_EQ(DateValue::create(2000 + k, 1, 1), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, yearsSubDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto year = Int32Column::create();
+    for (int j = 0; j < 20; ++j) {
+        tc->append(DateValue::create(2020, 6, 15));
+        year->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(year);
+
+    ColumnPtr result = TimeFunctions::years_sub_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 20; ++k) {
+        ASSERT_EQ(DateValue::create(2020 - k, 6, 15), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, yearsAddSubDateLeapDayTest) {
+    // Feb 29 clamps to Feb 28 on non-leap target years, stays Feb 29 on leap ones.
+    auto tc = DateColumn::create();
+    auto year = Int32Column::create();
+    tc->append(DateValue::create(2000, 2, 29)); // + 1 year  -> 2001-02-28 (non-leap)
+    year->append(1);
+    tc->append(DateValue::create(2000, 2, 29)); // + 4 years -> 2004-02-29 (leap)
+    year->append(4);
+
+    Columns add_columns = {tc, year};
+    ColumnPtr add_result = TimeFunctions::years_add_date(_utils->get_fn_ctx(), add_columns).value();
+    auto av = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(add_result)->data_column());
+    ASSERT_EQ(DateValue::create(2001, 2, 28), av->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2004, 2, 29), av->immutable_data()[1]);
+
+    // 2004-02-29 - 4 years -> 2000-02-29 (leap); 2004-02-29 - 1 year -> 2003-02-28 (non-leap)
+    auto tc2 = DateColumn::create();
+    auto year2 = Int32Column::create();
+    tc2->append(DateValue::create(2004, 2, 29));
+    year2->append(4);
+    tc2->append(DateValue::create(2004, 2, 29));
+    year2->append(1);
+
+    Columns sub_columns = {tc2, year2};
+    ColumnPtr sub_result = TimeFunctions::years_sub_date(_utils->get_fn_ctx(), sub_columns).value();
+    auto sv = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(sub_result)->data_column());
+    ASSERT_EQ(DateValue::create(2000, 2, 29), sv->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2003, 2, 28), sv->immutable_data()[1]);
+}
+
+TEST_F(TimeFunctionsTest, daysAddDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto day = Int32Column::create();
+    for (int j = 0; j < 10; ++j) {
+        tc->append(DateValue::create(2020, 6, 1));
+        day->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(day);
+
+    ColumnPtr result = TimeFunctions::days_add_date(_utils->get_fn_ctx(), columns).value();
+
+    // DATE input keeps a DATE result (no promotion to DATETIME).
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 10; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 6, 1 + k), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, daysSubDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto day = Int32Column::create();
+    for (int j = 0; j < 10; ++j) {
+        tc->append(DateValue::create(2020, 6, 20));
+        day->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(day);
+
+    ColumnPtr result = TimeFunctions::days_sub_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 10; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 6, 20 - k), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, daysAddSubDateBoundaryTest) {
+    // Crossing month / leap-day / year boundaries.
+    auto tc = DateColumn::create();
+    auto day = Int32Column::create();
+    tc->append(DateValue::create(2020, 2, 28)); // + 1 day  -> 2020-02-29 (leap)
+    day->append(1);
+    tc->append(DateValue::create(2020, 2, 28)); // + 2 days -> 2020-03-01
+    day->append(2);
+    tc->append(DateValue::create(2020, 12, 31)); // + 1 day -> 2021-01-01 (year boundary)
+    day->append(1);
+
+    Columns add_columns = {tc, day};
+    ColumnPtr add_result = TimeFunctions::days_add_date(_utils->get_fn_ctx(), add_columns).value();
+    auto av = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(add_result)->data_column());
+    ASSERT_EQ(DateValue::create(2020, 2, 29), av->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2020, 3, 1), av->immutable_data()[1]);
+    ASSERT_EQ(DateValue::create(2021, 1, 1), av->immutable_data()[2]);
+
+    auto tc2 = DateColumn::create();
+    auto day2 = Int32Column::create();
+    tc2->append(DateValue::create(2020, 3, 1)); // - 1 day -> 2020-02-29 (leap)
+    day2->append(1);
+    tc2->append(DateValue::create(2021, 1, 1)); // - 1 day -> 2020-12-31 (year boundary)
+    day2->append(1);
+
+    Columns sub_columns = {tc2, day2};
+    ColumnPtr sub_result = TimeFunctions::days_sub_date(_utils->get_fn_ctx(), sub_columns).value();
+    auto sv = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(sub_result)->data_column());
+    ASSERT_EQ(DateValue::create(2020, 2, 29), sv->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2020, 12, 31), sv->immutable_data()[1]);
+}
+
+TEST_F(TimeFunctionsTest, weeksAddDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto week = Int32Column::create();
+    for (int j = 0; j < 5; ++j) {
+        tc->append(DateValue::create(2020, 6, 1));
+        week->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(week);
+
+    ColumnPtr result = TimeFunctions::weeks_add_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 5; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 6, 1 + 7 * k), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, weeksSubDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto week = Int32Column::create();
+    for (int j = 0; j < 5; ++j) {
+        tc->append(DateValue::create(2020, 6, 29));
+        week->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(week);
+
+    ColumnPtr result = TimeFunctions::weeks_sub_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 5; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 6, 29 - 7 * k), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, weeksAddSubDateBoundaryTest) {
+    // A week crossing month / leap-Feb / year boundaries.
+    auto tc = DateColumn::create();
+    auto week = Int32Column::create();
+    tc->append(DateValue::create(2020, 12, 28)); // + 1 week -> 2021-01-04 (year boundary)
+    week->append(1);
+    tc->append(DateValue::create(2020, 2, 26)); // + 1 week -> 2020-03-04 (across leap Feb)
+    week->append(1);
+
+    Columns add_columns = {tc, week};
+    ColumnPtr add_result = TimeFunctions::weeks_add_date(_utils->get_fn_ctx(), add_columns).value();
+    auto av = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(add_result)->data_column());
+    ASSERT_EQ(DateValue::create(2021, 1, 4), av->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2020, 3, 4), av->immutable_data()[1]);
+
+    auto tc2 = DateColumn::create();
+    auto week2 = Int32Column::create();
+    tc2->append(DateValue::create(2021, 1, 4)); // - 1 week -> 2020-12-28 (year boundary)
+    week2->append(1);
+
+    Columns sub_columns = {tc2, week2};
+    ColumnPtr sub_result = TimeFunctions::weeks_sub_date(_utils->get_fn_ctx(), sub_columns).value();
+    auto sv = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(sub_result)->data_column());
+    ASSERT_EQ(DateValue::create(2020, 12, 28), sv->immutable_data()[0]);
+}
+
+TEST_F(TimeFunctionsTest, monthsAddDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto month = Int32Column::create();
+    for (int j = 0; j < 6; ++j) {
+        tc->append(DateValue::create(2020, 3, 10));
+        month->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(month);
+
+    ColumnPtr result = TimeFunctions::months_add_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 6; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 3 + k, 10), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, monthsSubDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto month = Int32Column::create();
+    for (int j = 0; j < 6; ++j) {
+        tc->append(DateValue::create(2020, 8, 10));
+        month->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(month);
+
+    ColumnPtr result = TimeFunctions::months_sub_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 6; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 8 - k, 10), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, monthsAddSubDateBoundaryTest) {
+    // Month-end day clamps to the target month's last day; year boundary crosses cleanly.
+    auto tc = DateColumn::create();
+    auto month = Int32Column::create();
+    tc->append(DateValue::create(2021, 1, 31)); // + 1 month -> 2021-02-28 (clamp, non-leap)
+    month->append(1);
+    tc->append(DateValue::create(2020, 1, 31)); // + 1 month -> 2020-02-29 (clamp, leap)
+    month->append(1);
+    tc->append(DateValue::create(2020, 12, 15)); // + 1 month -> 2021-01-15 (year boundary)
+    month->append(1);
+
+    Columns add_columns = {tc, month};
+    ColumnPtr add_result = TimeFunctions::months_add_date(_utils->get_fn_ctx(), add_columns).value();
+    auto av = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(add_result)->data_column());
+    ASSERT_EQ(DateValue::create(2021, 2, 28), av->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2020, 2, 29), av->immutable_data()[1]);
+    ASSERT_EQ(DateValue::create(2021, 1, 15), av->immutable_data()[2]);
+
+    auto tc2 = DateColumn::create();
+    auto month2 = Int32Column::create();
+    tc2->append(DateValue::create(2021, 3, 31)); // - 1 month -> 2021-02-28 (clamp)
+    month2->append(1);
+    tc2->append(DateValue::create(2021, 1, 15)); // - 1 month -> 2020-12-15 (year boundary)
+    month2->append(1);
+
+    Columns sub_columns = {tc2, month2};
+    ColumnPtr sub_result = TimeFunctions::months_sub_date(_utils->get_fn_ctx(), sub_columns).value();
+    auto sv = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(sub_result)->data_column());
+    ASSERT_EQ(DateValue::create(2021, 2, 28), sv->immutable_data()[0]);
+    ASSERT_EQ(DateValue::create(2020, 12, 15), sv->immutable_data()[1]);
+}
+
+TEST_F(TimeFunctionsTest, quartersAddDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto quarter = Int32Column::create();
+    for (int j = 0; j < 4; ++j) {
+        tc->append(DateValue::create(2020, 1, 15));
+        quarter->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(quarter);
+
+    ColumnPtr result = TimeFunctions::quarters_add_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 4; ++k) {
+        ASSERT_EQ(DateValue::create(2020, 1 + 3 * k, 15), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, quartersSubDateTest) {
+    Columns columns;
+
+    auto tc = DateColumn::create();
+    auto quarter = Int32Column::create();
+    for (int j = 0; j < 4; ++j) {
+        tc->append(DateValue::create(2021, 12, 15));
+        quarter->append(j);
+    }
+
+    columns.emplace_back(tc);
+    columns.emplace_back(quarter);
+
+    ColumnPtr result = TimeFunctions::quarters_sub_date(_utils->get_fn_ctx(), columns).value();
+
+    ASSERT_TRUE(result->is_nullable());
+
+    auto v = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+    for (int k = 0; k < 4; ++k) {
+        ASSERT_EQ(DateValue::create(2021, 12 - 3 * k, 15), v->immutable_data()[k]);
+        ASSERT_FALSE(result->is_null(k));
+    }
+}
+
+TEST_F(TimeFunctionsTest, quartersAddSubDateBoundaryTest) {
+    // A quarter is 3 months; month-end day clamps to the target month's last day.
+    auto tc = DateColumn::create();
+    auto quarter = Int32Column::create();
+    tc->append(DateValue::create(2020, 11, 30)); // + 1 quarter -> 2021-02-28 (clamp, non-leap)
+    quarter->append(1);
+
+    Columns add_columns = {tc, quarter};
+    ColumnPtr add_result = TimeFunctions::quarters_add_date(_utils->get_fn_ctx(), add_columns).value();
+    auto av = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(add_result)->data_column());
+    ASSERT_EQ(DateValue::create(2021, 2, 28), av->immutable_data()[0]);
+
+    auto tc2 = DateColumn::create();
+    auto quarter2 = Int32Column::create();
+    tc2->append(DateValue::create(2020, 5, 31)); // - 1 quarter -> 2020-02-29 (clamp, leap)
+    quarter2->append(1);
+
+    Columns sub_columns = {tc2, quarter2};
+    ColumnPtr sub_result = TimeFunctions::quarters_sub_date(_utils->get_fn_ctx(), sub_columns).value();
+    auto sv = ColumnHelper::cast_to<TYPE_DATE>(ColumnHelper::as_column<NullableColumn>(sub_result)->data_column());
+    ASSERT_EQ(DateValue::create(2020, 2, 29), sv->immutable_data()[0]);
+}
+
 TEST_F(TimeFunctionsTest, quarterAddTest) {
     Columns columns;
 

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -528,26 +528,48 @@ vectorized_functions = [
 
     [50100, 'weekday', True, False, 'INT', ['DATETIME'], 'TimeFunctions::week_day'],
 
+    # The DATE overload is listed first and given a smaller id (the free slot just below the DATETIME
+    # overload) so a DATE argument binds it (returns DATE); a DATETIME argument cannot narrow to DATE and
+    # still binds the DATETIME overload. DATETIME overload ids are kept at their original values for
+    # upgrade compatibility; only the newly added DATE overloads take new (smaller) ids.
+    [50108, 'years_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::years_add_date'],
+    [50109, 'years_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::years_sub_date'],
     [50110, 'years_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_add'],
     [50111, 'years_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_sub'],
+
+    [50113, 'quarters_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::quarters_add_date'],
+    [50114, 'quarters_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::quarters_sub_date'],
     [50115, 'quarters_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::quarters_add'],
     [50116, 'quarters_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::quarters_sub'],
+
+    [50117, 'months_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::months_add_date'],
+    [50118, 'months_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::months_sub_date'],
+    [50119, 'add_months', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::months_add_date'],
     [50120, 'months_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_add'],
     [50121, 'months_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_sub'],
     [50122, 'add_months', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_add'],
+
+    [50128, 'weeks_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::weeks_add_date'],
+    [50129, 'weeks_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::weeks_sub_date'],
     [50130, 'weeks_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::weeks_add'],
     [50131, 'weeks_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::weeks_sub'],
+
+    [50134, 'days_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_add_date'],
+    [50135, 'days_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_sub_date'],
+    [50136, 'date_add', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_add_date'],
+    [50137, 'date_sub', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_sub_date'],
+    [50138, 'adddate', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_add_date'],
+    [50139, 'subdate', True, False, 'DATE', ['DATE', 'INT'], 'TimeFunctions::days_sub_date'],
     [50140, 'days_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_add'],
     [50141, 'days_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_sub'],
-
     [50142, 'date_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_add'],
     [50143, 'date_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_sub'],
-
     [50144, 'adddate', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_add'],
     [50145, 'subdate', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::days_sub'],
 
     [50150, 'hours_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::hours_add'],
     [50151, 'hours_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::hours_sub'],
+
     [50160, 'minutes_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::minutes_add'],
     [50161, 'minutes_sub', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::minutes_sub'],
     [50170, 'seconds_add', True, False, 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::seconds_add'],

--- a/test/sql/test_time_fn/R/test_date_arith_date_overload
+++ b/test/sql/test_time_fn/R/test_date_arith_date_overload
@@ -1,0 +1,98 @@
+-- name: test_date_arith_date_overload
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (id int, d date)
+duplicate key(id) distributed by hash(id) properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t values
+    (1, '2020-05-15'),
+    (2, '2020-02-29'),
+    (3, '2020-12-31'),
+    (4, '2020-01-31');
+-- result:
+-- !result
+select id, days_add(d, 7) from t order by id;
+-- result:
+1	2020-05-22
+2	2020-03-07
+3	2021-01-07
+4	2020-02-07
+-- !result
+select id, weeks_add(d, 1) from t order by id;
+-- result:
+1	2020-05-22
+2	2020-03-07
+3	2021-01-07
+4	2020-02-07
+-- !result
+select id, weeks_sub(d, 1) from t order by id;
+-- result:
+1	2020-05-08
+2	2020-02-22
+3	2020-12-24
+4	2020-01-24
+-- !result
+select id, months_add(d, 1) from t order by id;
+-- result:
+1	2020-06-15
+2	2020-03-29
+3	2021-01-31
+4	2020-02-29
+-- !result
+select id, months_sub(d, 1) from t order by id;
+-- result:
+1	2020-04-15
+2	2020-01-29
+3	2020-11-30
+4	2019-12-31
+-- !result
+select id, add_months(d, 1) from t order by id;
+-- result:
+1	2020-06-15
+2	2020-03-29
+3	2021-01-31
+4	2020-02-29
+-- !result
+select id, quarters_add(d, 1) from t order by id;
+-- result:
+1	2020-08-15
+2	2020-05-29
+3	2021-03-31
+4	2020-04-30
+-- !result
+select id, quarters_sub(d, 1) from t order by id;
+-- result:
+1	2020-02-15
+2	2019-11-29
+3	2020-09-30
+4	2019-10-31
+-- !result
+select id, years_add(d, 1) from t order by id;
+-- result:
+1	2021-05-15
+2	2021-02-28
+3	2021-12-31
+4	2021-01-31
+-- !result
+select id, years_sub(d, 1) from t order by id;
+-- result:
+1	2019-05-15
+2	2019-02-28
+3	2019-12-31
+4	2019-01-31
+-- !result
+select id, months_add(days_add(d, 1), 1) from t order by id;
+-- result:
+1	2020-06-16
+2	2020-04-01
+3	2021-02-01
+4	2020-03-01
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_time_fn/T/test_date_arith_date_overload
+++ b/test/sql/test_time_fn/T/test_date_arith_date_overload
@@ -1,0 +1,43 @@
+-- name: test_date_arith_date_overload
+-- description: Direct calls to the date-arithmetic builtins on a DATE *column* (a non-constant argument, so
+-- FE constant folding cannot apply) resolve to the new (DATE, INT) -> DATE overloads and are evaluated by
+-- the BE. The result renders as 'yyyy-MM-dd' (DATE), not 'yyyy-MM-dd 00:00:00' (DATETIME). Only the direct
+-- function-call form is exercised here: date_add/date_sub/adddate/subdate/days_sub and the operator
+-- (+/- INTERVAL) form still route through the analyzer and stay DATETIME without the analyzer change.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (id int, d date)
+duplicate key(id) distributed by hash(id) properties("replication_num" = "1");
+
+insert into t values
+    (1, '2020-05-15'),
+    (2, '2020-02-29'),
+    (3, '2020-12-31'),
+    (4, '2020-01-31');
+
+-- days_add: not in DATE_FUNCTIONS, so it is a plain function call that resolves to the DATE overload
+select id, days_add(d, 7) from t order by id;
+
+-- weeks_add / weeks_sub
+select id, weeks_add(d, 1) from t order by id;
+select id, weeks_sub(d, 1) from t order by id;
+
+-- months_add / months_sub / add_months (month-end clamp exercised by id 3 and 4)
+select id, months_add(d, 1) from t order by id;
+select id, months_sub(d, 1) from t order by id;
+select id, add_months(d, 1) from t order by id;
+
+-- quarters_add / quarters_sub
+select id, quarters_add(d, 1) from t order by id;
+select id, quarters_sub(d, 1) from t order by id;
+
+-- years_add / years_sub (leap-day clamp exercised by id 2)
+select id, years_add(d, 1) from t order by id;
+select id, years_sub(d, 1) from t order by id;
+
+-- multiple date columns / expression argument still evaluate at the BE and keep DATE
+select id, months_add(days_add(d, 1), 1) from t order by id;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Register DATE-domain overloads for days/weeks/months/quarters/years add/sub (plus date_add/date_sub/adddate/subdate/add_months) so arithmetic on a DATE value stays in the DATE domain instead of widening to DATETIME, matching MySQL

## What I'm doing:

Add (DATE, INT) -> DATE overloads for date-arithmetic functions

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
