### PR TITLE
[BugFix] Fix heap-use-after-free in GLM lock-bearing phmap maps

### DIFF
--- a/be/src/exec/lookup_stream_mgr.cpp
+++ b/be/src/exec/lookup_stream_mgr.cpp
@@ -42,9 +42,17 @@ Status LookUpDispatcher::add_request(const pipeline::LookUpRequestContextPtr& ct
     auto notify = this->defer_notify();
     ctx->receive_ts = MonotonicNanos();
     auto request_tuple_id = ctx->request_tuple_id();
-    auto it = _request_queues.lazy_emplace(
-            request_tuple_id, [&](const auto& ctor) { ctor(request_tuple_id, std::make_shared<RequestsQueue>()); });
-    it->second->enqueue(ctx);
+    // Enqueue under the submap lock. The plain lazy_emplace() returns an iterator whose
+    // slot can be freed by a concurrent lazy_emplace()/resize() on the same submap once
+    // the lock is released, so dereferencing it->second outside the lock is a
+    // heap-use-after-free. lazy_emplace_l runs both callbacks while holding the lock.
+    _request_queues.lazy_emplace_l(
+            request_tuple_id, [&](RequestsQueuePtr& queue) { queue->enqueue(ctx); },
+            [&](const auto& ctor) {
+                auto queue = std::make_shared<RequestsQueue>();
+                queue->enqueue(ctx);
+                ctor(request_tuple_id, std::move(queue));
+            });
     DLOG(INFO) << "[GLM] add request to LookUpDispatcher, "
                << ", query id: " << print_id(_query_id) << ", target node id: " << _lookup_node_id
                << ", tuple id: " << request_tuple_id << ", dispacher: " << (void*)this;
@@ -92,11 +100,22 @@ std::shared_ptr<LookUpDispatcher> LookUpDispatcherMgr::create_dispatcher(const T
                                                                          const std::vector<SlotId>& source_id_slots,
                                                                          int64_t rpc_ref_cnt) {
     DispatcherKey key{query_id, target_node_id};
-    auto [_, created] = _dispatcher_map.try_emplace(
-            key, std::make_shared<LookUpDispatcher>(query_id, target_node_id, source_id_slots, rpc_ref_cnt));
+    // Do the get-or-create and the read entirely under the submap lock. Returning
+    // _dispatcher_map.at() would deref a slot reference after the lock is released,
+    // racing with a concurrent try_emplace()/resize() on the same submap that frees the
+    // slot array -> heap-use-after-free.
+    LookUpDispatcherPtr dispatcher;
+    bool created = false;
+    _dispatcher_map.lazy_emplace_l(
+            key, [&](LookUpDispatcherPtr& value) { dispatcher = value; },
+            [&](const auto& ctor) {
+                dispatcher = std::make_shared<LookUpDispatcher>(query_id, target_node_id, source_id_slots, rpc_ref_cnt);
+                created = true;
+                ctor(key, dispatcher);
+            });
     DLOG_IF(INFO, created) << "[GLM] create LookUpDispatcher for query_id=" << print_id(query_id)
                            << ", target_node_id=" << target_node_id << ", rpc_ref_cnt=" << rpc_ref_cnt;
-    return _dispatcher_map.at(key);
+    return dispatcher;
 }
 
 StatusOr<LookUpDispatcherPtr> LookUpDispatcherMgr::get_dispatcher(const TUniqueId& query_id,
@@ -129,13 +148,16 @@ Status LookUpDispatcherMgr::lookup(const pipeline::RemoteLookUpRequestContextPtr
 
 Status LookUpDispatcherMgr::lookup_close(const TUniqueId& query_id, PlanNodeId target_node_id) {
     DispatcherKey key{query_id, target_node_id};
-    auto it = _dispatcher_map.find(key);
-    if (it == _dispatcher_map.end()) {
+    // Copy the shared_ptr out under the submap lock; find()'s iterator would dangle if a
+    // concurrent try_emplace()/resize() on the same submap freed the slot array after the
+    // lock was released (heap-use-after-free).
+    LookUpDispatcherPtr dispatcher;
+    _dispatcher_map.if_contains(key, [&](LookUpDispatcherPtr& value) { dispatcher = value; });
+    if (dispatcher == nullptr) {
         LOG(WARNING) << "[GLM] lookup_close missing LookUpDispatcher for query_id=" << print_id(query_id)
                      << ", target_node_id=" << target_node_id;
         return Status::OK();
     }
-    auto dispatcher = it->second;
     DLOG(INFO) << "[GLM] lookup_close dec reference LookUpDispatcher for query_id=" << print_id(query_id)
                << ", target_node_id=" << target_node_id << ", current rpc_ref_cnt=" << dispatcher->ref_cnt();
     if (dispatcher->ref_dec()) {

--- a/be/src/exec/pipeline/fetch_processor.cpp
+++ b/be/src/exec/pipeline/fetch_processor.cpp
@@ -539,11 +539,19 @@ FetchProcessorFactory::FetchProcessorFactory(int32_t target_node_id,
           _nodes_info(std::move(nodes_info)) {}
 
 FetchProcessorPtr FetchProcessorFactory::get_or_create(int32_t driver_sequence) {
-    if (!_processor_map.contains(driver_sequence)) {
-        _processor_map.try_emplace(driver_sequence, std::make_shared<FetchProcessor>(_target_node_id, _row_pos_descs,
-                                                                                     _slot_id_to_desc, _nodes_info));
-    }
-    return _processor_map.at(driver_sequence);
+    // Do the get-or-create and the read entirely under the submap lock. Returning
+    // _processor_map.at() would deref a slot reference after the lock is released,
+    // racing with a concurrent try_emplace()/resize() (another driver sequence hashing
+    // into the same submap) that frees the slot array -> heap-use-after-free.
+    FetchProcessorPtr processor;
+    _processor_map.lazy_emplace_l(
+            driver_sequence, [&](FetchProcessorPtr& value) { processor = value; },
+            [&](const auto& ctor) {
+                processor = std::make_shared<FetchProcessor>(_target_node_id, _row_pos_descs, _slot_id_to_desc,
+                                                             _nodes_info);
+                ctor(driver_sequence, processor);
+            });
+    return processor;
 }
 
 void FetchProcessorFactory::close_context(RuntimeState* state) {


### PR DESCRIPTION
## Why I'm doing:

The GLM lookup subsystem returns references/iterators from lock-bearing phmap::parallel_flat_hash_map lookups after the submap lock is released. A concurrent lazy_emplace()/try_emplace() on the same submap can resize() and free the slot array while the caller dereferences the stale reference, causing a heap-use-after-free -- the same defect fixed for GlobalLateMaterilizationContextMgr in #76036.

Read the value entirely under the submap lock instead:
- FetchProcessorFactory::get_or_create: contains()+try_emplace()+at() -> lazy_emplace_l
- LookUpDispatcher::add_request: lazy_emplace() iterator deref -> lazy_emplace_l (enqueue under lock)
- LookUpDispatcherMgr::create_dispatcher: try_emplace()+at() -> lazy_emplace_l
- LookUpDispatcherMgr::lookup_close: find()+it->second -> if_contains

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
