### PR TITLE
[BugFix] Exclude NULL rows from NOT MATCH answered by GIN inverted index (backport #75578)

### DIFF
--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -363,6 +363,9 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
     if (with_not) {
         *row_bitmap -= roaring;
+        roaring::Roaring null_roaring;
+        RETURN_IF_ERROR(iterator->read_null(column_name, &null_roaring));
+        *row_bitmap -= null_roaring;
     } else {
         *row_bitmap &= roaring;
     }

--- a/test/sql/test_index/R/test_gin_index
+++ b/test/sql/test_index/R/test_gin_index
@@ -251,3 +251,38 @@ PROPERTIES (
 drop database test_gin_index;
 -- result:
 -- !result
+-- name: test_gin_not_match_excludes_null @native
+create database test_gin_null_${uuid0};
+-- result:
+-- !result
+use test_gin_null_${uuid0};
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
+-- result:
+-- !result
+CREATE TABLE t_null (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_null values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
+-- result:
+-- !result
+[ORDER] select id, c from t_null where c match 'hello';
+-- result:
+1	hello
+-- !result
+[ORDER] select id, c from t_null where c not match 'hello';
+-- result:
+2	world
+4	hxllo
+-- !result
+drop database test_gin_null_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_index/T/test_gin_index
+++ b/test/sql/test_index/T/test_gin_index
@@ -126,11 +126,26 @@ show create table t2_primary;
 
 drop database test_gin_index;
 
+-- name: test_gin_not_match_excludes_null @native
+create database test_gin_null_${uuid0};
+use test_gin_null_${uuid0};
+ADMIN SET FRONTEND CONFIG ("enable_experimental_gin" = "true");
 
+CREATE TABLE t_null (
+    id int NOT NULL,
+    c  varchar(30) NULL,
+    INDEX idx_c (c) USING GIN ("parser" = "none")
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
 
+insert into t_null values (1, 'hello'), (2, 'world'), (3, NULL), (4, 'hxllo');
 
+-- 基线/回归：正向 MATCH 不应返回 NULL 行（期望 1 hello）
+[ORDER] select id, c from t_null where c match 'hello';
 
+-- Bug-1：NOT MATCH 必须排除 NULL 行 id=3（期望 2 world / 4 hxllo，不含 3）
+[ORDER] select id, c from t_null where c not match 'hello';
 
-
-
-
+drop database test_gin_null_${uuid0};

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -400,7 +400,6 @@ SELECT * FROM t_gin_index_single_predicate_english WHERE text_column not match "
 1	ABC
 2	abc
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_single_predicate_english WHERE text_column <= "this";
 -- result:
@@ -554,7 +553,6 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 1	ABC
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column match_any "abc ABC";
 -- result:
@@ -565,7 +563,6 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 1	ABC
 3	ABD
 4	This is Gin Index
-5	None
 -- !result
 DROP TABLE t_gin_index_multiple_predicate_none;
 -- result:
@@ -616,12 +613,10 @@ SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column match_any
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match "this" AND text_column not match "abc";
 -- result:
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match_any "this abc";
 -- result:
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column LIKE "this" OR text_column LIKE "abc";
 -- result:


### PR DESCRIPTION
## Why I'm doing:

On a column with a GIN inverted index, a NOT MATCH predicate returns NULL rows
that it should not.

- Before: SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' AND the NULL row
- After:  SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' (NULL excluded)

NULL rows are kept in a separate null bitmap, not in the term postings. The NOT
path subtracted only the matched rows from the candidate set, so NULL rows
survived. Under SQL three-valued logic, NOT MATCH over a NULL value is NULL (not
TRUE), so those rows must not be returned.

## What I'm doing:

In ColumnExprPredicate::seek_inverted_index, the NOT branch now also reads the
null bitmap via iterator->read_null(...) and subtracts it (after subtracting the
matched rows), mirroring ColumnNotNullPredicate::seek_inverted_index. The
positive branch is unchanged.

Added a SQL regression test (test/sql/test_index/test_gin_index, case
test_gin_not_match_excludes_null) for NOT MATCH over a GIN column with a NULL row.

Fixes #75577 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
