### PR TITLE
[Enhancement] Support right-outer/semi/anti and full-outer range-colocate joins

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -106,9 +106,15 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
      *     {@code HINT_JOIN_SKEW}, or {@code HINT_JOIN_BUCKET} disables
      *     colocate. Only {@code null} or {@code HINT_JOIN_COLOCATE} lets
      *     the range fast path proceed.
-     * <li>Join-type allowlist: INNER, LEFT OUTER, LEFT SEMI, LEFT ANTI.
-     *     Right-family and full-outer joins are rejected (NULL-key runtime
-     *     correctness validation deferred past P2).
+     * <li>Join-type allowlist: INNER, LEFT/RIGHT OUTER, LEFT/RIGHT SEMI,
+     *     LEFT/RIGHT ANTI, FULL OUTER. All equi-join families are colocate-safe
+     *     because a colocate range join is bucket-local: rows sharing a colocate
+     *     key (NULL included — NULL sorts into the first ColocateRange on every
+     *     table in the group) always land in the same bucket, so the unmatched
+     *     right rows a right/full-outer join must emit are produced by the right
+     *     scan node in the same fragment. CROSS, NULL-aware anti, and ASOF joins
+     *     stay rejected (no covering equijoin key / cross-bucket NULL semantics /
+     *     inequality match).
      * <li>{@code disable_colocate_join} session kill switch (shared with
      *     hash colocate).
      * <li>Structural {@link RangeDistributionSpec#canColocate}: same group,
@@ -139,10 +145,15 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
                 || HintNode.HINT_JOIN_BUCKET.equals(hint)) {
             return false;
         }
-        if (joinType != JoinOperator.INNER_JOIN
-                && joinType != JoinOperator.LEFT_OUTER_JOIN
-                && joinType != JoinOperator.LEFT_SEMI_JOIN
-                && joinType != JoinOperator.LEFT_ANTI_JOIN) {
+        boolean supportedJoinType = joinType == JoinOperator.INNER_JOIN
+                || joinType == JoinOperator.LEFT_OUTER_JOIN
+                || joinType == JoinOperator.LEFT_SEMI_JOIN
+                || joinType == JoinOperator.LEFT_ANTI_JOIN
+                || joinType == JoinOperator.RIGHT_OUTER_JOIN
+                || joinType == JoinOperator.RIGHT_SEMI_JOIN
+                || joinType == JoinOperator.RIGHT_ANTI_JOIN
+                || joinType == JoinOperator.FULL_OUTER_JOIN;
+        if (!supportedJoinType) {
             return false;
         }
         if (ConnectContext.get().getSessionVariable().isDisableColocateJoin()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -352,14 +352,27 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
         List<DistributionCol> leftOnPredicateColumns = joinHelper.getLeftCols();
         List<DistributionCol> rightOnPredicateColumns = joinHelper.getRightCols();
 
-        // Range-colocate join: both children are RangeDistributionSpec.
-        // ChildOutputPropertyGuarantor.canRangeColocateJoin already rejected
-        // right-family / full-outer joins, so the join type here is safe.
+        // Range-colocate join: both children are RangeDistributionSpec. The
+        // dominated output side mirrors the hash-colocate mapping in
+        // computeColocateJoinOutputProperty: right-family joins (right outer /
+        // semi / anti) output the right-side range spec, full-outer outputs the
+        // null-relaxed left-side spec (either side may be NULL-padded), and
+        // everything else (inner / left outer / left semi / left anti) outputs
+        // the left-side spec.
         DistributionSpec leftRawSpec = leftChildOutputProperty.getDistributionProperty().getSpec();
         DistributionSpec rightRawSpec = rightChildOutputProperty.getDistributionProperty().getSpec();
         if (leftRawSpec instanceof RangeDistributionSpec && rightRawSpec instanceof RangeDistributionSpec) {
-            // Left-dominated output (inner / left-outer / left-semi / left-anti).
-            PhysicalPropertySet outputProperty = createPropertySetByDistribution(leftRawSpec);
+            JoinOperator joinType = node.getJoinType();
+            DistributionSpec dominatedRangeSpec;
+            if (joinType.isRightJoin()) {
+                dominatedRangeSpec = rightRawSpec;
+            } else if (joinType.isFullOuterJoin()) {
+                RangeDistributionSpec leftRange = (RangeDistributionSpec) leftRawSpec;
+                dominatedRangeSpec = leftRange.getNullRelaxSpec(leftRange.getEquivalentDescriptor());
+            } else {
+                dominatedRangeSpec = leftRawSpec;
+            }
+            PhysicalPropertySet outputProperty = createPropertySetByDistribution(dominatedRangeSpec);
             return updateEquivalentDescriptor(node, outputProperty,
                     leftOnPredicateColumns, rightOnPredicateColumns);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionProperty.java
@@ -104,8 +104,11 @@ public class DistributionProperty implements PhysicalProperty {
                         hashDistributionSpec.getEquivDesc()), isCTERequired);
             }
         }
-        // RangeDistributionSpec always builds colocate columns with
-        // nullStrict=true (see RangeDistributionSpec constructor); no conversion needed.
+        // Non-hash specs (gather / broadcast / any / range) need no conversion. A
+        // RangeDistributionSpec in particular is scan-local and never a required
+        // distribution property (appendEnforcers rejects it, and this method only runs
+        // on context.getRequiredProperty()), so a range spec never reaches here even
+        // though a full-outer range-colocate join can produce a null-relaxed one.
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/RangeDistributionSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/RangeDistributionSpec.java
@@ -187,10 +187,10 @@ public final class RangeDistributionSpec extends DistributionSpec {
     }
 
     /**
-     * Null-relaxed variant for symmetry with {@code HashDistributionSpec}.
-     * Not invoked by the P2 join planner because full-outer range colocate
-     * is rejected by the join-type allowlist; retained for parallelism and
-     * future phases.
+     * Null-relaxed variant (colocate columns rebuilt with {@code nullStrict=false}),
+     * mirroring {@code HashDistributionSpec.getNullRelaxSpec}. Used to derive the
+     * output distribution of a full-outer range-colocate join, where either side
+     * may be NULL-padded.
      */
     public RangeDistributionSpec getNullRelaxSpec(EquivalentDescriptor descriptor) {
         List<DistributionCol> relaxed = colocateColumns.stream()

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateMixedJoinPlanTest.java
@@ -208,6 +208,46 @@ public class RangeColocateMixedJoinPlanTest {
                 "INNER JOIN (PARTITIONED)");
     }
 
+    // ---------- Range × range colocate: right-family / full-outer join types ----------
+
+    /** T13: range×range RIGHT OUTER on the colocate key must remain colocate. */
+    @Test
+    public void t13_rangeRightOuterRangeStillColocate() throws Exception {
+        String fragmentPlan = plan("select count(*) from cd a right outer join cd2 b on a.k1 = b.k1");
+        Assertions.assertTrue(fragmentPlan.contains("colocate: true"),
+                () -> "range×range RIGHT OUTER on colocate key must remain colocate, plan was:\n" + fragmentPlan);
+    }
+
+    /** T14: range×range FULL OUTER on the colocate key must remain colocate. */
+    @Test
+    public void t14_rangeFullOuterRangeStillColocate() throws Exception {
+        String fragmentPlan = plan("select count(*) from cd a full outer join cd2 b on a.k1 = b.k1");
+        Assertions.assertTrue(fragmentPlan.contains("colocate: true"),
+                () -> "range×range FULL OUTER on colocate key must remain colocate, plan was:\n" + fragmentPlan);
+    }
+
+    /** T15: [shuffle] hint defeats range×range RIGHT OUTER colocate. */
+    @Test
+    public void t15_rangeRightOuterRangeShuffleHint() throws Exception {
+        String fragmentPlan = plan("select count(*) from cd a right outer join [shuffle] cd2 b on a.k1 = b.k1");
+        Assertions.assertFalse(fragmentPlan.contains("colocate: true"),
+                () -> "shuffle hint must defeat range×range RIGHT OUTER colocate, plan was:\n" + fragmentPlan);
+    }
+
+    /** T16: disable_colocate_join defeats range×range FULL OUTER colocate. */
+    @Test
+    public void t16_rangeFullOuterRangeDisableColocate() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        try {
+            String fragmentPlan = plan("select count(*) from cd a full outer join cd2 b on a.k1 = b.k1");
+            Assertions.assertFalse(fragmentPlan.contains("colocate: true"),
+                    () -> "disable_colocate_join must defeat range×range FULL OUTER colocate, plan was:\n"
+                            + fragmentPlan);
+        } finally {
+            Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", false);
+        }
+    }
+
     // ---------- Optimizer-level invariant ----------
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantorRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantorRangeTest.java
@@ -40,8 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Covers:
  * <ul>
- * <li>Join-type allowlist (INNER, LEFT OUTER, LEFT SEMI, LEFT ANTI) —
- *     RIGHT / FULL rejected.
+ * <li>Join-type allowlist accepts all equi-join families (INNER, LEFT/RIGHT
+ *     OUTER, LEFT/RIGHT SEMI, LEFT/RIGHT ANTI, FULL OUTER); CROSS and NULL-aware
+ *     left anti stay rejected.
  * <li>Position-preserving pairing accepts identity join keys.
  * <li>Position-preserving pairing rejects swapped-column joins.
  * <li>Partial shuffle coverage rejected.
@@ -92,13 +93,81 @@ class ChildOutputPropertyGuarantorRangeTest {
                 hint, joinType, left, right, leftShuffle, rightShuffle);
     }
 
+    /**
+     * Installs the "same group, stable, non-empty" expectations shared by every
+     * accepts-* test: colocate is not session-disabled, both tables are in the
+     * same stable colocate group. Group ids 100L/200L match {@link #buildSide}.
+     */
+    private static void expectStableSameGroup(ConnectContext connectContext,
+                                              SessionVariable sessionVariable,
+                                              GlobalStateMgr globalStateMgr,
+                                              ColocateTableIndex colocateTableIndex,
+                                              ColocateTableIndex.GroupId groupId) {
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = connectContext;
+                connectContext.getSessionVariable();
+                result = sessionVariable;
+                sessionVariable.isDisableColocateJoin();
+                result = false;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getColocateTableIndex();
+                result = colocateTableIndex;
+                colocateTableIndex.isSameGroup(100L, 200L);
+                result = true;
+                colocateTableIndex.getGroup(100L);
+                result = groupId;
+                colocateTableIndex.getGroup(200L);
+                result = groupId;
+                colocateTableIndex.isGroupUnstable(groupId);
+                result = false;
+            }
+        };
+    }
+
+    /**
+     * Asserts an identity-key join of {@code joinType} on a stable same-group
+     * range-colocate pair is accepted (colocate = (1,2), shuffle = (1,2)).
+     */
+    private void assertJoinTypeAccepted(TaskContext taskContext, ConnectContext connectContext,
+                                        SessionVariable sessionVariable, GlobalStateMgr globalStateMgr,
+                                        ColocateTableIndex colocateTableIndex, JoinOperator joinType) {
+        ColocateTableIndex.GroupId groupId = new ColocateTableIndex.GroupId(1L, 1L);
+        expectStableSameGroup(connectContext, sessionVariable, globalStateMgr, colocateTableIndex, groupId);
+        assertTrue(invokeGate(newGuarantor(taskContext), joinType,
+                buildSide(100L, 1, 2), buildSide(200L, 1, 2), cols(1, 2), cols(1, 2)));
+    }
+
     @Test
-    void rejectsRightOuterJoin(@Mocked TaskContext taskContext) {
-        // Join-type allowlist is the earliest gate; no ConnectContext access.
-        RangeDistributionSpec left = buildSide(100L, 1, 2);
-        RangeDistributionSpec right = buildSide(200L, 1, 2);
-        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.RIGHT_OUTER_JOIN,
-                left, right, cols(1, 2), cols(1, 2)));
+    void acceptsRightOuterJoin(@Mocked TaskContext taskContext,
+                               @Mocked ConnectContext connectContext,
+                               @Mocked SessionVariable sessionVariable,
+                               @Mocked GlobalStateMgr globalStateMgr,
+                               @Mocked ColocateTableIndex colocateTableIndex) {
+        assertJoinTypeAccepted(taskContext, connectContext, sessionVariable, globalStateMgr,
+                colocateTableIndex, JoinOperator.RIGHT_OUTER_JOIN);
+    }
+
+    @Test
+    void acceptsRightSemiJoin(@Mocked TaskContext taskContext,
+                              @Mocked ConnectContext connectContext,
+                              @Mocked SessionVariable sessionVariable,
+                              @Mocked GlobalStateMgr globalStateMgr,
+                              @Mocked ColocateTableIndex colocateTableIndex) {
+        assertJoinTypeAccepted(taskContext, connectContext, sessionVariable, globalStateMgr,
+                colocateTableIndex, JoinOperator.RIGHT_SEMI_JOIN);
+    }
+
+    @Test
+    void acceptsRightAntiJoin(@Mocked TaskContext taskContext,
+                              @Mocked ConnectContext connectContext,
+                              @Mocked SessionVariable sessionVariable,
+                              @Mocked GlobalStateMgr globalStateMgr,
+                              @Mocked ColocateTableIndex colocateTableIndex) {
+        assertJoinTypeAccepted(taskContext, connectContext, sessionVariable, globalStateMgr,
+                colocateTableIndex, JoinOperator.RIGHT_ANTI_JOIN);
     }
 
     @Test
@@ -131,11 +200,33 @@ class ChildOutputPropertyGuarantorRangeTest {
     }
 
     @Test
-    void rejectsFullOuterJoin(@Mocked TaskContext taskContext) {
-        // Join-type allowlist is the earliest gate; no ConnectContext access.
+    void acceptsFullOuterJoin(@Mocked TaskContext taskContext,
+                              @Mocked ConnectContext connectContext,
+                              @Mocked SessionVariable sessionVariable,
+                              @Mocked GlobalStateMgr globalStateMgr,
+                              @Mocked ColocateTableIndex colocateTableIndex) {
+        assertJoinTypeAccepted(taskContext, connectContext, sessionVariable, globalStateMgr,
+                colocateTableIndex, JoinOperator.FULL_OUTER_JOIN);
+    }
+
+    @Test
+    void rejectsCrossJoin(@Mocked TaskContext taskContext) {
+        // CROSS join stays rejected by the allowlist (earliest gate after hint;
+        // no ConnectContext access). It has no covering equijoin key anyway.
         RangeDistributionSpec left = buildSide(100L, 1, 2);
         RangeDistributionSpec right = buildSide(200L, 1, 2);
-        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.FULL_OUTER_JOIN,
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.CROSS_JOIN,
+                left, right, cols(1, 2), cols(1, 2)));
+    }
+
+    @Test
+    void rejectsNullAwareLeftAntiJoin(@Mocked TaskContext taskContext) {
+        // NULL-aware left anti (NOT IN with nullable) needs cross-bucket NULL
+        // knowledge, which bucket-local colocate execution cannot provide, so it
+        // stays rejected by the allowlist.
+        RangeDistributionSpec left = buildSide(100L, 1, 2);
+        RangeDistributionSpec right = buildSide(200L, 1, 2);
+        assertFalse(invokeGate(newGuarantor(taskContext), JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN,
                 left, right, cols(1, 2), cols(1, 2)));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
@@ -49,17 +49,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Direct unit tests for the range-aware branches of {@link OutputPropertyDeriver}:
- * scan rebuild with partitions, Repeat preserve/drop, projection remap.
- * {@code visitPhysicalJoin} range emission is exercised indirectly via
- * {@link ChildOutputPropertyGuarantorRangeTest}; here we keep the tests
- * constructor-driven to avoid a full {@code GroupExpression} fixture.
+ * scan rebuild with partitions, Repeat preserve/drop, projection remap, and the
+ * range-colocate dominated-side output selection in {@code visitPhysicalJoin}
+ * (left / right / full-outer null-relaxed). Tests are constructor-driven to
+ * avoid a full {@code GroupExpression} fixture.
  */
 class OutputPropertyDeriverRangeTest {
 
@@ -238,10 +240,22 @@ class OutputPropertyDeriverRangeTest {
      */
     private static void stubInnerJoinWithEmptyColumns(PhysicalHashJoinOperator node,
                                                       ExpressionContext context) {
+        stubJoinWithEmptyColumns(node, context, JoinOperator.INNER_JOIN);
+    }
+
+    /**
+     * Stubs the join-operator and expression-context methods that
+     * {@code visitPhysicalJoin} touches before it inspects the child
+     * distribution specs, for an arbitrary join type. Empty ON columns keep
+     * {@code updateEquivalentDescriptor} a no-op so a test can assert the
+     * dominated-side spec selection in isolation.
+     */
+    private static void stubJoinWithEmptyColumns(PhysicalHashJoinOperator node,
+                                                 ExpressionContext context, JoinOperator joinType) {
         new Expectations() {
             {
                 node.getJoinType();
-                result = JoinOperator.INNER_JOIN;
+                result = joinType;
                 minTimes = 0;
                 node.getOnPredicate();
                 result = null;
@@ -259,18 +273,89 @@ class OutputPropertyDeriverRangeTest {
         };
     }
 
+    private static Method visitPhysicalJoinMethod() throws NoSuchMethodException {
+        Method method = OutputPropertyDeriver.class.getDeclaredMethod(
+                "visitPhysicalJoin",
+                com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator.class,
+                ExpressionContext.class);
+        method.setAccessible(true);
+        return method;
+    }
+
+    private static PhysicalPropertySet invokeVisitPhysicalJoin(
+            OutputPropertyDeriver deriver, PhysicalHashJoinOperator node, ExpressionContext context)
+            throws Exception {
+        return (PhysicalPropertySet) visitPhysicalJoinMethod().invoke(deriver, node, context);
+    }
+
+    /**
+     * Asserts a range×range join of {@code joinType} derives the left- or
+     * right-side range spec (the non-null-relaxed dominated cases). Full-outer
+     * has distinct null-relaxed assertions and is tested separately.
+     */
+    private void assertRangeJoinEmitsDominatedSide(PhysicalHashJoinOperator node, ExpressionContext context,
+            JoinOperator joinType, boolean expectRightSide) throws Exception {
+        RangeDistributionSpec leftSpec = buildRangeSkeleton(100L, 1, 2);
+        RangeDistributionSpec rightSpec = buildRangeSkeleton(200L, 1, 2);
+        OutputPropertyDeriver deriver = newDeriver(List.of(propertyOf(leftSpec), propertyOf(rightSpec)));
+        stubJoinWithEmptyColumns(node, context, joinType);
+
+        PhysicalPropertySet out = invokeVisitPhysicalJoin(deriver, node, context);
+        assertSame(expectRightSide ? rightSpec : leftSpec, out.getDistributionProperty().getSpec(),
+                joinType + " range-colocate join must output the "
+                        + (expectRightSide ? "right" : "left") + "-side range spec");
+    }
+
+    @Test
+    void visitPhysicalJoinRangeInnerEmitsLeftSpec(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) throws Exception {
+        assertRangeJoinEmitsDominatedSide(node, context, JoinOperator.INNER_JOIN, false);
+    }
+
+    @Test
+    void visitPhysicalJoinRangeRightOuterEmitsRightSpec(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) throws Exception {
+        assertRangeJoinEmitsDominatedSide(node, context, JoinOperator.RIGHT_OUTER_JOIN, true);
+    }
+
+    @Test
+    void visitPhysicalJoinRangeRightSemiEmitsRightSpec(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) throws Exception {
+        assertRangeJoinEmitsDominatedSide(node, context, JoinOperator.RIGHT_SEMI_JOIN, true);
+    }
+
+    @Test
+    void visitPhysicalJoinRangeFullOuterEmitsNullRelaxedLeftSpec(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) throws Exception {
+        RangeDistributionSpec leftSpec = buildRangeSkeleton(100L, 1, 2);
+        RangeDistributionSpec rightSpec = buildRangeSkeleton(200L, 1, 2);
+        OutputPropertyDeriver deriver = newDeriver(List.of(propertyOf(leftSpec), propertyOf(rightSpec)));
+        stubJoinWithEmptyColumns(node, context, JoinOperator.FULL_OUTER_JOIN);
+
+        PhysicalPropertySet out = invokeVisitPhysicalJoin(deriver, node, context);
+        DistributionSpec outSpec = out.getDistributionProperty().getSpec();
+        assertInstanceOf(RangeDistributionSpec.class, outSpec);
+        RangeDistributionSpec rangeOut = (RangeDistributionSpec) outSpec;
+        // Full-outer output is a fresh null-relaxed spec derived from the left side.
+        assertNotSame(leftSpec, rangeOut, "full-outer must produce a new null-relaxed range spec");
+        assertEquals(leftSpec.getColocateColumns().size(), rangeOut.getColocateColumns().size());
+        rangeOut.getColocateColumns().forEach(col ->
+                assertFalse(col.isNullStrict(), "full-outer output colocate cols must be null-relaxed"));
+        assertEquals(100L, rangeOut.getEquivalentDescriptor().getTableId(),
+                "null-relaxed spec keeps the left-side table id");
+    }
+
     private static StarRocksPlannerException invokeVisitPhysicalJoinExpectingThrow(
             OutputPropertyDeriver deriver, PhysicalHashJoinOperator node, ExpressionContext context) {
         // visitPhysicalJoin is private; reflect to invoke it.  Wrap the
         // InvocationTargetException so JUnit's assertThrows sees the real cause.
         return assertThrows(StarRocksPlannerException.class, () -> {
             try {
-                Method method = OutputPropertyDeriver.class.getDeclaredMethod(
-                        "visitPhysicalJoin",
-                        com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator.class,
-                        ExpressionContext.class);
-                method.setAccessible(true);
-                method.invoke(deriver, node, context);
+                visitPhysicalJoinMethod().invoke(deriver, node, context);
             } catch (java.lang.reflect.InvocationTargetException e) {
                 if (e.getCause() instanceof RuntimeException) {
                     throw (RuntimeException) e.getCause();


### PR DESCRIPTION
## Why I'm doing:

Shared-data (存算分离) RANGE-distribution colocate tables only produced the shuffle-free colocate-join plan for INNER / LEFT OUTER / LEFT SEMI / LEFT ANTI. RIGHT OUTER / RIGHT SEMI / RIGHT ANTI / FULL OUTER fell back to a hash shuffle even when both sides are range-colocated on the join key. This was the last open join-type gap in the range-colocate optimizer.

## What I'm doing:

Extend the range-colocate join planner to RIGHT OUTER / RIGHT SEMI / RIGHT ANTI / FULL OUTER. FE-optimizer-only:

- `ChildOutputPropertyGuarantor.canRangeColocateJoin`: accept the four additional equi-join families (CROSS, NULL-aware anti, and ASOF joins stay rejected). The join-hint short-circuit, `disable_colocate_join` kill switch, structural `canColocate`, and position-preserving join-key pairing gates are unchanged.
- `OutputPropertyDeriver.visitPhysicalJoin`: for a range × range colocate join, derive the dominated output distribution — the right-side range spec for right-family joins, the null-relaxed left-side spec for full-outer, the left-side spec otherwise — mirroring the existing hash `computeColocateJoinOutputProperty` mapping.

**Why it is correct** (the same invariant INNER/LEFT already rely on): a range-colocate join is bucket-local — rows sharing a colocate key land in the same ColocateRange/bucket on every table in the group, PACK-colocated on one CN. The unmatched right rows a right/full-outer join must emit — including NULL-key rows, which sort into the first ColocateRange consistently on both the FE range geometry and the BE ingest routing — are produced by the right scan node of the same COLOCATE fragment, the identical mechanism hash colocate already uses for right/full. No scheduler or BE change is needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Plan-shape optimization only: the colocate plan returns results byte-identical to the pre-existing hash-shuffle plan (that identity is exactly what the shared-data cluster e2e below verifies).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Test coverage

FE unit tests (45/45 pass, checkstyle clean):
- `ChildOutputPropertyGuarantorRangeTest` — allowlist accepts RIGHT OUTER/SEMI/ANTI + FULL OUTER; CROSS and NULL-aware left anti stay rejected; join hints, `disable_colocate_join`, arity/swapped/partial-prefix pairing still fall back to shuffle.
- `OutputPropertyDeriverRangeTest` — dominated-side output derivation (left / right / full-outer null-relaxed).
- `RangeColocateMixedJoinPlanTest` — range×range RIGHT OUTER and FULL OUTER on the colocate key plan as `colocate: true`; `[shuffle]` hint and `disable_colocate_join` fall back to shuffle.

Shared-data cluster e2e (ship gate): for RIGHT OUTER / RIGHT SEMI / RIGHT ANTI / FULL OUTER (incl. NULL-safe `<=>`) the colocate result set is compared byte-identical against the `set disable_colocate_join = true` hash-shuffle oracle, over matched / left-only / right-only / duplicate / NULL keys spanning multiple ColocateRanges with right-only buckets inside populated partitions.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5