### PR TITLE
[BugFix] Fix nullable outputs for aggregate pushdown below UNION ALL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
@@ -183,8 +183,9 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
             List<ColumnRefOperator> unionOutputColumns = Lists.newArrayList();
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : ctx.localAgg().getAggregations().entrySet()) {
                 ColumnRefOperator output = entry.getKey();
+                boolean nullable = isPushedDownAggregateOutputNullable(output, entry.getValue());
                 unionOutputColumns.add(new ColumnRefOperator(output.getId(), entry.getValue().getType(),
-                        output.getName(), output.isNullable()));
+                        output.getName(), nullable));
             }
 
             // 1. Rewrite each branch of UNION ALL.
@@ -268,8 +269,9 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : localAgg.getAggregations().entrySet()) {
                 ColumnRefOperator oldOutput = entry.getKey();
                 CallOperator newCall = (CallOperator) aggRewriter.rewrite(entry.getValue());
+                boolean nullable = isPushedDownAggregateOutputNullable(oldOutput, newCall);
                 ColumnRefOperator newOutput = factory.create(oldOutput.getName(), newCall.getType(),
-                        oldOutput.isNullable());
+                        nullable);
                 newAggregations.put(newOutput, newCall);
                 localAggOutputRewriteMap.put(oldOutput, newOutput);
             }
@@ -308,6 +310,10 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
                     .setCost(cost)
                     .build();
             return new BranchRewriteResult(newExchangeExpr, branchOutputColumns);
+        }
+
+        private boolean isPushedDownAggregateOutputNullable(ColumnRefOperator output, CallOperator call) {
+            return output.isNullable() || !FunctionSet.COUNT.equals(call.getFnName());
         }
 
         private AggInputRewriteResult rewriteAggInput(RewriteContext ctx, PhysicalUnionOperator union,
@@ -372,7 +378,7 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
                 ColumnRefOperator oldOutput = entry.getKey();
                 ScalarOperator newExpression = childRewriter.rewrite(entry.getValue());
                 ColumnRefOperator newOutput = factory.create(oldOutput.getName(), newExpression.getType(),
-                        oldOutput.isNullable());
+                        newExpression.isNullable());
                 newProjectMap.put(newOutput, newExpression);
                 projectOutputRewriteMap.put(oldOutput, newOutput);
             }


### PR DESCRIPTION
## Why I'm doing:

When `PushDownNonGroupedAggregateBelowUnion` pushes a non-grouped aggregate below `UNION ALL`, each union child computes a partial aggregate result. For non-count aggregate functions, if one child has no input rows, the partial aggregate result can be `NULL`.

The rewrite previously reused the original aggregate output nullability when constructing pushed-down outputs. If the original output was inferred as non-nullable, BE could receive a nullable column containing NULL values but treat the destination column as non-nullable, causing a debug CHECK failure in `ColumnHelper::update_column_nullable`.

This PR fixes the nullability propagation for this rewrite.

## What I'm doing:

This PR fixes nullable propagation in `PushDownNonGroupedAggregateBelowUnion`.

1. For the pushed-down branch aggregate outputs and the rewritten `UNION` outputs, non-count aggregate results are marked as nullable so they can accept NULL columns produced by empty union children. `COUNT` outputs keep their non-null behavior. 
2. The rewritten branch project output also derives nullable from the rewritten expression itself.

Fixes #issue https://github.com/StarRocks/StarRocksTest/issues/11530

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5