### PR TITLE
[Tool] Skip module-risk PR comment when the assessment could not run

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -337,6 +337,21 @@ jobs:
             echo "no high-confidence, diff-aligned module risk — not commenting"
             exit 0
           fi
+          # Defense-in-depth against an "assessment could not run" body. The skill's --comment
+          # contract makes an access/environment failure (no code_kb context-base MCP connection, or
+          # USAGE denied) emit the markerless `MODULE-RISK: unavailable` sentinel, so it normally
+          # arrives here empty and is dropped above. But the model is non-deterministic — if it
+          # regresses and emits a marker'd "cannot assess" body, that failure recurs identically on
+          # every PR, so posting it per-PR is pure noise. Drop it here too. We KEEP a real briefing
+          # (carries the fixed "High-confidence risks" section) and the genuine per-PR "coverage
+          # incomplete" caveat (PR-too-large); we drop only a body that is neither AND carries a
+          # context-base/code_kb access-failure signature (tool names / contextbase name never
+          # appear in a real StarRocks bug briefing).
+          if ! printf '%s' "$body" | grep -qiE 'High-confidence risks|coverage incomplete' \
+             && printf '%s' "$body" | grep -qiE 'context-base MCP|list_collections|context_get|code_kb|MODULE-RISK: unavailable'; then
+            echo "module-risk not assessed — no code_kb MCP connection / access; environment failure, not commenting"
+            exit 0
+          fi
           # Stamp the PR head SHA as line 2 (right after the marker, which the brief job's sed
           # guaranteed is line 1) so reviewers can detect a briefing that predates the latest push.
           # awk avoids sed escaping pitfalls; the SHA is hex so it is injection-safe.


### PR DESCRIPTION
## Why I'm doing:

The module-risk CI bot posted `⚠️ module risk NOT assessed — this environment has no code_kb context-base MCP connection ...` on a PR. That is an environment/infra failure (the `context-base` MCP was not connected in the CI session), **not** a per-PR signal — and it recurs identically on every PR, so surfacing it as a per-PR comment is pure noise that trains reviewers to ignore the bot.

## What I'm doing:

The `module-risk-comment` job posts whatever marker'd body the model emits. This adds a deterministic guard to that job:

- **KEEP** a real briefing (carries the fixed `### High-confidence risks` section).
- **KEEP** the genuine per-PR `coverage incomplete` (PR-too-large) caveat.
- **DROP** a body that is neither of the above **and** carries a context-base / `code_kb` access-failure signature (`context-base MCP`, `list_collections`, `context_get`, `code_kb`, `MODULE-RISK: unavailable`) — i.e. the assessment could not run.

Verified against the real infra-failure body, the coverage-incomplete caveat, and real briefings (including one that mentions `code_kb`/`USAGE` in prose — kept, because it carries the briefing section).

This is defense-in-depth. The skill's `--comment` contract (the `github-pr-module-risk` plugin, in a separate repo) is updated in lockstep to emit a **markerless** `MODULE-RISK: unavailable` sentinel on preflight failure, which the existing "no marker ⇒ empty body ⇒ no comment" gate already drops. This guard covers the case where a non-deterministic model regresses and still emits a marker'd body.

CI-only workflow change; no product code paths, and no user-facing config/metric changes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
