### PR TITLE
[BugFix] Report actual finalized segment bytes as lake compaction write volume

### DIFF
--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -40,7 +40,11 @@ void CompactionTaskStats::collect(const OlapReaderStatistics& reader_stats) {
 
 void CompactionTaskStats::collect(const OlapWriterStatistics& writer_stats) {
     write_segment_count = writer_stats.segment_count;
-    write_segment_bytes = writer_stats.bytes_write_remote;
+    // Prefer the actual finalized segment bytes (ground truth from SegmentWriter::finalize()). The
+    // underlying stream's bytes_write_remote counter is not populated on every write path (it stays
+    // 0 e.g. for shared-data segment writes), which made the profile report 0 bytes written despite
+    // writing real segments. Fall back to the stream counter if the segment size is unavailable.
+    write_segment_bytes = writer_stats.bytes_written > 0 ? writer_stats.bytes_written : writer_stats.bytes_write_remote;
     io_ns_write_remote = writer_stats.write_remote_ns;
 }
 

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -348,6 +348,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         segment_file_info.num_rows = _seg_writer->num_rows();
         record_segment_vector_index_ids(segment_file_info, _seg_writer.get());
         _data_size += segment_size;
+        _stats.bytes_written += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
         _stats.segment_count++;
         if (segment) {
@@ -508,6 +509,7 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
             segment_file_info.segment_vector_index_uid = _tablet_id;
         }
         _data_size += segment_size;
+        _stats.bytes_written += segment_size;
         collect_writer_stats(_stats, segment_writer.get());
         _stats.segment_count++;
         segment_writer.reset();

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -136,6 +136,7 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         // files are never vacuumed.
         record_segment_vector_index_ids(segment_file_info, _seg_writer.get());
         _data_size += segment_size;
+        _stats.bytes_written += segment_size;
         collect_writer_stats(_stats, _seg_writer.get());
         _stats.segment_count++;
         if (segment) {

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -171,7 +171,8 @@ struct OlapReaderStatistics {
 // OlapWriterStatistics used to collect statistics when write data to storage
 struct OlapWriterStatistics {
     int64_t write_remote_ns = 0;    // how much time is spent on write
-    int64_t bytes_write_remote = 0; // how many bytes are written
+    int64_t bytes_write_remote = 0; // how many bytes the underlying stream reports as written to remote
+    int64_t bytes_written = 0;      // actual finalized segment bytes written (ground truth from finalize())
     int64_t segment_count = 0;      // how many files are written
 };
 


### PR DESCRIPTION
## Why I'm doing it

The cloud-native (lake) compaction profile reports **`write_remote_mb = 0`** even when the compaction writes real output segments. This makes the compaction profile / `show proc '/compactions'` useless for judging how much data a compaction actually wrote — the write side of the IO accounting is silently blank.

Root cause: `CompactionTaskStats::collect(const OlapWriterStatistics&)` sources the written volume from `OlapWriterStatistics::bytes_write_remote`. That field is filled from the underlying output stream's numeric counter (`kBytesWriteRemote`), which is **not populated on every write path** — for shared-data segment writes it stays `0`. So the profile reports 0 bytes despite flushing real segments.

Meanwhile the tablet writer already knows the ground-truth size: `SegmentWriter::finalize()` returns the finalized `segment_size`, which is accumulated into `_data_size` and stored on each `SegmentFileInfo`. That value is authoritative (it is the actual on-storage segment size) and is available at every flush site.

## What I'm doing

- Add `OlapWriterStatistics::bytes_written` — the sum of finalized `segment_size` values, the ground truth for bytes written.
- Accumulate it at each segment flush site alongside the existing `_data_size += segment_size` (general horizontal/vertical writers + PK writer).
- In `CompactionTaskStats::collect(...)`, prefer `bytes_written`, falling back to the stream counter `bytes_write_remote` when the segment size is unavailable, so no path regresses.

Net effect: the compaction profile's `write_remote_mb` now reflects the real bytes written.

## What type of PR is this

- [x] BugFix

## Does this PR entail a change in behavior?

- [x] Yes — an observability field that previously read 0 now reports the real value. No functional/data-path change.