### PR TITLE
[BugFix] Carry forward untouched indexes into the file-bundling bundle on compaction publish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -1227,13 +1227,13 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // version without any data change. The count must match the real transactions because the BE requires
     // new_version == base_version + txns.size() for a multi-transaction batch (a batch of pre-rollup compactions
     // can span several versions).
-    private static void aggregatePublishWithCarryForward(List<Tablet> touchedTablets, List<TxnInfoPB> txnInfos,
-                                                         List<Tablet> carryForwardTablets, long baseVersion,
-                                                         long newVersion, Map<ComputeNode, List<Long>> nodeToTablets,
-                                                         ComputeResource computeResource,
-                                                         Map<Long, Double> compactionScores,
-                                                         Map<Long, TabletStatPB> tabletStats,
-                                                         List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
+    static void aggregatePublishWithCarryForward(List<Tablet> touchedTablets, List<TxnInfoPB> txnInfos,
+                                                 List<Tablet> carryForwardTablets, long baseVersion,
+                                                 long newVersion, Map<ComputeNode, List<Long>> nodeToTablets,
+                                                 ComputeResource computeResource,
+                                                 Map<Long, Double> compactionScores,
+                                                 Map<Long, TabletStatPB> tabletStats,
+                                                 List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
             throws NoAliveBackendException, RpcException {
         AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
         Utils.createSubRequestForAggregatePublish(touchedTablets, txnInfos, baseVersion, newVersion,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.LeaderDaemon;
@@ -65,6 +66,7 @@ import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
@@ -612,6 +614,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
         //  The mapping is shadow index id -> ShadowIndexTxnBatch
         Map<Long, ShadowIndexTxnBatch> shadowIndexTxnBatches = null;
         Set<Tablet> normalTablets = null;
+        List<Tablet> carryForwardTablets = null;
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -641,6 +644,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
 
             useAggregatePublish = table.isFileBundling();
+            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
             for (int i = 0; i < transactionStates.size(); i++) {
                 TransactionState txnState = transactionStates.get(i);
                 computeResource = txnState.getComputeResource();
@@ -665,8 +669,20 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     } else {
                         normalTablets = (normalTablets == null) ? Sets.newHashSet() : normalTablets;
                         normalTablets.addAll(index.getTablets());
+                        publishedNormalIndexIds.add(index.getId());
                     }
                 }
+            }
+            // File bundling stores the metadata of ALL tablets of a partition version in a single bundle file.
+            // The batched transactions' index views are point-in-time (for lake compaction snapshotted at txn
+            // begin); if a rollup/MV index became visible after they began, none of them touch it, so publishing
+            // the new version would write a bundle WITHOUT that index's tablets and permanently wedge the
+            // partition. Carry forward every currently-visible NORMAL index none of these transactions touched
+            // so the new bundle stays a complete whole-partition snapshot. See collectFileBundlingCarryForwardTablets.
+            if (useAggregatePublish) {
+                carryForwardTablets = collectFileBundlingCarryForwardTablets(
+                        partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
+                        publishedNormalIndexIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -712,6 +728,10 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     Utils.publishVersionBatch(publishTablets, txnInfos,
                             startVersion - 1, endVersion, compactionScores, nodeToTablets,
                             computeResource, tabletStats, vectorIndexBuildInfos);
+                } else if (CollectionUtils.isNotEmpty(carryForwardTablets)) {
+                    aggregatePublishWithCarryForward(publishTablets, txnInfos, carryForwardTablets,
+                            startVersion - 1, endVersion, nodeToTablets, computeResource, compactionScores,
+                            tabletStats, vectorIndexBuildInfos);
                 } else {
                     Utils.aggregatePublishVersion(publishTablets, txnInfos, startVersion - 1, endVersion,
                             compactionScores, nodeToTablets, computeResource, tabletStats, vectorIndexBuildInfos);
@@ -1141,23 +1161,9 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 Map<Long, TabletStatPB> tabletStats = new HashMap<>();
                 List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
                 if (useAggregatePublish && CollectionUtils.isNotEmpty(carryForwardTablets)) {
-                    // Publish the touched tablets (this txn) and the carry-forward tablets (empty version
-                    // bump) in ONE aggregate request, so the whole partition's metadata for the new version
-                    // is written into a single bundle file. Two separate aggregate publishes would each
-                    // truncate-write the same meta/0_<version>.meta and lose one of the two sets.
-                    AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
-                    Utils.createSubRequestForAggregatePublish(normalTablets, Lists.newArrayList(txnInfo),
-                            baseVersion, txnVersion, null, computeResource, request);
-                    TxnInfoPB emptyTxnInfo = new TxnInfoPB();
-                    emptyTxnInfo.txnId = -1L;
-                    emptyTxnInfo.combinedTxnLog = false;
-                    emptyTxnInfo.commitTime = txnInfo.commitTime;
-                    emptyTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
-                    emptyTxnInfo.gtid = txnInfo.gtid;
-                    Utils.createSubRequestForAggregatePublish(carryForwardTablets, Lists.newArrayList(emptyTxnInfo),
-                            baseVersion, txnVersion, null, computeResource, request);
-                    Utils.sendAggregatePublishVersionRequest(request, baseVersion, computeResource,
-                            compactionScores, null, tabletStats, vectorIndexBuildInfos);
+                    aggregatePublishWithCarryForward(normalTablets, Lists.newArrayList(txnInfo), carryForwardTablets,
+                            baseVersion, txnVersion, null, computeResource, compactionScores, tabletStats,
+                            vectorIndexBuildInfos);
                 } else {
                     Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
                             computeResource, tabletStats, useAggregatePublish, vectorIndexBuildInfos);
@@ -1209,6 +1215,46 @@ public class PublishVersionDaemon extends LeaderDaemon {
             carryForwardTablets.addAll(index.getTablets());
         }
         return carryForwardTablets;
+    }
+
+    // File bundling only. Publish the touched tablets (this publish's real transactions) together with the
+    // carry-forward tablets (untouched but currently-visible indexes) in ONE aggregate request, so the whole
+    // partition's metadata for the new version lands in a single bundle file (meta/0_<newVersion>.meta). Two
+    // separate aggregate publishes would each truncate-write that same bundle and lose one of the two sets.
+    //
+    // The carry-forward tablets have no txn log for these transactions, so for every real transaction we emit a
+    // matching no-op empty transaction (no_op_publish=true): the BE bypasses log loading and advances the tablet
+    // version without any data change. The count must match the real transactions because the BE requires
+    // new_version == base_version + txns.size() for a multi-transaction batch (a batch of pre-rollup compactions
+    // can span several versions).
+    private static void aggregatePublishWithCarryForward(List<Tablet> touchedTablets, List<TxnInfoPB> txnInfos,
+                                                         List<Tablet> carryForwardTablets, long baseVersion,
+                                                         long newVersion, Map<ComputeNode, List<Long>> nodeToTablets,
+                                                         ComputeResource computeResource,
+                                                         Map<Long, Double> compactionScores,
+                                                         Map<Long, TabletStatPB> tabletStats,
+                                                         List<VectorIndexBuildInfoPB> vectorIndexBuildInfos)
+            throws NoAliveBackendException, RpcException {
+        AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
+        Utils.createSubRequestForAggregatePublish(touchedTablets, txnInfos, baseVersion, newVersion,
+                nodeToTablets, computeResource, request);
+
+        List<TxnInfoPB> carryForwardTxnInfos = Lists.newArrayListWithCapacity(txnInfos.size());
+        for (TxnInfoPB txnInfo : txnInfos) {
+            TxnInfoPB emptyTxnInfo = new TxnInfoPB();
+            emptyTxnInfo.txnId = -1L;
+            emptyTxnInfo.combinedTxnLog = false;
+            emptyTxnInfo.commitTime = txnInfo.commitTime;
+            emptyTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
+            emptyTxnInfo.gtid = txnInfo.gtid;
+            emptyTxnInfo.noOpPublish = true;
+            carryForwardTxnInfos.add(emptyTxnInfo);
+        }
+        // The carry-forward tablets have no txn log to delete on success, so do not thread nodeToTablets here.
+        Utils.createSubRequestForAggregatePublish(carryForwardTablets, carryForwardTxnInfos, baseVersion, newVersion,
+                null, computeResource, request);
+        Utils.sendAggregatePublishVersionRequest(request, baseVersion, computeResource, compactionScores, null,
+                tabletStats, vectorIndexBuildInfos);
     }
 
     // Per-partition publishPartition phase breakdown for slow outliers.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -56,10 +56,12 @@ import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.Quantiles;
 import com.starrocks.lake.vector.VectorIndexBuildScheduler;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.TabletStatPB;
 import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.TxnTypePB;
 import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -1057,6 +1059,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
         ComputeResource computeResource = txnState.getComputeResource();
         List<Tablet> normalTablets = null;
         List<Tablet> shadowTablets = null;
+        List<Tablet> carryForwardTablets = null;
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1086,6 +1089,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
             baseVersion = partition.getVisibleVersion();
             List<MaterializedIndex> indexes = txnState.getPartitionLoadedIndexes(table.getId(), partition);
+            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
                     LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getMetaId()), txnId);
@@ -1097,7 +1101,22 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 } else {
                     normalTablets = (normalTablets == null) ? Lists.newArrayList() : normalTablets;
                     normalTablets.addAll(index.getTablets());
+                    publishedNormalIndexIds.add(index.getId());
                 }
+            }
+            // File bundling stores the metadata of ALL tablets of a partition version in a single bundle
+            // file (meta/0_<version>.meta). The index set above comes from the transaction's point-in-time
+            // view (for lake compaction it is snapshotted at txn begin). If a materialized-view/rollup
+            // index became visible after this transaction began, that stale view omits it, so publishing
+            // the new version would write a bundle WITHOUT the rollup index's tablets, dropping them from
+            // this version and permanently wedging the partition's publish queue (a later publish reading
+            // those tablets at this version gets a 404). Carry forward every currently-visible NORMAL index
+            // this transaction did not touch, so the new bundle remains a complete whole-partition snapshot.
+            // Only needed for file bundling; without it each tablet keeps its own per-version metadata file.
+            if (useAggregatePublish) {
+                carryForwardTablets = collectFileBundlingCarryForwardTablets(
+                        partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
+                        publishedNormalIndexIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1121,8 +1140,28 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 // collection, and range-distribution tablet sizes for real-time reshard triggering.
                 Map<Long, TabletStatPB> tabletStats = new HashMap<>();
                 List<VectorIndexBuildInfoPB> vectorIndexBuildInfos = new ArrayList<>();
-                Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
-                        computeResource, tabletStats, useAggregatePublish, vectorIndexBuildInfos);
+                if (useAggregatePublish && CollectionUtils.isNotEmpty(carryForwardTablets)) {
+                    // Publish the touched tablets (this txn) and the carry-forward tablets (empty version
+                    // bump) in ONE aggregate request, so the whole partition's metadata for the new version
+                    // is written into a single bundle file. Two separate aggregate publishes would each
+                    // truncate-write the same meta/0_<version>.meta and lose one of the two sets.
+                    AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
+                    Utils.createSubRequestForAggregatePublish(normalTablets, Lists.newArrayList(txnInfo),
+                            baseVersion, txnVersion, null, computeResource, request);
+                    TxnInfoPB emptyTxnInfo = new TxnInfoPB();
+                    emptyTxnInfo.txnId = -1L;
+                    emptyTxnInfo.combinedTxnLog = false;
+                    emptyTxnInfo.commitTime = txnInfo.commitTime;
+                    emptyTxnInfo.txnType = TxnTypePB.TXN_EMPTY;
+                    emptyTxnInfo.gtid = txnInfo.gtid;
+                    Utils.createSubRequestForAggregatePublish(carryForwardTablets, Lists.newArrayList(emptyTxnInfo),
+                            baseVersion, txnVersion, null, computeResource, request);
+                    Utils.sendAggregatePublishVersionRequest(request, baseVersion, computeResource,
+                            compactionScores, null, tabletStats, vectorIndexBuildInfos);
+                } else {
+                    Utils.publishVersion(normalTablets, txnInfo, baseVersion, txnVersion, compactionScores,
+                            computeResource, tabletStats, useAggregatePublish, vectorIndexBuildInfos);
+                }
 
                 VectorIndexBuildScheduler.onPublishComplete(vectorIndexBuildInfos, txnState.isFromLakeCompaction());
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
@@ -1148,6 +1187,28 @@ public class PublishVersionDaemon extends LeaderDaemon {
             maybeLogSlowPublishPartition(txnId, partitionCommitInfo.getPhysicalPartitionId(), tableId,
                     submitTimeMs, lambdaEntryMs, lockAcquiredMs, rpcStartMs, System.currentTimeMillis());
         }
+    }
+
+    // For file bundling only: from the partition's currently-visible indexes, return the tablets of every
+    // NORMAL index that this transaction did not touch (i.e. whose index id is not in publishedNormalIndexIds).
+    // These must be carried forward (empty version bump) into the new version's bundle so it stays a complete
+    // whole-partition snapshot; otherwise a transaction with a stale index view (notably lake compaction
+    // whose loaded-index set is snapshotted at txn begin, before a rollup/MV index became visible) would
+    // publish a bundle missing that index and permanently wedge the partition. Returns null when nothing
+    // needs carrying forward (e.g. a normal load already covers every visible index). Caller must hold the
+    // table read lock while obtaining visibleIndexes.
+    static List<Tablet> collectFileBundlingCarryForwardTablets(List<MaterializedIndex> visibleIndexes,
+                                                               Set<Long> publishedNormalIndexIds) {
+        List<Tablet> carryForwardTablets = null;
+        for (MaterializedIndex index : visibleIndexes) {
+            if (index.getState() == MaterializedIndex.IndexState.SHADOW
+                    || publishedNormalIndexIds.contains(index.getId())) {
+                continue;
+            }
+            carryForwardTablets = (carryForwardTablets == null) ? Lists.newArrayList() : carryForwardTablets;
+            carryForwardTablets.addAll(index.getTablets());
+        }
+        return carryForwardTablets;
     }
 
     // Per-partition publishPartition phase breakdown for slow outliers.

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -16,14 +16,19 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.PublishVersionTask;
+import com.starrocks.thrift.TStorageMedium;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -41,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 public class PublishVersionDaemonTest {
     public int oldValue;
@@ -673,5 +679,45 @@ public class PublishVersionDaemonTest {
         Assertions.assertDoesNotThrow(() -> PublishVersionDaemon.maybeLogSlowPublishPartition(
                 11L, 21L, 31L,
                 submitTimeMs, lambdaEntryMs, lockAcquiredMs, rpcStartMs, submitTimeMs + 3000));
+    }
+
+    // Regression for the file-bundling compaction-vs-rollup bug: a transaction whose touched-index set
+    // (publishedNormalIndexIds) misses a currently-visible NORMAL index (e.g. a rollup/MV index that a
+    // lake compaction did not touch) must carry that index's tablets forward, so the new version's bundle
+    // stays a complete whole-partition snapshot. SHADOW indexes are never carried forward.
+    @Test
+    public void testCollectFileBundlingCarryForwardTablets() {
+        TStorageMedium medium = TStorageMedium.HDD;
+        // base index (id=1): tablets 101,102 ; rollup index (id=2): tablets 201,202 ; shadow index (id=3): 301
+        MaterializedIndex baseIndex = new MaterializedIndex(1L, MaterializedIndex.IndexState.NORMAL);
+        baseIndex.addTablet(new LakeTablet(101L), new TabletMeta(1L, 2L, 3L, 1L, medium, true), false);
+        baseIndex.addTablet(new LakeTablet(102L), new TabletMeta(1L, 2L, 3L, 1L, medium, true), false);
+
+        MaterializedIndex rollupIndex = new MaterializedIndex(2L, MaterializedIndex.IndexState.NORMAL);
+        rollupIndex.addTablet(new LakeTablet(201L), new TabletMeta(1L, 2L, 3L, 2L, medium, true), false);
+        rollupIndex.addTablet(new LakeTablet(202L), new TabletMeta(1L, 2L, 3L, 2L, medium, true), false);
+
+        MaterializedIndex shadowIndex = new MaterializedIndex(3L, MaterializedIndex.IndexState.SHADOW);
+        shadowIndex.addTablet(new LakeTablet(301L), new TabletMeta(1L, 2L, 3L, 3L, medium, true), false);
+
+        List<MaterializedIndex> visibleIndexes = Lists.newArrayList(baseIndex, rollupIndex, shadowIndex);
+
+        // Compaction touched only the base index (id=1): the rollup index (id=2) must be carried forward,
+        // and the SHADOW index (id=3) must be excluded.
+        List<Tablet> carry = PublishVersionDaemon.collectFileBundlingCarryForwardTablets(
+                visibleIndexes, Sets.newHashSet(1L));
+        Assertions.assertNotNull(carry);
+        Assertions.assertEquals(Lists.newArrayList(201L, 202L),
+                carry.stream().map(Tablet::getId).sorted().collect(Collectors.toList()));
+
+        // Every visible NORMAL index already touched (normal load): nothing to carry forward.
+        Assertions.assertNull(PublishVersionDaemon.collectFileBundlingCarryForwardTablets(
+                visibleIndexes, Sets.newHashSet(1L, 2L)));
+
+        // Nothing touched: both NORMAL indexes carried forward, SHADOW still excluded.
+        List<Tablet> carryAll = PublishVersionDaemon.collectFileBundlingCarryForwardTablets(
+                visibleIndexes, Sets.newHashSet());
+        Assertions.assertEquals(Lists.newArrayList(101L, 102L, 201L, 202L),
+                carryAll.stream().map(Tablet::getId).sorted().collect(Collectors.toList()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -19,16 +19,26 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.Config;
 import com.starrocks.common.ConfigRefreshDaemon;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.Utils;
+import com.starrocks.proto.AggregatePublishVersionRequest;
+import com.starrocks.proto.TabletStatPB;
+import com.starrocks.proto.TxnInfoPB;
+import com.starrocks.proto.TxnTypePB;
+import com.starrocks.proto.VectorIndexBuildInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.PublishVersionTask;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -43,6 +53,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -719,5 +730,83 @@ public class PublishVersionDaemonTest {
                 visibleIndexes, Sets.newHashSet());
         Assertions.assertEquals(Lists.newArrayList(101L, 102L, 201L, 202L),
                 carryAll.stream().map(Tablet::getId).sorted().collect(Collectors.toList()));
+    }
+
+    // The touched tablets (this publish's real transactions) and the carry-forward tablets (untouched but
+    // visible indexes) must go into ONE aggregate request; two separate aggregate publishes would each
+    // truncate-write the same meta/0_<version>.meta and drop one set. Because a batch can span several
+    // versions, the carry-forward emits one no-op empty transaction per real transaction so the untouched
+    // tablets advance across every version (the BE requires new_version == base_version + txns.size()).
+    @Test
+    public void testAggregatePublishWithCarryForwardBuildsSingleRequest() throws Exception {
+        List<List<Tablet>> capturedTablets = new ArrayList<>();
+        List<List<TxnInfoPB>> capturedTxnInfos = new ArrayList<>();
+        List<AggregatePublishVersionRequest> capturedRequests = new ArrayList<>();
+        AtomicInteger sendCount = new AtomicInteger(0);
+        List<AggregatePublishVersionRequest> sentRequests = new ArrayList<>();
+
+        new MockUp<Utils>() {
+            @Mock
+            public void createSubRequestForAggregatePublish(List<Tablet> tablets, List<TxnInfoPB> txnInfos,
+                    long baseVersion, long newVersion, Map<ComputeNode, List<Long>> nodeToTablets,
+                    ComputeResource computeResource, AggregatePublishVersionRequest request) {
+                capturedTablets.add(tablets);
+                capturedTxnInfos.add(txnInfos);
+                capturedRequests.add(request);
+            }
+
+            @Mock
+            public void sendAggregatePublishVersionRequest(AggregatePublishVersionRequest request,
+                    long baseVersion, ComputeResource computeResource, Map<Long, Double> compactionScores,
+                    Map<Long, TabletRange> tabletRanges, Map<Long, TabletStatPB> tabletStats,
+                    List<VectorIndexBuildInfoPB> vectorIndexBuildInfos) {
+                sendCount.incrementAndGet();
+                sentRequests.add(request);
+            }
+        };
+
+        List<Tablet> touched = Lists.newArrayList(new LakeTablet(101L), new LakeTablet(102L));
+        List<Tablet> carryForward = Lists.newArrayList(new LakeTablet(201L), new LakeTablet(202L));
+        // A two-transaction batch (versions 5 and 6): base is version 4, new version is 6.
+        TxnInfoPB t1 = new TxnInfoPB();
+        t1.txnId = 1001L;
+        t1.commitTime = 111L;
+        t1.gtid = 9001L;
+        TxnInfoPB t2 = new TxnInfoPB();
+        t2.txnId = 1002L;
+        t2.commitTime = 222L;
+        t2.gtid = 9002L;
+        List<TxnInfoPB> txnInfos = Lists.newArrayList(t1, t2);
+
+        PublishVersionDaemon.aggregatePublishWithCarryForward(touched, txnInfos, carryForward,
+                4L, 6L, null, WarehouseManager.DEFAULT_RESOURCE, new java.util.HashMap<>(),
+                new java.util.HashMap<>(), new ArrayList<>());
+
+        // Exactly two sub-requests, both attached to the SAME request, sent exactly once.
+        Assertions.assertEquals(2, capturedRequests.size());
+        Assertions.assertSame(capturedRequests.get(0), capturedRequests.get(1));
+        Assertions.assertEquals(1, sendCount.get());
+        Assertions.assertSame(capturedRequests.get(0), sentRequests.get(0));
+
+        // First sub-request: the touched tablets with the real transactions unchanged.
+        Assertions.assertEquals(Lists.newArrayList(101L, 102L),
+                capturedTablets.get(0).stream().map(Tablet::getId).sorted().collect(Collectors.toList()));
+        Assertions.assertSame(txnInfos, capturedTxnInfos.get(0));
+
+        // Second sub-request: the carry-forward tablets with one no-op empty transaction per real transaction.
+        Assertions.assertEquals(Lists.newArrayList(201L, 202L),
+                capturedTablets.get(1).stream().map(Tablet::getId).sorted().collect(Collectors.toList()));
+        List<TxnInfoPB> carryTxnInfos = capturedTxnInfos.get(1);
+        Assertions.assertEquals(txnInfos.size(), carryTxnInfos.size());
+        for (int i = 0; i < carryTxnInfos.size(); i++) {
+            TxnInfoPB empty = carryTxnInfos.get(i);
+            Assertions.assertTrue(empty.noOpPublish, "carry-forward txn must be a no-op publish");
+            Assertions.assertEquals(-1L, empty.txnId, "carry-forward txn must carry the empty txn id");
+            Assertions.assertEquals(TxnTypePB.TXN_EMPTY, empty.txnType);
+            Assertions.assertFalse(empty.combinedTxnLog);
+            // commitTime / gtid are copied from the corresponding real transaction.
+            Assertions.assertEquals(txnInfos.get(i).commitTime, empty.commitTime);
+            Assertions.assertEquals(txnInfos.get(i).gtid, empty.gtid);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

With `file_bundling` enabled (the default for shared-data tables since 4.0), one
physical bundle file (`meta/0_<version>.meta`) holds the metadata of **all**
tablets of a partition at a given version.

`PublishVersionDaemon.publishPartition` builds the tablet set to publish from the
transaction's point-in-time index view (`getPartitionLoadedIndexes`). For a lake
compaction that index set is snapshotted at transaction begin
(`CompactionScheduler.beginTransaction`). If a rollup / synchronous-MV index
becomes visible **after** the compaction transaction begins but **before** it
publishes, the stale view omits that index, so the compaction writes the new
version's bundle **without** the rollup index's tablets. Their metadata then
disappears at that version, and the next publish that reads a rollup tablet at
that base version fails with `can not find tablet <id> from shared tablet
metadata` (a 404 on the bundle object), permanently wedging the partition's
publish queue.

Reproduced/diagnosed via StarRocksTest#11536 (file_bundling table + sync MV +
a subsequent import hangs). Confirmed on the affected cluster by reading the
bundle objects directly: `0_12.meta` contained 20 tablets (base + rollup) while
`0_13.meta`, written by a compaction, contained only the 10 base tablets.

## What I'm doing:

When publishing a file-bundling partition version, carry forward every
currently-visible NORMAL index that the transaction did not touch, publishing
those tablets as an empty-txn version bump within the **same** aggregate request
as the touched tablets — two separate aggregate publishes would each
truncate-write the same `0_<version>.meta` and drop one of the two sets. This
keeps the new bundle a complete whole-partition snapshot.

Only affects the file-bundling path; a normal load already covers every visible
index, so nothing is carried forward and its behavior is unchanged. Added a unit
test for the carry-forward selection (`collectFileBundlingCarryForwardTablets`).

Fixes https://github.com/StarRocks/StarRocksTest/issues/11536

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

