### PR TITLE
[BugFix] Guard expression partition prune with monotonic function check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
@@ -27,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.OperatorFunctionChecker;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
@@ -92,8 +93,14 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
 
     @Override
     public ScalarOperator visitCall(CallOperator call, Void context) {
+        // PartitionColPredicateEvaluator evaluates a call by mapping each partition range's two
+        // boundary values through it, which is only sound for monotonic expressions. A non-monotonic
+        // function like month()/day()/hour() wraps around inside a partition's span: for a partition
+        // [2024-01-01, 2025-01-01), month() maps both bounds to 1, so a predicate month(dt) = 5
+        // would incorrectly prune the partition even though it contains matching rows.
         if (ConnectContext.get().getSessionVariable().isEnableExprPrunePartition()
-                && call.getColumnRefs().size() == 1 && partitionColumnSet.containsAll(call.getUsedColumns())) {
+                && call.getColumnRefs().size() == 1 && partitionColumnSet.containsAll(call.getUsedColumns())
+                && OperatorFunctionChecker.onlyContainMonotonicFunctions(call).first) {
             BaseScalarOperatorShuttle replaceShuttle = new BaseScalarOperatorShuttle() {
                 @Override
                 public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -500,6 +500,32 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         PlanTestBase.assertContains(plan, expect);
     }
 
+    private static Stream<Arguments> nonMonotonicExprNoPruneSqls() {
+        List<Arguments> arguments = Lists.newArrayList();
+        // month()/day()/dayofyear()/dayofweek() wrap around inside a partition's span, so mapping a
+        // partition's two boundary values through them says nothing about the values inside: ptest's
+        // p202001 [1000-01-01, 2020-01-01) maps to month [1, 1] yet contains rows of every month.
+        // These predicates must not prune any partition.
+        arguments.add(Arguments.of("select * from ptest where month(d2) = 5", "partitions=4/4"));
+        arguments.add(Arguments.of("select * from ptest where day(d2) = 15", "partitions=4/4"));
+        arguments.add(Arguments.of("select * from ptest where dayofyear(d2) = 135", "partitions=4/4"));
+        arguments.add(Arguments.of("select * from ptest where month(d2) = 5 or month(d2) = 6", "partitions=4/4"));
+        arguments.add(Arguments.of("select * from less_than_tbl where dayofweek(k1) = 3", "partitions=4/4"));
+        // a monotonic predicate in the same conjunction still prunes; the non-monotonic one only
+        // stops contributing
+        arguments.add(Arguments.of("select * from ptest where month(d2) = 5 and d2 < '2020-01-01'",
+                "partitions=1/4"));
+        return arguments.stream();
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("nonMonotonicExprNoPruneSqls")
+    @Order(9)
+    void testNonMonotonicExprNoPrune(String sql, String expect) throws Exception {
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertContains(plan, expect);
+    }
+
     private static Stream<Arguments> exprPrunePartitionSqls() {
         List<String> sqlList = Lists.newArrayList();
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");


### PR DESCRIPTION
## Why I'm doing:

Expression-based range partition pruning ("further prune", `enable_expr_prune_partition`, on by default) evaluates a predicate `f(partition_col) cmp const` by mapping each candidate partition's two boundary values through `f` and intersecting the result with the predicate range (`PartitionColPredicateEvaluator.visitCall`). That is only sound when `f` is monotonic, but `PartitionColPredicateExtractor.visitCall` admits **any** FE-foldable single-column function without a monotonicity check. A non-monotonic function wraps around inside a partition's span, so both boundaries can map to the same value while the partition covers the whole domain — and the partition is pruned with matching rows inside.

Reproduction (default settings):

```sql
create table t (dt date, v int)
partition by range(dt) (
  partition p2024 values [('2024-01-01'), ('2025-01-01')),
  partition p2025 values [('2025-01-01'), ('2026-01-01')))
distributed by hash(v) properties("replication_num"="1");

insert into t values ('2024-05-15', 1);
select * from t where month(dt) = 5;  -- returns empty
```

Both partitions map to month range [1, 1] (`month` of Jan 1 for every year boundary), [1, 1] does not intersect [5, 5], both partitions are pruned, the row silently disappears. Same class: `day()`, `hour()`, `dayofweek()`, `dayofyear()`. The endpoint swap in the evaluator handles *decreasing* monotonic functions but masks wraparound instead of failing.

## What I'm doing:

Gate `PartitionColPredicateExtractor.visitCall` with `OperatorFunctionChecker.onlyContainMonotonicFunctions` — the same registry already used for this purpose by `ListPartitionPruner` (generated-column conjunct deduction) and `PartitionSelector`. Monotonic expressions (`date_trunc`, `days_add`, `last_day`, `datediff`, order-preserving `date_format`, ...) keep pruning — every pruning expression in the existing `FurtherPartitionPruneTest` suite is registry-flagged and stays green. Non-monotonic expressions now degrade to scan-level predicates instead of pruning incorrectly, so affected queries scan more partitions — correctness over performance.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
