### PR TITLE
[BugFix] Fix Iceberg manifest row-count estimation when a string date partition column is compared with a temporal value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -261,8 +261,13 @@ public class PartitionCastPredicatePruner {
     }
 
     private static String temporalCastColumnName(ScalarOperator operator) {
-        if (operator instanceof CastOperator
-                && (operator.getType().isDate() || operator.getType().isDatetime())) {
+        // Only DATETIME casts are range-pruned. CAST(col AS DATE) compares with day-truncation semantics,
+        // but the manifest bounds/constant here are full LocalDateTimes; range-pruning such a cast could drop
+        // a day-matching manifest (e.g. bound 2020-06-14T12:00 vs a midnight DATE constant), turning the safe
+        // over-estimate into an under-estimate. So DATE casts are left unhandled here (conservatively kept).
+        // string-vs-temporal binary predicates coerce to DATETIME, so a bare CAST(col AS DATE) only arises
+        // from explicit user casts and is rare.
+        if (operator instanceof CastOperator && operator.getType().isDatetime()) {
             ScalarOperator child = operator.getChild(0);
             if (child instanceof ColumnRefOperator && child.getType().isStringType()) {
                 return ((ColumnRefOperator) child).getName();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -24,6 +25,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -187,6 +189,86 @@ public class PartitionCastPredicatePruner {
         } catch (Exception e) {
             // Strict cast parse failure or any other folding issue: fall back to keeping the file.
             LOG.debug("residual partition predicate not foldable, keep file: {}", conjunct, e);
+        }
+        return null;
+    }
+
+    /**
+     * Coarse manifest/partition-group level check for the residual conjuncts, given each referenced column's
+     * temporal value range {@code [min, max]} (parsed from the group's partition summary). Returns {@code false}
+     * only when some residual conjunct provably cannot be satisfied by ANY value within the ranges, so the group
+     * can be pruned; returns {@code true} (keep) for anything it cannot decide. This never prunes a group that
+     * might contain a match, so the resulting row-count estimate stays a safe over-estimate.
+     *
+     * @param partitionDateRanges column name (any case) -> [minDate, maxDate] for the group.
+     */
+    public static boolean rangeMayMatch(List<ScalarOperator> residualConjuncts,
+                                        Map<String, LocalDateTime[]> partitionDateRanges) {
+        Map<String, LocalDateTime[]> lowerRanges = new HashMap<>();
+        for (Map.Entry<String, LocalDateTime[]> entry : partitionDateRanges.entrySet()) {
+            lowerRanges.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+        }
+        for (ScalarOperator conjunct : residualConjuncts) {
+            if (!conjunctMayMatchRange(conjunct, lowerRanges)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // False only if the conjunct provably cannot be satisfied by any value within the ranges. Handles the simple
+    // CAST(<string col>) <op> <temporal const> shape (column on the left); everything else keeps the group.
+    private static boolean conjunctMayMatchRange(ScalarOperator conjunct, Map<String, LocalDateTime[]> lowerRanges) {
+        if (!(conjunct instanceof BinaryPredicateOperator)) {
+            return true;
+        }
+        BinaryPredicateOperator bp = (BinaryPredicateOperator) conjunct;
+        String columnName = temporalCastColumnName(bp.getChild(0));
+        ConstantOperator constant = asTemporalConstant(bp.getChild(1));
+        if (columnName == null || constant == null) {
+            return true;
+        }
+        LocalDateTime[] range = lowerRanges.get(columnName.toLowerCase(Locale.ROOT));
+        if (range == null || range.length != 2 || range[0] == null || range[1] == null) {
+            return true;
+        }
+        LocalDateTime lo = range[0];
+        LocalDateTime hi = range[1];
+        LocalDateTime c = constant.getDatetime();
+        // Does some value d in [lo, hi] satisfy (d <op> c)?
+        switch (bp.getBinaryType()) {
+            case EQ:
+                return !c.isBefore(lo) && !c.isAfter(hi);
+            case LT:
+                return lo.isBefore(c);
+            case LE:
+                return !lo.isAfter(c);
+            case GT:
+                return hi.isAfter(c);
+            case GE:
+                return !hi.isBefore(c);
+            default:
+                return true;
+        }
+    }
+
+    private static String temporalCastColumnName(ScalarOperator operator) {
+        if (operator instanceof CastOperator
+                && (operator.getType().isDate() || operator.getType().isDatetime())) {
+            ScalarOperator child = operator.getChild(0);
+            if (child instanceof ColumnRefOperator && child.getType().isStringType()) {
+                return ((ColumnRefOperator) child).getName();
+            }
+        }
+        return null;
+    }
+
+    private static ConstantOperator asTemporalConstant(ScalarOperator operator) {
+        if (operator instanceof ConstantOperator) {
+            ConstantOperator constant = (ConstantOperator) operator;
+            if (!constant.isNull() && (constant.getType().isDate() || constant.getType().isDatetime())) {
+                return constant;
+            }
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -234,6 +234,14 @@ public class PartitionCastPredicatePruner {
         }
         LocalDateTime lo = range[0];
         LocalDateTime hi = range[1];
+        // The comparisons below assume an ordered range (lo <= hi). A caller may supply an inverted
+        // range when min/max was computed in a different ordering domain than the parsed temporal
+        // values (e.g. Iceberg's string-domain partition summary parsed back into dates for non
+        // lexicographically-sortable date strings). Treat it as unknown and conservatively keep, so
+        // pruning stays a safe over-estimate instead of silently under-counting.
+        if (lo.isAfter(hi)) {
+            return true;
+        }
         LocalDateTime c = constant.getDatetime();
         // Does some value d in [lo, hi] satisfy (d <op> c)?
         switch (bp.getBinaryType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1972,7 +1972,13 @@ public class IcebergMetadata implements ConnectorMetadata {
                 continue;
             }
             String name = table.getPartitionSourceName(nativeTable.schema(), field);
-            if (!stringPartitionColumns.contains(name.toLowerCase(Locale.ROOT))) {
+            // findColumnName returns null when the field's source id is not in the current schema
+            // (e.g. partition evolution / dropped source column). Skip it -> manifest conservatively kept.
+            if (name == null) {
+                continue;
+            }
+            String nameLower = name.toLowerCase(Locale.ROOT);
+            if (!stringPartitionColumns.contains(nameLower)) {
                 continue;
             }
             ManifestFile.PartitionFieldSummary summary = summaries.get(i);
@@ -1983,11 +1989,11 @@ public class IcebergMetadata implements ConnectorMetadata {
                 org.apache.iceberg.types.Type type = partitionTypeFields.get(i).type();
                 String lower = Conversions.fromByteBuffer(type, summary.lowerBound()).toString();
                 String upper = Conversions.fromByteBuffer(type, summary.upperBound()).toString();
-                ranges.put(name.toLowerCase(Locale.ROOT), new LocalDateTime[] {
+                ranges.put(nameLower, new LocalDateTime[] {
                         DateUtils.parseStrictDateTime(lower), DateUtils.parseStrictDateTime(upper)});
             } catch (Exception e) {
                 // Undecodable / non-temporal bounds -> leave the column out so the manifest is conservatively kept.
-                LOG.debug("skip manifest partition range for column {}: {}", name, e.toString());
+                LOG.debug("skip manifest partition range for column {}", name, e);
             }
         }
         return ranges;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1989,8 +1989,17 @@ public class IcebergMetadata implements ConnectorMetadata {
                 org.apache.iceberg.types.Type type = partitionTypeFields.get(i).type();
                 String lower = Conversions.fromByteBuffer(type, summary.lowerBound()).toString();
                 String upper = Conversions.fromByteBuffer(type, summary.upperBound()).toString();
-                ranges.put(nameLower, new LocalDateTime[] {
-                        DateUtils.parseStrictDateTime(lower), DateUtils.parseStrictDateTime(upper)});
+                LocalDateTime lo = DateUtils.parseStrictDateTime(lower);
+                LocalDateTime hi = DateUtils.parseStrictDateTime(upper);
+                // Iceberg computes the summary min/max in the string domain. For values that parse as
+                // dates but are not lexicographically ordered as dates (e.g. non-zero-padded fields),
+                // the parsed bounds can come out inverted (lo > hi). Skip such a column so the manifest
+                // is conservatively kept rather than pruned on an inverted range.
+                if (lo.isAfter(hi)) {
+                    LOG.debug("skip inverted manifest partition range for column {}: [{}, {}]", name, lower, upper);
+                    continue;
+                }
+                ranges.put(nameLower, new LocalDateTime[] {lo, hi});
             } catch (Exception e) {
                 // Undecodable / non-temporal bounds -> leave the column out so the manifest is conservatively kept.
                 LOG.debug("skip manifest partition range for column {}", name, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1924,8 +1924,9 @@ public class IcebergMetadata implements ConnectorMetadata {
         // predicate. They are instead evaluated below against each manifest's partition summary in the DATETIME
         // domain, so a manifest whose partition range definitely cannot satisfy them is still pruned. A kept
         // manifest is counted in full (manifest-level granularity), so the result stays a safe over-estimate.
+        Set<String> stringPartitionColumns = identityStringPartitionColumns(icebergTable);
         PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
-                Utils.extractConjuncts(predicate), identityStringPartitionColumns(icebergTable));
+                Utils.extractConjuncts(predicate), stringPartitionColumns);
         ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
                 new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct());
         Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
@@ -1936,7 +1937,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         long rowCount = 0;
         for (ManifestFile manifest : matchingManifests) {
             if (residual.hasResidual() && !PartitionCastPredicatePruner.rangeMayMatch(
-                    residual.residual, manifestPartitionDateRanges(manifest, icebergTable))) {
+                    residual.residual, manifestPartitionDateRanges(manifest, icebergTable, stringPartitionColumns))) {
                 continue;
             }
             if (!canCountRowsFromManifest(manifest)) {
@@ -1951,7 +1952,8 @@ public class IcebergMetadata implements ConnectorMetadata {
     // domain, for coarse residual pruning. A column is omitted (treated as "unknown range" -> keep) when its
     // bounds are absent or cannot be parsed as a temporal value, so pruning never drops a possibly-matching
     // manifest.
-    private Map<String, LocalDateTime[]> manifestPartitionDateRanges(ManifestFile manifest, IcebergTable table) {
+    private Map<String, LocalDateTime[]> manifestPartitionDateRanges(ManifestFile manifest, IcebergTable table,
+                                                                     Set<String> stringPartitionColumns) {
         Map<String, LocalDateTime[]> ranges = new HashMap<>();
         List<ManifestFile.PartitionFieldSummary> summaries = manifest.partitions();
         if (summaries == null || summaries.isEmpty()) {
@@ -1962,7 +1964,6 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (spec == null) {
             return ranges;
         }
-        Set<String> stringPartitionColumns = identityStringPartitionColumns(table);
         List<PartitionField> fields = spec.fields();
         List<org.apache.iceberg.types.Types.NestedField> partitionTypeFields = spec.partitionType().fields();
         for (int i = 0; i < fields.size() && i < summaries.size() && i < partitionTypeFields.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -40,6 +40,7 @@ import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorMetadata;
@@ -152,6 +153,7 @@ import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializationUtil;
@@ -1917,22 +1919,77 @@ public class IcebergMetadata implements ConnectorMetadata {
             return 1;
         }
 
-        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+        // Cast-on-string-partition conjuncts (e.g. CAST(c AS DATETIME) = <ts> against a 'yyyy-MM-dd' partition)
+        // are pruned unsoundly by Iceberg's string-domain manifest evaluator, so keep them out of the pushed
+        // predicate. They are instead evaluated below against each manifest's partition summary in the DATETIME
+        // domain, so a manifest whose partition range definitely cannot satisfy them is still pruned. A kept
+        // manifest is counted in full (manifest-level granularity), so the result stays a safe over-estimate.
+        PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
+                Utils.extractConjuncts(predicate), identityStringPartitionColumns(icebergTable));
         ScalarOperatorToIcebergExpr.IcebergContext icebergContext =
                 new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct());
-        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
 
         List<ManifestFile> dataManifests = snapshot.dataManifests(nativeTbl.io());
         List<ManifestFile> matchingManifests = filterManifests(dataManifests, nativeTbl, icebergPredicate);
 
         long rowCount = 0;
         for (ManifestFile manifest : matchingManifests) {
+            if (residual.hasResidual() && !PartitionCastPredicatePruner.rangeMayMatch(
+                    residual.residual, manifestPartitionDateRanges(manifest, icebergTable))) {
+                continue;
+            }
             if (!canCountRowsFromManifest(manifest)) {
                 return -1;
             }
             rowCount += orZeroRows(manifest.addedRowsCount()) + orZeroRows(manifest.existingRowsCount());
         }
         return Math.max(rowCount, 1);
+    }
+
+    // Per identity string partition column, the manifest's [min, max] partition value parsed into the DATETIME
+    // domain, for coarse residual pruning. A column is omitted (treated as "unknown range" -> keep) when its
+    // bounds are absent or cannot be parsed as a temporal value, so pruning never drops a possibly-matching
+    // manifest.
+    private Map<String, LocalDateTime[]> manifestPartitionDateRanges(ManifestFile manifest, IcebergTable table) {
+        Map<String, LocalDateTime[]> ranges = new HashMap<>();
+        List<ManifestFile.PartitionFieldSummary> summaries = manifest.partitions();
+        if (summaries == null || summaries.isEmpty()) {
+            return ranges;
+        }
+        org.apache.iceberg.Table nativeTable = table.getNativeTable();
+        PartitionSpec spec = nativeTable.specs().get(manifest.partitionSpecId());
+        if (spec == null) {
+            return ranges;
+        }
+        Set<String> stringPartitionColumns = identityStringPartitionColumns(table);
+        List<PartitionField> fields = spec.fields();
+        List<org.apache.iceberg.types.Types.NestedField> partitionTypeFields = spec.partitionType().fields();
+        for (int i = 0; i < fields.size() && i < summaries.size() && i < partitionTypeFields.size(); i++) {
+            PartitionField field = fields.get(i);
+            if (!field.transform().isIdentity()) {
+                continue;
+            }
+            String name = table.getPartitionSourceName(nativeTable.schema(), field);
+            if (!stringPartitionColumns.contains(name.toLowerCase(Locale.ROOT))) {
+                continue;
+            }
+            ManifestFile.PartitionFieldSummary summary = summaries.get(i);
+            if (summary.lowerBound() == null || summary.upperBound() == null) {
+                continue;
+            }
+            try {
+                org.apache.iceberg.types.Type type = partitionTypeFields.get(i).type();
+                String lower = Conversions.fromByteBuffer(type, summary.lowerBound()).toString();
+                String upper = Conversions.fromByteBuffer(type, summary.upperBound()).toString();
+                ranges.put(name.toLowerCase(Locale.ROOT), new LocalDateTime[] {
+                        DateUtils.parseStrictDateTime(lower), DateUtils.parseStrictDateTime(upper)});
+            } catch (Exception e) {
+                // Undecodable / non-temporal bounds -> leave the column out so the manifest is conservatively kept.
+                LOG.debug("skip manifest partition range for column {}: {}", name, e.toString());
+            }
+        }
+        return ranges;
     }
 
     private static long orZeroRows(Long value) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -232,6 +232,9 @@ public class PartitionCastPredicatePrunerTest {
         // non-binary conjunct (OR) -> keep
         ScalarOperator or = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, eqConj, eqConj);
         Assertions.assertTrue(mayMatch(or, range("c2", dt(2020, 1, 1), dt(2020, 1, 1))));
+        // inverted range (lo > hi) -> treat as unknown and keep, so pruning stays a safe over-estimate.
+        // Without the guard the EQ check would collapse to an empty interval and wrongly prune.
+        Assertions.assertTrue(mayMatch(eqConj, range("c2", dt(2020, 12, 1), dt(2020, 1, 1))));
     }
 
     private Map<String, String> singletonMap(String k, String v) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -237,6 +237,19 @@ public class PartitionCastPredicatePrunerTest {
         Assertions.assertTrue(mayMatch(eqConj, range("c2", dt(2020, 12, 1), dt(2020, 1, 1))));
     }
 
+    @Test
+    public void testRangeMayMatchDateCastConservative() {
+        // CAST(c2 AS DATE) compares with day-truncation semantics; range pruning uses full LocalDateTimes,
+        // so a DATE cast must be conservatively kept. A noon bound [12:00,12:00] compared as full datetime
+        // against the midnight constant would falsely prune, but the row's date still matches.
+        LocalDateTime noon = LocalDateTime.of(2020, 6, 14, 12, 0);
+        ScalarOperator dateEq = eq(castTo(strPartCol, DateType.DATE), datetime("2020-06-14 00:00:00"));
+        Assertions.assertTrue(mayMatch(dateEq, range("c2", noon, noon)));
+        // Sanity: the guard is DATE-specific. A DATETIME cast still range-prunes (12:00 != midnight).
+        ScalarOperator dtEq = eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+        Assertions.assertFalse(mayMatch(dtEq, range("c2", noon, noon)));
+    }
+
     private Map<String, String> singletonMap(String k, String v) {
         Map<String, String> map = new HashMap<>();
         map.put(k, v);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -189,6 +189,51 @@ public class PartitionCastPredicatePrunerTest {
         Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(residual, withNull));
     }
 
+    private LocalDateTime dt(int y, int m, int d) {
+        return LocalDateTime.of(y, m, d, 0, 0, 0);
+    }
+
+    private Map<String, LocalDateTime[]> range(String col, LocalDateTime lo, LocalDateTime hi) {
+        Map<String, LocalDateTime[]> map = new HashMap<>();
+        map.put(col, new LocalDateTime[] {lo, hi});
+        return map;
+    }
+
+    private boolean mayMatch(ScalarOperator conjunct, Map<String, LocalDateTime[]> ranges) {
+        return PartitionCastPredicatePruner.rangeMayMatch(Lists.newArrayList(conjunct), ranges);
+    }
+
+    @Test
+    public void testRangeMayMatchEquality() {
+        ScalarOperator eqConj = eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+        // single-value range == the value / range contains the value -> may match
+        Assertions.assertTrue(mayMatch(eqConj, range("c2", dt(2020, 6, 14), dt(2020, 6, 14))));
+        Assertions.assertTrue(mayMatch(eqConj, range("c2", dt(2020, 6, 10), dt(2020, 6, 20))));
+        // value above / below the range -> prune
+        Assertions.assertFalse(mayMatch(eqConj, range("c2", dt(2020, 6, 15), dt(2020, 6, 20))));
+        Assertions.assertFalse(mayMatch(eqConj, range("c2", dt(2020, 1, 1), dt(2020, 6, 13))));
+    }
+
+    @Test
+    public void testRangeMayMatchRangeComparison() {
+        // CAST(c2 AS DATETIME) >= '2020-06-15'
+        ScalarOperator geConj = new BinaryPredicateOperator(BinaryType.GE,
+                castTo(strPartCol, DateType.DATETIME), datetime("2020-06-15 00:00:00"));
+        Assertions.assertTrue(mayMatch(geConj, range("c2", dt(2020, 6, 10), dt(2020, 6, 20))));
+        // whole range below the bound -> prune
+        Assertions.assertFalse(mayMatch(geConj, range("c2", dt(2020, 1, 1), dt(2020, 6, 10))));
+    }
+
+    @Test
+    public void testRangeMayMatchConservativeKeep() {
+        ScalarOperator eqConj = eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00"));
+        // no range known for the referenced column -> keep
+        Assertions.assertTrue(mayMatch(eqConj, range("other", dt(2020, 1, 1), dt(2020, 1, 1))));
+        // non-binary conjunct (OR) -> keep
+        ScalarOperator or = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, eqConj, eqConj);
+        Assertions.assertTrue(mayMatch(or, range("c2", dt(2020, 1, 1), dt(2020, 1, 1))));
+    }
+
     private Map<String, String> singletonMap(String k, String v) {
         Map<String, String> map = new HashMap<>();
         map.put(k, v);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1503,7 +1503,7 @@ public class IcebergMetadataTest extends TableTestBase {
     private IcebergMetadata newStatsMetadata() {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
         return new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
-                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
                 new ConnectorProperties(ConnectorType.ICEBERG,
                         Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")), null);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1513,7 +1513,9 @@ public class IcebergMetadataTest extends TableTestBase {
         Map<ColumnRefOperator, Column> colMap = new HashMap<>();
         colMap.put(new ColumnRefOperator(3, VARCHAR, "k2", true), new Column("k2", VARCHAR));
         OptimizerContext context = OptimizerFactory.mockContext(new ColumnRefFactory());
-        Assertions.assertFalse(context.getSessionVariable().enableIcebergColumnStatistics());
+        // Force the manifest-statistics path (Path C) explicitly, so the test does not depend on the
+        // default of enableIcebergColumnStatistics staying false.
+        context.getSessionVariable().setEnableIcebergColumnStatistics(false);
         TvrVersionRange versionRange = TvrTableSnapshot.of(Optional.of(table.currentSnapshot().snapshotId()));
         return metadata.getTableStatistics(context, icebergTable, colMap, null, predicate, -1, versionRange)
                 .getOutputRowCount();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1500,6 +1500,83 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertTrue(statistics.getColumnStatistic(columnRefOperator2).isUnknown());
     }
 
+    private IcebergMetadata newStatsMetadata() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        return new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES,
+                new ConnectorProperties(ConnectorType.ICEBERG,
+                        Map.of(ConnectorProperties.ENABLE_GET_STATS_FROM_EXTERNAL_METADATA, "true")), null);
+    }
+
+    private double manifestPrunedRowCount(IcebergMetadata metadata, IcebergTable icebergTable,
+                                          TestTables.TestTable table, ScalarOperator predicate) {
+        Map<ColumnRefOperator, Column> colMap = new HashMap<>();
+        colMap.put(new ColumnRefOperator(3, VARCHAR, "k2", true), new Column("k2", VARCHAR));
+        OptimizerContext context = OptimizerFactory.mockContext(new ColumnRefFactory());
+        Assertions.assertFalse(context.getSessionVariable().enableIcebergColumnStatistics());
+        TvrVersionRange versionRange = TvrTableSnapshot.of(Optional.of(table.currentSnapshot().snapshotId()));
+        return metadata.getTableStatistics(context, icebergTable, colMap, null, predicate, -1, versionRange)
+                .getOutputRowCount();
+    }
+
+    private ScalarOperator k2EqDate(int year, int month, int day) {
+        return new BinaryPredicateOperator(BinaryType.EQ,
+                new CastOperator(DATETIME, new ColumnRefOperator(3, VARCHAR, "k2", true)),
+                ConstantOperator.createDatetime(LocalDateTime.of(year, month, day, 0, 0, 0)));
+    }
+
+    @Test
+    public void testGetManifestPrunedRowCountSinglePartitionManifests() throws Exception {
+        // STRING partition column, CAST(k2 AS DATETIME) = <ts>. Two commits => two single-partition manifests.
+        // The residual is evaluated against each manifest's partition range in the DATETIME domain: the
+        // 2020-06-15 manifest is pruned, the 2020-06-14 one is kept -> rowCount=3 (NOT the string-pruned 1, and
+        // tighter than the whole-table 7).
+        IcebergMetadata metadata = newStatsMetadata();
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbManifestSinglePart", 1);
+        table.newFastAppend().appendFile(DataFiles.builder(spec)
+                .withPath("/path/to/data-0614.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-14").withRecordCount(3).build()).commit();
+        table.newFastAppend().appendFile(DataFiles.builder(spec)
+                .withPath("/path/to/data-0615.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-15").withRecordCount(4).build()).commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+
+        Assertions.assertEquals(3.0, manifestPrunedRowCount(metadata, icebergTable, table, k2EqDate(2020, 6, 14)), 0.001);
+        // A date outside every partition -> both manifests pruned -> floor of 1.
+        Assertions.assertEquals(1.0, manifestPrunedRowCount(metadata, icebergTable, table, k2EqDate(2019, 1, 1)), 0.001);
+    }
+
+    @Test
+    public void testGetManifestPrunedRowCountMultiPartitionManifest() throws Exception {
+        // A single commit => ONE manifest spanning two partitions [2020-06-14, 2020-06-15]. A kept manifest is
+        // counted in full, so a match inside the range over-estimates (3+4=7); a const outside the whole range is
+        // still pruned (floor of 1).
+        IcebergMetadata metadata = newStatsMetadata();
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbManifestMultiPart", 1);
+        table.newFastAppend()
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/data-0614.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-14").withRecordCount(3).build())
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/data-0615.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-15").withRecordCount(4).build())
+                .commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+
+        // Const inside the manifest's [2020-06-14, 2020-06-15] range -> kept whole -> over-estimate 7.
+        Assertions.assertEquals(7.0, manifestPrunedRowCount(metadata, icebergTable, table, k2EqDate(2020, 6, 14)), 0.001);
+        // Const outside the whole range -> pruned -> floor of 1.
+        Assertions.assertEquals(1.0, manifestPrunedRowCount(metadata, icebergTable, table, k2EqDate(2019, 1, 1)), 0.001);
+    }
+
     @Test
     public void testGetTableStatisticsManifestPrunedKeepsIncrementalDelivery() throws Exception {
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);

--- a/test/sql/test_iceberg/R/test_iceberg_string_date_partition_cardinality
+++ b/test/sql/test_iceberg/R/test_iceberg_string_date_partition_cardinality
@@ -1,0 +1,65 @@
+-- name: test_iceberg_string_date_partition_cardinality
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+use ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+create table t_card (
+    c1 int,
+    c2 string
+) partition by (c2);
+-- result:
+-- !result
+insert into t_card select generate_series, '2020-06-14' from table(generate_series(1, 17));
+-- result:
+-- !result
+insert into t_card select generate_series, '2020-06-22' from table(generate_series(1, 23));
+-- result:
+-- !result
+insert into t_card select generate_series, '2020-01-02' from table(generate_series(1, 5));
+-- result:
+-- !result
+set enable_iceberg_column_statistics = false;
+-- result:
+-- !result
+set disable_table_stats_from_metadata_for_single_table = false;
+-- result:
+-- !result
+set enable_query_trigger_analyze = false;
+-- result:
+-- !result
+drop stats t_card;
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from t_card where c2 = cast('2020-06-15' as date) - interval 1 day", "cardinality=17")
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains("select * from t_card where c2 = cast('2020-06-21' as date) + interval 1 day", "cardinality=23")
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains("select * from t_card where c2 = date_sub(cast('2020-06-15' as date), interval 1 day)", "cardinality=17")
+-- result:
+None
+-- !result
+function: assert_explain_costs_contains("select * from t_card where c2 = '2020-06-14'", "cardinality=17")
+-- result:
+None
+-- !result
+drop table t_card force;
+-- result:
+-- !result
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_string_date_partition_cardinality
+++ b/test/sql/test_iceberg/T/test_iceberg_string_date_partition_cardinality
@@ -1,0 +1,54 @@
+-- name: test_iceberg_string_date_partition_cardinality
+-- description: PR2 — a STRING date partition column compared with a temporal value coerces to
+-- CAST(c2 AS DATETIME) = <ts>. On the manifest-level cardinality path (Path C, column stats off),
+-- the old code pushed the cast to Iceberg's string-domain manifest evaluator, which pruned every
+-- manifest and returned rowCount=1 (a severe under-estimate that produces bad CBO/join plans).
+-- PR2 keeps such a cast-on-string-partition conjunct as a StarRocks-side residual and prunes
+-- manifests by DATETIME-domain partition range, so a matching partition's manifest is counted in
+-- full instead of collapsing to 1.
+--
+-- NOTE: single-table queries are short-circuited to default statistics by
+-- disable_table_stats_from_metadata_for_single_table (default true, #64443), so the connector
+-- metadata path is never reached. We turn it off here to exercise the path; column statistics stay
+-- off so we stay on the manifest path (Path C); query-trigger-analyze is off so cached column
+-- statistics do not flip the estimate to ESTIMATE mid-run.
+
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+set catalog ice_cat_${uuid0};
+use ice_cat_${uuid0}.ice_db_${uuid0};
+
+create table t_card (
+    c1 int,
+    c2 string
+) partition by (c2);
+
+-- One INSERT per partition => one manifest per partition with a tight partition range, so
+-- range-overlap pruning keeps exactly the matching partition's manifest (deterministic row count).
+insert into t_card select generate_series, '2020-06-14' from table(generate_series(1, 17));
+insert into t_card select generate_series, '2020-06-22' from table(generate_series(1, 23));
+insert into t_card select generate_series, '2020-01-02' from table(generate_series(1, 5));
+
+set enable_iceberg_column_statistics = false;
+set disable_table_stats_from_metadata_for_single_table = false;
+set enable_query_trigger_analyze = false;
+
+-- Clear any internal column statistics so MetadataMgr falls through to the connector metadata path
+-- (with known internal stats it would return those instead, bypassing the manifest path entirely).
+-- Safe here: query-trigger-analyze is off above, and a fresh external table has no analyze job, so
+-- nothing repopulates them. This is table-scoped; do NOT disable the global enable_statistic_collect
+-- FE config in a shared SQLTester run — it would leak into concurrent cases.
+drop stats t_card;
+
+-- cast/interval form: pre-PR2 this collapsed to cardinality=1; PR2 keeps the 2020-06-14 manifest (17 rows).
+function: assert_explain_costs_contains("select * from t_card where c2 = cast('2020-06-15' as date) - interval 1 day", "cardinality=17")
+-- a different partition value keeps a different manifest (23 rows), proving range pruning selects per value.
+function: assert_explain_costs_contains("select * from t_card where c2 = cast('2020-06-21' as date) + interval 1 day", "cardinality=23")
+-- date_sub builtin form must agree with the operator form.
+function: assert_explain_costs_contains("select * from t_card where c2 = date_sub(cast('2020-06-15' as date), interval 1 day)", "cardinality=17")
+-- control: bare 'yyyy-MM-dd' literal (no cast, always worked) must agree with the cast forms.
+function: assert_explain_costs_contains("select * from t_card where c2 = '2020-06-14'", "cardinality=17")
+
+drop table t_card force;
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing

  Follow-up to #76068 ([BugFix] Fix Iceberg partition pruning when a string date
  partition column is compared with a temporal value). That PR fixed the **scan
  side** (which files/partitions are read). This PR fixes the **cardinality
  estimation side** of the exact same root cause.

  When a STRING date partition column is compared with a temporal value, e.g.

      WHERE c2 = cast('2020-06-15' as date) - interval 1 day

  the optimizer coerces it to `CAST(c2 AS DATETIME) = '2020-06-14 00:00:00'`.
  On the manifest-level statistics path (`IcebergMetadata.getManifestPrunedRowCount`,
  used when column statistics are off — the default), the cast conjunct was pushed
  to Iceberg's manifest evaluator, which **unwraps the cast and compares in the
  string domain**. That wrongly prunes every manifest, so the estimated row count
  collapses to `1` — a severe under-estimate that produces bad CBO/join plans
  (the table gets picked as the broadcast/build side, wrong join order, etc.).

  ## What I'm doing

  Reuse the `PartitionCastPredicatePruner.split(...)` helper introduced in #76068 to
  separate conjuncts in `getManifestPrunedRowCount`:

  - **pushable** conjuncts (no cast-on-string-partition) are still converted and
    handed to `filterManifests` as before;
  - **residual** conjuncts (`CAST(<string partition col> AS date/datetime) <op> <ts>`)
    are kept out of the pushed predicate and instead evaluated against each
    manifest's partition summary in the **DATETIME domain**:
    - `manifestPartitionDateRanges(...)` decodes each identity string-partition
      column's `[min, max]` from the manifest-list `PartitionFieldSummary`
      (`Conversions.fromByteBuffer` + `DateUtils.parseStrictDateTime`);
    - `rangeMayMatch(...)` prunes a manifest only when a residual conjunct
      provably cannot be satisfied by any value in that range; anything it cannot
      decide is conservatively kept.

  A kept manifest is counted in full (manifest-level granularity), so the result
  is always a **safe over-estimate** instead of the previous `1`. Decoding is fully
  guarded: undecodable/non-temporal bounds leave the column out and keep the
  manifest, so we never under-count.

  Note: single-table queries short-circuit to default statistics via
  `disable_table_stats_from_metadata_for_single_table` (default true, #64443), so
  this estimate is what feeds **multi-table / join** planning — exactly where a
  wrong cardinality does damage. The regression test therefore disables that
  short-circuit to exercise the path directly.

  ## Reproduce

  See `test/sql/test_iceberg/T/test_iceberg_string_date_partition_cardinality`:

      create table t_card (c1 int, c2 string) partition by (c2);
      -- one INSERT per partition => one manifest per partition
      insert into t_card select generate_series, '2020-06-14' from table(generate_series(1, 17));
      insert into t_card select generate_series, '2020-06-22' from table(generate_series(1, 23));
      insert into t_card select generate_series, '2020-01-02' from table(generate_series(1, 5));

      set enable_iceberg_column_statistics = false;              -- stay on the manifest path (Path C)
      set disable_table_stats_from_metadata_for_single_table = false;  -- reach the connector stats path
      set enable_query_trigger_analyze = false;
      drop stats t_card;

      -- Before this PR: cardinality=1 (string-domain pruning collapses it).
      -- After  this PR: cardinality=17 (the 2020-06-14 manifest, counted whole).
      explain costs select * from t_card where c2 = cast('2020-06-15' as date) - interval 1 day;

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
