### PR TITLE
[Enhancement] Project only file_path when scanning Iceberg manifest entries in remove_orphan_files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -67,6 +67,9 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
     private static final String PROCEDURE_NAME = "remove_orphan_files";
 
+    // We only need each content file's path to build the set of reachable file names
+    private static final List<String> MANIFEST_ENTRY_PROJECTION = List.of("file_path");
+
     public static final String OLDER_THAN = "older_than";
     public static final String LOCATION = "location";
 
@@ -229,8 +232,9 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
     private ManifestReader<? extends ContentFile<?>> readerForManifest(Table table, ManifestFile manifest) {
         return switch (manifest.content()) {
-            case DATA -> ManifestFiles.read(manifest, table.io());
-            case DELETES -> ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs());
+            case DATA -> ManifestFiles.read(manifest, table.io()).select(MANIFEST_ENTRY_PROJECTION);
+            case DELETES ->
+                    ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs()).select(MANIFEST_ENTRY_PROJECTION);
         };
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -405,6 +405,7 @@ public class RemoveOrphanFilesProcedureTest {
         when(dataFile.location()).thenReturn("s3://bucket/table/data/file.parquet");
 
         ManifestReader<DataFile> manifestReader = mock(ManifestReader.class);
+        when(manifestReader.select(any())).thenReturn(manifestReader);
         when(manifestReader.iterator()).thenReturn(
                 CloseableIterable.withNoopClose(Collections.singletonList(dataFile)).iterator());
 
@@ -465,6 +466,7 @@ public class RemoveOrphanFilesProcedureTest {
         when(manifest.content()).thenReturn(ManifestContent.DATA);
 
         ManifestReader<DataFile> manifestReader = mock(ManifestReader.class);
+        when(manifestReader.select(any())).thenReturn(manifestReader);
         when(manifestReader.iterator()).thenReturn(
                 CloseableIterable.withNoopClose(Collections.<DataFile>emptyList()).iterator());
         doThrow(new IOException("simulated read failure")).when(manifestReader).close();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedureTest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.InternalData;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
@@ -425,6 +426,69 @@ public class RemoveOrphanFilesProcedureTest {
                         mockStatic(org.apache.iceberg.ReachableFileUtil.class);
                 MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
             mfStatic.when(() -> ManifestFiles.read(any(ManifestFile.class), any(FileIO.class)))
+                    .thenReturn(manifestReader);
+
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.metadataFileLocations(any(Table.class), eq(false)))
+                    .thenReturn(Collections.emptySet());
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.statisticsFilesLocations(any(Table.class)))
+                    .thenReturn(Collections.emptyList());
+
+            FileSystem mockFs = mock(FileSystem.class);
+            RemoteIterator<LocatedFileStatus> emptyIterator = new RemoteIterator<LocatedFileStatus>() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public LocatedFileStatus next() {
+                    throw new java.util.NoSuchElementException();
+                }
+            };
+            when(mockFs.listFiles(any(Path.class), eq(true))).thenReturn(emptyIterator);
+            fsStatic.when(() -> FileSystem.get(any(), any())).thenReturn(mockFs);
+
+            IcebergTableProcedureContext context = createContext(table);
+            assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+        }
+    }
+
+    /**
+     * Covers: a DELETE manifest is opened via readDeleteManifest (the DELETES branch of
+     * readerForManifest) and its content file locations are added to the valid file names.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteWithDeleteManifestContainingContentFile_addsContentFileToValidNames() throws Exception {
+        RemoveOrphanFilesProcedure procedure = RemoveOrphanFilesProcedure.getInstance();
+        ManifestFile manifest = mock(ManifestFile.class);
+        when(manifest.path()).thenReturn("s3://bucket/table/metadata/m-del.avro");
+        when(manifest.content()).thenReturn(ManifestContent.DELETES);
+
+        DeleteFile deleteFile = mock(DeleteFile.class);
+        when(deleteFile.location()).thenReturn("s3://bucket/table/data/delete-file.parquet");
+
+        ManifestReader<DeleteFile> manifestReader = mock(ManifestReader.class);
+        when(manifestReader.select(any())).thenReturn(manifestReader);
+        when(manifestReader.iterator()).thenReturn(
+                CloseableIterable.withNoopClose(Collections.singletonList(deleteFile)).iterator());
+
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(null);
+        when(snapshot.allManifests(any(FileIO.class))).thenReturn(Collections.singletonList(manifest));
+
+        FileIO fileIO = mock(FileIO.class);
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.io()).thenReturn(fileIO);
+
+        try (MockedStatic<ManifestFiles> mfStatic = mockStatic(ManifestFiles.class);
+                MockedStatic<org.apache.iceberg.ReachableFileUtil> reachableUtil =
+                        mockStatic(org.apache.iceberg.ReachableFileUtil.class);
+                MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+            mfStatic.when(() -> ManifestFiles.readDeleteManifest(any(ManifestFile.class), any(FileIO.class), any()))
                     .thenReturn(manifestReader);
 
             reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil.metadataFileLocations(any(Table.class), eq(false)))


### PR DESCRIPTION
## Why I'm doing:

When `remove_orphan_files` scans each manifest to collect the set of reachable file names, it opens the manifest with a full `ManifestReader` (`ManifestFiles.read` / `readDeleteManifest`) and iterates the content files, but only uses `contentFile.location()`.

Without a column projection the reader:
- deserializes every manifest-entry column from the Avro file, including the per-column statistics (`lower_bounds`, `upper_bounds`, `value_counts`, `null_value_counts`, `nan_value_counts`, `column_sizes`), and
- because `reuseContainers()` is set, `iterator()` makes a defensive copy of every entry — and with no projection `dropStats(columns)` is `false`, so each copy also deep-copies those (potentially large) stats maps.

For wide tables this is a lot of wasted I/O and allocation, since only the file path is needed.

## What I'm doing:

Project only the `file_path` column when opening the manifest reader in `readerForManifest`, for both data and delete manifests. This mirrors Iceberg's own `ManifestFiles.readPaths()` (used by `FileCleanupStrategy`/`ReachableFileCleanup`): the narrow projection avoids reading the stats columns, and the per-entry copy no longer clones the stats maps.

Also updates `RemoveOrphanFilesProcedureTest` so the mocked `ManifestReader` returns itself from `select(...)` (the tests previously only stubbed `iterator()`).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
