### PR TITLE
[BugFix] Fix GCS vended credentials ignored due to gcs-connector 3.x config rename

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
@@ -775,6 +775,10 @@ If you choose Google GCS as storage for your Iceberg cluster, take one of the fo
 
 - To choose REST catalog with vended credential (supported from v4.0 onwards), you do not need to configure `StorageCredentialParams`.
 
+  :::note
+  When vended credentials are used, StarRocks accesses GCS directly with the token vended by the REST catalog. Any `gcp.gcs.impersonation_service_account` configured on the catalog is ignored for that access.
+  :::
+
 `StorageCredentialParams` for Google GCS:
 
 ###### gcp.gcs.service_account_email

--- a/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
@@ -774,6 +774,10 @@ Iceberg クラスターのストレージとして Google GCS を選択した場
 
 - REST カタログで Vended Credential（v4.0以降でサポート）を選択する場合、`StorageCredentialParams` を設定する必要はありません。
 
+  :::note
+  Vended Credential を使用する場合、StarRocks は REST カタログから払い出されたトークンで GCS に直接アクセスします。このとき、カタログに設定された `gcp.gcs.impersonation_service_account` は無視されます。
+  :::
+
 Google GCS 用の `StorageCredentialParams`:
 
 ###### gcp.gcs.service_account_email

--- a/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
@@ -815,6 +815,10 @@ Microsoft Azure 的 `StorageCredentialParams`：
 
 - 要选择基于 REST Catalog 的 Vended Credential（自 v4.0 起支持），则无需配置 `StorageCredentialParams`。
 
+  :::note
+  使用 Vended Credential 时，StarRocks 会直接使用 REST Catalog 下发的 Token 访问 GCS。此时 Catalog 上配置的 `gcp.gcs.impersonation_service_account` 将被忽略。
+  :::
+
 Google GCS 的 `StorageCredentialParams`：
 
 ###### gcp.gcs.service_account_email

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -240,6 +240,9 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                 copied.set(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY,
                         GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
                 copied.set(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY, "true");
+                // The base conf may carry catalog-level impersonation, which gcs-connector would apply
+                // on top of the vended token; vended tokens typically lack IAM impersonation permission.
+                copied.unset(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY);
                 copied.set(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY, entry.getValue());
                 copied.set(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY,
                         properties.getOrDefault(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN_EXPIRES_AT,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -233,7 +233,13 @@ public class IcebergCachingFileIO implements FileIO, HadoopConfigurable {
                 return copied;
             } else if (entry.getKey().equals(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN)) {
                 // Handle GCS access token
-                copied.set("fs.gs.auth.access.token.provider.impl", GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
+                copied.set(GCPCloudConfigurationProvider.AUTH_TYPE_KEY,
+                        GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER);
+                copied.set(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY,
+                        GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
+                copied.set(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY,
+                        GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL);
+                copied.set(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY, "true");
                 copied.set(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY, entry.getValue());
                 copied.set(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY,
                         properties.getOrDefault(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN_EXPIRES_AT,

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
@@ -39,6 +39,7 @@ public class GCPCloudConfigurationProvider implements CloudConfigurationProvider
     public static final String LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY = "fs.gs.auth.access.token.provider.impl";
     // Hadoop's FileSystem cache ignores Configuration; disable it so rotating vended tokens take effect
     public static final String DISABLE_FS_CACHE_KEY = "fs.gs.impl.disable.cache";
+    public static final String IMPERSONATION_SERVICE_ACCOUNT_KEY = "fs.gs.auth.impersonation.service.account";
     public static final String ACCESS_TOKEN_PROVIDER_IMPL =
             "com.starrocks.connector.gcp.TemporaryGCPAccessTokenProvider";
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
@@ -32,6 +32,13 @@ public class GCPCloudConfigurationProvider implements CloudConfigurationProvider
     public static final String GCS_ACCESS_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
     public static final String ACCESS_TOKEN_KEY = "fs.gs.temporary.access.token";
     public static final String TOKEN_EXPIRATION_KEY = "fs.gs.temporary.token.expiration";
+    // gcs-connector 3.x auth keys; 3.x ignores the legacy 2.x ".impl" key
+    public static final String AUTH_TYPE_KEY = "fs.gs.auth.type";
+    public static final String AUTH_TYPE_ACCESS_TOKEN_PROVIDER = "ACCESS_TOKEN_PROVIDER";
+    public static final String ACCESS_TOKEN_PROVIDER_KEY = "fs.gs.auth.access.token.provider";
+    public static final String LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY = "fs.gs.auth.access.token.provider.impl";
+    // Hadoop's FileSystem cache ignores Configuration; disable it so rotating vended tokens take effect
+    public static final String DISABLE_FS_CACHE_KEY = "fs.gs.impl.disable.cache";
     public static final String ACCESS_TOKEN_PROVIDER_IMPL =
             "com.starrocks.connector.gcp.TemporaryGCPAccessTokenProvider";
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
@@ -88,8 +88,13 @@ public class GCPCloudCredential implements CloudCredential {
             hadoopConfiguration.put("fs.gs.auth.impersonation.service.account", impersonationServiceAccount);
         }
         if (hasAccessToken()) {
-            hadoopConfiguration.put("fs.gs.auth.access.token.provider.impl",
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.AUTH_TYPE_KEY,
+                    GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY,
                     ACCESS_TOKEN_PROVIDER_IMPL);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY,
+                    ACCESS_TOKEN_PROVIDER_IMPL);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY, "true");
             hadoopConfiguration.put(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY, accessToken);
             hadoopConfiguration.put(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY, accessTokenExpiresAt);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
@@ -84,8 +84,11 @@ public class GCPCloudCredential implements CloudCredential {
             hadoopConfiguration.put("fs.gs.auth.service.account.private.key.id", serviceAccountPrivateKeyId);
             hadoopConfiguration.put("fs.gs.auth.service.account.private.key", serviceAccountPrivateKey);
         }
-        if (!impersonationServiceAccount.isEmpty()) {
-            hadoopConfiguration.put("fs.gs.auth.impersonation.service.account", impersonationServiceAccount);
+        // Skip impersonation when a vended access token is present: gcs-connector would apply
+        // impersonation on top of the token, and vended tokens lack IAM impersonation permission.
+        if (!impersonationServiceAccount.isEmpty() && !hasAccessToken()) {
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY,
+                    impersonationServiceAccount);
         }
         if (hasAccessToken()) {
             hadoopConfiguration.put(GCPCloudConfigurationProvider.AUTH_TYPE_KEY,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -19,6 +19,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
@@ -136,12 +137,22 @@ public class IcebergCachingFileIOTest {
         String path = "gs://iceberg_gcp/iceberg_catalog/path/1/2";
 
         IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO();
-        cachingFileIO.setConf(new Configuration());
+        Configuration baseConf = new Configuration();
+        baseConf.set(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY,
+                "impersonated@project.iam.gserviceaccount.com");
+        cachingFileIO.setConf(baseConf);
         Configuration configuration = cachingFileIO.buildConfFromProperties(properties, path);
         String token = configuration.get("fs.gs.temporary.access.token");
         Assertions.assertEquals(accessToken, token);
         Assertions.assertEquals(ACCESS_TOKEN_PROVIDER_IMPL,
                 configuration.get("fs.gs.auth.access.token.provider.impl"));
+        Assertions.assertEquals(GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER,
+                configuration.get(GCPCloudConfigurationProvider.AUTH_TYPE_KEY));
+        Assertions.assertEquals(ACCESS_TOKEN_PROVIDER_IMPL,
+                configuration.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
+        Assertions.assertEquals("true", configuration.get(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY));
+        // catalog-level impersonation must not ride on top of the vended token
+        Assertions.assertNull(configuration.get(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -415,7 +415,7 @@ public class CloudConfigurationFactoryTest {
                 cloudConfiguration.toConfString());
         Configuration conf = new Configuration();
         cloudConfiguration.applyToConfiguration(conf);
-        Assertions.assertNull(conf.get("fs.gs.auth.type"));
+        Assertions.assertEquals("ACCESS_TOKEN_PROVIDER", conf.get("fs.gs.auth.type"));
         Assertions.assertEquals("access_token", conf.get("fs.gs.temporary.access.token"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
@@ -56,11 +56,35 @@ public class GCPCloudCredentialTest {
         Configuration conf = new Configuration();
         credential.applyToConfiguration(conf);
 
-        assertNull(conf.get("fs.gs.auth.type"));
+        assertEquals(GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER,
+                conf.get(GCPCloudConfigurationProvider.AUTH_TYPE_KEY));
+        assertEquals(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
+        assertEquals(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY));
+        assertEquals("true", conf.get(GCPCloudConfigurationProvider.DISABLE_FS_CACHE_KEY));
         assertNull(conf.get("fs.gs.auth.service.account.email"));
         assertEquals("ya29.access-token",
                 conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
         assertTrue(credential.validate());
+    }
+
+    @Test
+    public void testAccessTokenDropsImpersonation() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", false,
+                "", "", "",
+                "impersonated@project.iam.gserviceaccount.com",
+                "ya29.access-token", "2026-12-31T00:00:00Z");
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        assertNull(conf.get(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY));
+        assertEquals(GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER,
+                conf.get(GCPCloudConfigurationProvider.AUTH_TYPE_KEY));
+        assertEquals("ya29.access-token",
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
     }
 
     @Test


### PR DESCRIPTION
Fixes #75978

## Why I'm doing:

Iceberg REST catalog vended credentials for GCS (added in #61335) do not work: queries against an Iceberg REST catalog (e.g. Apache Polaris) backed by GCS fail on FE metadata reads with

```
Failed to get status for file: gs://<bucket>/<table>/metadata/snap-xxx.avro
Caused by: GoogleJsonResponseException: 403 Forbidden — <node-SA> does not have storage.objects.get access
```

even though the REST server vends a valid `gcs.oauth2.token` in the `loadTable` response (verified with a manual `loadTable` call carrying `X-Iceberg-Access-Delegation: vended-credentials` — the response contains `config.gcs.oauth2.token`, `gcs.oauth2.token-expires-at` and a `storage-credentials` block).

Root cause is two stacked issues:

1. **gcs-connector 2.x → 3.x config rename.** The vended token is wired using the 2.x property `fs.gs.auth.access.token.provider.impl`. The gcs-connector 3.x bundled with StarRocks (3.0.13 shaded) does not read that key at all — 3.x requires `fs.gs.auth.type=ACCESS_TOKEN_PROVIDER` plus `fs.gs.auth.access.token.provider=<class>` (`HadoopCredentialsConfiguration.AUTHENTICATION_TYPE_SUFFIX` / `ACCESS_TOKEN_PROVIDER_SUFFIX`). With the key ignored, auth silently falls back to application-default credentials. (Notably `GCPCloudCredential` already uses the 3.x style `fs.gs.auth.type` for the SERVICE_ACCOUNT_JSON_KEYFILE branch — only the access-token branch was left on 2.x keys.)

2. **Hadoop FileSystem cache.** `FileSystem` instances are cached by (scheme, authority, ugi) and ignore `Configuration`, so once a `GoogleHadoopFileSystem` is created for a bucket without the token, later reads never see the corrected configuration — and since vended tokens rotate per table and expiry, a cached FS is unsound for this path in general. The fix sets `fs.gs.impl.disable.cache=true` on the vended-token path only.

## What I'm doing:

- `GCPCloudConfigurationProvider`: add constants for the gcs-connector 3.x keys (`fs.gs.auth.type`, `fs.gs.auth.access.token.provider`) and `fs.gs.impl.disable.cache`.
- `IcebergCachingFileIO.buildConfFromProperties`: when `gcs.oauth2.token` is present, set the 3.x auth-type/provider keys and disable the FS cache; keep the legacy 2.x `.impl` key for backward compatibility with 2.x connectors.
- `GCPCloudCredential.tryGenerateHadoopConfiguration`: same for the `hasAccessToken()` branch.

## Verification

Tested against Apache Polaris (Iceberg REST, `security=oauth2`, warehouse on GCS), StarRocks 4.1.1 shared-data on GKE, with a catalog created exactly per the docs (`iceberg.catalog.security=oauth2` + credential + scope). Before the fix: 403 as node SA on every read. After the fix (patched classes hot-swapped into the running FE):

- `SELECT count(*)` (FE manifest read path): correct result
- `SELECT * ... LIMIT 5` (CN scan): correct rows
- `GROUP BY partition` over a 3-billion-row Iceberg table: counts byte-identical to Trino 482 (which reads the same catalog with vended credentials) — three partitions, 3.0–3.1B rows each

Fixes the GCS half of vended-credential support; no changes to S3/Azure paths.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
