### PR TITLE
[BugFix] Exclude NULL rows from NOT MATCH answered by GIN inverted index (backport #75578)

### DIFF
--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -360,6 +360,9 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     RETURN_IF_ERROR(iterator->read_from_inverted_index(column_name, &padded_value, query_type, &roaring));
     if (with_not) {
         *row_bitmap -= roaring;
+        roaring::Roaring null_roaring;
+        RETURN_IF_ERROR(iterator->read_null(column_name, &null_roaring));
+        *row_bitmap -= null_roaring;
     } else {
         *row_bitmap &= roaring;
     }

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -359,7 +359,6 @@ SELECT * FROM t_gin_index_single_predicate_english WHERE text_column not match "
 1	ABC
 2	abc
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_single_predicate_english WHERE text_column <= "this";
 -- result:
@@ -547,7 +546,6 @@ SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column match "th
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column not match "this" AND text_column not match "abc";
 -- result:
 3	ABD
-5	None
 -- !result
 SELECT * FROM t_gin_index_multiple_predicate_english WHERE text_column LIKE "this" OR text_column LIKE "abc";
 -- result:


### PR DESCRIPTION
## Why I'm doing:

On a column with a GIN inverted index, a NOT MATCH predicate returns NULL rows
that it should not.

- Before: SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' AND the NULL row
- After:  SELECT * FROM t WHERE c NOT MATCH 'hello'  ->  returns 'world' (NULL excluded)

NULL rows are kept in a separate null bitmap, not in the term postings. The NOT
path subtracted only the matched rows from the candidate set, so NULL rows
survived. Under SQL three-valued logic, NOT MATCH over a NULL value is NULL (not
TRUE), so those rows must not be returned.

## What I'm doing:

In ColumnExprPredicate::seek_inverted_index, the NOT branch now also reads the
null bitmap via iterator->read_null(...) and subtracts it (after subtracting the
matched rows), mirroring ColumnNotNullPredicate::seek_inverted_index. The
positive branch is unchanged.

Added a SQL regression test (test/sql/test_index/test_gin_index, case
test_gin_not_match_excludes_null) for NOT MATCH over a GIN column with a NULL row.

Fixes #75577 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
