### PR TITLE
[Enhancement] Pre-place IVM refresh __op as a fixed output column; recognize PK-target MV at refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -113,6 +113,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.NullType;
 import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
@@ -570,6 +571,9 @@ public class InsertPlanner {
     private ExecPlan buildExecPlan(InsertStmt insertStmt, ConnectContext session, List<ColumnRefOperator> outputColumns,
                                    LogicalPlan logicalPlan, ColumnRefFactory columnRefFactory,
                                    QueryRelation queryRelation, Table targetTable) {
+        // Retractable IVM: pre-place the sink __op control column as a fixed trailing output before optimize,
+        // so it flows into the sink tuple by position; IvmRewriter binds its value to __ACTION__.
+        boolean ivmOpPreplaced = preplaceIvmLoadOpColumn(session, targetTable, outputColumns, columnRefFactory);
         PreOptimizePlanContext preOptimizePlanContext = preparePreOptimizePlanContext(
                 insertStmt, session.getSessionVariable(), targetTable, outputColumns, columnRefFactory, logicalPlan);
 
@@ -597,13 +601,41 @@ public class InsertPlanner {
         //8. Build fragment exec plan
         boolean hasOutputFragment = ((queryRelation instanceof SelectRelation && queryRelation.hasLimit())
                 || targetTable instanceof MysqlTable);
+        List<String> sinkColNames = queryRelation.getColumnOutputNames();
+        if (ivmOpPreplaced) {
+            sinkColNames = new ArrayList<>(sinkColNames);
+            sinkColNames.add(Load.LOAD_OP_COLUMN);
+        }
         ExecPlan execPlan;
         try (Timer ignore3 = Tracers.watchScope("PlanBuilder")) {
             execPlan = PlanFragmentBuilder.createPhysicalPlan(
                     optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory,
-                    queryRelation.getColumnOutputNames(), TResultSinkType.MYSQL_PROTOCAL, hasOutputFragment);
+                    sinkColNames, TResultSinkType.MYSQL_PROTOCAL, hasOutputFragment);
         }
         return execPlan;
+    }
+
+    // Pre-place the sink __op control column (Load.LOAD_OP_COLUMN) as a fixed trailing output for a
+    // retractable PRIMARY KEY IVM refresh: append it to outputColumns and outputFullSchema (last) so it
+    // gets a trailing tuple slot and OUTPUT expr; IvmRewriter binds its value to __ACTION__.
+    private boolean preplaceIvmLoadOpColumn(ConnectContext session, Table targetTable,
+                                            List<ColumnRefOperator> outputColumns, ColumnRefFactory columnRefFactory) {
+        if (!session.getSessionVariable().isEnableIVMRefresh()
+                || !(targetTable instanceof OlapTable olapTable)
+                || olapTable.getKeysType() != KeysType.PRIMARY_KEYS) {
+            return false;
+        }
+        // Idempotent across optimistic-lock retries (buildExecPlanWithRetry runs this per attempt):
+        // strip a prior attempt's __op before re-appending, or the columns accumulate a duplicate.
+        outputColumns.removeIf(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        outputColumns.add(columnRefFactory.create(Load.LOAD_OP_COLUMN, IntegerType.TINYINT, false));
+        Column opColumn = new Column(Load.LOAD_OP_COLUMN, IntegerType.TINYINT);
+        opColumn.setIsAllowNull(false);
+        List<Column> extendedSchema = new ArrayList<>(outputFullSchema);
+        extendedSchema.removeIf(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
+        extendedSchema.add(opColumn);
+        outputFullSchema = extendedSchema;
+        return true;
     }
 
     private PreOptimizePlanContext preparePreOptimizePlanContext(InsertStmt insertStmt,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/ivm/IvmRewriter.java
@@ -28,7 +28,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -166,31 +165,36 @@ public class IvmRewriter {
     }
 
     private static boolean isPrimaryKeyTargetMv(OptimizerContext optimizerContext) {
-        StatementBase statement = optimizerContext.getStatement();
-        if (!(statement instanceof InsertStmt insertStmt)) {
-            return false;
+        // At refresh the optimizer's statement is not the InsertStmt, so resolve the target MV from the tvr
+        // context (loadTargetMv), falling back to the InsertStmt target for the direct-insert plan.
+        MaterializedView targetMv = loadTargetMv(optimizerContext);
+        if (targetMv == null && optimizerContext.getStatement() instanceof InsertStmt insertStmt
+                && insertStmt.getTargetTable() instanceof MaterializedView insertTarget) {
+            targetMv = insertTarget;
         }
-        if (!(insertStmt.getTargetTable() instanceof MaterializedView targetMv)) {
-            return false;
-        }
-        return targetMv.getKeysType() == KeysType.PRIMARY_KEYS;
+        return targetMv != null && targetMv.getKeysType() == KeysType.PRIMARY_KEYS;
     }
 
     private static OptExpression appendPkLoadOpColumn(OptExpression root, TaskContext rootTaskContext,
                                                       ColumnRefSet requiredColumns,
                                                       ColumnRefOperator actionColumn) {
+        OptimizerContext optimizerContext = rootTaskContext.getOptimizerContext();
         List<ColumnRefOperator> rootOutputColumns = root.getOutputColumns()
-                .getColumnRefOperators(rootTaskContext.getOptimizerContext().getColumnRefFactory());
-        boolean hasLoadOpColumn = rootOutputColumns.stream()
-                .anyMatch(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()));
-        if (hasLoadOpColumn) {
+                .getColumnRefOperators(optimizerContext.getColumnRefFactory());
+        // __op is pre-placed as a fixed trailing output before optimize (InsertPlanner); bind it to
+        // __ACTION__ (same domain: INSERT_ACTION=UPSERT, DELETE_ACTION=DELETE) so it rides the sink by
+        // position. Fall back to creating one for a direct insert that did not pre-place it.
+        List<ColumnRefOperator> ivmOutputColumns = optimizerContext.getTvrOptContext().getIvmInsertOutputColumns();
+        ColumnRefOperator loadOpColumn = ivmOutputColumns == null ? null : ivmOutputColumns.stream()
+                .filter(col -> Load.LOAD_OP_COLUMN.equalsIgnoreCase(col.getName()))
+                .findFirst().orElse(null);
+        if (loadOpColumn != null && rootOutputColumns.contains(loadOpColumn)) {
             return root;
         }
-
-        ColumnRefOperator loadOpColumn = rootTaskContext.getOptimizerContext().getColumnRefFactory()
-                .create(Load.LOAD_OP_COLUMN, IntegerType.TINYINT, false);
-        // __op shares __ACTION__'s domain (INSERT_ACTION = UPSERT, DELETE_ACTION = DELETE) — direct alias.
-        ScalarOperator loadOpExpr = actionColumn;
+        if (loadOpColumn == null) {
+            loadOpColumn = optimizerContext.getColumnRefFactory()
+                    .create(Load.LOAD_OP_COLUMN, IntegerType.TINYINT, false);
+        }
 
         Map<ColumnRefOperator, ScalarOperator> projectMap = Maps.newHashMap();
         for (ColumnRefOperator outputColumn : rootOutputColumns) {
@@ -198,7 +202,7 @@ public class IvmRewriter {
                 projectMap.put(outputColumn, outputColumn);
             }
         }
-        projectMap.put(loadOpColumn, loadOpExpr);
+        projectMap.put(loadOpColumn, actionColumn);
 
         requiredColumns.union(loadOpColumn);
         rootTaskContext.getRequiredColumns().union(loadOpColumn);
@@ -222,6 +226,12 @@ public class IvmRewriter {
                 optimizerContext.getTvrOptContext().getIvmInsertOutputColumns();
         if (outputColumns == null) {
             return;
+        }
+        // __op is a pre-placed sink control column appended last (InsertPlanner), not an MV schema column;
+        // exclude it so the positional binding against the MV schema stays aligned.
+        if (!outputColumns.isEmpty()
+                && Load.LOAD_OP_COLUMN.equalsIgnoreCase(outputColumns.get(outputColumns.size() - 1).getName())) {
+            outputColumns = outputColumns.subList(0, outputColumns.size() - 1);
         }
         Map<ColumnRefOperator, ScalarOperator> translations = Maps.newHashMap();
         LogicalAggregationOperator aggOperator = null;


### PR DESCRIPTION
## Why I'm doing:

At IVM refresh, the `__op` sink control column (UPSERT/DELETE) for a PRIMARY KEY target materialized view was created **inside the optimizer** (`IvmRewriter.appendPkLoadOpColumn`), *after* `InsertPlanner` had already frozen the sink's output columns — so on the refresh path the optimizer-produced `__op` never reached the sink. Append-only PK-target MVs (aggregate / dedup `QUERY_COMPUTED` MVs) stayed correct only because a PRIMARY KEY table sink defaults to UPSERT, so the dropped `__op` was harmless there. Separately, `isPrimaryKeyTargetMv` read `optimizerContext.getStatement()`, which is not the `InsertStmt` at refresh, so it failed to recognize a PK-target MV at refresh.

## What I'm doing:

- Pre-place `__op` as a fixed trailing output column in `InsertPlanner` **before** optimize, so it flows into the sink tuple by position like any other column. `IvmRewriter` binds its value to `__ACTION__` instead of creating a new column ref (with a fallback that creates one when `__op` was not pre-placed, so a direct insert and `IvmRewriterTest` are unaffected). `bindStateColumnsForAggregate` excludes the pre-placed `__op` so the positional MV-state binding stays aligned.
- Fix `isPrimaryKeyTargetMv` to resolve the target MV via `loadTargetMv` (the tvr context), matching `bindStateColumnsForAggregate`, so a PK-target MV is recognized at refresh.

This routes the refresh `__op` through the normal positional `outputColumns`/tuple machinery, aligning the create-time and refresh paths. Append-only MV results are unchanged — the refresh plan now carries an explicit `__op` = UPSERT column that was previously dropped and defaulted at the sink.

Covered by the existing `IVMBasedMvRefreshProcessorIcebergTest` (refresh plan structure) and `IvmRewriterTest` (append-only `__op` bind/fallback); both green. Also validated end-to-end on a cloud-native cluster: append-only IVM refresh (dup projection / join / union / aggregate forms) and PK projection refresh (insert / value-update / filter move-out-and-back / delete / change-PK), MV equals base with diff=0.

Fixes #issue: N/A — internal IVM refresh correctness/refactor, no change to MV results.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
