### PR TITLE
[BugFix] Fix heavy-expr pushdown when a heavy expr references a heavy common sub-expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -513,6 +513,24 @@ public class PlanFragmentBuilder {
                 return Collections.emptyMap();
             }
 
+            // The scan computes each pushed expression independently from base columns, so an expression that
+            // references a heavy common sub-expression (directly, or through the light common sub-expressions
+            // inlined before the pushdown) cannot be pushed down. Keep it in the ProjectNode, where it reads
+            // the referenced sub-expression's slot; heavy common sub-expressions computed purely from base
+            // columns are still pushed down and materialized by the scan.
+            Map<ColumnRefOperator, ScalarOperator> lightCommonSubExprs = new HashMap<>(commonSubExprs);
+            heavyCommonSubExprs.keySet().forEach(lightCommonSubExprs::remove);
+            ReplaceColumnRefRewriter lightCommonSubExprInliner =
+                    new ReplaceColumnRefRewriter(lightCommonSubExprs, true);
+            ColumnRefSet heavyCommonSubExprRefs = new ColumnRefSet(heavyCommonSubExprs.keySet());
+            Predicate<ScalarOperator> referencesHeavyCommonSubExpr = expr ->
+                    lightCommonSubExprInliner.rewrite(expr).getUsedColumns().isIntersect(heavyCommonSubExprRefs);
+            heavyExprs.values().removeIf(referencesHeavyCommonSubExpr);
+            heavyCommonSubExprs.values().removeIf(referencesHeavyCommonSubExpr);
+            if (heavyCommonSubExprs.isEmpty() && heavyExprs.isEmpty()) {
+                return Collections.emptyMap();
+            }
+
             // Heavy exprs should be removed from ProjectNode's commonSubExprs to avoid trivial mapping from
             // slotId to itself in commonSubExprs.
             heavyCommonSubExprs.forEach((k, v) -> commonSubExprs.remove(k));

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
@@ -155,4 +155,50 @@ public class PushDownHeavyExprsTest {
                 "          <slot 12> : regexp_replace(get_json_object(7: field_text_1, '$.key_json_2'), " +
                 "'^\\\\[\\\\\"|\\\\\"]$', '')\n"), plan);
     }
+
+    @Test
+    public void testHeavyExprReferencingHeavyCommonSubExpr() throws Exception {
+        String q = "SELECT regexp_count(field_varchar_1, 'a') + regexp_count(field_varchar_1, 'b') AS x, " +
+                "regexp_count(field_varchar_1, 'b') AS y " +
+                "FROM tbl_transaction_001";
+        String plan = UtFrameUtils.getFragmentPlan(ctx, q);
+        // The shared regexp_count is still pushed down; the heavy expr referencing it stays in the
+        // ProjectNode and reads its slot.
+        Assertions.assertTrue(plan.contains("heavy exprs: \n" +
+                "          <slot 10> : regexp_count(4: field_varchar_1, 'b')"), plan);
+        Assertions.assertTrue(plan.contains("<slot 8> : regexp_count(4: field_varchar_1, 'a') + 10: regexp_count"),
+                plan);
+    }
+
+    @Test
+    public void testNestedHeavyCommonSubExprReuse() throws Exception {
+        String q = "SELECT regexp_replace(regexp_replace(field_varchar_1, '[A-Z]', ''), '[0-9]', '') AS a, " +
+                "regexp_replace(regexp_replace(field_varchar_1, '[A-Z]', ''), '[0-9]', '') AS b, " +
+                "regexp_replace(field_varchar_1, '[A-Z]', '') AS c, " +
+                "regexp_replace(field_varchar_1, '[A-Z]', '') AS d " +
+                "FROM tbl_transaction_001";
+        String plan = UtFrameUtils.getFragmentPlan(ctx, q);
+        // The inner common sub-expression is pushed down; the outer one references its slot, so it is
+        // computed once in the ProjectNode.
+        Assertions.assertTrue(plan.contains("heavy exprs: \n" +
+                "          <slot 10> : regexp_replace(4: field_varchar_1, '[A-Z]', '')"), plan);
+        Assertions.assertTrue(plan.contains("<slot 8> : regexp_replace(10: regexp_replace, '[0-9]', '')"), plan);
+        Assertions.assertFalse(plan.contains("regexp_replace(regexp_replace("), plan);
+    }
+
+    @Test
+    public void testHeavyExprReferencingHeavyCommonSubExprThroughLightCommonSubExpr() throws Exception {
+        String q = "SELECT regexp_count(substr(regexp_replace(field_varchar_1, '[0-9]', ''), 1, 3), 'a') AS p, " +
+                "regexp_count(substr(regexp_replace(field_varchar_1, '[0-9]', ''), 1, 3), 'b') AS q, " +
+                "substr(regexp_replace(field_varchar_1, '[0-9]', ''), 1, 3) AS r, " +
+                "regexp_replace(field_varchar_1, '[0-9]', '') AS w " +
+                "FROM tbl_transaction_001";
+        String plan = UtFrameUtils.getFragmentPlan(ctx, q);
+        // The heavy common sub-expression is pushed down; the heavy exprs referencing it through the
+        // light substr common sub-expression stay in the ProjectNode.
+        Assertions.assertTrue(plan.contains("heavy exprs: \n" +
+                "          <slot 12> : regexp_replace(4: field_varchar_1, '[0-9]', '')"), plan);
+        Assertions.assertTrue(plan.contains("<slot 13> : substr(12: regexp_replace, 1, 3)"), plan);
+        Assertions.assertTrue(plan.contains("<slot 8> : regexp_count(13: substr, 'a')"), plan);
+    }
 }

--- a/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
@@ -254,3 +254,78 @@ WHERE field_date_1 BETWEEN '2025-12-23' AND '2025-12-25'
 -- result:
 0
 -- !result
+create table hcse_basic (x bigint, y bigint) properties("replication_num"="1");
+-- result:
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into hcse_basic select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_count(c0, "a") + regexp_count(c0, "b"), regexp_count(c0, "b") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(cast(x as string), ",", cast(y as string)))) fp from hcse_basic;
+-- result:
+-- !result
+truncate table hcse_basic;
+-- result:
+-- !result
+insert into hcse_basic select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_count(c0, "a") + regexp_count(c0, "b"), regexp_count(c0, "b") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(cast(x as string), ",", cast(y as string)))) fp from hcse_basic;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+create table hcse_nested (a varchar(65533), b varchar(65533), c varchar(65533), d varchar(65533)) properties("replication_num"="1");
+-- result:
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into hcse_nested select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(c0, "[0-9]", ""), regexp_replace(c0, "[0-9]", "") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(a, "|", b, "|", c, "|", d))) fp from hcse_nested;
+-- result:
+-- !result
+truncate table hcse_nested;
+-- result:
+-- !result
+insert into hcse_nested select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(c0, "[0-9]", ""), regexp_replace(c0, "[0-9]", "") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(a, "|", b, "|", c, "|", d))) fp from hcse_nested;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+create table hcse_trans (p bigint, q bigint, r varchar(65533), w varchar(65533)) properties("replication_num"="1");
+-- result:
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into hcse_trans select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "a"), regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "b"), substr(regexp_replace(c0, "[0-9]", ""), 1, 3), regexp_replace(c0, "[0-9]", "") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(cast(p as string), ",", cast(q as string), ",", r, ",", w))) fp from hcse_trans;
+-- result:
+-- !result
+truncate table hcse_trans;
+-- result:
+-- !result
+insert into hcse_trans select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "a"), regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "b"), substr(regexp_replace(c0, "[0-9]", ""), 1, 3), regexp_replace(c0, "[0-9]", "") from t0;
+-- result:
+-- !result
+insert into result select sum(murmur_hash3_32(concat(cast(p as string), ",", cast(q as string), ",", r, ",", w))) fp from hcse_trans;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result

--- a/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
@@ -226,3 +226,31 @@ WHERE field_date_1 BETWEEN '2025-12-23' AND '2025-12-25'
         1,
         0
     ) = 1;
+
+
+create table hcse_basic (x bigint, y bigint) properties("replication_num"="1");
+truncate table result;
+insert into hcse_basic select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_count(c0, "a") + regexp_count(c0, "b"), regexp_count(c0, "b") from t0;
+insert into result select sum(murmur_hash3_32(concat(cast(x as string), ",", cast(y as string)))) fp from hcse_basic;
+truncate table hcse_basic;
+insert into hcse_basic select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_count(c0, "a") + regexp_count(c0, "b"), regexp_count(c0, "b") from t0;
+insert into result select sum(murmur_hash3_32(concat(cast(x as string), ",", cast(y as string)))) fp from hcse_basic;
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+create table hcse_nested (a varchar(65533), b varchar(65533), c varchar(65533), d varchar(65533)) properties("replication_num"="1");
+truncate table result;
+insert into hcse_nested select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(c0, "[0-9]", ""), regexp_replace(c0, "[0-9]", "") from t0;
+insert into result select sum(murmur_hash3_32(concat(a, "|", b, "|", c, "|", d))) fp from hcse_nested;
+truncate table hcse_nested;
+insert into hcse_nested select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(regexp_replace(c0, "[0-9]", ""), "[.]", ""), regexp_replace(c0, "[0-9]", ""), regexp_replace(c0, "[0-9]", "") from t0;
+insert into result select sum(murmur_hash3_32(concat(a, "|", b, "|", c, "|", d))) fp from hcse_nested;
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+create table hcse_trans (p bigint, q bigint, r varchar(65533), w varchar(65533)) properties("replication_num"="1");
+truncate table result;
+insert into hcse_trans select /*+SET_VAR(push_down_heavy_exprs=true)*/ regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "a"), regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "b"), substr(regexp_replace(c0, "[0-9]", ""), 1, 3), regexp_replace(c0, "[0-9]", "") from t0;
+insert into result select sum(murmur_hash3_32(concat(cast(p as string), ",", cast(q as string), ",", r, ",", w))) fp from hcse_trans;
+truncate table hcse_trans;
+insert into hcse_trans select /*+SET_VAR(push_down_heavy_exprs=false)*/ regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "a"), regexp_count(substr(regexp_replace(c0, "[0-9]", ""), 1, 3), "b"), substr(regexp_replace(c0, "[0-9]", ""), 1, 3), regexp_replace(c0, "[0-9]", "") from t0;
+insert into result select sum(murmur_hash3_32(concat(cast(p as string), ",", cast(q as string), ",", r, ",", w))) fp from hcse_trans;
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;


### PR DESCRIPTION
## Why I'm doing:

With the default `push_down_heavy_exprs = true`, a query where a heavy expression references a heavy common sub-expression fails to plan:

```sql
SELECT
    regexp_count(s, 'a') + regexp_count(s, 'b') AS x,
    regexp_count(s, 'b') AS y
FROM t;
```

```
Getting analyzing error. Detail message: Cannot convert ColumnRefOperator to Expr, please check the input expression: 4: regexp_count.
```

`regexp_count(s, 'b')` is shared, so it is removed from the projection's commonSubOperatorMap to be pushed down to the scan (since #67477), but the heavy expression that references it stays, and its column ref can no longer be resolved during translation. More fundamentally, the scan computes each pushed expression independently from base columns, so an expression that references another pushed expression's slot cannot itself be pushed down.

Affects main, 4.1.x, and 4.0.5+ (on 4.0.1-4.0.4 the same query overflows the stack during planning instead).

## What I'm doing:

Exclude from the pushdown every heavy expression (or heavy common sub-expression) that references a heavy common sub-expression — directly, or through the light common sub-expressions that are inlined before the pushdown (light ones can be chained, so the check inlines them recursively). Excluded expressions stay in the ProjectNode and read the referenced sub-expression's slot.

Heavy common sub-expressions computed purely from base columns are still pushed down and materialized by the scan, so the expensive shared regexp keeps being evaluated in the scan and only the dependent expressions fall back to the ProjectNode. This reuses the mechanism that already serves light expressions referencing a pushed-down heavy common sub-expression; independent heavy expressions are pushed down exactly as before.

Tests: three `PushDownHeavyExprsTest` cases (direct reference, nested heavy CSEs, reference through a light CSE) and a `test_push_down_heavy_exprs_common_subexpr` SQL-Tester case asserting identical results with the pushdown ON and OFF.

Fixes #75975

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
