### PR TITLE
[Doc] delta lake remove the limitation stating that MAP and STRUCT are not supported

### DIFF
--- a/docs/en/data_source/catalog/deltalake_catalog.md
+++ b/docs/en/data_source/catalog/deltalake_catalog.md
@@ -14,7 +14,6 @@ import DatabricksDataParams from '../../_assets/catalog/_databricks_data_params.
 ## Usage notes
 
 - The file format of Delta Lake that StarRocks supports is Parquet. Parquet files support the following compression formats: SNAPPY, LZ4, ZSTD, GZIP, and NO_COMPRESSION.
-- The data types of Delta Lake that StarRocks does not support are MAP and STRUCT.
 
 ## Integration preparations
 

--- a/docs/ja/data_source/catalog/deltalake_catalog.md
+++ b/docs/ja/data_source/catalog/deltalake_catalog.md
@@ -12,7 +12,6 @@ import DatabricksParams from '../../_assets/catalog/_databricks_params.mdx'
 ## 使用上の注意
 
 - StarRocks がサポートする Delta Lake のファイル形式は Parquet です。Parquet ファイルは次の圧縮形式をサポートしています: SNAPPY, LZ4, ZSTD, GZIP, NO_COMPRESSION。
-- StarRocks がサポートしていない Delta Lake のデータ型は MAP と STRUCT です。
 
 ## 統合準備
 

--- a/docs/zh/data_source/catalog/deltalake_catalog.md
+++ b/docs/zh/data_source/catalog/deltalake_catalog.md
@@ -12,7 +12,6 @@ import DatabricksParams from '../../_assets/catalog/_databricks_params.mdx'
 ## 使用说明
 
 - StarRocks 支持的 Delta Lake 文件格式是 Parquet。Parquet 文件支持以下压缩格式：SNAPPY、LZ4、ZSTD、GZIP 和 NO_COMPRESSION。
-- StarRocks 不支持 Delta Lake 的数据类型为 MAP 和 STRUCT。
 
 ## 集成准备
 


### PR DESCRIPTION
Contrary to the catalog documentation, support for reading `MAP` and `STRUCT` data types from Delta Lake tables is already fully implemented in the StarRocks codebase.

## Why I'm doing:

 Support was merged in PR #28761, which was merged in Starrocks 3.1 (as far as I can tell). The documentation 

https://docs.starrocks.io/docs/data_source/catalog/deltalake_catalog/

States:

> Usage notes
>
> The file format of Delta Lake that StarRocks supports is Parquet. Parquet files support the following compression formats: SNAPPY, LZ4, ZSTD, GZIP, and NO_COMPRESSION.
>
> The data types of Delta Lake that StarRocks does not support are MAP and STRUCT.
>


## What I'm doing:

This is purely a documentation fix that corrects the type support statement.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5