### PR TITLE
[Tool] Unstable-case workflows: fail loud when ci-tool git pull can't update

### DIFF
--- a/.github/workflows/unstable-case-ai-analysis.yml
+++ b/.github/workflows/unstable-case-ai-analysis.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
       - name: Analyze unstable cases (history-aware)
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
 
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           [[ "$owner" == "starrocks" ]] && bucket="starrocks-ci-release" || bucket="${owner}-ci-release"

--- a/.github/workflows/unstable-case-promote-demote.yml
+++ b/.github/workflows/unstable-case-promote-demote.yml
@@ -50,7 +50,9 @@ jobs:
     steps:
       - name: Evaluate probation cases & (optionally) open PR
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
 
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           [[ "$owner" == "starrocks" ]] && bucket="starrocks-ci-release" || bucket="${owner}-ci-release"

--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -154,7 +154,7 @@ jobs:
     env:
       BRANCH:        ${{ needs.prepare.outputs.BRANCH }}
       PR_NUMBER:     ${{ needs.prepare.outputs.COMMIT_SHA }}
-      WEEKLY_REVIEW: 'true'
+      UNSTABLE_REVIEW: 'true'
       LINUX_DISTRO:  ubuntu
       BUILD_TYPE:    Release
     outputs:

--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -52,7 +52,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
 
           BRANCH="${{ inputs.branch || 'main' }}"
           CASE_TYPES="${{ inputs.case_types || 'all' }}"
@@ -85,7 +86,9 @@ jobs:
         id: run_ut
         timeout-minutes: 180
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
           ./bin/elastic-ut-review.sh \
             --repository ${{ github.repository }} \
             --branch ${BRANCH} \
@@ -121,7 +124,9 @@ jobs:
         id: run_ut
         timeout-minutes: 240
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
           ./bin/elastic-ut-review.sh \
             --repository ${{ github.repository }} \
             --branch ${BRANCH} \
@@ -172,7 +177,9 @@ jobs:
         id: deploy
         timeout-minutes: 30
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
           ./bin/elastic-cluster.sh --template ci-admit --linuxdistro ubuntu
           _oss="/var/local/env/ossutil64 --config-file /root/.ossutilconfig"
           _base="oss://starrocks-ci-release/${BRANCH}/Release/inspection/pr/ubuntu"
@@ -243,7 +250,9 @@ jobs:
       - name: Generate report & update unstable_case.json
         id: gen
         run: |
-          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
+          rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool
+          git pull >/dev/null || { echo "::error::ci-tool 'git pull' failed on the runner (dirty /var/lib/ci-tool); refusing to run stale code. Clean the runner tree and re-run."; exit 1; }
+          source lib/init.sh
 
           CASE_TYPES="${{ inputs.case_types || 'all' }}"
           FE_OSS="${{ needs.fe-ut-review.outputs.oss_path }}"

--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -154,7 +154,7 @@ jobs:
     env:
       BRANCH:        ${{ needs.prepare.outputs.BRANCH }}
       PR_NUMBER:     ${{ needs.prepare.outputs.COMMIT_SHA }}
-      UNSTABLE_REVIEW: 'true'
+      WEEKLY_REVIEW: 'true'
       LINUX_DISTRO:  ubuntu
       BUILD_TYPE:    Release
     outputs:


### PR DESCRIPTION
## Why I'm doing:
The lifecycle workflows' setup prefix `... && cd ci-tool && git pull >/dev/null && source lib/init.sh` silently runs stale code when the runner's `/var/lib/ci-tool` working tree is dirty. Under `bash -e`, a non-final command in an `&&` chain is exempt from `set -e`, so a failing `git pull` neither aborts the step nor updates the code — the job stays green while running an outdated copy. Observed live on CelerData: a promote-demote canary reported success while `git pull` had actually failed on `Your local changes ... would be overwritten`.

## What I'm doing:
Pull `git pull` out of the `&&` chain onto its own line and guard it with `|| { echo "::error::..."; exit 1; }`, so a dirty/blocked runner tree becomes a **red** job instead of a silent stale-code run. `source lib/init.sh` stays as before. Applied to all three unstable-case workflows (review ×5 steps, ai-analysis, promote-demote).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

(Behavior change is intentional and narrow: the affected steps now FAIL when ci-tool cannot be updated, instead of silently proceeding on stale code.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Not included
The same `git pull && source lib/init.sh` convention is used repo-wide (see CLAUDE.md invocation convention). This PR only hardens the three unstable-case lifecycle workflows, where stale code causes wrong promote/demote decisions. Broadening the change to every workflow is out of scope.