### PR TITLE
[Enhancement] Tantivy FTS: enable phrase/BM25 by default, configurable writer, optimized tokenizer, and segment_iterator context refactor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "contrib/tantivy"]
 	path = contrib/tantivy
-        url = https://github.com/quickwit-oss/tantivy.git
-	branch = branch-0.25.0
+        url = https://github.com/zenoyang/tantivy.git
+	branch = dev/0.25.0-opt-thread-pool

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -862,6 +862,7 @@ set(STARROCKS_LINK_LIBS
     IO
     Serde
     Storage
+    tantivy_binding
     Rowset
     Runtime
     Service
@@ -912,7 +913,6 @@ set(STARROCKS_DEPENDENCIES
     clucene-core
     clucene-shared
     clucene-contribs-lib
-    tantivy_binding
     rocksdb
     libs2
     snappy

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1750,4 +1750,16 @@ CONF_Int32(cow_optimization_diagnose_level, "0");
 CONF_mBool(tantivy_ignore_write_error, "false");
 CONF_String(tantivy_index_local_tmp_dir, "tmp/tantivy_tmp");
 
+// tantivy IndexWriter memory budget per writer (bytes). When buffered
+// postings exceed this threshold tantivy spills an internal segment.
+// Larger values reduce segment count (fewer merges, faster writes) at
+// the cost of higher per-writer memory usage.  Default 256 MB.
+CONF_mInt64(tantivy_writer_memory_budget_bytes, "268435456");
+
+// tantivy merge policy applied after commit.
+// Options: "default" (= LogMergePolicy), "no_merge" (skip merging entirely).
+// Use "no_merge" for write-once scenarios (StarRocks packs the temp dir
+// into a compound .idx immediately after commit, so merging is pure overhead
+// unless query-time multi-segment perf is critical).
+CONF_mString(tantivy_writer_merge_policy, "default");
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1771,11 +1771,28 @@ CONF_mString(tantivy_writer_merge_policy, "default");
 // because the BE row id is stored in an explicit tantivy FAST field.
 CONF_mInt32(tantivy_writer_num_threads, "1");
 
-// Size (max threads) of the shared thread pool that runs all tantivy index
-// build work (indexing workers, segment-updater serial queue, and merges). 0
-// means adaptive sizing based on CPU cores. This bounds the total number of
-// tantivy background threads across all concurrent writers, preventing the
-// thread explosion of tantivy spawning its own threads per writer.
+// Max threads of the *elastic* build pool that runs tantivy indexing workers
+// (the tasks that turn incoming documents into in-memory segments). Indexing
+// workers are RESIDENT: each blocks on its document channel from writer creation
+// until commit, holding its thread the whole time, and blocks on a maintenance
+// task (add_segment) submitted to the separate merge pool. A resident task that
+// never gets a running thread deadlocks any thread that joins it (commit) or
+// feeds it (flush) — so this pool grows a thread per worker on demand (queue
+// size 0) and must never reject in practice. 0 means adaptive:
+// max(1024, cpu_cores * 16). Idle threads are reaped, so the resting thread
+// count returns to zero when no import is running. Raise only if the number of
+// concurrent (flush_threads * indexed_columns * tantivy_writer_num_threads) live
+// workers could exceed the adaptive cap.
 CONF_Int32(tantivy_index_build_thread_pool_num_threads, "0");
+
+// Size (max threads) of the bounded *merge* pool that runs tantivy's segment
+// lifecycle maintenance: the segment-updater serial queue (registering built
+// segments via add_segment) and background merges. 0 means adaptive sizing based
+// on CPU cores. These tasks are transient — each releases its slot on completion
+// and never blocks on another task in this pool — so a bounded pool always makes
+// progress while capping merge concurrency. Indexing workers are NOT run here;
+// see tantivy_index_build_thread_pool_num_threads above and the two-pool
+// rationale in tantivy_ffi_pool_bridge.cpp.
+CONF_Int32(tantivy_index_merge_thread_pool_num_threads, "0");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1742,7 +1742,7 @@ CONF_mBool(enable_cow_optimization, "true");
 // The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means diagnose when use_count > 2.
 CONF_Int32(cow_optimization_diagnose_level, "0");
 
-// Whether to swallow per-row tantivy write errors stored in
+// Whether to swallow per-row tantivy write errors stoeed in
 // `TantivyInvertedWriter::_error_status` so finish_compound still proceeds to
 // commit. Default false: a real tantivy add/commit failure should fail the
 // segment fast (and surface a clear error) instead of being silently
@@ -1762,4 +1762,20 @@ CONF_mInt64(tantivy_writer_memory_budget_bytes, "268435456");
 // into a compound .idx immediately after commit, so merging is pure overhead
 // unless query-time multi-segment perf is critical).
 CONF_mString(tantivy_writer_merge_policy, "default");
+
+// Number of tantivy indexing worker threads per IndexWriter. 0 uses tantivy's
+// built-in default (1). Workers are submitted to the shared
+// `tantivy_index_build` thread pool rather than dedicated OS threads, so
+// raising this increases per-writer indexing concurrency while the total thread
+// count stays bounded by the pool. Row-id alignment is preserved at any value
+// because the BE row id is stored in an explicit tantivy FAST field.
+CONF_mInt32(tantivy_writer_num_threads, "1");
+
+// Size (max threads) of the shared thread pool that runs all tantivy index
+// build work (indexing workers, segment-updater serial queue, and merges). 0
+// means adaptive sizing based on CPU cores. This bounds the total number of
+// tantivy background threads across all concurrent writers, preventing the
+// thread explosion of tantivy spawning its own threads per writer.
+CONF_Int32(tantivy_index_build_thread_pool_num_threads, "0");
+
 } // namespace starrocks::config

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -820,23 +820,42 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 #endif
 
     {
-        // Shared pool for all tantivy inverted-index build work. Bounds the
-        // total tantivy background thread count (indexing workers + merges +
-        // segment-updater queue) across every concurrent writer. An unbounded
-        // queue guarantees submit never blocks/fails, so tantivy never stalls
-        // waiting for a slot; concurrency is capped by max_threads.
+        // Two pools back tantivy's background work. See tantivy_ffi_pool_bridge
+        // for why the two task classes must not share one bounded pool.
         int nproc = CpuInfo::num_cores();
-        int configured = config::tantivy_index_build_thread_pool_num_threads;
-        int pool_threads = configured > 0 ? configured : std::max(4, nproc);
-        LOG(INFO) << "tantivy index build thread pool: nproc=" << nproc << " threads=" << pool_threads;
+
+        // Build pool: runs the RESIDENT indexing workers. It must grow a thread
+        // per live worker on demand, so use an elastic pool (min 0, queue size 0
+        // => every submit either reuses an idle thread or spawns a new one up to
+        // max_threads; it only rejects at the cap). The cap is set high so it is
+        // never hit in practice — a rejected worker would run inline and hang its
+        // flush thread. Idle threads are reaped by the default idle timeout.
+        int build_cfg = config::tantivy_index_build_thread_pool_num_threads;
+        int build_threads = build_cfg > 0 ? build_cfg : std::max(1024, nproc * 16);
         RETURN_IF_ERROR(ThreadPoolBuilder("tantivy_index_build")
                                 .set_min_threads(0)
-                                .set_max_threads(pool_threads)
-                                .set_max_queue_size(std::numeric_limits<int>::max())
+                                .set_max_threads(build_threads)
+                                .set_max_queue_size(0)
                                 .build(&_tantivy_index_build_thread_pool));
-        register_tantivy_index_thread_pool(_tantivy_index_build_thread_pool.get());
+
+        // Merge pool: runs the TRANSIENT segment-updater serial queue and merges.
+        // A bounded pool with an unbounded queue is safe here because these tasks
+        // never block on another task in this pool, so it always drains.
+        int merge_cfg = config::tantivy_index_merge_thread_pool_num_threads;
+        int merge_threads = merge_cfg > 0 ? merge_cfg : std::max(4, nproc);
+        RETURN_IF_ERROR(ThreadPoolBuilder("tantivy_index_merge")
+                                .set_min_threads(0)
+                                .set_max_threads(merge_threads)
+                                .set_max_queue_size(std::numeric_limits<int>::max())
+                                .build(&_tantivy_index_merge_thread_pool));
+
+        LOG(INFO) << "tantivy index thread pools: nproc=" << nproc << " build(elastic)_max=" << build_threads
+                  << " merge(bounded)_max=" << merge_threads;
+        register_tantivy_index_thread_pool(_tantivy_index_build_thread_pool.get(),
+                                           _tantivy_index_merge_thread_pool.get());
     }
     REGISTER_THREAD_POOL_METRICS(tantivy_index_build, _tantivy_index_build_thread_pool);
+    REGISTER_THREAD_POOL_METRICS(tantivy_index_merge, _tantivy_index_merge_thread_pool);
 
     _agent_server = new AgentServer(this, false);
     _agent_server->init_or_die();
@@ -921,6 +940,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _tantivy_index_build_thread_pool->shutdown();
         component_times.emplace_back("tantivy_index_build_thread_pool", MonotonicMillis() - start);
+    }
+
+    if (_tantivy_index_merge_thread_pool) {
+        start = MonotonicMillis();
+        _tantivy_index_merge_thread_pool->shutdown();
+        component_times.emplace_back("tantivy_index_merge_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -1104,6 +1129,7 @@ void ExecEnv::destroy() {
     _dictionary_cache_pool.reset();
     _automatic_partition_pool.reset();
     _tantivy_index_build_thread_pool.reset();
+    _tantivy_index_merge_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -86,6 +86,7 @@
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/transaction_mgr.h"
 #include "service/staros_worker.h"
+#include "storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/starlet_location_provider.h"
@@ -818,6 +819,25 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
 #endif
 
+    {
+        // Shared pool for all tantivy inverted-index build work. Bounds the
+        // total tantivy background thread count (indexing workers + merges +
+        // segment-updater queue) across every concurrent writer. An unbounded
+        // queue guarantees submit never blocks/fails, so tantivy never stalls
+        // waiting for a slot; concurrency is capped by max_threads.
+        int nproc = CpuInfo::num_cores();
+        int configured = config::tantivy_index_build_thread_pool_num_threads;
+        int pool_threads = configured > 0 ? configured : std::max(4, nproc);
+        LOG(INFO) << "tantivy index build thread pool: nproc=" << nproc << " threads=" << pool_threads;
+        RETURN_IF_ERROR(ThreadPoolBuilder("tantivy_index_build")
+                                .set_min_threads(0)
+                                .set_max_threads(pool_threads)
+                                .set_max_queue_size(std::numeric_limits<int>::max())
+                                .build(&_tantivy_index_build_thread_pool));
+        register_tantivy_index_thread_pool(_tantivy_index_build_thread_pool.get());
+    }
+    REGISTER_THREAD_POOL_METRICS(tantivy_index_build, _tantivy_index_build_thread_pool);
+
     _agent_server = new AgentServer(this, false);
     _agent_server->init_or_die();
 
@@ -895,6 +915,12 @@ void ExecEnv::stop() {
         start = MonotonicMillis();
         _pipeline_sink_io_pool->shutdown();
         component_times.emplace_back("pipeline_sink_io_pool", MonotonicMillis() - start);
+    }
+
+    if (_tantivy_index_build_thread_pool) {
+        start = MonotonicMillis();
+        _tantivy_index_build_thread_pool->shutdown();
+        component_times.emplace_back("tantivy_index_build_thread_pool", MonotonicMillis() - start);
     }
 
     if (_agent_server) {
@@ -1077,6 +1103,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_diagnose_daemon);
     _dictionary_cache_pool.reset();
     _automatic_partition_pool.reset();
+    _tantivy_index_build_thread_pool.reset();
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -383,6 +383,8 @@ public:
 
     ThreadPool* delete_file_thread_pool();
 
+    ThreadPool* tantivy_index_build_thread_pool() { return _tantivy_index_build_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -452,6 +454,12 @@ private:
     std::shared_ptr<lake::LocationProvider> _lake_location_provider;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
+
+    // Shared pool running all tantivy inverted-index build work (indexing
+    // workers, segment-updater serial queue, merges). Bounds tantivy background
+    // threads across all writers and carries the caller's mem tracker into each
+    // task. See tantivy_ffi_pool_bridge.{h,cpp}.
+    std::unique_ptr<ThreadPool> _tantivy_index_build_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -385,6 +385,8 @@ public:
 
     ThreadPool* tantivy_index_build_thread_pool() { return _tantivy_index_build_thread_pool.get(); }
 
+    ThreadPool* tantivy_index_merge_thread_pool() { return _tantivy_index_merge_thread_pool.get(); }
+
     void try_release_resource_before_core_dump();
 
     DiagnoseDaemon* diagnose_daemon() const { return _diagnose_daemon; }
@@ -454,12 +456,17 @@ private:
     std::shared_ptr<lake::LocationProvider> _lake_location_provider;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
-
-    // Shared pool running all tantivy inverted-index build work (indexing
-    // workers, segment-updater serial queue, merges). Bounds tantivy background
-    // threads across all writers and carries the caller's mem tracker into each
-    // task. See tantivy_ffi_pool_bridge.{h,cpp}.
+    // Elastic pool running tantivy's RESIDENT indexing workers (documents ->
+    // in-memory segments). Grows a thread per live worker on demand (queue size
+    // 0) so a worker never sits queued waiting for a slot, which would deadlock
+    // the commit that joins it and the flush that feeds it. Idle threads are
+    // reaped back to zero. See tantivy_ffi_pool_bridge.{h,cpp}.
     std::unique_ptr<ThreadPool> _tantivy_index_build_thread_pool = nullptr;
+    // Bounded pool running tantivy's segment lifecycle maintenance: the
+    // segment-updater serial queue (add_segment) and merges. Transient tasks
+    // only; caps merge concurrency and carries the caller's mem tracker into each
+    // task. See tantivy_ffi_pool_bridge.{h,cpp}.
+    std::unique_ptr<ThreadPool> _tantivy_index_merge_thread_pool = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -269,6 +269,7 @@ set(STORAGE_FILES
     index/inverted/tantivy/tantivy_inverted_writer.cpp
     index/inverted/tantivy/tantivy_inverted_reader.cpp
     index/inverted/tantivy/random_access_bridge.cpp
+    index/inverted/tantivy/tantivy_ffi_pool_bridge.cpp
     index/vector/empty_index_reader.cpp
     index/vector/vector_index_builder_factory.cpp
     index/vector/vector_index_writer.cpp

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -349,9 +349,9 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     } else if (vaild_match && expr->op() == TExprOpcode::MATCH_PHRASE) {
         query_type = InvertedIndexQueryType::MATCH_PHRASE_QUERY;
     } else if (vaild_match && expr->op() == TExprOpcode::MATCH) {
-        // plain MATCH tokenizes the pattern and matches any term (not a raw term lookup).
-        query_type =
-                has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY : InvertedIndexQueryType::MATCH_ANY_QUERY;
+        // MATCH should use MATCH_ALL (AND semantics) so that all tokens produced by the analyzer must be present.
+        query_type = has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY
+                                  : InvertedIndexQueryType::MATCH_ALL_QUERY;
     } else {
         query_type = has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY : InvertedIndexQueryType::EQUAL_QUERY;
     }

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -350,8 +350,8 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
         query_type = InvertedIndexQueryType::MATCH_PHRASE_QUERY;
     } else if (vaild_match && expr->op() == TExprOpcode::MATCH) {
         // MATCH should use MATCH_ALL (AND semantics) so that all tokens produced by the analyzer must be present.
-        query_type = has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY
-                                  : InvertedIndexQueryType::MATCH_ALL_QUERY;
+        query_type =
+                has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY : InvertedIndexQueryType::MATCH_ALL_QUERY;
     } else {
         query_type = has_wildcard ? InvertedIndexQueryType::MATCH_WILDCARD_QUERY : InvertedIndexQueryType::EQUAL_QUERY;
     }

--- a/be/src/storage/index/inverted/tantivy/AGENTS.md
+++ b/be/src/storage/index/inverted/tantivy/AGENTS.md
@@ -214,15 +214,16 @@ C++ files in this module must include the standard Apache 2.0 license header.
 
 CJK bigram produces overlapping tokens, so `MATCH_PHRASE` requires slop proportional to the gap
 between target characters (e.g. matching "字节...推荐" with 3 intermediate bigrams needs `~3`
-slop). Phrase matching for CJK indexes is opt-in via:
+slop). Phrase matching is enabled by default for tantivy indexes:
 
 ```sql
 INDEX idx (col) USING GIN (
-    "imp_lib"="tantivy", "parser"="chinese", "support_phrase"="true"
+    "imp_lib"="tantivy", "parser"="chinese"
 )
 ```
 
-`support_phrase` defaults to `"false"` and is tantivy-only.
+`support_phrase` and `support_bm25` default to `"true"` for tantivy indexes and are auto-filled
+at DDL time, visible in `SHOW CREATE TABLE`.
 
 ## Query Types
 

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
@@ -105,17 +105,17 @@ struct RustStringArray {
  * Submit a joinable task to the BE pool. Takes ownership of `task` (opaque
  * boxed closure). Returns an opaque handle to be passed to the join callback.
  */
-using TantivyPoolSubmitFn = void*(*)(void *task);
+using TantivyPoolSubmitFn = void* (*)(void* task);
 
 /**
  * Submit a fire-and-forget task to the BE pool. Takes ownership of `task`.
  */
-using TantivyPoolSubmitDetachedFn = void(*)(void *task);
+using TantivyPoolSubmitDetachedFn = void (*)(void* task);
 
 /**
  * Block until the joinable task behind `handle` completes, then free `handle`.
  */
-using TantivyPoolJoinFn = void(*)(void *handle);
+using TantivyPoolJoinFn = void (*)(void* handle);
 
 extern "C" {
 
@@ -253,14 +253,9 @@ void tantivy_free_index_reader(void* reader);
  * SAFETY: `path`, `field_name`, `tokenizer` must be valid NUL-terminated
  * C strings. `merge_policy` may be NULL.
  */
-RustResult tantivy_create_index_writer(const char *path,
-                                       const char *field_name,
-                                       const char *tokenizer,
-                                       bool support_phrase,
-                                       bool support_bm25,
-                                       uintptr_t memory_budget_bytes,
-                                       uintptr_t num_threads,
-                                       const char *merge_policy);
+RustResult tantivy_create_index_writer(const char* path, const char* field_name, const char* tokenizer,
+                                       bool support_phrase, bool support_bm25, uintptr_t memory_budget_bytes,
+                                       uintptr_t num_threads, const char* merge_policy);
 
 /**
  * Append a batch of UTF-8 strings as documents in order. `values_ptr` is an
@@ -334,7 +329,7 @@ RustResult tantivy_tokenize(const char* tokenizer_name, const uint8_t* text_ptr,
  * SAFETY: `task` must be a pointer produced by this crate's spawner and not
  * previously run or dropped.
  */
-void tantivy_binding_run_pool_task(void *task);
+void tantivy_binding_run_pool_task(void* task);
 
 /**
  * Drop a queued task without running it. Called by the BE pool for tasks still
@@ -342,7 +337,7 @@ void tantivy_binding_run_pool_task(void *task);
  *
  * SAFETY: same as [`tantivy_binding_run_pool_task`].
  */
-void tantivy_binding_drop_pool_task(void *task);
+void tantivy_binding_drop_pool_task(void* task);
 
 /**
  * Install the BE thread pool as tantivy's global spawner. Call once at BE
@@ -352,11 +347,10 @@ void tantivy_binding_drop_pool_task(void *task);
  * SAFETY: the three callbacks must be valid for the entire process lifetime
  * and implement the ownership contract described in this module.
  */
-void tantivy_binding_init_thread_pool(TantivyPoolSubmitFn submit,
-                                      TantivyPoolSubmitDetachedFn submit_detached,
+void tantivy_binding_init_thread_pool(TantivyPoolSubmitFn submit, TantivyPoolSubmitDetachedFn submit_detached,
                                       TantivyPoolJoinFn join);
 
-}  // extern "C"
+} // extern "C"
 
 } // namespace starrocks::tantivy_binding
 

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
@@ -101,6 +101,22 @@ struct RustStringArray {
     uintptr_t len;
 };
 
+/**
+ * Submit a joinable task to the BE pool. Takes ownership of `task` (opaque
+ * boxed closure). Returns an opaque handle to be passed to the join callback.
+ */
+using TantivyPoolSubmitFn = void*(*)(void *task);
+
+/**
+ * Submit a fire-and-forget task to the BE pool. Takes ownership of `task`.
+ */
+using TantivyPoolSubmitDetachedFn = void(*)(void *task);
+
+/**
+ * Block until the joinable task behind `handle` completes, then free `handle`.
+ */
+using TantivyPoolJoinFn = void(*)(void *handle);
+
 extern "C" {
 
 /**
@@ -227,6 +243,9 @@ void tantivy_free_index_reader(void* reader);
  * `memory_budget_bytes`: memory budget for the IndexWriter. 0 uses the
  * compile-time default (256 MB).
  *
+ * `num_threads`: number of tantivy indexing worker threads. 0 uses the
+ * compile-time default (1). Workers run on the shared BE thread pool.
+ *
  * `merge_policy`: NUL-terminated C string selecting the merge policy.
  * `"no_merge"` disables merging; anything else uses `LogMergePolicy`.
  * NULL is treated as `"default"`.
@@ -240,6 +259,7 @@ RustResult tantivy_create_index_writer(const char *path,
                                        bool support_phrase,
                                        bool support_bm25,
                                        uintptr_t memory_budget_bytes,
+                                       uintptr_t num_threads,
                                        const char *merge_policy);
 
 /**
@@ -307,7 +327,36 @@ void tantivy_free_string_array(RustStringArray array);
 RustResult tantivy_tokenize(const char* tokenizer_name, const uint8_t* text_ptr, uintptr_t text_len,
                             RustStringArray* out);
 
-} // extern "C"
+/**
+ * Run and drop a task previously handed to the BE pool. Called by the BE pool
+ * on a pool thread (with the captured mem tracker already installed).
+ *
+ * SAFETY: `task` must be a pointer produced by this crate's spawner and not
+ * previously run or dropped.
+ */
+void tantivy_binding_run_pool_task(void *task);
+
+/**
+ * Drop a queued task without running it. Called by the BE pool for tasks still
+ * pending when the pool shuts down, so the boxed closure is not leaked.
+ *
+ * SAFETY: same as [`tantivy_binding_run_pool_task`].
+ */
+void tantivy_binding_drop_pool_task(void *task);
+
+/**
+ * Install the BE thread pool as tantivy's global spawner. Call once at BE
+ * startup, after the pool exists and before any tantivy index writer is
+ * created. A later call replaces the previous spawner.
+ *
+ * SAFETY: the three callbacks must be valid for the entire process lifetime
+ * and implement the ownership contract described in this module.
+ */
+void tantivy_binding_init_thread_pool(TantivyPoolSubmitFn submit,
+                                      TantivyPoolSubmitDetachedFn submit_detached,
+                                      TantivyPoolJoinFn join);
+
+}  // extern "C"
 
 } // namespace starrocks::tantivy_binding
 

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
@@ -224,14 +224,23 @@ void tantivy_free_index_reader(void* reader);
  * `support_bm25`: when true, per-document fieldnorms are stored (needed for
  * BM25 length normalization). When false, fieldnorms are omitted.
  *
+ * `memory_budget_bytes`: memory budget for the IndexWriter. 0 uses the
+ * compile-time default (256 MB).
+ *
+ * `merge_policy`: NUL-terminated C string selecting the merge policy.
+ * `"no_merge"` disables merging; anything else uses `LogMergePolicy`.
+ * NULL is treated as `"default"`.
+ *
  * SAFETY: `path`, `field_name`, `tokenizer` must be valid NUL-terminated
- * C strings.
+ * C strings. `merge_policy` may be NULL.
  */
 RustResult tantivy_create_index_writer(const char *path,
                                        const char *field_name,
                                        const char *tokenizer,
                                        bool support_phrase,
-                                       bool support_bm25);
+                                       bool support_bm25,
+                                       uintptr_t memory_budget_bytes,
+                                       const char *merge_policy);
 
 /**
  * Append a batch of UTF-8 strings as documents in order. `values_ptr` is an

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/include/tantivy_binding.h
@@ -218,10 +218,20 @@ void tantivy_free_index_reader(void* reader);
  * opaque writer handle in `RustResult.value.ptr`. Caller MUST release with
  * `tantivy_free_index_writer` and the result with `free_rust_result`.
  *
+ * `support_phrase`: when true, term positions are stored (needed for phrase
+ * queries). When false, only term frequencies are stored (smaller on disk).
+ *
+ * `support_bm25`: when true, per-document fieldnorms are stored (needed for
+ * BM25 length normalization). When false, fieldnorms are omitted.
+ *
  * SAFETY: `path`, `field_name`, `tokenizer` must be valid NUL-terminated
  * C strings.
  */
-RustResult tantivy_create_index_writer(const char* path, const char* field_name, const char* tokenizer);
+RustResult tantivy_create_index_writer(const char *path,
+                                       const char *field_name,
+                                       const char *tokenizer,
+                                       bool support_phrase,
+                                       bool support_bm25);
 
 /**
  * Append a batch of UTF-8 strings as documents in order. `values_ptr` is an

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
@@ -16,7 +16,7 @@
 //!
 //! Surface:
 //!   - tantivy_create_index_writer(path, field_name, tokenizer, support_phrase,
-//!     support_bm25, memory_budget_bytes, merge_policy)
+//!     support_bm25, memory_budget_bytes, num_threads, merge_policy)
 //!   - tantivy_index_add_strings_batch(writer, values_ptr, count)
 //!   - tantivy_commit_index(writer)
 //!   - tantivy_free_index_writer(writer)
@@ -60,6 +60,9 @@ macro_rules! cstr_or_err {
 /// `memory_budget_bytes`: memory budget for the IndexWriter. 0 uses the
 /// compile-time default (256 MB).
 ///
+/// `num_threads`: number of tantivy indexing worker threads. 0 uses the
+/// compile-time default (1). Workers run on the shared BE thread pool.
+///
 /// `merge_policy`: NUL-terminated C string selecting the merge policy.
 /// `"no_merge"` disables merging; anything else uses `LogMergePolicy`.
 /// NULL is treated as `"default"`.
@@ -74,6 +77,7 @@ pub unsafe extern "C" fn tantivy_create_index_writer(
     support_phrase: bool,
     support_bm25: bool,
     memory_budget_bytes: usize,
+    num_threads: usize,
     merge_policy: *const c_char,
 ) -> RustResult {
     catch_ffi(|| {
@@ -95,6 +99,7 @@ pub unsafe extern "C" fn tantivy_create_index_writer(
             support_phrase,
             support_bm25,
             memory_budget_bytes,
+            num_threads,
             merge_policy_str,
         ) {
             Ok(w) => RustResult::ok_ptr(create_binding(w)),

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
@@ -15,7 +15,7 @@
 //! C ABI shim for the writer side.
 //!
 //! Surface:
-//!   - tantivy_create_index_writer(path, field_name, tokenizer)
+//!   - tantivy_create_index_writer(path, field_name, tokenizer, support_phrase, support_bm25)
 //!   - tantivy_index_add_strings_batch(writer, values_ptr, count)
 //!   - tantivy_commit_index(writer)
 //!   - tantivy_free_index_writer(writer)
@@ -50,6 +50,12 @@ macro_rules! cstr_or_err {
 /// opaque writer handle in `RustResult.value.ptr`. Caller MUST release with
 /// `tantivy_free_index_writer` and the result with `free_rust_result`.
 ///
+/// `support_phrase`: when true, term positions are stored (needed for phrase
+/// queries). When false, only term frequencies are stored (smaller on disk).
+///
+/// `support_bm25`: when true, per-document fieldnorms are stored (needed for
+/// BM25 length normalization). When false, fieldnorms are omitted.
+///
 /// SAFETY: `path`, `field_name`, `tokenizer` must be valid NUL-terminated
 /// C strings.
 #[no_mangle]
@@ -57,6 +63,8 @@ pub unsafe extern "C" fn tantivy_create_index_writer(
     path: *const c_char,
     field_name: *const c_char,
     tokenizer: *const c_char,
+    support_phrase: bool,
+    support_bm25: bool,
 ) -> RustResult {
     catch_ffi(|| {
         let path_str = cstr_or_err!(path, "path");
@@ -66,6 +74,8 @@ pub unsafe extern "C" fn tantivy_create_index_writer(
             std::path::Path::new(path_str),
             field_name_str,
             tokenizer_str,
+            support_phrase,
+            support_bm25,
         ) {
             Ok(w) => RustResult::ok_ptr(create_binding(w)),
             Err(e) => RustResult::err(e.to_string()),

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/index_writer_c.rs
@@ -15,7 +15,8 @@
 //! C ABI shim for the writer side.
 //!
 //! Surface:
-//!   - tantivy_create_index_writer(path, field_name, tokenizer, support_phrase, support_bm25)
+//!   - tantivy_create_index_writer(path, field_name, tokenizer, support_phrase,
+//!     support_bm25, memory_budget_bytes, merge_policy)
 //!   - tantivy_index_add_strings_batch(writer, values_ptr, count)
 //!   - tantivy_commit_index(writer)
 //!   - tantivy_free_index_writer(writer)
@@ -56,8 +57,15 @@ macro_rules! cstr_or_err {
 /// `support_bm25`: when true, per-document fieldnorms are stored (needed for
 /// BM25 length normalization). When false, fieldnorms are omitted.
 ///
+/// `memory_budget_bytes`: memory budget for the IndexWriter. 0 uses the
+/// compile-time default (256 MB).
+///
+/// `merge_policy`: NUL-terminated C string selecting the merge policy.
+/// `"no_merge"` disables merging; anything else uses `LogMergePolicy`.
+/// NULL is treated as `"default"`.
+///
 /// SAFETY: `path`, `field_name`, `tokenizer` must be valid NUL-terminated
-/// C strings.
+/// C strings. `merge_policy` may be NULL.
 #[no_mangle]
 pub unsafe extern "C" fn tantivy_create_index_writer(
     path: *const c_char,
@@ -65,17 +73,29 @@ pub unsafe extern "C" fn tantivy_create_index_writer(
     tokenizer: *const c_char,
     support_phrase: bool,
     support_bm25: bool,
+    memory_budget_bytes: usize,
+    merge_policy: *const c_char,
 ) -> RustResult {
     catch_ffi(|| {
         let path_str = cstr_or_err!(path, "path");
         let field_name_str = cstr_or_err!(field_name, "field_name");
         let tokenizer_str = cstr_or_err!(tokenizer, "tokenizer");
+        let merge_policy_str = if merge_policy.is_null() {
+            "default"
+        } else {
+            match CStr::from_ptr(merge_policy).to_str() {
+                Ok(s) => s,
+                Err(_) => "default",
+            }
+        };
         match IndexWriterWrapper::create(
             std::path::Path::new(path_str),
             field_name_str,
             tokenizer_str,
             support_phrase,
             support_bm25,
+            memory_budget_bytes,
+            merge_policy_str,
         ) {
             Ok(w) => RustResult::ok_ptr(create_binding(w)),
             Err(e) => RustResult::err(e.to_string()),

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/mod.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/mod.rs
@@ -17,6 +17,7 @@ pub mod handle;
 pub mod index_reader_c;
 pub mod index_writer_c;
 pub mod lifecycle_c;
+pub mod pool_c;
 pub mod result;
 
 pub use result::{RustResult, RustStringArray, RustU32Array, Value, ValueTag};

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/pool_c.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/ffi/pool_c.rs
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! C ABI shim wiring tantivy's background work onto a BE-owned thread pool.
+//!
+//! tantivy normally spawns its own OS threads for indexing workers and its own
+//! rayon pools for the segment-updater serial queue and merges. That both
+//! explodes the thread count (one set per `IndexWriter`) and breaks the BE's
+//! per-thread memory accounting (documents are allocated on the caller thread
+//! but freed on tantivy's worker thread, so `consume`/`release` land on
+//! different mem trackers).
+//!
+//! With the [`tantivy::executor`] hook, all such work is instead submitted here
+//! and forwarded to the shared BE `ThreadPool` via C callbacks. The BE side
+//! captures the caller's thread-local mem tracker at submit time and restores it
+//! on the pool thread before running the task, so allocation and deallocation
+//! land on the same tracker (capture-at-submit + set-at-run).
+//!
+//! Ownership across the boundary: a tantivy task is a `Box<dyn FnOnce() + Send>`
+//! (a fat pointer). We box it once more so it fits a single `*mut c_void`, hand
+//! that raw pointer to the BE pool, and the BE pool later calls
+//! [`tantivy_binding_run_pool_task`] on a pool thread to run + drop it. If the
+//! pool is shut down with tasks still queued, the BE side must call
+//! [`tantivy_binding_drop_pool_task`] on each to avoid leaking the closure.
+
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use tantivy::executor::{set_global_spawner, PooledJoinHandle, ThreadSpawner};
+
+/// Submit a joinable task to the BE pool. Takes ownership of `task` (opaque
+/// boxed closure). Returns an opaque handle to be passed to the join callback.
+pub type TantivyPoolSubmitFn = unsafe extern "C" fn(task: *mut c_void) -> *mut c_void;
+
+/// Submit a fire-and-forget task to the BE pool. Takes ownership of `task`.
+pub type TantivyPoolSubmitDetachedFn = unsafe extern "C" fn(task: *mut c_void);
+
+/// Block until the joinable task behind `handle` completes, then free `handle`.
+pub type TantivyPoolJoinFn = unsafe extern "C" fn(handle: *mut c_void);
+
+/// The boxed tantivy closure, double-boxed so a `Box<dyn FnOnce()>` fat pointer
+/// fits in a single thin `*mut c_void`.
+type BoxedTask = Box<dyn FnOnce() + Send>;
+
+/// Run and drop a task previously handed to the BE pool. Called by the BE pool
+/// on a pool thread (with the captured mem tracker already installed).
+///
+/// SAFETY: `task` must be a pointer produced by this crate's spawner and not
+/// previously run or dropped.
+#[no_mangle]
+pub unsafe extern "C" fn tantivy_binding_run_pool_task(task: *mut c_void) {
+    if task.is_null() {
+        return;
+    }
+    // Never let a Rust panic unwind across the FFI boundary into C++.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let boxed: Box<BoxedTask> = Box::from_raw(task as *mut BoxedTask);
+        (*boxed)();
+    }));
+}
+
+/// Drop a queued task without running it. Called by the BE pool for tasks still
+/// pending when the pool shuts down, so the boxed closure is not leaked.
+///
+/// SAFETY: same as [`tantivy_binding_run_pool_task`].
+#[no_mangle]
+pub unsafe extern "C" fn tantivy_binding_drop_pool_task(task: *mut c_void) {
+    if task.is_null() {
+        return;
+    }
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        drop(Box::from_raw(task as *mut BoxedTask));
+    }));
+}
+
+/// A [`ThreadSpawner`] backed by the BE C++ thread pool via C callbacks.
+struct BeSpawner {
+    submit: TantivyPoolSubmitFn,
+    submit_detached: TantivyPoolSubmitDetachedFn,
+    join: TantivyPoolJoinFn,
+}
+
+// The callbacks are plain C function pointers; sending/sharing them is safe.
+unsafe impl Send for BeSpawner {}
+unsafe impl Sync for BeSpawner {}
+
+/// Join handle wrapping the opaque handle returned by the BE submit callback.
+struct BeJoinHandle {
+    handle: *mut c_void,
+    join: TantivyPoolJoinFn,
+}
+
+// The opaque handle is owned by exactly one `BeJoinHandle` and only touched via
+// the join callback, so moving it across threads is safe.
+unsafe impl Send for BeJoinHandle {}
+
+impl PooledJoinHandle for BeJoinHandle {
+    fn join(self: Box<Self>) {
+        unsafe { (self.join)(self.handle) }
+    }
+}
+
+fn into_raw_task(task: BoxedTask) -> *mut c_void {
+    Box::into_raw(Box::new(task)) as *mut c_void
+}
+
+impl ThreadSpawner for BeSpawner {
+    fn spawn(&self, _name: String, task: BoxedTask) -> Box<dyn PooledJoinHandle> {
+        let raw = into_raw_task(task);
+        let handle = unsafe { (self.submit)(raw) };
+        Box::new(BeJoinHandle {
+            handle,
+            join: self.join,
+        })
+    }
+
+    fn spawn_detached(&self, _name: String, task: BoxedTask) {
+        let raw = into_raw_task(task);
+        unsafe { (self.submit_detached)(raw) }
+    }
+}
+
+/// Install the BE thread pool as tantivy's global spawner. Call once at BE
+/// startup, after the pool exists and before any tantivy index writer is
+/// created. A later call replaces the previous spawner.
+///
+/// SAFETY: the three callbacks must be valid for the entire process lifetime
+/// and implement the ownership contract described in this module.
+#[no_mangle]
+pub unsafe extern "C" fn tantivy_binding_init_thread_pool(
+    submit: TantivyPoolSubmitFn,
+    submit_detached: TantivyPoolSubmitDetachedFn,
+    join: TantivyPoolJoinFn,
+) {
+    let _ = std::panic::catch_unwind(|| {
+        set_global_spawner(Arc::new(BeSpawner {
+            submit,
+            submit_detached,
+            join,
+        }));
+    });
+}

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
@@ -57,17 +57,40 @@ pub struct IndexWriterWrapper {
 
 impl IndexWriterWrapper {
     /// Create a fresh tantivy index at `path` (must be empty/non-existent)
-    /// with one TEXT field named `field_name` and the analyzer chain identified by `tokenizer_name`.
-    pub fn create(path: &Path, field_name: &str, tokenizer_name: &str) -> Result<Self> {
+    /// with one TEXT field named `field_name` and the analyzer chain identified
+    /// by `tokenizer_name`.
+    ///
+    /// `support_phrase` controls whether term positions are stored (required for
+    /// `PhraseQuery`). When `true`, `IndexRecordOption::WithFreqsAndPositions`
+    /// is used; when `false`, `IndexRecordOption::WithFreqs` (smaller on disk).
+    ///
+    /// `support_bm25` controls whether per-document field length norms
+    /// (fieldnorms) are stored. These are required for BM25 scoring to
+    /// differentiate short vs. long documents. When `false`,
+    /// `set_fieldnorms(false)` is applied.
+    pub fn create(
+        path: &Path,
+        field_name: &str,
+        tokenizer_name: &str,
+        support_phrase: bool,
+        support_bm25: bool,
+    ) -> Result<Self> {
         std::fs::create_dir_all(path)?;
 
         let analyzer = tokenizer::build(tokenizer_name)?;
+
+        let record_option = if support_phrase {
+            IndexRecordOption::WithFreqsAndPositions
+        } else {
+            IndexRecordOption::WithFreqs
+        };
 
         let mut schema_builder = Schema::builder();
         let text_options = TextOptions::default().set_indexing_options(
             TextFieldIndexing::default()
                 .set_tokenizer(TOKENIZER_NAME)
-                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+                .set_index_option(record_option)
+                .set_fieldnorms(support_bm25),
         );
         let text_field = schema_builder.add_text_field(field_name, text_options);
         let row_id_field = schema_builder.add_u64_field("row_id", FAST);

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
@@ -23,6 +23,7 @@
 
 use std::path::Path;
 
+use tantivy::indexer::NoMergePolicy;
 use tantivy::schema::{FAST, IndexRecordOption, Field, Schema, TextFieldIndexing, TextOptions};
 use tantivy::{Index, IndexWriter, TantivyDocument};
 
@@ -32,7 +33,10 @@ use crate::safe::tokenizer::{self, TOKENIZER_NAME};
 /// Memory budget handed to tantivy's IndexWriter for one BE segment. tantivy
 /// will spill to internal segments if buffered beyond this; the reader path
 /// handles multi-segment via per-segment doc-id offsets.
-const WRITER_MEMORY_BUDGET_BYTES: usize = 50 * 1024 * 1024;
+///
+/// This is a compile-time fallback. The actual value is passed at runtime
+/// from the C++ config `tantivy_writer_memory_budget_bytes`.
+const DEFAULT_WRITER_MEMORY_BUDGET_BYTES: usize = 256 * 1024 * 1024;
 
 /// Hardcode the tantivy writer to a single indexing worker thread for now.
 /// Write concurrency is controlled by StarRocks-side parameters instead, so
@@ -40,6 +44,10 @@ const WRITER_MEMORY_BUDGET_BYTES: usize = 50 * 1024 * 1024;
 /// this binding layer. If higher per-writer throughput is needed in the
 /// future, make this value configurable.
 const WRITER_NUM_THREADS: usize = 1;
+
+/// Merge policy names accepted from the C++ config layer.
+const MERGE_POLICY_NO_MERGE: &str = "no_merge";
+// "default" and everything else → LogMergePolicy (tantivy's built-in default).
 
 pub struct IndexWriterWrapper {
     // Held in an Option because `commit()` must take ownership of the underlying
@@ -68,12 +76,21 @@ impl IndexWriterWrapper {
     /// (fieldnorms) are stored. These are required for BM25 scoring to
     /// differentiate short vs. long documents. When `false`,
     /// `set_fieldnorms(false)` is applied.
+    ///
+    /// `memory_budget_bytes` controls the memory budget for the IndexWriter.
+    /// When `0`, the compile-time default is used.
+    ///
+    /// `merge_policy` selects the segment merge policy applied after commit.
+    /// `"no_merge"` disables merging entirely; any other value (including
+    /// `"default"`) uses tantivy's built-in `LogMergePolicy`.
     pub fn create(
         path: &Path,
         field_name: &str,
         tokenizer_name: &str,
         support_phrase: bool,
         support_bm25: bool,
+        memory_budget_bytes: usize,
+        merge_policy: &str,
     ) -> Result<Self> {
         std::fs::create_dir_all(path)?;
 
@@ -98,8 +115,18 @@ impl IndexWriterWrapper {
 
         let index = Index::create_in_dir(path, schema)?;
         index.tokenizers().register(TOKENIZER_NAME, analyzer);
+        let budget = if memory_budget_bytes > 0 {
+            memory_budget_bytes
+        } else {
+            DEFAULT_WRITER_MEMORY_BUDGET_BYTES
+        };
         let writer: IndexWriter =
-            index.writer_with_num_threads(WRITER_NUM_THREADS, WRITER_MEMORY_BUDGET_BYTES)?;
+            index.writer_with_num_threads(WRITER_NUM_THREADS, budget)?;
+
+        if merge_policy == MERGE_POLICY_NO_MERGE {
+            writer.set_merge_policy(Box::new(NoMergePolicy));
+        }
+        // else: keep tantivy's default LogMergePolicy
 
         Ok(Self { writer: Some(writer), text_field, row_id_field, next_row_id: 0 })
     }

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/index_writer.rs
@@ -38,12 +38,16 @@ use crate::safe::tokenizer::{self, TOKENIZER_NAME};
 /// from the C++ config `tantivy_writer_memory_budget_bytes`.
 const DEFAULT_WRITER_MEMORY_BUDGET_BYTES: usize = 256 * 1024 * 1024;
 
-/// Hardcode the tantivy writer to a single indexing worker thread for now.
-/// Write concurrency is controlled by StarRocks-side parameters instead, so
-/// we can avoid introducing the extra complexity of multi-threaded writes in
-/// this binding layer. If higher per-writer throughput is needed in the
-/// future, make this value configurable.
-const WRITER_NUM_THREADS: usize = 1;
+/// Number of tantivy indexing worker threads per writer. `0` means fall back to
+/// this compile-time default. The actual value is supplied at runtime from the
+/// C++ config `tantivy_writer_num_threads`. Workers no longer map to dedicated
+/// OS threads: they are submitted to the shared BE thread pool via the injected
+/// `tantivy::executor` spawner, so raising this only raises indexing
+/// concurrency, not the total thread count. Row ids stay correct at any worker
+/// count because the BE row id is stored explicitly in the `row_id` FAST field
+/// (assigned on the caller thread before dispatch), not inferred from tantivy
+/// DocId ordering.
+const DEFAULT_WRITER_NUM_THREADS: usize = 1;
 
 /// Merge policy names accepted from the C++ config layer.
 const MERGE_POLICY_NO_MERGE: &str = "no_merge";
@@ -80,6 +84,11 @@ impl IndexWriterWrapper {
     /// `memory_budget_bytes` controls the memory budget for the IndexWriter.
     /// When `0`, the compile-time default is used.
     ///
+    /// `num_threads` controls the number of tantivy indexing worker threads.
+    /// When `0`, [`DEFAULT_WRITER_NUM_THREADS`] is used. Workers run on the
+    /// shared BE thread pool, so this bounds indexing concurrency, not OS
+    /// threads.
+    ///
     /// `merge_policy` selects the segment merge policy applied after commit.
     /// `"no_merge"` disables merging entirely; any other value (including
     /// `"default"`) uses tantivy's built-in `LogMergePolicy`.
@@ -90,6 +99,7 @@ impl IndexWriterWrapper {
         support_phrase: bool,
         support_bm25: bool,
         memory_budget_bytes: usize,
+        num_threads: usize,
         merge_policy: &str,
     ) -> Result<Self> {
         std::fs::create_dir_all(path)?;
@@ -120,8 +130,13 @@ impl IndexWriterWrapper {
         } else {
             DEFAULT_WRITER_MEMORY_BUDGET_BYTES
         };
+        let num_threads = if num_threads > 0 {
+            num_threads
+        } else {
+            DEFAULT_WRITER_NUM_THREADS
+        };
         let writer: IndexWriter =
-            index.writer_with_num_threads(WRITER_NUM_THREADS, budget)?;
+            index.writer_with_num_threads(num_threads, budget)?;
 
         if merge_policy == MERGE_POLICY_NO_MERGE {
             writer.set_merge_policy(Box::new(NoMergePolicy));

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
@@ -21,7 +21,7 @@ use crate::safe::{IndexReaderWrapper, IndexWriterWrapper};
 
 fn build(values: &[&str]) -> TempDir {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
     w.add_strings_batch(values).expect("add");
     w.commit().expect("commit");
     drop(w);
@@ -165,7 +165,7 @@ mod wildcard {
     /// gives wildcard the parser=none semantics.
     fn build_raw(values: &[&str]) -> TempDir {
         let tmp = TempDir::new().expect("tempdir");
-        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw", true, true).expect("create");
+        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw", true, true, 0, "default").expect("create");
         w.add_strings_batch(values).expect("add");
         w.commit().expect("commit");
         drop(w);

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
@@ -21,7 +21,7 @@ use crate::safe::{IndexReaderWrapper, IndexWriterWrapper};
 
 fn build(values: &[&str]) -> TempDir {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english").expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
     w.add_strings_batch(values).expect("add");
     w.commit().expect("commit");
     drop(w);
@@ -165,7 +165,7 @@ mod wildcard {
     /// gives wildcard the parser=none semantics.
     fn build_raw(values: &[&str]) -> TempDir {
         let tmp = TempDir::new().expect("tempdir");
-        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw").expect("create");
+        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw", true, true).expect("create");
         w.add_strings_batch(values).expect("add");
         w.commit().expect("commit");
         drop(w);

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_reader_tests.rs
@@ -21,7 +21,7 @@ use crate::safe::{IndexReaderWrapper, IndexWriterWrapper};
 
 fn build(values: &[&str]) -> TempDir {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, 0, "default").expect("create");
     w.add_strings_batch(values).expect("add");
     w.commit().expect("commit");
     drop(w);
@@ -165,7 +165,7 @@ mod wildcard {
     /// gives wildcard the parser=none semantics.
     fn build_raw(values: &[&str]) -> TempDir {
         let tmp = TempDir::new().expect("tempdir");
-        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw", true, true, 0, "default").expect("create");
+        let mut w = IndexWriterWrapper::create(tmp.path(), "f", "raw", true, true, 0, 0, "default").expect("create");
         w.add_strings_batch(values).expect("add");
         w.commit().expect("commit");
         drop(w);

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
@@ -22,7 +22,7 @@ fn round_trip_create_add_commit_query() {
     let field = "title";
 
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), field, "english", true, true, 0, "default").expect("create writer");
+        IndexWriterWrapper::create(tmp.path(), field, "english", true, true, 0, 0, "default").expect("create writer");
     w.add_strings_batch(&["hello world", "tantivy ffi", "starrocks integration"])
         .expect("add batch");
     w.commit().expect("commit");
@@ -43,11 +43,11 @@ fn create_fails_when_index_already_exists() {
     // pins that contract so a future tantivy version change is caught.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("first create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, 0, "default").expect("first create");
     w.commit().expect("commit");
     drop(w);
 
-    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default") {
+    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, 0, "default") {
         Ok(_) => panic!("second create over existing index must fail"),
         Err(e) => e.to_string(),
     };
@@ -65,7 +65,7 @@ fn commit_is_single_use() {
     // silently no-op'ing.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, 0, "default").expect("create");
     w.add_strings_batch(&["a", "b"]).expect("add ok");
     w.commit().expect("first commit");
 
@@ -87,7 +87,7 @@ fn commit_is_single_use() {
 #[test]
 fn null_placeholders_preserve_doc_id_alignment() {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, 0, "default").expect("create");
     // Row 0 = "alpha", row 1 = NULL placeholder, row 2 = "alpha", row 3 = NULL.
     w.add_strings_batch(&["alpha", "", "alpha", ""]).expect("add");
     w.commit().expect("commit");
@@ -105,7 +105,7 @@ fn phrase_disabled_omits_positions() {
     // positions). Phrase queries should fail because positions are missing.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", false, true, 0, "default").expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, true, 0, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "world hello"])
         .expect("add");
     w.commit().expect("commit");
@@ -133,7 +133,7 @@ fn bm25_disabled_omits_fieldnorms() {
     // at this layer, but we verify the index is functional.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, false, 0, "default").expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, false, 0, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "tantivy ffi"])
         .expect("add");
     w.commit().expect("commit");
@@ -151,7 +151,7 @@ fn both_disabled_minimal_index() {
     // term-frequency-based features.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", false, false, 0, "default").expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, false, 0, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "tantivy ffi", "hello tantivy"])
         .expect("add");
     w.commit().expect("commit");

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
@@ -22,7 +22,7 @@ fn round_trip_create_add_commit_query() {
     let field = "title";
 
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), field, "english", true, true).expect("create writer");
+        IndexWriterWrapper::create(tmp.path(), field, "english", true, true, 0, "default").expect("create writer");
     w.add_strings_batch(&["hello world", "tantivy ffi", "starrocks integration"])
         .expect("add batch");
     w.commit().expect("commit");
@@ -43,11 +43,11 @@ fn create_fails_when_index_already_exists() {
     // pins that contract so a future tantivy version change is caught.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("first create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("first create");
     w.commit().expect("commit");
     drop(w);
 
-    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english", true, true) {
+    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default") {
         Ok(_) => panic!("second create over existing index must fail"),
         Err(e) => e.to_string(),
     };
@@ -65,7 +65,7 @@ fn commit_is_single_use() {
     // silently no-op'ing.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
     w.add_strings_batch(&["a", "b"]).expect("add ok");
     w.commit().expect("first commit");
 
@@ -87,7 +87,7 @@ fn commit_is_single_use() {
 #[test]
 fn null_placeholders_preserve_doc_id_alignment() {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true, 0, "default").expect("create");
     // Row 0 = "alpha", row 1 = NULL placeholder, row 2 = "alpha", row 3 = NULL.
     w.add_strings_batch(&["alpha", "", "alpha", ""]).expect("add");
     w.commit().expect("commit");
@@ -105,7 +105,7 @@ fn phrase_disabled_omits_positions() {
     // positions). Phrase queries should fail because positions are missing.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", false, true).expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, true, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "world hello"])
         .expect("add");
     w.commit().expect("commit");
@@ -133,7 +133,7 @@ fn bm25_disabled_omits_fieldnorms() {
     // at this layer, but we verify the index is functional.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", true, false).expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, false, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "tantivy ffi"])
         .expect("add");
     w.commit().expect("commit");
@@ -151,7 +151,7 @@ fn both_disabled_minimal_index() {
     // term-frequency-based features.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english", false, false).expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, false, 0, "default").expect("create");
     w.add_strings_batch(&["hello world", "tantivy ffi", "hello tantivy"])
         .expect("add");
     w.commit().expect("commit");

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tests/index_writer_tests.rs
@@ -22,7 +22,7 @@ fn round_trip_create_add_commit_query() {
     let field = "title";
 
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), field, "english").expect("create writer");
+        IndexWriterWrapper::create(tmp.path(), field, "english", true, true).expect("create writer");
     w.add_strings_batch(&["hello world", "tantivy ffi", "starrocks integration"])
         .expect("add batch");
     w.commit().expect("commit");
@@ -43,11 +43,11 @@ fn create_fails_when_index_already_exists() {
     // pins that contract so a future tantivy version change is caught.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english").expect("first create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("first create");
     w.commit().expect("commit");
     drop(w);
 
-    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english") {
+    let msg = match IndexWriterWrapper::create(tmp.path(), "f", "english", true, true) {
         Ok(_) => panic!("second create over existing index must fail"),
         Err(e) => e.to_string(),
     };
@@ -65,7 +65,7 @@ fn commit_is_single_use() {
     // silently no-op'ing.
     let tmp = TempDir::new().expect("tempdir");
     let mut w =
-        IndexWriterWrapper::create(tmp.path(), "f", "english").expect("create");
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
     w.add_strings_batch(&["a", "b"]).expect("add ok");
     w.commit().expect("first commit");
 
@@ -87,7 +87,7 @@ fn commit_is_single_use() {
 #[test]
 fn null_placeholders_preserve_doc_id_alignment() {
     let tmp = TempDir::new().expect("tempdir");
-    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english").expect("create");
+    let mut w = IndexWriterWrapper::create(tmp.path(), "f", "english", true, true).expect("create");
     // Row 0 = "alpha", row 1 = NULL placeholder, row 2 = "alpha", row 3 = NULL.
     w.add_strings_batch(&["alpha", "", "alpha", ""]).expect("add");
     w.commit().expect("commit");
@@ -97,4 +97,68 @@ fn null_placeholders_preserve_doc_id_alignment() {
     let mut hits = r.term_query("alpha").expect("query");
     hits.sort_unstable();
     assert_eq!(hits, vec![0u32, 2u32], "rows 0 and 2 should match");
+}
+
+#[test]
+fn phrase_disabled_omits_positions() {
+    // When support_phrase=false, the index is built with WithFreqs (no
+    // positions). Phrase queries should fail because positions are missing.
+    let tmp = TempDir::new().expect("tempdir");
+    let mut w =
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, true).expect("create");
+    w.add_strings_batch(&["hello world", "world hello"])
+        .expect("add");
+    w.commit().expect("commit");
+    drop(w);
+
+    let r = IndexReaderWrapper::load(tmp.path(), "f", "english").expect("load");
+
+    // Term query should still work (WithFreqs stores doc ids and TF).
+    let hits = r.term_query("hello").expect("term query");
+    assert_eq!(hits.len(), 2, "term query should still find both docs");
+
+    // Phrase query should fail — no positional data in the index.
+    let phrase_result = r.phrase_query(&["hello", "world"], 0);
+    assert!(
+        phrase_result.is_err(),
+        "phrase query should fail without position data, got: {:?}",
+        phrase_result
+    );
+}
+
+#[test]
+fn bm25_disabled_omits_fieldnorms() {
+    // When support_bm25=false, the index is built with fieldnorms=false.
+    // Basic queries should still work; scoring differences are not testable
+    // at this layer, but we verify the index is functional.
+    let tmp = TempDir::new().expect("tempdir");
+    let mut w =
+        IndexWriterWrapper::create(tmp.path(), "f", "english", true, false).expect("create");
+    w.add_strings_batch(&["hello world", "tantivy ffi"])
+        .expect("add");
+    w.commit().expect("commit");
+    drop(w);
+
+    let r = IndexReaderWrapper::load(tmp.path(), "f", "english").expect("load");
+    let hits = r.term_query("hello").expect("query");
+    assert_eq!(hits, vec![0u32], "basic query should work without fieldnorms");
+}
+
+#[test]
+fn both_disabled_minimal_index() {
+    // When both support_phrase=false and support_bm25=false, the index uses
+    // WithFreqs + fieldnorms=false — the smallest index that still supports
+    // term-frequency-based features.
+    let tmp = TempDir::new().expect("tempdir");
+    let mut w =
+        IndexWriterWrapper::create(tmp.path(), "f", "english", false, false).expect("create");
+    w.add_strings_batch(&["hello world", "tantivy ffi", "hello tantivy"])
+        .expect("add");
+    w.commit().expect("commit");
+    drop(w);
+
+    let r = IndexReaderWrapper::load(tmp.path(), "f", "english").expect("load");
+    let mut hits = r.term_query("hello").expect("query");
+    hits.sort_unstable();
+    assert_eq!(hits, vec![0u32, 2u32], "term query should work on minimal index");
 }

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/cjk_bigram.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/cjk_bigram.rs
@@ -14,9 +14,15 @@
 
 //! CJK bigram tokenizer (Lucene-style overlapping pairs).
 //!
+//! Streaming design: reuses a single `Token` buffer across the entire
+//! token stream, eliminating per-token heap allocations. ASCII tokens
+//! are lowercased inline so the `LowerCaser` filter is not needed.
+//!
 //! Constructed only via the `tokenizer::build` factory; visibility is
-//! `pub(super)` so callers cannot bypass the LowerCaser filter applied
-//! at factory time.
+//! `pub(super)` so callers cannot bypass the factory.
+
+use std::iter::Peekable;
+use std::str::CharIndices;
 
 use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
 
@@ -34,126 +40,169 @@ fn is_cjk_char(c: char) -> bool {
     )
 }
 
-#[derive(Clone, Default)]
-pub(super) struct CjkBigramTokenizer;
-
-pub(super) struct CjkBigramTokenStream {
-    tokens: Vec<Token>,
-    index: usize,
+#[inline]
+fn is_word_char(c: char) -> bool {
+    !is_cjk_char(c) && (c.is_alphanumeric() || c == '_' || c == '+' || c == '#')
 }
 
-impl CjkBigramTokenStream {
-    fn build(text: &str) -> Self {
-        let mut tokens = Vec::new();
-        let mut position = 0usize;
+#[derive(Clone)]
+pub(super) struct CjkBigramTokenizer {
+    token: Token,
+}
 
-        let chars: Vec<(usize, char)> = text.char_indices().collect();
-        let len = chars.len();
-        let mut i = 0;
+impl Default for CjkBigramTokenizer {
+    fn default() -> Self {
+        Self {
+            token: Token::default(),
+        }
+    }
+}
 
-        while i < len {
-            let (byte_offset, c) = chars[i];
+pub(super) struct CjkBigramTokenStream<'a> {
+    text: &'a str,
+    chars: Peekable<CharIndices<'a>>,
+    token: &'a mut Token,
+    position: usize,
+    /// Previous CJK char waiting to form the next bigram.
+    prev_cjk: Option<(usize, char)>,
+    /// Whether `prev_cjk` has already been emitted as part of a bigram.
+    prev_emitted: bool,
+}
 
-            if is_cjk_char(c) {
-                // CJK bigram: overlapping pairs
-                let cjk_start = i;
-                // Collect contiguous CJK run
-                let mut cjk_end = i + 1;
-                while cjk_end < len && is_cjk_char(chars[cjk_end].1) {
-                    cjk_end += 1;
+impl<'a> CjkBigramTokenStream<'a> {
+    /// Byte offset of the next character in the iterator, or `text.len()`
+    /// if exhausted. Used to compute `offset_to` for bigram tokens.
+    #[inline]
+    fn next_byte_offset(&mut self) -> usize {
+        self.chars
+            .peek()
+            .map(|&(off, _)| off)
+            .unwrap_or(self.text.len())
+    }
+
+    /// Emit a token whose text is copied from `self.text[from..to]` with
+    /// no transformation (used for CJK tokens that need no lowercasing).
+    #[inline]
+    fn emit_raw(&mut self, from: usize, to: usize) {
+        self.token.text.clear();
+        self.token.text.push_str(&self.text[from..to]);
+        self.token.offset_from = from;
+        self.token.offset_to = to;
+        self.token.position = self.position;
+        self.token.position_length = 1;
+        self.position += 1;
+    }
+
+    /// Emit an ASCII/Latin word token with inline lowercasing.
+    #[inline]
+    fn emit_word_lowered(&mut self, from: usize, to: usize) {
+        self.token.text.clear();
+        for c in self.text[from..to].chars() {
+            if c.is_ascii() {
+                self.token.text.push(c.to_ascii_lowercase());
+            } else {
+                // Non-ASCII, non-CJK alphanumeric (e.g. accented Latin):
+                // use full Unicode lowercase for correctness.
+                for lc in c.to_lowercase() {
+                    self.token.text.push(lc);
                 }
+            }
+        }
+        self.token.offset_from = from;
+        self.token.offset_to = to;
+        self.token.position = self.position;
+        self.token.position_length = 1;
+        self.position += 1;
+    }
+}
 
-                let run_len = cjk_end - cjk_start;
-                if run_len == 1 {
-                    // Single CJK char: emit as-is
-                    let byte_start = chars[cjk_start].0;
-                    let byte_end = if cjk_start + 1 < len {
-                        chars[cjk_start + 1].0
-                    } else {
-                        text.len()
-                    };
-                    tokens.push(Token {
-                        offset_from: byte_start,
-                        offset_to: byte_end,
-                        position,
-                        text: text[byte_start..byte_end].to_owned(),
-                        position_length: 1,
-                    });
-                    position += 1;
-                } else {
-                    // Emit overlapping bigrams
-                    for j in cjk_start..cjk_end - 1 {
-                        let byte_start = chars[j].0;
-                        let byte_end = if j + 2 < len {
-                            chars[j + 2].0
-                        } else {
-                            text.len()
-                        };
-                        tokens.push(Token {
-                            offset_from: byte_start,
-                            offset_to: byte_end,
-                            position,
-                            text: text[byte_start..byte_end].to_owned(),
-                            position_length: 1,
-                        });
-                        position += 1;
+impl TokenStream for CjkBigramTokenStream<'_> {
+    fn advance(&mut self) -> bool {
+        // --- Phase 1: continue a CJK run from the previous advance() call ---
+        if let Some((prev_start, prev_c)) = self.prev_cjk {
+            if let Some(&(next_start, next_c)) = self.chars.peek() {
+                if is_cjk_char(next_c) {
+                    // Consume the next CJK char and emit bigram(prev, next).
+                    self.chars.next();
+                    let end = self.next_byte_offset();
+                    self.emit_raw(prev_start, end);
+                    self.prev_cjk = Some((next_start, next_c));
+                    self.prev_emitted = true;
+                    return true;
+                }
+            }
+            // CJK run ended. Emit prev as a single char only if it was
+            // never part of a bigram (run length == 1).
+            if !self.prev_emitted {
+                let end = prev_start + prev_c.len_utf8();
+                self.emit_raw(prev_start, end);
+                self.prev_cjk = None;
+                self.prev_emitted = false;
+                return true;
+            }
+            // prev was already emitted in a bigram; drop it and scan on.
+            self.prev_cjk = None;
+            self.prev_emitted = false;
+        }
+
+        // --- Phase 2: scan for the next token ---
+        while let Some((byte_offset, c)) = self.chars.next() {
+            if is_cjk_char(c) {
+                // Check if the next char is also CJK → bigram.
+                if let Some(&(next_start, next_c)) = self.chars.peek() {
+                    if is_cjk_char(next_c) {
+                        self.chars.next();
+                        let end = self.next_byte_offset();
+                        self.emit_raw(byte_offset, end);
+                        self.prev_cjk = Some((next_start, next_c));
+                        self.prev_emitted = true;
+                        return true;
                     }
                 }
-                i = cjk_end;
-            } else if c.is_alphanumeric() || c == '_' || c == '+' || c == '#' {
-                // ASCII/Latin word: collect contiguous alphanumeric (but not CJK)
+                // Single CJK char (run of length 1).
+                let end = byte_offset + c.len_utf8();
+                self.emit_raw(byte_offset, end);
+                return true;
+            } else if is_word_char(c) {
+                // Collect a contiguous ASCII/Latin word.
                 let word_start = byte_offset;
-                i += 1;
-                while i < len {
-                    let ch = chars[i].1;
-                    if !is_cjk_char(ch) && (ch.is_alphanumeric() || ch == '_' || ch == '+' || ch == '#') {
-                        i += 1;
+                while let Some(&(_next_start, next_c)) = self.chars.peek() {
+                    if is_word_char(next_c) {
+                        self.chars.next();
                     } else {
                         break;
                     }
                 }
-                let word_end = if i < len { chars[i].0 } else { text.len() };
-                tokens.push(Token {
-                    offset_from: word_start,
-                    offset_to: word_end,
-                    position,
-                    text: text[word_start..word_end].to_owned(),
-                    position_length: 1,
-                });
-                position += 1;
-            } else {
-                // Punctuation, whitespace, other: skip
-                i += 1;
+                let word_end = self.next_byte_offset();
+                self.emit_word_lowered(word_start, word_end);
+                return true;
             }
+            // Punctuation, whitespace, etc.: skip.
         }
-
-        CjkBigramTokenStream { tokens, index: 0 }
-    }
-}
-
-impl TokenStream for CjkBigramTokenStream {
-    fn advance(&mut self) -> bool {
-        if self.index < self.tokens.len() {
-            self.index += 1;
-            true
-        } else {
-            false
-        }
+        false
     }
 
     fn token(&self) -> &Token {
-        &self.tokens[self.index - 1]
+        self.token
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        &mut self.tokens[self.index - 1]
+        self.token
     }
 }
 
 impl Tokenizer for CjkBigramTokenizer {
-    type TokenStream<'a> = CjkBigramTokenStream;
+    type TokenStream<'a> = CjkBigramTokenStream<'a>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
-        CjkBigramTokenStream::build(text)
+        self.token.reset();
+        CjkBigramTokenStream {
+            text,
+            chars: text.char_indices().peekable(),
+            token: &mut self.token,
+            position: 0,
+            prev_cjk: None,
+            prev_emitted: false,
+        }
     }
 }

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/jieba.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/jieba.rs
@@ -14,9 +14,13 @@
 
 //! Jieba dictionary-based Chinese segmentation.
 //!
+//! Streaming design: reuses a single `Token` buffer across the entire
+//! token stream, eliminating per-token `String` allocations. ASCII
+//! characters are lowercased inline so the `LowerCaser` filter is not
+//! needed.
+//!
 //! Constructed only via the `tokenizer::build` factory; visibility is
-//! `pub(super)` so callers cannot bypass the LowerCaser filter applied
-//! at factory time.
+//! `pub(super)` so callers cannot bypass the factory.
 
 use std::sync::Arc;
 
@@ -24,12 +28,14 @@ use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
 
 pub(super) struct JiebaTokenizer {
     jieba: Arc<jieba_rs::Jieba>,
+    token: Token,
 }
 
 impl Clone for JiebaTokenizer {
     fn clone(&self) -> Self {
         Self {
             jieba: self.jieba.clone(),
+            token: Token::default(),
         }
     }
 }
@@ -38,56 +44,75 @@ impl Default for JiebaTokenizer {
     fn default() -> Self {
         Self {
             jieba: Arc::new(jieba_rs::Jieba::new()),
+            token: Token::default(),
         }
     }
 }
 
-pub(super) struct JiebaTokenStream {
-    tokens: Vec<Token>,
+pub(super) struct JiebaTokenStream<'a> {
+    /// Raw jieba output — borrows word slices from the input text.
+    words: Vec<jieba_rs::Token<'a>>,
+    text: &'a str,
     index: usize,
+    position: usize,
+    token: &'a mut Token,
 }
 
-impl TokenStream for JiebaTokenStream {
+impl TokenStream for JiebaTokenStream<'_> {
     fn advance(&mut self) -> bool {
-        if self.index < self.tokens.len() {
+        while self.index < self.words.len() {
+            let w = &self.words[self.index];
             self.index += 1;
-            true
-        } else {
-            false
+
+            if w.word.trim().is_empty() {
+                continue;
+            }
+
+            let byte_start = w.word.as_ptr() as usize - self.text.as_ptr() as usize;
+            let byte_end = byte_start + w.word.len();
+
+            // Reuse the token buffer — no allocation.
+            self.token.text.clear();
+            // Inline lowercasing: ASCII chars are lowercased, CJK chars
+            // (and other non-ASCII) pass through unchanged.
+            for c in w.word.chars() {
+                if c.is_ascii() {
+                    self.token.text.push(c.to_ascii_lowercase());
+                } else {
+                    self.token.text.push(c);
+                }
+            }
+            self.token.offset_from = byte_start;
+            self.token.offset_to = byte_end;
+            self.token.position = self.position;
+            self.token.position_length = 1;
+            self.position += 1;
+            return true;
         }
+        false
     }
 
     fn token(&self) -> &Token {
-        &self.tokens[self.index - 1]
+        self.token
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        &mut self.tokens[self.index - 1]
+        self.token
     }
 }
 
 impl Tokenizer for JiebaTokenizer {
-    type TokenStream<'a> = JiebaTokenStream;
+    type TokenStream<'a> = JiebaTokenStream<'a>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         let words = self.jieba.tokenize(text, jieba_rs::TokenizeMode::Search, true);
-        let mut tokens = Vec::with_capacity(words.len());
-        let mut position = 0usize;
-        for w in &words {
-            if w.word.trim().is_empty() {
-                continue;
-            }
-            let byte_start = w.word.as_ptr() as usize - text.as_ptr() as usize;
-            let byte_end = byte_start + w.word.len();
-            tokens.push(Token {
-                offset_from: byte_start,
-                offset_to: byte_end,
-                position,
-                text: w.word.to_owned(),
-                position_length: 1,
-            });
-            position += 1;
+        self.token.reset();
+        JiebaTokenStream {
+            words,
+            text,
+            index: 0,
+            position: 0,
+            token: &mut self.token,
         }
-        JiebaTokenStream { tokens, index: 0 }
     }
 }

--- a/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/mod.rs
+++ b/be/src/storage/index/inverted/tantivy/tantivy-binding/src/safe/tokenizer/mod.rs
@@ -29,6 +29,9 @@ use tantivy::tokenizer::{
     Language, LowerCaser, RawTokenizer, RemoveLongFilter, SimpleTokenizer, StopWordFilter,
     TextAnalyzer,
 };
+// Note: LowerCaser is still imported for english_analyzer().
+// CJK and jieba handle lowercasing inline to avoid the overhead of
+// Unicode case-mapping on CJK characters that have no case.
 
 use crate::error::{Result, TantivyBindingError};
 use cjk_bigram::CjkBigramTokenizer;
@@ -44,11 +47,9 @@ pub const TOKENIZER_NAME: &str = "sr_default";
 pub fn build(name: &str) -> Result<TextAnalyzer> {
     match name {
         TOKENIZER_ENGLISH => Ok(english_analyzer()),
-        TOKENIZER_CJK => Ok(TextAnalyzer::builder(CjkBigramTokenizer)
-            .filter(LowerCaser)
+        TOKENIZER_CJK => Ok(TextAnalyzer::builder(CjkBigramTokenizer::default())
             .build()),
         TOKENIZER_JIEBA => Ok(TextAnalyzer::builder(JiebaTokenizer::default())
-            .filter(LowerCaser)
             .build()),
         TOKENIZER_RAW => Ok(TextAnalyzer::builder(RawTokenizer::default()).build()),
         other => Err(TantivyBindingError::InvalidArgument(format!(

--- a/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.cpp
+++ b/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.cpp
@@ -28,8 +28,16 @@ namespace tb = ::starrocks::tantivy_binding;
 
 namespace {
 
-// Shared pool the tantivy tasks run on. Owned by ExecEnv; borrowed here.
-ThreadPool* g_tantivy_index_pool = nullptr;
+// The two pools the tantivy tasks run on. Owned by ExecEnv; borrowed here.
+//
+// `g_tantivy_build_pool` runs the resident indexing workers (joinable submits);
+// it is an elastic pool that grows a thread per worker on demand.
+// `g_tantivy_merge_pool` runs the transient segment-updater serial queue and
+// merges (detached submits) on a bounded pool. Splitting the two task classes is
+// what prevents the "resident worker starves the maintenance task it waits on"
+// deadlock — see register_tantivy_index_thread_pool in the header.
+ThreadPool* g_tantivy_build_pool = nullptr;
+ThreadPool* g_tantivy_merge_pool = nullptr;
 
 // Join handle backing a joinable submit. A single-count latch flipped when the
 // task finishes; `sr_tantivy_pool_join` waits on it and frees the handle.
@@ -47,20 +55,26 @@ void run_with_tracker(void* task, MemTracker* tracker) {
     tb::tantivy_binding_run_pool_task(task);
 }
 
-// Submit a joinable task. Matches `tantivy_binding::TantivyPoolSubmitFn`.
+// Submit a joinable task (a resident indexing worker). Matches
+// `tantivy_binding::TantivyPoolSubmitFn`. Routed to the elastic build pool so
+// every worker gets a running thread immediately and never sits queued.
 void* sr_tantivy_pool_submit(void* task) {
     MemTracker* tracker = CurrentThread::mem_tracker();
     auto* handle = new PoolJoinHandle();
-    if (g_tantivy_index_pool != nullptr) {
-        auto st = g_tantivy_index_pool->submit_func([task, tracker, handle]() {
+    if (g_tantivy_build_pool != nullptr) {
+        auto st = g_tantivy_build_pool->submit_func([task, tracker, handle]() {
             run_with_tracker(task, tracker);
             handle->latch.count_down();
         });
         if (st.ok()) {
             return handle;
         }
-        LOG(WARNING) << "tantivy: submit joinable task to pool failed: " << st.to_string()
-                     << ", running inline";
+        // Rejection means the elastic pool hit its max_threads cap. Running a
+        // resident worker inline on the caller (a flush thread) would hang that
+        // thread forever, so this path signals a misconfigured cap far more than
+        // it recovers — surface it loudly.
+        LOG(WARNING) << "tantivy: submit worker task to build pool failed: " << st.to_string()
+                     << ", running inline (raise tantivy_index_build_thread_pool_num_threads)";
     }
     // Fallback (pool absent or submit rejected): run inline on the caller thread
     // so tantivy keeps making progress. The caller's tracker is already active.
@@ -69,15 +83,17 @@ void* sr_tantivy_pool_submit(void* task) {
     return handle;
 }
 
-// Submit a fire-and-forget task. Matches `TantivyPoolSubmitDetachedFn`.
+// Submit a fire-and-forget maintenance task (segment-updater serial queue or a
+// merge). Matches `TantivyPoolSubmitDetachedFn`. Routed to the bounded merge
+// pool.
 void sr_tantivy_pool_submit_detached(void* task) {
     MemTracker* tracker = CurrentThread::mem_tracker();
-    if (g_tantivy_index_pool != nullptr) {
-        auto st = g_tantivy_index_pool->submit_func([task, tracker]() { run_with_tracker(task, tracker); });
+    if (g_tantivy_merge_pool != nullptr) {
+        auto st = g_tantivy_merge_pool->submit_func([task, tracker]() { run_with_tracker(task, tracker); });
         if (st.ok()) {
             return;
         }
-        LOG(WARNING) << "tantivy: submit detached task to pool failed: " << st.to_string()
+        LOG(WARNING) << "tantivy: submit maintenance task to merge pool failed: " << st.to_string()
                      << ", running inline";
     }
     tb::tantivy_binding_run_pool_task(task);
@@ -96,8 +112,9 @@ void sr_tantivy_pool_join(void* handle) {
 
 } // namespace
 
-void register_tantivy_index_thread_pool(ThreadPool* pool) {
-    g_tantivy_index_pool = pool;
+void register_tantivy_index_thread_pool(ThreadPool* build_pool, ThreadPool* merge_pool) {
+    g_tantivy_build_pool = build_pool;
+    g_tantivy_merge_pool = merge_pool;
     tb::tantivy_binding_init_thread_pool(&sr_tantivy_pool_submit, &sr_tantivy_pool_submit_detached,
                                          &sr_tantivy_pool_join);
 }

--- a/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.cpp
+++ b/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.cpp
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h"
+
+#include <tantivy_binding.h>
+
+#include "common/logging.h"
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
+#include "util/countdown_latch.h"
+#include "util/threadpool.h"
+
+namespace starrocks {
+
+namespace tb = ::starrocks::tantivy_binding;
+
+namespace {
+
+// Shared pool the tantivy tasks run on. Owned by ExecEnv; borrowed here.
+ThreadPool* g_tantivy_index_pool = nullptr;
+
+// Join handle backing a joinable submit. A single-count latch flipped when the
+// task finishes; `sr_tantivy_pool_join` waits on it and frees the handle.
+struct PoolJoinHandle {
+    CountDownLatch latch{1};
+};
+
+// Run a boxed Rust task with `tracker` installed as the current thread's mem
+// tracker. This is the crux of the fix: the task (allocated on the submitting
+// thread, e.g. a compaction/load thread) is run here on a pool thread with the
+// SAME tracker, so allocations and their matching frees both charge to it —
+// `consume` and `release` no longer land on different trackers.
+void run_with_tracker(void* task, MemTracker* tracker) {
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(tracker);
+    tb::tantivy_binding_run_pool_task(task);
+}
+
+// Submit a joinable task. Matches `tantivy_binding::TantivyPoolSubmitFn`.
+void* sr_tantivy_pool_submit(void* task) {
+    MemTracker* tracker = CurrentThread::mem_tracker();
+    auto* handle = new PoolJoinHandle();
+    if (g_tantivy_index_pool != nullptr) {
+        auto st = g_tantivy_index_pool->submit_func([task, tracker, handle]() {
+            run_with_tracker(task, tracker);
+            handle->latch.count_down();
+        });
+        if (st.ok()) {
+            return handle;
+        }
+        LOG(WARNING) << "tantivy: submit joinable task to pool failed: " << st.to_string()
+                     << ", running inline";
+    }
+    // Fallback (pool absent or submit rejected): run inline on the caller thread
+    // so tantivy keeps making progress. The caller's tracker is already active.
+    tb::tantivy_binding_run_pool_task(task);
+    handle->latch.count_down();
+    return handle;
+}
+
+// Submit a fire-and-forget task. Matches `TantivyPoolSubmitDetachedFn`.
+void sr_tantivy_pool_submit_detached(void* task) {
+    MemTracker* tracker = CurrentThread::mem_tracker();
+    if (g_tantivy_index_pool != nullptr) {
+        auto st = g_tantivy_index_pool->submit_func([task, tracker]() { run_with_tracker(task, tracker); });
+        if (st.ok()) {
+            return;
+        }
+        LOG(WARNING) << "tantivy: submit detached task to pool failed: " << st.to_string()
+                     << ", running inline";
+    }
+    tb::tantivy_binding_run_pool_task(task);
+}
+
+// Wait for a joinable task to finish and release the handle. Matches
+// `TantivyPoolJoinFn`.
+void sr_tantivy_pool_join(void* handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    auto* h = static_cast<PoolJoinHandle*>(handle);
+    h->latch.wait();
+    delete h;
+}
+
+} // namespace
+
+void register_tantivy_index_thread_pool(ThreadPool* pool) {
+    g_tantivy_index_pool = pool;
+    tb::tantivy_binding_init_thread_pool(&sr_tantivy_pool_submit, &sr_tantivy_pool_submit_detached,
+                                         &sr_tantivy_pool_join);
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+
+class ThreadPool;
+
+// Register the shared BE thread pool as tantivy's background-work executor.
+//
+// Call exactly once at BE startup, after `pool` is built and before any tantivy
+// index writer is created. This installs C submit/join callbacks into the Rust
+// binding (via `tantivy_binding_init_thread_pool`) so tantivy's indexing
+// workers, serial segment-updater queue, and merges all run on `pool` instead
+// of tantivy-spawned threads. Each task runs with the submitting thread's mem
+// tracker restored, keeping `consume`/`release` on the same tracker.
+//
+// `pool` must outlive all tantivy index writing (it is owned by ExecEnv).
+void register_tantivy_index_thread_pool(ThreadPool* pool);
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy_ffi_pool_bridge.h
@@ -18,16 +18,30 @@ namespace starrocks {
 
 class ThreadPool;
 
-// Register the shared BE thread pool as tantivy's background-work executor.
+// Register the BE thread pools that back tantivy's background-work executor.
 //
-// Call exactly once at BE startup, after `pool` is built and before any tantivy
-// index writer is created. This installs C submit/join callbacks into the Rust
-// binding (via `tantivy_binding_init_thread_pool`) so tantivy's indexing
-// workers, serial segment-updater queue, and merges all run on `pool` instead
-// of tantivy-spawned threads. Each task runs with the submitting thread's mem
-// tracker restored, keeping `consume`/`release` on the same tracker.
+// Call exactly once at BE startup, after both pools are built and before any
+// tantivy index writer is created. This installs C submit/join callbacks into
+// the Rust binding (via `tantivy_binding_init_thread_pool`) so tantivy's
+// background work runs on these pools instead of tantivy-spawned threads. Each
+// task runs with the submitting thread's mem tracker restored, keeping
+// `consume`/`release` on the same tracker.
 //
-// `pool` must outlive all tantivy index writing (it is owned by ExecEnv).
-void register_tantivy_index_thread_pool(ThreadPool* pool);
+// Two pools are required because tantivy mixes two incompatible task classes:
+//
+//   * `build_pool` runs the RESIDENT indexing workers (joinable submits) that
+//     turn documents into in-memory segments. Each worker holds its thread from
+//     writer creation until commit and blocks on a maintenance task, so it must
+//     be an ELASTIC pool that grows a thread per worker on demand — putting these
+//     on a bounded pool deadlocks once the number of live workers reaches the
+//     pool size (a queued worker never runs, so the commit that joins it, and
+//     the flush that feeds it, hang forever).
+//
+//   * `merge_pool` runs the TRANSIENT segment-updater serial queue (add_segment)
+//     and merges (detached submits). These never block on another task in the
+//     pool, so a bounded pool always drains and safely caps merge concurrency.
+//
+// Both pools must outlive all tantivy index writing (they are owned by ExecEnv).
+void register_tantivy_index_thread_pool(ThreadPool* build_pool, ThreadPool* merge_pool);
 
 } // namespace starrocks

--- a/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
@@ -86,6 +86,7 @@ Status TantivyInvertedWriter::init() {
     tb::RustResult r = tb::tantivy_create_index_writer(
             _temp_dir.c_str(), _field_name.c_str(), _tokenizer.c_str(), _support_phrase, _support_bm25,
             static_cast<uintptr_t>(config::tantivy_writer_memory_budget_bytes),
+            static_cast<uintptr_t>(config::tantivy_writer_num_threads),
             config::tantivy_writer_merge_policy.value().c_str());
     TantivyResultGuard guard(r);
     if (!r.success) {

--- a/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
@@ -29,11 +29,13 @@ namespace starrocks {
 namespace tb = ::starrocks::tantivy_binding;
 
 TantivyInvertedWriter::TantivyInvertedWriter(std::string field_name, std::string temp_dir, std::string tokenizer,
-                                             int64_t index_id)
+                                             int64_t index_id, bool support_phrase, bool support_bm25)
         : _field_name(std::move(field_name)),
           _temp_dir(std::move(temp_dir)),
           _tokenizer(std::move(tokenizer)),
-          _index_id(index_id) {}
+          _index_id(index_id),
+          _support_phrase(support_phrase),
+          _support_bm25(support_bm25) {}
 
 Status TantivyInvertedWriter::create(const TypeInfoPtr& typeinfo, const std::string& field_name,
                                      const std::string& path, TabletIndex* tablet_index,
@@ -52,9 +54,21 @@ Status TantivyInvertedWriter::create(const TypeInfoPtr& typeinfo, const std::str
         return Status::NotSupported("tantivy: unsupported parser '" + parser_str + "'");
     }
 
+    // Read support_phrase / support_bm25 from search properties to control the
+    // tantivy schema: positions (for phrase queries) and fieldnorms (for BM25).
+    const auto& search_props = tablet_index->search_properties();
+    bool support_phrase = true;
+    bool support_bm25 = true;
+    if (auto it = search_props.find("support_phrase"); it != search_props.end()) {
+        support_phrase = (it->second == "true");
+    }
+    if (auto it = search_props.find("support_bm25"); it != search_props.end()) {
+        support_bm25 = (it->second == "true");
+    }
+
     int64_t index_id = tablet_index->index_id();
     auto writer = std::unique_ptr<TantivyInvertedWriter>(
-            new TantivyInvertedWriter(field_name, path, std::move(tokenizer), index_id));
+            new TantivyInvertedWriter(field_name, path, std::move(tokenizer), index_id, support_phrase, support_bm25));
     *res = std::move(writer);
     return Status::OK();
 }
@@ -69,7 +83,8 @@ Status TantivyInvertedWriter::init() {
         return Status::IOError("tantivy: failed to create temp dir '" + _temp_dir + "': " + ec.message());
     }
 
-    tb::RustResult r = tb::tantivy_create_index_writer(_temp_dir.c_str(), _field_name.c_str(), _tokenizer.c_str());
+    tb::RustResult r = tb::tantivy_create_index_writer(_temp_dir.c_str(), _field_name.c_str(), _tokenizer.c_str(),
+                                                       _support_phrase, _support_bm25);
     TantivyResultGuard guard(r);
     if (!r.success) {
         return tantivy_status_from_error(r);

--- a/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.cpp
@@ -83,8 +83,10 @@ Status TantivyInvertedWriter::init() {
         return Status::IOError("tantivy: failed to create temp dir '" + _temp_dir + "': " + ec.message());
     }
 
-    tb::RustResult r = tb::tantivy_create_index_writer(_temp_dir.c_str(), _field_name.c_str(), _tokenizer.c_str(),
-                                                       _support_phrase, _support_bm25);
+    tb::RustResult r = tb::tantivy_create_index_writer(
+            _temp_dir.c_str(), _field_name.c_str(), _tokenizer.c_str(), _support_phrase, _support_bm25,
+            static_cast<uintptr_t>(config::tantivy_writer_memory_budget_bytes),
+            config::tantivy_writer_merge_policy.value().c_str());
     TantivyResultGuard guard(r);
     if (!r.success) {
         return tantivy_status_from_error(r);

--- a/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.h
+++ b/be/src/storage/index/inverted/tantivy/tantivy_inverted_writer.h
@@ -41,12 +41,15 @@ public:
     uint64_t size() const override;
 
 private:
-    TantivyInvertedWriter(std::string field_name, std::string temp_dir, std::string tokenizer, int64_t index_id);
+    TantivyInvertedWriter(std::string field_name, std::string temp_dir, std::string tokenizer, int64_t index_id,
+                          bool support_phrase, bool support_bm25);
 
     std::string _field_name;
     std::string _temp_dir;
     std::string _tokenizer;
     int64_t _index_id = 0;
+    bool _support_phrase = true;
+    bool _support_bm25 = true;
 
     TantivyWriterGuard _writer;
     roaring::Roaring _null_bitmap;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -723,10 +723,9 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
         } else {
             result_ids.resize(_vector_index_ctx->k);
             result_distances.resize(_vector_index_ctx->k);
-            st = _vector_index_ctx->ann_reader->search(_vector_index_ctx->query_view, _vector_index_ctx->k,
-                                                       (result_ids.data()),
-                                                       reinterpret_cast<uint8_t*>(result_distances.data()),
-                                                       &del_id_filter);
+            st = _vector_index_ctx->ann_reader->search(
+                    _vector_index_ctx->query_view, _vector_index_ctx->k, (result_ids.data()),
+                    reinterpret_cast<uint8_t*>(result_distances.data()), &del_id_filter);
         }
     }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -219,6 +219,81 @@ private:
         bool _prune_column_after_index_filter = false;
     };
 
+    // Vector index related context, only created when needed
+    struct VectorIndexContext {
+        VectorIndexContext() = default;
+        ~VectorIndexContext() = default;
+
+        // Vector index parameters
+        int64_t k = 0;
+        bool use_vector_index = false;
+        std::string vector_distance_column_name;
+        int vector_column_id = -1;
+        SlotId vector_slot_id = -1;
+        std::unordered_map<rowid_t, float> id2distance_map;
+        std::map<std::string, std::string> query_params;
+        double vector_range = -1.0;
+        int result_order = 0;
+        bool use_ivfpq = false;
+
+#ifdef WITH_TENANN
+        tenann::PrimitiveSeqView query_view;
+        std::shared_ptr<tenann::IndexMeta> index_meta;
+#endif
+
+        std::shared_ptr<VectorIndexReader> ann_reader;
+
+        bool always_build_rowid() const { return use_vector_index && !use_ivfpq; }
+    };
+
+    // Inverted index related context, only created when needed
+    struct InvertedIndexContext {
+        InvertedIndexContext() = default;
+        ~InvertedIndexContext() = default;
+
+        // Inverted index state
+        bool has_inverted_index = false;
+        std::vector<InvertedIndexIterator*> inverted_index_iterators;
+        std::unordered_set<ColumnId> prune_cols_candidate_by_inverted_index;
+
+        // BM25 score(): mirror of the vector distance path. When requested, the
+        // GIN/tantivy MATCH predicate runs in scoring mode; the per-row BM25 score
+        // (segment-local row id -> score) is captured in _apply_inverted_index and
+        // materialized into the synthetic score output column in _do_get_next.
+        bool bm25_score_requested = false;
+        // -1 = score column not in scan output (count(*)/filter-only); gate still filters.
+        int bm25_score_column_id = -1;
+        SlotId bm25_score_slot_id = 0;
+        int32_t bm25_score_limit = 0;
+        // BM25 score(): inclusive [min, max] gate for a `WHERE score() > c` predicate,
+        // pushed into the scored GIN query; -/+INFINITY = unbounded.
+        float bm25_score_min = -std::numeric_limits<float>::infinity();
+        float bm25_score_max = std::numeric_limits<float>::infinity();
+        std::string bm25_score_column_name;
+        std::unordered_map<rowid_t, float> bm25_score_map;
+
+        // Build rowids only when a score column is actually materialized (>= 0); the
+        // [min,max] gate filters via the inverted-index seek and needs no rowid, so
+        // count(*) / filter-only queries (column id -1) don't build rowids.
+        bool bm25_score_materialized() const { return bm25_score_requested && bm25_score_column_id >= 0; }
+
+        // Build the synthetic BM25 score Field for appending to a chunk.
+        FieldPtr make_bm25_score_field(size_t i) const {
+            return std::make_shared<Field>(i, bm25_score_column_name, get_type_info(TYPE_FLOAT), false);
+        }
+
+        // Cleanup method to properly delete iterators
+        void cleanup() {
+            for (auto* iter : inverted_index_iterators) {
+                if (iter != nullptr) {
+                    delete iter;
+                }
+            }
+            inverted_index_iterators.clear();
+            has_inverted_index = false;
+        }
+    };
+
     Status _init();
     Status _init_internal();
     Status _try_to_update_ranges_by_runtime_filter();
@@ -269,7 +344,6 @@ private:
     Status _encode_to_global_id(ScanContext* ctx);
 
     FieldPtr _make_field(size_t i);
-    FieldPtr _make_bm25_score_field(size_t i);
 
     Status _switch_context(ScanContext* to);
 
@@ -329,7 +403,6 @@ private:
     RawColumnIterators _column_iterators;
     std::vector<int> _io_coalesce_column_index;
     ColumnDecoders _column_decoders;
-    std::shared_ptr<VectorIndexReader> _ann_reader;
     BitmapIndexEvaluator _bitmap_index_evaluator;
     // delete predicates
     std::map<ColumnId, ColumnOrPredicate> _del_predicates;
@@ -377,53 +450,22 @@ private:
     int _reserve_chunk_size = 0;
 
     bool _inited = false;
-    bool _has_inverted_index = false;
-
-    std::vector<InvertedIndexIterator*> _inverted_index_iterators;
 
     std::unordered_map<ColumnId, ColumnAccessPath*> _column_access_paths;
     std::unordered_map<ColumnId, ColumnAccessPath*> _predicate_column_access_paths;
 
-    std::unordered_set<ColumnId> _prune_cols_candidate_by_inverted_index;
-
-    // vector index params
-    int64_t _k;
-#ifdef WITH_TENANN
-    tenann::PrimitiveSeqView _query_view;
-    std::shared_ptr<tenann::IndexMeta> _index_meta;
-#endif
+    // Vector index context - only created when needed
+    std::unique_ptr<VectorIndexContext> _vector_index_ctx;
+    // Inverted index context - only created when needed
+    std::unique_ptr<InvertedIndexContext> _inverted_index_ctx;
 
     // Build rowids only when a score column is actually materialized (>= 0); the
     // [min,max] gate filters via the inverted-index seek and needs no rowid, so
     // count(*) / filter-only queries (column id -1) don't build rowids.
-    bool _bm25_score_materialized() const { return _bm25_score_requested && _bm25_score_column_id >= 0; }
-    bool _always_build_rowid() const { return (_use_vector_index && !_use_ivfpq) || _bm25_score_materialized(); }
-
-    bool _use_vector_index;
-    std::string _vector_distance_column_name;
-    int _vector_column_id;
-    SlotId _vector_slot_id;
-    std::unordered_map<rowid_t, float> _id2distance_map;
-    std::map<std::string, std::string> _query_params;
-    double _vector_range;
-    int _result_order;
-    bool _use_ivfpq;
-
-    // BM25 score(): mirror of the vector distance path. When requested, the
-    // GIN/tantivy MATCH predicate runs in scoring mode; the per-row BM25 score
-    // (segment-local row id -> score) is captured in _apply_inverted_index and
-    // materialized into the synthetic score output column in _do_get_next.
-    bool _bm25_score_requested = false;
-    // -1 = score column not in scan output (count(*)/filter-only); gate still filters.
-    int _bm25_score_column_id = -1;
-    SlotId _bm25_score_slot_id = 0;
-    int32_t _bm25_score_limit = 0;
-    // BM25 score(): inclusive [min, max] gate for a `WHERE score() > c` predicate,
-    // pushed into the scored GIN query; -/+INFINITY = unbounded.
-    float _bm25_score_min = -std::numeric_limits<float>::infinity();
-    float _bm25_score_max = std::numeric_limits<float>::infinity();
-    std::string _bm25_score_column_name;
-    std::unordered_map<rowid_t, float> _bm25_score_map;
+    bool _always_build_rowid() const {
+        return (_vector_index_ctx && _vector_index_ctx->always_build_rowid()) ||
+               (_inverted_index_ctx && _inverted_index_ctx->bm25_score_materialized());
+    }
 
     Status _init_reader_from_file(const std::string& index_path, const std::shared_ptr<TabletIndex>& tablet_index_meta,
                                   const std::map<std::string, std::string>& query_params);
@@ -434,41 +476,45 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, Schema schema
           _segment(std::move(segment)),
           _opts(std::move(options)),
           _bitmap_index_evaluator(_schema, _opts.pred_tree),
-          _predicate_columns(_opts.pred_tree.num_columns()),
-          _use_vector_index(_opts.use_vector_index) {
-    if (_use_vector_index) {
+          _predicate_columns(_opts.pred_tree.num_columns()) {
+    if (_opts.use_vector_index) {
+        _vector_index_ctx = std::make_unique<VectorIndexContext>();
+        _vector_index_ctx->use_vector_index = true;
         // The K in front of Fe is long, which can be changed to uint32. This can be a problem,
         // but this k is wasted memory allocation, so it should not exceed the accuracy of uint32
         // options.query_vector is a string, passed to tenann as a float string, see if you need to use the stof function to convert
         // and consider precision loss
-        _vector_distance_column_name = _opts.vector_search_option->vector_distance_column_name;
-        _vector_column_id = _opts.vector_search_option->vector_column_id;
-        _vector_slot_id = _opts.vector_search_option->vector_slot_id;
-        _vector_range = _opts.vector_search_option->vector_range;
-        _result_order = _opts.vector_search_option->result_order;
-        _use_ivfpq = _opts.vector_search_option->use_ivfpq;
-        _query_params = _opts.vector_search_option->query_params;
-        if (_vector_range >= 0 && _use_ivfpq) {
-            _k = _opts.vector_search_option->k * _opts.vector_search_option->pq_refine_factor *
-                 _opts.vector_search_option->k_factor;
+        _vector_index_ctx->vector_distance_column_name = _opts.vector_search_option->vector_distance_column_name;
+        _vector_index_ctx->vector_column_id = _opts.vector_search_option->vector_column_id;
+        _vector_index_ctx->vector_slot_id = _opts.vector_search_option->vector_slot_id;
+        _vector_index_ctx->vector_range = _opts.vector_search_option->vector_range;
+        _vector_index_ctx->result_order = _opts.vector_search_option->result_order;
+        _vector_index_ctx->use_ivfpq = _opts.vector_search_option->use_ivfpq;
+        _vector_index_ctx->query_params = _opts.vector_search_option->query_params;
+        if (_vector_index_ctx->vector_range >= 0 && _vector_index_ctx->use_ivfpq) {
+            _vector_index_ctx->k = _opts.vector_search_option->k * _opts.vector_search_option->pq_refine_factor *
+                                   _opts.vector_search_option->k_factor;
         } else {
-            _k = _opts.vector_search_option->k * _opts.vector_search_option->k_factor;
+            _vector_index_ctx->k = _opts.vector_search_option->k * _opts.vector_search_option->k_factor;
         }
 #ifdef WITH_TENANN
-        _query_view = tenann::PrimitiveSeqView{
+        _vector_index_ctx->query_view = tenann::PrimitiveSeqView{
                 .data = reinterpret_cast<uint8_t*>(_opts.vector_search_option->query_vector.data()),
                 .size = static_cast<uint32_t>(_opts.vector_search_option->query_vector.size()),
                 .elem_type = tenann::PrimitiveType::kFloatType};
 #endif
     }
     if (_opts.use_bm25_score) {
-        _bm25_score_requested = true;
-        _bm25_score_column_id = _opts.bm25_score_column_id;
-        _bm25_score_slot_id = _opts.bm25_score_slot_id;
-        _bm25_score_column_name = _opts.bm25_score_column_name;
-        _bm25_score_limit = _opts.bm25_score_limit;
-        _bm25_score_min = _opts.bm25_score_min;
-        _bm25_score_max = _opts.bm25_score_max;
+        if (!_inverted_index_ctx) {
+            _inverted_index_ctx = std::make_unique<InvertedIndexContext>();
+        }
+        _inverted_index_ctx->bm25_score_requested = true;
+        _inverted_index_ctx->bm25_score_column_id = _opts.bm25_score_column_id;
+        _inverted_index_ctx->bm25_score_slot_id = _opts.bm25_score_slot_id;
+        _inverted_index_ctx->bm25_score_column_name = _opts.bm25_score_column_name;
+        _inverted_index_ctx->bm25_score_limit = _opts.bm25_score_limit;
+        _inverted_index_ctx->bm25_score_min = _opts.bm25_score_min;
+        _inverted_index_ctx->bm25_score_max = _opts.bm25_score_max;
     }
     // For small segment file (the number of rows is less than chunk_size),
     // the segment iterator will reserve a large amount of memory,
@@ -604,12 +650,13 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
                                                       const std::map<std::string, std::string>& query_params) {
 #ifdef WITH_TENANN
     ASSIGN_OR_RETURN(auto meta, get_vector_meta(tablet_index_meta, query_params))
-    _index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
-    RETURN_IF_ERROR(VectorIndexReaderFactory::create_from_file(index_path, _index_meta, &_ann_reader));
-    auto status = _ann_reader->init_searcher(*_index_meta.get(), index_path);
+    _vector_index_ctx->index_meta = std::make_shared<tenann::IndexMeta>(std::move(meta));
+    RETURN_IF_ERROR(VectorIndexReaderFactory::create_from_file(index_path, _vector_index_ctx->index_meta,
+                                                               &_vector_index_ctx->ann_reader));
+    auto status = _vector_index_ctx->ann_reader->init_searcher(*_vector_index_ctx->index_meta.get(), index_path);
     // means empty ann reader
     if (status.is_not_supported()) {
-        _use_vector_index = false;
+        _vector_index_ctx->use_vector_index = false;
         return Status::OK();
     }
     return status;
@@ -620,7 +667,7 @@ inline Status SegmentIterator::_init_reader_from_file(const std::string& index_p
 
 Status SegmentIterator::_init_ann_reader() {
 #ifdef WITH_TENANN
-    RETURN_IF(!_use_vector_index, Status::OK());
+    RETURN_IF(!_vector_index_ctx || !_vector_index_ctx->use_vector_index, Status::OK());
     std::unordered_map<int32_t, TabletIndex> col_map_index;
     for (const auto& index : *_segment->tablet_schema().indexes()) {
         if (index.index_type() == VECTOR) {
@@ -647,7 +694,7 @@ Status SegmentIterator::_init_ann_reader() {
     std::string index_path = IndexDescriptor::vector_index_file_path(_opts.rowset_path, _opts.rowsetid.to_string(),
                                                                      segment_id(), tablet_index_meta->index_id());
 
-    return _init_reader_from_file(index_path, tablet_index_meta, _query_params);
+    return _init_reader_from_file(index_path, tablet_index_meta, _vector_index_ctx->query_params);
 #else
     return Status::OK();
 #endif
@@ -655,7 +702,7 @@ Status SegmentIterator::_init_ann_reader() {
 
 Status SegmentIterator::_get_row_ranges_by_vector_index() {
 #ifdef WITH_TENANN
-    RETURN_IF(!_use_vector_index, Status::OK());
+    RETURN_IF(!_vector_index_ctx || !_vector_index_ctx->use_vector_index, Status::OK());
     RETURN_IF(_scan_range.empty(), Status::OK());
 
     SCOPED_RAW_TIMER(&_opts.stats->get_row_ranges_by_vector_index_timer);
@@ -669,14 +716,17 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
 
     {
         SCOPED_RAW_TIMER(&_opts.stats->vector_search_timer);
-        if (_vector_range >= 0) {
-            st = _ann_reader->range_search(_query_view, _k, &result_ids, &result_distances, &del_id_filter,
-                                           static_cast<float>(_vector_range), _result_order);
+        if (_vector_index_ctx->vector_range >= 0) {
+            st = _vector_index_ctx->ann_reader->range_search(
+                    _vector_index_ctx->query_view, _vector_index_ctx->k, &result_ids, &result_distances, &del_id_filter,
+                    static_cast<float>(_vector_index_ctx->vector_range), _vector_index_ctx->result_order);
         } else {
-            result_ids.resize(_k);
-            result_distances.resize(_k);
-            st = _ann_reader->search(_query_view, _k, (result_ids.data()),
-                                     reinterpret_cast<uint8_t*>(result_distances.data()), &del_id_filter);
+            result_ids.resize(_vector_index_ctx->k);
+            result_distances.resize(_vector_index_ctx->k);
+            st = _vector_index_ctx->ann_reader->search(_vector_index_ctx->query_view, _vector_index_ctx->k,
+                                                       (result_ids.data()),
+                                                       reinterpret_cast<uint8_t*>(result_distances.data()),
+                                                       &del_id_filter);
         }
     }
 
@@ -706,9 +756,10 @@ Status SegmentIterator::_get_row_ranges_by_vector_index() {
         }
     }
 
-    _id2distance_map.reserve(filtered_result_ids.size());
+    _vector_index_ctx->id2distance_map.reserve(filtered_result_ids.size());
     for (size_t i = 0; i < filtered_result_ids.size(); i++) {
-        _id2distance_map[static_cast<rowid_t>(filtered_result_ids[i])] = id2distance_map[filtered_result_ids[i]];
+        _vector_index_ctx->id2distance_map[static_cast<rowid_t>(filtered_result_ids[i])] =
+                id2distance_map[filtered_result_ids[i]];
     }
     return Status::OK();
 #else
@@ -1608,13 +1659,13 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         chunk = _context->_adapt_global_dict_chunk.get();
     }
 
-    if (_use_vector_index && !_use_ivfpq) {
+    if (_vector_index_ctx && _vector_index_ctx->always_build_rowid()) {
         DCHECK(rowid != nullptr);
         FloatColumn::MutablePtr distance_column = FloatColumn::create();
         vector<rowid_t> rowids;
         for (const auto& rid : *rowid) {
-            auto it = _id2distance_map.find(rid);
-            if (LIKELY(it != _id2distance_map.end())) {
+            auto it = _vector_index_ctx->id2distance_map.find(rid);
+            if (LIKELY(it != _vector_index_ctx->id2distance_map.end())) {
                 rowids.emplace_back(it->first);
             } else {
                 DCHECK(false) << "not found row id:" << rid << " in distance map";
@@ -1622,22 +1673,25 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
             }
         }
         for (const auto& vrid : rowids) {
-            distance_column->append(_id2distance_map[vrid]);
+            distance_column->append(_vector_index_ctx->id2distance_map[vrid]);
         }
 
         // TODO: plan vector column in FE Planner
-        chunk->append_vector_column(std::move(distance_column), _make_field(_vector_column_id), _vector_slot_id);
+        chunk->append_vector_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
+                                    _vector_index_ctx->vector_slot_id);
     }
 
-    if (_bm25_score_materialized()) {
+    if (_inverted_index_ctx && _inverted_index_ctx->bm25_score_materialized()) {
         DCHECK(rowid != nullptr);
         FloatColumn::MutablePtr score_column = FloatColumn::create();
         for (const auto& rid : *rowid) {
-            auto it = _bm25_score_map.find(rid);
-            score_column->append(it != _bm25_score_map.end() ? it->second : 0.0f);
+            auto it = _inverted_index_ctx->bm25_score_map.find(rid);
+            score_column->append(it != _inverted_index_ctx->bm25_score_map.end() ? it->second : 0.0f);
         }
-        chunk->append_vector_column(std::move(score_column), _make_bm25_score_field(_bm25_score_column_id),
-                                    _bm25_score_slot_id);
+        chunk->append_vector_column(
+                std::move(score_column),
+                _inverted_index_ctx->make_bm25_score_field(_inverted_index_ctx->bm25_score_column_id),
+                _inverted_index_ctx->bm25_score_slot_id);
     }
 
     result->swap_chunk(*chunk);
@@ -1650,11 +1704,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
 }
 
 FieldPtr SegmentIterator::_make_field(size_t i) {
-    return std::make_shared<Field>(i, _vector_distance_column_name, get_type_info(TYPE_FLOAT), false);
-}
-
-FieldPtr SegmentIterator::_make_bm25_score_field(size_t i) {
-    return std::make_shared<Field>(i, _bm25_score_column_name, get_type_info(TYPE_FLOAT), false);
+    return std::make_shared<Field>(i, _vector_index_ctx->vector_distance_column_name, get_type_info(TYPE_FLOAT), false);
 }
 
 Status SegmentIterator::_switch_context(ScanContext* to) {
@@ -1844,9 +1894,9 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
             ctx->_skip_dict_decode_indexes.push_back(false);
         } else {
             ctx->_skip_dict_decode_indexes.push_back(true);
-            if (_prune_cols_candidate_by_inverted_index.count(f->id())) {
+            if (_inverted_index_ctx && _inverted_index_ctx->prune_cols_candidate_by_inverted_index.count(f->id())) {
                 // The column is pruneable if and only if:
-                // 1. column in _prune_cols_candidate_by_inverted_index
+                // 1. column in prune_cols_candidate_by_inverted_index
                 // 2. column not in output schema
                 // 3. column is not one of the delete predicate columns
                 // 4. column must not be dict decoded when the read is finished
@@ -2334,7 +2384,11 @@ Status SegmentIterator::_apply_del_vector() {
 }
 
 Status SegmentIterator::_init_inverted_index_iterators() {
-    _inverted_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
+    if (!_inverted_index_ctx) {
+        _inverted_index_ctx = std::make_unique<InvertedIndexContext>();
+    }
+    auto& inverted_index_iterators = _inverted_index_ctx->inverted_index_iterators;
+    inverted_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
     std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
 
     for (auto& field : _schema.fields()) {
@@ -2352,10 +2406,10 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         index_opts.stats = _opts.stats;
         index_opts.segment_rows = num_rows();
 
-        if (_inverted_index_iterators[cid] == nullptr) {
+        if (inverted_index_iterators[cid] == nullptr) {
             RETURN_IF_ERROR(
-                    _segment->new_inverted_index_iterator(ucid, &_inverted_index_iterators[cid], _opts, index_opts));
-            _has_inverted_index |= (_inverted_index_iterators[cid] != nullptr);
+                    _segment->new_inverted_index_iterator(ucid, &inverted_index_iterators[cid], _opts, index_opts));
+            _inverted_index_ctx->has_inverted_index |= (inverted_index_iterators[cid] != nullptr);
         }
     }
     return Status::OK();
@@ -2366,9 +2420,10 @@ Status SegmentIterator::_apply_inverted_index() {
     RETURN_IF(!_opts.enable_gin_filter, Status::OK());
 
     RETURN_IF_ERROR(_init_inverted_index_iterators());
-    RETURN_IF(!_has_inverted_index, Status::OK());
+    RETURN_IF(!_inverted_index_ctx->has_inverted_index, Status::OK());
     SCOPED_RAW_TIMER(&_opts.stats->gin_index_filter_ns);
 
+    auto& inverted_index_iterators = _inverted_index_ctx->inverted_index_iterators;
     roaring::Roaring row_bitmap = range2roaring(_scan_range);
     size_t input_rows = row_bitmap.cardinality();
     std::unordered_set<const ColumnPredicate*> erased_preds;
@@ -2380,7 +2435,7 @@ Status SegmentIterator::_apply_inverted_index() {
     }
 
     for (const auto& [cid, pred_list] : _opts.pred_tree.get_immediate_column_predicate_map()) {
-        InvertedIndexIterator* inverted_iter = _inverted_index_iterators[cid];
+        InvertedIndexIterator* inverted_iter = inverted_index_iterators[cid];
         if (inverted_iter == nullptr) {
             continue;
         }
@@ -2388,17 +2443,19 @@ Status SegmentIterator::_apply_inverted_index() {
         RETURN_IF(it == cid_2_fid.end(),
                   Status::InternalError(strings::Substitute("No fid can be mapped by cid $0", cid)));
         std::string column_name(_schema.field(it->second)->name());
-        if (_bm25_score_requested) {
+        if (_inverted_index_ctx->bm25_score_requested) {
             // Push the SQL LIMIT into the scored GIN query so tantivy returns only
             // the top-k rows (see InvertedIndexIterator::set_bm25_topk_limit).
-            _inverted_index_iterators[cid]->set_bm25_topk_limit(_bm25_score_limit);
+            inverted_index_iterators[cid]->set_bm25_topk_limit(_inverted_index_ctx->bm25_score_limit);
             // Push the WHERE score() >/< c threshold so tantivy gates hits by score.
-            _inverted_index_iterators[cid]->set_bm25_score_range(_bm25_score_min, _bm25_score_max);
+            inverted_index_iterators[cid]->set_bm25_score_range(_inverted_index_ctx->bm25_score_min,
+                                                                _inverted_index_ctx->bm25_score_max);
         }
         for (const ColumnPredicate* pred : pred_list) {
-            if (_inverted_index_iterators[cid]->is_untokenized() || pred->type() == PredicateType::kExpr) {
-                Status res = pred->seek_inverted_index(column_name, _inverted_index_iterators[cid], &row_bitmap,
-                                                       _bm25_score_requested ? &_bm25_score_map : nullptr);
+            if (inverted_index_iterators[cid]->is_untokenized() || pred->type() == PredicateType::kExpr) {
+                Status res = pred->seek_inverted_index(
+                        column_name, inverted_index_iterators[cid], &row_bitmap,
+                        _inverted_index_ctx->bm25_score_requested ? &_inverted_index_ctx->bm25_score_map : nullptr);
                 if (res.ok()) {
                     erased_preds.emplace(pred);
                     erased_pred_col_ids.emplace(cid);
@@ -2423,12 +2480,12 @@ Status SegmentIterator::_apply_inverted_index() {
             if (!new_cid_to_predicates.contains(cid)) {
                 // predicate for pred->column_id() has been total erased by
                 // inverted index filtering.These columns may can be pruned.
-                _prune_cols_candidate_by_inverted_index.insert(cid);
+                _inverted_index_ctx->prune_cols_candidate_by_inverted_index.insert(cid);
             }
         }
     }
 
-    for (auto* iter : _inverted_index_iterators) {
+    for (auto* iter : inverted_index_iterators) {
         if (iter != nullptr) {
             RETURN_IF_ERROR(iter->close());
         }
@@ -2656,10 +2713,8 @@ void SegmentIterator::close() {
 
     _bitmap_index_evaluator.close();
 
-    for (auto* iter : _inverted_index_iterators) {
-        if (iter != nullptr) {
-            delete iter;
-        }
+    if (_inverted_index_ctx) {
+        _inverted_index_ctx->cleanup();
     }
 }
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -374,6 +374,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(compact_pool);
     METRICS_DEFINE_THREAD_POOL(pindex_load);
     METRICS_DEFINE_THREAD_POOL(tantivy_index_build);
+    METRICS_DEFINE_THREAD_POOL(tantivy_index_merge);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
 

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -373,6 +373,7 @@ public:
     METRICS_DEFINE_THREAD_POOL(pk_index_compaction);
     METRICS_DEFINE_THREAD_POOL(compact_pool);
     METRICS_DEFINE_THREAD_POOL(pindex_load);
+    METRICS_DEFINE_THREAD_POOL(tantivy_index_build);
     METRICS_DEFINE_THREAD_POOL(exec_state_report);
     METRICS_DEFINE_THREAD_POOL(priority_exec_state_report);
 

--- a/be/test/storage/index/inverted/tantivy/tantivy_compaction_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_compaction_test.cpp
@@ -56,6 +56,7 @@ CompoundIndexEntry write_segment_index(const std::string& index_dir, const std::
     TypeInfoPtr typeinfo = get_type_info(TYPE_VARCHAR);
     TabletIndex tablet_index;
     tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+    tablet_index.add_index_properties("parser", "english");
 
     std::unique_ptr<InvertedWriter> writer;
     EXPECT_OK(TantivyPlugin::get_instance().create_inverted_index_writer(typeinfo, "content", index_dir, &tablet_index,
@@ -100,6 +101,7 @@ std::unique_ptr<TantivyInvertedReader> open_compound_reader(const std::string& b
     auto fs = FileSystem::Default();
     TabletIndex ti;
     ti.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+    ti.add_index_properties("parser", "english");
     auto ti_sp = std::make_shared<TabletIndex>(ti);
     std::unique_ptr<InvertedReader> reader;
     EXPECT_OK(TantivyPlugin::get_instance().create_inverted_index_reader(dummy_dir, ti_sp, TYPE_VARCHAR, &reader));

--- a/be/test/storage/index/inverted/tantivy/tantivy_compound_reader_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_compound_reader_test.cpp
@@ -56,6 +56,7 @@ CompoundIndexEntry write_and_pack(const std::string& index_dir, const std::vecto
     TypeInfoPtr typeinfo = get_type_info(TYPE_VARCHAR);
     TabletIndex tablet_index;
     tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+    tablet_index.add_index_properties("parser", "english");
 
     std::unique_ptr<InvertedWriter> writer;
     EXPECT_OK(TantivyPlugin::get_instance().create_inverted_index_writer(typeinfo, "content", index_dir, &tablet_index,
@@ -125,6 +126,7 @@ TEST(TantivyCompoundReaderTest, FullRoundTrip) {
     // Create tantivy reader and load via compound path.
     TabletIndex tablet_index;
     tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+    tablet_index.add_index_properties("parser", "english");
     auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
     std::unique_ptr<InvertedReader> reader;
     ASSERT_OK(TantivyPlugin::get_instance().create_inverted_index_reader(index_dir, tablet_index_sp, TYPE_VARCHAR,
@@ -230,6 +232,7 @@ TEST(TantivyCompoundReaderTest, MultipleIndexesInOneBin) {
 
         TabletIndex ti;
         ti.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+        ti.add_index_properties("parser", "english");
         auto ti_sp = std::make_shared<TabletIndex>(ti);
         std::unique_ptr<InvertedReader> reader;
         ASSERT_OK(TantivyPlugin::get_instance().create_inverted_index_reader(idx0_dir, ti_sp, TYPE_VARCHAR, &reader));
@@ -253,6 +256,7 @@ TEST(TantivyCompoundReaderTest, MultipleIndexesInOneBin) {
 
         TabletIndex ti;
         ti.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+        ti.add_index_properties("parser", "english");
         auto ti_sp = std::make_shared<TabletIndex>(ti);
         std::unique_ptr<InvertedReader> reader;
         ASSERT_OK(TantivyPlugin::get_instance().create_inverted_index_reader(idx1_dir, ti_sp, TYPE_VARCHAR, &reader));

--- a/be/test/storage/index/inverted/tantivy/tantivy_plugin_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_plugin_test.cpp
@@ -90,8 +90,10 @@ TEST(TantivyPluginTest, WriteAndFinishCompound) {
     TabletIndex tablet_index;
     tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
 
+    std::string idx_dir = temp_dir + "/index";
+
     std::unique_ptr<InvertedWriter> writer;
-    ASSERT_OK(plugin->create_inverted_index_writer(typeinfo, "content", temp_dir, &tablet_index, &writer));
+    ASSERT_OK(plugin->create_inverted_index_writer(typeinfo, "content", idx_dir, &tablet_index, &writer));
     ASSERT_OK(writer->init());
 
     // Add some values.
@@ -144,11 +146,14 @@ TEST(TantivyPluginTest, ReadAfterWrite) {
     TypeInfoPtr typeinfo = get_type_info(TYPE_VARCHAR);
     TabletIndex tablet_index;
     tablet_index.add_common_properties(INVERTED_IMP_KEY, TYPE_TANTIVY);
+    tablet_index.add_index_properties("parser", "english");
+
+    std::string idx_dir = temp_dir + "/index";
 
     // Write phase.
     {
         std::unique_ptr<InvertedWriter> writer;
-        ASSERT_OK(plugin->create_inverted_index_writer(typeinfo, "content", temp_dir, &tablet_index, &writer));
+        ASSERT_OK(plugin->create_inverted_index_writer(typeinfo, "content", idx_dir, &tablet_index, &writer));
         ASSERT_OK(writer->init());
 
         Slice slices[] = {Slice("the quick brown fox"), Slice("lazy brown dog"), Slice("quick fox jumps")};
@@ -162,7 +167,7 @@ TEST(TantivyPluginTest, ReadAfterWrite) {
     // Read phase — load from the same local directory.
     auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
     std::unique_ptr<InvertedReader> reader;
-    ASSERT_OK(plugin->create_inverted_index_reader(temp_dir, tablet_index_sp, TYPE_VARCHAR, &reader));
+    ASSERT_OK(plugin->create_inverted_index_reader(idx_dir, tablet_index_sp, TYPE_VARCHAR, &reader));
 
     IndexReadOptions opts;
     ASSERT_OK(reader->load(opts, nullptr));

--- a/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
@@ -71,8 +71,7 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 }
 
 // Build a writer at `index_path`, append `docs` in order, commit, and free.
-void build_index(const std::string& index_path, const std::string& field,
-                 const std::vector<std::string>& docs) {
+void build_index(const std::string& index_path, const std::string& field, const std::vector<std::string>& docs) {
     tb::RustResult cw =
             tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "english", true, true, 0, 0, "default");
     RustResultGuard g_cw{cw};
@@ -265,8 +264,8 @@ TEST(TantivySmoke, NullPlaceholdersPreserveAlignment) {
 
 TEST(TantivySmoke, CreateWriterReportsError) {
     // /proc is read-only on Linux, so create_dir_all + index init should fail.
-    tb::RustResult r = tb::tantivy_create_index_writer("/proc/sr_tantivy_should_fail", "title",
-                                                       "english", true, true, 0, 0, "default");
+    tb::RustResult r = tb::tantivy_create_index_writer("/proc/sr_tantivy_should_fail", "title", "english", true, true,
+                                                       0, 0, "default");
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     EXPECT_NE(r.error, nullptr);
@@ -286,8 +285,8 @@ TEST(TantivySmoke, UnsupportedTokenizerReportsError) {
         }
     } cleanup{index_path};
 
-    tb::RustResult r =
-            tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer", true, true, 0, 0, "default");
+    tb::RustResult r = tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer", true,
+                                                       true, 0, 0, "default");
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     ASSERT_NE(r.error, nullptr);

--- a/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
@@ -71,8 +71,10 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 }
 
 // Build a writer at `index_path`, append `docs` in order, commit, and free.
-void build_index(const std::string& index_path, const std::string& field, const std::vector<std::string>& docs) {
-    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "english");
+void build_index(const std::string& index_path, const std::string& field,
+                 const std::vector<std::string>& docs) {
+    tb::RustResult cw =
+            tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "english", true, true);
     RustResultGuard g_cw{cw};
     ASSERT_TRUE(cw.success) << "create_index_writer: " << (cw.error ? cw.error : "?");
     void* writer = cw.value.ptr;
@@ -263,7 +265,8 @@ TEST(TantivySmoke, NullPlaceholdersPreserveAlignment) {
 
 TEST(TantivySmoke, CreateWriterReportsError) {
     // /proc is read-only on Linux, so create_dir_all + index init should fail.
-    tb::RustResult r = tb::tantivy_create_index_writer("/proc/sr_tantivy_should_fail", "title", "english");
+    tb::RustResult r = tb::tantivy_create_index_writer("/proc/sr_tantivy_should_fail", "title",
+                                                       "english", true, true);
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     EXPECT_NE(r.error, nullptr);
@@ -283,7 +286,8 @@ TEST(TantivySmoke, UnsupportedTokenizerReportsError) {
         }
     } cleanup{index_path};
 
-    tb::RustResult r = tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer");
+    tb::RustResult r =
+            tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer", true, true);
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     ASSERT_NE(r.error, nullptr);

--- a/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_smoke_test.cpp
@@ -74,7 +74,7 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 void build_index(const std::string& index_path, const std::string& field,
                  const std::vector<std::string>& docs) {
     tb::RustResult cw =
-            tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "english", true, true);
+            tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "english", true, true, 0, 0, "default");
     RustResultGuard g_cw{cw};
     ASSERT_TRUE(cw.success) << "create_index_writer: " << (cw.error ? cw.error : "?");
     void* writer = cw.value.ptr;
@@ -266,7 +266,7 @@ TEST(TantivySmoke, NullPlaceholdersPreserveAlignment) {
 TEST(TantivySmoke, CreateWriterReportsError) {
     // /proc is read-only on Linux, so create_dir_all + index init should fail.
     tb::RustResult r = tb::tantivy_create_index_writer("/proc/sr_tantivy_should_fail", "title",
-                                                       "english", true, true);
+                                                       "english", true, true, 0, 0, "default");
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     EXPECT_NE(r.error, nullptr);
@@ -287,7 +287,7 @@ TEST(TantivySmoke, UnsupportedTokenizerReportsError) {
     } cleanup{index_path};
 
     tb::RustResult r =
-            tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer", true, true);
+            tb::tantivy_create_index_writer(index_path.c_str(), "f", "definitely_not_a_tokenizer", true, true, 0, 0, "default");
     RustResultGuard g{r};
     EXPECT_FALSE(r.success);
     ASSERT_NE(r.error, nullptr);

--- a/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
@@ -64,7 +64,7 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 void build_index_raw(const std::string& index_path, const std::string& field, const std::vector<std::string>& docs) {
     // tokenizer="raw" → no tokenization, term dict equals the original strings.
     // This gives the wildcard FFI parser=none semantics.
-    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw");
+    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw", true, true);
     RustResultGuard g_cw{cw};
     ASSERT_TRUE(cw.success) << "create_index_writer: " << (cw.error ? cw.error : "?");
     void* writer = cw.value.ptr;

--- a/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
@@ -64,7 +64,7 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 void build_index_raw(const std::string& index_path, const std::string& field, const std::vector<std::string>& docs) {
     // tokenizer="raw" → no tokenization, term dict equals the original strings.
     // This gives the wildcard FFI parser=none semantics.
-    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw", true, true);
+    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw", true, true, 0, 0, "default");
     RustResultGuard g_cw{cw};
     ASSERT_TRUE(cw.success) << "create_index_writer: " << (cw.error ? cw.error : "?");
     void* writer = cw.value.ptr;

--- a/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
+++ b/be/test/storage/index/inverted/tantivy/tantivy_wildcard_test.cpp
@@ -64,7 +64,8 @@ std::vector<uint32_t> array_to_vector(const tb::RustU32Array& arr) {
 void build_index_raw(const std::string& index_path, const std::string& field, const std::vector<std::string>& docs) {
     // tokenizer="raw" → no tokenization, term dict equals the original strings.
     // This gives the wildcard FFI parser=none semantics.
-    tb::RustResult cw = tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw", true, true, 0, 0, "default");
+    tb::RustResult cw =
+            tb::tantivy_create_index_writer(index_path.c_str(), field.c_str(), "raw", true, true, 0, 0, "default");
     RustResultGuard g_cw{cw};
     ASSERT_TRUE(cw.success) << "create_index_writer: " << (cw.error ? cw.error : "?");
     void* writer = cw.value.ptr;

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InvertedIndexUtil.java
@@ -144,12 +144,14 @@ public class InvertedIndexUtil {
         // add default properties
         addDefaultProperties(properties);
 
-        // Tantivy-specific: ensure support_phrase is always present so that
-        // SHOW CREATE TABLE displays it for tantivy indexes.
+        // Tantivy-specific: ensure support_phrase and support_bm25 are always present
+        // so that SHOW CREATE TABLE displays them for tantivy indexes.
         String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
         if (TANTIVY.name().equalsIgnoreCase(impValue)) {
             String spKey = InvertedIndexParams.SearchParamsKey.SUPPORT_PHRASE.name().toLowerCase(Locale.ROOT);
-            properties.putIfAbsent(spKey, "false");
+            properties.putIfAbsent(spKey, "true");
+            String bm25Key = InvertedIndexParams.SearchParamsKey.SUPPORT_BM25.name().toLowerCase(Locale.ROOT);
+            properties.putIfAbsent(bm25Key, "true");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
@@ -103,9 +103,9 @@ public class IndexParams {
         register(builder, IndexType.GIN, IndexParamType.SEARCH, InvertedIndexParams.SearchParamsKey.RERANK, false, false,
                 "false", null);
         register(builder, IndexType.GIN, IndexParamType.SEARCH, InvertedIndexParams.SearchParamsKey.SUPPORT_PHRASE, false, false,
-                "false", null);
+                "true", null);
         register(builder, IndexType.GIN, IndexParamType.SEARCH, InvertedIndexParams.SearchParamsKey.SUPPORT_BM25, false, false,
-                "false", null);
+                "true", null);
 
         /* NGramFilter */
         // index

--- a/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
@@ -89,13 +89,13 @@ public class InvertedIndexParams {
          * Tantivy-only hint: enable phrase matching capability on the index.
          * Phase 1 only validates whitelist; BE always supports phrase regardless.
          */
-        SUPPORT_PHRASE("false"),
+        SUPPORT_PHRASE("true"),
         /**
          * Tantivy-only hint: enable BM25 scoring capability on the index.
          * Phase 1 only validates whitelist; Phase 2 will use this to enable
          * fieldnorms in the tantivy schema.
          */
-        SUPPORT_BM25("false");
+        SUPPORT_BM25("true");
 
         private String defaultValue;
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InvertedIndexUtilTantivyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InvertedIndexUtilTantivyTest.java
@@ -165,8 +165,19 @@ public class InvertedIndexUtilTantivyTest extends PlanTestBase {
         Assertions.assertDoesNotThrow(
                 () -> InvertedIndexUtil.checkInvertedIndexValid(col, props, KeysType.DUP_KEYS));
         String spKey = SearchParamsKey.SUPPORT_PHRASE.name().toLowerCase(Locale.ROOT);
-        Assertions.assertEquals("false", props.get(spKey),
-                "support_phrase should be auto-filled with 'false' for tantivy");
+        Assertions.assertEquals("true", props.get(spKey),
+                "support_phrase should be auto-filled with 'true' for tantivy");
+    }
+
+    @Test
+    public void supportBm25DefaultFilled_forTantivy() {
+        Column col = new Column("txt", Type.STRING, true);
+        Map<String, String> props = tantivyProps();
+        Assertions.assertDoesNotThrow(
+                () -> InvertedIndexUtil.checkInvertedIndexValid(col, props, KeysType.DUP_KEYS));
+        String bm25Key = SearchParamsKey.SUPPORT_BM25.name().toLowerCase(Locale.ROOT);
+        Assertions.assertEquals("true", props.get(bm25Key),
+                "support_bm25 should be auto-filled with 'true' for tantivy");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

The tantivy full-text-search (FTS) write path had several gaps that this PR closes by back-porting a batch of fixes and enhancements from the 3.5.14-opt-tantivy-write line:

- support_phrase / support_bm25 were FE-only metadata — they didn't actually affect the tantivy index schema at write time. The schema was always built with WithFreqsAndPositions + fieldnorms=true, so users could neither turn phrase/BM25 on as a first-class default nor opt out to save disk.
- The tantivy writer memory budget and merge policy were hardcoded (50 MB budget, always LogMergePolicy). For our write-once → compound .idx flow, post-commit merging is pure overhead, and the small fixed budget produced excessive internal segments.
- The tokenizer applied LowerCaser to CJK/jieba (meaningless for CJK) and was built on a non-streaming design, wasting work on the hot write path.
- A CentOS CI link error occurred because tantivy_binding was in a different link group than Storage.
- segment_iterator.cpp on this branch used a flat-member layout for vector-index and BM25/inverted-index state, which is hard to extend and diverges from the intended context-struct design.



## What I'm doing:
1. Enable support_phrase/support_bm25 by default and wire them to the tantivy schema (#870546)
  - Flip FE defaults false → true and auto-fill both at DDL time so SHOW CREATE TABLE always displays them.
  - Thread the flags FE DDL → C++ writer → FFI → Rust to actually control the schema:
      - support_phrase=true → WithFreqsAndPositions, false → WithFreqs (~25% smaller .idx).
    - support_bm25=true → set_fieldnorms(true), false → set_fieldnorms(false).
2. Make the tantivy writer memory budget and merge policy configurable (#948192)
  - New mutable BE configs tantivy_writer_memory_budget_bytes (default 256 MB) and tantivy_writer_merge_policy (default | no_merge).
  - Propagated through the FFI into IndexWriterWrapper::create(); no_merge applies NoMergePolicy for write-once compound-.idx scenarios.
3. Optimize the tantivy tokenizer (#948192)
  - Remove LowerCaser from the CJK/jieba analyzers and rewrite the tokenizers to a streaming design.
4. Fix CentOS CI link error (#944969)
  - Move tantivy_binding into the same link group as Storage in be/CMakeLists.txt.
5. Refactor segment_iterator.cpp to context structs (#870546)
  - Replace the flat vector-index and inverted/BM25 members with VectorIndexContext / InvertedIndexContext (lazily created unique_ptrs), migrating all usages.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
