### PR TITLE
[BugFix] Fix PARTITION-TOP-N partition-by rewritten to pruned dict slot (backport #75956)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -357,9 +357,12 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         List<ColumnRefOperator> newPartitionByColumns = null;
 
         if (topN.getPartitionByColumns() != null) {
-            newPartitionByColumns =
-                    topN.getPartitionByColumns().stream().map(c -> context.stringRefToDictRefMap.getOrDefault(c, c))
-                            .collect(Collectors.toList());
+            // only rewrite to the dict ref when the column still arrives at this TopN in dict
+            // form; a column decoded below (e.g. under a join) must keep its string ref
+            newPartitionByColumns = topN.getPartitionByColumns().stream()
+                    .map(c -> info.inputStringColumns.contains(c.getId())
+                            ? context.stringRefToDictRefMap.getOrDefault(c, c) : c)
+                    .collect(Collectors.toList());
         }
 
         Map<ColumnRefOperator, CallOperator> preAggCall = null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriterTest.java
@@ -14,7 +14,8 @@
 
 package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
 
-import com.starrocks.qe.SessionVariable;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -26,8 +27,6 @@ import com.starrocks.sql.optimizer.operator.SortPhase;
 import com.starrocks.sql.optimizer.operator.TopNType;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.type.IntegerType;
-import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,7 @@ public class DecodeRewriterTest {
                 1,
                 SortPhase.FINAL,
                 TopNType.ROW_NUMBER,
-                false, false, false,
+                false, false,
                 null, null, null);
     }
 
@@ -58,8 +57,8 @@ public class DecodeRewriterTest {
     @Test
     public void testTopNPartitionColumnDecodedBelowKeepsStringRef() {
         ColumnRefFactory factory = new ColumnRefFactory();
-        ColumnRefOperator stringRef = factory.create("s", TypeFactory.createVarcharType(128), true);
-        ColumnRefOperator dictRef = factory.create("s", IntegerType.INT, true);
+        ColumnRefOperator stringRef = factory.create("s", ScalarType.createVarcharType(128), true);
+        ColumnRefOperator dictRef = factory.create("s", Type.INT, true);
 
         DecodeContext context = new DecodeContext(factory);
         context.stringRefToDictRefMap.put(stringRef, dictRef);
@@ -69,7 +68,7 @@ public class DecodeRewriterTest {
         // arrive in dict form, so inputStringColumns stays empty
         context.operatorDecodeInfo.put(topN, DecodeInfo.create());
 
-        DecodeRewriter rewriter = new DecodeRewriter(factory, context, new SessionVariable());
+        DecodeRewriter rewriter = new DecodeRewriter(factory, context);
         OptExpression result = rewriter.visitPhysicalTopN(newOptExpression(topN), new ColumnRefSet());
 
         PhysicalTopNOperator newTopN = result.getOp().cast();
@@ -82,8 +81,8 @@ public class DecodeRewriterTest {
     @Test
     public void testTopNPartitionColumnInDictFormRewrittenToDictRef() {
         ColumnRefFactory factory = new ColumnRefFactory();
-        ColumnRefOperator stringRef = factory.create("s", TypeFactory.createVarcharType(128), true);
-        ColumnRefOperator dictRef = factory.create("s", IntegerType.INT, true);
+        ColumnRefOperator stringRef = factory.create("s", ScalarType.createVarcharType(128), true);
+        ColumnRefOperator dictRef = factory.create("s", Type.INT, true);
 
         DecodeContext context = new DecodeContext(factory);
         context.stringRefToDictRefMap.put(stringRef, dictRef);
@@ -94,7 +93,7 @@ public class DecodeRewriterTest {
         info.inputStringColumns.union(new ColumnRefSet(stringRef.getId()));
         context.operatorDecodeInfo.put(topN, info);
 
-        DecodeRewriter rewriter = new DecodeRewriter(factory, context, new SessionVariable());
+        DecodeRewriter rewriter = new DecodeRewriter(factory, context);
         OptExpression result = rewriter.visitPhysicalTopN(newOptExpression(topN), new ColumnRefSet());
 
         PhysicalTopNOperator newTopN = result.getOp().cast();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriterTest.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree.lowcardinality;
+
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.base.LogicalProperty;
+import com.starrocks.sql.optimizer.base.OrderSpec;
+import com.starrocks.sql.optimizer.base.Ordering;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.SortPhase;
+import com.starrocks.sql.optimizer.operator.TopNType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class DecodeRewriterTest {
+
+    private static PhysicalTopNOperator newPartitionTopN(ColumnRefOperator partitionRef) {
+        return new PhysicalTopNOperator(
+                new OrderSpec(List.of(new Ordering(partitionRef, true, true))),
+                Operator.DEFAULT_LIMIT, 0,
+                List.of(partitionRef),
+                1,
+                SortPhase.FINAL,
+                TopNType.ROW_NUMBER,
+                false, false, false,
+                null, null, null);
+    }
+
+    private static OptExpression newOptExpression(Operator op) {
+        return OptExpression.builder()
+                .setOp(op)
+                .setInputs(List.of())
+                .setLogicalProperty(new LogicalProperty(new ColumnRefSet()))
+                .build();
+    }
+
+    @Test
+    public void testTopNPartitionColumnDecodedBelowKeepsStringRef() {
+        ColumnRefFactory factory = new ColumnRefFactory();
+        ColumnRefOperator stringRef = factory.create("s", TypeFactory.createVarcharType(128), true);
+        ColumnRefOperator dictRef = factory.create("s", IntegerType.INT, true);
+
+        DecodeContext context = new DecodeContext(factory);
+        context.stringRefToDictRefMap.put(stringRef, dictRef);
+
+        PhysicalTopNOperator topN = newPartitionTopN(stringRef);
+        // the column was decoded below this TopN (e.g. under a join): it does NOT
+        // arrive in dict form, so inputStringColumns stays empty
+        context.operatorDecodeInfo.put(topN, DecodeInfo.create());
+
+        DecodeRewriter rewriter = new DecodeRewriter(factory, context, new SessionVariable());
+        OptExpression result = rewriter.visitPhysicalTopN(newOptExpression(topN), new ColumnRefSet());
+
+        PhysicalTopNOperator newTopN = result.getOp().cast();
+        // partition-by must keep the string ref; the dict slot does not exist here and
+        // referencing it fails on BE with "slot_id not found"
+        Assertions.assertEquals(List.of(stringRef), newTopN.getPartitionByColumns());
+        Assertions.assertEquals(stringRef, newTopN.getOrderSpec().getOrderDescs().get(0).getColumnRef());
+    }
+
+    @Test
+    public void testTopNPartitionColumnInDictFormRewrittenToDictRef() {
+        ColumnRefFactory factory = new ColumnRefFactory();
+        ColumnRefOperator stringRef = factory.create("s", TypeFactory.createVarcharType(128), true);
+        ColumnRefOperator dictRef = factory.create("s", IntegerType.INT, true);
+
+        DecodeContext context = new DecodeContext(factory);
+        context.stringRefToDictRefMap.put(stringRef, dictRef);
+
+        PhysicalTopNOperator topN = newPartitionTopN(stringRef);
+        // the column arrives at this TopN still in dict form
+        DecodeInfo info = DecodeInfo.create();
+        info.inputStringColumns.union(new ColumnRefSet(stringRef.getId()));
+        context.operatorDecodeInfo.put(topN, info);
+
+        DecodeRewriter rewriter = new DecodeRewriter(factory, context, new SessionVariable());
+        OptExpression result = rewriter.visitPhysicalTopN(newOptExpression(topN), new ColumnRefSet());
+
+        PhysicalTopNOperator newTopN = result.getOp().cast();
+        Assertions.assertEquals(List.of(dictRef), newTopN.getPartitionByColumns());
+        Assertions.assertEquals(dictRef, newTopN.getOrderSpec().getOrderDescs().get(0).getColumnRef());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2410,16 +2410,17 @@ public class LowCardinalityTest2 extends PlanTestBase {
                     ") y WHERE rn = 1";
             String plan = getVerboseExplain(sql);
             Assertions.assertEquals(2, plan.split("PARTITION-TOP-N", -1).length - 1, plan);
-            // `s` keeps its dict form through the join up to the outer window, so both
-            // PARTITION-TOP-N and both ANALYTIC nodes must agree on the same dict ref;
-            // a partition-by referencing a dict ref already decoded below would fail on
-            // BE with "slot_id not found"
-            assertContains(plan, "  10:PARTITION-TOP-N\n" +
-                    "  |  partition by: [10: s, INT, true]");
-            assertContains(plan, "  13:ANALYTIC\n" +
+            // on branch-3.5 the inner window's Decode sits below the join, so `s` arrives
+            // at the outer window already decoded; the outer PARTITION-TOP-N and ANALYTIC
+            // must keep the string ref — a partition-by referencing the dict ref already
+            // decoded below would fail on BE with "slot_id not found"
+            assertContains(plan, "  11:PARTITION-TOP-N\n" +
+                    "  |  partition by: [3: s, VARCHAR(128), true]");
+            assertContains(plan, "  14:ANALYTIC\n" +
                     "  |  functions: [, row_number[(); args: ; result: BIGINT; " +
                     "args nullable: false; result nullable: true], ]\n" +
-                    "  |  partition by: [10: s, INT, true]");
+                    "  |  partition by: [3: s, VARCHAR(128), true]");
+            // the inner PARTITION-TOP-N still consumes `s` in dict form and keeps the dict ref
             assertContains(plan, "  1:PARTITION-TOP-N\n" +
                     "  |  partition by: [10: s, INT, true]");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2376,6 +2376,81 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testPartitionTopNPartitionByDecodedColumnKeepsStringRef() throws Exception {
+        boolean enablePipelineEngine = connectContext.getSessionVariable().isEnablePipelineEngine();
+        starRocksAssert.withTable("CREATE TABLE `topn_decoded_fact` (\n" +
+                "  `id` bigint NOT NULL,\n" +
+                "  `pid` bigint,\n" +
+                "  `s` varchar(128),\n" +
+                "  `ts` datetime\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+        starRocksAssert.withTable("CREATE TABLE `topn_decoded_map` (\n" +
+                "  `id` bigint NOT NULL,\n" +
+                "  `pid` bigint,\n" +
+                "  `m` varchar(128)\n" +
+                ") ENGINE=OLAP DUPLICATE KEY(`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 16\n" +
+                "PROPERTIES (\"replication_num\" = \"1\")");
+        try {
+            connectContext.getSessionVariable().setEnablePipelineEngine(true);
+            // The inner window consumes `s` in dict form, so its Decode sits below the join.
+            // The outer ranking-window filter becomes a PARTITION-TOP-N above the join whose
+            // partition-by column must keep the string ref of `s` — rewriting it to the dict
+            // ref would reference a slot already pruned below (slot_id not found on BE).
+            String sql = "SELECT m, rn FROM (\n" +
+                    "  SELECT t.s, r.m,\n" +
+                    "         row_number() over (partition by t.s order by t.s) rn\n" +
+                    "  FROM (\n" +
+                    "    SELECT pid, s FROM (\n" +
+                    "      SELECT pid, s, row_number() over (partition by s order by ts) rn2\n" +
+                    "      FROM topn_decoded_fact\n" +
+                    "    ) x WHERE rn2 = 1\n" +
+                    "  ) t\n" +
+                    "  LEFT JOIN topn_decoded_map r ON r.pid = t.pid\n" +
+                    ") y WHERE rn = 1";
+            String plan = getVerboseExplain(sql);
+            Assertions.assertEquals(2, plan.split("PARTITION-TOP-N", -1).length - 1, plan);
+            // `s` keeps its dict form through the join up to the outer window, so both
+            // PARTITION-TOP-N and both ANALYTIC nodes must agree on the same dict ref;
+            // a partition-by referencing a dict ref already decoded below would fail on
+            // BE with "slot_id not found"
+            assertContains(plan, "  10:PARTITION-TOP-N\n" +
+                    "  |  partition by: [10: s, INT, true]");
+            assertContains(plan, "  13:ANALYTIC\n" +
+                    "  |  functions: [, row_number[(); args: ; result: BIGINT; " +
+                    "args nullable: false; result nullable: true], ]\n" +
+                    "  |  partition by: [10: s, INT, true]");
+            assertContains(plan, "  1:PARTITION-TOP-N\n" +
+                    "  |  partition by: [10: s, INT, true]");
+
+            // lead() with a non-null default disables the dict form of `s` below the join,
+            // so `s` arrives at the outer PARTITION-TOP-N already decoded; its partition-by
+            // must keep the string ref — the dict slot no longer exists at that point and
+            // referencing it fails on BE with "slot_id not found"
+            String decodedSql = "SELECT m, rn FROM (\n" +
+                    "  SELECT t.s, r.m,\n" +
+                    "         row_number() over (partition by t.s order by t.s) rn\n" +
+                    "  FROM (\n" +
+                    "    SELECT pid, s FROM (\n" +
+                    "      SELECT pid, s, lead(s, 1, 'NONE') over (partition by pid order by ts) nxt\n" +
+                    "      FROM topn_decoded_fact\n" +
+                    "    ) x WHERE nxt != 'ZZZ'\n" +
+                    "  ) t\n" +
+                    "  LEFT JOIN topn_decoded_map r ON r.pid = t.pid\n" +
+                    ") y WHERE rn = 1";
+            String decodedPlan = getVerboseExplain(decodedSql);
+            int topnIdx = decodedPlan.indexOf("PARTITION-TOP-N");
+            Assertions.assertTrue(topnIdx > 0, decodedPlan);
+            String topnSection = decodedPlan.substring(topnIdx,
+                    decodedPlan.indexOf("order by", topnIdx));
+            Assertions.assertTrue(topnSection.contains(": s, VARCHAR"), decodedPlan);
+            Assertions.assertFalse(topnSection.contains(": s, INT"), decodedPlan);
+        } finally {
+            connectContext.getSessionVariable().setEnablePipelineEngine(enablePipelineEngine);
+        }
+    }
+
+    @Test
     public void testShuffleJoinWithDistributionCheck() throws Exception {
         FeConstants.runningUnitTest = true;
         try {

--- a/test/sql/test_low_cardinality/R/test_partition_topn_decoded_partition_column
+++ b/test/sql/test_low_cardinality/R/test_partition_topn_decoded_partition_column
@@ -1,0 +1,103 @@
+-- name: test_partition_topn_decoded_partition_column
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = true;
+-- result:
+-- !result
+CREATE TABLE `topn_decoded_fact` (
+  `id` bigint NOT NULL,
+  `pid` bigint NULL,
+  `s` varchar(128) NULL,
+  `ts` datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `topn_decoded_map` (
+  `id` bigint NOT NULL,
+  `pid` bigint NULL,
+  `m` varchar(128) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into topn_decoded_fact
+select
+    generate_series,
+    generate_series,
+    concat('S', generate_series % 2),
+    seconds_add('2026-01-01 00:00:00', generate_series)
+from TABLE(generate_series(0, 299));
+-- result:
+-- !result
+insert into topn_decoded_map
+select
+    generate_series,
+    generate_series % 300,
+    concat('M', generate_series % 2)
+from TABLE(generate_series(0, 599));
+-- result:
+-- !result
+[UC] analyze full table topn_decoded_fact;
+[UC] analyze full table topn_decoded_map;
+function: wait_global_dict_ready('s', 'topn_decoded_fact')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('m', 'topn_decoded_map')
+-- result:
+
+-- !result
+function: assert_explain_contains('SELECT s, m, rn FROM (SELECT t.s, r.m, row_number() over (partition by t.s order by t.s, r.m) rn FROM (SELECT pid, s FROM (SELECT pid, s, row_number() over (partition by s order by ts) rn2 FROM topn_decoded_fact) x WHERE rn2 = 1) t LEFT JOIN topn_decoded_map r ON r.pid = t.pid) y WHERE rn = 1', 'PARTITION-TOP-N')
+-- result:
+None
+-- !result
+[ORDER]SELECT s, m, rn
+FROM (
+  SELECT t.s, r.m,
+         row_number() over (partition by t.s order by t.s, r.m) rn
+  FROM (
+    SELECT pid, s
+    FROM (
+      SELECT pid, s, row_number() over (partition by s order by ts) rn2
+      FROM topn_decoded_fact
+    ) x
+    WHERE rn2 = 1
+  ) t
+  LEFT JOIN topn_decoded_map r ON r.pid = t.pid
+) y
+WHERE rn = 1
+ORDER BY s;
+-- result:
+S0	M0	1
+S1	M1	1
+-- !result
+[ORDER]SELECT s, m, rn
+FROM (
+  SELECT t.s, r.m,
+         row_number() over (partition by t.s order by t.s, r.m) rn
+  FROM (
+    SELECT pid, s
+    FROM (
+      SELECT pid, s, lead(s, 1, 'NONE') over (partition by pid order by ts) nxt
+      FROM topn_decoded_fact
+    ) x
+    WHERE nxt != 'ZZZ'
+  ) t
+  LEFT JOIN topn_decoded_map r ON r.pid = t.pid
+) y
+WHERE rn = 1
+ORDER BY s;
+-- result:
+S0	M0	1
+S1	M1	1
+-- !result

--- a/test/sql/test_low_cardinality/T/test_partition_topn_decoded_partition_column
+++ b/test/sql/test_low_cardinality/T/test_partition_topn_decoded_partition_column
@@ -1,0 +1,90 @@
+-- name: test_partition_topn_decoded_partition_column
+
+set cbo_enable_low_cardinality_optimize = true;
+set low_cardinality_optimize_v2 = true;
+
+CREATE TABLE `topn_decoded_fact` (
+  `id` bigint NOT NULL,
+  `pid` bigint NULL,
+  `s` varchar(128) NULL,
+  `ts` datetime NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `topn_decoded_map` (
+  `id` bigint NOT NULL,
+  `pid` bigint NULL,
+  `m` varchar(128) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into topn_decoded_fact
+select
+    generate_series,
+    generate_series,
+    concat('S', generate_series % 2),
+    seconds_add('2026-01-01 00:00:00', generate_series)
+from TABLE(generate_series(0, 299));
+
+insert into topn_decoded_map
+select
+    generate_series,
+    generate_series % 300,
+    concat('M', generate_series % 2)
+from TABLE(generate_series(0, 599));
+
+[UC] analyze full table topn_decoded_fact;
+[UC] analyze full table topn_decoded_map;
+
+function: wait_global_dict_ready('s', 'topn_decoded_fact')
+function: wait_global_dict_ready('m', 'topn_decoded_map')
+
+-- The inner window consumes `s` in dict form, so its Decode sits below the join;
+-- the outer ranking-window filter becomes a PARTITION-TOP-N above the join whose
+-- partition-by must keep the string ref of `s` (the dict slot is pruned below),
+-- otherwise BE fails with "slot_id not found".
+function: assert_explain_contains('SELECT s, m, rn FROM (SELECT t.s, r.m, row_number() over (partition by t.s order by t.s, r.m) rn FROM (SELECT pid, s FROM (SELECT pid, s, row_number() over (partition by s order by ts) rn2 FROM topn_decoded_fact) x WHERE rn2 = 1) t LEFT JOIN topn_decoded_map r ON r.pid = t.pid) y WHERE rn = 1', 'PARTITION-TOP-N')
+
+[ORDER]SELECT s, m, rn
+FROM (
+  SELECT t.s, r.m,
+         row_number() over (partition by t.s order by t.s, r.m) rn
+  FROM (
+    SELECT pid, s
+    FROM (
+      SELECT pid, s, row_number() over (partition by s order by ts) rn2
+      FROM topn_decoded_fact
+    ) x
+    WHERE rn2 = 1
+  ) t
+  LEFT JOIN topn_decoded_map r ON r.pid = t.pid
+) y
+WHERE rn = 1
+ORDER BY s;
+
+-- lead() with a non-null default disables the dict form of `s` below the join, so the
+-- outer PARTITION-TOP-N receives `s` already decoded and must partition by the string ref
+[ORDER]SELECT s, m, rn
+FROM (
+  SELECT t.s, r.m,
+         row_number() over (partition by t.s order by t.s, r.m) rn
+  FROM (
+    SELECT pid, s
+    FROM (
+      SELECT pid, s, lead(s, 1, 'NONE') over (partition by pid order by ts) nxt
+      FROM topn_decoded_fact
+    ) x
+    WHERE nxt != 'ZZZ'
+  ) t
+  LEFT JOIN topn_decoded_map r ON r.pid = t.pid
+) y
+WHERE rn = 1
+ORDER BY s;


### PR DESCRIPTION
## Why I'm doing:

For low-cardinality string columns, `DecodeRewriter` rewrites the partition-by columns of PARTITION-TOP-N to dict slots unconditionally, without checking whether the column is still in dict form at this node. If the column was already decoded below (e.g. under a join, or forced by `lead()` with a non-null default), the dict slot no longer exists: `ERROR 1064 (HY000): Expr evaluate meet error: slot_id 11 not found`

On debug builds the BE crashes on `Check failed: is_slot_exist(slot_id)`.

Note: the buggy code exists on all branches; on main the DecodeCollector refactor (#74970) keeps columns in dict form in most cases so it is harder to hit, while on branch-3.5/4.0/4.1 a simple window-join-window query triggers it.

## What I'm doing:

Only rewrite a partition-by column to its dict slot when it still arrives in dict form (`DecodeInfo.inputStringColumns`) — the same check order-by columns already use. Add UT and SQL tests.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr
