### PR TITLE
[BugFix] Fix ASAN crash for BOOLEAN nested in Avro complex-type columns (backport #76041)

### DIFF
--- a/be/src/formats/avro/nullable_column.cpp
+++ b/be/src/formats/avro/nullable_column.cpp
@@ -138,7 +138,7 @@ static Status add_nullable_column(Column* column, const TypeDescriptor& type_des
                                   const avro_value_t& value) {
     switch (type_desc.type) {
     case TYPE_BOOLEAN:
-        return add_nullable_numeric_column<int8_t>(column, type_desc, name, value);
+        return add_nullable_numeric_column<uint8_t>(column, type_desc, name, value);
     case TYPE_BIGINT:
         return add_nullable_numeric_column<int64_t>(column, type_desc, name, value);
     case TYPE_INT:

--- a/be/test/exec/avro_scanner_test.cpp
+++ b/be/test/exec/avro_scanner_test.cpp
@@ -841,6 +841,66 @@ TEST_F(AvroScannerTest, test_array) {
     ASSERT_EQ(4294967298, array[1].get_int64());
 }
 
+// Regression for issue #11522: a BOOLEAN element nested inside a native ARRAY target column.
+// BooleanColumn is FixedLengthColumn<uint8_t>, but the nested add_nullable_column dispatched
+// TYPE_BOOLEAN through add_nullable_numeric_column<int8_t>, so add_numeric_column's
+// down_cast<FixedLengthColumn<int8_t>*> tripped the dynamic_cast assert (casts.h) under ASAN/DEBUG.
+TEST_F(AvroScannerTest, test_array_with_boolean) {
+    // record root { array<boolean> a }
+    std::string schema_json =
+            R"({"type":"record","name":"root","fields":[{"name":"a","type":{"type":"array","items":"boolean"}}]})";
+
+    AvroHelper avro_helper;
+    init_avro_value(schema_json.data(), schema_json.size(), avro_helper);
+    DeferOp avro_helper_deleter([&] {
+        avro_schema_decref(avro_helper.schema);
+        avro_value_iface_decref(avro_helper.iface);
+        avro_value_decref(&avro_helper.avro_val);
+    });
+
+    avro_value_t a_value;
+    ASSERT_EQ(0, avro_value_get_by_name(&avro_helper.avro_val, "a", &a_value, NULL));
+    avro_value_t e0;
+    avro_value_append(&a_value, &e0, NULL);
+    avro_value_set_boolean(&e0, true);
+    avro_value_t e1;
+    avro_value_append(&a_value, &e1, NULL);
+    avro_value_set_boolean(&e1, false);
+    avro_value_t e2;
+    avro_value_append(&a_value, &e2, NULL);
+    avro_value_set_boolean(&e2, true);
+
+    std::string data_path = "./be/test/exec/test_data/avro_scanner/tmp/avro_array_boolean_data.avro";
+    ASSERT_TRUE(write_avro_data(avro_helper, data_path).ok());
+
+    std::vector<TypeDescriptor> types;
+    TypeDescriptor t(TYPE_ARRAY);
+    t.children.emplace_back(TYPE_BOOLEAN);
+    types.emplace_back(t);
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range;
+    range.format_type = TFileFormatType::FORMAT_AVRO;
+    range.__isset.jsonpaths = false;
+    range.__set_path(data_path);
+    ranges.emplace_back(range);
+
+    auto scanner = create_avro_scanner(types, ranges, {"a"}, avro_helper.schema_text);
+    Status st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st;
+    auto st2 = scanner->get_next();
+    ASSERT_TRUE(st2.ok()) << st2.status();
+
+    ChunkPtr chunk = st2.value();
+    EXPECT_EQ(1, chunk->num_columns());
+    EXPECT_EQ(1, chunk->num_rows());
+    auto array = chunk->get(0)[0].get_array();
+    ASSERT_EQ(3, array.size());
+    EXPECT_EQ(1, array[0].get_int8());
+    EXPECT_EQ(0, array[1].get_int8());
+    EXPECT_EQ(1, array[2].get_int8());
+}
+
 TEST_F(AvroScannerTest, test_complex_schema) {
     std::string schema_path = "./be/test/exec/test_data/avro_scanner/avro_complex_schema.json";
     AvroHelper avro_helper;


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #76041 to branch-4.0. The mergify auto-backport (#76065) could not apply: on main the avro scanner test lives at `be/test/exec/file_scanner/avro_scanner_test.cpp` and depends on the native STRUCT target reader from #74901, which is not in 4.0, so the test hunk produced a large rename/content conflict.

## What I'm doing:

`BooleanColumn` is `FixedLengthColumn<uint8_t>`, but the nested `add_nullable_column` in `be/src/formats/avro/nullable_column.cpp` dispatched `TYPE_BOOLEAN` through `add_nullable_numeric_column<int8_t>`. `add_numeric_column<int8_t>` then `down_cast`s the uint8 column to `FixedLengthColumn<int8_t>*`, tripping the `dynamic_cast` assert (`gutil/casts.h`) under ASAN/DEBUG when a BOOLEAN is nested inside a native complex-type target column of an Avro routine load (StarRocks/StarRocksTest#11522).

The one-line fix (dispatch `TYPE_BOOLEAN` through `<uint8_t>`, matching the adaptive path) is identical to #76041; `add_numeric_column<uint8_t>` is already explicitly instantiated on 4.0.

On branch-4.0 only the nested **ARRAY** path is reachable (native STRUCT/MAP target support came later on main via #74901), so the regression test is `AvroScannerTest.test_array_with_boolean` in `be/test/exec/avro_scanner_test.cpp` (4.0's path), using only helpers already present on 4.0. It drives the same `add_nullable_column` `TYPE_BOOLEAN` dispatch that the fix corrects.

Fixes StarRocks/StarRocksTest#11522

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

