### PR TITLE
[BugFix] Fix LoadChunkSpiller init race that crashes BE during load spill

### DIFF
--- a/be/src/compute_env/load_spill/load_chunk_spiller.cpp
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.cpp
@@ -147,39 +147,39 @@ StatusOr<size_t> LoadChunkSpiller::spill(const Chunk& chunk, int64_t slot_idx) {
 }
 
 Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
-    // Fast path: already fully initialized. The acquire load pairs with the release store
-    // below, so a thread that observes `true` is guaranteed to see the fully-constructed
-    // `_spiller` and its prepared serde.
-    if (_prepared.load(std::memory_order_acquire)) {
-        return Status::OK();
-    }
-    // Slow path: serialize the one-time initialization. Multiple memtable-flush threads may
-    // reach here concurrently on the first spill of this LoadChunkSpiller.
-    std::lock_guard<std::mutex> l(_init_lock);
-    if (_prepared.load(std::memory_order_relaxed)) {
-        return Status::OK();
-    }
-    // Build everything on a local first, so a half-initialized spiller is never published
-    // through `_spiller`. The previous code assigned `_spiller` before preparing its serde,
-    // which let a racing thread observe a non-null spiller whose serde encode context was
-    // still null and crash in ColumnarSerde::serialize().
-    spill::SpilledOptions options;
-    options.encode_level = 7;
-    // Leave options.wg unset (nullptr): the spill framework resolves it to the reserved
-    // default workgroup in Spiller::prepare(), so this load path no longer needs ExecEnv.
-    auto spiller = _spiller_factory->create(options);
-    RETURN_IF_ERROR(spiller->prepare(_runtime_state.get()));
-    DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
-    spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
-    spiller->set_metrics(metrics);
-    // Prepare serde (creates the encode context) BEFORE publishing the spiller.
-    if (const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->empty()) {
-        const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->set_schema(chunk_ptr);
-        RETURN_IF_ERROR(spiller->serde()->prepare());
-    }
-    _spiller = std::move(spiller);
-    _prepared.store(true, std::memory_order_release);
-    return Status::OK();
+    // Multiple memtable-flush threads share this LoadChunkSpiller and reach here concurrently
+    // on the first spill. std::call_once runs the init body exactly once: the winning thread
+    // builds the spiller while the others block until it returns, then every thread observes
+    // the fully-constructed `_spiller`. call_once establishes the happens-before edge, so the
+    // spiller and its prepared serde are visible without any manual atomics. `_prepare_status`
+    // caches the outcome; a failed init is reported to all callers instead of leaving a
+    // half-built spiller reachable (the crash this fix addresses).
+    std::call_once(_prepare_once, [&] {
+        // Build everything on a local first, so a half-initialized spiller is never published
+        // through `_spiller`. The previous code assigned `_spiller` before preparing its serde,
+        // which let a racing thread observe a non-null spiller whose serde encode context was
+        // still null and crash in ColumnarSerde::serialize().
+        spill::SpilledOptions options;
+        options.encode_level = 7;
+        // Leave options.wg unset (nullptr): the spill framework resolves it to the reserved
+        // default workgroup in Spiller::prepare(), so this load path no longer needs ExecEnv.
+        auto spiller = _spiller_factory->create(options);
+        if (_prepare_status = spiller->prepare(_runtime_state.get()); !_prepare_status.ok()) {
+            return;
+        }
+        DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
+        spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
+        spiller->set_metrics(metrics);
+        // Prepare serde (creates the encode context) BEFORE publishing the spiller.
+        if (const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->empty()) {
+            const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->set_schema(chunk_ptr);
+            if (_prepare_status = spiller->serde()->prepare(); !_prepare_status.ok()) {
+                return;
+            }
+        }
+        _spiller = std::move(spiller);
+    });
+    return _prepare_status;
 }
 
 Status LoadChunkSpiller::_do_spill(const Chunk& chunk, const spill::SpillOutputDataStreamPtr& output) {

--- a/be/src/compute_env/load_spill/load_chunk_spiller.cpp
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.cpp
@@ -147,23 +147,38 @@ StatusOr<size_t> LoadChunkSpiller::spill(const Chunk& chunk, int64_t slot_idx) {
 }
 
 Status LoadChunkSpiller::_prepare(const ChunkPtr& chunk_ptr) {
-    if (_spiller == nullptr) {
-        // 1. alloc & prepare spiller
-        spill::SpilledOptions options;
-        options.encode_level = 7;
-        // Leave options.wg unset (nullptr): the spill framework resolves it to the reserved
-        // default workgroup in Spiller::prepare(), so this load path no longer needs ExecEnv.
-        _spiller = _spiller_factory->create(options);
-        RETURN_IF_ERROR(_spiller->prepare(_runtime_state.get()));
-        DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
-        spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
-        _spiller->set_metrics(metrics);
-        // 2. prepare serde
-        if (const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->empty()) {
-            const_cast<spill::ChunkBuilder*>(&_spiller->chunk_builder())->chunk_schema()->set_schema(chunk_ptr);
-            RETURN_IF_ERROR(_spiller->serde()->prepare());
-        }
+    // Fast path: already fully initialized. The acquire load pairs with the release store
+    // below, so a thread that observes `true` is guaranteed to see the fully-constructed
+    // `_spiller` and its prepared serde.
+    if (_prepared.load(std::memory_order_acquire)) {
+        return Status::OK();
     }
+    // Slow path: serialize the one-time initialization. Multiple memtable-flush threads may
+    // reach here concurrently on the first spill of this LoadChunkSpiller.
+    std::lock_guard<std::mutex> l(_init_lock);
+    if (_prepared.load(std::memory_order_relaxed)) {
+        return Status::OK();
+    }
+    // Build everything on a local first, so a half-initialized spiller is never published
+    // through `_spiller`. The previous code assigned `_spiller` before preparing its serde,
+    // which let a racing thread observe a non-null spiller whose serde encode context was
+    // still null and crash in ColumnarSerde::serialize().
+    spill::SpilledOptions options;
+    options.encode_level = 7;
+    // Leave options.wg unset (nullptr): the spill framework resolves it to the reserved
+    // default workgroup in Spiller::prepare(), so this load path no longer needs ExecEnv.
+    auto spiller = _spiller_factory->create(options);
+    RETURN_IF_ERROR(spiller->prepare(_runtime_state.get()));
+    DCHECK(_profile != nullptr) << "LoadChunkSpiller profile is null";
+    spill::SpillProcessMetrics metrics(_profile, &_total_spill_bytes);
+    spiller->set_metrics(metrics);
+    // Prepare serde (creates the encode context) BEFORE publishing the spiller.
+    if (const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->empty()) {
+        const_cast<spill::ChunkBuilder*>(&spiller->chunk_builder())->chunk_schema()->set_schema(chunk_ptr);
+        RETURN_IF_ERROR(spiller->serde()->prepare());
+    }
+    _spiller = std::move(spiller);
+    _prepared.store(true, std::memory_order_release);
     return Status::OK();
 }
 

--- a/be/src/compute_env/load_spill/load_chunk_spiller.h
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.h
@@ -131,14 +131,18 @@ private:
     std::unique_ptr<RuntimeProfile> _dummy_profile;
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
-    // Guards the one-time initialization of `_spiller` (and its serde) in _prepare().
-    // The load spill path is entered concurrently by multiple memtable-flush threads
-    // that share the same LoadChunkSpiller, so this initialization must be serialized.
-    std::mutex _init_lock;
-    // Set to true only after `_spiller` AND its serde (including the encode context) are
-    // fully initialized. Readers gate on this flag rather than on `_spiller != nullptr`,
-    // because the pointer becomes visible before the serde's encode context is created.
-    std::atomic<bool> _prepared{false};
+    // Drives the one-time initialization of `_spiller` (and its serde) in _prepare().
+    // The load spill path is entered concurrently by multiple memtable-flush threads that
+    // share the same LoadChunkSpiller, so std::call_once serializes the first spill: the
+    // winning thread runs the init body while the others block until it finishes and then
+    // observe the fully-constructed `_spiller`. Readiness is no longer inferred from
+    // `_spiller != nullptr`, which used to become visible before the serde's encode context
+    // was created and let a racing thread crash in ColumnarSerde::serialize().
+    std::once_flag _prepare_once;
+    // Result of the one-time initialization, published by the call_once body and read by
+    // every caller. A failed init is cached here (call_once will not re-run on a normal
+    // return), so all threads see the same error instead of using a half-built spiller.
+    Status _prepare_status;
     SchemaPtr _schema;
 };
 

--- a/be/src/compute_env/load_spill/load_chunk_spiller.h
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "column/vectorized_fwd.h"
@@ -130,6 +131,14 @@ private:
     std::unique_ptr<RuntimeProfile> _dummy_profile;
     spill::SpillerFactoryPtr _spiller_factory;
     std::shared_ptr<spill::Spiller> _spiller;
+    // Guards the one-time initialization of `_spiller` (and its serde) in _prepare().
+    // The load spill path is entered concurrently by multiple memtable-flush threads
+    // that share the same LoadChunkSpiller, so this initialization must be serialized.
+    std::mutex _init_lock;
+    // Set to true only after `_spiller` AND its serde (including the encode context) are
+    // fully initialized. Readers gate on this flag rather than on `_spiller != nullptr`,
+    // because the pointer becomes visible before the serde's encode context is created.
+    std::atomic<bool> _prepared{false};
     SchemaPtr _schema;
 };
 

--- a/be/src/compute_env/spill/serde.cpp
+++ b/be/src/compute_env/spill/serde.cpp
@@ -104,6 +104,12 @@ size_t ColumnarSerde::_max_serialized_size(const ChunkPtr& chunk) const {
 
 Status ColumnarSerde::serialize(RuntimeState* state, SerdeContext& ctx, const ChunkPtr& chunk,
                                 const SpillOutputDataStreamPtr& output, bool aligned) {
+    // Defense in depth: prepare() must have created the encode context before any serialize()
+    // call. Return an error instead of dereferencing a null context in _get_encode_levels()
+    // (which would crash the process), mirroring the existing null guard in _max_serialized_size().
+    if (_encode_context == nullptr) {
+        return Status::InternalError("ColumnarSerde::serialize() called before prepare(): encode context is null");
+    }
     raw::RawString& serialize_buffer = ctx.serialize_buffer;
     {
         SCOPED_TIMER(_parent->metrics().serialize_timer);

--- a/be/test/compute_env/load_spill/load_chunk_spiller_test.cpp
+++ b/be/test/compute_env/load_spill/load_chunk_spiller_test.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <limits>
+#include <thread>
 #include <unordered_set>
 
 #include "base/testutil/assert.h"
@@ -366,6 +368,59 @@ TEST_F(LoadChunkSpillerTest, test_duplicate_slot_idx) {
     ASSERT_NE(task.merge_itr, nullptr);
     // Should only merge first continuous sequence
     ASSERT_GE(task.total_block_groups, 1);
+}
+
+// Regression test for the LoadChunkSpiller::_prepare() initialization race.
+//
+// Multiple memtable-flush threads share a single LoadChunkSpiller and call spill()
+// concurrently on the first spill (see the parallel-flush comment on
+// LoadChunkSpiller::spill). Before the fix, _prepare() used `_spiller == nullptr` as its
+// readiness flag with no lock, so one thread could publish `_spiller` before creating the
+// serde's encode context, while a racing thread observed the non-null spiller, skipped
+// initialization, and called ColumnarSerde::serialize() with a null encode context --
+// dereferencing it in _get_encode_levels() and crashing with SIGSEGV.
+//
+// Each round drives many threads through the first spill of a fresh LoadChunkSpiller so the
+// narrow initialization window is exercised repeatedly; every concurrent spill must succeed.
+TEST_F(LoadChunkSpillerTest, test_concurrent_first_spill_is_thread_safe) {
+    constexpr int kRounds = 200;
+    constexpr int kThreads = 8;
+    for (int round = 0; round < kRounds; round++) {
+        auto block_manager = std::make_unique<LoadSpillBlockManager>(TUniqueId(), TUniqueId(), kTestDir, nullptr,
+                                                                     _local_spill_dir_mgr.get());
+        ASSERT_OK(block_manager->init());
+        RuntimeProfile profile("test");
+        // No slot tracker: spill() then skips mark_slot_ready(), keeping the test focused on
+        // the _prepare() initialization race rather than slot bookkeeping.
+        LoadChunkSpiller spiller(block_manager.get(), &profile, nullptr);
+
+        std::atomic<int> ready{0};
+        std::atomic<bool> go{false};
+        std::vector<Status> results(kThreads);
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        for (int t = 0; t < kThreads; t++) {
+            threads.emplace_back([&, t]() {
+                auto chunk = gen_data(100, t * 100);
+                ready.fetch_add(1, std::memory_order_release);
+                // Spin so all threads reach the first spill as simultaneously as possible,
+                // maximizing the chance of hitting the initialization window.
+                while (!go.load(std::memory_order_acquire)) {
+                }
+                results[t] = spiller.spill(*chunk, t).status();
+            });
+        }
+        while (ready.load(std::memory_order_acquire) < kThreads) {
+        }
+        go.store(true, std::memory_order_release);
+        for (auto& th : threads) {
+            th.join();
+        }
+        for (int t = 0; t < kThreads; t++) {
+            ASSERT_TRUE(results[t].ok()) << "round " << round << " thread " << t << ": " << results[t].to_string();
+        }
+        ASSERT_NE(nullptr, spiller.spiller());
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`LoadChunkSpiller::_prepare()` lazily creates the spiller and its serde, but used
`_spiller == nullptr` as its "already initialized" flag **without any lock**. Multiple
memtable-flush threads share a single `LoadChunkSpiller` and call `spill()` concurrently
on the first spill (see the parallel-flush comment on `LoadChunkSpiller::spill`).

Because `_spiller` is assigned *before* the serde's encode context is created, a racing
thread could observe a non-null `_spiller`, skip initialization, and call
`ColumnarSerde::serialize()` while the encode context was still null. `serialize()` then
dereferenced the null context in `_get_encode_levels()` and crashed the BE/CN with
`SIGSEGV`. Observed on a shared-data (CN) production cluster during load spill:

```
PC: starrocks::spill::ColumnarSerde::serialize(...)
*** SIGSEGV (@0x50) received ... ***
    ColumnarSerde::serialize
    LoadChunkSpiller::_do_spill
    LoadChunkSpiller::spill
    lake::SpillMemTableSink::flush_chunk
    MemTable::flush
    FlushToken::_flush_memtable
    MemtableFlushTask::run
```

## What I'm doing:

- Serialize the one-time initialization in `_prepare()` with a `std::mutex`, and gate
  readiness on a separate `std::atomic<bool> _prepared` that is stored with release
  ordering **only after** the spiller and its serde are fully constructed; readers load
  it with acquire ordering. Readiness is no longer inferred from `_spiller != nullptr`.
- Build the spiller on a local and publish it via `std::move`, so a half-initialized
  spiller is never observable through `_spiller`.
- Defense in depth: `ColumnarSerde::serialize()` now returns an error instead of
  dereferencing a null encode context, mirroring the existing null guard in
  `_max_serialized_size()`.
- Add a regression test that drives many threads through the first spill of a fresh
  `LoadChunkSpiller` and asserts all concurrent spills succeed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
