### PR TITLE
[Tool] Disable scheduled inspection-pipeline runs

### DIFF
--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -1,11 +1,13 @@
 name: INSPECTION PIPELINE
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
-    - cron: "30 4 * * 1-5"
-    - cron: "0 11 * * 1,3,5"
-    - cron: "0 11 * * 2,4"
+  # Scheduled inspection runs disabled 2026-07-08: the runs are not currently
+  # meaningful. Kept here (commented) for easy re-enable. Manual dispatch stays.
+  # schedule:
+  #   - cron: "0 0 * * 1-5"
+  #   - cron: "30 4 * * 1-5"
+  #   - cron: "0 11 * * 1,3,5"
+  #   - cron: "0 11 * * 2,4"
   workflow_dispatch:
     inputs:
       BRANCH:


### PR DESCRIPTION
## Why I'm doing:
The periodic (cron) inspection-pipeline runs are not meaningful right now and just consume CI resources.

## What I'm doing:
Comment out the `schedule:` cron block in `.github/workflows/inspection-pipeline.yml`; keep `workflow_dispatch` so it can still be run manually. Crons are left commented for easy re-enable. This propagates to CelerData/celerdata-enterprise via the normal StarRocks→CelerData sync, so no separate change is needed there.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5