### PR TITLE
[BugFix] Fix Iceberg partition pruning when a string date partition column is compared with a temporal value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -1,0 +1,203 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * StarRocks-side residual partition pruning for STRING partition columns compared against a temporal value.
+ *
+ * <p>When a query compares a STRING partition column with a DATE/DATETIME value, binary-predicate coercion
+ * wraps the column in a cast, e.g. {@code CAST(c AS DATETIME) = '2020-06-14 00:00:00'}. The backend evaluates
+ * this in the DATETIME domain (parses the string then compares). Several connectors' native predicate
+ * pushdown, however, only compare the column in its declared STRING type: they unwrap the cast and render the
+ * temporal constant back to a string ({@code '2020-06-14 00:00:00'}), which never equals a {@code 'yyyy-MM-dd'}
+ * partition value, so every data file is pruned and the query wrongly returns empty.
+ *
+ * <p>To keep pruning consistent with the backend filter, such conjuncts are kept out of the pushed predicate
+ * and evaluated here against each file's partition values, reusing StarRocks' own {@code CAST(VARCHAR AS
+ * DATETIME)} folding (identical parsing semantics to the backend). A file is dropped only when a residual
+ * conjunct definitively folds to {@code false}; anything indeterminate (unfoldable, parse failure, non-boolean)
+ * keeps the file, so the pruning can only ever be more conservative than the backend filter (never unsound).
+ *
+ * <p>The connector supplies the identity string partition column names and, per file, the raw string partition
+ * values; the split/evaluation logic here is connector agnostic.
+ */
+public class PartitionCastPredicatePruner {
+    private static final Logger LOG = LogManager.getLogger(PartitionCastPredicatePruner.class);
+
+    private PartitionCastPredicatePruner() {
+    }
+
+    /**
+     * A conjunct "contains a string-to-temporal cast" if somewhere in it a string column is wrapped in a cast to
+     * a temporal type, e.g. {@code CAST(<string col> AS DATETIME)}. Native pushdown unwraps such casts and then
+     * compares in the STRING domain, which over-prunes, so these conjuncts must not be pushed.
+     */
+    public static boolean containsStringToTemporalCast(ScalarOperator operator) {
+        if (operator instanceof CastOperator) {
+            ScalarOperator child = operator.getChild(0);
+            if (child instanceof ColumnRefOperator && child.getType().isStringType()
+                    && (operator.getType().isDate() || operator.getType().isDatetime())) {
+                return true;
+            }
+        }
+        for (ScalarOperator child : operator.getChildren()) {
+            if (containsStringToTemporalCast(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean allColumnsAreIdentityStringPartition(ScalarOperator conjunct,
+                                                                Set<String> identityStringPartitionColumns) {
+        List<ColumnRefOperator> refs = conjunct.getColumnRefs();
+        if (refs.isEmpty()) {
+            return false;
+        }
+        for (ColumnRefOperator ref : refs) {
+            if (!identityStringPartitionColumns.contains(ref.getName().toLowerCase(Locale.ROOT))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Classifies conjuncts for a connector that pushes predicates to a native engine:
+     * <ul>
+     *   <li>no string-to-temporal cast -> {@code pushable} (pushed to the native engine as usual);</li>
+     *   <li>has such a cast and every referenced column is an identity string partition column -> {@code residual}
+     *       (not pushed; pruned here against partition values, consistent with the backend filter);</li>
+     *   <li>has such a cast but references a non-(identity string partition) column - e.g. a data column or a
+     *       mixed OR - is dropped from both: not pushed (so the native engine cannot over-prune in the string
+     *       domain) and not residual (it cannot be evaluated from partition values alone). Correctness is kept by
+     *       the backend filter; only that conjunct's native pruning is given up.</li>
+     * </ul>
+     * {@code identityStringPartitionColumns} must be lower-cased column names.
+     */
+    public static PartitionResidual split(List<ScalarOperator> conjuncts, Set<String> identityStringPartitionColumns) {
+        List<ScalarOperator> pushable = Lists.newArrayList();
+        List<ScalarOperator> residual = Lists.newArrayList();
+        for (ScalarOperator conjunct : conjuncts) {
+            if (!containsStringToTemporalCast(conjunct)) {
+                pushable.add(conjunct);
+            } else if (allColumnsAreIdentityStringPartition(conjunct, identityStringPartitionColumns)) {
+                residual.add(conjunct);
+            }
+            // else: contains a string-to-temporal cast that cannot be evaluated against partition values;
+            // drop it from pushdown to avoid unsound native pruning (the backend filter still applies it).
+        }
+        return new PartitionResidual(pushable, residual);
+    }
+
+    /**
+     * Returns {@code true} if the partition (given as column name -> raw string value) may satisfy the residual
+     * conjuncts, i.e. no conjunct definitively evaluates to {@code false}. Any conjunct that cannot be folded to
+     * a boolean constant (parse failure, unbound reference, etc.) is treated as a possible match.
+     *
+     * @param partitionValues column name (any case) -> raw partition string value.
+     */
+    public static boolean partitionMayMatch(List<ScalarOperator> residualConjuncts,
+                                            Map<String, String> partitionValues) {
+        if (residualConjuncts.isEmpty()) {
+            return true;
+        }
+
+        Map<String, String> lowerValues = new HashMap<>();
+        for (Map.Entry<String, String> entry : partitionValues.entrySet()) {
+            if (entry.getValue() != null) {
+                lowerValues.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+            }
+        }
+
+        for (ScalarOperator conjunct : residualConjuncts) {
+            Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
+            boolean allBound = true;
+            for (ColumnRefOperator ref : conjunct.getColumnRefs()) {
+                String value = lowerValues.get(ref.getName().toLowerCase(Locale.ROOT));
+                if (value == null) {
+                    allBound = false;
+                    break;
+                }
+                replaceMap.put(ref, ConstantOperator.createVarchar(value));
+            }
+            if (!allBound) {
+                // Cannot bind every reference to a partition value; be conservative and keep the file.
+                continue;
+            }
+
+            Boolean result = tryFoldToBoolean(conjunct, replaceMap);
+            if (result != null && !result) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Boolean tryFoldToBoolean(ScalarOperator conjunct,
+                                            Map<ColumnRefOperator, ScalarOperator> replaceMap) {
+        try {
+            ScalarOperator replaced = new ReplaceColumnRefRewriter(replaceMap).rewrite(conjunct);
+            ScalarOperator folded = new ScalarOperatorRewriter().rewrite(
+                    replaced, Lists.newArrayList(new FoldConstantsRule()));
+            if (folded instanceof ConstantOperator) {
+                ConstantOperator constant = (ConstantOperator) folded;
+                if (constant.isNull()) {
+                    // NULL predicate = not true -> this partition value does not match.
+                    return false;
+                }
+                if (constant.getType().isBoolean()) {
+                    return constant.getBoolean();
+                }
+            }
+        } catch (Exception e) {
+            // Strict cast parse failure or any other folding issue: fall back to keeping the file.
+            LOG.debug("residual partition predicate not foldable, keep file: {}", conjunct, e);
+        }
+        return null;
+    }
+
+    /** Result of splitting conjuncts for partition pruning. */
+    public static class PartitionResidual {
+        public final List<ScalarOperator> pushable;
+        public final List<ScalarOperator> residual;
+
+        public PartitionResidual(List<ScalarOperator> pushable, List<ScalarOperator> residual) {
+            this.pushable = pushable;
+            this.residual = residual;
+        }
+
+        public boolean hasResidual() {
+            return !residual.isEmpty();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -21,11 +21,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
-import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -102,15 +102,20 @@ public class PartitionCastPredicatePruner {
      *       domain) and not residual (it cannot be evaluated from partition values alone). Correctness is kept by
      *       the backend filter; only that conjunct's native pruning is given up.</li>
      * </ul>
-     * {@code identityStringPartitionColumns} must be lower-cased column names.
+     * {@code identityStringPartitionColumns} may be passed in any case; membership is case-insensitive.
      */
     public static PartitionResidual split(List<ScalarOperator> conjuncts, Set<String> identityStringPartitionColumns) {
+        // Normalize to lower case here so callers need not pre-normalize the set.
+        Set<String> normalizedPartitionColumns = new HashSet<>();
+        for (String name : identityStringPartitionColumns) {
+            normalizedPartitionColumns.add(name.toLowerCase(Locale.ROOT));
+        }
         List<ScalarOperator> pushable = Lists.newArrayList();
         List<ScalarOperator> residual = Lists.newArrayList();
         for (ScalarOperator conjunct : conjuncts) {
             if (!containsStringToTemporalCast(conjunct)) {
                 pushable.add(conjunct);
-            } else if (allColumnsAreIdentityStringPartition(conjunct, identityStringPartitionColumns)) {
+            } else if (allColumnsAreIdentityStringPartition(conjunct, normalizedPartitionColumns)) {
                 residual.add(conjunct);
             }
             // else: contains a string-to-temporal cast that cannot be evaluated against partition values;
@@ -168,7 +173,7 @@ public class PartitionCastPredicatePruner {
         try {
             ScalarOperator replaced = new ReplaceColumnRefRewriter(replaceMap).rewrite(conjunct);
             ScalarOperator folded = new ScalarOperatorRewriter().rewrite(
-                    replaced, Lists.newArrayList(new FoldConstantsRule()));
+                    replaced, ScalarOperatorRewriter.FOLD_CONSTANT_RULES);
             if (folded instanceof ConstantOperator) {
                 ConstantOperator constant = (ConstantOperator) folded;
                 if (constant.isNull()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -52,6 +52,7 @@ import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetaPreparationItem;
+import com.starrocks.connector.PartitionCastPredicatePruner;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.PlanMode;
@@ -1138,8 +1139,14 @@ public class IcebergMetadata implements ConnectorMetadata {
         Types.StructType schema = nativeTbl.schema().asStruct();
 
         List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
+        // Cast-on-string-partition-column conjuncts (e.g. CAST(c AS DATETIME) = <ts>) are pruned unsoundly
+        // by Iceberg's native string comparison, so keep them out of the pushed predicate and evaluate them
+        // here against each file's partition values (consistent with the backend filter).
+        PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
+                scalarOperators, identityStringPartitionColumns(icebergTable));
+        boolean existPartitionTransformedEvolution = icebergTable.hasPartitionTransformedEvolution();
         ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(schema);
-        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
 
         List<FileScanTask> icebergScanTasks = Lists.newArrayList();
         try (CloseableIterator<FileScanTask> iterator =
@@ -1147,6 +1154,10 @@ public class IcebergMetadata implements ConnectorMetadata {
                              connectContext, enableCollectColumnStatistics, params.getFieldNames())) {
             while (iterator.hasNext()) {
                 FileScanTask scanTask = iterator.next();
+                if (residual.hasResidual() && !PartitionCastPredicatePruner.partitionMayMatch(residual.residual,
+                        icebergPartitionValues(scanTask, icebergTable, existPartitionTransformedEvolution))) {
+                    continue;
+                }
 
                 FileScanTask icebergSplitScanTask = scanTask;
                 if (enableCollectColumnStatistics) {
@@ -1201,10 +1212,18 @@ public class IcebergMetadata implements ConnectorMetadata {
             baseSource = buildRemoteInfoSource(splitTasks.get(predicateSearchKey), params);
         } else {
             List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
+            // See collectTableStatisticsAndCacheIcebergSplit: keep cast-on-string-partition conjuncts out of the
+            // pushed predicate and evaluate them here so pruning stays consistent with the backend filter.
+            PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
+                    scalarOperators, identityStringPartitionColumns(icebergTable));
             ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
                     icebergTable.getNativeTable().schema().asStruct());
-            Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+            Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
             baseSource = buildRemoteInfoSource(icebergTable, icebergPredicate, tvrVersionRange, params);
+            if (residual.hasResidual()) {
+                baseSource = filterByPartitionResidual(baseSource, residual.residual, icebergTable,
+                        icebergTable.hasPartitionTransformedEvolution());
+            }
         }
 
         IcebergTableMORParams tableFullMORParams = param.getTableFullMORParams();
@@ -1261,6 +1280,101 @@ public class IcebergMetadata implements ConnectorMetadata {
                 }
             }
         };
+    }
+
+    // Wraps a streaming source, dropping files whose partition value cannot satisfy the residual conjuncts
+    // (cast-on-string-partition-column predicates that Iceberg cannot prune soundly).
+    private RemoteFileInfoSource filterByPartitionResidual(RemoteFileInfoSource base,
+                                                           List<ScalarOperator> residual,
+                                                           IcebergTable table,
+                                                           boolean existPartitionTransformedEvolution) {
+        return new RemoteFileInfoSource() {
+            private RemoteFileInfo next;
+
+            private void advance() {
+                while (next == null && base.hasMoreOutput()) {
+                    RemoteFileInfo candidate = base.getOutput();
+                    if (candidate instanceof IcebergRemoteFileInfo) {
+                        FileScanTask task = ((IcebergRemoteFileInfo) candidate).getFileScanTask();
+                        if (!PartitionCastPredicatePruner.partitionMayMatch(
+                                residual, icebergPartitionValues(task, table, existPartitionTransformedEvolution))) {
+                            continue;
+                        }
+                    }
+                    next = candidate;
+                }
+            }
+
+            @Override
+            public RemoteFileInfo getOutput() {
+                advance();
+                RemoteFileInfo result = next;
+                next = null;
+                return result;
+            }
+
+            @Override
+            public boolean hasMoreOutput() {
+                advance();
+                return next != null;
+            }
+
+            @Override
+            public void close() throws Exception {
+                base.close();
+            }
+        };
+    }
+
+    // Identity partition columns of string type (lower-cased names). Only these can be residual-pruned here:
+    // their partition value round-trips through the same string cast the predicate carries.
+    private static Set<String> identityStringPartitionColumns(IcebergTable table) {
+        Set<String> names = new HashSet<>();
+        org.apache.iceberg.Table nativeTable = table.getNativeTable();
+        for (PartitionField field : nativeTable.spec().fields()) {
+            if (!field.transform().isIdentity()) {
+                continue;
+            }
+            String name = table.getPartitionSourceName(nativeTable.schema(), field);
+            Column column = table.getColumn(name);
+            if (column != null && column.getType().isStringType()) {
+                names.add(name.toLowerCase(Locale.ROOT));
+            }
+        }
+        return names;
+    }
+
+    // Raw string partition values for the file, keyed by (identity) partition column name. Returns an empty map
+    // under partition-transform evolution, where getIcebergPartitionValues drops non-identity fields and would
+    // misalign the value-to-column mapping (residual pruning then conservatively keeps every file).
+    private static Map<String, String> icebergPartitionValues(FileScanTask task, IcebergTable table,
+                                                              boolean existPartitionTransformedEvolution) {
+        if (existPartitionTransformedEvolution) {
+            return Collections.emptyMap();
+        }
+        PartitionSpec spec = table.getNativeTable().spec();
+        org.apache.iceberg.PartitionData partitionData =
+                (org.apache.iceberg.PartitionData) task.file().partition();
+        List<String> values = PartitionUtil.getIcebergPartitionValues(spec, partitionData, false);
+        Map<String, String> result = new HashMap<>();
+        int index = 0;
+        for (PartitionField field : spec.fields()) {
+            if (field.transform().isVoid()) {
+                continue;
+            }
+            if (index >= values.size()) {
+                break;
+            }
+            String value = values.get(index++);
+            if (!field.transform().isIdentity()) {
+                continue;
+            }
+            String name = table.getPartitionSourceName(table.getNativeTable().schema(), field);
+            if (value != null) {
+                result.put(name, value);
+            }
+        }
+        return result;
     }
 
     private RemoteFileInfoSource buildRemoteInfoSource(List<FileScanTask> tasks, GetRemoteFilesParams params) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -1,0 +1,186 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.collect.Lists;
+import com.starrocks.connector.PartitionCastPredicatePruner.PartitionResidual;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PartitionCastPredicatePrunerTest {
+
+    private final ColumnRefOperator strPartCol = new ColumnRefOperator(1, VarcharType.VARCHAR, "c2", true);
+    private final ColumnRefOperator dateCol = new ColumnRefOperator(2, DateType.DATE, "d", true);
+    private final ColumnRefOperator intCol = new ColumnRefOperator(3, IntegerType.INT, "id", true);
+
+    private ConstantOperator datetime(String v) {
+        // v like "2020-06-14 00:00:00"
+        String[] parts = v.split("[ :-]");
+        return ConstantOperator.createDatetime(LocalDateTime.of(
+                Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]),
+                Integer.parseInt(parts[3]), Integer.parseInt(parts[4]), Integer.parseInt(parts[5])));
+    }
+
+    private BinaryPredicateOperator eq(ScalarOperator left, ScalarOperator right) {
+        return new BinaryPredicateOperator(BinaryType.EQ, left, right);
+    }
+
+    private CastOperator castTo(ColumnRefOperator col, DateType type) {
+        return new CastOperator(type, col);
+    }
+
+    private Set<String> partitionColumns(String... names) {
+        return new HashSet<>(Arrays.asList(names));
+    }
+
+    @Test
+    public void testContainsStringToTemporalCast() {
+        // CAST(<string col> AS DATETIME/DATE) -> true
+        Assertions.assertTrue(PartitionCastPredicatePruner.containsStringToTemporalCast(
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"))));
+        Assertions.assertTrue(PartitionCastPredicatePruner.containsStringToTemporalCast(
+                eq(castTo(strPartCol, DateType.DATE), ConstantOperator.createVarchar("2020-06-14"))));
+
+        // CAST on a DATE column (not a string) -> false; DATE->DATETIME is native-safe.
+        Assertions.assertFalse(PartitionCastPredicatePruner.containsStringToTemporalCast(
+                eq(castTo(dateCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"))));
+
+        // bare string column, no cast -> false
+        Assertions.assertFalse(PartitionCastPredicatePruner.containsStringToTemporalCast(
+                eq(strPartCol, ConstantOperator.createVarchar("2020-06-14"))));
+
+        // nested inside OR -> found by recursion
+        ScalarOperator or = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")),
+                eq(intCol, ConstantOperator.createInt(5)));
+        Assertions.assertTrue(PartitionCastPredicatePruner.containsStringToTemporalCast(or));
+    }
+
+    @Test
+    public void testSplitResidualPushableDropped() {
+        Set<String> partCols = partitionColumns("c2");
+
+        // pure-partition cast -> residual
+        ScalarOperator residualConjunct = eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+        // no cast -> pushable
+        ScalarOperator pushableConjunct = eq(strPartCol, ConstantOperator.createVarchar("2020-06-14"));
+        // cast but references a non-partition column (mixed OR) -> dropped (neither pushed nor residual)
+        ScalarOperator mixedOr = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")),
+                eq(intCol, ConstantOperator.createInt(5)));
+
+        PartitionResidual result = PartitionCastPredicatePruner.split(
+                Lists.newArrayList(residualConjunct, pushableConjunct, mixedOr), partCols);
+
+        Assertions.assertEquals(1, result.residual.size());
+        Assertions.assertSame(residualConjunct, result.residual.get(0));
+        Assertions.assertEquals(1, result.pushable.size());
+        Assertions.assertSame(pushableConjunct, result.pushable.get(0));
+        Assertions.assertTrue(result.hasResidual());
+        // mixedOr is in neither list
+        Assertions.assertFalse(result.pushable.contains(mixedOr));
+        Assertions.assertFalse(result.residual.contains(mixedOr));
+    }
+
+    @Test
+    public void testSplitDataColumnCastDropped() {
+        // A string data column (not in the partition set) with a temporal cast is dropped, not pushed.
+        ColumnRefOperator strDataCol = new ColumnRefOperator(4, VarcharType.VARCHAR, "s", true);
+        ScalarOperator conjunct = eq(castTo(strDataCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+
+        PartitionResidual result = PartitionCastPredicatePruner.split(
+                Lists.newArrayList(conjunct), partitionColumns("c2"));
+
+        Assertions.assertTrue(result.pushable.isEmpty());
+        Assertions.assertTrue(result.residual.isEmpty());
+    }
+
+    @Test
+    public void testPurePartitionOrIsResidual() {
+        Set<String> partCols = partitionColumns("c2");
+        ScalarOperator or = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")),
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-15 00:00:00")));
+
+        PartitionResidual result = PartitionCastPredicatePruner.split(Lists.newArrayList(or), partCols);
+        Assertions.assertEquals(1, result.residual.size());
+        Assertions.assertTrue(result.pushable.isEmpty());
+    }
+
+    @Test
+    public void testPartitionMayMatch() {
+        List<ScalarOperator> residual = Lists.newArrayList(
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")));
+
+        // partition value casts to the constant -> keep
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(
+                residual, singletonMap("c2", "2020-06-14")));
+        // case-insensitive column name lookup
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(
+                residual, singletonMap("C2", "2020-06-14")));
+
+        // partition value does not match -> prune
+        Assertions.assertFalse(PartitionCastPredicatePruner.partitionMayMatch(
+                residual, singletonMap("c2", "2020-06-15")));
+    }
+
+    @Test
+    public void testPartitionMayMatchConservativeKeep() {
+        List<ScalarOperator> residual = Lists.newArrayList(
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")));
+
+        // empty residual -> keep
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(
+                Collections.emptyList(), singletonMap("c2", "2020-06-15")));
+
+        // unparseable partition value (strict parse fails) -> conservatively keep
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(
+                residual, singletonMap("c2", "not-a-date")));
+
+        // partition value missing for the referenced column -> unbound -> conservatively keep
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(
+                residual, singletonMap("other", "2020-06-14")));
+
+        // null partition value -> conservatively keep
+        Map<String, String> withNull = new HashMap<>();
+        withNull.put("c2", null);
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(residual, withNull));
+    }
+
+    private Map<String, String> singletonMap(String k, String v) {
+        Map<String, String> map = new HashMap<>();
+        map.put(k, v);
+        return map;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -127,6 +127,17 @@ public class PartitionCastPredicatePrunerTest {
     }
 
     @Test
+    public void testSplitPartitionColumnsCaseInsensitive() {
+        // The column ref is "c2"; the partition set is passed upper-cased. split() must still classify it as
+        // residual (membership is case-insensitive; callers need not pre-normalize).
+        ScalarOperator conjunct = eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+        PartitionResidual result = PartitionCastPredicatePruner.split(
+                Lists.newArrayList(conjunct), partitionColumns("C2"));
+        Assertions.assertEquals(1, result.residual.size());
+        Assertions.assertTrue(result.pushable.isEmpty());
+    }
+
+    @Test
     public void testPurePartitionOrIsResidual() {
         Set<String> partCols = partitionColumns("c2");
         ScalarOperator or = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -106,6 +106,7 @@ import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -1394,6 +1395,51 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(
                 "Filter{databaseName='db', tableName='table', version=Snapshot@(1), predicate=true, enableColumnStats=false}",
                 filter.toString());
+    }
+
+    @Test
+    public void testGetRemoteFileStringDatePartitionPrune() throws Exception {
+        // A table partitioned by an identity STRING column holding date strings. A predicate
+        // CAST(datestr AS DATETIME) = <ts> must prune to the matching partition StarRocks-side, since Iceberg's
+        // native string comparison would render the constant with a time part and wrongly prune every file.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbStringDatePart", 1);
+
+        DataFile file0614 = DataFiles.builder(spec)
+                .withPath("/path/to/data-0614.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-14").withRecordCount(3).build();
+        DataFile file0615 = DataFiles.builder(spec)
+                .withPath("/path/to/data-0615.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-15").withRecordCount(4).build();
+        table.newAppend().appendFile(file0614).appendFile(file0615).commit();
+        table.refresh();
+        long snapshotId = table.currentSnapshot().snapshotId();
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        List<Column> columns = Lists.newArrayList(new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+
+        // CAST(k2 AS DATETIME) = '2020-06-14 00:00:00' -> only the k2=2020-06-14 file survives.
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new CastOperator(DATETIME, new ColumnRefOperator(3, VARCHAR, "k2", true)),
+                ConstantOperator.createDatetime(LocalDateTime.of(2020, 6, 14, 0, 0, 0)));
+        List<RemoteFileInfo> res = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                        .setPredicate(predicate).setFieldNames(Lists.newArrayList()).setLimit(10).build());
+        Assertions.assertEquals(1, res.size());
+        Assertions.assertEquals(3, ((IcebergRemoteFileInfo) res.get(0)).getFileScanTask().file().recordCount());
+
+        // A non-matching constant prunes everything.
+        ScalarOperator noMatch = new BinaryPredicateOperator(BinaryType.EQ,
+                new CastOperator(DATETIME, new ColumnRefOperator(3, VARCHAR, "k2", true)),
+                ConstantOperator.createDatetime(LocalDateTime.of(2020, 1, 1, 0, 0, 0)));
+        List<RemoteFileInfo> empty = metadata.getRemoteFiles(icebergTable,
+                GetRemoteFilesParams.newBuilder().setTableVersionRange(TvrTableSnapshot.of(Optional.of(snapshotId)))
+                        .setPredicate(noMatch).setFieldNames(Lists.newArrayList()).setLimit(10).build());
+        Assertions.assertEquals(0, empty.size());
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_string_date_partition_prune
+++ b/test/sql/test_iceberg/R/test_iceberg_string_date_partition_prune
@@ -1,0 +1,121 @@
+-- name: test_iceberg_string_date_partition_prune
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+use ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+create table t_datestr (
+    c1 int,
+    c2 string
+) partition by (c2);
+-- result:
+-- !result
+insert into t_datestr values (1, '2020-01-02'), (2, '2020-06-08'), (3, '2020-06-14'), (4, '2020-06-15'), (5, '2020-06-22');
+-- result:
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 day order by c1;
+-- result:
+3	2020-06-14
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-06-14' as date) + interval 1 day order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) + interval 1 week order by c1;
+-- result:
+5	2020-06-22
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 week order by c1;
+-- result:
+2	2020-06-08
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-05-15' as date) + interval 1 month order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-07-15' as date) - interval 1 month order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2019-06-15' as date) + interval 1 year order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2021-06-15' as date) - interval 1 year order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-03-15' as date) + interval 1 quarter order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = cast('2020-09-15' as date) - interval 1 quarter order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = date_add(cast('2020-06-15' as date), interval 7 day) order by c1;
+-- result:
+5	2020-06-22
+-- !result
+select c1, c2 from t_datestr where c2 = date_sub(cast('2020-06-15' as date), interval 7 day) order by c1;
+-- result:
+2	2020-06-08
+-- !result
+select c1, c2 from t_datestr where c2 = adddate(cast('2020-06-14' as date), 1) order by c1;
+-- result:
+4	2020-06-15
+-- !result
+select c1, c2 from t_datestr where c2 = subdate(cast('2020-06-15' as date), 1) order by c1;
+-- result:
+3	2020-06-14
+-- !result
+select c1, c2 from t_datestr where c2 = days_sub(cast('2020-06-15' as date), 1) order by c1;
+-- result:
+3	2020-06-14
+-- !result
+select c1, c2 from t_datestr where c2 >= cast('2020-06-15' as date) - interval 1 day order by c1;
+-- result:
+3	2020-06-14
+4	2020-06-15
+5	2020-06-22
+-- !result
+select c1, c2 from t_datestr where c2 = '2020-06-14' order by c1;
+-- result:
+3	2020-06-14
+-- !result
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 day", "partitions=1/5")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2019-06-15' as date) + interval 1 year", "partitions=1/5")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2020-09-15' as date) - interval 1 quarter", "partitions=1/5")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = date_sub(cast('2020-06-15' as date), interval 7 day)", "partitions=1/5")
+-- result:
+None
+-- !result
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 >= cast('2020-06-15' as date) - interval 1 day", "partitions=3/5")
+-- result:
+None
+-- !result
+drop table t_datestr force;
+-- result:
+-- !result
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_string_date_partition_prune
+++ b/test/sql/test_iceberg/T/test_iceberg_string_date_partition_prune
@@ -1,0 +1,57 @@
+-- name: test_iceberg_string_date_partition_prune
+-- description: A STRING date partition column compared with a DATE/DATETIME value (operator +/- INTERVAL and
+-- the date_add/date_sub/adddate/subdate/days_sub builtins) coerces to CAST(c2 AS DATETIME) = <ts>. Iceberg's
+-- native pushdown would unwrap the cast and compare in the string domain, wrongly pruning every file and
+-- returning empty. StarRocks now evaluates such cast-on-string-partition conjuncts against each file's
+-- partition value, so the matching partition is kept and pruned to exactly 1 of 5.
+
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+set catalog ice_cat_${uuid0};
+use ice_cat_${uuid0}.ice_db_${uuid0};
+
+create table t_datestr (
+    c1 int,
+    c2 string
+) partition by (c2);
+
+insert into t_datestr values (1, '2020-01-02'), (2, '2020-06-08'), (3, '2020-06-14'), (4, '2020-06-15'), (5, '2020-06-22');
+
+-- operator form, DAY
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 day order by c1;
+select c1, c2 from t_datestr where c2 = cast('2020-06-14' as date) + interval 1 day order by c1;
+-- operator form, WEEK
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) + interval 1 week order by c1;
+select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 week order by c1;
+-- operator form, MONTH (add and sub)
+select c1, c2 from t_datestr where c2 = cast('2020-05-15' as date) + interval 1 month order by c1;
+select c1, c2 from t_datestr where c2 = cast('2020-07-15' as date) - interval 1 month order by c1;
+-- operator form, YEAR (add and sub)
+select c1, c2 from t_datestr where c2 = cast('2019-06-15' as date) + interval 1 year order by c1;
+select c1, c2 from t_datestr where c2 = cast('2021-06-15' as date) - interval 1 year order by c1;
+-- operator form, QUARTER (add and sub)
+select c1, c2 from t_datestr where c2 = cast('2020-03-15' as date) + interval 1 quarter order by c1;
+select c1, c2 from t_datestr where c2 = cast('2020-09-15' as date) - interval 1 quarter order by c1;
+-- date_add / date_sub (interval), DAY
+select c1, c2 from t_datestr where c2 = date_add(cast('2020-06-15' as date), interval 7 day) order by c1;
+select c1, c2 from t_datestr where c2 = date_sub(cast('2020-06-15' as date), interval 7 day) order by c1;
+-- adddate / subdate (bare int -> DAY)
+select c1, c2 from t_datestr where c2 = adddate(cast('2020-06-14' as date), 1) order by c1;
+select c1, c2 from t_datestr where c2 = subdate(cast('2020-06-15' as date), 1) order by c1;
+-- days_sub
+select c1, c2 from t_datestr where c2 = days_sub(cast('2020-06-15' as date), 1) order by c1;
+-- range comparison keeps the correct partitions
+select c1, c2 from t_datestr where c2 >= cast('2020-06-15' as date) - interval 1 day order by c1;
+-- control: bare 'yyyy-MM-dd' literal (always worked); interval forms above must agree with it
+select c1, c2 from t_datestr where c2 = '2020-06-14' order by c1;
+
+-- verify partitions are actually pruned StarRocks-side (equality selects exactly 1 of 5, the >= range selects 3):
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2020-06-15' as date) - interval 1 day", "partitions=1/5")
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2019-06-15' as date) + interval 1 year", "partitions=1/5")
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = cast('2020-09-15' as date) - interval 1 quarter", "partitions=1/5")
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 = date_sub(cast('2020-06-15' as date), interval 7 day)", "partitions=1/5")
+function: assert_explain_verbose_contains("select c1, c2 from t_datestr where c2 >= cast('2020-06-15' as date) - interval 1 day", "partitions=3/5")
+
+drop table t_datestr force;
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing:

  ### Reproduce
  
  ```sql
  -- Iceberg catalog partitioned by a STRING column holding date strings
  SET CATALOG <iceberg_catalog>;
  CREATE DATABASE db_repro;
  USE db_repro;
  
  CREATE TABLE t (c1 INT, c2 STRING) PARTITION BY (c2);
  INSERT INTO t VALUES (1, '2020-06-08'), (2, '2020-06-14'), (3, '2020-06-15');
  
  -- Compare the STRING partition column with a DATE value:
  SELECT * FROM t WHERE c2 = cast('2020-06-15' as date) - interval 1 day ORDER BY c1;
  
  Expected: 2  2020-06-14
  
  Before this PR: 0 rows — every partition is pruned away.
  
  EXPLAIN VERBOSE shows the whole table is pruned:
  
  0:IcebergScanNode
     TABLE: t
     PREDICATES: CAST(2: c2 AS DATETIME) = '2020-06-14 00:00:00'
     partitions=0/3          <-- all partitions wrongly pruned  (after the fix: partitions=1/3)
  ```

  On an Iceberg table partitioned by a STRING column that stores date strings
  (e.g. 'yyyy-MM-dd'), a predicate that compares the partition column with a
  DATE/DATETIME value returns an empty result.

  Example:

  ```sql
  -- c2 is a STRING partition column holding date strings
  SELECT * FROM t WHERE c2 = current_date() - interval 1 day;   -- wrongly returns 0 rows
  ```

  Binary-predicate coercion rewrites this to CAST(c2 AS DATETIME) = <datetime const>.
  The backend row filter evaluates it in the DATETIME domain (parses the string, then
  compares), which is correct. But Iceberg's native predicate pushdown
  (ScalarOperatorToIcebergExpr) unwraps the cast, treats c2 as its declared STRING
  type, and renders the constant back to a string '2020-06-14 00:00:00'. That never
  equals a '2020-06-14' partition value, so every data file is pruned and the query
  returns empty. The pruning is inconsistent with (and more aggressive than) the
  backend filter — an unsound pruning.

  What I'm doing:

  Keep such cast-on-string-partition-column conjuncts out of the pushed Iceberg
  predicate and evaluate them StarRocks-side against each file's partition values,
  reusing StarRocks' own CAST(VARCHAR AS DATETIME) folding so the pruning uses the
  exact same semantics as the backend filter.

  - Add PartitionCastPredicatePruner (connector-agnostic):
    - split(...) classifies each conjunct into
        - pushable (no string→temporal cast) → pushed to Iceberg as before;
      - residual (has such a cast and every referenced column is an identity
  string partition column) → not pushed; evaluated here;
      - dropped (has such a cast but references a non-partition column, e.g. a data
  column or a mixed OR) → not pushed and not residual, so the native engine
  cannot over-prune; correctness is preserved by the backend filter.
    - partitionMayMatch(...) binds the partition value into the conjunct and folds
  it; a file is dropped only when the conjunct definitively folds to false.
  Anything indeterminate (strict-parse failure, unbound reference, non-boolean)
  keeps the file, so the pruning can only ever be more conservative than the
  backend filter — never unsound.
  - Wire it into IcebergMetadata on both scan paths
  (collectTableStatisticsAndCacheIcebergSplit and the streaming
  getRemoteFilesAsync).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
