### PR TITLE
[BugFix] Return the rollup's own schema from the index_schema proc on shared-data tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndexInfoProcDir.java
@@ -43,7 +43,6 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
@@ -148,7 +147,15 @@ public class IndexInfoProcDir implements ProcDirInterface {
         try {
             List<Column> schema = null;
             Set<String> bfColumns = null;
-            if (table.getType() == TableType.OLAP) {
+            // Cloud-native (lake) OLAP tables also carry per-index metadata and must resolve
+            // the schema by the requested index meta id. The old `getType() == OLAP` check
+            // excluded lake tables (whose type is CLOUD_NATIVE), so
+            // `SHOW PROC .../index_schema/<id>` fell into the else branch and returned the base
+            // index schema for every rollup on a shared-data table instead of that rollup's own
+            // declared columns. Keep materialized views on the getBaseSchema() path (as before):
+            // DESC on an async MV routes here with an index meta id that is not in the MV's own
+            // index-meta map, so getSchemaByIndexMetaId() would return an empty schema.
+            if (table.isOlapOrCloudNativeTable()) {
                 OlapTable olapTable = (OlapTable) table;
                 schema = olapTable.getSchemaByIndexMetaId(idxMetaId);
                 if (schema == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -463,7 +463,10 @@ public class ShowStmtAnalyzer {
                     // show base table schema only
                     String procString = "/dbs/" + db.getId() + "/" + table.getId() + "/" + TableProcDir.INDEX_SCHEMA
                             + "/";
-                    if (table.getType() == Table.TableType.OLAP) {
+                    // Cloud-native (lake) tables must also address the base index by its meta id:
+                    // IndexInfoProcDir.lookup() now resolves cloud-native tables per index meta id,
+                    // so passing table.getId() here would yield an empty schema for DESC <lake_table>.
+                    if (table.isOlapOrCloudNativeTable()) {
                         procString += ((OlapTable) table).getBaseIndexMetaId();
                     } else {
                         procString += table.getId();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.LightWeightDeltaLakeTable;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
@@ -28,6 +29,8 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.proc.IndexInfoProcDir;
+import com.starrocks.common.proc.ProcResult;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.connector.metastore.MetastoreTable;
 import com.starrocks.qe.ConnectContext;
@@ -39,6 +42,7 @@ import com.starrocks.service.FrontendServiceImpl;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.DescribeStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.thrift.TBatchGetTabletMetadataRequest;
@@ -59,6 +63,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -982,5 +987,66 @@ public class CreateLakeTableTest {
         Assertions.assertTrue(table.isLightWeightTabletCreation());
         Assertions.assertFalse(backfillSeen.get(),
                 "false -> true must not trigger backfill");
+    }
+
+    @Test
+    public void testIndexSchemaProcReturnsRollupSchemaForLakeTable() throws Exception {
+        // Regression: SHOW PROC '/dbs/db/tbl/index_schema/<metaId>' (IndexInfoProcDir.lookup)
+        // used to gate on `getType() == OLAP`, which excludes shared-data LakeTable
+        // (type CLOUD_NATIVE). Lake tables fell into the else branch and returned the base
+        // index schema for every rollup instead of that rollup's own declared columns.
+        createTable("create table lake_test.t_index_schema_proc " +
+                "(k1 varchar(10) not null, k2 int not null, v1 int)\n" +
+                "duplicate key(k1, k2) distributed by hash(k1) buckets 1\n" +
+                "rollup (r1(k2, k1))\n" +
+                "properties('replication_num' = '1');");
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("lake_test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_index_schema_proc");
+        Assertions.assertTrue(table.isCloudNativeTable());
+
+        IndexInfoProcDir dir = new IndexInfoProcDir(db, table);
+
+        // rollup r1 was declared as (k2, k1): the per-index proc must report exactly those
+        // two columns in that order, not the base table's full schema (k1, k2, v1).
+        long rollupMetaId = table.getIndexMetaIdByName("r1");
+        ProcResult rollupResult = dir.lookup(String.valueOf(rollupMetaId)).fetchResult();
+        List<String> rollupColumns = new ArrayList<>();
+        for (List<String> row : rollupResult.getRows()) {
+            rollupColumns.add(row.get(0));
+        }
+        Assertions.assertEquals(List.of("k2", "k1"), rollupColumns);
+
+        // base index still reports its own full schema.
+        long baseMetaId = table.getBaseIndexMetaId();
+        ProcResult baseResult = dir.lookup(String.valueOf(baseMetaId)).fetchResult();
+        List<String> baseColumns = new ArrayList<>();
+        for (List<String> row : baseResult.getRows()) {
+            baseColumns.add(row.get(0));
+        }
+        Assertions.assertEquals(List.of("k1", "k2", "v1"), baseColumns);
+    }
+
+    @Test
+    public void testDescShowsBaseColumnsForLakeTable() throws Exception {
+        // Regression for the DESC production path: ShowStmtAnalyzer builds
+        // /dbs/<db>/<tbl>/index_schema/<baseIndexMetaId> for the base schema, and
+        // IndexInfoProcDir.lookup() must resolve the base schema for a shared-data table.
+        // Previously the analyzer passed table.getId() for non-OLAP tables and relied on the
+        // getBaseSchema() fallback; after routing cloud-native tables through
+        // getSchemaByIndexMetaId(), the analyzer must pass the base index meta id instead.
+        createTable("create table lake_test.t_desc_lake " +
+                "(k1 varchar(10) not null, k2 int not null, v1 int)\n" +
+                "duplicate key(k1, k2) distributed by hash(k1) buckets 1\n" +
+                "rollup (r1(k2, k1))\n" +
+                "properties('replication_num' = '1');");
+        DescribeStmt stmt = (DescribeStmt) UtFrameUtils.parseStmtWithNewParser(
+                "desc lake_test.t_desc_lake", connectContext);
+        ShowResultSet rs = ShowExecutor.execute(stmt, connectContext);
+        List<String> fields = new ArrayList<>();
+        for (List<String> row : rs.getResultRows()) {
+            fields.add(row.get(0));
+        }
+        Assertions.assertEquals(List.of("k1", "k2", "v1"), fields);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

On shared-data tables, `SHOW PROC '/dbs/<db>/<tbl>/index_schema/<indexMetaId>'`
returned the base table's full schema for every rollup index instead of the
rollup's own declared columns. Surfaced by StarRocks/StarRocksTest#11529
(`test_fast_schema_evolution/R/test_varchar_widen_cloud`): an inline
`ROLLUP (r1(k2, k1))` was reported as the base schema `(k1, k2, v1)`.

Root cause: the per-index handler `IndexInfoProcDir.lookup()` gated schema
resolution on `table.getType() == TableType.OLAP`. Shared-data tables are
`LakeTable` whose type is `CLOUD_NATIVE`, so the check was false and lookup fell
into the `else` branch returning `table.getBaseSchema()` — the base index's
columns — regardless of the requested index meta id. The sibling list handler
`fetchResult()` already used `isNativeTableOrMaterializedView()`, which is why
the `index_schema` list was correct while the per-index lookup was wrong. The
rollup metadata itself was always correct (`DESC ... ALL` and the index_schema
list show it right); only this proc read path was affected. The bug is
independent of `cloud_native_fast_schema_evolution_v2` and reproduces on any
inline rollup on a shared-data table.

## What I'm doing:

Gate `IndexInfoProcDir.lookup()` on `table.isOlapOrCloudNativeTable()` instead,
so lake OLAP tables resolve the schema by the requested index meta id via
`getSchemaByIndexMetaId()`. Materialized views are deliberately excluded and keep
the previous `getBaseSchema()` behavior (DESC on an async MV routes here with an
index meta id absent from the MV's own map, which would otherwise yield an empty
schema). 

Also fix `ShowStmtAnalyzer.descInternalCatalogTable`: it built the DESC proc path `/index_schema/<id>` appending `getBaseIndexMetaId()` only for `TableType.OLAP` and `table.getId()` otherwise (which `lookup()` ignored via `getBaseSchema()`). Now that cloud-native tables resolve per index meta id, it appends `getBaseIndexMetaId()` for them too so `DESC <lake_table>` keeps returning the base schema. Added a test that drives the real DESC path (`ShowExecutor.execute`), not just `lookup()` directly. Added a regression test in `CreateLakeTableTest`
that creates a shared-data table with an inline rollup and asserts the per-index
proc returns the rollup's own columns.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
