### PR TITLE
[UT] Fix FunctionContext leaks in base64ToBitmapConstNullHandling

### DIFF
--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -18,7 +18,6 @@
 #include <gtest/gtest.h>
 
 #include "base/base64.h"
-#include "base/phmap/phmap.h"
 #include "base/testutil/assert.h"
 #include "column/array_column.h"
 #include "column/column_helper.h"
@@ -36,9 +35,9 @@ public:
         ctx = ctx_ptr.get();
     }
 
-private:
+protected:
     std::unique_ptr<FunctionContext> ctx_ptr;
-    FunctionContext* ctx;
+    FunctionContext* ctx = nullptr;
 };
 
 TEST_F(VecBitmapFunctionsTest, bitmapEmptyTest) {
@@ -3538,7 +3537,8 @@ TEST_F(VecBitmapFunctionsTest, base64ToBitmapConstOptimization) {
 }
 
 TEST_F(VecBitmapFunctionsTest, base64ToBitmapConstNullHandling) {
-    auto* ctx2 = FunctionContext::create_test_context();
+    std::unique_ptr<FunctionContext> ctx2_ptr(FunctionContext::create_test_context());
+    auto* ctx2 = ctx2_ptr.get();
 
     // NULL constant
     {
@@ -3562,7 +3562,8 @@ TEST_F(VecBitmapFunctionsTest, base64ToBitmapConstNullHandling) {
 
     // Empty string constant
     {
-        auto* ctx3 = FunctionContext::create_test_context();
+        std::unique_ptr<FunctionContext> ctx3_ptr(FunctionContext::create_test_context());
+        auto* ctx3 = ctx3_ptr.get();
 
         auto value_col = BinaryColumn::create();
         value_col->append(Slice(""));
@@ -3588,7 +3589,8 @@ TEST_F(VecBitmapFunctionsTest, base64ToBitmapConstNullHandling) {
 
     // Invalid base64 constant
     {
-        auto* ctx4 = FunctionContext::create_test_context();
+        std::unique_ptr<FunctionContext> ctx4_ptr(FunctionContext::create_test_context());
+        auto* ctx4 = ctx4_ptr.get();
 
         auto value_col = BinaryColumn::create();
         value_col->append(Slice("!!!invalid_base64!!!"));
@@ -3614,7 +3616,8 @@ TEST_F(VecBitmapFunctionsTest, base64ToBitmapConstNullHandling) {
 
     // Truncated valid base64 constant (missing last char -> incomplete final group)
     {
-        auto* ctx5 = FunctionContext::create_test_context();
+        std::unique_ptr<FunctionContext> ctx5_ptr(FunctionContext::create_test_context());
+        auto* ctx5 = ctx5_ptr.get();
 
         const std::string truncated_base64 =
                 "CgsAAABaAAAAAAAAAFsAAAAAAAAAXAAAAAAAAABdAAAAAAAAAF4AAAAAAAAAXwAAAAAAAABgAAAAAAAAAGEAAAAAAAAA"


### PR DESCRIPTION
The local test contexts created via FunctionContext::create_test_context() (which does a raw new) were never deleted. Wrap ctx2-ctx5 in unique_ptr so the FunctionContext objects are freed on scope exit.

## Why I'm doing:

## What I'm doing:

Fix FunctionContext leaks in base64ToBitmapConstNullHandling

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
