### PR TITLE
[Refactor] Pass connector sink runtime context at creation

### DIFF
--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -98,18 +98,19 @@ protected:
 
 struct ConnectorChunkSinkContext {
     virtual ~ConnectorChunkSinkContext() = default;
+};
 
-    // Called by ConnectorSinkOperatorFactory after SinkMemoryManager is created.
-    // Composite sinks (e.g. IcebergRowDeltaSink) override this to receive the
-    // manager and create per-sub-sink child managers during initialization.
-    virtual void set_sink_mem_mgr(SinkMemoryManager* /*mgr*/) {}
+struct ConnectorChunkSinkCreateContext {
+    AsyncFlushStreamPoller* io_poller = nullptr;
+    SinkMemoryManager* sink_mem_mgr = nullptr;
 };
 
 class ConnectorChunkSinkProvider {
 public:
     virtual ~ConnectorChunkSinkProvider() = default;
 
-    virtual StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) = 0;
+    virtual StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) = 0;
 };
 
 using ConnectorChunkSinkProviderPtr = std::unique_ptr<ConnectorChunkSinkProvider>;

--- a/be/src/connector/file_chunk_sink.cpp
+++ b/be/src/connector/file_chunk_sink.cpp
@@ -51,7 +51,8 @@ void FileChunkSink::callback_on_commit(const CommitResult& result) {
     }
 }
 
-StatusOr<std::unique_ptr<ConnectorChunkSink>> FileChunkSinkProvider::create_chunk_sink(int32_t driver_id) {
+StatusOr<std::unique_ptr<ConnectorChunkSink>> FileChunkSinkProvider::create_chunk_sink(
+        int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) {
     auto ctx = _ctx;
     auto runtime_state = ctx->fragment_context->runtime_state();
     std::shared_ptr<FileSystem> fs =
@@ -110,8 +111,10 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> FileChunkSinkProvider::create_chun
                 std::make_unique<BufferPartitionChunkWriterFactory>(partition_chunk_writer_ctx);
     }
 
-    return std::make_unique<connector::FileChunkSink>(partition_columns, std::move(partition_column_evaluators),
-                                                      std::move(partition_chunk_writer_factory), runtime_state);
+    auto sink = std::make_unique<connector::FileChunkSink>(partition_columns, std::move(partition_column_evaluators),
+                                                           std::move(partition_chunk_writer_factory), runtime_state);
+    sink->set_io_poller(create_context.io_poller);
+    return sink;
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/file_chunk_sink.h
+++ b/be/src/connector/file_chunk_sink.h
@@ -60,7 +60,8 @@ public:
     explicit FileChunkSinkProvider(std::shared_ptr<FileChunkSinkContext> ctx);
     ~FileChunkSinkProvider() override = default;
 
-    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) override;
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) override;
 
 private:
     std::shared_ptr<FileChunkSinkContext> _ctx;

--- a/be/src/connector/hive_chunk_sink.cpp
+++ b/be/src/connector/hive_chunk_sink.cpp
@@ -57,7 +57,8 @@ void HiveChunkSink::callback_on_commit(const CommitResult& result) {
     }
 }
 
-StatusOr<std::unique_ptr<ConnectorChunkSink>> HiveChunkSinkProvider::create_chunk_sink(int32_t driver_id) {
+StatusOr<std::unique_ptr<ConnectorChunkSink>> HiveChunkSinkProvider::create_chunk_sink(
+        int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) {
     auto ctx = _ctx;
     auto runtime_state = ctx->fragment_context->runtime_state();
     std::shared_ptr<FileSystem> fs =
@@ -110,9 +111,11 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> HiveChunkSinkProvider::create_chun
     }
 
     auto partition_column_evaluators = ColumnEvaluator::clone(ctx->partition_column_evaluators);
-    return std::make_unique<connector::HiveChunkSink>(ctx->partition_column_names,
-                                                      std::move(partition_column_evaluators),
-                                                      std::move(partition_chunk_writer_factory), runtime_state);
+    auto sink = std::make_unique<connector::HiveChunkSink>(ctx->partition_column_names,
+                                                           std::move(partition_column_evaluators),
+                                                           std::move(partition_chunk_writer_factory), runtime_state);
+    sink->set_io_poller(create_context.io_poller);
+    return sink;
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/hive_chunk_sink.h
+++ b/be/src/connector/hive_chunk_sink.h
@@ -63,7 +63,8 @@ public:
     explicit HiveChunkSinkProvider(std::shared_ptr<HiveChunkSinkContext> ctx);
     ~HiveChunkSinkProvider() override = default;
 
-    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) override;
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) override;
 
 private:
     std::shared_ptr<HiveChunkSinkContext> _ctx;

--- a/be/src/connector/iceberg_chunk_sink.cpp
+++ b/be/src/connector/iceberg_chunk_sink.cpp
@@ -88,7 +88,8 @@ void IcebergChunkSink::callback_on_commit(const CommitResult& result) {
     }
 }
 
-StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_chunk_sink(int32_t driver_id) {
+StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_chunk_sink(
+        int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) {
     auto ctx = _ctx;
     auto runtime_state = ctx->fragment_context->runtime_state();
     std::shared_ptr<FileSystem> fs =
@@ -134,9 +135,11 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergChunkSinkProvider::create_c
                 std::make_unique<BufferPartitionChunkWriterFactory>(partition_chunk_writer_ctx);
     }
 
-    return std::make_unique<connector::IcebergChunkSink>(partition_columns, transform_exprs,
-                                                         std::move(partition_evaluators),
-                                                         std::move(partition_chunk_writer_factory), runtime_state);
+    auto sink = std::make_unique<connector::IcebergChunkSink>(partition_columns, transform_exprs,
+                                                              std::move(partition_evaluators),
+                                                              std::move(partition_chunk_writer_factory), runtime_state);
+    sink->set_io_poller(create_context.io_poller);
+    return sink;
 }
 
 Status IcebergChunkSink::add(const ChunkPtr& chunk) {

--- a/be/src/connector/iceberg_chunk_sink.h
+++ b/be/src/connector/iceberg_chunk_sink.h
@@ -82,7 +82,8 @@ public:
     explicit IcebergChunkSinkProvider(std::shared_ptr<IcebergChunkSinkContext> ctx);
     ~IcebergChunkSinkProvider() override = default;
 
-    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) override;
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) override;
 
 private:
     std::shared_ptr<IcebergChunkSinkContext> _ctx;

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -217,7 +217,8 @@ bool IcebergDeleteSink::is_finished() {
 //   driver_id - The driver ID for this sink instance
 //
 // Returns the created sink on success, or an error if creation fails.
-StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_chunk_sink(int32_t driver_id) {
+StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_chunk_sink(
+        int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) {
     auto ctx = _ctx;
     if (ctx == nullptr) {
         return Status::InternalError("IcebergDeleteSinkProvider: context is not IcebergDeleteSinkContext");
@@ -337,10 +338,11 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergDeleteSinkProvider::create_
             sort_ordering});
     partition_chunk_writer_factory = std::make_unique<SpillPartitionChunkWriterFactory>(writer_ctx);
 
-    // Create the delete sink
-    return std::make_unique<IcebergDeleteSink>(
+    auto sink = std::make_unique<IcebergDeleteSink>(
             ctx->partition_column_names, ctx->transform_exprs, ColumnEvaluator::clone(ctx->partition_evaluators),
             std::move(partition_chunk_writer_factory), runtime_state, ctx->column_slot_map);
+    sink->set_io_poller(create_context.io_poller);
+    return sink;
 }
 
 // Writes a chunk to the file-level delete file for a specific source data file.

--- a/be/src/connector/iceberg_delete_sink.h
+++ b/be/src/connector/iceberg_delete_sink.h
@@ -78,7 +78,8 @@ public:
     ~IcebergDeleteSinkProvider() override = default;
 
     // Create a sink for writing delete files
-    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) override;
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) override;
 
 private:
     std::shared_ptr<IcebergDeleteSinkContext> _ctx;

--- a/be/src/connector/iceberg_row_delta_sink.cpp
+++ b/be/src/connector/iceberg_row_delta_sink.cpp
@@ -152,7 +152,8 @@ bool IcebergRowDeltaSink::is_finished() {
     return _delete_sink->is_finished() && _data_sink->is_finished();
 }
 
-StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergRowDeltaSinkProvider::create_chunk_sink(int32_t driver_id) {
+StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergRowDeltaSinkProvider::create_chunk_sink(
+        int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) {
     auto ctx = _ctx;
     if (ctx == nullptr) {
         return Status::InternalError("IcebergRowDeltaSinkProvider: context is not IcebergRowDeltaSinkContext");
@@ -161,13 +162,15 @@ StatusOr<std::unique_ptr<ConnectorChunkSink>> IcebergRowDeltaSinkProvider::creat
     auto runtime_state = ctx->data_sink_ctx->fragment_context->runtime_state();
 
     IcebergDeleteSinkProvider delete_provider(ctx->delete_sink_ctx);
-    ASSIGN_OR_RETURN(auto delete_sink, delete_provider.create_chunk_sink(driver_id));
+    ASSIGN_OR_RETURN(auto delete_sink, delete_provider.create_chunk_sink(driver_id, create_context));
 
     IcebergChunkSinkProvider data_provider(ctx->data_sink_ctx);
-    ASSIGN_OR_RETURN(auto data_sink, data_provider.create_chunk_sink(driver_id));
+    ASSIGN_OR_RETURN(auto data_sink, data_provider.create_chunk_sink(driver_id, create_context));
 
-    return std::make_unique<IcebergRowDeltaSink>(std::move(delete_sink), std::move(data_sink), ctx->op_code_index,
-                                                 ctx->sink_mem_mgr, runtime_state);
+    auto sink = std::make_unique<IcebergRowDeltaSink>(std::move(delete_sink), std::move(data_sink), ctx->op_code_index,
+                                                      create_context.sink_mem_mgr, runtime_state);
+    sink->set_io_poller(create_context.io_poller);
+    return sink;
 }
 
 } // namespace starrocks::connector

--- a/be/src/connector/iceberg_row_delta_sink.h
+++ b/be/src/connector/iceberg_row_delta_sink.h
@@ -37,12 +37,6 @@ struct IcebergRowDeltaSinkContext : public ConnectorChunkSinkContext {
     // The default -1 means no extra op_code column (such as UPDATE operation),
     // every row goes to both delete and data sub-sinks.
     int32_t op_code_index = -1;
-
-    // Query-level memory manager for creating child managers for sub-sinks.
-    // Set by ConnectorSinkOperatorFactory via set_sink_mem_mgr() after construction.
-    SinkMemoryManager* sink_mem_mgr = nullptr;
-
-    void set_sink_mem_mgr(SinkMemoryManager* mgr) override { sink_mem_mgr = mgr; }
 };
 
 // IcebergRowDeltaSinkProvider creates IcebergRowDeltaSink for Iceberg row-delta operations.
@@ -52,7 +46,8 @@ public:
     explicit IcebergRowDeltaSinkProvider(std::shared_ptr<IcebergRowDeltaSinkContext> ctx);
     ~IcebergRowDeltaSinkProvider() override = default;
 
-    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(int32_t driver_id) override;
+    StatusOr<std::unique_ptr<ConnectorChunkSink>> create_chunk_sink(
+            int32_t driver_id, const ConnectorChunkSinkCreateContext& create_context) override;
 
 private:
     std::shared_ptr<IcebergRowDeltaSinkContext> _ctx;

--- a/be/src/exec/data_sinks/hive_table_sink.cpp
+++ b/be/src/exec/data_sinks/hive_table_sink.cpp
@@ -115,8 +115,8 @@ Status HiveTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operators
     auto connector = connector::ConnectorRegistry::default_instance()->get(connector::Connector::HIVE);
     ASSIGN_OR_RETURN(auto sink_provider,
                      connector->create_sink_provider(starrocks::connector::ConnectorSinkProviderType::DATA, sink_ctx));
-    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
-            context->next_operator_id(), std::move(sink_provider), sink_ctx, fragment_ctx);
+    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(context->next_operator_id(),
+                                                                       std::move(sink_provider), fragment_ctx);
     size_t sink_dop = context->data_sink_dop();
     if (t_hive_sink.partition_column_names.size() == 0 || t_hive_sink.is_static_partition_sink) {
         auto ops = ::starrocks::pipeline::builder::maybe_interpolate_local_passthrough_exchange(

--- a/be/src/exec/data_sinks/iceberg_table_sink.cpp
+++ b/be/src/exec/data_sinks/iceberg_table_sink.cpp
@@ -126,23 +126,22 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
     std::unique_ptr<connector::ConnectorChunkSinkProvider> sink_provider;
-    std::shared_ptr<connector::ConnectorChunkSinkContext> sink_ctx;
     std::vector<TExpr> partition_expr;
     std::vector<std::string> transform_exprs = iceberg_table_desc->get_transform_exprs();
 
     if (thrift_sink.type == TDataSinkType::ICEBERG_ROW_DELTA_SINK) {
         RETURN_IF_ERROR(create_row_delta_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
-                                                      sink_provider, sink_ctx, partition_expr));
+                                                      sink_provider, partition_expr));
     } else if (thrift_sink.type == TDataSinkType::ICEBERG_DELETE_SINK) {
         RETURN_IF_ERROR(create_delete_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc,
-                                                   sink_provider, sink_ctx, partition_expr));
+                                                   sink_provider, partition_expr));
     } else {
         RETURN_IF_ERROR(create_data_sink_context(thrift_sink, runtime_state, context, iceberg_table_desc, sink_provider,
-                                                 sink_ctx, partition_expr));
+                                                 partition_expr));
     }
 
-    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
-            context->next_operator_id(), std::move(sink_provider), sink_ctx, fragment_ctx);
+    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(context->next_operator_id(),
+                                                                       std::move(sink_provider), fragment_ctx);
     size_t sink_dop = context->data_sink_dop();
 
     if (iceberg_table_desc->is_unpartitioned_table() || t_iceberg_sink.is_static_partition_sink) {
@@ -181,7 +180,7 @@ Status IcebergTableSink::create_delete_sink_context(
         const TDataSink& thrift_sink, RuntimeState* runtime_state, pipeline::PipelineBuilderContext* context,
         IcebergTableDescriptor* iceberg_table_desc,
         std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-        std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx, std::vector<TExpr>& partition_expr) const {
+        std::vector<TExpr>& partition_expr) const {
     auto* fragment_ctx = context->fragment_context();
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
@@ -247,7 +246,6 @@ Status IcebergTableSink::create_delete_sink_context(
         delete_sink_ctx->partition_evaluators = ColumnExprEvaluator::from_exprs(partition_expr, runtime_state);
     }
 
-    sink_ctx = delete_sink_ctx;
     auto connector = connector::ConnectorRegistry::default_instance()->get(connector::Connector::ICEBERG);
     ASSIGN_OR_RETURN(auto provider, connector->create_sink_provider(
                                             starrocks::connector::ConnectorSinkProviderType::DELETE, delete_sink_ctx));
@@ -260,7 +258,6 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
                                                   pipeline::PipelineBuilderContext* context,
                                                   IcebergTableDescriptor* iceberg_table_desc,
                                                   std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-                                                  std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                                   std::vector<TExpr>& partition_expr) const {
     auto* fragment_ctx = context->fragment_context();
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
@@ -327,7 +324,6 @@ Status IcebergTableSink::create_data_sink_context(const TDataSink& thrift_sink, 
         }
     }
 
-    sink_ctx = data_sink_ctx;
     auto connector = connector::ConnectorRegistry::default_instance()->get(connector::Connector::ICEBERG);
     ASSIGN_OR_RETURN(auto provider, connector->create_sink_provider(
                                             starrocks::connector::ConnectorSinkProviderType::DATA, data_sink_ctx));
@@ -384,7 +380,7 @@ Status IcebergTableSink::create_row_delta_sink_context(
         const TDataSink& thrift_sink, RuntimeState* runtime_state, pipeline::PipelineBuilderContext* context,
         IcebergTableDescriptor* iceberg_table_desc,
         std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-        std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx, std::vector<TExpr>& partition_expr) const {
+        std::vector<TExpr>& partition_expr) const {
     auto* fragment_ctx = context->fragment_context();
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
@@ -594,7 +590,6 @@ Status IcebergTableSink::create_row_delta_sink_context(
     row_delta_ctx->data_sink_ctx = data_sink_ctx;
     row_delta_ctx->op_code_index = op_code_index;
 
-    sink_ctx = row_delta_ctx;
     auto connector = connector::ConnectorRegistry::default_instance()->get(connector::Connector::ICEBERG);
     ASSIGN_OR_RETURN(auto provider, connector->create_sink_provider(
                                             starrocks::connector::ConnectorSinkProviderType::ROW_DELTA, row_delta_ctx));

--- a/be/src/exec/data_sinks/iceberg_table_sink.h
+++ b/be/src/exec/data_sinks/iceberg_table_sink.h
@@ -60,21 +60,18 @@ private:
                                       pipeline::PipelineBuilderContext* context,
                                       IcebergTableDescriptor* iceberg_table_desc,
                                       std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-                                      std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                       std::vector<TExpr>& partition_expr) const;
 
     Status create_data_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
                                     pipeline::PipelineBuilderContext* context,
                                     IcebergTableDescriptor* iceberg_table_desc,
                                     std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-                                    std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                     std::vector<TExpr>& partition_expr) const;
 
     Status create_row_delta_sink_context(const TDataSink& thrift_sink, RuntimeState* runtime_state,
                                          pipeline::PipelineBuilderContext* context,
                                          IcebergTableDescriptor* iceberg_table_desc,
                                          std::unique_ptr<connector::ConnectorChunkSinkProvider>& sink_provider,
-                                         std::shared_ptr<connector::ConnectorChunkSinkContext>& sink_ctx,
                                          std::vector<TExpr>& partition_expr) const;
 
     ObjectPool* _pool;

--- a/be/src/exec/data_sinks/table_function_table_sink.cpp
+++ b/be/src/exec/data_sinks/table_function_table_sink.cpp
@@ -138,8 +138,8 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     auto connector = connector::ConnectorRegistry::default_instance()->get(connector::Connector::FILE);
     ASSIGN_OR_RETURN(auto sink_provider,
                      connector->create_sink_provider(starrocks::connector::ConnectorSinkProviderType::DATA, sink_ctx));
-    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(
-            context->next_operator_id(), std::move(sink_provider), sink_ctx, fragment_ctx);
+    auto op = std::make_shared<pipeline::ConnectorSinkOperatorFactory>(context->next_operator_id(),
+                                                                       std::move(sink_provider), fragment_ctx);
 
     size_t sink_dop = target_table.write_single_file ? 1 : context->data_sink_dop();
     if (sink_ctx->partition_column_indices.empty()) {

--- a/be/src/exec/pipeline/sink/connector_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.cpp
@@ -133,23 +133,19 @@ Status ConnectorSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& ch
 
 ConnectorSinkOperatorFactory::ConnectorSinkOperatorFactory(
         int32_t id, std::unique_ptr<connector::ConnectorChunkSinkProvider> data_sink_provider,
-        std::shared_ptr<connector::ConnectorChunkSinkContext> sink_context, FragmentContext* fragment_context)
+        FragmentContext* fragment_context)
         : OperatorFactory(id, "connector_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
           _data_sink_provider(std::move(data_sink_provider)),
-          _sink_context(std::move(sink_context)),
           _fragment_context(fragment_context) {
     MemTracker* query_pool_tracker = RuntimeEnv::GetInstance()->query_pool_mem_tracker();
     MemTracker* query_tracker = _fragment_context->runtime_state()->query_mem_tracker_ptr().get();
     _sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(query_pool_tracker, query_tracker);
-
-    // Pass SinkMemoryManager to RowDelta context so sub-sinks can get their own child managers
-    _sink_context->set_sink_mem_mgr(_sink_mem_mgr.get());
 }
 
 OperatorPtr ConnectorSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
-    auto chunk_sink = _data_sink_provider->create_chunk_sink(driver_sequence).value();
     auto io_poller = std::make_unique<connector::AsyncFlushStreamPoller>();
-    chunk_sink->set_io_poller(io_poller.get());
+    connector::ConnectorChunkSinkCreateContext create_context{io_poller.get(), _sink_mem_mgr.get()};
+    auto chunk_sink = _data_sink_provider->create_chunk_sink(driver_sequence, create_context).value();
     auto op_mem_mgr = _sink_mem_mgr->create_child_manager();
     chunk_sink->set_operator_mem_mgr(op_mem_mgr);
     return std::make_shared<ConnectorSinkOperator>(this, _id, Operator::s_pseudo_plan_node_id_for_final_sink,

--- a/be/src/exec/pipeline/sink/connector_sink_operator.h
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.h
@@ -70,7 +70,6 @@ private:
 class ConnectorSinkOperatorFactory final : public OperatorFactory {
 public:
     ConnectorSinkOperatorFactory(int32_t id, std::unique_ptr<connector::ConnectorChunkSinkProvider> data_sink_provider,
-                                 std::shared_ptr<connector::ConnectorChunkSinkContext> sink_context,
                                  FragmentContext* fragment_context);
 
     ~ConnectorSinkOperatorFactory() override = default;
@@ -79,7 +78,6 @@ public:
 
 private:
     std::unique_ptr<connector::ConnectorChunkSinkProvider> _data_sink_provider;
-    std::shared_ptr<connector::ConnectorChunkSinkContext> _sink_context;
     std::shared_ptr<connector::SinkMemoryManager> _sink_mem_mgr;
     FragmentContext* _fragment_context;
 };

--- a/be/test/connector_sink/file_chunk_sink_test.cpp
+++ b/be/test/connector_sink/file_chunk_sink_test.cpp
@@ -148,7 +148,7 @@ TEST_F(FileChunkSinkTest, test_factory) {
                 {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_INT)});
         sink_ctx->fragment_context = _fragment_context.get();
         FileChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_OK(sink->init());
@@ -168,7 +168,7 @@ TEST_F(FileChunkSinkTest, test_factory) {
                 {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_INT)});
         sink_ctx->fragment_context = _fragment_context.get();
         FileChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_OK(sink->init());
@@ -188,7 +188,7 @@ TEST_F(FileChunkSinkTest, test_factory) {
                 {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_INT)});
         sink_ctx->fragment_context = _fragment_context.get();
         FileChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_ERROR(sink->init());

--- a/be/test/connector_sink/hive_chunk_sink_test.cpp
+++ b/be/test/connector_sink/hive_chunk_sink_test.cpp
@@ -110,7 +110,7 @@ TEST_F(HiveChunkSinkTest, test_factory) {
         sink_ctx->max_file_size = 1 << 30;
         sink_ctx->fragment_context = _fragment_context.get();
         HiveChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_OK(sink->init());
@@ -132,7 +132,7 @@ TEST_F(HiveChunkSinkTest, test_factory) {
         sink_ctx->max_file_size = 1 << 30;
         sink_ctx->fragment_context = _fragment_context.get();
         HiveChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_OK(sink->init());
@@ -154,7 +154,7 @@ TEST_F(HiveChunkSinkTest, test_factory) {
         sink_ctx->max_file_size = 1 << 30;
         sink_ctx->fragment_context = _fragment_context.get();
         HiveChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_ERROR(sink->init());

--- a/be/test/connector_sink/iceberg_chunk_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_chunk_sink_test.cpp
@@ -175,7 +175,7 @@ TEST_F(IcebergChunkSinkTest, test_factory) {
                 {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_INT)});
         sink_ctx->fragment_context = _fragment_context.get();
         IcebergChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_OK(sink->init());
@@ -195,7 +195,7 @@ TEST_F(IcebergChunkSinkTest, test_factory) {
                 {TypeDescriptor::from_logical_type(TYPE_VARCHAR), TypeDescriptor::from_logical_type(TYPE_INT)});
         sink_ctx->fragment_context = _fragment_context.get();
         IcebergChunkSinkProvider provider(sink_ctx);
-        auto sink = provider.create_chunk_sink(0).value();
+        auto sink = provider.create_chunk_sink(0, {}).value();
         SinkOperatorMemoryManager mm;
         sink->set_operator_mem_mgr(&mm);
         EXPECT_ERROR(sink->init()); // format is not supported

--- a/be/test/connector_sink/iceberg_delete_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_delete_sink_test.cpp
@@ -141,7 +141,7 @@ TEST_F(IcebergDeleteSinkTest, create_delete_sink) {
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
 
     // Should create sink successfully
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -156,7 +156,7 @@ TEST_F(IcebergDeleteSinkTest, create_delete_sink) {
 TEST_F(IcebergDeleteSinkTest, add_empty_chunk) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -172,7 +172,7 @@ TEST_F(IcebergDeleteSinkTest, add_empty_chunk) {
 TEST_F(IcebergDeleteSinkTest, is_finished_no_data) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -235,7 +235,7 @@ TEST_F(IcebergDeleteSinkTest, context_required_fields) {
 TEST_F(IcebergDeleteSinkTest, callback_on_commit_empty) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -269,7 +269,7 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_empty) {
 TEST_F(IcebergDeleteSinkTest, callback_on_commit_with_delete_file) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -321,7 +321,7 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_with_delete_file) {
 TEST_F(IcebergDeleteSinkTest, callback_on_commit_io_failure) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -349,7 +349,7 @@ TEST_F(IcebergDeleteSinkTest, callback_on_commit_io_failure) {
 TEST_F(IcebergDeleteSinkTest, callback_on_commit_partial_stats) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -410,7 +410,7 @@ TEST_F(IcebergDeleteSinkTest, commit_result_set_referenced_data_file) {
 TEST_F(IcebergDeleteSinkTest, finish_function) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();
@@ -439,7 +439,7 @@ TEST_F(IcebergDeleteSinkTest, missing_file_column) {
     context->column_slot_map["_pos"] = pos_node;
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
 
     // Should fail because _file column is missing
     ASSERT_FALSE(result.ok());
@@ -464,7 +464,7 @@ TEST_F(IcebergDeleteSinkTest, missing_pos_column) {
     context->column_slot_map["_file"] = file_node;
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
 
     // Should fail because _pos column is missing
     ASSERT_FALSE(result.ok());
@@ -498,7 +498,7 @@ TEST_F(IcebergDeleteSinkTest, not_enough_evaluators) {
     context->column_evaluators.push_back(create_mock_column_evaluator());
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
 
     // Should fail because not enough evaluators
     ASSERT_FALSE(result.ok());
@@ -533,7 +533,7 @@ TEST_F(IcebergDeleteSinkTest, invalid_tuple_descriptor_id) {
     context->column_evaluators.push_back(create_mock_column_evaluator());
 
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
 
     // Should fail because tuple descriptor ID is invalid
     ASSERT_FALSE(result.ok());
@@ -544,7 +544,7 @@ TEST_F(IcebergDeleteSinkTest, invalid_tuple_descriptor_id) {
 TEST_F(IcebergDeleteSinkTest, verify_required_columns_in_parquet) {
     auto context = create_delete_sink_context();
     auto provider = std::make_unique<IcebergDeleteSinkProvider>(context);
-    auto result = provider->create_chunk_sink(0);
+    auto result = provider->create_chunk_sink(0, {});
     ASSERT_TRUE(result.ok());
 
     auto sink = std::move(result).value();

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -56,6 +56,22 @@ protected:
     RuntimeState* _runtime_state;
 };
 
+namespace {
+
+connector::IcebergChunkSinkContext* get_iceberg_chunk_sink_context(
+        pipeline::ConnectorSinkOperatorFactory* connector_sink_factory) {
+    auto* provider =
+            dynamic_cast<connector::IcebergChunkSinkProvider*>(connector_sink_factory->_data_sink_provider.get());
+    return provider == nullptr ? nullptr : provider->_ctx.get();
+}
+
+connector::IcebergRowDeltaSinkProvider* get_iceberg_row_delta_sink_provider(
+        pipeline::ConnectorSinkOperatorFactory* connector_sink_factory) {
+    return dynamic_cast<connector::IcebergRowDeltaSinkProvider*>(connector_sink_factory->_data_sink_provider.get());
+}
+
+} // namespace
+
 TEST_F(IcebergTableSinkTest, decompose_to_pipeline) {
     TDescriptorTableBuilder table_desc_builder;
     TSlotDescriptorBuilder slot_desc_builder;
@@ -102,7 +118,8 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline) {
     pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
     pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+    ASSERT_NE(sink_ctx, nullptr);
     EXPECT_EQ(sink_ctx->sort_ordering->sort_key_idxes.size(), 1);
     EXPECT_EQ(sink_ctx->sort_ordering->sort_descs.descs.size(), 1);
 }
@@ -150,7 +167,8 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+        ASSERT_NE(sink_ctx, nullptr);
 
         // Should use data_location when it's set and not empty
         EXPECT_EQ(sink_ctx->path, "s3://bucket/data-location");
@@ -173,7 +191,8 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+        ASSERT_NE(sink_ctx, nullptr);
 
         // Should use location + "/data" when data_location is not set
         EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
@@ -196,7 +215,8 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+        ASSERT_NE(sink_ctx, nullptr);
 
         // Should use location + "/data" when data_location is empty
         EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
@@ -414,7 +434,8 @@ TEST_F(IcebergTableSinkTest, row_lineage_columns_extended_during_compaction) {
     pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
     pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+    ASSERT_NE(sink_ctx, nullptr);
 
     // Verify column_names was extended with row lineage columns
     ASSERT_EQ(sink_ctx->column_names.size(), 3);
@@ -500,7 +521,8 @@ TEST_F(IcebergTableSinkTest, row_lineage_field_ids_extended_when_column_names_al
     pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
     pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+    ASSERT_NE(sink_ctx, nullptr);
 
     ASSERT_EQ(sink_ctx->column_names.size(), 3);
     ASSERT_EQ(sink_ctx->parquet_field_ids.size(), 3);
@@ -584,7 +606,8 @@ TEST_F(IcebergTableSinkTest, row_lineage_field_ids_ignore_non_written_hidden_col
     pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
     pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
-    auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* sink_ctx = get_iceberg_chunk_sink_context(connector_sink_factory);
+    ASSERT_NE(sink_ctx, nullptr);
 
     ASSERT_EQ(sink_ctx->column_names.size(), 3);
     EXPECT_EQ(sink_ctx->column_names[0], "c1");
@@ -677,8 +700,9 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta_update) {
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
     ASSERT_NE(connector_sink_factory, nullptr);
 
-    auto* row_delta_ctx =
-            dynamic_cast<connector::IcebergRowDeltaSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* row_delta_provider = get_iceberg_row_delta_sink_provider(connector_sink_factory);
+    ASSERT_NE(row_delta_provider, nullptr);
+    auto* row_delta_ctx = row_delta_provider->_ctx.get();
     ASSERT_NE(row_delta_ctx, nullptr);
     EXPECT_EQ(row_delta_ctx->op_code_index, -1);
 
@@ -763,8 +787,9 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta_update_complex_type
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
     ASSERT_NE(connector_sink_factory, nullptr);
 
-    auto* row_delta_ctx =
-            dynamic_cast<connector::IcebergRowDeltaSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* row_delta_provider = get_iceberg_row_delta_sink_provider(connector_sink_factory);
+    ASSERT_NE(row_delta_provider, nullptr);
+    auto* row_delta_ctx = row_delta_provider->_ctx.get();
     ASSERT_NE(row_delta_ctx, nullptr);
 
     // The data-only tuple descriptor must preserve the full ARRAY<INT> type, children included.
@@ -859,8 +884,9 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
     auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
     ASSERT_NE(connector_sink_factory, nullptr);
 
-    auto* row_delta_ctx =
-            dynamic_cast<connector::IcebergRowDeltaSinkContext*>(connector_sink_factory->_sink_context.get());
+    auto* row_delta_provider = get_iceberg_row_delta_sink_provider(connector_sink_factory);
+    ASSERT_NE(row_delta_provider, nullptr);
+    auto* row_delta_ctx = row_delta_provider->_ctx.get();
     ASSERT_NE(row_delta_ctx, nullptr);
     ASSERT_NE(row_delta_ctx->delete_sink_ctx, nullptr);
     ASSERT_NE(row_delta_ctx->data_sink_ctx, nullptr);
@@ -886,11 +912,7 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline_row_delta) {
     EXPECT_EQ(row_delta_ctx->data_sink_ctx->parquet_field_ids[0].field_id, 1);
 
     // Now drive IcebergRowDeltaSinkProvider::create_chunk_sink() success path.
-    auto row_delta_shared_ctx =
-            std::dynamic_pointer_cast<connector::IcebergRowDeltaSinkContext>(connector_sink_factory->_sink_context);
-    ASSERT_NE(row_delta_shared_ctx, nullptr);
-    connector::IcebergRowDeltaSinkProvider provider(row_delta_shared_ctx);
-    auto sink_or = provider.create_chunk_sink(/*driver_id=*/0);
+    auto sink_or = row_delta_provider->create_chunk_sink(/*driver_id=*/0, {});
     ASSERT_OK(sink_or.status());
     auto created_sink = std::move(sink_or).value();
     ASSERT_NE(created_sink, nullptr);

--- a/be/test/exec/sink/connector_sink_operator_test.cpp
+++ b/be/test/exec/sink/connector_sink_operator_test.cpp
@@ -189,8 +189,7 @@ TEST_F(ConnectorSinkOperatorTest, test_factory) {
         sink_ctx->max_file_size = 1 << 30;
         sink_ctx->fragment_context = _fragment_context;
         auto provider = std::make_unique<connector::HiveChunkSinkProvider>(sink_ctx);
-        auto op_factory =
-                std::make_unique<ConnectorSinkOperatorFactory>(0, std::move(provider), sink_ctx, _fragment_context);
+        auto op_factory = std::make_unique<ConnectorSinkOperatorFactory>(0, std::move(provider), _fragment_context);
         auto op = op_factory->create(1, 0);
         EXPECT_OK(op->prepare(_runtime_state));
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
