### PR TITLE
[BugFix][CVE] Remove vulnerable stale transitive dependencies and enforce bans

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -128,6 +128,8 @@ subprojects {
             implementation("com.qcloud:chdfs_hadoop_plugin_network:3.2")
             implementation("com.squareup.okhttp3:okhttp:4.10.0")
             implementation("com.squareup.okio:okio:3.4.0")
+            // okhttp 4.10.0 drags in okio-jvm 3.0.0 (CVE-2023-3635); keep it aligned with okio
+            implementation("com.squareup.okio:okio-jvm:3.4.0")
             implementation("com.starrocks:fe-testing:${project.version}")
             implementation("com.starrocks:hive-udf:${project.version}")
             implementation("com.starrocks:jprotobuf-starrocks:${project.ext["jprotobuf-starrocks.version"]}")
@@ -173,7 +175,8 @@ subprojects {
             implementation("org.apache.arrow:flight-sql-jdbc-driver:${project.ext["arrow.version"]}")
             implementation("org.apache.avro:avro:${project.ext["avro.version"]}")
             implementation("org.apache.commons:commons-dbcp2:2.9.0")
-            implementation("org.apache.commons:commons-lang3:3.9")
+            // 3.18.0 fixes CVE-2025-48924
+            implementation("org.apache.commons:commons-lang3:3.18.0")
             implementation("org.apache.commons:commons-pool2:2.3")
             implementation("org.apache.groovy:groovy-groovysh:4.0.9")
             implementation("org.apache.hadoop:hadoop-aliyun:${project.ext["hadoop.version"]}")
@@ -256,6 +259,20 @@ subprojects {
             implementation("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}")
             // dependency sync end
         }
+    }
+
+    // Mirror the Maven-side CVE exclusions/enforcer bans (see fe/pom.xml):
+    // these artifacts must never appear on any FE classpath.
+    configurations.all {
+        // superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs
+        exclude(group = "org.bouncycastle", module = "bcprov-jdk15on")
+        // EOL okhttp 2.x line (okhttp3 lives under com.squareup.okhttp3)
+        exclude(group = "com.squareup.okhttp")
+        // JSP engine, unused by FE; tomcat 9.0.93 carries CVE-2025-55754/CVE-2025-52434
+        exclude(group = "org.apache.tomcat")
+        exclude(group = "org.apache.tomcat.embed")
+        // COS SSE-KMS SDK, drags in EOL okhttp 2.7.5
+        exclude(group = "com.tencentcloudapi")
     }
 
     // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java

--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -127,9 +127,14 @@ subprojects {
             implementation("com.qcloud.cos:hadoop-cos:3.3.0-8.3.2")
             implementation("com.qcloud:chdfs_hadoop_plugin_network:3.2")
             implementation("com.squareup.okhttp3:okhttp:4.10.0")
+            // keep on the same train as okhttp (tencentcloud-sdk declares 3.12.x)
+            implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
             implementation("com.squareup.okio:okio:3.4.0")
             // okhttp 4.10.0 drags in okio-jvm 3.0.0 (CVE-2023-3635); keep it aligned with okio
             implementation("com.squareup.okio:okio-jvm:3.4.0")
+            // tencentcloud-sdk below 3.1.1471 drags in EOL okhttp 2.7.5 (via hadoop-cos)
+            implementation("com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.1471")
+            implementation("com.tencentcloudapi:tencentcloud-sdk-java-kms:3.1.1471")
             implementation("com.starrocks:fe-testing:${project.version}")
             implementation("com.starrocks:hive-udf:${project.version}")
             implementation("com.starrocks:jprotobuf-starrocks:${project.ext["jprotobuf-starrocks.version"]}")
@@ -271,8 +276,6 @@ subprojects {
         // JSP engine, unused by FE; tomcat 9.0.93 carries CVE-2025-55754/CVE-2025-52434
         exclude(group = "org.apache.tomcat")
         exclude(group = "org.apache.tomcat.embed")
-        // COS SSE-KMS SDK, drags in EOL okhttp 2.7.5
-        exclude(group = "com.tencentcloudapi")
     }
 
     // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1675,6 +1675,8 @@ under the License.
                                         <exclude>com.squareup.okhttp:*</exclude>
                                         <!-- okio-jvm below 3.4.0 is affected by CVE-2023-3635 -->
                                         <exclude>com.squareup.okio:okio-jvm:[,3.4.0)</exclude>
+                                        <!-- commons-lang3 below 3.18.0 is affected by CVE-2025-48924 -->
+                                        <exclude>org.apache.commons:commons-lang3:[,3.18.0)</exclude>
                                         <!-- JSP engine, unused by FE; 9.0.93 carries CVE-2025-55754/CVE-2025-52434 -->
                                         <exclude>org.apache.tomcat:*</exclude>
                                         <exclude>org.apache.tomcat.embed:*</exclude>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -53,7 +53,6 @@ under the License.
         <!-- jackson-annotations doesn't have 2.21.4 version released -->
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <spark.version>3.5.7</spark.version>
-        <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.16.0</parquet.version>
         <orc.version>1.9.1</orc.version>
         <hadoop.version>3.4.3</hadoop.version>
@@ -1653,6 +1652,43 @@ under the License.
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>ban-vulnerable-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs -->
+                                        <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                        <!-- EOL okhttp 2.x line -->
+                                        <exclude>com.squareup.okhttp:*</exclude>
+                                        <!-- okio-jvm below 3.4.0 is affected by CVE-2023-3635 -->
+                                        <exclude>com.squareup.okio:okio-jvm:[,3.4.0)</exclude>
+                                        <!-- JSP engine, unused by FE; 9.0.93 carries CVE-2025-55754/CVE-2025-52434 -->
+                                        <exclude>org.apache.tomcat:*</exclude>
+                                        <exclude>org.apache.tomcat.embed:*</exclude>
+                                        <!-- COS SSE-KMS SDK, drags in EOL okhttp 2.7.5 -->
+                                        <exclude>com.tencentcloudapi:*</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <reporting>
         <plugins>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -594,6 +594,14 @@ under the License.
                 <version>3.4.0</version>
             </dependency>
 
+            <!-- pin okio-jvm to the same version as okio; okhttp 4.10.0 drags in
+                 okio-jvm 3.0.0 which is affected by CVE-2023-3635 -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/javax.validation/validation-api -->
             <dependency>
                 <groupId>javax.validation</groupId>
@@ -1047,6 +1055,14 @@ under the License.
                 <groupId>com.qcloud.cos</groupId>
                 <artifactId>hadoop-cos</artifactId>
                 <version>3.3.0-8.3.2</version>
+                <exclusions>
+                    <!-- tencentcloud KMS SDK drags in EOL okhttp 2.7.5 (com.squareup.okhttp);
+                         only used for COS SSE-KMS which StarRocks does not support -->
+                    <exclusion>
+                        <groupId>com.tencentcloudapi</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
@@ -1138,6 +1154,11 @@ under the License.
                     <exclusion>
                         <groupId>org.apache.hbase.thirdparty</groupId>
                         <artifactId>hbase-shaded-netty</artifactId>
+                    </exclusion>
+                    <!-- JSP engine, unused here; tomcat-jasper 9.0.93 carries open CVEs -->
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1296,6 +1317,12 @@ under the License.
                     <exclusion>
                         <groupId>org.lz4</groupId>
                         <artifactId>lz4-pure-java</artifactId>
+                    </exclusion>
+                    <!-- aliyun-java-auth drags in bcprov-jdk15on 1.70 (multiple CVEs);
+                         bcprov-jdk18on 1.84 on the classpath provides the same packages -->
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -587,6 +587,13 @@ under the License.
                 <version>4.10.0</version>
             </dependency>
 
+            <!-- keep on the same train as okhttp (tencentcloud-sdk declares 3.12.x) -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>logging-interceptor</artifactId>
+                <version>4.10.0</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.squareup.okio/okio -->
             <dependency>
                 <groupId>com.squareup.okio</groupId>
@@ -1055,14 +1062,19 @@ under the License.
                 <groupId>com.qcloud.cos</groupId>
                 <artifactId>hadoop-cos</artifactId>
                 <version>3.3.0-8.3.2</version>
-                <exclusions>
-                    <!-- tencentcloud KMS SDK drags in EOL okhttp 2.7.5 (com.squareup.okhttp);
-                         only used for COS SSE-KMS which StarRocks does not support -->
-                    <exclusion>
-                        <groupId>com.tencentcloudapi</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
+            </dependency>
+
+            <!-- hadoop-cos pulls tencentcloud-sdk 3.1.213 whose okhttp 2.7.5 is EOL;
+                 3.1.1471+ ships okhttp3, keeping COS client-side encryption usable -->
+            <dependency>
+                <groupId>com.tencentcloudapi</groupId>
+                <artifactId>tencentcloud-sdk-java-kms</artifactId>
+                <version>3.1.1471</version>
+            </dependency>
+            <dependency>
+                <groupId>com.tencentcloudapi</groupId>
+                <artifactId>tencentcloud-sdk-java-common</artifactId>
+                <version>3.1.1471</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
@@ -1680,8 +1692,8 @@ under the License.
                                         <!-- JSP engine, unused by FE; 9.0.93 carries CVE-2025-55754/CVE-2025-52434 -->
                                         <exclude>org.apache.tomcat:*</exclude>
                                         <exclude>org.apache.tomcat.embed:*</exclude>
-                                        <!-- COS SSE-KMS SDK, drags in EOL okhttp 2.7.5 -->
-                                        <exclude>com.tencentcloudapi:*</exclude>
+                                        <!-- tencentcloud-sdk below 3.1.1471 drags in EOL okhttp 2.7.5 -->
+                                        <exclude>com.tencentcloudapi:*:[,3.1.1471)</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -262,10 +262,11 @@ under the License.
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+            <!-- 3.18.0 fixes CVE-2025-48924 (ClassUtils.getClass StackOverflow) -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
+                <version>3.18.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-pool2 -->

--- a/java-extensions/odps-reader/pom.xml
+++ b/java-extensions/odps-reader/pom.xml
@@ -100,6 +100,14 @@
             </exclusions>
         </dependency>
 
+        <!-- aliyun-java-auth needs org.bouncycastle.*; the vulnerable bcprov-jdk15on
+             is excluded above, so ship bcprov-jdk18on in odps-reader-lib instead
+             (each BE reader has its own isolated classpath) -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/java-extensions/odps-reader/pom.xml
+++ b/java-extensions/odps-reader/pom.xml
@@ -91,6 +91,12 @@
                     <artifactId>lz4-pure-java</artifactId>
                     <groupId>org.lz4</groupId>
                 </exclusion>
+                <!-- aliyun-java-auth drags in bcprov-jdk15on 1.70 (multiple CVEs);
+                     bcprov-jdk18on 1.84 on the classpath provides the same packages -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -521,6 +521,13 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <!-- 3.18.0 fixes CVE-2025-48924; udf-extensions bundles this into its
+                 jar-with-dependencies shipped under be/lib/jni-packages -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
             <!-- hadoop-yarn-common drags in 2.12.7 copies of these; keep them
                  aligned with the managed jackson version -->
             <dependency>
@@ -697,6 +704,8 @@
                                         <exclude>junit:junit:*:jar:runtime</exclude>
                                         <!-- keep jackson-jaxrs aligned with the managed jackson version -->
                                         <exclude>com.fasterxml.jackson.jaxrs:*:[,2.15.0)</exclude>
+                                        <!-- commons-lang3 below 3.18.0 is affected by CVE-2025-48924 -->
+                                        <exclude>org.apache.commons:commons-lang3:[,3.18.0)</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -360,6 +360,12 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <!-- json-simple 1.1.1 leaks junit 4.10 as a compile dependency
+                         (CVE-2020-15250); it must not ship in the runtime lib -->
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -513,6 +519,23 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <!-- hadoop-yarn-common drags in 2.12.7 copies of these; keep them
+                 aligned with the managed jackson version -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <!-- jackson -->

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -677,6 +677,35 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>ban-vulnerable-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs -->
+                                        <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                        <!-- junit must never leak into runtime libs (CVE-2020-15250);
+                                             test scope stays allowed -->
+                                        <exclude>junit:junit:*:jar:compile</exclude>
+                                        <exclude>junit:junit:*:jar:runtime</exclude>
+                                        <!-- keep jackson-jaxrs aligned with the managed jackson version -->
+                                        <exclude>com.fasterxml.jackson.jaxrs:*:[,2.15.0)</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>

--- a/java-extensions/udf-extensions/pom.xml
+++ b/java-extensions/udf-extensions/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
         </dependency>
 
         <!-- Apache Arrow: vectorized ("input"="arrow") Java UDF support.


### PR DESCRIPTION
## Why I'm doing:

A vulnerability scan against the release package showed several EOL/vulnerable artifacts physically shipping in `fe/lib` and `be/lib` **side by side with their fixed counterparts**, because unmanaged transitive dependencies leak through:

- `bcprov-jdk15on-1.70.jar` (multiple BC CVEs, e.g. CVE-2024-29857) next to `bcprov-jdk18on-1.84.jar`, via `odps-sdk-core -> aliyun-java-auth`
- `okhttp-2.7.5.jar` + `logging-interceptor-2.7.5.jar` (EOL 2.x line) next to okhttp 4.10.0, via `hadoop-cos -> tencentcloud-sdk-java-kms` 3.1.213
- `tomcat-* 9.0.93` (7 jars, CVE-2025-55754 / CVE-2025-52434) via `hudi-common -> hbase-server -> tomcat-jasper`; FE never runs JSP
- `okio-jvm-3.0.0.jar` (CVE-2023-3635) next to okio 3.4.0, resolved by okhttp 4.10.0
- `junit-4.10.jar` (CVE-2020-15250) leaking into the runtime hadoop lib via `hadoop-hdfs-httpfs -> json-simple 1.1.1` compile-scope leak
- `jackson-jaxrs-* 2.12.7` via `hadoop-yarn-common`, out of line with the managed jackson 2.21.4
- `commons-lang3` 3.9 (CVE-2025-48924, fixed in 3.18.0)

## What I'm doing:

Six commits, pom/gradle-only, no Java code changes:

1. **Exclude/converge the stale artifacts** (`8689a51`): exclusions for bcprov-jdk15on, `org.apache.tomcat:*`, junit; pin `okio-jvm` 3.4.0 and manage `jackson-jaxrs-*` to `${jackson.version}`. On the FE flat classpath the existing `bcprov-jdk18on` 1.84 takes over; BE readers load from isolated per-module lib dirs, so odps-reader additionally declares `bcprov-jdk18on` explicitly (see commit 4).
2. **Bump commons-lang3 to 3.18.0** (`941df6e`).
3. **Add maven-enforcer `bannedDependencies` gates** (`e05ae4f`) in both fe and java-extensions root poms so a future dependency bump cannot silently re-introduce the removed artifacts (junit ban is compile/runtime scope only — test scope stays allowed). Also drops the unreferenced `tomcat.version` property.
4. **Address review findings** (`b5acbaf`): ship `bcprov-jdk18on` in `odps-reader-lib` (BE readers cannot see the FE classpath), and manage `commons-lang3` 3.18.0 in java-extensions — `udf-extensions` hardcoded 3.9 and bundles it into the jar-with-dependencies under `be/lib/jni-packages`; the enforcer ban list now covers `commons-lang3:[,3.18.0)` as well.
5. **Mirror everything in the Gradle build** (`95fe509`, `743fd71`): fe/README-gradle.md promises the same artifacts, so the Gradle scripts get equivalent global excludes and constraints.
6. **Eliminate okhttp 2.7.5 by upgrading the tencentcloud SDK instead of excluding it** (`743fd71`): manage `tencentcloud-sdk-java-kms/common` at 3.1.1471, which ships okhttp3; converge `okhttp3:logging-interceptor` to 4.10.0. The enforcer rule is a version-range ban `com.tencentcloudapi:*:[,3.1.1471)` so the vulnerable SDK line stays banned while the fixed one is allowed.

**Verification**
- `mvn dependency:tree` on fe-core and the java-extensions reactor: stale artifacts gone, replacements converge to managed versions (tencentcloud 3.1.1471, okhttp family unified at 4.10.0, no `com.squareup.okhttp` anywhere)
- Full `./build.sh --fe` packaging diff: exactly the intended jars disappeared; `okio-jvm-3.4.0`, `tencentcloud-sdk-java-{kms,common}-3.1.1471` and `logging-interceptor-4.10.0` appeared
- FE restart + smoke (DML, string functions, paimon filesystem catalog): clean, zero `ClassNotFound`/`NoClassDefFound` in fe.log
- Full FE UT: 41,716 cases; the only 2 failures (`PaimonTableTest`, `RefreshTableStmtTest`) reproduce identically on unmodified main (pre-existing)
- Enforcer negative-tested: temporarily banning guava fails the build as expected; `mvn validate` passes on both reactors with the real ban list
- Clean `mvn install -pl odps-reader,udf-extensions -am`: odps-reader-lib contains bcprov-jdk18on-1.84.jar only; the udf-extensions fat jar embeds commons-lang3 3.18.0

**Note for reviewers (COS/tencentcloud)**: the KMS SDK is only consumed by COS *client-side* encryption (`COSEncryptionClient`/`QCLOUDKMS` generate/decrypt data keys); server-side encryption incl. SSE-KMS never calls it. An earlier revision of this PR excluded `com.tencentcloudapi:*` outright; since "no one uses client-side encryption" cannot be proven, the final revision upgrades the SDK instead — the capability keeps working and the EOL okhttp 2.x line disappears. **No COS behavior change remains.**

**Note on the Gradle path**: the Gradle build could not be executed in this environment (no network access to gradle.org); the changes mirror the Maven semantics 1:1 and follow the existing lz4-substitution precedent in the same file.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)