### PR TITLE
[Refactor] Rename IVMAnalyzer's rewriting check* methods to rewrite*

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -247,18 +247,18 @@ public class IVMAnalyzer {
         if (queryRelation instanceof SelectRelation) {
             SelectRelation selectRelation = (SelectRelation) queryRelation;
             // For SelectRelation, we rewrite it to support incremental view maintenance.
-            return checkSelectRelation(selectRelation);
+            return rewriteSelectRelation(selectRelation);
         } else if (queryRelation instanceof SetOperationRelation) {
-            return checkSetRelation((SetOperationRelation) queryRelation);
+            return rewriteSetRelation((SetOperationRelation) queryRelation);
         } else if (queryRelation instanceof SubqueryRelation) {
-            return checkSubqueryRelation((SubqueryRelation) queryRelation);
+            return rewriteSubqueryRelation((SubqueryRelation) queryRelation);
         } else {
             throw new SemanticException("IVMAnalyzer can only handle SelectRelation/UnionRelation, but got: %s",
                     queryRelation.getClass().getSimpleName());
         }
     }
 
-    private boolean checkSubqueryRelation(SubqueryRelation subqueryRelation) throws AnalysisException {
+    private boolean rewriteSubqueryRelation(SubqueryRelation subqueryRelation) throws AnalysisException {
         QueryStatement subQueryStatement = subqueryRelation.getQueryStatement();
         boolean childHasComputedRowId = rewriteImpl(subQueryStatement.getQueryRelation());
         if (childHasComputedRowId) {
@@ -268,7 +268,7 @@ public class IVMAnalyzer {
         return false;
     }
 
-    private boolean checkSetRelation(SetOperationRelation setOperationRelation) throws AnalysisException {
+    private boolean rewriteSetRelation(SetOperationRelation setOperationRelation) throws AnalysisException {
         if (!(setOperationRelation instanceof UnionRelation)) {
             throw new SemanticException("IVMAnalyzer can only handle UnionRelation, " +
                     "but got: %s", setOperationRelation.getClass().getSimpleName());
@@ -291,7 +291,7 @@ public class IVMAnalyzer {
                 throw new SemanticException("UnionRelation in IVMAnalyzer should not have aggregate functions, " +
                         "but got: %s", aggregateExprs);
             }
-            boolean childHasComputedRowId = checkRelation(selectChild);
+            boolean childHasComputedRowId = rewriteRelation(selectChild);
             if (childHasComputedRowId) {
                 throw new SemanticException("IVMAnalyzer does not support UnionRelation with retractable sink, " +
                         "but got: %s", unionRelation.getClass().getSimpleName());
@@ -300,7 +300,7 @@ public class IVMAnalyzer {
         return false;
     }
 
-    private boolean checkSelectRelation(SelectRelation selectRelation) throws AnalysisException {
+    private boolean rewriteSelectRelation(SelectRelation selectRelation) throws AnalysisException {
         if (CollectionUtils.isNotEmpty(selectRelation.getOutputAnalytic())) {
             throw new SemanticException("IVMAnalyzer does not support window functions, " +
                     "but got: %s", selectRelation.getOutputAnalytic());
@@ -324,13 +324,13 @@ public class IVMAnalyzer {
             throw new SemanticException("IVMAnalyzer does not support %s for incremental view maintenance",
                     groupByClause.getGroupingType());
         }
-        boolean hasComputedRowId = checkAggregate(selectRelation);
+        boolean hasComputedRowId = rewriteAggregate(selectRelation);
         Relation innerRelation = selectRelation.getRelation();
-        hasComputedRowId |= checkRelation(innerRelation);
+        hasComputedRowId |= rewriteRelation(innerRelation);
         return hasComputedRowId;
     }
 
-    private boolean checkRelation(Relation relation) throws AnalysisException {
+    private boolean rewriteRelation(Relation relation) throws AnalysisException {
         if (relation == null) {
             return false;
         }
@@ -341,11 +341,11 @@ public class IVMAnalyzer {
             if (!IVM_SUPPORTED_JOIN_OPS.contains(joinType)) {
                 throw new SemanticException("IVMAnalyzer does not support join type: %s", joinType);
             }
-            if (checkRelation(joinRelation.getLeft())) {
+            if (rewriteRelation(joinRelation.getLeft())) {
                 throw new SemanticException("IVMAnalyzer does not support with retractable left input, " +
                         "but got: %s", joinRelation.getLeft());
             }
-            if (checkRelation(joinRelation.getRight())) {
+            if (rewriteRelation(joinRelation.getRight())) {
                 throw new SemanticException("IVMAnalyzer does not support with retractable right input, " +
                         "but got: %s", joinRelation.getRight());
             }
@@ -372,7 +372,7 @@ public class IVMAnalyzer {
         }
     }
 
-    private boolean checkAggregate(SelectRelation selectRelation) throws AnalysisException {
+    private boolean rewriteAggregate(SelectRelation selectRelation) throws AnalysisException {
         List<FunctionCallExpr> aggregateExprs = selectRelation.getAggregate();
         List<Expr> groupByExprs = selectRelation.getGroupBy();
 
@@ -428,7 +428,7 @@ public class IVMAnalyzer {
             // Whitelist gate: only (function, argument-type) combinations validated end-to-end
             // are allowed. Unsupported combinations would either fail at refresh time or silently
             // produce wrong data; reject them here so the user sees a clear CREATE-time error.
-            checkAggregateFunctionInWhitelist(aggFuncExpr, aggFuncName);
+            validateAggregateFunctionInWhitelist(aggFuncExpr, aggFuncName);
             FunctionCallExpr intermediateAggFuncExpr = buildIntermediateAggregateFunc(aggFuncExpr);
             String newAggFuncName = IvmOpUtils.getIvmAggStateColumnName(aggFuncExpr);
 
@@ -515,7 +515,7 @@ public class IVMAnalyzer {
         return ExprSubstitutionVisitor.rewrite(expr, substitutionMap);
     }
 
-    private static void checkAggregateFunctionInWhitelist(FunctionCallExpr aggFuncExpr, String aggFuncName) {
+    private static void validateAggregateFunctionInWhitelist(FunctionCallExpr aggFuncExpr, String aggFuncName) {
         Predicate<Type[]> rule = IVM_SUPPORTED_AGG_FUNCTIONS.get(aggFuncName.toLowerCase());
         if (rule == null) {
             throw new SemanticException(


### PR DESCRIPTION
## Why I'm doing:

`IVMAnalyzer`'s query-relation dispatch entry point is named `rewriteImpl`, but the five helpers it drives are named `check*` (`checkSelectRelation`, `checkSetRelation`, `checkSubqueryRelation`, `checkRelation`, `checkAggregate`). The `check*` prefix reads as a side-effect-free predicate, but these methods **rewrite** the query for incremental view maintenance — they prepend the encoded `__ROW_ID__` output, lower `SELECT DISTINCT` to `GROUP BY`, collapse aggregate state, and shift group-by ordinals — and reject unsupported shapes. The name hides the mutation and diverges from the `rewriteImpl` entry point one level up.

## What I'm doing:

Rename the rewriting helpers to `rewrite*` so the family matches `rewriteImpl` and the name reflects that they rewrite the AST:

- `checkSelectRelation` → `rewriteSelectRelation`
- `checkSetRelation` → `rewriteSetRelation`
- `checkSubqueryRelation` → `rewriteSubqueryRelation`
- `checkRelation` → `rewriteRelation`
- `checkAggregate` → `rewriteAggregate`

`checkAggregateFunctionInWhitelist` is a genuine validation (throws on an unsupported aggregate, no mutation), so it becomes `validateAggregateFunctionInWhitelist` rather than `rewrite*`.

Pure rename of private methods within `IVMAnalyzer` (no call sites outside the file — all private). Line count unchanged (15 insertions / 15 deletions). No behavior change; existing IVM analyzer tests cover the unchanged behavior.

Fixes #issue: N/A — internal refactor, no functional change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
