### PR TITLE
[Enhancement] Adopt JDK 21 and warn on deprecated JDK versions

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -102,14 +102,20 @@ if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
     jvm_arch="aarch64"
 fi
 
+# min jdk version required for jni features
+MIN_JDK_VERSION=17
+# recommended jdk version; versions in [MIN_JDK_VERSION, RECOMMENDED_JDK_VERSION) are deprecated
+RECOMMENDED_JDK_VERSION=21
 if [ "$JAVA_HOME" = "" ]; then
     echo "[WARNING] JAVA_HOME env not set. Functions or features that requires jni will not work at all."
     export LD_LIBRARY_PATH=$STARROCKS_HOME/lib:$LD_LIBRARY_PATH
 else
     export LD_LIBRARY_PATH=$JAVA_HOME/lib/server:$JAVA_HOME/lib:$LD_LIBRARY_PATH
     java_version=$(jdk_version)
-    if [[ $java_version -lt 17 ]]; then
-        echo "[WARNING] jdk versions lower than 17 are not supported"
+    if [[ $java_version -lt $MIN_JDK_VERSION ]]; then
+        echo "[ERROR] JDK $java_version is not supported, please use JDK version $RECOMMENDED_JDK_VERSION or higher"
+    elif [[ $java_version -lt $RECOMMENDED_JDK_VERSION ]]; then
+        echo "[WARNING] JDK $java_version is deprecated and support will be removed in a future release, please upgrade to JDK version $RECOMMENDED_JDK_VERSION or higher"
     fi
 fi
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -60,6 +60,8 @@ FAILPOINT=
 RUN_LOG_CONSOLE=${SYS_LOG_TO_CONSOLE:-0}
 # min jdk version required
 MIN_JDK_VERSION=17
+# recommended jdk version; versions in [MIN_JDK_VERSION, RECOMMENDED_JDK_VERSION) are deprecated
+RECOMMENDED_JDK_VERSION=21
 while true; do
     case "$1" in
         --daemon) RUN_DAEMON=1 ; shift ;;
@@ -149,8 +151,10 @@ JAVA=$JAVA_HOME/bin/java
 # check java version and choose correct JAVA_OPTS
 JAVA_VERSION=$(jdk_version)
 if [[ "$JAVA_VERSION" -lt $MIN_JDK_VERSION ]]; then
-    echo "Error: JDK $JAVA_VERSION is not supported, please use JDK version $MIN_JDK_VERSION or higher"
+    echo "Error: JDK $JAVA_VERSION is not supported, please use JDK version $RECOMMENDED_JDK_VERSION or higher"
     exit -1
+elif [[ "$JAVA_VERSION" -lt $RECOMMENDED_JDK_VERSION ]]; then
+    echo "Warning: JDK $JAVA_VERSION is deprecated and support will be removed in a future release, please upgrade to JDK version $RECOMMENDED_JDK_VERSION or higher"
 fi
 
 final_java_opt=${JAVA_OPTS}

--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -33,14 +33,14 @@ ARG DEPLOYDIR=/data/deploy
 ENV SR_HOME=${DEPLOYDIR}/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk python3 python-is-python3 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat-traditional locales tini  libssl-dev && \
+        openjdk-21-jdk python3 python-is-python3 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat-traditional locales tini  libssl-dev && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN echo "export PATH=/usr/lib/linux-tools/linux-tools-6.8.0-106:$PATH" >> /etc/bash.bashrc ; ARCH=`uname -m` && cd /lib/jvm && \
-    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
-ENV JAVA_HOME=/lib/jvm/java-17-openjdk
+RUN echo "export PATH=/usr/lib/linux-tools/linux-tools-6.8.0-106:$PATH" >> /etc/bash.bashrc && cd /lib/jvm && \
+    ln -s java-21-openjdk-$(dpkg --print-architecture) java-21-openjdk
+ENV JAVA_HOME=/lib/jvm/java-21-openjdk
 
 WORKDIR $DEPLOYDIR
 

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -44,16 +44,16 @@ ARG GROUP=starrocks
 ARG MINIMAL
 
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
-RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-17-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
+RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-21-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk mysql-client tzdata locales tini libssl-dev $OPTIONAL_PKGS && \
+        openjdk-21-jdk mysql-client tzdata locales tini libssl-dev $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN touch /.dockerenv ; ARCH=`uname -m` && cd /lib/jvm && \
-    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
-ENV JAVA_HOME=/lib/jvm/java-17-openjdk
+RUN touch /.dockerenv && cd /lib/jvm && \
+    ln -s java-21-openjdk-$(dpkg --print-architecture) java-21-openjdk
+ENV JAVA_HOME=/lib/jvm/java-21-openjdk
 
 WORKDIR $STARROCKS_ROOT
 

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -42,16 +42,16 @@ ARG GROUP=starrocks
 ARG MINIMAL
 
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
-RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-17-jdk curl vim tree net-tools less pigz rclone" ; fi && \
+RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-21-jdk curl vim tree net-tools less pigz rclone" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
-        openjdk-17-jdk mysql-client tzdata locales netcat-traditional tini libssl-dev $OPTIONAL_PKGS && \
+        openjdk-21-jdk mysql-client tzdata locales netcat-traditional tini libssl-dev $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \
         rm -rf /var/lib/apt/lists/*
-RUN touch /.dockerenv ; ARCH=`uname -m` && cd /lib/jvm && \
-    if [ "$ARCH" = "aarch64" ] ; then ln -s java-17-openjdk-arm64 java-17-openjdk ; else ln -s java-17-openjdk-amd64 java-17-openjdk  ; fi ;
-ENV JAVA_HOME=/lib/jvm/java-17-openjdk
+RUN touch /.dockerenv && cd /lib/jvm && \
+    ln -s java-21-openjdk-$(dpkg --print-architecture) java-21-openjdk
+ENV JAVA_HOME=/lib/jvm/java-21-openjdk
 
 WORKDIR $STARROCKS_ROOT
 


### PR DESCRIPTION
Introduce a recommended JDK version (21) alongside the minimum (17) in the FE and BE start scripts, and split the version check into tiers:

- FE (start_fe.sh):
  - version < 17: error and abort (unchanged behavior)
  - 17 <= version < 21: print a deprecation warning, continue
  - version >= 21: no message
- BE (start_backend.sh):
  - no JAVA_HOME: warning, continue (unchanged behavior)
  - version < 17: print an error, continue (JDK is optional for JNI)
  - 17 <= version < 21: print a deprecation warning, continue
  - version >= 21: no message

Upgrade the Ubuntu runtime images (fe, be, allin1) from openjdk-17-jdk to openjdk-21-jdk. Also replace the arch-conditional JVM symlink with a single dpkg --print-architecture substitution.

## Why I'm doing:

## What I'm doing:

Fixes #74519

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
