### PR TITLE
[Enhancement] Support UTC-adjusted Parquet TIMESTAMP and ORC TIMESTAMP_INSTANT sort keys on the tablet pre-split meta tier

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
@@ -145,8 +145,11 @@ public final class BrokerLoadPreSplitHook {
             PreSplitMetrics.recordEligibilitySkip(tableLevelSkip);
             return;
         }
+        // The load session timezone. This same context feeds JobSpec.fromBrokerLoadJobSpec ->
+        // loadPlanner.getContext() for the BE query globals, so it matches the offset the BE applies to
+        // a UTC-adjusted / TIMESTAMP_INSTANT value. A non-fixed zone -> the readers defer to data tier.
         BrokerLoadScanContext scanContext = new BrokerLoadScanContext(
-                brokerDesc, fileGroups, fileStatuses, computeResource);
+                brokerDesc, fileGroups, fileStatuses, computeResource, context.getSessionVariable().getTimeZone());
         PreSplitFlow.Prepared prepared = new PreSplitFlow.Prepared(
                 scanContext,
                 MetaUtils.getRangeDistributionColumns(targetTable),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
@@ -86,7 +86,7 @@ final class BrokerLoadRowGroupStatisticsProvider implements RowGroupStatisticsPr
                 MetaTierFormat format = MetaTierFormat.fromBrokerFormatType(
                         Load.getFormatType(declaredFormat, brokerFileStatus.path), brokerFileStatus.path);
                 FileStatus hadoopFileStatus = PreSplitHadoopAccess.toHadoopFileStatus(brokerFileStatus);
-                aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn));
+                aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn, context.loadTimeZone()));
             }
         }
         return aggregated;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadScanContext.java
@@ -38,12 +38,18 @@ import java.util.Objects;
  * <p>The {@code brokerDesc} may be {@code null} for HDFS-style direct loads
  * that don't go through a broker — matching the same nullability rule the
  * load planner already follows.
+ *
+ * <p>{@code loadTimeZone} is the load session timezone (the same value the BE
+ * query globals use). The meta-tier readers use it to reproduce the BE's
+ * offset for a UTC-adjusted / TIMESTAMP_INSTANT value; a non-fixed / null
+ * zone -> data tier.
  */
 public record BrokerLoadScanContext(
         BrokerDesc brokerDesc,
         List<BrokerFileGroup> fileGroups,
         List<List<TBrokerFileStatus>> fileStatusesPerGroup,
-        ComputeResource computeResource) implements ScanContext {
+        ComputeResource computeResource,
+        String loadTimeZone) implements ScanContext {
 
     public BrokerLoadScanContext {
         Objects.requireNonNull(fileGroups, "fileGroups");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
@@ -75,7 +75,8 @@ final class FilesPreSplitSource implements InsertPreSplitSource {
             return null;
         }
         InsertFromFilesScanContext scanContext =
-                new InsertFromFilesScanContext(sourceTable, context.getCurrentComputeResource());
+                new InsertFromFilesScanContext(sourceTable, context.getCurrentComputeResource(),
+                        context.getSessionVariable().getTimeZone());
         List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(target);
         List<Column> partitionColumns =
                 target.getPartitionInfo().getPartitionColumns(target.getIdToColumn());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProvider.java
@@ -58,7 +58,7 @@ final class InsertFromFilesRowGroupStatisticsProvider implements RowGroupStatist
                 continue;
             }
             FileStatus hadoopFileStatus = PreSplitHadoopAccess.toHadoopFileStatus(brokerFileStatus);
-            aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn));
+            aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn, context.loadTimeZone()));
         }
         return aggregated;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesScanContext.java
@@ -29,10 +29,15 @@ import java.util.Objects;
  * <p>This context is built BEFORE the load's {@code ExecPlan} exists, so it
  * carries the connector inputs directly rather than the planner's already-
  * built {@code FileScanNode}.
+ *
+ * <p>{@code loadTimeZone} is the load session timezone (the same value the BE
+ * query globals use). The meta-tier readers use it to reproduce the BE's
+ * offset for a UTC-adjusted timestamp; a non-fixed / null zone -> data tier.
  */
 public record InsertFromFilesScanContext(
         TableFunctionTable sourceTable,
-        ComputeResource computeResource) implements ScanContext {
+        ComputeResource computeResource,
+        String loadTimeZone) implements ScanContext {
 
     public InsertFromFilesScanContext {
         Objects.requireNonNull(sourceTable, "sourceTable");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
@@ -61,11 +61,11 @@ enum MetaTierFormat {
                 filePath, formatType));
     }
 
-    List<RowGroupStatistics> read(FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn)
-            throws StarRocksException {
+    List<RowGroupStatistics> read(FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn,
+            String loadTimeZone) throws StarRocksException {
         return switch (this) {
-            case PARQUET -> ParquetRowGroupStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn);
-            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn);
+            case PARQUET -> ParquetRowGroupStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn, loadTimeZone);
+            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn, loadTimeZone);
         };
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindow.java
@@ -16,8 +16,14 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.common.util.DateUtils;
 
+import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.zone.ZoneRules;
+import java.util.Optional;
 
 /**
  * The value window the meta tier accepts for DATE and DATETIME sort-key boundaries:
@@ -82,5 +88,38 @@ final class MetaTierTemporalWindow {
             return dateTime.format(DateUtils.DATE_TIME_FORMATTER_UNIX);
         }
         return dateTime.format(DateUtils.DATE_TIME_MS_FORMATTER_UNIX);
+    }
+
+    /**
+     * Resolve the load session timezone to the FIXED UTC offset the BE load applies when shifting a
+     * UTC-adjusted Parquet timestamp / ORC TIMESTAMP_INSTANT to a local DATETIME wall clock, or empty
+     * when the meta tier cannot safely reproduce that shift.
+     *
+     * <p>The BE adds the session-tz offset to the UTC instant (Parquet Int64ToDateTimeConverter when
+     * isAdjustedToUTC=true; ORC orc_ts_to_native_ts when is_instant=true). We can match that boundary
+     * only for a FIXED-OFFSET zone, where every instant (incl. pre-1970) gets the same constant offset,
+     * so adding it to the decoded UTC min/max is order-preserving. A DST / named zone applies a
+     * per-instant offset (the BE row load uses per-instant cctz), which one scalar cannot reproduce and
+     * which can even reorder wall clocks near a fall-back transition -- return empty so the reader defers
+     * to the data tier (never a wrong split). Named-zone aliases (CST/PRC) resolve to Asia/Shanghai, also
+     * non-fixed, so they defer too.
+     *
+     * <p>FE reproduces the exact BE zone: the FE stamps TQueryGlobals.time_zone from the session variable
+     * (CoordinatorPreprocessor.genQueryGlobals) and offset forms are canonicalized to +-HH:MM at SET time,
+     * so ZoneId.of parses them. Any unresolvable / non-fixed zone -> empty (fail-safe).
+     */
+    static Optional<ZoneOffset> fixedLoadOffset(String loadTimeZone) {
+        if (loadTimeZone == null || loadTimeZone.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            ZoneRules rules = ZoneId.of(loadTimeZone).getRules();
+            if (!rules.isFixedOffset()) {
+                return Optional.empty();
+            }
+            return Optional.of(rules.getOffset(Instant.EPOCH));
+        } catch (DateTimeException unresolvable) {
+            return Optional.empty();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -44,6 +44,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Reads one ORC file's footer and emits per-stripe min/max/row-count statistics
@@ -64,8 +65,11 @@ import java.util.Objects;
  *   <li>ORC TIMESTAMP (local, no timezone) → StarRocks DATETIME, using the tz-independent UTC stat,
  *       gated to {@code [0001-01-01, 9999-12-31]} (the load reconstructs the same wall clock — incl.
  *       a pre-1970 sub-second — and packs the calendar date through the same proleptic conversion as
- *       the boundary parse). TIMESTAMP_INSTANT is deferred (the load applies a session-tz offset this
- *       reader cannot reproduce).</li>
+ *       the boundary parse). No session-tz offset is applied to a plain TIMESTAMP.</li>
+ *   <li>ORC TIMESTAMP_INSTANT (timestamp with local time zone) -> StarRocks DATETIME, but ONLY when
+ *       the load session timezone is a fixed offset: the reader adds that constant offset (the same
+ *       one the BE load applies) to the tz-independent UTC stat to get the stored local wall clock.
+ *       A DST / named / unknown load timezone -> data tier.</li>
  *   <li>ORC STRING/VARCHAR -> StarRocks VARCHAR or CHAR, using the stripe min/max when ORC
  *       kept them exact (getMinimum()/getMaximum() non-null); a truncated bound (value
  *       > 1024 bytes -> getMinimum()/getMaximum() null) marks the stripe truncated -> data
@@ -76,8 +80,8 @@ import java.util.Objects;
  *       a '\0' is rejected -> data tier (the BE truncates a CHAR boundary at the first NUL). The
  *       ORC CHAR source category (space-padded in its own stats) stays deferred -> data tier.</li>
  * </ul>
- * Everything else -- BOOLEAN, FLOAT/DOUBLE, TIMESTAMP_INSTANT (load applies a session-tz offset this
- * reader cannot reproduce), non-matching-precision/scale DECIMAL, ORC CHAR, and any complex type --
+ * Everything else -- BOOLEAN, FLOAT/DOUBLE, TIMESTAMP_INSTANT under a non-fixed-offset load timezone,
+ * non-matching-precision/scale DECIMAL, ORC CHAR, and any complex type --
  * makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier. That is
  * NOT a load failure. Pure I/O failures surface as {@link StarRocksException}.
@@ -104,7 +108,8 @@ public final class OrcStripeStatisticsReader {
         // the same way via HadoopInputFile.fromStatus).
         try (Reader reader = OrcFile.createReader(
                 fileStatus.getPath(), OrcFile.readerOptions(hadoopConfig).maxLength(fileStatus.getLen()))) {
-            SortKeyLocation location = locateSortKeyColumn(reader.getSchema(), sortKeyColumn);
+            Optional<ZoneOffset> loadOffset = MetaTierTemporalWindow.fixedLoadOffset(loadTimeZone);
+            SortKeyLocation location = locateSortKeyColumn(reader.getSchema(), sortKeyColumn, loadOffset);
             List<StripeStatistics> stripeStatistics = reader.getStripeStatistics();
             List<StripeInformation> stripes = reader.getStripes();
             if (stripeStatistics.size() != stripes.size()) {
@@ -125,8 +130,8 @@ public final class OrcStripeStatisticsReader {
         }
     }
 
-    private static SortKeyLocation locateSortKeyColumn(TypeDescription schema, Column sortKeyColumn)
-            throws MetaTierUnavailableException {
+    private static SortKeyLocation locateSortKeyColumn(TypeDescription schema, Column sortKeyColumn,
+            Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
         List<String> fieldNames = schema.getFieldNames();
         List<TypeDescription> fieldTypes = schema.getChildren();
         if (fieldNames == null || fieldTypes == null) {
@@ -154,10 +159,15 @@ public final class OrcStripeStatisticsReader {
                     "ORC schema does not contain sort-key column \"" + columnName + "\"");
         }
         TypeDescription fieldType = fieldTypes.get(fieldIndex);
-        rejectIncompatibleTypeMapping(fieldType, sortKeyColumn);
+        rejectIncompatibleTypeMapping(fieldType, sortKeyColumn, loadOffset);
+        // TIMESTAMP_INSTANT is stored by the BE as a local wall clock = UTC instant + the fixed
+        // session-tz offset. The gate accepted it only when loadOffset is present, so capture that
+        // constant offset to apply per stripe; plain TIMESTAMP (and every other type) leaves it null.
+        ZoneOffset instantOffset = fieldType.getCategory() == TypeDescription.Category.TIMESTAMP_INSTANT
+                ? loadOffset.orElse(null) : null;
         // ORC assigns column ids in schema pre-order; getColumnStatistics() is
         // indexed by that id (index 0 is the struct root).
-        return new SortKeyLocation(fieldType.getId(), sortKeyColumn);
+        return new SortKeyLocation(fieldType.getId(), sortKeyColumn, instantOffset);
     }
 
     /**
@@ -171,7 +181,8 @@ public final class OrcStripeStatisticsReader {
      * deferred (fall back to data tier).
      */
     private static void rejectIncompatibleTypeMapping(
-            TypeDescription fieldType, Column sortKeyColumn) throws MetaTierUnavailableException {
+            TypeDescription fieldType, Column sortKeyColumn, Optional<ZoneOffset> loadOffset)
+            throws MetaTierUnavailableException {
         TypeDescription.Category orcCategory = fieldType.getCategory();
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (orcCategory) {
@@ -184,6 +195,9 @@ public final class OrcStripeStatisticsReader {
             // Plain ORC TIMESTAMP is local (no timezone); the BE load stores its UTC wall clock
             // verbatim (no session-tz offset, unlike TIMESTAMP_INSTANT) → StarRocks DATETIME.
             case TIMESTAMP -> starRocksPrimitive == PrimitiveType.DATETIME;
+            // TIMESTAMP_INSTANT (timestamp with local time zone): the BE adds the session-tz offset.
+            // Match the boundary only for a fixed-offset load timezone (loadOffset present) -- else data tier.
+            case TIMESTAMP_INSTANT -> starRocksPrimitive == PrimitiveType.DATETIME && loadOffset.isPresent();
             // ORC STRING/VARCHAR source categories are unpadded; their stripe min/max are
             // unsigned-byte-ordered (Text/WritableComparator), matching BE routing. A CHAR target
             // is safe too: the BE right-pads a CHAR routing key with '\0' to its fixed width before
@@ -378,6 +392,13 @@ public final class OrcStripeStatisticsReader {
             // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateStripe.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
+            if (location.instantOffset != null) {
+                // TIMESTAMP_INSTANT: add the fixed session-tz offset to the UTC instant to get the
+                // stored local wall clock -- matching the BE load. Plain TIMESTAMP (instantOffset null)
+                // is stored verbatim. A constant offset is monotonic, so min/max ordering is preserved.
+                minDateTime = minDateTime.plusSeconds(location.instantOffset.getTotalSeconds());
+                maxDateTime = maxDateTime.plusSeconds(location.instantOffset.getTotalSeconds());
+            }
             MetaTierTemporalWindow.rejectOutsideWindow(minDateTime.toLocalDate());
             MetaTierTemporalWindow.rejectOutsideWindow(maxDateTime.toLocalDate());
             minVariant = Variant.of(location.starRocksColumn.getType(), MetaTierTemporalWindow.renderDateTime(minDateTime));
@@ -400,6 +421,6 @@ public final class OrcStripeStatisticsReader {
         return LocalDateTime.ofEpochSecond(epochSecond, utcTimestamp.getNanos(), ZoneOffset.UTC);
     }
 
-    private record SortKeyLocation(int columnId, Column starRocksColumn) {
+    private record SortKeyLocation(int columnId, Column starRocksColumn, ZoneOffset instantOffset) {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -91,7 +91,8 @@ public final class OrcStripeStatisticsReader {
     }
 
     public static List<RowGroupStatistics> read(
-            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn) throws StarRocksException {
+            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn, String loadTimeZone)
+            throws StarRocksException {
         Objects.requireNonNull(fileStatus, "fileStatus");
         Objects.requireNonNull(hadoopConfig, "hadoopConfig");
         Objects.requireNonNull(sortKeyColumn, "sortKeyColumn");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -112,7 +112,8 @@ public final class ParquetRowGroupStatisticsReader {
     }
 
     public static List<RowGroupStatistics> read(
-            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn) throws StarRocksException {
+            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn, String loadTimeZone)
+            throws StarRocksException {
         Objects.requireNonNull(fileStatus, "fileStatus");
         Objects.requireNonNull(hadoopConfig, "hadoopConfig");
         Objects.requireNonNull(sortKeyColumn, "sortKeyColumn");

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -55,6 +55,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Reads one Parquet file's footer and emits per-row-group min/max/row-count
@@ -69,9 +70,11 @@ import java.util.Objects;
  *   <li>Unannotated Parquet INT32/INT64 → StarRocks TINYINT/SMALLINT/INT/BIGINT</li>
  *   <li>Unannotated Parquet BOOLEAN → StarRocks BOOLEAN</li>
  *   <li>Parquet INT32 with DATE annotation → StarRocks DATE</li>
- *   <li>Parquet INT64 with TIMESTAMP annotation, {@code isAdjustedToUTC=false}
- *       (MILLIS/MICROS/NANOS) → StarRocks DATETIME. UTC-adjusted timestamps are
- *       deferred (the load applies a session-tz offset this reader cannot reproduce).</li>
+ *   <li>Parquet INT64 with a TIMESTAMP annotation (MILLIS/MICROS/NANOS) -> StarRocks DATETIME.
+ *       A non-UTC-adjusted (local) timestamp is stored verbatim. A UTC-adjusted
+ *       ({@code isAdjustedToUTC=true}) timestamp reaches the meta tier only when the load session
+ *       timezone is a fixed offset: the reader then adds that constant offset (the same one the BE
+ *       load applies) to the decoded UTC value. A DST / named / unknown load timezone -> data tier.</li>
  *   <li>Parquet BINARY with UTF8 (string) annotation -> StarRocks VARCHAR or CHAR
  *       (footer min/max are decoded as UTF-8 and used directly; FE compares them in the
  *       same unsigned-byte order the BE uses to route rows). CHAR is safe even though the BE
@@ -97,7 +100,8 @@ import java.util.Objects;
  * {@code floorDiv}/{@code floorMod} split computes (it borrows a whole second for a negative
  * sub-second remainder), so the boundary is FE/BE-identical down to year 1
  * (see {@link MetaTierTemporalWindow}).
- * Anything else (UINT_64, signed INT_8/16/32 annotations, UTC-adjusted/INT96 timestamps, JSON,
+ * Anything else (UINT_64, signed INT_8/16/32 annotations, INT96 timestamps, UTC-adjusted timestamps
+ * under a non-fixed-offset load timezone, JSON,
  * BSON, UUID, FLOAT, DOUBLE, byte-array DECIMAL without a footer-declared TypeDefinedOrder,
  * raw BINARY for VARBINARY) makes the reader throw
  * {@link MetaTierUnavailableException} so the pipeline falls back to data tier — not a
@@ -122,8 +126,9 @@ public final class ParquetRowGroupStatisticsReader {
             HadoopInputFile inputFile = HadoopInputFile.fromStatus(fileStatus, hadoopConfig);
             try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
                 ParquetMetadata metadata = reader.getFooter();
+                Optional<ZoneOffset> loadOffset = MetaTierTemporalWindow.fixedLoadOffset(loadTimeZone);
                 SortKeyLocation location = locateSortKeyColumn(
-                        metadata.getFileMetaData().getSchema(), inputFile, sortKeyColumn);
+                        metadata.getFileMetaData().getSchema(), inputFile, sortKeyColumn, loadOffset);
                 List<BlockMetaData> blocks = metadata.getBlocks();
                 List<RowGroupStatistics> rowGroupStatistics = new ArrayList<>(blocks.size());
                 for (BlockMetaData block : blocks) {
@@ -138,8 +143,8 @@ public final class ParquetRowGroupStatisticsReader {
         }
     }
 
-    private static SortKeyLocation locateSortKeyColumn(MessageType schema, InputFile inputFile, Column sortKeyColumn)
-            throws MetaTierUnavailableException {
+    private static SortKeyLocation locateSortKeyColumn(MessageType schema, InputFile inputFile, Column sortKeyColumn,
+            Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
         String columnName = sortKeyColumn.getName();
         int fieldIndex = -1;
         for (int i = 0; i < schema.getFieldCount(); i++) {
@@ -179,8 +184,17 @@ public final class ParquetRowGroupStatisticsReader {
             typeDefinedColumnOrder = declaresTypeDefinedColumnOrder(
                     readColumnOrders(inputFile), leafColumnIndex(schema, path));
         }
-        rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, typeDefinedColumnOrder, sortKeyColumn);
-        return new SortKeyLocation(path, parquetTypeName, logicalAnnotation, sortKeyColumn);
+        rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, typeDefinedColumnOrder, sortKeyColumn,
+                loadOffset);
+        // A UTC-adjusted INT64 TIMESTAMP is stored by the BE as a local wall clock = UTC instant + the
+        // fixed session-tz offset. The gate above accepted it only when loadOffset is present, so capture
+        // that constant offset to apply per row group; every other mapping leaves it null (no shift).
+        ZoneOffset utcAdjustedOffset = null;
+        if (logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation
+                && timestampAnnotation.isAdjustedToUTC()) {
+            utcAdjustedOffset = loadOffset.orElse(null);
+        }
+        return new SortKeyLocation(path, parquetTypeName, logicalAnnotation, sortKeyColumn, utcAdjustedOffset);
     }
 
     /**
@@ -200,7 +214,8 @@ public final class ParquetRowGroupStatisticsReader {
             PrimitiveTypeName parquetTypeName,
             LogicalTypeAnnotation logicalAnnotation,
             boolean typeDefinedColumnOrder,
-            Column sortKeyColumn) throws MetaTierUnavailableException {
+            Column sortKeyColumn,
+            Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
         PrimitiveType starRocksPrimitive = sortKeyColumn.getType().getPrimitiveType();
         boolean compatible = switch (parquetTypeName) {
             case INT32 -> {
@@ -233,11 +248,12 @@ public final class ParquetRowGroupStatisticsReader {
                     yield starRocksPrimitive.isIntegerType();
                 }
                 if (logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
-                    // Only local (non-UTC-adjusted) timestamps: the load stores those ticks
-                    // verbatim as the DATETIME wall clock, so the FE-rendered boundary matches.
-                    // UTC-adjusted timestamps get a session-tz offset at load time → data tier.
-                    yield !timestampAnnotation.isAdjustedToUTC()
-                            && starRocksPrimitive == PrimitiveType.DATETIME;
+                    // Local (non-UTC-adjusted) timestamps store their ticks verbatim as the DATETIME
+                    // wall clock. UTC-adjusted timestamps get a session-tz offset at load time; the meta
+                    // tier can match that boundary only for a fixed-offset load timezone (loadOffset
+                    // present) -- otherwise data tier.
+                    yield starRocksPrimitive == PrimitiveType.DATETIME
+                            && (!timestampAnnotation.isAdjustedToUTC() || loadOffset.isPresent());
                 }
                 // INT64-backed DECIMAL: same signed-order safety as INT32. Exact precision/scale.
                 yield logicalAnnotation instanceof DecimalLogicalTypeAnnotation decimalAnnotation
@@ -326,7 +342,13 @@ public final class ParquetRowGroupStatisticsReader {
         if (location.logicalAnnotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation) {
             long ticks = ((Number) parquetValue).longValue();
             LocalDateTime dateTime = epochTicksToUtcDateTime(ticks, timestampAnnotation.getUnit());
-            // A pre-1970 (negative) tick is now in window: epochTicksToUtcDateTime's floorDiv/floorMod
+            if (timestampAnnotation.isAdjustedToUTC()) {
+                // UTC-adjusted ticks are a UTC instant; add the fixed session-tz offset (captured on the
+                // location, guaranteed present for an accepted UTC-adjusted timestamp) to get the stored
+                // local wall clock -- matching the BE load. A non-UTC-adjusted tick is already local.
+                dateTime = dateTime.plusSeconds(location.utcAdjustedOffset.getTotalSeconds());
+            }
+            // A pre-1970 (negative) tick is in window too: epochTicksToUtcDateTime's floorDiv/floorMod
             // split matches the BE timestamp load, so the boundary equals the loaded value
             // (see MetaTierTemporalWindow).
             MetaTierTemporalWindow.rejectOutsideWindow(dateTime.toLocalDate());
@@ -520,6 +542,6 @@ public final class ParquetRowGroupStatisticsReader {
 
     private record SortKeyLocation(
             ColumnPath path, PrimitiveTypeName parquetTypeName,
-            LogicalTypeAnnotation logicalAnnotation, Column starRocksColumn) {
+            LogicalTypeAnnotation logicalAnnotation, Column starRocksColumn, ZoneOffset utcAdjustedOffset) {
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
@@ -139,7 +139,7 @@ class BrokerLoadRowGroupStatisticsProviderTest {
         SampleRequest request = new SampleRequest(
                 new InsertFromFilesScanContext(
                         Mockito.mock(com.starrocks.catalog.TableFunctionTable.class),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -163,7 +163,7 @@ class BrokerLoadRowGroupStatisticsProviderTest {
                         brokerBackedDesc,
                         List.of(parquetFileGroup()),
                         List.of(List.of(brokerFileStatus(parquetPath))),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -178,7 +178,7 @@ class BrokerLoadRowGroupStatisticsProviderTest {
                         /*brokerDesc=*/ null,
                         List.of(parquetFileGroup()),
                         List.of(List.<TBrokerFileStatus>of()),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -216,7 +216,7 @@ class BrokerLoadRowGroupStatisticsProviderTest {
         Mockito.when(brokerDesc.getProperties()).thenReturn(new HashMap<>());
         return new SampleRequest(
                 new BrokerLoadScanContext(
-                        brokerDesc, fileGroups, fileStatusesPerGroup, Mockito.mock(ComputeResource.class)),
+                        brokerDesc, fileGroups, fileStatusesPerGroup, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadSampleSubqueryExecutorTest.java
@@ -309,7 +309,7 @@ class BrokerLoadSampleSubqueryExecutorTest {
         SampleRequest request = new SampleRequest(
                 new InsertFromFilesScanContext(
                         Mockito.mock(com.starrocks.catalog.TableFunctionTable.class),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -334,7 +334,7 @@ class BrokerLoadSampleSubqueryExecutorTest {
                         new BrokerDesc(Map.of()),
                         List.of(mockFileGroup("parquet")),
                         List.of(List.of(brokerFileStatus("s3://b/x.parquet", 1024L))),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("tenant"), bigintColumn("position")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -366,7 +366,7 @@ class BrokerLoadSampleSubqueryExecutorTest {
                         new BrokerDesc(Map.of()),
                         List.of(mockFileGroup("parquet")),
                         List.of(List.of(brokerFileStatus("s3://b/x.parquet", 1024L))),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(groupId, nullableTrailing),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -396,7 +396,7 @@ class BrokerLoadSampleSubqueryExecutorTest {
                         new BrokerDesc(Map.of()),
                         List.of(mockFileGroup("parquet")),
                         List.of(List.of(brokerFileStatus("s3://b/x.parquet", 1024L))),
-                        expectedComputeResource),
+                        expectedComputeResource, "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -418,7 +418,7 @@ class BrokerLoadSampleSubqueryExecutorTest {
             List<List<TBrokerFileStatus>> fileStatusesPerGroup) {
         return new SampleRequest(
                 new BrokerLoadScanContext(brokerDesc, fileGroups, fileStatusesPerGroup,
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/FilesSampleSubqueryExecutorPartitionColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/FilesSampleSubqueryExecutorPartitionColumnTest.java
@@ -136,7 +136,7 @@ class FilesSampleSubqueryExecutorPartitionColumnTest {
                             "{\"data\":[2, \"2026-05-27\"]}"));
                 });
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 /*sortKey=*/ List.of(bigintColumn("user_id")),
                 /*partitionSourceColumns=*/ List.of(varcharColumn("ts")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
@@ -172,7 +172,7 @@ class FilesSampleSubqueryExecutorPartitionColumnTest {
                         "{\"data\":[20, \"west\"]}")));
         ReservoirSampler sampler = new ReservoirSampler(executor);
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 /*sortKey=*/ List.of(bigintColumn("user_id")),
                 /*partitionSourceColumns=*/ List.of(varcharColumn("region")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
@@ -205,7 +205,7 @@ class FilesSampleSubqueryExecutorPartitionColumnTest {
                 /*sampleQueryRunner=*/ (sql, computeResource, ignoredQueryTimeoutSeconds) -> List.of(jsonResultBatch(
                         "{\"data\":[1, \"east\", \"unexpected\"]}")));
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 /*sortKey=*/ List.of(bigintColumn("user_id")),
                 /*partitionSourceColumns=*/ List.of(varcharColumn("region")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
@@ -237,7 +237,7 @@ class FilesSampleSubqueryExecutorPartitionColumnTest {
         // bigintColumn(...) is non-nullable by default, used here as the
         // partition-source slot so a null cell hits the non-nullable branch.
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 /*sortKey=*/ List.of(bigintColumn("user_id")),
                 /*partitionSourceColumns=*/ List.of(bigintColumn("region_id")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
@@ -91,7 +91,7 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
 
         TableFunctionTable orcSourceTable = mockTableFunctionTable("orc", List.of(brokerFileStatus(orcPath)));
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(orcSourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(orcSourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -106,7 +106,7 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
     void nonParquetFormatFallsBackToDataTier() throws Exception {
         TableFunctionTable csvSourceTable = mockTableFunctionTable("csv", Collections.emptyList());
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(csvSourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(csvSourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -119,7 +119,7 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
         SampleRequest request = new SampleRequest(
                 new BrokerLoadScanContext(
                         null, Collections.emptyList(), Collections.emptyList(),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -147,7 +147,7 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
     private SampleRequest bigintSampleRequest(List<TBrokerFileStatus> fileStatuses, long byteLimit) {
         TableFunctionTable sourceTable = mockTableFunctionTable("parquet", fileStatuses);
         return new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 byteLimit,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesSampleSubqueryExecutorTest.java
@@ -94,7 +94,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
                         /*brokerDesc=*/ null,
                         List.of(),
                         List.of(),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -161,7 +161,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
                         "{\"data\":[null]}", "{\"data\":[42]}")));
 
         SampleSubqueryExecutor.SampleExecution execution = executor.execute(new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(nullableSortKey), /*sampleByteLimit=*/ Long.MAX_VALUE, /*seed=*/ 0L));
 
         List<SampleRow> rows = Lists.newArrayList(execution.rows());
@@ -280,7 +280,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
                             "{\"data\":[100, 300]}"));
                 });
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("tenant"), bigintColumn("position")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -309,7 +309,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
                 /*sampleQueryRunner=*/ (sql, computeResource, ignoredQueryTimeoutSeconds) ->
                         List.of(jsonResultBatch("{\"data\":[100]}")));
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("tenant"), bigintColumn("position")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -332,7 +332,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
 
         // 25_600 bytes / 256 bytes-per-row estimate = 100 rows, well below the 200_000 hard cap.
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ 25_600L,
                 /*seed=*/ 0L);
@@ -356,7 +356,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
                     return List.of();
                 });
         SampleRequest request = new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, expectedComputeResource),
+                new InsertFromFilesScanContext(sourceTable, expectedComputeResource, "UTC"),
                 List.of(bigintColumn("sort_key")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);
@@ -457,7 +457,7 @@ class InsertFromFilesSampleSubqueryExecutorTest {
 
     private static SampleRequest bigintRequest(TableFunctionTable sourceTable, Column sortKeyColumn) {
         return new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(sortKeyColumn),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutorTest.java
@@ -176,7 +176,7 @@ class InsertFromTableSampleSubqueryExecutorTest {
                         /*brokerDesc=*/ null,
                         List.of(),
                         List.of(),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("k")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -248,7 +248,7 @@ public class InsertPreSplitHookFilesPartitionedTest {
      */
     private static PreSplitFlow.Prepared filesPrepared() {
         InsertFromFilesScanContext scanContext =
-                new InsertFromFilesScanContext(mock(TableFunctionTable.class), mock(ComputeResource.class));
+                new InsertFromFilesScanContext(mock(TableFunctionTable.class), mock(ComputeResource.class), "UTC");
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         List<Column> partitionColumns = List.of(bigintColumn("p_col"));
         return new PreSplitFlow.Prepared(scanContext, sortKey, partitionColumns,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InternalPartitionSampleSubqueryExecutorTest.java
@@ -185,7 +185,7 @@ class InternalPartitionSampleSubqueryExecutorTest {
                         /*brokerDesc=*/ null,
                         List.of(),
                         List.of(),
-                        Mockito.mock(ComputeResource.class)),
+                        Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(bigintColumn("k")),
                 /*sampleByteLimit=*/ Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
+import java.util.Optional;
 
 public class MetaTierTemporalWindowTest {
 
@@ -97,5 +98,31 @@ public class MetaTierTemporalWindowTest {
         String yearOneText = MetaTierTemporalWindow.renderDateTime(yearOne);
         Assertions.assertEquals("0001-01-01 00:00:00.000001", yearOneText);
         Assertions.assertEquals(yearOne, DateUtils.parseStrictDateTime(yearOneText));
+    }
+
+    @Test
+    void fixedOffsetZoneResolvesToConstantOffset() {
+        Assertions.assertEquals(ZoneOffset.ofHoursMinutes(8, 0),
+                MetaTierTemporalWindow.fixedLoadOffset("+08:00").orElseThrow());
+        Assertions.assertEquals(ZoneOffset.UTC,
+                MetaTierTemporalWindow.fixedLoadOffset("UTC").orElseThrow());
+        Assertions.assertEquals(ZoneOffset.ofHours(-5),
+                MetaTierTemporalWindow.fixedLoadOffset("-05:00").orElseThrow());
+    }
+
+    @Test
+    void namedOrDstOrAliasZoneResolvesToEmpty() {
+        // DST / named zones apply a per-instant offset the meta tier cannot reproduce with one scalar.
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset("America/New_York").isEmpty());
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset("Asia/Shanghai").isEmpty());
+        // CST resolves (via FE) to Asia/Shanghai, itself non-fixed; ZoneId.of("CST") throws -- either way empty.
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset("CST").isEmpty());
+    }
+
+    @Test
+    void nullEmptyOrUnparseableZoneResolvesToEmpty() {
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset(null).isEmpty());
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset("").isEmpty());
+        Assertions.assertTrue(MetaTierTemporalWindow.fixedLoadOffset("not-a-zone").isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/MetaTierTemporalWindowTest.java
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Locale;
-import java.util.Optional;
 
 public class MetaTierTemporalWindowTest {
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcMetaTierIntegrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcMetaTierIntegrationTest.java
@@ -107,7 +107,7 @@ class OrcMetaTierIntegrationTest {
         Mockito.when(sourceTable.getProperties()).thenReturn(new HashMap<>());
         Mockito.when(sourceTable.loadFileList()).thenReturn(new ArrayList<>(files));
         return new SampleRequest(
-                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class)),
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -56,7 +56,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -87,7 +87,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex + 100);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("region_id", IntegerType.INT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("region_id", IntegerType.INT), null);
 
         long globalMin = Long.MAX_VALUE;
         long globalMax = Long.MIN_VALUE;
@@ -110,7 +110,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         Assertions.assertNotNull(stripeStatistics.get(0).getMinTuple());
@@ -125,7 +125,7 @@ class OrcStripeStatisticsReaderTest {
                         .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -154,7 +154,7 @@ class OrcStripeStatisticsReaderTest {
                         .setVal(batchRow, (longPrefix + rowIndex).getBytes(StandardCharsets.UTF_8)));
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         for (RowGroupStatistics stripe : stripeStatistics) {
@@ -179,7 +179,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)));
+                new Column("tenant", TypeFactory.createCharType(16)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -210,7 +210,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("tenant", VarcharType.VARCHAR)));
+                        new Column("tenant", VarcharType.VARCHAR), null));
     }
 
     @Test
@@ -227,7 +227,7 @@ class OrcStripeStatisticsReaderTest {
         // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
         List<RowGroupStatistics> charStats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)));
+                new Column("tenant", TypeFactory.createCharType(16)), null);
         Assertions.assertFalse(charStats.isEmpty());
         for (RowGroupStatistics stripe : charStats) {
             Assertions.assertEquals("a", stripe.getMinTuple().getValues().get(0).getStringValue());
@@ -237,7 +237,7 @@ class OrcStripeStatisticsReaderTest {
         // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
         List<RowGroupStatistics> varcharStats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", VarcharType.VARCHAR));
+                new Column("tenant", VarcharType.VARCHAR), null);
         Assertions.assertFalse(varcharStats.isEmpty());
         for (RowGroupStatistics stripe : varcharStats) {
             Assertions.assertTrue(stripe.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
@@ -255,7 +255,7 @@ class OrcStripeStatisticsReaderTest {
         // DOUBLE is outside the meta-tier mapping window even for a numeric sort key.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("payload", IntegerType.BIGINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("payload", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -270,7 +270,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("region_id", VarcharType.VARCHAR)));
+                        new Column("region_id", VarcharType.VARCHAR), null));
     }
 
     @Test
@@ -284,7 +284,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("missing_sort_key", IntegerType.BIGINT)));
+                        new Column("missing_sort_key", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -301,7 +301,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT)));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -317,7 +317,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("wide_value", IntegerType.TINYINT)));
+                        new Column("wide_value", IntegerType.TINYINT), null));
     }
 
     @Test
@@ -336,7 +336,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         long totalRowCount = 0L;
         for (RowGroupStatistics stripe : stripeStatistics) {
@@ -355,7 +355,7 @@ class OrcStripeStatisticsReaderTest {
                 (batch, batchRow, rowIndex) -> { });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         Assertions.assertTrue(stripeStatistics.isEmpty());
     }
@@ -370,7 +370,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -401,7 +401,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_day", IntegerType.BIGINT)));
+                        new Column("event_day", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -417,7 +417,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -441,7 +441,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = -1 - rowIndex);
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1969-12-31",
@@ -459,7 +459,7 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = -171499);
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1500-06-15",
@@ -481,7 +481,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertFalse(stats.isEmpty());
         String globalMin = null;
@@ -517,7 +517,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals("1970-01-01 00:00:01.500123",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -540,7 +540,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME)));
+                        new Column("event_ts", DateType.DATETIME), null));
     }
 
     @Test
@@ -558,7 +558,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", IntegerType.BIGINT)));
+                        new Column("event_ts", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -578,7 +578,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1969-12-31 23:59:58",
@@ -608,7 +608,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         String min = stats.get(0).getMinTuple().getValues().get(0).getStringValue();
         Assertions.assertTrue(min.startsWith("1969-12-31 23:59:5"), "expected a pre-1970 datetime, got " + min);
@@ -632,7 +632,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1500-06-15 12:00:00",
@@ -655,7 +655,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME)));
+                        new Column("event_ts", DateType.DATETIME), null));
     }
 
     @Test
@@ -669,7 +669,7 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertFalse(stats.isEmpty());
         long totalRowCount = 0L;
@@ -692,7 +692,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         // Assert on BigDecimal VALUE, not the exact string: ORC's decimal-stats round-trip may
         // normalize trailing-zero scale ("1.00" vs "1"). Both are accepted downstream because the
@@ -722,7 +722,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         // Value-based comparison (ORC may render scale as "1" vs "1.00"); proves signed order.
         BigDecimal globalMin = null;
@@ -756,7 +756,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         BigDecimal globalMin = null;
@@ -783,7 +783,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
     }
 
     @Test
@@ -797,7 +797,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))));
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2)), null));
     }
 
     @Test
@@ -811,7 +811,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", IntegerType.BIGINT)));
+                        new Column("d", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -827,7 +827,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         long totalRowCount = 0L;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -525,8 +525,8 @@ class OrcStripeStatisticsReaderTest {
 
     @Test
     void timestampInstantFallsBackToDataTier() throws Exception {
-        // TIMESTAMP_INSTANT (timestamp with local time zone) gets a session-tz offset at load time
-        // that this reader cannot reproduce → defer to data tier.
+        // No load timezone (null) -> no fixed offset -> the meta tier cannot match the BE session-tz
+        // offset for a TIMESTAMP_INSTANT, so it defers to the data tier.
         Path orcPath = writeOrc(
                 "struct<event_ts:timestamp with local time zone>",
                 /*rowCount=*/ 2,
@@ -541,6 +541,120 @@ class OrcStripeStatisticsReaderTest {
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME), null));
+    }
+
+    @Test
+    void timestampInstantWithFixedOffsetReachesMetaTier() throws Exception {
+        // TIMESTAMP_INSTANT stores the UTC instant; a +08:00 load adds a constant +8h offset (BE does the
+        // same for a fixed-offset zone). getMinimumUTC() = raw UTC millis; 1000ms = 1970-01-01 00:00:01 UTC
+        // -> 1970-01-01 08:00:01 local; +1000ms/row.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
+                /*rowCount=*/ 3,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = (rowIndex + 1) * 1000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("event_ts", DateType.DATETIME), "+08:00");
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics stripe : stats) {
+            Assertions.assertFalse(stripe.isTruncated());
+            String minValue = stripe.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = stripe.getMaxTuple().getValues().get(0).getStringValue();
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("1970-01-01 08:00:01", globalMin);
+        Assertions.assertTrue(globalMax.startsWith("1970-01-01 08:00:03"), "unexpected max " + globalMax);
+    }
+
+    @Test
+    void timestampInstantWithFixedOffsetKeepsMicroseconds() throws Exception {
+        // Sub-second must survive the offset add. time=1000ms + nanos=500123000 = 1.500123 s UTC; +8h ->
+        // 1970-01-01 08:00:01.500123 local.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = 1000L;
+                    vector.nanos[batchRow] = 500_123_000;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                new Column("event_ts", DateType.DATETIME), "+08:00");
+
+        Assertions.assertEquals("1970-01-01 08:00:01.500123",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void timestampInstantWithDstZoneFallsBackToDataTier() throws Exception {
+        // A DST zone applies a per-instant offset the meta tier cannot reproduce with one scalar -> data tier.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
+                /*rowCount=*/ 2,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = (rowIndex + 1) * 1000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "America/New_York"));
+    }
+
+    @Test
+    void timestampInstantOffsetCrossesDate() throws Exception {
+        // The offset must roll the calendar date. UTC 1970-01-01 20:00:00 (time=72000000 ms) + 08:00 ->
+        // 1970-01-02 04:00:00 local.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = 72_000_000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertEquals("1970-01-02 04:00:00",
+                OrcStripeStatisticsReader.read(PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "+08:00")
+                        .get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void timestampInstantOutsideWindowAfterOffsetFallsBackToDataTier() throws Exception {
+        // The window gate runs on the OFFSET-ADJUSTED local date. MAX time 253402300799000 ms =
+        // 9999-12-31 23:59:59 UTC; +08:00 -> year 10000 -> data tier.
+        Path orcPath = writeOrc(
+                "struct<event_ts:timestamp with local time zone>",
+                /*rowCount=*/ 1,
+                (batch, batchRow, rowIndex) -> {
+                    TimestampColumnVector vector = (TimestampColumnVector) batch.cols[0];
+                    vector.setIsUTC(true);
+                    vector.time[batchRow] = 253_402_300_799_000L;
+                    vector.nanos[batchRow] = 0;
+                });
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                OrcStripeStatisticsReader.read(
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "+08:00"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -255,7 +255,8 @@ class OrcStripeStatisticsReaderTest {
         // DOUBLE is outside the meta-tier mapping window even for a numeric sort key.
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("payload", IntegerType.BIGINT), null));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("payload", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -301,7 +302,8 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
-                        PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null));
+                        PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                        new Column("sort_key", IntegerType.BIGINT), null));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -578,8 +578,8 @@ class ParquetRowGroupStatisticsReaderTest {
 
     @Test
     void utcAdjustedTimestampFallsBackToDataTier() throws Exception {
-        // isAdjustedToUTC=true: the load applies a session-tz offset the FE reader cannot
-        // reproduce here, so meta tier must defer to data tier rather than risk an offset boundary.
+        // No load timezone (null) -> no fixed offset resolvable -> the meta tier cannot match the BE's
+        // session-tz offset for a UTC-adjusted timestamp, so it defers to the data tier.
         Path parquetPath = writeParquet(
                 timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
                 /*rowCount=*/ 2,
@@ -589,6 +589,104 @@ class ParquetRowGroupStatisticsReaderTest {
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
                         new Column("event_ts", DateType.DATETIME), null));
+    }
+
+    @Test
+    void utcAdjustedTimestampWithFixedOffsetReachesMetaTier() throws Exception {
+        // isAdjustedToUTC=true stores the UTC instant; a +08:00 load adds a constant +8h offset (the BE
+        // does the same for a fixed-offset zone). epoch milli 0 -> 1970-01-01 08:00:00 local; +1000ms/row.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("event_ts", DateType.DATETIME), "+08:00");
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMin = null;
+        String globalMax = null;
+        for (RowGroupStatistics rowGroup : stats) {
+            Assertions.assertFalse(rowGroup.isTruncated());
+            String minValue = rowGroup.getMinTuple().getValues().get(0).getStringValue();
+            String maxValue = rowGroup.getMaxTuple().getValues().get(0).getStringValue();
+            globalMin = (globalMin == null || minValue.compareTo(globalMin) < 0) ? minValue : globalMin;
+            globalMax = (globalMax == null || maxValue.compareTo(globalMax) > 0) ? maxValue : globalMax;
+        }
+        Assertions.assertEquals("1970-01-01 08:00:00", globalMin);
+        Assertions.assertEquals("1970-01-01 08:00:02", globalMax);
+    }
+
+    @Test
+    void utcAdjustedTimestampWithFixedOffsetKeepsMicroseconds() throws Exception {
+        // MICROS sub-second must survive the offset add. tick 1_500_123 us = 1.500123 s UTC; +8h ->
+        // 1970-01-01 08:00:01.500123 local.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MICROS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 1_500_123L));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                new Column("event_ts", DateType.DATETIME), "+08:00");
+
+        Assertions.assertEquals("1970-01-01 08:00:01.500123",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void utcAdjustedTimestampWithDstZoneFallsBackToDataTier() throws Exception {
+        // A DST zone applies a per-instant offset the meta tier cannot reproduce with one scalar -> data tier.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "America/New_York"));
+    }
+
+    @Test
+    void utcAdjustedTimestampOffsetCrossesDate() throws Exception {
+        // The offset must roll the calendar date, not just the time. UTC 1969-12-31 20:00:00
+        // (tick -14400000 ms) + 08:00 -> 1970-01-01 04:00:00 local; and a negative offset rolls back:
+        // UTC 1970-01-01 02:00:00 (tick 7200000) + (-05:00) -> 1969-12-31 21:00:00 local.
+        Path plusPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", -14_400_000L));
+        Assertions.assertEquals("1970-01-01 04:00:00",
+                ParquetRowGroupStatisticsReader.read(PresplitTestSupport.statusOf(plusPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "+08:00")
+                        .get(0).getMinTuple().getValues().get(0).getStringValue());
+
+        Path minusPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 7_200_000L));
+        Assertions.assertEquals("1969-12-31 21:00:00",
+                ParquetRowGroupStatisticsReader.read(PresplitTestSupport.statusOf(minusPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "-05:00")
+                        .get(0).getMinTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void utcAdjustedTimestampOutsideWindowAfterOffsetFallsBackToDataTier() throws Exception {
+        // The window gate runs on the OFFSET-ADJUSTED local date. A UTC value inside [0001,9999] can be
+        // pushed past 9999-12-31 by a positive offset -> data tier (the BE would store an out-of-domain
+        // DATETIME). MAX MILLIS tick 253402300799000 = 9999-12-31 23:59:59 UTC; +08:00 -> year 10000.
+        Path parquetPath = writeParquet(
+                timestampSchema(LogicalTypeAnnotation.TimeUnit.MILLIS, /*isAdjustedToUTC=*/ true),
+                /*rowCount=*/ 1,
+                (group, rowIndex) -> group.append("event_ts", 253_402_300_799_000L));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        new Column("event_ts", DateType.DATETIME), "+08:00"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -57,7 +57,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("sort_key", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -88,7 +88,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         String globalMin = null;
@@ -121,7 +121,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)));
+                new Column("tenant", TypeFactory.createCharType(16)), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         String globalMin = null;
@@ -150,7 +150,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
         List<RowGroupStatistics> charStats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)));
+                new Column("tenant", TypeFactory.createCharType(16)), null);
         Assertions.assertFalse(charStats.isEmpty());
         for (RowGroupStatistics rowGroup : charStats) {
             Assertions.assertEquals("a", rowGroup.getMinTuple().getValues().get(0).getStringValue());
@@ -160,7 +160,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
         List<RowGroupStatistics> varcharStats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", VarcharType.VARCHAR));
+                new Column("tenant", VarcharType.VARCHAR), null);
         Assertions.assertFalse(varcharStats.isEmpty());
         for (RowGroupStatistics rowGroup : varcharStats) {
             Assertions.assertTrue(rowGroup.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
@@ -180,7 +180,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("opaque_bytes", VarcharType.VARCHAR)));
+                        new Column("opaque_bytes", VarcharType.VARCHAR), null));
     }
 
     @Test
@@ -191,7 +191,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("region_id", rowIndex + 100));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("region_id", IntegerType.INT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("region_id", IntegerType.INT), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("100", rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -206,7 +206,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("flag", rowIndex % 2 == 0));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("flag", BooleanType.BOOLEAN));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("flag", BooleanType.BOOLEAN), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals(2L, rowGroupStatistics.get(0).getRowCount());
@@ -222,7 +222,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("missing_sort_key", IntegerType.BIGINT)));
+                        new Column("missing_sort_key", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -237,7 +237,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("payload", IntegerType.BIGINT)));
+                        new Column("payload", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -251,7 +251,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("region_id", VarcharType.VARCHAR)));
+                        new Column("region_id", VarcharType.VARCHAR), null));
     }
 
     @Test
@@ -270,7 +270,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("sort_key", IntegerType.BIGINT)));
+                        new Column("sort_key", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -286,7 +286,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("wide_value", IntegerType.TINYINT)));
+                        new Column("wide_value", IntegerType.TINYINT), null));
     }
 
     @Test
@@ -300,7 +300,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("keepalive", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         RowGroupStatistics only = rowGroupStatistics.get(0);
@@ -320,7 +320,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertFalse(rowGroupStatistics.get(0).isTruncated());
@@ -342,7 +342,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", IntegerType.BIGINT)));
+                        new Column("event_day", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -356,7 +356,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -1 - rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("1969-12-31",
@@ -373,7 +373,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -171499));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("1500-06-15",
@@ -389,7 +389,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -719162));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("0001-01-01",
@@ -407,7 +407,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", DateType.DATE)));
+                        new Column("event_day", DateType.DATE), null));
     }
 
     @Test
@@ -419,7 +419,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", 2932896));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("9999-12-31",
@@ -437,7 +437,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", DateType.DATE)));
+                        new Column("event_day", DateType.DATE), null));
     }
 
     private static MessageType timestampSchema(LogicalTypeAnnotation.TimeUnit unit, boolean isAdjustedToUTC) {
@@ -464,7 +464,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -483,7 +483,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
@@ -501,7 +501,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000_500L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -519,7 +519,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", -2000L + rowIndex * 1000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("1969-12-31 23:59:58",
@@ -538,7 +538,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", -500L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals("1969-12-31 23:59:59.500000",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -556,7 +556,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", millis));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
 
         Assertions.assertEquals("1500-06-15 12:00:00",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -573,7 +573,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME)));
+                        new Column("event_ts", DateType.DATETIME), null));
     }
 
     @Test
@@ -588,7 +588,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME)));
+                        new Column("event_ts", DateType.DATETIME), null));
     }
 
     @Test
@@ -601,7 +601,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", IntegerType.BIGINT)));
+                        new Column("event_ts", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -614,7 +614,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -633,7 +633,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -652,7 +652,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("-2.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -670,7 +670,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
     }
 
     @Test
@@ -684,7 +684,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))));
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2)), null));
     }
 
     @Test
@@ -698,7 +698,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", IntegerType.BIGINT)));
+                        new Column("d", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -714,7 +714,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -750,7 +750,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -780,7 +780,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 2)));
+                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 2)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -802,7 +802,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))));
+                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
     }
 
     @Test
@@ -839,7 +839,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 250 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.SMALLINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.SMALLINT), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -854,7 +854,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 65530 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT), null);
 
         Assertions.assertEquals("65530", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("65534", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
@@ -869,7 +869,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", (int) (3_000_000_000L + rowIndex)));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.BIGINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.BIGINT), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -886,7 +886,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("u", IntegerType.BIGINT)));
+                        new Column("u", IntegerType.BIGINT), null));
     }
 
     @Test
@@ -898,7 +898,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("u", IntegerType.INT)));
+                        new Column("u", IntegerType.INT), null));
     }
 
     @Test
@@ -909,7 +909,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 2_000_000_000 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("2000000000", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -924,7 +924,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 100 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.TINYINT));
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.TINYINT), null);
 
         Assertions.assertEquals("100", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("104", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split has a "meta tier" that plans split boundaries from
Parquet/ORC footer statistics (no sub-query), falling back to a "data tier"
sub-query for types it cannot decode safely. Two high-frequency timestamp
flavors were still rejected by the meta tier and paid the data-tier cost:

- **Parquet INT64 TIMESTAMP with `isAdjustedToUTC=true`** -- the default modern
  Parquet writing (Spark / pyarrow with a timezone), a UTC-normalized instant.
- **ORC `TIMESTAMP_INSTANT`** (timestamp with local time zone).

Both are the same case: the BE load adds the load session-timezone offset to the
stored UTC instant to obtain the local DATETIME wall clock, so the footer's raw
UTC min/max did not match the value the BE routes/stores, and the reader
conservatively deferred to the data tier. This was the last common gap in the
meta-tier type coverage line (DATE/DATETIME/DECIMAL/VARCHAR/CHAR/local-TIMESTAMP
already covered).

## What I'm doing:

FE-only. When the load session timezone resolves to a **fixed offset**, the two
footer readers reproduce the exact offset the BE load applies and lift these two
flavors onto the meta tier:

- New shared helper `MetaTierTemporalWindow.fixedLoadOffset(String)` resolves the
  load timezone to a constant `ZoneOffset` **only** for a fixed-offset zone
  (`ZoneId.getRules().isFixedOffset()`, offset sampled at `Instant.EPOCH`);
  a DST / named / alias (CST, PRC) / unresolvable / absent timezone returns empty.
- `ParquetRowGroupStatisticsReader` accepts INT64 + TIMESTAMP with
  `isAdjustedToUTC=true`, and `OrcStripeStatisticsReader` accepts
  `TIMESTAMP_INSTANT`, **only** when that fixed offset is present; each decodes the
  raw UTC footer min/max, adds the constant offset (order-preserving, so min/max
  are preserved), then applies the existing `[0001-01-01, 9999-12-31]` window gate
  on the offset-adjusted **local** date.
- The load timezone is threaded from each load kind's scan context, sourced from
  the pre-split hook's own `ConnectContext` session timezone -- the same object
  `JobSpec` builds the BE query globals from -- so the FE boundary and the BE
  stored value use the identical timezone by construction, for both
  INSERT-from-FILES and Broker Load.

**Conservative first version (fail-safe):** only fixed-offset load timezones are
lifted. A DST / named zone (including the FE default `Asia/Shanghai`) applies a
per-instant offset the BE row load computes with cctz that a single scalar cannot
reproduce; those keep using the data tier. Any unresolvable case -> data tier.
Getting the meta tier for these types therefore requires an explicit fixed-offset
`SET time_zone` (e.g. `+08:00`). Pre-split boundaries are advisory: the BE routes
every row by its true value, so this is never a wrong split or a load failure.

**Behavior change: No.** This only changes which planning tier computes the
split boundaries (footer stats vs sub-query); the loaded data, the resulting
tablet layout (by value), and all user-facing surfaces are unchanged.

Verified: 197 focused FE unit tests pass (fixed-offset accept + correct offset
boundary, sub-second preserved, offset crossing the date, DST/named/null rejected,
out-of-window-after-offset rejected, both load kinds); `mvn checkstyle` clean.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
