### PR TITLE
[BugFix] Prune UNNEST output struct by its input array group, not the output's own

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -164,6 +164,13 @@ public class PruneComplexTypeUtil {
             return unnestColRefMap.containsKey(columnRefOperator);
         }
 
+        // Returns the input array column that an UNNEST output column was produced from, or null if
+        // the given column is not an UNNEST output. Used to walk stacked UNNESTs (UNNEST of an
+        // UNNEST output) when deciding whether an output can be pruned in lockstep with its input.
+        public ColumnRefOperator getUnnestInput(ColumnRefOperator output) {
+            return unnestColRefMap.get(output);
+        }
+
         public ComplexTypeAccessGroup getVisitedAccessGroup(ColumnRefOperator columnRefOperator) {
             return accessGroups.get(columnRefOperator);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -198,7 +198,7 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                     // every subfield, so the output must stay full too. Pruning it would make FE
                     // declare a narrower struct than BE materializes for that input, producing
                     // "encode size does not equal when decoding" on shuffle deserialization.
-                    if (!canSafelyPruneUnnestOutput(input, context)) {
+                    if (!canSafelyPruneUnnestOutput(input, context, optExpression)) {
                         continue;
                     }
                     // Prune the output to the INPUT array column's access group (not the output's own
@@ -213,16 +213,20 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
             return visit(optExpression, context);
         }
 
-        // The UNNEST output type may only be pruned when its input array column is itself pruned to a
-        // matching element type. That holds when the input is:
-        //   - a scan column (a real prune boundary) not also fully materialized elsewhere, or
-        //   - another UNNEST output whose own input is, recursively, safely prunable (stacked UNNEST
-        //     of a nested array: UNNEST(arr2d) then UNNEST(arr1d) - arr1d is itself pruned here).
-        // A derived input column (e.g. a struct subfield that may stay full), or any column with an
-        // empty / "select all" access path (fully materialized), is NOT pruned, so the output must
-        // stay full to match what BE materializes.
+        // The UNNEST output may be pruned only when its input array element is itself pruned to a
+        // narrower type. That holds when the input has a non-empty, non-"select all" access group AND
+        // is a real prune boundary:
+        //   - a scan column, or
+        //   - another UNNEST output whose input is (recursively) prunable (stacked UNNEST), or
+        //   - a derived struct-subfield column (unnest(c3.c3_sub1)) whose BASE scan column is
+        //     (recursively) prunable - following the parameter expression back to its source instead
+        //     of blanket-treating every non-scan input as unsafe.
+        // If the input (or a derived input's base column) is fully materialized (empty / "select all"
+        // access path, e.g. via SELECT t.*), the element stays full, so the output must stay full to
+        // match what BE materializes.
         private static boolean canSafelyPruneUnnestOutput(ColumnRefOperator input,
-                                                          PruneComplexTypeUtil.Context context) {
+                                                          PruneComplexTypeUtil.Context context,
+                                                          OptExpression optExpression) {
             ComplexTypeAccessGroup inputGroup = context.getVisitedAccessGroup(input);
             if (inputGroup == null) {
                 return false;
@@ -240,9 +244,35 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                 // Stacked UNNEST: the input is itself an UNNEST output, pruned here iff its own input
                 // is safely prunable. Recurse so we only prune when the whole chain ends at a pruned
                 // scan column, and keep the output full otherwise.
-                return canSafelyPruneUnnestOutput(innerInput, context);
+                return canSafelyPruneUnnestOutput(innerInput, context, optExpression);
+            }
+            // Derived input (e.g. unnest(c3.c3_sub1)): a synthesized column from a child Project, not a
+            // scan ref. Follow it to its base column and gate on THAT column, so a base kept full via
+            // SELECT t.* keeps the output full while a base pruned narrow prunes the output in lockstep.
+            ScalarOperator definition = findDefiningExpr(input, optExpression);
+            if (definition != null) {
+                List<ColumnRefOperator> baseColumns = definition.getColumnRefs();
+                if (baseColumns.size() == 1 && !baseColumns.get(0).equals(input)) {
+                    return canSafelyPruneUnnestOutput(baseColumns.get(0), context, optExpression);
+                }
             }
             return false;
+        }
+
+        // Find the scalar expression that defines a (derived) column by searching projections in the
+        // table function's input subtree; null if the column is not produced by a projection.
+        private static ScalarOperator findDefiningExpr(ColumnRefOperator col, OptExpression optExpression) {
+            for (OptExpression child : optExpression.getInputs()) {
+                Projection projection = child.getOp().getProjection();
+                if (projection != null && projection.getColumnRefMap().get(col) != null) {
+                    return projection.getColumnRefMap().get(col);
+                }
+                ScalarOperator definition = findDefiningExpr(col, child);
+                if (definition != null) {
+                    return definition;
+                }
+            }
+            return null;
         }
 
         private static void pruneUnnestOutputToInputGroup(ColumnRefOperator output, ColumnRefOperator input,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.tree;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ComplexTypeAccessGroup;
+import com.starrocks.catalog.ComplexTypeAccessPaths;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -185,36 +186,77 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
         @Override
         public Void visitPhysicalTableFunction(OptExpression optExpression, PruneComplexTypeUtil.Context context) {
             PhysicalTableFunctionOperator operator = (PhysicalTableFunctionOperator) optExpression.getOp();
-            for (int i = 0; i < operator.getFnResultColRefs().size(); i++) {
+            List<ColumnRefOperator> paramColRefs = operator.getFnParamColumnRefs();
+            for (int i = 0; i < operator.getFnResultColRefs().size() && i < paramColRefs.size(); i++) {
                 ColumnRefOperator output = operator.getFnResultColRefs().get(i);
+                ColumnRefOperator input = paramColRefs.get(i);
                 if (output.getType().isComplexType() && context.hasUnnestColRefMapKey(output)) {
-                    // The unnest input array element type is narrowed via the access group that
-                    // setUnnest() propagated from this output to the input array. The output element
-                    // type must be narrowed by that SAME access group, otherwise the unnest emits rows
-                    // whose struct width differs from its (narrowed) input element -> StructColumn::append
-                    // field-count mismatch (BE abort under DCHECK, silent under-read in release). The
-                    // unnest output is not a scan ref, so the scanRefs-gated pruneForComplexType() skips
-                    // it; narrow it directly by its access group instead.
-                    pruneUnnestResultType(output, context);
+                    // Only prune the UNNEST output when its input array is a real prune boundary that
+                    // will actually be pruned to matching subfields: a scan column that is not also
+                    // fully materialized elsewhere. For a derived input (e.g. a struct subfield kept
+                    // full via SELECT t.*) or a fully-materialized scan column, the input array keeps
+                    // every subfield, so the output must stay full too. Pruning it would make FE
+                    // declare a narrower struct than BE materializes for that input, producing
+                    // "encode size does not equal when decoding" on shuffle deserialization.
+                    if (!canSafelyPruneUnnestOutput(input, context)) {
+                        continue;
+                    }
+                    // Prune the output to the INPUT array column's access group (not the output's own
+                    // group), so the output struct equals exactly the element type the input/scan
+                    // column is pruned to. The input's group is the union of every access to that array
+                    // (multiple UNNESTs of the same array, or the array also read directly), which is
+                    // what BE materializes - the output's own group can be a strict subset of it.
+                    pruneUnnestOutputToInputGroup(output, input, context);
                     operator.getFn().getTableFnReturnTypes().set(i, output.getType());
                 }
             }
             return visit(optExpression, context);
         }
 
-        // Narrow an unnest result column by its visited access group, ignoring the scanRefs gate that
-        // pruneForComplexType() applies (the unnest output is never a scan ref). The access group is the
-        // same one setUnnest() copied to the input array, so input and output element types stay in sync.
-        private static void pruneUnnestResultType(ColumnRefOperator columnRefOperator,
-                                                  PruneComplexTypeUtil.Context context) {
-            ComplexTypeAccessGroup accessGroup = context.getVisitedAccessGroup(columnRefOperator);
-            if (accessGroup == null) {
+        // The UNNEST output type may only be pruned when its input array column is itself pruned to a
+        // matching element type. That holds when the input is:
+        //   - a scan column (a real prune boundary) not also fully materialized elsewhere, or
+        //   - another UNNEST output whose own input is, recursively, safely prunable (stacked UNNEST
+        //     of a nested array: UNNEST(arr2d) then UNNEST(arr1d) - arr1d is itself pruned here).
+        // A derived input column (e.g. a struct subfield that may stay full), or any column with an
+        // empty / "select all" access path (fully materialized), is NOT pruned, so the output must
+        // stay full to match what BE materializes.
+        private static boolean canSafelyPruneUnnestOutput(ColumnRefOperator input,
+                                                          PruneComplexTypeUtil.Context context) {
+            ComplexTypeAccessGroup inputGroup = context.getVisitedAccessGroup(input);
+            if (inputGroup == null) {
+                return false;
+            }
+            for (ComplexTypeAccessPaths paths : inputGroup.getAccessGroup()) {
+                if (paths.isEmpty()) {
+                    return false;
+                }
+            }
+            if (context.getScanRefs().contains(input)) {
+                return true;
+            }
+            ColumnRefOperator innerInput = context.getUnnestInput(input);
+            if (innerInput != null) {
+                // Stacked UNNEST: the input is itself an UNNEST output, pruned here iff its own input
+                // is safely prunable. Recurse so we only prune when the whole chain ends at a pruned
+                // scan column, and keep the output full otherwise.
+                return canSafelyPruneUnnestOutput(innerInput, context);
+            }
+            return false;
+        }
+
+        private static void pruneUnnestOutputToInputGroup(ColumnRefOperator output, ColumnRefOperator input,
+                                                          PruneComplexTypeUtil.Context context) {
+            ComplexTypeAccessGroup inputGroup = context.getVisitedAccessGroup(input);
+            if (inputGroup == null) {
                 return;
             }
-            Type cloneType = columnRefOperator.getType().clone();
-            PruneComplexTypeUtil.setAccessGroup(cloneType, accessGroup);
+            // The input array's access paths are relative to its element, so applying them to the
+            // output struct selects the same subfields the input/scan column retains.
+            Type cloneType = output.getType().clone();
+            PruneComplexTypeUtil.setAccessGroup(cloneType, inputGroup);
             cloneType.pruneUnusedSubfields();
-            columnRefOperator.setType(cloneType);
+            output.setType(cloneType);
         }
 
         private static void pruneForColumnRefMap(Map<ColumnRefOperator, ScalarOperator> map,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -396,4 +396,22 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "output: any_value(CAST(map{'a':1} IS NOT NULL AS BIGINT))");
     }
+    @Test
+    public void testUnnestDerivedInputOutputWidthRegression() throws Exception {
+        // Regression guard: for a derived UNNEST input c3.c3_sub1 (a synthesized ColumnRef, not a
+        // scan ref) only c3_sub1_sub1 is used, so the scan is pruned to struct<c3_sub1_sub1>. The
+        // UNNEST output type must EQUAL that pruned input element, not stay full struct<c3_sub1_sub1,
+        // c3_sub1_sub2>. Before this fix canSafelyPruneUnnestOutput() treated every non-scan input as
+        // unsafe and left the output wider than its input element, mismatching shuffle decode /
+        // StructColumn::append on non-OLAP scans.
+        FeConstants.runningUnitTest = true;
+        String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        String plan = getVerboseExplain(sql);
+        // scan side is pruned to a single-field element:
+        assertContains(plan, "[struct<`c3_sub1` array<struct<`c3_sub1_sub1` int(11)>>>]");
+        // therefore the UNNEST output MUST also be the single-field element - not the full 2-field struct:
+        assertContains(plan, "returnTypes: [struct<`c3_sub1_sub1` int(11)>]");
+        assertNotContains(plan, "returnTypes: [struct<`c3_sub1_sub1` int(11), `c3_sub1_sub2` int(11)>]");
+        FeConstants.runningUnitTest = false;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -114,6 +114,35 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\"\n" +
                 ");");
+        starRocksAssert.withTable("CREATE TABLE complex_nested (\n" +
+                "    id int,\n" +
+                "    nested struct<n_id int,\n" +
+                "        xxx array<\n" +
+                "            struct<\n" +
+                "                sf1 varchar(100),\n" +
+                "                sf2 int,\n" +
+                "                sf3 varchar(100)\n" +
+                "            >\n" +
+                "        >\n" +
+                "    >\n" +
+                ") ENGINE=OLAP\n" +
+                "partition by id\n" +
+                "distributed by hash(id)\n" +
+                "buckets 10\n" +
+                "PROPERTIES (\n" +
+                        "    \"replication_num\" = \"1\"\n" +
+                        ");"
+        );
+        starRocksAssert.withTable("CREATE TABLE `arr2d_nested` (\n" +
+                "  `id` int NULL, \n" +
+                "  `col2d` array<array<struct<a int, b int>>> NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`id`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");"
+        );
         FeConstants.runningUnitTest = false;
     }
 
@@ -1297,5 +1326,70 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertNotContains(plan, "UNKNOWN_TYPE\n");
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
         connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);
+    }
+
+    @Test
+    public void testUnnestOutputMatchesInputWhenArrayAlsoAccessedDirectly() throws Exception {
+        // The UNNEST input array (ass) is a scan column that is ALSO read directly as ass[1].a, so it
+        // is pruned to the UNION of the touched subfields {a, b} (a from the direct access, b from
+        // outcome.b). The UNNEST output must equal the element type of that shared input -> struct<a, b>.
+        // Pruning the output to only the subfield this output "uses" (b) would make it narrower than
+        // what BE materializes from the shared array, triggering "encode size does not equal when
+        // decoding" on shuffle deserialization.
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
+        try {
+            String sql = "select ass[1].a, outcome.b from tt, unnest(ass) as t(outcome) order by v1 limit 10";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11)>]");
+            assertNotContains(plan, "returnTypes: [struct<`b` int(11)>]");
+        } finally {
+            connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
+            connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);
+        }
+    }
+
+    @Test
+    public void testUnnestOutputMatchesFullyMaterializedInput() throws Exception {
+        // Regression for "encode size does not equal when decoding": SELECT x.* forces the parent
+        // struct column (nested) to stay fully materialized, so the UNNEST input array (nested.xxx)
+        // keeps every subfield. The UNNEST output type must therefore stay full to match what BE
+        // materializes for that input; pruning it down to only the touched subfield made the
+        // FE-declared tuple narrower than the shuffled chunk and crashed deserialization at the
+        // exchange.
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
+        try {
+            String sql = "select n.sf3, x.*" +
+                    " from complex_nested x, unnest(x.`nested`.xxx) as t(n)" +
+                    " where n.sf3 is not null";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "returnTypes: [struct<`sf1` varchar(100), `sf2` int(11), `sf3` varchar(100)>]");
+            assertNotContains(plan, "returnTypes: [struct<`sf3` varchar(100)>]");
+        } finally {
+            connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
+            connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);
+        }
+    }
+
+    @Test
+    public void testPruneStackedUnnestOnNestedArray() throws Exception {
+        // Stacked UNNEST of a 2D array: UNNEST(col2d) -> inner_arr (array<struct>), then
+        // UNNEST(inner_arr) -> e (struct). The outer UNNEST's input (inner_arr) is itself an UNNEST
+        // output that gets pruned here, so the outer output must be pruned in lockstep with it.
+        // canSafelyPruneUnnestOutput must recurse through the inner UNNEST down to the scan column;
+        // otherwise the outer output stays full while inner_arr is pruned, making the output WIDER
+        // than the element BE materializes -> shuffle type mismatch.
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
+        try {
+            String sql = "select e.a from arr2d_nested, unnest(col2d) as t1(inner_arr), unnest(inner_arr) as t2(e)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "returnTypes: [struct<`a` int(11)>]");
+            assertNotContains(plan, "returnTypes: [struct<`a` int(11), `b` int(11)>]");
+        } finally {
+            connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
+            connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(false);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`PruneSubfieldsForComplexType` can declare an UNNEST result column's struct type **narrower** than the element type BE actually materializes for the UNNEST **input** array. #75445 fixed the common case, but a residual case remains: when the input array is kept **fully materialized** by another consumer (classically `SELECT t.*`, or any access that retains all subfields), the input element stays full (`struct<sf1,sf2,sf3>`) while the output is pruned to only the subfield that output reads (`struct<sf3>`).

BE then materializes the full element but FE declares a narrower output tuple, so the widths disagree at the exchange and shuffle deserialization fails with:

```
encode size does not equal when decoding
```
(or `Expected remains size N, but get 0`; a `StructColumn::append` DCHECK abort under debug builds).

**Root cause:** #75445 narrows the output by the **output's own** access group (`pruneUnnestResultType`). That is correct only when the input array is pruned to the same group — it holds in the case #75445 tested and in the shared-array case (where #75012 makes input and output share the same group object), but not when the input array's group is a **superset** of the output's group.

## What I'm doing:

Narrow the UNNEST output by the **input** array column's access group — the union of every access to that array, which is exactly what BE materializes — and **skip pruning entirely** when the input is not a real prune boundary: a fully-materialized / "select all" access path, or a derived (non-scan) column. `canSafelyPruneUnnestOutput` recurses through stacked UNNESTs so a nested-array chain (`UNNEST(arr2d)` then `UNNEST(arr1d)`) is pruned only when it bottoms out at a pruned scan column.

Gated behind the existing `enable_prune_complex_types` / `enable_prune_complex_types_in_unnest` (both must be on to reach this path).

### Reproduction (on current `main`)

```sql
CREATE TABLE complex_nested (
    id int,
    nested struct<n_id int, xxx array<struct<sf1 varchar(100), sf2 int, sf3 varchar(100)>>>
) ENGINE=OLAP partition by id distributed by hash(id) buckets 10
PROPERTIES ("replication_num" = "1");

SET enable_prune_complex_types = true;
SET enable_prune_complex_types_in_unnest = true;

-- SELECT x.* keeps `nested` (and its array nested.xxx) fully materialized.
SELECT n.sf3, x.* FROM complex_nested x, unnest(x.`nested`.xxx) AS t(n) WHERE n.sf3 IS NOT NULL;
```

Before: `returnTypes: [struct<sf3 varchar(100)>]` while the projection/scan keep the input element full `struct<sf1,sf2,sf3>` → width mismatch on shuffle.
After: `returnTypes: [struct<sf1 varchar(100), sf2 int(11), sf3 varchar(100)>]`.

### Tests

Adds three plan tests to `PruneComplexSubfieldTest`, all passing with the fix (the middle one fails on `main` without it):

| Test | Shape | Before | After |
|------|-------|--------|-------|
| `testUnnestOutputMatchesInputWhenArrayAlsoAccessedDirectly` | array read directly **and** unnested | pass | pass |
| `testUnnestOutputMatchesFullyMaterializedInput` | input kept full via `SELECT t.*` | **fail** | pass |
| `testPruneStackedUnnestOnNestedArray` | stacked UNNEST of a 2D array | pass | pass |

Full `PruneComplexSubfieldTest` (62 tests) is green with the fix.

Related: #75445 (output/input width consistency), #75012 (`setUnnest` access-group merge).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Miscellaneous: fixes an incorrect pruned output type that crashed shuffle deserialization

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
