### PR TITLE
[BugFix] Make relation alias case-insensitive for all connector views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -1591,8 +1591,8 @@ public class QueryAnalyzer {
             boolean isRelationAliasCaseInSensitive = false;
             if (ConnectContext.get() != null) {
                 isRelationAliasCaseInSensitive = ConnectContext.get().isRelationAliasCaseInsensitive();
-                // For hive view, relation alias is case-insensitive
-                if (node.getView().isHiveView()) {
+                // For connector view (hive/iceberg/paimon), relation alias is case-insensitive
+                if (node.getView().isConnectorView()) {
                     ConnectContext.get().setRelationAliasCaseInSensitive(true);
                 }
             }
@@ -1608,7 +1608,7 @@ public class QueryAnalyzer {
                         "function(s) or definer/invoker of view lack rights to use them: " + e.getMessage(), e);
             } finally {
                 viewExpansionStack.remove(viewKey);
-                if (ConnectContext.get() != null && node.getView().isHiveView()) {
+                if (ConnectContext.get() != null && node.getView().isConnectorView()) {
                     ConnectContext.get().setRelationAliasCaseInSensitive(isRelationAliasCaseInSensitive);
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergViewCaseInsensitiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergViewCaseInsensitiveTest.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IcebergViewCaseInsensitiveTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    @Test
+    public void testQueryIcebergViewCaseInsensitive() throws Exception {
+        String sql = "select * from iceberg0.unpartitioned_db." + MockIcebergMetadata.MOCKED_CASE_INSENSITIVE_VIEW_NAME;
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "t0");
+
+        // Aliases are matched case-insensitively only while the view body is analyzed; outside of it
+        // the session default (case-sensitive) is restored.
+        Throwable exception = assertThrows(SemanticException.class, () -> {
+            getFragmentPlan("select * from iceberg0.unpartitioned_db."
+                    + MockIcebergMetadata.MOCKED_CASE_INSENSITIVE_VIEW_NAME
+                    + " v1 join test.t0 T0 on v1.id = t0.v1");
+        });
+        assertThat(exception.getMessage(), containsString("Column '`t0`.`v1`' cannot be resolved"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -83,6 +83,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_TRANSFORMS_DB_NAME = "partitioned_transforms_db";
 
     public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
+    // iceberg view whose definition references a relation alias in mixed case
+    public static final String MOCKED_CASE_INSENSITIVE_VIEW_NAME = "t0_case_insensitive_view";
     public static final String MOCKED_UNPARTITIONED_V2_TABLE_NAME = "t0_v2";
     public static final String MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME = "variant_t0";
     public static final String MOCKED_UNPARTITIONED_TABLE_NUMERIC = "t_numeric";
@@ -815,6 +817,20 @@ public class MockIcebergMetadata implements ConnectorMetadata {
             return new IcebergView(idGen.getAndIncrement(), MOCKED_ICEBERG_CATALOG_NAME, dbName, viewName, schema,
                     def, MOCKED_ICEBERG_CATALOG_NAME, dbName, "view_location", Maps.newHashMap());
         }
+        if (dbName.equalsIgnoreCase(MOCKED_UNPARTITIONED_DB_NAME)
+                && viewName.equalsIgnoreCase(MOCKED_CASE_INSENSITIVE_VIEW_NAME)) {
+            return buildMockedCaseInsensitiveView();
+        }
         return null;
+    }
+
+    private com.starrocks.catalog.Table buildMockedCaseInsensitiveView() {
+        List<Column> schema = ImmutableList.of(new Column("id", IntegerType.INT, true),
+                new Column("data", StringType.STRING, true));
+        // T0_UPPER alias is referenced both as t0_upper and T0_UPPER
+        String definition = "select t0_upper.id, T0_UPPER.data from (select * from t0) T0_UPPER";
+        return new IcebergView(idGen.getAndIncrement(), MOCKED_ICEBERG_CATALOG_NAME, MOCKED_UNPARTITIONED_DB_NAME,
+                MOCKED_CASE_INSENSITIVE_VIEW_NAME, schema, definition,
+                MOCKED_ICEBERG_CATALOG_NAME, MOCKED_UNPARTITIONED_DB_NAME, "view_location", Maps.newHashMap());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Querying an Iceberg or Paimon view fails with `references invalid table(s) or column(s)` when the view's stored definition references a relation alias in a different case than it was declared (for example `SELECT t.id FROM orders T`). Such mixed-case definitions are common because the external engines that author these views (Spark, Trino, Hive) resolve identifiers case-insensitively. StarRocks already accounts for this by making relation-alias matching case-insensitive while it analyzes an external view body, but the switch in `QueryAnalyzer.visitView` was gated on `isHiveView()`, so Iceberg and Paimon views (which are also connector views) never got it and are resolved case-sensitively.

The switch was introduced in #40921, when Hive views were the only connector views; Iceberg views (#46071) and Paimon views (#56058) were added later without widening it. #70217 fixed the same shape of omission for another Hive-view-only special case.

## What I'm doing:

Guard the relation-alias case-insensitivity on `isConnectorView()` (Hive/Iceberg/Paimon) instead of `isHiveView()`, both where it is enabled and where it is restored, so all connector views get the same handling. Internal (Olap) views are unaffected because they are not connector views: their definitions are normalized by StarRocks at creation time, so they never need this. Case-insensitive alias matching is a superset of case-sensitive matching, so consistently-cased definitions (including views authored through the StarRocks dialect) resolve exactly as before.

Adds an Iceberg regression test mirroring the existing Hive one (`HiveViewTest.testQueryHiveViewCaseInsensitive`): a view whose body references a mixed-case relation alias resolves, and alias matching outside the view body stays case-sensitive after the flag is restored. Paimon views take exactly the same `isConnectorView()` path in `visitView`, so they are covered by the same guard; there is no query-level Paimon view mock infrastructure yet to write an equivalent Paimon test against.

Fixes #75974

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
