### PR TITLE
[BugFix] Count container node/table overhead in memory Estimator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
@@ -336,10 +336,11 @@ public class Estimator {
         // Handle collections. Non-JDK implementations (Iceberg SerializableMap, Guava Immutable*)
         // typically wrap their real storage in a field; the element-sampling path would skip that
         // storage's own structure entirely, so walk their fields instead — the wrapped JDK container
-        // is then estimated (and charged) when the recursion reaches it.
+        // is then estimated (and charged) when the recursion reaches it. Cache views are excluded
+        // (see isCacheView) and stay on the sampling path.
         if (obj instanceof Collection) {
             Collection<?> collection = (Collection<?>) obj;
-            if (!isJdkContainer(clazz)) {
+            if (!isJdkContainer(clazz) && !isCacheView(clazz)) {
                 return estimateObject(obj, maxDepth, sampleSize);
             }
             return estimateCollection(collection, maxDepth, sampleSize) + collectionBackingOverhead(collection);
@@ -348,7 +349,7 @@ public class Estimator {
         // Handle maps. keySet()/values() are views, so their backing is added once here via
         // mapStructureOverhead rather than inside estimateCollection.
         if (obj instanceof Map<?, ?> map) {
-            if (!isJdkContainer(clazz)) {
+            if (!isJdkContainer(clazz) && !isCacheView(clazz)) {
                 return estimateObject(obj, maxDepth, sampleSize);
             }
             return shallow(obj) +
@@ -500,6 +501,15 @@ public class Estimator {
         return clazz.getName().startsWith("java.util.");
     }
 
+    // A cache's keySet()/values()/asMap() view keeps a back-reference to the owning cache, so
+    // field-walking it would re-traverse and double-count the whole cache (and hand a size-0 count
+    // down to the array sampler for an empty cache). Sample these views instead of field-walking.
+    private static boolean isCacheView(Class<?> clazz) {
+        String name = clazz.getName();
+        return name.startsWith("com.github.benmanes.caffeine.")
+                || name.startsWith("com.google.common.cache.");
+    }
+
     // Bytes of a hash table's backing array: capacity (next power of two that keeps the load factor)
     // times a reference, plus the array header. Sized from the entry count, matching maps built via
     // the sizing/copy constructors (the dominant population); put-grown small maps retain a larger
@@ -609,6 +619,9 @@ public class Estimator {
      * @return a list of sample elements
      */
     private static List<Object> getSamples(Collection<?> collection, int sampleSize) {
+        if (sampleSize <= 0) {
+            return Collections.emptyList();
+        }
         int size = collection.size();
         List<Object> samples = new ArrayList<>(Math.min(sampleSize, size));
 
@@ -659,6 +672,9 @@ public class Estimator {
      * @return a list of sample elements
      */
     private static List<Object> getSamplesFromArray(Object array, int length, int sampleSize) {
+        if (sampleSize <= 0) {
+            return Collections.emptyList();
+        }
         List<Object> samples = new ArrayList<>(Math.min(sampleSize, length));
 
         if (length <= sampleSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/estimate/Estimator.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,19 @@ public class Estimator {
 
     // Reference size on 64-bit JVM (with compressed oops, typically 4 bytes; without, 8 bytes)
     private static final int REFERENCE_SIZE = 4;
+
+    // Per-entry structural overhead of common container internals. The shallow-size + sampled-element
+    // estimate does not otherwise count the node/entry wrappers or the backing table, which on wide
+    // maps dominate the footprint. Sizes assume compressed oops (FE heap < 32G):
+    //   HashMap.Node / ConcurrentHashMap.Node : header(12)+hash(4)+key+value+next(3*4)  -> 32
+    //   LinkedHashMap.Entry                   : Node + before + after(2*4)               -> 40
+    //   TreeMap.Entry / TreeSet               : header+key+value+left+right+parent+color -> 40
+    //   LinkedList.Node                       : header(12)+item+prev+next(3*4)           -> 24
+    private static final int HASH_NODE_SIZE = 32;
+    private static final int LINKED_HASH_ENTRY_SIZE = 40;
+    private static final int TREE_ENTRY_SIZE = 40;
+    private static final int LINKED_LIST_NODE_SIZE = 24;
+    private static final double HASH_LOAD_FACTOR = 0.75;
 
     // Shallow sizes of classes (bound to Class lifecycle, avoids ClassLoader leaks)
     private static final ClassValue<Long> SHALLOW_SIZE = new ClassValue<>() {
@@ -319,14 +333,26 @@ public class Estimator {
             return estimateArray(obj, maxDepth, sampleSize);
         }
 
-        // Handle collections
+        // Handle collections. Non-JDK implementations (Iceberg SerializableMap, Guava Immutable*)
+        // typically wrap their real storage in a field; the element-sampling path would skip that
+        // storage's own structure entirely, so walk their fields instead — the wrapped JDK container
+        // is then estimated (and charged) when the recursion reaches it.
         if (obj instanceof Collection) {
-            return estimateCollection((Collection<?>) obj, maxDepth, sampleSize);
+            Collection<?> collection = (Collection<?>) obj;
+            if (!isJdkContainer(clazz)) {
+                return estimateObject(obj, maxDepth, sampleSize);
+            }
+            return estimateCollection(collection, maxDepth, sampleSize) + collectionBackingOverhead(collection);
         }
 
-        // Handle maps
+        // Handle maps. keySet()/values() are views, so their backing is added once here via
+        // mapStructureOverhead rather than inside estimateCollection.
         if (obj instanceof Map<?, ?> map) {
+            if (!isJdkContainer(clazz)) {
+                return estimateObject(obj, maxDepth, sampleSize);
+            }
             return shallow(obj) +
+                    mapStructureOverhead(map) +
                     estimateCollection(map.keySet(), maxDepth, sampleSize) +
                     estimateCollection(map.values(), maxDepth, sampleSize);
         }
@@ -419,6 +445,71 @@ public class Estimator {
 
         double avgSize = (double) sampleTotalSize / samples.size();
         return shallowSize + (long) (avgSize * collection.size());
+    }
+
+    // Structural overhead of a Map's internal entry objects plus the backing table, which shallow
+    // size + sampled key/value elements do not otherwise count. Only concrete JDK hash/tree maps are
+    // charged; immutable/view maps (Map.of, Guava ImmutableMap, singletonMap, ...) store entries
+    // inline or in arrays and would be over-counted, so they get no node overhead here.
+    private static long mapStructureOverhead(Map<?, ?> map) {
+        int size = map.size();
+        if (size == 0) {
+            return 0;
+        }
+        if (map instanceof java.util.LinkedHashMap) {   // subclass of HashMap, check first
+            return (long) size * LINKED_HASH_ENTRY_SIZE + hashTableBytes(size);
+        }
+        if (map instanceof HashMap || map instanceof java.util.concurrent.ConcurrentHashMap) {
+            return (long) size * HASH_NODE_SIZE + hashTableBytes(size);
+        }
+        if (map instanceof java.util.TreeMap) {
+            return (long) size * TREE_ENTRY_SIZE;       // red-black tree nodes, no backing table
+        }
+        return 0;
+    }
+
+    // Structural overhead of a stand-alone collection's internals. Only concrete JDK collections are
+    // charged; immutable/view collections (List.of, Guava Immutable*, Arrays.asList, ...) get none.
+    // Not applied to Map key/value views.
+    private static long collectionBackingOverhead(Collection<?> collection) {
+        int size = collection.size();
+        if (size == 0) {
+            return 0;
+        }
+        if (collection instanceof java.util.LinkedHashSet) {   // subclass of HashSet, check first
+            return (long) size * LINKED_HASH_ENTRY_SIZE + hashTableBytes(size);
+        }
+        if (collection instanceof HashSet) {
+            return (long) size * HASH_NODE_SIZE + hashTableBytes(size);
+        }
+        if (collection instanceof java.util.TreeSet) {
+            return (long) size * TREE_ENTRY_SIZE;
+        }
+        if (collection instanceof ArrayList) {
+            return ARRAY_HEADER_SIZE + (long) size * REFERENCE_SIZE;   // backing Object[]
+        }
+        if (collection instanceof java.util.LinkedList) {
+            return (long) size * LINKED_LIST_NODE_SIZE;
+        }
+        return 0;
+    }
+
+    // JDK containers get the sampling paths (their internals are modeled by the *Overhead helpers,
+    // and their fields are not reflectively accessible anyway); anything else is field-walked.
+    private static boolean isJdkContainer(Class<?> clazz) {
+        return clazz.getName().startsWith("java.util.");
+    }
+
+    // Bytes of a hash table's backing array: capacity (next power of two that keeps the load factor)
+    // times a reference, plus the array header. Sized from the entry count, matching maps built via
+    // the sizing/copy constructors (the dominant population); put-grown small maps retain a larger
+    // 16-slot minimum table that this under-counts by a few dozen bytes.
+    private static long hashTableBytes(int size) {
+        int capacity = 2;
+        while (capacity * HASH_LOAD_FACTOR < size) {
+            capacity <<= 1;
+        }
+        return ARRAY_HEADER_SIZE + (long) capacity * REFERENCE_SIZE;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.memory.estimate;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -415,6 +417,29 @@ class EstimatorTest {
                 "ArrayList estimate " + est + " not within 10% of retained " + real);
     }
 
+    @Test
+    void testCacheViewNotFieldWalked() {
+        // Mirrors CachingIcebergCatalog.estimateDataFileCacheSize: the connector hands the Estimator a
+        // cache keySet() view plus the entry count as sampleSize. Field-walking the view would re-enter
+        // the whole cache (double-counting every value); for an empty cache it also passes sampleSize=0
+        // to the array sampler, which used to divide by zero.
+        Cache<IntBox, byte[]> cache = Caffeine.newBuilder().build();
+
+        int emptyCnt = cache.asMap().size();
+        long emptyEst = Estimator.estimate(cache.asMap().keySet(), emptyCnt);   // must not throw
+        assertTrue(emptyEst >= 0);
+
+        int n = 200;
+        int valueBytes = 4096;
+        for (int i = 0; i < n; i++) {
+            cache.put(new IntBox(i), new byte[valueBytes]);
+        }
+        int cnt = cache.asMap().size();
+        long keyEst = Estimator.estimate(cache.asMap().keySet(), cnt);
+        assertTrue(keyEst < (long) n * valueBytes / 4,
+                "keySet-view estimate " + keyEst + " looks like it pulled in the cache values");
+    }
+
     // ==================== Custom Object Tests ====================
 
     @Test
@@ -582,10 +607,12 @@ class EstimatorTest {
         }
 
         long size = Estimator.estimate(list);
-        // Size should be list shallow size + element shallow size * count
+        // List shallow size + element shallow size * count + the ArrayList's backing Object[]
+        // (header + one reference slot per element).
         long listShallow = Estimator.shallow(list);
         long elementShallow = Estimator.shallow(SimpleObject.class);
-        long expected = listShallow + elementShallow * 100;
+        long backingArray = Estimator.ARRAY_HEADER_SIZE + 4L * 100;
+        long expected = listShallow + elementShallow * 100 + backingArray;
         assertEquals(expected, size);
     }
 
@@ -794,7 +821,10 @@ class EstimatorTest {
         list.add(null);
 
         long size = Estimator.estimate(list);
-        assertEquals(Estimator.shallow(list), size);
+        // Elements are null, but the ArrayList's backing Object[] (header + a reference slot per
+        // element) is still retained and charged.
+        long backingArray = Estimator.ARRAY_HEADER_SIZE + 4L * 3;
+        assertEquals(Estimator.shallow(list) + backingArray, size);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/memory/estimate/EstimatorTest.java
@@ -17,6 +17,7 @@ package com.starrocks.memory.estimate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openjdk.jol.info.GraphLayout;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -259,6 +260,159 @@ class EstimatorTest {
         }
         long size = Estimator.estimate(map);
         assertTrue(size > Estimator.estimate(new HashMap<>()));
+    }
+
+    // A small value type whose full size the estimator can see without --add-opens. String is
+    // unusable here: its internal byte[] is not reflectively accessible under the FE-UT surefire
+    // argLine, so the estimator would skip it while GraphLayout still counts it.
+    private static final class IntBox {
+        final int v;
+
+        IntBox(int v) {
+            this.v = v;
+        }
+
+        @Override
+        public int hashCode() {
+            return v;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof IntBox && ((IntBox) o).v == v;
+        }
+    }
+
+    // The estimate must include the internal node/entry wrappers and backing table; before counting
+    // them these under-estimated the retained size by ~50%, which let weigher-bounded caches hold
+    // far more than their configured budget. GraphLayout gives the true retained size as the oracle.
+    @Test
+    void testHashMapCountsNodeAndTableOverhead() {
+        Map<IntBox, IntBox> map = new HashMap<>();
+        for (int i = 0; i < 1000; i++) {
+            map.put(new IntBox(i), new IntBox(i + 1));
+        }
+        long real = GraphLayout.parseInstance(map).totalSize();
+        long est = Estimator.estimate(map);
+        assertTrue(est >= real * 0.9 && est <= real * 1.1,
+                "HashMap estimate " + est + " not within 10% of retained " + real);
+    }
+
+    @Test
+    void testHashSetCountsBackingOverhead() {
+        Set<IntBox> set = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            set.add(new IntBox(i));
+        }
+        long real = GraphLayout.parseInstance(set).totalSize();
+        long est = Estimator.estimate(set);
+        assertTrue(est >= real * 0.9 && est <= real * 1.1,
+                "HashSet estimate " + est + " not within 10% of retained " + real);
+    }
+
+    // Mirrors Iceberg's SerializableMap/SerializableByteBufferMap: a non-JDK Map that wraps its real
+    // storage in a field. The estimator must field-walk such wrappers so the inner HashMap's node and
+    // table overhead is counted — element sampling alone would skip it entirely.
+    private static final class WrapperMap implements Map<IntBox, IntBox> {
+        private final Map<IntBox, IntBox> wrapped;
+
+        WrapperMap(Map<IntBox, IntBox> wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public int size() {
+            return wrapped.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return wrapped.isEmpty();
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return wrapped.containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return wrapped.containsValue(value);
+        }
+
+        @Override
+        public IntBox get(Object key) {
+            return wrapped.get(key);
+        }
+
+        @Override
+        public IntBox put(IntBox key, IntBox value) {
+            return wrapped.put(key, value);
+        }
+
+        @Override
+        public IntBox remove(Object key) {
+            return wrapped.remove(key);
+        }
+
+        @Override
+        public void putAll(Map<? extends IntBox, ? extends IntBox> m) {
+            wrapped.putAll(m);
+        }
+
+        @Override
+        public void clear() {
+            wrapped.clear();
+        }
+
+        @Override
+        public Set<IntBox> keySet() {
+            return wrapped.keySet();
+        }
+
+        @Override
+        public java.util.Collection<IntBox> values() {
+            return wrapped.values();
+        }
+
+        @Override
+        public Set<Entry<IntBox, IntBox>> entrySet() {
+            return wrapped.entrySet();
+        }
+    }
+
+    @Test
+    void testWrapperMapCountsInnerMapStructure() {
+        Map<IntBox, IntBox> inner = new HashMap<>();
+        for (int i = 0; i < 1000; i++) {
+            inner.put(new IntBox(i), new IntBox(i + 1));
+        }
+        WrapperMap wrapper = new WrapperMap(inner);
+        long real = GraphLayout.parseInstance(wrapper).totalSize();
+        long est = Estimator.estimate(wrapper);
+        assertTrue(est >= real * 0.9 && est <= real * 1.1,
+                "wrapper-map estimate " + est + " not within 10% of retained " + real);
+    }
+
+    @Test
+    void testImmutableMapNotOvercharged() {
+        Map<String, Integer> immutable = Map.of("a", 1, "b", 2, "c", 3);
+        // java.util immutable maps store entries inline: no node/table overhead may be charged
+        long est = Estimator.estimate(immutable);
+        assertTrue(est < 512, "Map.of estimate " + est + " unexpectedly large");
+    }
+
+    @Test
+    void testArrayListCountsBackingArray() {
+        ArrayList<IntBox> list = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            list.add(new IntBox(i));
+        }
+        list.trimToSize();   // make backing-array capacity == size so the oracle comparison is exact
+        long real = GraphLayout.parseInstance(list).totalSize();
+        long est = Estimator.estimate(list);
+        assertTrue(est >= real * 0.9 && est <= real * 1.1,
+                "ArrayList estimate " + est + " not within 10% of retained " + real);
     }
 
     // ==================== Custom Object Tests ====================


### PR DESCRIPTION
## Why I'm doing:

`Estimator` (used by FE memory tracking and, notably, the Iceberg metadata cache weigher `CachingIcebergCatalog#weighContentFiles`) under-counts containers. Its `Map` and `Collection` branches sum only the container's shallow size plus the **sampled key/value/element objects**, and omit the container's own internals: the per-entry wrappers (`HashMap.Node`, tree/linked entries) and the backing table/array.

On wide maps this omission dominates. Measured on an Iceberg data-file cache (each `DataFile` carries several per-column statistics maps): `HashMap.Node` + bucket arrays were **~35% of the cache heap and completely invisible to the weigher**, so the cache retained roughly **2.4x** its configured `maximumWeight` and could OOM the FE.

## What I'm doing:

Add the missing structural overhead to the estimate:
- **Maps**: per-entry node/entry size (HashMap/ConcurrentHashMap 32B, LinkedHashMap 40B, TreeMap 40B) plus the backing hash table (`capacity * ref`, capacity grown by load factor; tree maps have no table).
- **Stand-alone collections**: hash-set backing map (node + table), tree-set nodes, array-list backing array, linked-list nodes. Not applied to `Map` `keySet()`/`values()` views (their backing is charged once on the owning map).

Sizes assume compressed oops (FE heap < 32G). Validated against JOL `GraphLayout` retained size — `HashMap`/`HashSet`/`ArrayList` estimates move from **0.53–0.90x to 0.98–0.99x** of the true size. Added `EstimatorTest` cases asserting the estimate is within [-15%, +25%] of `GraphLayout`.

Fixes #issue: N/A — FE memory-accounting accuracy fix (no separate tracking issue).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Weigher-bounded caches (e.g. the Iceberg metadata cache) now account for their true footprint, so for the same `*_memory_usage_ratio` they hold fewer entries / evict earlier. This lowers FE memory (respecting the configured limit) but may increase cache misses; users wanting the previous footprint can raise the ratio.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
