### PR TITLE
[BugFix] Surface local-disk (datacache) write bytes/time in lake compaction stats

### DIFF
--- a/be/src/compute_env/staros/starlet_filesystem.cpp
+++ b/be/src/compute_env/staros/starlet_filesystem.cpp
@@ -303,9 +303,15 @@ public:
         }
         const auto& io_stats = (*stream_st)->get_io_stats();
         auto stats = std::make_unique<io::NumericStatistics>();
-        stats->reserve(2);
+        stats->reserve(4);
         stats->append(kIONsWriteRemote, io_stats.io_ns_write_remote);
         stats->append(kBytesWriteRemote, io_stats.bytes_write_remote);
+        // Also surface local-disk (datacache) writes: with a write-back datacache the bytes land on
+        // local disk first and are uploaded asynchronously, so bytes_write_remote stays 0 at write
+        // time. Without this the compaction/writer profile reports 0 bytes written despite writing
+        // real segments.
+        stats->append(kIONsWriteLocalDisk, io_stats.io_ns_write_local_disk);
+        stats->append(kBytesWriteLocalDisk, io_stats.bytes_write_local_disk);
         return std::move(stats);
     }
 

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -42,6 +42,8 @@ void CompactionTaskStats::collect(const OlapWriterStatistics& writer_stats) {
     write_segment_count = writer_stats.segment_count;
     write_segment_bytes = writer_stats.bytes_write_remote;
     io_ns_write_remote = writer_stats.write_remote_ns;
+    write_local_disk_bytes = writer_stats.bytes_write_local_disk;
+    io_ns_write_local_disk = writer_stats.write_local_disk_ns;
 }
 
 CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& that) const {
@@ -58,6 +60,8 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.write_segment_count += that.write_segment_count;
     diff.write_segment_bytes += that.write_segment_bytes;
     diff.io_ns_write_remote += that.io_ns_write_remote;
+    diff.write_local_disk_bytes += that.write_local_disk_bytes;
+    diff.io_ns_write_local_disk += that.io_ns_write_local_disk;
     diff.in_queue_time_sec += that.in_queue_time_sec;
     diff.pk_sst_merge_ns += that.pk_sst_merge_ns;
     diff.input_file_size += that.input_file_size;
@@ -78,6 +82,8 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.write_segment_count -= that.write_segment_count;
     diff.write_segment_bytes -= that.write_segment_bytes;
     diff.io_ns_write_remote -= that.io_ns_write_remote;
+    diff.write_local_disk_bytes -= that.write_local_disk_bytes;
+    diff.io_ns_write_local_disk -= that.io_ns_write_local_disk;
     diff.in_queue_time_sec -= that.in_queue_time_sec;
     diff.pk_sst_merge_ns -= that.pk_sst_merge_ns;
     diff.input_file_size -= that.input_file_size;
@@ -99,6 +105,8 @@ static void fill_stats_fields(rapidjson::Document& root, const CompactionTaskSta
     root.AddMember("write_segment_count", rapidjson::Value(s.write_segment_count), allocator);
     root.AddMember("write_remote_mb", rapidjson::Value(s.write_segment_bytes / BYTES_UNIT_MB), allocator);
     root.AddMember("write_remote_sec", rapidjson::Value(s.io_ns_write_remote / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("write_local_mb", rapidjson::Value(s.write_local_disk_bytes / BYTES_UNIT_MB), allocator);
+    root.AddMember("write_local_sec", rapidjson::Value(s.io_ns_write_local_disk / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("in_queue_sec", rapidjson::Value(s.in_queue_time_sec), allocator);
     root.AddMember("pk_sst_merge_sec", rapidjson::Value(s.pk_sst_merge_ns / TIME_UNIT_NS_PER_SECOND), allocator);
     root.AddMember("input_file_size", rapidjson::Value(s.input_file_size), allocator);

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -56,6 +56,8 @@ struct CompactionTaskStats {
     int64_t write_segment_count = 0;
     int64_t write_segment_bytes = 0;
     int64_t io_ns_write_remote = 0;
+    int64_t write_local_disk_bytes = 0;
+    int64_t io_ns_write_local_disk = 0;
     int64_t pk_sst_merge_ns = 0;
     int64_t input_file_size = 0;
 

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -142,6 +142,10 @@ void collect_writer_stats(OlapWriterStatistics& writer_stats, SegmentWriter* seg
             writer_stats.bytes_write_remote += value;
         } else if (name == kIONsWriteRemote) {
             writer_stats.write_remote_ns += value;
+        } else if (name == kBytesWriteLocalDisk) {
+            writer_stats.bytes_write_local_disk += value;
+        } else if (name == kIONsWriteLocalDisk) {
+            writer_stats.write_local_disk_ns += value;
         }
     }
 }

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -170,9 +170,11 @@ struct OlapReaderStatistics {
 
 // OlapWriterStatistics used to collect statistics when write data to storage
 struct OlapWriterStatistics {
-    int64_t write_remote_ns = 0;    // how much time is spent on write
-    int64_t bytes_write_remote = 0; // how many bytes are written
-    int64_t segment_count = 0;      // how many files are written
+    int64_t write_remote_ns = 0;        // how much time is spent on remote write
+    int64_t bytes_write_remote = 0;     // how many bytes are written to remote storage
+    int64_t write_local_disk_ns = 0;    // how much time is spent on local-disk (datacache) write
+    int64_t bytes_write_local_disk = 0; // how many bytes are written to local disk (datacache)
+    int64_t segment_count = 0;          // how many files are written
 };
 
 const char* const kBytesReadLocalDisk = "bytes_read_local_disk";


### PR DESCRIPTION
## Why I'm doing:

The lake compaction profile (`SHOW PROC '/compactions'` and the BE-log statistics) reports **0 bytes written** even when a compaction writes many segments — e.g. observed `write_segment_count=76` with `write_*_mb=0` and `write_*_sec=0` on a compaction that read 72&nbsp;GB.

Root cause: with a write-back **datacache**, compaction output lands on **local disk first** and is uploaded to remote storage **asynchronously**, so `bytes_write_remote` / `io_ns_write_remote` are 0 at write time. The writer and compaction stats only surfaced the *remote* write counters, so the write side of the profile is effectively invisible — you can't tell how much was written or how long writing took, which makes it impossible to account for a compaction's wall-clock time.

The `StarletOutputStream` io stats already track `bytes_write_local_disk` / `io_ns_write_local_disk`, and the `kBytesWriteLocalDisk` / `kIONsWriteLocalDisk` stat-name constants already exist — they were just never exported by the writable file's `get_numeric_statistics()`, so nothing downstream (writer stats → compaction profile) could observe them.

## What I'm doing:

Plumb the local-disk write bytes/time through end to end (purely additive, observability only — no behavior change):
- `StarletOutputStream::get_numeric_statistics()`: also `append(kIONsWriteLocalDisk, …)` and `append(kBytesWriteLocalDisk, …)` (reserve 4).
- `OlapWriterStatistics` + `collect_writer_stats()`: add `bytes_write_local_disk` / `write_local_disk_ns` and collect them.
- `CompactionTaskStats`: carry the two fields (with matching `operator+`/`operator-`) and emit `write_local_mb` / `write_local_sec` in the compaction profile JSON.

After this, a datacache-backed compaction that writes N segments reports the real local write volume/time instead of `0`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Observability only — adds two profile fields; no execution-path change.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Verification
Verifying on a shared-data cluster with datacache: before, a compaction writing 76 segments reports `write_*_mb=0`; after, the profile reports `write_local_mb` = the real bytes written. (On-cluster verification in progress; will comment the before/after profile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)