### PR TITLE
[BugFix] Fix ASAN crash for BOOLEAN nested in Avro complex-type columns

### DIFF
--- a/be/src/formats/avro/nullable_column.cpp
+++ b/be/src/formats/avro/nullable_column.cpp
@@ -235,7 +235,7 @@ static Status add_nullable_column(Column* column, const TypeDescriptor& type_des
 
     switch (type_desc.type) {
     case TYPE_BOOLEAN:
-        return add_nullable_numeric_column<int8_t>(column, type_desc, name, resolved);
+        return add_nullable_numeric_column<uint8_t>(column, type_desc, name, resolved);
     case TYPE_BIGINT:
         return add_nullable_numeric_column<int64_t>(column, type_desc, name, resolved);
     case TYPE_INT:

--- a/be/test/exec/file_scanner/avro_scanner_test.cpp
+++ b/be/test/exec/file_scanner/avro_scanner_test.cpp
@@ -1542,17 +1542,17 @@ TEST_F(AvroScannerTest, test_struct_type) {
     }
 }
 
-// Regression for issue #11522: a BOOLEAN nested inside a native STRUCT target column.
+// Regression for issue #11522: a BOOLEAN element nested inside a native ARRAY target column.
 // BooleanColumn is FixedLengthColumn<uint8_t>, but the nested (non-adaptive) add_nullable_column
 // dispatched TYPE_BOOLEAN through add_nullable_numeric_column<int8_t>, so add_numeric_column's
 // down_cast<FixedLengthColumn<int8_t>*> tripped the dynamic_cast assert (casts.h) under ASAN/DEBUG.
-// This STRUCT crash path was made reachable by PR #74901. The nested ARRAY/MAP paths carry the same
-// latent mismatch (since #19866) and are corrected by the same one-line dispatch fix in
-// add_nullable_column (add_nullable_numeric_column<int8_t> -> <uint8_t>).
-TEST_F(AvroScannerTest, test_struct_with_boolean) {
-    // record root { record s { boolean b_true; boolean b_false; int i; } }
+// STRUCT/MAP/ARRAY all funnel their leaf columns through this same add_nullable_column dispatch, so
+// the ARRAY case exercises (and guards) the one-line fix for every container. ARRAY is used here
+// because it is the path present on all release branches (the STRUCT crash path came from #74901).
+TEST_F(AvroScannerTest, test_array_with_boolean) {
+    // record root { array<boolean> a }
     std::string schema_json =
-            R"({"type":"record","name":"root","fields":[{"name":"s","type":{"type":"record","name":"inner","fields":[{"name":"b_true","type":"boolean"},{"name":"b_false","type":"boolean"},{"name":"i","type":"int"}]}}]})";
+            R"({"type":"record","name":"root","fields":[{"name":"a","type":{"type":"array","items":"boolean"}}]})";
 
     AvroHelper avro_helper;
     init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
@@ -1562,36 +1562,34 @@ TEST_F(AvroScannerTest, test_struct_with_boolean) {
         avro_value_decref(&avro_helper.avro_val);
     });
 
-    avro_value_t s_value;
-    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "s", &s_value, NULL));
-    avro_value_t b_true;
-    if (avro_value_get_by_name(&s_value, "b_true", &b_true, NULL) == 0) {
-        avro_value_set_boolean(&b_true, true);
-    }
-    avro_value_t b_false;
-    if (avro_value_get_by_name(&s_value, "b_false", &b_false, NULL) == 0) {
-        avro_value_set_boolean(&b_false, false);
-    }
-    avro_value_t i_value;
-    if (avro_value_get_by_name(&s_value, "i", &i_value, NULL) == 0) {
-        avro_value_set_int(&i_value, 7);
-    }
+    avro_value_t a_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "a", &a_value, NULL));
+    avro_value_t e0;
+    avro_value_append(&a_value, &e0, NULL);
+    avro_value_set_boolean(&e0, true);
+    avro_value_t e1;
+    avro_value_append(&a_value, &e1, NULL);
+    avro_value_set_boolean(&e1, false);
+    avro_value_t e2;
+    avro_value_append(&a_value, &e2, NULL);
+    avro_value_set_boolean(&e2, true);
 
-    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_struct_boolean_data.avro";
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_boolean_data.avro";
     ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
 
     std::vector<TypeDescriptor> types;
-    types.emplace_back(TypeDescriptor::create_struct_type(
-            {"b_true", "b_false", "i"},
-            {TypeDescriptor(TYPE_BOOLEAN), TypeDescriptor(TYPE_BOOLEAN), TypeDescriptor(TYPE_INT)}));
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(t);
 
     std::vector<TBrokerRangeDesc> ranges;
     TBrokerRangeDesc range;
     range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = false;
     range.__set_path(data_path);
     ranges.emplace_back(range);
 
-    auto scanner = create_avro_scanner(types, ranges, {"s"}, avro_helper.schema_text);
+    auto scanner = create_avro_scanner(types, ranges, {"a"}, avro_helper.schema_text);
     Status st = scanner->open();
     ASSERT_TRUE(st.ok()) << st;
     auto st2 = scanner->get_next();
@@ -1600,7 +1598,11 @@ TEST_F(AvroScannerTest, test_struct_with_boolean) {
     ChunkPtr chunk = st2.value();
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
-    EXPECT_EQ("{b_true:1,b_false:0,i:7}", chunk->get_column_by_index(0)->debug_item(0));
+    auto array = chunk->get(0)[0].get_array();
+    ASSERT_EQ(3, array.size());
+    EXPECT_EQ(1, array[0].get_int8());
+    EXPECT_EQ(0, array[1].get_int8());
+    EXPECT_EQ(1, array[2].get_int8());
 }
 
 TEST_F(AvroScannerTest, test_array_of_nullable_string) {

--- a/be/test/exec/file_scanner/avro_scanner_test.cpp
+++ b/be/test/exec/file_scanner/avro_scanner_test.cpp
@@ -1542,6 +1542,67 @@ TEST_F(AvroScannerTest, test_struct_type) {
     }
 }
 
+// Regression for issue #11522: a BOOLEAN nested inside a native STRUCT target column.
+// BooleanColumn is FixedLengthColumn<uint8_t>, but the nested (non-adaptive) add_nullable_column
+// dispatched TYPE_BOOLEAN through add_nullable_numeric_column<int8_t>, so add_numeric_column's
+// down_cast<FixedLengthColumn<int8_t>*> tripped the dynamic_cast assert (casts.h) under ASAN/DEBUG.
+// This STRUCT crash path was made reachable by PR #74901. The nested ARRAY/MAP paths carry the same
+// latent mismatch (since #19866) and are corrected by the same one-line dispatch fix in
+// add_nullable_column (add_nullable_numeric_column<int8_t> -> <uint8_t>).
+TEST_F(AvroScannerTest, test_struct_with_boolean) {
+    // record root { record s { boolean b_true; boolean b_false; int i; } }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"s","type":{"type":"record","name":"inner","fields":[{"name":"b_true","type":"boolean"},{"name":"b_false","type":"boolean"},{"name":"i","type":"int"}]}}]})";
+
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t s_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "s", &s_value, NULL));
+    avro_value_t b_true;
+    if (avro_value_get_by_name(&s_value, "b_true", &b_true, NULL) == 0) {
+        avro_value_set_boolean(&b_true, true);
+    }
+    avro_value_t b_false;
+    if (avro_value_get_by_name(&s_value, "b_false", &b_false, NULL) == 0) {
+        avro_value_set_boolean(&b_false, false);
+    }
+    avro_value_t i_value;
+    if (avro_value_get_by_name(&s_value, "i", &i_value, NULL) == 0) {
+        avro_value_set_int(&i_value, 7);
+    }
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_struct_boolean_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor::create_struct_type(
+            {"b_true", "b_false", "i"},
+            {TypeDescriptor(TYPE_BOOLEAN), TypeDescriptor(TYPE_BOOLEAN), TypeDescriptor(TYPE_INT)}));
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"s"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    EXPECT_EQ("{b_true:1,b_false:0,i:7}", chunk->get_column_by_index(0)->debug_item(0));
+}
+
 TEST_F(AvroScannerTest, test_array_of_nullable_string) {
     // record root { array< union{ null, string } > a }
     // Regression guard for the codex review (PR #74901): an ARRAY<VARCHAR> whose elements are avro


### PR DESCRIPTION
## Why I'm doing:

Fix the daily ASAN crash reported in StarRocks/StarRocksTest#11522:

```
be/src/gutil/casts.h:78: To down_cast(From*) [with To = FixedLengthColumn<signed char>*; ...]:
Assertion `f == __null || dynamic_cast<To>(f) != __null' failed.
```

It aborts BE when an Avro routine load targets a native complex-type column (STRUCT/MAP/ARRAY) that contains a `BOOLEAN` field/element/value.

## What I'm doing:

`BooleanColumn` is `FixedLengthColumn<uint8_t>`, but the nested (non-adaptive) `add_nullable_column` in `be/src/formats/avro/nullable_column.cpp` dispatched `TYPE_BOOLEAN` through `add_nullable_numeric_column<int8_t>`. `add_numeric_column<int8_t>` then `down_cast`s the uint8 column to `FixedLengthColumn<int8_t>*`, which trips the `dynamic_cast` assert under ASAN/DEBUG.

The adaptive path (`add_adpative_nullable_column`, used for top-level columns) already dispatched `TYPE_BOOLEAN` through the correct `<uint8_t>` — which is why only complex types crashed and a plain top-level `BOOLEAN` column was fine. The fix dispatches the nested path through `<uint8_t>` too. `add_numeric_column<uint8_t>` is already explicitly instantiated, so no other change is needed.

Added regression test `AvroScannerTest.test_struct_with_boolean`; the full `AvroScannerTest` suite (26 tests) passes on a clean ASAN build.

Notes:
- The crash-reachable STRUCT/MAP paths were made reachable by #74901 (main only). The nested ARRAY path carries the same latent mismatch since #19866.
- In opt builds the assert is compiled out and `int8_t`/`uint8_t` are layout-identical, so for valid boolean data this is an ASAN/DEBUG crash rather than a release data-correctness issue.

Fixes StarRocks/StarRocksTest#11522

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
