### PR TITLE
[Refactor] Move connector sink memory manager to primitive layer

### DIFF
--- a/be/AGENTS.md
+++ b/be/AGENTS.md
@@ -269,12 +269,12 @@ Operator-tree execution framework for query and fragment contexts, driver lifecy
 - Remediation: Keep ExecRuntime limited to the operator-tree execution framework and runtime behavior that can be expressed through ComputeEnv and ExecPrimitive contracts; move concrete operators, storage, service, connector, cache, HTTP, and broad Exec integration upward.
 
 ### ConnectorPrimitive (`connectorprimitive`)
-Connector contracts, DataSource, DataSourceProvider default mechanics, and primitive connector sink commit/profile types without concrete connectors, sinks, registry composition, storage, service, or full Exec coupling.
+Connector contracts, DataSource, DataSourceProvider default mechanics, primitive connector sink commit/profile types, and generic connector sink memory management without concrete connectors, sinks, registry composition, storage, service, or full Exec coupling.
 - Targets: `ConnectorPrimitive`
 - Allowed internal include prefixes: `connector_primitive/`, `exec_primitive/`, `exprs/`, `runtime/`, `formats/`, `column/`, `types/`, `common/`, `base/`, `gutil/`, `gen_cpp/`
 - Allowed target deps: `FormatCore`, `ExecPrimitive`, `Expr`, `Runtime`, `ChunkCore`, `ColumnCore`, `Types`, `Common`, `Base`, `Gutil`, `StarRocksGen`
 - Core tests: `connector_primitive_test`
-- Remediation: Keep ConnectorPrimitive limited to connector contracts, default scan-range-to-morsel mechanics, and primitive sink commit/profile types; move concrete connectors, concrete sinks, registry wiring, storage, service, and full Exec integration upward.
+- Remediation: Keep ConnectorPrimitive limited to connector contracts, default scan-range-to-morsel mechanics, primitive sink commit/profile types, and generic sink memory policies expressed through lower-level interfaces; move concrete connectors, concrete sinks, registry wiring, storage, service, and full Exec integration upward.
 
 ### ConnectorBuiltinRegistry (`connectorbuiltinregistry`)
 Top-level built-in connector registration composition above connector contracts and concrete connector libraries.

--- a/be/module_boundary_manifest.json
+++ b/be/module_boundary_manifest.json
@@ -770,7 +770,7 @@
     {
       "id": "connectorprimitive",
       "doc_label": "ConnectorPrimitive",
-      "summary": "Connector contracts, DataSource, DataSourceProvider default mechanics, and primitive connector sink commit/profile types without concrete connectors, sinks, registry composition, storage, service, or full Exec coupling.",
+      "summary": "Connector contracts, DataSource, DataSourceProvider default mechanics, primitive connector sink commit/profile types, and generic connector sink memory management without concrete connectors, sinks, registry composition, storage, service, or full Exec coupling.",
       "owned_targets": ["ConnectorPrimitive"],
       "owned_roots": ["be/src/connector_primitive"],
       "allowed_include_prefixes": [
@@ -795,7 +795,7 @@
       "allowed_target_deps": ["FormatCore", "ExecPrimitive", "Expr", "Runtime", "ChunkCore", "ColumnCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
       "allowed_test_targets": ["connector_primitive_test"],
       "allowed_test_link_deps": ["ConnectorPrimitive", "FormatCore", "ExecPrimitive", "Expr", "Runtime", "ChunkCore", "ColumnCore", "Types", "Common", "Base", "Gutil", "StarRocksGen"],
-      "remediation": "Keep ConnectorPrimitive limited to connector contracts, default scan-range-to-morsel mechanics, and primitive sink commit/profile types; move concrete connectors, concrete sinks, registry wiring, storage, service, and full Exec integration upward."
+      "remediation": "Keep ConnectorPrimitive limited to connector contracts, default scan-range-to-morsel mechanics, primitive sink commit/profile types, and generic sink memory policies expressed through lower-level interfaces; move concrete connectors, concrete sinks, registry wiring, storage, service, and full Exec integration upward."
     },
     {
       "id": "connectorbenchmark",

--- a/be/src/connector/CMakeLists.txt
+++ b/be/src/connector/CMakeLists.txt
@@ -26,8 +26,8 @@ ADD_BE_LIB(Connector
         hive_chunk_sink.cpp
         iceberg_chunk_sink.cpp
         utils.cpp
-        sink_memory_manager.cpp
         partition_chunk_writer.cpp
+        partition_chunk_writer_memory_manager.cpp
         connector_sink_executor.cpp
         deletion_vector/deletion_vector.cpp
         iceberg_delete_sink.cpp

--- a/be/src/connector/connector_chunk_sink.cpp
+++ b/be/src/connector/connector_chunk_sink.cpp
@@ -16,7 +16,7 @@
 
 #include "column/chunk.h"
 #include "common/status.h"
-#include "connector/sink_memory_manager.h"
+#include "connector/partition_chunk_writer_memory_manager.h"
 #include "formats/file_writer.h"
 #include "runtime/runtime_state.h"
 
@@ -37,11 +37,13 @@ Status ConnectorChunkSink::init(formats::AsyncFlushStreamPoller* poller, Runtime
     _io_poller = poller;
     _profile = profile;
     DCHECK(sink_mem_mgr != nullptr);
-    _op_mem_mgr = sink_mem_mgr->register_child_manager(std::make_unique<SinkOperatorMemoryManager>());
+    auto op_mem_mgr = std::make_unique<PartitionChunkWriterMemoryManager>();
     init_profile();
     RETURN_IF_ERROR(ColumnEvaluator::init(_partition_column_evaluators));
     RETURN_IF_ERROR(_partition_chunk_writer_factory->init());
-    RETURN_IF_ERROR(_op_mem_mgr->init(&_writers, _io_poller));
+    RETURN_IF_ERROR(op_mem_mgr->init(&_writers, _io_poller));
+    _partition_writer_mem_mgr = op_mem_mgr.get();
+    _op_mem_mgr = sink_mem_mgr->register_child_manager(std::move(op_mem_mgr));
     return Status::OK();
 }
 

--- a/be/src/connector/connector_chunk_sink.h
+++ b/be/src/connector/connector_chunk_sink.h
@@ -31,6 +31,7 @@ class AsyncFlushStreamPoller;
 
 namespace starrocks::connector {
 
+class PartitionChunkWriterMemoryManager;
 class SinkMemoryManager;
 class SinkOperatorMemoryManager;
 
@@ -77,6 +78,7 @@ protected:
 
     formats::AsyncFlushStreamPoller* _io_poller = nullptr;
     SinkOperatorMemoryManager* _op_mem_mgr = nullptr;
+    PartitionChunkWriterMemoryManager* _partition_writer_mem_mgr = nullptr;
 
     std::vector<std::string> _partition_column_names;
     std::vector<std::unique_ptr<ColumnEvaluator>> _partition_column_evaluators;
@@ -86,7 +88,7 @@ protected:
     std::vector<std::function<void()>> _rollback_actions;
 
     std::map<PartitionKey, PartitionChunkWriterPtr> _partition_chunk_writers;
-    // passed to SinkOperatorMemoryManager to check memory usage
+    // passed to PartitionChunkWriterMemoryManager to check memory usage
     std::vector<PartitionChunkWriterPtr> _writers;
     inline static std::string DEFAULT_PARTITION = "__DEFAULT_PARTITION__";
 

--- a/be/src/connector/file_chunk_sink.cpp
+++ b/be/src/connector/file_chunk_sink.cpp
@@ -18,7 +18,7 @@
 
 #include "base/url_coding.h"
 #include "common/logging.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/expr.h"
 #include "formats/csv/csv_file_writer.h"

--- a/be/src/connector/hive_chunk_sink.cpp
+++ b/be/src/connector/hive_chunk_sink.cpp
@@ -18,7 +18,7 @@
 
 #include "base/url_coding.h"
 #include "common/logging.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/expr.h"
 #include "formats/csv/csv_file_writer.h"

--- a/be/src/connector/hive_chunk_sink.h
+++ b/be/src/connector/hive_chunk_sink.h
@@ -22,7 +22,6 @@
 #include "common/status.h"
 #include "common/thread/priority_thread_pool.hpp"
 #include "connector/connector_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
 #include "connector/utils.h"
 #include "formats/column_evaluator.h"
 #include "formats/file_writer.h"

--- a/be/src/connector/iceberg_chunk_sink.cpp
+++ b/be/src/connector/iceberg_chunk_sink.cpp
@@ -19,7 +19,7 @@
 #include "base/url_coding.h"
 #include "common/config_connector_sink_fwd.h"
 #include "common/logging.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/expr.h"
 #include "formats/io/async_flush_stream_poller.h"

--- a/be/src/connector/iceberg_delete_sink.cpp
+++ b/be/src/connector/iceberg_delete_sink.cpp
@@ -25,7 +25,7 @@
 #include "column/sorting/sorting.h"
 #include "common/config_exec_fwd.h"
 #include "connector/partition_chunk_writer.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exprs/expr.h"
 #include "formats/column_evaluator.h"

--- a/be/src/connector/iceberg_row_delta_sink.cpp
+++ b/be/src/connector/iceberg_row_delta_sink.cpp
@@ -17,6 +17,7 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "common/logging.h"
+#include "connector/partition_chunk_writer_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 
 namespace starrocks::connector {
@@ -44,17 +45,18 @@ Status IcebergRowDeltaSink::init(formats::AsyncFlushStreamPoller* poller, Runtim
     RETURN_IF_ERROR(_delete_sink->init(poller, _profile, sink_mem_mgr));
     RETURN_IF_ERROR(_data_sink->init(poller, _profile, sink_mem_mgr));
 
-    _op_mem_mgr = sink_mem_mgr->register_child_manager(std::make_unique<SinkOperatorMemoryManager>());
-    RETURN_IF_ERROR(_op_mem_mgr->init(&_writers, _io_poller));
+    auto op_mem_mgr = std::make_unique<PartitionChunkWriterMemoryManager>();
+    RETURN_IF_ERROR(op_mem_mgr->init(&_writers, _io_poller));
 
     // This composite sink owns no writers of its own (NopPartitionChunkWriterFactory),
     // so the operator-level kill-victim / backpressure path would see an empty
     // candidate list. Register sub-sink writer lists with the outer manager so
     // memory pressure logic can flush real writers held by the sub-sinks.
-    if (_op_mem_mgr != nullptr) {
-        _op_mem_mgr->add_candidates(_delete_sink->writers());
-        _op_mem_mgr->add_candidates(_data_sink->writers());
-    }
+    op_mem_mgr->add_candidates(_delete_sink->writers());
+    op_mem_mgr->add_candidates(_data_sink->writers());
+
+    _partition_writer_mem_mgr = op_mem_mgr.get();
+    _op_mem_mgr = sink_mem_mgr->register_child_manager(std::move(op_mem_mgr));
 
     return Status::OK();
 }

--- a/be/src/connector/iceberg_row_delta_sink.h
+++ b/be/src/connector/iceberg_row_delta_sink.h
@@ -20,7 +20,6 @@
 #include "connector/connector_chunk_sink.h"
 #include "connector/iceberg_chunk_sink.h"
 #include "connector/iceberg_delete_sink.h"
-#include "connector/sink_memory_manager.h"
 
 namespace starrocks::connector {
 

--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -22,7 +22,6 @@
 #include "compute_env/load_spill/load_spill_block_manager.h"
 #include "compute_env/load_spill/load_spill_block_merge_executor.h"
 #include "connector/connector_sink_executor.h"
-#include "connector/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"
 #include "formats/io/async_flush_stream_poller.h"

--- a/be/src/connector/partition_chunk_writer_memory_manager.cpp
+++ b/be/src/connector/partition_chunk_writer_memory_manager.cpp
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "connector/partition_chunk_writer_memory_manager.h"
+
+#include "common/logging.h"
+
+namespace starrocks::connector {
+
+Status PartitionChunkWriterMemoryManager::init(std::vector<PartitionChunkWriterPtr>* writers,
+                                               formats::AsyncFlushStreamPoller* io_poller) {
+    _candidate_lists.clear();
+    _candidate_lists.push_back(writers);
+    _io_poller = io_poller;
+    return Status::OK();
+}
+
+void PartitionChunkWriterMemoryManager::add_candidates(std::vector<PartitionChunkWriterPtr>* writers) {
+    if (writers == nullptr) {
+        return;
+    }
+    _candidate_lists.push_back(writers);
+}
+
+bool PartitionChunkWriterMemoryManager::kill_victim() {
+    // Find a target file writer to flush across all registered candidate lists.
+    // For buffered partition writer, choose the the writer with the largest file size.
+    // For spillable partition writer, choose the the writer with the largest memory size that can be spilled.
+    PartitionChunkWriterPtr victim = nullptr;
+    for (auto* candidates : _candidate_lists) {
+        if (candidates == nullptr) {
+            continue;
+        }
+        for (auto& writer : *candidates) {
+            int64_t flushable_bytes = writer->get_flushable_bytes();
+            if (flushable_bytes == 0) {
+                continue;
+            }
+            if (victim && flushable_bytes < victim->get_flushable_bytes()) {
+                continue;
+            }
+            victim = writer;
+        }
+    }
+    if (victim == nullptr) {
+        return false;
+    }
+
+    // The flush will decrease the writer flushable memory bytes, so it usually
+    // will not be choosed in a short time.
+    const auto filename = victim->out_stream()->filename();
+    size_t flush_bytes = victim->get_flushable_bytes();
+    const auto result = victim->flush();
+    LOG(INFO) << "kill victim: " << filename << ", result: " << result << ", flushable_bytes: " << flush_bytes;
+    return true;
+}
+
+int64_t PartitionChunkWriterMemoryManager::update_releasable_memory() {
+    int64_t releasable_memory = _io_poller->releasable_memory();
+    _releasable_memory.store(releasable_memory);
+    return releasable_memory;
+}
+
+int64_t PartitionChunkWriterMemoryManager::update_writer_occupied_memory() {
+    int64_t writer_occupied_memory = 0;
+    for (auto* candidates : _candidate_lists) {
+        if (candidates == nullptr) {
+            continue;
+        }
+        for (auto& writer : *candidates) {
+            writer_occupied_memory += writer->get_flushable_bytes();
+        }
+    }
+    _writer_occupied_memory.store(writer_occupied_memory);
+    return writer_occupied_memory;
+}
+
+} // namespace starrocks::connector

--- a/be/src/connector/partition_chunk_writer_memory_manager.h
+++ b/be/src/connector/partition_chunk_writer_memory_manager.h
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+
+#include "common/status.h"
+#include "connector/partition_chunk_writer.h"
+#include "connector_primitive/sink_memory_manager.h"
+#include "formats/io/async_flush_stream_poller.h"
+
+namespace starrocks::connector {
+
+/// manage memory of a single partition-writer sink operator
+/// not thread-safe except `releasable_memory()` and `writer_occupied_memory()`
+class PartitionChunkWriterMemoryManager final : public SinkOperatorMemoryManager {
+public:
+    PartitionChunkWriterMemoryManager() = default;
+
+    Status init(std::vector<PartitionChunkWriterPtr>* writers, formats::AsyncFlushStreamPoller* io_poller);
+
+    // Register an additional writer list. Used by composite sinks
+    // (e.g. IcebergRowDeltaSink) so memory pressure logic can see writers
+    // owned by their sub-sinks.
+    void add_candidates(std::vector<PartitionChunkWriterPtr>* writers);
+
+    bool kill_victim() override;
+
+    int64_t update_releasable_memory() override;
+
+    int64_t update_writer_occupied_memory() override;
+
+    int64_t releasable_memory() const override { return _releasable_memory.load(); }
+
+    int64_t writer_occupied_memory() const override { return _writer_occupied_memory.load(); }
+
+private:
+    // One or more references to writer lists owned by sink operator(s).
+    std::vector<std::vector<PartitionChunkWriterPtr>*> _candidate_lists;
+    formats::AsyncFlushStreamPoller* _io_poller = nullptr;
+    std::atomic_int64_t _releasable_memory{0};
+    std::atomic_int64_t _writer_occupied_memory{0};
+};
+
+} // namespace starrocks::connector

--- a/be/src/connector_primitive/CMakeLists.txt
+++ b/be/src/connector_primitive/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CONNECTOR_PRIMITIVE_FILES
         connector.cpp
         data_source.cpp
         data_source_provider.cpp
+        sink_memory_manager.cpp
 )
 
 ADD_BE_LIB(ConnectorPrimitive

--- a/be/src/connector_primitive/sink_memory_manager.cpp
+++ b/be/src/connector_primitive/sink_memory_manager.cpp
@@ -12,80 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
+
+#include <algorithm>
 
 #include "common/config_connector_sink_fwd.h"
-#include "exec/exec_env.h"
+#include "common/logging.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_env.h"
 
 namespace starrocks::connector {
-
-Status SinkOperatorMemoryManager::init(std::vector<PartitionChunkWriterPtr>* writers,
-                                       formats::AsyncFlushStreamPoller* io_poller) {
-    _candidate_lists.clear();
-    _candidate_lists.push_back(writers);
-    _io_poller = io_poller;
-    return Status::OK();
-}
-
-void SinkOperatorMemoryManager::add_candidates(std::vector<PartitionChunkWriterPtr>* writers) {
-    if (writers == nullptr) {
-        return;
-    }
-    _candidate_lists.push_back(writers);
-}
-
-bool SinkOperatorMemoryManager::kill_victim() {
-    // Find a target file writer to flush across all registered candidate lists.
-    // For buffered partition writer, choose the the writer with the largest file size.
-    // For spillable partition writer, choose the the writer with the largest memory size that can be spilled.
-    PartitionChunkWriterPtr victim = nullptr;
-    for (auto* candidates : _candidate_lists) {
-        if (candidates == nullptr) {
-            continue;
-        }
-        for (auto& writer : *candidates) {
-            int64_t flushable_bytes = writer->get_flushable_bytes();
-            if (flushable_bytes == 0) {
-                continue;
-            }
-            if (victim && flushable_bytes < victim->get_flushable_bytes()) {
-                continue;
-            }
-            victim = writer;
-        }
-    }
-    if (victim == nullptr) {
-        return false;
-    }
-
-    // The flush will decrease the writer flushable memory bytes, so it usually
-    // will not be choosed in a short time.
-    const auto filename = victim->out_stream()->filename();
-    size_t flush_bytes = victim->get_flushable_bytes();
-    const auto result = victim->flush();
-    LOG(INFO) << "kill victim: " << filename << ", result: " << result << ", flushable_bytes: " << flush_bytes;
-    return true;
-}
-
-int64_t SinkOperatorMemoryManager::update_releasable_memory() {
-    int64_t releasable_memory = _io_poller->releasable_memory();
-    _releasable_memory.store(releasable_memory);
-    return releasable_memory;
-}
-
-int64_t SinkOperatorMemoryManager::update_writer_occupied_memory() {
-    int64_t writer_occupied_memory = 0;
-    for (auto* candidates : _candidate_lists) {
-        if (candidates == nullptr) {
-            continue;
-        }
-        for (auto& writer : *candidates) {
-            writer_occupied_memory += writer->get_flushable_bytes();
-        }
-    }
-    _writer_occupied_memory.store(writer_occupied_memory);
-    return _writer_occupied_memory;
-}
 
 SinkMemoryManager::SinkMemoryManager(MemTracker* query_pool_tracker, MemTracker* query_tracker)
         : _query_pool_tracker(query_pool_tracker), _query_tracker(query_tracker) {

--- a/be/src/connector_primitive/sink_memory_manager.h
+++ b/be/src/connector_primitive/sink_memory_manager.h
@@ -14,55 +14,39 @@
 
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <vector>
 
-#include "common/status.h"
-#include "connector/partition_chunk_writer.h"
-#include "formats/io/async_flush_stream_poller.h"
-#include "runtime/mem_tracker.h"
+namespace starrocks {
 
-namespace starrocks::connector {
+class MemTracker;
 
-/// manage memory of a single sink operator
-/// not thread-safe except `releasable_memory()`
+namespace connector {
+
+/// Interface for operator-level sink memory managers.
 class SinkOperatorMemoryManager {
 public:
-    SinkOperatorMemoryManager() = default;
-
-    Status init(std::vector<PartitionChunkWriterPtr>* writers, formats::AsyncFlushStreamPoller* io_poller);
-
-    // Register an additional writer list. Used by composite sinks
-    // (e.g. IcebergRowDeltaSink) so memory pressure logic can see writers
-    // owned by their sub-sinks.
-    void add_candidates(std::vector<PartitionChunkWriterPtr>* writers);
+    virtual ~SinkOperatorMemoryManager() = default;
 
     // return true if a victim is found and killed, otherwise return false
-    bool kill_victim();
+    virtual bool kill_victim() = 0;
 
-    int64_t update_releasable_memory();
+    virtual int64_t update_releasable_memory() = 0;
 
-    int64_t update_writer_occupied_memory();
-
-    // thread-safe
-    int64_t releasable_memory() { return _releasable_memory.load(); }
+    virtual int64_t update_writer_occupied_memory() = 0;
 
     // thread-safe
-    int64_t writer_occupied_memory() { return _writer_occupied_memory.load(); }
+    virtual int64_t releasable_memory() const = 0;
 
-private:
-    // One or more references to writer lists owned by sink operator(s).
-    std::vector<std::vector<PartitionChunkWriterPtr>*> _candidate_lists;
-    formats::AsyncFlushStreamPoller* _io_poller;
-    std::atomic_int64_t _releasable_memory{0};
-    std::atomic_int64_t _writer_occupied_memory{0};
+    // thread-safe
+    virtual int64_t writer_occupied_memory() const = 0;
 };
 
 /// 1. manage all sink operators in a query
 /// 2. calculates releasable memory across all
-/// 3. kill (early-close) writers to enlarge releasable memory, which are flushed to remote storage and freed asynchronously
+/// 3. kill (early-close) writers to enlarge releasable memory, which are flushed to remote storage and freed
+/// asynchronously
 class SinkMemoryManager {
 public:
     SinkMemoryManager(MemTracker* query_pool_tracker, MemTracker* query_tracker);
@@ -88,4 +72,5 @@ private:
     std::vector<std::unique_ptr<SinkOperatorMemoryManager>> _children;
 };
 
-} // namespace starrocks::connector
+} // namespace connector
+} // namespace starrocks

--- a/be/src/exec/pipeline/sink/connector_sink_operator.h
+++ b/be/src/exec/pipeline/sink/connector_sink_operator.h
@@ -18,8 +18,8 @@
 
 #include "common/logging.h"
 #include "connector/connector_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
 #include "connector/utils.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec_primitive/pipeline/operator_factory.h"
 #include "formats/io/async_flush_stream_poller.h"

--- a/be/test/connector_primitive/connector_primitive_test.cpp
+++ b/be/test/connector_primitive/connector_primitive_test.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include "base/testutil/scoped_updater.h"
+#include "common/config_connector_sink_fwd.h"
 #include "connector_primitive/connector.h"
 #include "connector_primitive/connector_sink_commit.h"
 #include "connector_primitive/data_source_provider.h"
@@ -138,6 +140,8 @@ TEST(ConnectorPrimitiveTest, SinkMemoryManagerRegistersAbstractOperatorManagers)
 }
 
 TEST(ConnectorPrimitiveTest, SinkMemoryManagerUsesAbstractChildrenForBackpressure) {
+    SCOPED_UPDATE(double, config::connector_sink_mem_low_watermark_ratio, 0.1);
+    SCOPED_UPDATE(double, config::connector_sink_mem_urgent_space_ratio, 0.05);
     MemTracker query_pool_tracker(MemTrackerType::QUERY_POOL, 1000, "connector_primitive_query_pool");
     query_pool_tracker.consume(950);
     SinkMemoryManager manager(&query_pool_tracker, nullptr);
@@ -159,6 +163,8 @@ TEST(ConnectorPrimitiveTest, SinkMemoryManagerUsesAbstractChildrenForBackpressur
 }
 
 TEST(ConnectorPrimitiveTest, SinkMemoryManagerRejectsInputWhenReleasableMemoryRemains) {
+    SCOPED_UPDATE(double, config::connector_sink_mem_low_watermark_ratio, 0.1);
+    SCOPED_UPDATE(double, config::connector_sink_mem_urgent_space_ratio, 0.05);
     MemTracker query_pool_tracker(MemTrackerType::QUERY_POOL, 1000, "connector_primitive_releasable_pool");
     query_pool_tracker.consume(950);
     SinkMemoryManager manager(&query_pool_tracker, nullptr);

--- a/be/test/connector_primitive/connector_primitive_test.cpp
+++ b/be/test/connector_primitive/connector_primitive_test.cpp
@@ -17,8 +17,10 @@
 #include "connector_primitive/connector.h"
 #include "connector_primitive/connector_sink_commit.h"
 #include "connector_primitive/data_source_provider.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "formats/file_writer.h"
 #include "formats/utils.h"
+#include "runtime/mem_tracker.h"
 
 namespace starrocks::connector {
 
@@ -33,6 +35,40 @@ class TestDataSourceProvider final : public DataSourceProvider {
 public:
     DataSourcePtr create_data_source(const TScanRange&) override { return nullptr; }
     const TupleDescriptor* tuple_descriptor(RuntimeState*) const override { return nullptr; }
+};
+
+class TestSinkOperatorMemoryManager final : public SinkOperatorMemoryManager {
+public:
+    bool kill_victim() override {
+        ++kill_victim_calls;
+        if (!kill_victim_result) {
+            return false;
+        }
+        kill_victim_result = false;
+        writer_occupied_memory_value = 0;
+        return true;
+    }
+
+    int64_t update_releasable_memory() override {
+        ++update_releasable_memory_calls;
+        return releasable_memory_value;
+    }
+
+    int64_t update_writer_occupied_memory() override {
+        ++update_writer_occupied_memory_calls;
+        return writer_occupied_memory_value;
+    }
+
+    int64_t releasable_memory() const override { return releasable_memory_value; }
+
+    int64_t writer_occupied_memory() const override { return writer_occupied_memory_value; }
+
+    bool kill_victim_result = true;
+    int64_t releasable_memory_value = 0;
+    int64_t writer_occupied_memory_value = 0;
+    int kill_victim_calls = 0;
+    int update_releasable_memory_calls = 0;
+    int update_writer_occupied_memory_calls = 0;
 };
 
 } // namespace
@@ -90,6 +126,51 @@ TEST(ConnectorPrimitiveTest, DefaultScanRangeConversionBuildsDynamicMorselQueue)
     auto queue = std::move(queue_or).value();
     ASSERT_EQ(pipeline::MorselQueue::Type::DYNAMIC, queue->type());
     ASSERT_EQ(1, queue->num_original_morsels());
+}
+
+TEST(ConnectorPrimitiveTest, SinkMemoryManagerRegistersAbstractOperatorManagers) {
+    SinkMemoryManager manager(nullptr, nullptr);
+
+    auto child = std::make_unique<TestSinkOperatorMemoryManager>();
+    auto* child_ptr = child.get();
+
+    ASSERT_EQ(child_ptr, manager.register_child_manager(std::move(child)));
+}
+
+TEST(ConnectorPrimitiveTest, SinkMemoryManagerUsesAbstractChildrenForBackpressure) {
+    MemTracker query_pool_tracker(MemTrackerType::QUERY_POOL, 1000, "connector_primitive_query_pool");
+    query_pool_tracker.consume(950);
+    SinkMemoryManager manager(&query_pool_tracker, nullptr);
+
+    auto child = std::make_unique<TestSinkOperatorMemoryManager>();
+    auto* child_ptr = child.get();
+    child_ptr->writer_occupied_memory_value = 10;
+    ASSERT_EQ(child_ptr, manager.register_child_manager(std::move(child)));
+
+    auto sibling = std::make_unique<TestSinkOperatorMemoryManager>();
+    auto* sibling_ptr = sibling.get();
+    sibling_ptr->writer_occupied_memory_value = 100;
+    ASSERT_EQ(sibling_ptr, manager.register_child_manager(std::move(sibling)));
+
+    EXPECT_TRUE(manager.can_accept_more_input(child_ptr));
+    EXPECT_GE(child_ptr->kill_victim_calls, 1);
+    EXPECT_GE(child_ptr->update_writer_occupied_memory_calls, 1);
+    EXPECT_EQ(0, sibling_ptr->update_writer_occupied_memory_calls);
+}
+
+TEST(ConnectorPrimitiveTest, SinkMemoryManagerRejectsInputWhenReleasableMemoryRemains) {
+    MemTracker query_pool_tracker(MemTrackerType::QUERY_POOL, 1000, "connector_primitive_releasable_pool");
+    query_pool_tracker.consume(950);
+    SinkMemoryManager manager(&query_pool_tracker, nullptr);
+
+    auto child = std::make_unique<TestSinkOperatorMemoryManager>();
+    auto* child_ptr = child.get();
+    child_ptr->releasable_memory_value = 64;
+    ASSERT_EQ(child_ptr, manager.register_child_manager(std::move(child)));
+
+    EXPECT_FALSE(manager.can_accept_more_input(child_ptr));
+    EXPECT_GE(child_ptr->update_releasable_memory_calls, 1);
+    EXPECT_EQ(0, child_ptr->kill_victim_calls);
 }
 
 } // namespace starrocks::connector

--- a/be/test/connector_sink/file_chunk_sink_test.cpp
+++ b/be/test/connector_sink/file_chunk_sink_test.cpp
@@ -24,7 +24,7 @@
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
 #include "connector/connector_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"

--- a/be/test/connector_sink/hive_chunk_sink_test.cpp
+++ b/be/test/connector_sink/hive_chunk_sink_test.cpp
@@ -24,7 +24,7 @@
 #include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
 #include "connector/connector_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"

--- a/be/test/connector_sink/iceberg_chunk_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_chunk_sink_test.cpp
@@ -28,10 +28,11 @@
 #include "column/chunk_extra_data.h"
 #include "common/config_connector_sink_fwd.h"
 #include "connector/connector_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"
+#include "formats/io/async_flush_stream_poller.h"
 #include "formats/utils.h"
 
 namespace starrocks::connector {

--- a/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_row_delta_sink_test.cpp
@@ -28,6 +28,7 @@
 #include "common/config_exec_fwd.h"
 #include "common/status.h"
 #include "connector/iceberg_connector.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/io/async_flush_stream_poller.h"

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -26,7 +26,7 @@
 #include "connector/builtin_connector_registry.h"
 #include "connector/connector_registry.h"
 #include "connector/iceberg_row_delta_sink.h"
-#include "connector/sink_memory_manager.h"
+#include "connector_primitive/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/empty_set_operator.h"
 #include "exec/pipeline/fragment_context.h"

--- a/be/test/connector_sink/partition_chunk_writer_test.cpp
+++ b/be/test/connector_sink/partition_chunk_writer_test.cpp
@@ -32,6 +32,7 @@
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"
+#include "formats/io/async_flush_stream_poller.h"
 #include "formats/parquet/parquet_test_util/util.h"
 #include "formats/utils.h"
 #include "runtime/chunk_helper.h"

--- a/be/test/connector_sink/partition_chunk_writer_test.cpp
+++ b/be/test/connector_sink/partition_chunk_writer_test.cpp
@@ -29,7 +29,6 @@
 #include "connector/connector_chunk_sink.h"
 #include "connector/connector_sink_executor.h"
 #include "connector/iceberg_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"

--- a/be/test/connector_sink/sink_memory_manager_test.cpp
+++ b/be/test/connector_sink/sink_memory_manager_test.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "connector/sink_memory_manager.h"
-
 #include <gmock/gmock.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
@@ -25,6 +23,7 @@
 #include "base/utility/integer_util.h"
 #include "connector/connector_chunk_sink.h"
 #include "connector/partition_chunk_writer.h"
+#include "connector/partition_chunk_writer_memory_manager.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"
@@ -114,7 +113,7 @@ TEST_F(SinkMemoryManagerTest, kill_victim) {
             std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
                     {nullptr, nullptr, 1024, false}, nullptr, _fragment_context.get(), nullptr, tuple_desc, nullptr});
 
-    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    auto sink_mem_mgr = std::make_shared<PartitionChunkWriterMemoryManager>();
     std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};
@@ -160,7 +159,7 @@ TEST_F(SinkMemoryManagerTest, init_with_vector) {
             std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
                     {nullptr, nullptr, 1024, false}, nullptr, _fragment_context.get(), nullptr, tuple_desc, nullptr});
 
-    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    auto sink_mem_mgr = std::make_shared<PartitionChunkWriterMemoryManager>();
     std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};
@@ -188,7 +187,7 @@ TEST_F(SinkMemoryManagerTest, kill_victim_selects_max_flushable_bytes) {
             std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
                     {nullptr, nullptr, 1024, false}, nullptr, _fragment_context.get(), nullptr, tuple_desc, nullptr});
 
-    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    auto sink_mem_mgr = std::make_shared<PartitionChunkWriterMemoryManager>();
     std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};
@@ -225,7 +224,7 @@ TEST_F(SinkMemoryManagerTest, update_writer_occupied_memory) {
             std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
                     {nullptr, nullptr, 1024, false}, nullptr, _fragment_context.get(), nullptr, tuple_desc, nullptr});
 
-    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    auto sink_mem_mgr = std::make_shared<PartitionChunkWriterMemoryManager>();
     std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};
@@ -261,11 +260,11 @@ TEST_F(SinkMemoryManagerTest, registered_children_participate_in_total_occupied_
     query_pool_tracker.consume(950);
     SinkMemoryManager manager(&query_pool_tracker, &query_tracker);
 
-    auto child1 = std::make_unique<SinkOperatorMemoryManager>();
+    auto child1 = std::make_unique<PartitionChunkWriterMemoryManager>();
     auto* child1_ptr = child1.get();
     ASSERT_EQ(manager.register_child_manager(std::move(child1)), child1_ptr);
 
-    auto child2 = std::make_unique<SinkOperatorMemoryManager>();
+    auto child2 = std::make_unique<PartitionChunkWriterMemoryManager>();
     auto* child2_ptr = child2.get();
     ASSERT_EQ(manager.register_child_manager(std::move(child2)), child2_ptr);
 
@@ -303,7 +302,7 @@ TEST_F(SinkMemoryManagerTest, iceberg_delete_sink_scenario) {
             std::make_shared<SpillPartitionChunkWriterContext>(SpillPartitionChunkWriterContext{
                     {nullptr, nullptr, 1024, false}, nullptr, _fragment_context.get(), nullptr, tuple_desc, nullptr});
 
-    auto sink_mem_mgr = std::make_shared<SinkOperatorMemoryManager>();
+    auto sink_mem_mgr = std::make_shared<PartitionChunkWriterMemoryManager>();
     std::vector<PartitionChunkWriterPtr> writers;
 
     std::vector<int8_t> partition_field_null_list = {};

--- a/be/test/connector_sink/sink_memory_manager_test.cpp
+++ b/be/test/connector_sink/sink_memory_manager_test.cpp
@@ -27,6 +27,7 @@
 #include "exec/exec_env.h"
 #include "exec/pipeline/fragment_context.h"
 #include "formats/file_writer.h"
+#include "formats/io/async_flush_stream_poller.h"
 #include "formats/parquet/parquet_test_util/util.h"
 #include "formats/utils.h"
 

--- a/be/test/exec/sink/connector_sink_operator_test.cpp
+++ b/be/test/exec/sink/connector_sink_operator_test.cpp
@@ -25,7 +25,7 @@
 #include "base/utility/defer_op.h"
 #include "connector/connector_chunk_sink.h"
 #include "connector/hive_chunk_sink.h"
-#include "connector/sink_memory_manager.h"
+#include "connector/partition_chunk_writer_memory_manager.h"
 #include "exec/exec_env.h"
 #include "formats/io/async_flush_output_stream.h"
 #include "formats/io/async_flush_stream_poller.h"
@@ -228,7 +228,9 @@ TEST_F(ConnectorSinkOperatorTest, need_input_releases_flush_memory_under_instanc
     ASSERT_EQ(_query_tracker->consumption(), kTrackedBytes);
 
     auto sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(_query_pool_tracker.get(), _query_tracker.get());
-    auto* op_mem_mgr = sink_mem_mgr->register_child_manager(std::make_unique<connector::SinkOperatorMemoryManager>());
+    auto op_mem_mgr_impl = std::make_unique<connector::PartitionChunkWriterMemoryManager>();
+    auto* op_mem_mgr = op_mem_mgr_impl.get();
+    ASSERT_EQ(sink_mem_mgr->register_child_manager(std::move(op_mem_mgr_impl)), op_mem_mgr);
     ASSERT_OK(op_mem_mgr->init(&writers, &poller));
 
     auto chunk_sink = std::make_unique<TestConnectorChunkSink>(_runtime_state);
@@ -263,7 +265,9 @@ TEST_F(ConnectorSinkOperatorTest, is_finished_releases_polled_stream_under_insta
     ASSERT_OK(stream->close());
 
     auto sink_mem_mgr = std::make_shared<connector::SinkMemoryManager>(_query_pool_tracker.get(), _query_tracker.get());
-    auto* op_mem_mgr = sink_mem_mgr->register_child_manager(std::make_unique<connector::SinkOperatorMemoryManager>());
+    auto op_mem_mgr_impl = std::make_unique<connector::PartitionChunkWriterMemoryManager>();
+    auto* op_mem_mgr = op_mem_mgr_impl.get();
+    ASSERT_EQ(sink_mem_mgr->register_child_manager(std::move(op_mem_mgr_impl)), op_mem_mgr);
     std::vector<connector::PartitionChunkWriterPtr> writers;
     formats::AsyncFlushStreamPoller empty_poller;
     ASSERT_OK(op_mem_mgr->init(&writers, &empty_poller));


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
