### PR TITLE
[BugFix] Fix null-padding size for missing columns in ParquetScanner

### DIFF
--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -173,7 +173,7 @@ Status ParquetScanner::append_batch_to_src_chunk(ChunkPtr* chunk) {
         auto* column = (*chunk)->get_column_raw_ptr_by_slot_id(slot_desc->id());
         auto array_ptr = _batch->GetColumnByName(std::string(slot_desc->col_name()));
         if (array_ptr == nullptr) {
-            (void)column->append_nulls(_batch->num_rows());
+            (void)column->append_nulls(num_elements);
         } else {
             auto st = convert_arrow_array_to_column(_conv_funcs[i].get(), num_elements, array_ptr.get(), column,
                                                     _batch_start_idx, _chunk_start_idx, &_chunk_filter, &_conv_ctx);

--- a/be/test/exec/file_scanner/parquet_scanner_test.cpp
+++ b/be/test/exec/file_scanner/parquet_scanner_test.cpp
@@ -133,7 +133,7 @@ private:
     std::unique_ptr<ParquetScanner> create_parquet_scanner(
             const std::string& timezone, DescriptorTbl* desc_tbl,
             const std::unordered_map<size_t, ::starrocks::TExpr>& dst_slot_exprs,
-            const std::vector<TBrokerRangeDesc>& ranges, int32_t chunk_size = 0) {
+            const std::vector<TBrokerRangeDesc>& ranges, int32_t chunk_size = 0, bool flexible_column_mapping = false) {
         /// Init RuntimeState
         TQueryOptions query_options;
         if (chunk_size > 0) {
@@ -152,6 +152,9 @@ private:
         /// TBrokerScanRangeParams
         TBrokerScanRangeParams* params = _obj_pool.add(new TBrokerScanRangeParams());
         params->strict_mode = true;
+        if (flexible_column_mapping) {
+            params->__set_flexible_column_mapping(true);
+        }
         std::vector<TupleDescriptor*> tuples;
         desc_tbl->get_tuple_descs(&tuples);
         const auto num_tuples = tuples.size();
@@ -1527,7 +1530,7 @@ TEST_F(ParquetScannerTest, test_missing_column_with_small_chunk_size) {
                                         {"missing_col", TypeDescriptor::from_logical_type(TYPE_INT), true}};
     auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
     auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
-    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges, 2);
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges, 2, /*flexible_column_mapping=*/true);
 
     std::vector<std::string> actual_zone_values;
     std::vector<size_t> chunk_rows;

--- a/be/test/exec/file_scanner/parquet_scanner_test.cpp
+++ b/be/test/exec/file_scanner/parquet_scanner_test.cpp
@@ -1517,4 +1517,35 @@ TEST_F(ParquetScannerTest, optional_map_key) {
     }
 }
 
+TEST_F(ParquetScannerTest, test_missing_column_with_small_chunk_size) {
+    std::string parquet_file_name;
+    create_dictionary_string_parquet("dictionary_string_missing_col.parquet",
+                                     {"Center", "Edge", "Middle", "Center", "North"}, &parquet_file_name);
+    DeferOp defer([&]() { std::filesystem::remove(parquet_file_name); });
+
+    SlotTypeDescInfoArray slot_infos = {{"zone", TypeDescriptor::create_varchar_type(1048576), true},
+                                        {"missing_col", TypeDescriptor::from_logical_type(TYPE_INT), true}};
+    auto ranges = generate_ranges({parquet_file_name}, slot_infos.size(), {});
+    auto* desc_tbl = DescTblHelper::generate_desc_tbl(_runtime_state, _obj_pool, {slot_infos, {}});
+    auto scanner = create_parquet_scanner("UTC", desc_tbl, {}, ranges, 2);
+
+    std::vector<std::string> actual_zone_values;
+    std::vector<size_t> chunk_rows;
+    auto check = [&](const ChunkPtr& chunk) {
+        ASSERT_EQ(2, chunk->num_columns());
+        chunk_rows.emplace_back(chunk->num_rows());
+        auto col_zone = chunk->columns()[0];
+        auto col_missing = chunk->columns()[1];
+        ASSERT_EQ(col_zone->size(), col_missing->size());
+        for (size_t i = 0; i < col_zone->size(); ++i) {
+            actual_zone_values.emplace_back(col_zone->debug_item(i));
+            EXPECT_TRUE(col_missing->is_null(i));
+        }
+    };
+    validate(scanner, 5, check);
+
+    ASSERT_EQ(std::vector<size_t>({2, 2, 1}), chunk_rows);
+    ASSERT_EQ((std::vector<std::string>{"'Center'", "'Edge'", "'Middle'", "'Center'", "'North'"}), actual_zone_values);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

While reviewing #74593, a bug was identified in `ParquetScanner` where missing columns in a Parquet/Arrow file are padded with nulls using the entire batch size (`_batch->num_rows()`) instead of the bounded iteration chunk size (`num_elements`).
When `_batch->num_rows() > _max_chunk_size`, the batch is split and processed across multiple calls to `append_batch_to_src_chunk`. Having the missing column padded using `_batch->num_rows()` causes column row count mismatches within the same chunk, resulting in out-of-bounds crashes during chunk materialisation/filtering in `finalize_src_chunk`.

## What I'm doing:

When a column is missing from the Parquet/Arrow file, ParquetScanner appended `_batch->num_rows()` nulls instead of the bounded `num_elements` in `append_batch_to_src_chunk`. Under small chunk size conditions where the batch is processed in increments of `num_elements`, this led to unequal column lengths within the same chunk and triggered crashes.

This patch fixes the issue by passing `num_elements` to `append_nulls` and adds a regression unit test.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
