### PR TITLE
[BugFix] Fix range-colocate null-safe join dropping matches under bucket-shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -562,9 +562,12 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
 
         // Range-colocate dispatch:
         // - both children range + canRangeColocateJoin → skip exchange (return).
-        // - otherwise, normalize any range child to hash SHUFFLE_JOIN via
-        //   convertRangeToHashShuffle, then fall through to the existing
-        //   hash/hash compatibility path unchanged.
+        // - both children range but NOT colocate → force a full (PARTITIONED)
+        //   shuffle on both sides and return (see below).
+        // - exactly one range child (range × hash) → normalize the range child to
+        //   hash SHUFFLE_JOIN via convertRangeToHashShuffle, then fall through to the
+        //   existing hash/hash compatibility path unchanged (the hash side is a valid
+        //   crc32 bucket-shuffle stay side).
         DistributionSpec leftRawSpec = leftChildOutputProperty.getDistributionProperty().getSpec();
         DistributionSpec rightRawSpec = rightChildOutputProperty.getDistributionProperty().getSpec();
         boolean leftIsRange = leftRawSpec instanceof RangeDistributionSpec;
@@ -576,6 +579,24 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
                     leftShuffleColumns, rightShuffleColumns)) {
                 return visitOperator(node, context);
             }
+            // Two range children that cannot colocate (disable_colocate_join, different
+            // group, unstable/empty group, unsupported join type, ...) must be joined
+            // via a full PARTITIONED shuffle — a range table can never be the local
+            // (stay) side of a bucket-shuffle, because bucket-shuffle re-buckets the
+            // other side with crc32 which does not match the range tablet layout.
+            //
+            // We must NOT use convertRangeToHashShuffle (SourceType.SHUFFLE_JOIN) here:
+            // a range scan natively satisfies a SHUFFLE_JOIN requirement
+            // (RangeDistributionSpec.isSatisfyHashShuffle), so for a null-safe key (<=>)
+            // — whose required distribution is already null-strict, matching the enforced
+            // one — the memo discards the shuffle enforcer and reuses the un-exchanged
+            // range scan, yielding a SHUFFLE_HASH_BUCKET join that silently drops all
+            // matches. enforceChildShuffleDistribution uses SourceType.SHUFFLE_ENFORCE,
+            // which a range scan does not satisfy, so the shuffle exchange is guaranteed
+            // on both sides and the join is PARTITIONED.
+            enforceChildShuffleDistribution(leftShuffleColumns, leftChild, leftChildOutputProperty, 0);
+            enforceChildShuffleDistribution(rightShuffleColumns, rightChild, rightChildOutputProperty, 1);
+            return visitOperator(node, context);
         }
         if (leftIsRange) {
             leftChild = convertRangeToHashShuffle(leftShuffleColumns, leftChild, leftChildOutputProperty, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateNullSafeJoinPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateNullSafeJoinPlanTest.java
@@ -1,0 +1,147 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A range-distributed table must never be the local (stay) side of a bucket-shuffle
+ * join: bucket-shuffle re-buckets the other side with crc32, which does not match the
+ * range tablet layout, so all matches are silently dropped. This surfaced for a
+ * null-safe equi-join ({@code a <=> b}) — whose required distribution is null-strict —
+ * where the memo reused the un-exchanged range scan as a {@code SHUFFLE_HASH_BUCKET}
+ * stay side. A range/range join that cannot colocate must be PARTITIONED.
+ *
+ * <p>Genuine range colocate joins ({@code disable_colocate_join=false}, same stable
+ * group, colocate key) must still plan as COLOCATE for {@code <=>} as well as {@code =}.
+ */
+public class RangeColocateNullSafeJoinPlanTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static boolean savedEnableRangeDistributionConfig;
+    private static boolean savedEnableRangeDistributionSessionVar;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        savedEnableRangeDistributionConfig = Config.enable_range_distribution;
+        savedEnableRangeDistributionSessionVar = connectContext.getSessionVariable().isEnableRangeDistribution();
+        Config.enable_range_distribution = true;
+        connectContext.getSessionVariable().setEnableRangeDistribution(true);
+
+        starRocksAssert.withDatabase("range_null_safe_join").useDatabase("range_null_safe_join");
+        // two range-colocate tables in the same group
+        starRocksAssert.withTable("create table cl (k1 int, v int) order by(k1) "
+                + "properties('replication_num' = '1', 'colocate_with' = 'rns_grp:k1');");
+        starRocksAssert.withTable("create table cr (k1 int, v int) order by(k1) "
+                + "properties('replication_num' = '1', 'colocate_with' = 'rns_grp:k1');");
+        // a range-colocate table in a different group
+        starRocksAssert.withTable("create table dg (k1 int, v int) order by(k1) "
+                + "properties('replication_num' = '1', 'colocate_with' = 'rns_grp_other:k1');");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        Config.enable_range_distribution = savedEnableRangeDistributionConfig;
+        if (connectContext != null) {
+            connectContext.getSessionVariable().setEnableRangeDistribution(savedEnableRangeDistributionSessionVar);
+        }
+    }
+
+    @BeforeEach
+    public void resetSessionState() {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", false);
+    }
+
+    private String plan(String sql) throws Exception {
+        return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.getExplainString(TExplainLevel.NORMAL);
+    }
+
+    private void assertPartitionedNotBucketShuffle(String sql) throws Exception {
+        String p = plan(sql);
+        Assertions.assertTrue(p.contains("(PARTITIONED)"),
+                () -> "expected PARTITIONED join, plan was:\n" + p);
+        Assertions.assertFalse(p.contains("BUCKET_SHUFFLE"),
+                () -> "range/range join that cannot colocate must not be a bucket-shuffle, plan was:\n" + p);
+        Assertions.assertFalse(p.contains("colocate: true"),
+                () -> "expected non-colocate join, plan was:\n" + p);
+    }
+
+    private void assertColocate(String sql) throws Exception {
+        String p = plan(sql);
+        Assertions.assertTrue(p.contains("COLOCATE"),
+                () -> "expected COLOCATE join, plan was:\n" + p);
+    }
+
+    // ---- the bug: range/range <=> that cannot colocate must be PARTITIONED, not bucket-shuffle ----
+
+    @Test
+    public void fullOuterNullSafeDisableColocate() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        assertPartitionedNotBucketShuffle("select * from cl full outer join cr on cl.k1 <=> cr.k1");
+    }
+
+    @Test
+    public void innerNullSafeDisableColocate() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        assertPartitionedNotBucketShuffle("select * from cl join cr on cl.k1 <=> cr.k1");
+    }
+
+    @Test
+    public void leftOuterNullSafeDisableColocate() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        assertPartitionedNotBucketShuffle("select * from cl left join cr on cl.k1 <=> cr.k1");
+    }
+
+    @Test
+    public void fullOuterNullSafeDifferentGroup() throws Exception {
+        // different colocate groups cannot colocate even with disable_colocate_join off
+        assertPartitionedNotBucketShuffle("select * from cl full outer join dg on cl.k1 <=> dg.k1");
+    }
+
+    // ---- control: plain '=' already partitions correctly in the same situations ----
+
+    @Test
+    public void fullOuterEqualsDisableColocate() throws Exception {
+        Deencapsulation.setField(connectContext.getSessionVariable(), "disableColocateJoin", true);
+        assertPartitionedNotBucketShuffle("select * from cl full outer join cr on cl.k1 = cr.k1");
+    }
+
+    // ---- genuine range colocate <=> must still be COLOCATE (optimization preserved) ----
+
+    @Test
+    public void fullOuterNullSafeSameGroupStaysColocate() throws Exception {
+        assertColocate("select * from cl full outer join cr on cl.k1 <=> cr.k1");
+    }
+
+    @Test
+    public void innerNullSafeSameGroupStaysColocate() throws Exception {
+        assertColocate("select * from cl join cr on cl.k1 <=> cr.k1");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

A range-distribution colocate join on a **null-safe** key (`a <=> b`) that cannot
colocate — `disable_colocate_join=true`, or the two tables in different colocate
groups — was planned as `FULL/INNER/... JOIN (BUCKET_SHUFFLE(S))` with the **range
table as the local/stay side**. Bucket shuffle re-buckets the other side with
crc32, which does not match the range tablet layout, so **every match was silently
dropped — including non-NULL equal keys** (e.g. `10 <=> 10`), turning the join into
an all-NULL-padded result.

The same query with `=`, or `<=>` with colocate enabled (`COLOCATE` plan), or on
plain hash tables (`PARTITIONED`), all returned correct results — only the range
bucket-shuffle `<=>` path was wrong.

Root cause (FE optimizer): a range scan natively satisfies a hash `SHUFFLE_JOIN`
required property (`RangeDistributionSpec.isSatisfyHashShuffle`) — this is what
enables the legitimate `COLOCATE` plan. When the join cannot colocate,
`ChildOutputPropertyGuarantor` normalized each range child via
`convertRangeToHashShuffle` (SourceType `SHUFFLE_JOIN`). For a `<=>` key the
required distribution is already null-strict, so the `enforceNullStrict` inside
that helper is a no-op: the enforced `SHUFFLE_JOIN[null-strict]` matches exactly
what the un-exchanged range scan is cached as satisfying, so plan extraction
discards the shuffle exchange and reuses the range scan — a `SHUFFLE_HASH_BUCKET`
join with a range stay side. A plain `=` key is null-relaxed, so `enforceNullStrict`
shifts the property to null-strict (which the range scan was not costed for),
forcing the exchange — which is why the bug was `<=>`-specific.

## What I'm doing:

A range-distributed scan must never be the local (stay) side of a bucket-shuffle
join. In `ChildOutputPropertyGuarantor.visitPhysicalJoin`, when both children are
range but `canRangeColocateJoin` is false, force a full **PARTITIONED** shuffle on
both sides via `enforceChildShuffleDistribution` (SourceType `SHUFFLE_ENFORCE`,
which a range scan does **not** natively satisfy) and return, instead of
`convertRangeToHashShuffle`. This guarantees the shuffle exchange is materialized
on both sides regardless of the key's null-strictness.

Unchanged:
- Range-colocate joins that **can** colocate still plan as `COLOCATE` (the
  `canRangeColocateJoin` early return runs first) — for `<=>` as well as `=`.
- Range × hash joins still use bucket-shuffle with the **hash** table as the stay
  side (a valid crc32 stay side), via the existing single-range-child path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

<!-- A correctness fix: it returns correct results where the old plan returned wrong
results. Plan-shape-only optimizer change; no SQL syntax/config/API change. -->

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
