### PR TITLE
[Enhancement] Support composite sort-key meta-tier tablet pre-split

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
@@ -50,6 +50,13 @@ import java.util.List;
  * FE-local access cannot reach. Routing footer reads through a
  * broker-backed seekable input is a deliberate follow-up.
  *
+ * <p>Non-identity file groups (per-group {@code WHERE}, {@code SET}/explicit
+ * column list, {@code columns_from_path}, negative-load, or legacy hadoop
+ * functions) map or filter the sort key, so the raw footer column would diverge
+ * from the loaded value; they are rejected before any footer read (reusing the
+ * data tier's {@code rejectNonIdentityFileGroups} guard) and fall back to data
+ * tier, which skips pre-split for the same shapes.
+ *
  * <p>Hadoop-side wiring (configuration build, broker → Hadoop file-status
  * conversion) is shared with the INSERT-from-FILES provider via
  * {@link PreSplitHadoopAccess}.
@@ -64,6 +71,17 @@ final class BrokerLoadRowGroupStatisticsProvider implements RowGroupStatisticsPr
         List<BrokerFileGroup> fileGroups = context.fileGroups();
         List<List<TBrokerFileStatus>> fileStatusesPerGroup = context.fileStatusesPerGroup();
         List<Column> sortKeyColumns = request.getSortKey();
+
+        // A non-identity file group (per-group WHERE / SET / columns_from_path / negative-load / hadoop
+        // functions) maps or filters the sort key, so the raw footer column diverges from the value the
+        // load actually inserts and footer-derived boundaries would be skewed. Reuse the data tier's
+        // identity guard as the single source of truth; on rejection defer to the data tier, which
+        // rejects the same shapes and skips pre-split.
+        try {
+            BrokerLoadSampleSubqueryExecutor.rejectNonIdentityFileGroups(fileGroups);
+        } catch (StarRocksException nonIdentity) {
+            throw new MetaTierUnavailableException(nonIdentity.getMessage());
+        }
 
         Configuration hadoopConfig = PreSplitHadoopAccess.buildHadoopConfiguration(brokerDesc.getProperties());
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProvider.java
@@ -63,10 +63,7 @@ final class BrokerLoadRowGroupStatisticsProvider implements RowGroupStatisticsPr
         rejectIfBrokerBacked(brokerDesc);
         List<BrokerFileGroup> fileGroups = context.fileGroups();
         List<List<TBrokerFileStatus>> fileStatusesPerGroup = context.fileStatusesPerGroup();
-        // ParquetMetadataSampler.rejectCompositeSortKey runs upstream in tryPlan
-        // before this provider is invoked, so a single-element sort key is the
-        // contract by the time we get here.
-        Column sortKeyColumn = request.getSortKey().get(0);
+        List<Column> sortKeyColumns = request.getSortKey();
 
         Configuration hadoopConfig = PreSplitHadoopAccess.buildHadoopConfiguration(brokerDesc.getProperties());
 
@@ -86,7 +83,7 @@ final class BrokerLoadRowGroupStatisticsProvider implements RowGroupStatisticsPr
                 MetaTierFormat format = MetaTierFormat.fromBrokerFormatType(
                         Load.getFormatType(declaredFormat, brokerFileStatus.path), brokerFileStatus.path);
                 FileStatus hadoopFileStatus = PreSplitHadoopAccess.toHadoopFileStatus(brokerFileStatus);
-                aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn, context.loadTimeZone()));
+                aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumns, context.loadTimeZone()));
             }
         }
         return aggregated;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadSampleSubqueryExecutor.java
@@ -110,7 +110,10 @@ final class BrokerLoadSampleSubqueryExecutor extends FilesSampleSubqueryExecutor
         }
     }
 
-    private static void rejectNonIdentityFileGroups(List<BrokerFileGroup> fileGroups) throws StarRocksException {
+    // Package-private: the meta-tier BrokerLoadRowGroupStatisticsProvider reuses this identity guard
+    // before reading footers, so both tiers reject the same non-identity shapes (a load that maps or
+    // filters the sort key makes the raw footer column diverge from the loaded value).
+    static void rejectNonIdentityFileGroups(List<BrokerFileGroup> fileGroups) throws StarRocksException {
         for (BrokerFileGroup fileGroup : fileGroups) {
             if (fileGroup.getWhereExpr() != null) {
                 throw new StarRocksException(ERROR_PREFIX

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProvider.java
@@ -41,10 +41,7 @@ final class InsertFromFilesRowGroupStatisticsProvider implements RowGroupStatist
         TableFunctionTable sourceTable = context.sourceTable();
         // FILES() reports one format for the whole table, so resolve the reader once.
         MetaTierFormat format = MetaTierFormat.fromTableFunctionFormat(sourceTable.getFormat());
-        // ParquetMetadataSampler.rejectCompositeSortKey runs upstream in tryPlan
-        // before this provider is invoked, so a single-element sort key is the
-        // contract by the time we get here.
-        Column sortKeyColumn = request.getSortKey().get(0);
+        List<Column> sortKeyColumns = request.getSortKey();
 
         Configuration hadoopConfig = PreSplitHadoopAccess.buildHadoopConfiguration(sourceTable.getProperties());
 
@@ -58,7 +55,7 @@ final class InsertFromFilesRowGroupStatisticsProvider implements RowGroupStatist
                 continue;
             }
             FileStatus hadoopFileStatus = PreSplitHadoopAccess.toHadoopFileStatus(brokerFileStatus);
-            aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumn, context.loadTimeZone()));
+            aggregated.addAll(format.read(hadoopFileStatus, hadoopConfig, sortKeyColumns, context.loadTimeZone()));
         }
         return aggregated;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
@@ -64,7 +64,8 @@ enum MetaTierFormat {
     List<RowGroupStatistics> read(FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn,
             String loadTimeZone) throws StarRocksException {
         return switch (this) {
-            case PARQUET -> ParquetRowGroupStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn, loadTimeZone);
+            case PARQUET -> ParquetRowGroupStatisticsReader.read(
+                    fileStatus, hadoopConfig, List.of(sortKeyColumn), loadTimeZone);
             case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn, loadTimeZone);
         };
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
@@ -61,12 +61,11 @@ enum MetaTierFormat {
                 filePath, formatType));
     }
 
-    List<RowGroupStatistics> read(FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn,
+    List<RowGroupStatistics> read(FileStatus fileStatus, Configuration hadoopConfig, List<Column> sortKeyColumns,
             String loadTimeZone) throws StarRocksException {
         return switch (this) {
-            case PARQUET -> ParquetRowGroupStatisticsReader.read(
-                    fileStatus, hadoopConfig, List.of(sortKeyColumn), loadTimeZone);
-            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, List.of(sortKeyColumn), loadTimeZone);
+            case PARQUET -> ParquetRowGroupStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumns, loadTimeZone);
+            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumns, loadTimeZone);
         };
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/MetaTierFormat.java
@@ -66,7 +66,7 @@ enum MetaTierFormat {
         return switch (this) {
             case PARQUET -> ParquetRowGroupStatisticsReader.read(
                     fileStatus, hadoopConfig, List.of(sortKeyColumn), loadTimeZone);
-            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, sortKeyColumn, loadTimeZone);
+            case ORC -> OrcStripeStatisticsReader.read(fileStatus, hadoopConfig, List.of(sortKeyColumn), loadTimeZone);
         };
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -330,7 +330,7 @@ public final class OrcStripeStatisticsReader {
             // rejectOutsideWindow throws a checked MetaTierUnavailableException (not a
             // RuntimeException), so a window rejection propagates past the catch below keeping its
             // own message. ofEpochDay and Variant.of RuntimeExceptions are wrapped as a meta-tier
-            // fallback signal — mirroring convertIntegerColumn — so any unrepresentable value falls
+            // fallback signal -- mirroring convertIntegerColumn -- so any unrepresentable value falls
             // back to data tier instead of escaping read() (which only catches IOException) as an
             // uncaught exception that would skip pre-split entirely.
             MetaTierTemporalWindow.rejectOutsideWindow(minDate);
@@ -354,7 +354,7 @@ public final class OrcStripeStatisticsReader {
             // (no Parquet-style unsigned-byte trap), and the exact precision/scale gate
             // guarantees the source scale equals the StarRocks column scale. Variant.of
             // RuntimeExceptions are wrapped as a meta-tier fallback signal — mirroring
-            // convertIntegerColumn/convertDateColumn — so an unrepresentable value falls back
+            // convertIntegerColumn/convertDateColumn -- so an unrepresentable value falls back
             // to data tier instead of escaping read() (which only catches IOException).
             // Render via toPlainString() (not toString()) so large-exponent values never
             // surface in scientific notation, which the BE datum_from_string would reject.
@@ -416,7 +416,7 @@ public final class OrcStripeStatisticsReader {
             // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
             // rejectOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
             // catch(RuntimeException) below (keeping its own message); getMinimumUTC/Variant.of
-            // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateColumn.
+            // RuntimeExceptions are wrapped as the data-tier fallback signal -- mirroring convertDateColumn.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
             if (location.instantOffset != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReader.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
@@ -48,10 +49,18 @@ import java.util.Optional;
 
 /**
  * Reads one ORC file's footer and emits per-stripe min/max/row-count statistics
- * projected onto a single StarRocks sort-key column. The ORC analogue of
- * {@link ParquetRowGroupStatisticsReader}: produced {@link RowGroupStatistics}
- * tuples already carry the StarRocks-side primitive type and feed the same
- * format-agnostic {@link ParquetMetadataSampler}.
+ * projected onto ALL of the StarRocks sort-key columns, one
+ * {@link com.starrocks.catalog.Variant} per column, composed into a per-column
+ * bounding-box {@link com.starrocks.catalog.Tuple}. Absent nulls, the box is a valid loose
+ * lexicographic bound of the stripe: minTuple/maxTuple are composed from each column's
+ * independent stripe min/max, not from a single co-occurring row. A NULL sorts below every
+ * value, so it can fall under minTuple, exactly as in the single-column meta tier -- but data
+ * safety never depends on the bound: the BE routes every row (including nulls) by its true
+ * value, so a null-leading row simply lands in the leftmost tablet. A stripe whose ANY string
+ * column was truncated by ORC (value > 1024 bytes) marks the whole stripe truncated -> data
+ * tier. The ORC analogue of {@link ParquetRowGroupStatisticsReader}: produced
+ * {@link RowGroupStatistics} tuples already carry the StarRocks-side primitive type and feed the
+ * same format-agnostic {@link ParquetMetadataSampler}.
  *
  * <p>Supported type window:
  * <ul>
@@ -95,11 +104,12 @@ public final class OrcStripeStatisticsReader {
     }
 
     public static List<RowGroupStatistics> read(
-            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn, String loadTimeZone)
+            FileStatus fileStatus, Configuration hadoopConfig, List<Column> sortKeyColumns, String loadTimeZone)
             throws StarRocksException {
         Objects.requireNonNull(fileStatus, "fileStatus");
         Objects.requireNonNull(hadoopConfig, "hadoopConfig");
-        Objects.requireNonNull(sortKeyColumn, "sortKeyColumn");
+        Objects.requireNonNull(sortKeyColumns, "sortKeyColumns");
+        Preconditions.checkArgument(!sortKeyColumns.isEmpty(), "sortKeyColumns must be non-empty");
 
         // Pin the footer read to the load's snapshotted file length. ORC otherwise
         // re-stats the path at open time, which could read a different file
@@ -109,7 +119,11 @@ public final class OrcStripeStatisticsReader {
         try (Reader reader = OrcFile.createReader(
                 fileStatus.getPath(), OrcFile.readerOptions(hadoopConfig).maxLength(fileStatus.getLen()))) {
             Optional<ZoneOffset> loadOffset = MetaTierTemporalWindow.fixedLoadOffset(loadTimeZone);
-            SortKeyLocation location = locateSortKeyColumn(reader.getSchema(), sortKeyColumn, loadOffset);
+            TypeDescription schema = reader.getSchema();
+            List<SortKeyLocation> locations = new ArrayList<>(sortKeyColumns.size());
+            for (Column sortKeyColumn : sortKeyColumns) {
+                locations.add(locateSortKeyColumn(schema, sortKeyColumn, loadOffset));
+            }
             List<StripeStatistics> stripeStatistics = reader.getStripeStatistics();
             List<StripeInformation> stripes = reader.getStripes();
             if (stripeStatistics.size() != stripes.size()) {
@@ -119,8 +133,7 @@ public final class OrcStripeStatisticsReader {
             }
             List<RowGroupStatistics> result = new ArrayList<>(stripeStatistics.size());
             for (int stripeIndex = 0; stripeIndex < stripeStatistics.size(); stripeIndex++) {
-                result.add(convertStripe(
-                        stripeStatistics.get(stripeIndex), stripes.get(stripeIndex), location));
+                result.add(convertStripe(stripeStatistics.get(stripeIndex), stripes.get(stripeIndex), locations));
             }
             return result;
         } catch (IOException ioException) {
@@ -232,39 +245,61 @@ public final class OrcStripeStatisticsReader {
     }
 
     private static RowGroupStatistics convertStripe(
-            StripeStatistics stripeStatistics, StripeInformation stripeInformation, SortKeyLocation location)
+            StripeStatistics stripeStatistics, StripeInformation stripeInformation, List<SortKeyLocation> locations)
             throws MetaTierUnavailableException {
         long rowCount = stripeInformation.getNumberOfRows();
         ColumnStatistics[] columnStatistics = stripeStatistics.getColumnStatistics();
-        ColumnStatistics sortKeyStatistics =
+        List<Variant> minValues = new ArrayList<>(locations.size());
+        List<Variant> maxValues = new ArrayList<>(locations.size());
+        // Scan ALL columns before deciding, so the truncated flag is the order-independent OR
+        // across columns (an early MISSING column plus a later TRUNCATED one still reports
+        // truncated=true). Any MISSING/TRUNCATED column -> the whole stripe has no usable box
+        // (a partial tuple is never emitted) -> data-tier fallback downstream.
+        boolean anyMissing = false;
+        boolean truncated = false;
+        for (SortKeyLocation location : locations) {
+            ColumnBounds bounds = computeColumnBounds(columnStatistics, location);
+            if (bounds.truncated()) {
+                truncated = true;
+            }
+            if (bounds.min() == null) {
+                anyMissing = true;
+            } else if (!anyMissing) {
+                minValues.add(bounds.min());
+                maxValues.add(bounds.max());
+            }
+        }
+        if (anyMissing) {
+            return new RowGroupStatistics(null, null, rowCount, truncated);
+        }
+        return new RowGroupStatistics(new Tuple(minValues), new Tuple(maxValues), rowCount, /*truncated=*/ false);
+    }
+
+    private static ColumnBounds computeColumnBounds(ColumnStatistics[] columnStatistics, SortKeyLocation location)
+            throws MetaTierUnavailableException {
+        ColumnStatistics stats =
                 location.columnId < columnStatistics.length ? columnStatistics[location.columnId] : null;
-        if (sortKeyStatistics instanceof IntegerColumnStatistics integerStatistics
-                && integerStatistics.getNumberOfValues() > 0) {
-            return convertIntegerStripe(integerStatistics, rowCount, location);
+        if (stats instanceof IntegerColumnStatistics i && i.getNumberOfValues() > 0) {
+            return convertIntegerColumn(i, location);
         }
-        if (sortKeyStatistics instanceof DateColumnStatistics dateStatistics
-                && dateStatistics.getNumberOfValues() > 0) {
-            return convertDateStripe(dateStatistics, rowCount, location);
+        if (stats instanceof DateColumnStatistics d && d.getNumberOfValues() > 0) {
+            return convertDateColumn(d, location);
         }
-        if (sortKeyStatistics instanceof DecimalColumnStatistics decimalStatistics
-                && decimalStatistics.getNumberOfValues() > 0) {
-            return convertDecimalStripe(decimalStatistics, rowCount, location);
+        if (stats instanceof DecimalColumnStatistics d && d.getNumberOfValues() > 0) {
+            return convertDecimalColumn(d, location);
         }
-        if (sortKeyStatistics instanceof TimestampColumnStatistics timestampStatistics
-                && timestampStatistics.getNumberOfValues() > 0) {
-            return convertTimestampStripe(timestampStatistics, rowCount, location);
+        if (stats instanceof TimestampColumnStatistics t && t.getNumberOfValues() > 0) {
+            return convertTimestampColumn(t, location);
         }
-        if (sortKeyStatistics instanceof StringColumnStatistics stringStatistics
-                && stringStatistics.getNumberOfValues() > 0) {
-            return convertStringStripe(stringStatistics, rowCount, location);
+        if (stats instanceof StringColumnStatistics s && s.getNumberOfValues() > 0) {
+            return convertStringColumn(s, location);
         }
         // Absent / all-null stats (no presence flag on ORC numeric/date stats, so an
         // empty stripe is detected via getNumberOfValues() == 0) → missing min/max.
-        return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+        return ColumnBounds.MISSING;
     }
 
-    private static RowGroupStatistics convertIntegerStripe(
-            IntegerColumnStatistics integerStatistics, long rowCount, SortKeyLocation location)
+    private static ColumnBounds convertIntegerColumn(IntegerColumnStatistics integerStatistics, SortKeyLocation location)
             throws MetaTierUnavailableException {
         Variant minVariant;
         Variant maxVariant;
@@ -281,12 +316,10 @@ public final class OrcStripeStatisticsReader {
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
         // ORC integer statistics are always exact (no truncation like Parquet binary).
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+        return ColumnBounds.present(minVariant, maxVariant);
     }
 
-    private static RowGroupStatistics convertDateStripe(
-            DateColumnStatistics dateStatistics, long rowCount, SortKeyLocation location)
+    private static ColumnBounds convertDateColumn(DateColumnStatistics dateStatistics, SortKeyLocation location)
             throws MetaTierUnavailableException {
         Variant minVariant;
         Variant maxVariant;
@@ -297,7 +330,7 @@ public final class OrcStripeStatisticsReader {
             // rejectOutsideWindow throws a checked MetaTierUnavailableException (not a
             // RuntimeException), so a window rejection propagates past the catch below keeping its
             // own message. ofEpochDay and Variant.of RuntimeExceptions are wrapped as a meta-tier
-            // fallback signal — mirroring convertIntegerStripe — so any unrepresentable value falls
+            // fallback signal — mirroring convertIntegerColumn — so any unrepresentable value falls
             // back to data tier instead of escaping read() (which only catches IOException) as an
             // uncaught exception that would skip pre-split entirely.
             MetaTierTemporalWindow.rejectOutsideWindow(minDate);
@@ -309,12 +342,10 @@ public final class OrcStripeStatisticsReader {
                     "ORC date stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+        return ColumnBounds.present(minVariant, maxVariant);
     }
 
-    private static RowGroupStatistics convertDecimalStripe(
-            DecimalColumnStatistics decimalStatistics, long rowCount, SortKeyLocation location)
+    private static ColumnBounds convertDecimalColumn(DecimalColumnStatistics decimalStatistics, SortKeyLocation location)
             throws MetaTierUnavailableException {
         Variant minVariant;
         Variant maxVariant;
@@ -323,7 +354,7 @@ public final class OrcStripeStatisticsReader {
             // (no Parquet-style unsigned-byte trap), and the exact precision/scale gate
             // guarantees the source scale equals the StarRocks column scale. Variant.of
             // RuntimeExceptions are wrapped as a meta-tier fallback signal — mirroring
-            // convertIntegerStripe/convertDateStripe — so an unrepresentable value falls back
+            // convertIntegerColumn/convertDateColumn — so an unrepresentable value falls back
             // to data tier instead of escaping read() (which only catches IOException).
             // Render via toPlainString() (not toString()) so large-exponent values never
             // surface in scientific notation, which the BE datum_from_string would reject.
@@ -336,12 +367,10 @@ public final class OrcStripeStatisticsReader {
                     "ORC decimal stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+        return ColumnBounds.present(minVariant, maxVariant);
     }
 
-    private static RowGroupStatistics convertStringStripe(
-            StringColumnStatistics stringStatistics, long rowCount, SortKeyLocation location)
+    private static ColumnBounds convertStringColumn(StringColumnStatistics stringStatistics, SortKeyLocation location)
             throws MetaTierUnavailableException {
         // ORC returns null minimum/maximum exactly when the value was truncated (only a
         // lower/upper BOUND is retained, for strings longer than 1024 bytes). A truncated
@@ -350,7 +379,7 @@ public final class OrcStripeStatisticsReader {
         String min = stringStatistics.getMinimum();
         String max = stringStatistics.getMaximum();
         if (min == null || max == null) {
-            return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ true);
+            return ColumnBounds.TRUNCATED;
         }
         // A CHAR value is NUL-canonicalized in the StringVariant constructor; VARCHAR keeps raw bytes.
         Variant minVariant;
@@ -363,13 +392,11 @@ public final class OrcStripeStatisticsReader {
                     "ORC string stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+        return ColumnBounds.present(minVariant, maxVariant);
     }
 
-    private static RowGroupStatistics convertTimestampStripe(
-            TimestampColumnStatistics timestampStatistics, long rowCount, SortKeyLocation location)
-            throws MetaTierUnavailableException {
+    private static ColumnBounds convertTimestampColumn(TimestampColumnStatistics timestampStatistics,
+            SortKeyLocation location) throws MetaTierUnavailableException {
         Variant minVariant;
         Variant maxVariant;
         try {
@@ -389,7 +416,7 @@ public final class OrcStripeStatisticsReader {
             // Modern writers (StarRocks unload, Spark, Hive, ORC >= 1.5) emit minimumUtc and are unaffected.
             // rejectOutsideWindow throws a CHECKED MetaTierUnavailableException that propagates past the
             // catch(RuntimeException) below (keeping its own message); getMinimumUTC/Variant.of
-            // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateStripe.
+            // RuntimeExceptions are wrapped as the data-tier fallback signal — mirroring convertDateColumn.
             LocalDateTime minDateTime = utcTimestampToDateTime(timestampStatistics.getMinimumUTC());
             LocalDateTime maxDateTime = utcTimestampToDateTime(timestampStatistics.getMaximumUTC());
             if (location.instantOffset != null) {
@@ -408,8 +435,7 @@ public final class OrcStripeStatisticsReader {
                     "ORC timestamp stats value not representable for sort-key column \"%s\": %s",
                     location.starRocksColumn.getName(), conversionFailure.getMessage()));
         }
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)), new Tuple(List.of(maxVariant)), rowCount, /*truncated=*/ false);
+        return ColumnBounds.present(minVariant, maxVariant);
     }
 
     private static LocalDateTime utcTimestampToDateTime(Timestamp utcTimestamp) {
@@ -422,5 +448,17 @@ public final class OrcStripeStatisticsReader {
     }
 
     private record SortKeyLocation(int columnId, Column starRocksColumn, ZoneOffset instantOffset) {
+    }
+
+    /** Per-column min/max result for one stripe, before the columns are composed into a tuple. */
+    private record ColumnBounds(Variant min, Variant max, boolean truncated) {
+        static ColumnBounds present(Variant min, Variant max) {
+            return new ColumnBounds(min, max, false);
+        }
+
+        // No usable stats for this column in this stripe (absent / all-null).
+        static final ColumnBounds MISSING = new ColumnBounds(null, null, false);
+        // ORC retained only a truncated bound (value > 1024 bytes) for a string column.
+        static final ColumnBounds TRUNCATED = new ColumnBounds(null, null, true);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSampler.java
@@ -31,10 +31,15 @@ import java.util.Objects;
  * statistics into {@code requestedTabletCount - 1} row-quantile boundaries
  * directly, without materializing a row sample.
  *
- * <p>Restricted to single-column sort keys — per-column Parquet min/max
- * doesn't imply real composite lex-tuples. Throws
- * {@link MetaTierUnavailableException} when statistics are
- * missing/all-null/truncated or row-group ranges overlap above
+ * <p>Plans row-quantile boundaries from per-row-group {@code (minTuple, maxTuple)}
+ * statistics via lexicographic {@link Tuple} comparison, for one OR MANY sort-key
+ * columns. For a composite key the reader supplies a per-column bounding-box tuple:
+ * absent nulls, this is a valid loose lexicographic bound; a NULL sorts below every
+ * value and can fall under minTuple, but the BE routes every row by its true value
+ * so data is never mis-split, only the meta-tier boundary is looser. A row group
+ * whose leading-column range overlaps another's is caught by the existing overlap
+ * check and falls back to the data tier. Throws {@link MetaTierUnavailableException}
+ * when statistics are missing/all-null/truncated or row-group ranges overlap above
  * {@code overlapThreshold}; the caller then retries with data tier.
  */
 public final class ParquetMetadataSampler {
@@ -66,7 +71,6 @@ public final class ParquetMetadataSampler {
         Objects.requireNonNull(request, "request");
         Preconditions.checkArgument(requestedTabletCount >= 2,
                 "requestedTabletCount must be >= 2, was %s", requestedTabletCount);
-        rejectCompositeSortKey(request);
 
         List<RowGroupStatistics> fetched = statisticsProvider.fetch(request);
         if (fetched == null) {
@@ -105,14 +109,6 @@ public final class ParquetMetadataSampler {
                     "row-group metadata too coarse to place row-quantile boundaries");
         }
         return BoundaryPlannerResult.NO_SPLIT;
-    }
-
-    private static void rejectCompositeSortKey(SampleRequest request) throws MetaTierUnavailableException {
-        int arity = request.getSortKey().size();
-        if (arity != 1) {
-            throw new MetaTierUnavailableException(
-                    "composite sort key (arity " + arity + ") — meta tier supports single-column only");
-        }
     }
 
     private static List<RowGroupStatistics> filterUsableRowGroups(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSampler.java
@@ -37,8 +37,10 @@ import java.util.Objects;
  * absent nulls, this is a valid loose lexicographic bound; a NULL sorts below every
  * value and can fall under minTuple, but the BE routes every row by its true value
  * so data is never mis-split, only the meta-tier boundary is looser. A row group
- * whose leading-column range overlaps another's is caught by the existing overlap
- * check and falls back to the data tier. Throws {@link MetaTierUnavailableException}
+ * whose box overlaps another's (full-tuple lexicographic comparison) is caught by
+ * the existing overlap check and falls back to the data tier -- composite boxes are
+ * disjoint exactly when the row groups separate on a leading sort-key column. Throws
+ * {@link MetaTierUnavailableException}
  * when statistics are missing/all-null/truncated or row-group ranges overlap above
  * {@code overlapThreshold}; the caller then retries with data tier.
  */

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
@@ -59,7 +60,14 @@ import java.util.Optional;
 
 /**
  * Reads one Parquet file's footer and emits per-row-group min/max/row-count
- * statistics projected onto a single StarRocks sort-key column. Produced
+ * statistics projected onto ALL of the StarRocks sort-key columns, one
+ * {@link com.starrocks.catalog.Variant} per column, composed into a per-column
+ * bounding-box {@link com.starrocks.catalog.Tuple}. Absent nulls, the box is a valid loose
+ * lexicographic bound of the row group: minTuple/maxTuple are composed from each column's
+ * independent footer min/max, not from a single co-occurring row. A NULL sorts below every
+ * value, so it can fall under minTuple, exactly as in the single-column meta tier -- but data
+ * safety never depends on the bound: the BE routes every row (including nulls) by its true
+ * value, so a null-leading row simply lands in the leftmost tablet. Produced
  * {@link RowGroupStatistics} tuples already carry the StarRocks-side
  * primitive type required by
  * {@link BoundaryPlanner#validateTupleAgainstSchema} — the caller (a
@@ -116,23 +124,31 @@ public final class ParquetRowGroupStatisticsReader {
     }
 
     public static List<RowGroupStatistics> read(
-            FileStatus fileStatus, Configuration hadoopConfig, Column sortKeyColumn, String loadTimeZone)
+            FileStatus fileStatus, Configuration hadoopConfig, List<Column> sortKeyColumns, String loadTimeZone)
             throws StarRocksException {
         Objects.requireNonNull(fileStatus, "fileStatus");
         Objects.requireNonNull(hadoopConfig, "hadoopConfig");
-        Objects.requireNonNull(sortKeyColumn, "sortKeyColumn");
+        Objects.requireNonNull(sortKeyColumns, "sortKeyColumns");
+        Preconditions.checkArgument(!sortKeyColumns.isEmpty(), "sortKeyColumns must be non-empty");
 
         try {
             HadoopInputFile inputFile = HadoopInputFile.fromStatus(fileStatus, hadoopConfig);
             try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
                 ParquetMetadata metadata = reader.getFooter();
+                MessageType schema = metadata.getFileMetaData().getSchema();
                 Optional<ZoneOffset> loadOffset = MetaTierTemporalWindow.fixedLoadOffset(loadTimeZone);
-                SortKeyLocation location = locateSortKeyColumn(
-                        metadata.getFileMetaData().getSchema(), inputFile, sortKeyColumn, loadOffset);
+                // Read the raw footer column_orders at most once per file (a leaf that needs the
+                // check indexes into this list). null -> unknown order for every leaf -> those
+                // leaves defer to data tier via declaresTypeDefinedColumnOrder.
+                List<ColumnOrder> columnOrders = readColumnOrders(inputFile);
+                List<SortKeyLocation> locations = new ArrayList<>(sortKeyColumns.size());
+                for (Column sortKeyColumn : sortKeyColumns) {
+                    locations.add(locateSortKeyColumn(schema, columnOrders, sortKeyColumn, loadOffset));
+                }
                 List<BlockMetaData> blocks = metadata.getBlocks();
                 List<RowGroupStatistics> rowGroupStatistics = new ArrayList<>(blocks.size());
                 for (BlockMetaData block : blocks) {
-                    rowGroupStatistics.add(convertBlock(block, location));
+                    rowGroupStatistics.add(convertBlock(block, locations));
                 }
                 return rowGroupStatistics;
             }
@@ -143,8 +159,8 @@ public final class ParquetRowGroupStatisticsReader {
         }
     }
 
-    private static SortKeyLocation locateSortKeyColumn(MessageType schema, InputFile inputFile, Column sortKeyColumn,
-            Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
+    private static SortKeyLocation locateSortKeyColumn(MessageType schema, List<ColumnOrder> columnOrders,
+            Column sortKeyColumn, Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
         String columnName = sortKeyColumn.getName();
         int fieldIndex = -1;
         for (int i = 0; i < schema.getFieldCount(); i++) {
@@ -181,8 +197,7 @@ public final class ParquetRowGroupStatisticsReader {
         // declaresTypeDefinedColumnOrder). Only those leaves pay the extra raw-footer read.
         boolean typeDefinedColumnOrder = false;
         if (requiresColumnOrderCheck(parquetTypeName, logicalAnnotation)) {
-            typeDefinedColumnOrder = declaresTypeDefinedColumnOrder(
-                    readColumnOrders(inputFile), leafColumnIndex(schema, path));
+            typeDefinedColumnOrder = declaresTypeDefinedColumnOrder(columnOrders, leafColumnIndex(schema, path));
         }
         rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, typeDefinedColumnOrder, sortKeyColumn,
                 loadOffset);
@@ -285,50 +300,45 @@ public final class ParquetRowGroupStatisticsReader {
         }
     }
 
-    private static RowGroupStatistics convertBlock(BlockMetaData block, SortKeyLocation location)
+    private static RowGroupStatistics convertBlock(BlockMetaData block, List<SortKeyLocation> locations)
             throws StarRocksException {
         long rowCount = block.getRowCount();
-        ColumnChunkMetaData chunk = findColumnChunk(block, location.path);
-        if (chunk == null) {
-            return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+        List<Variant> minValues = new ArrayList<>(locations.size());
+        List<Variant> maxValues = new ArrayList<>(locations.size());
+        for (SortKeyLocation location : locations) {
+            ColumnChunkMetaData chunk = findColumnChunk(block, location.path);
+            if (chunk == null) {
+                // A column with no chunk in this row group: cannot bound the tuple -> whole
+                // row group has no usable stats (data-tier fallback downstream).
+                return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+            }
+            Statistics<?> statistics = chunk.getStatistics();
+            if (statistics == null || statistics.isEmpty() || !statistics.hasNonNullValue()) {
+                return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
+            }
+            try {
+                minValues.add(toVariant(statistics.genericGetMin(), location));
+                maxValues.add(toVariant(statistics.genericGetMax(), location));
+            } catch (RuntimeException conversionFailure) {
+                // Variant.of and its subclass constructors throw IllegalArgumentException
+                // (e.g. unsupported type) or RuntimeException (e.g. BoolVariant on a
+                // malformed literal) when a stat value cannot be represented. Translate
+                // to a meta-tier fallback signal so the pipeline retries with data tier rather
+                // than aborting the load. NOTE: toVariant's date/datetime path also throws the
+                // checked MetaTierUnavailableException (out-of-window rejection); that is not a
+                // RuntimeException and intentionally propagates past this catch with its own
+                // message — do not widen this to catch (Exception).
+                throw new MetaTierUnavailableException(String.format(
+                        "Parquet stats value not representable for sort-key column \"%s\": %s",
+                        location.starRocksColumn.getName(), conversionFailure.getMessage()));
+            }
         }
-        Statistics<?> statistics = chunk.getStatistics();
-        if (statistics == null || statistics.isEmpty() || !statistics.hasNonNullValue()) {
-            return new RowGroupStatistics(null, null, rowCount, /*truncated=*/ false);
-        }
-        Variant minVariant;
-        Variant maxVariant;
-        try {
-            minVariant = toVariant(statistics.genericGetMin(), location);
-            maxVariant = toVariant(statistics.genericGetMax(), location);
-        } catch (RuntimeException conversionFailure) {
-            // Variant.of and its subclass constructors throw IllegalArgumentException
-            // (e.g. unsupported type) or RuntimeException (e.g. BoolVariant on a
-            // malformed literal) when a stat value cannot be represented. Translate
-            // to a meta-tier fallback signal so the pipeline retries with data tier rather
-            // than aborting the load. NOTE: toVariant's date/datetime path also throws the
-            // checked MetaTierUnavailableException (out-of-window rejection); that is not a
-            // RuntimeException and intentionally propagates past this catch with its own
-            // message — do not widen this to catch (Exception).
-            throw new MetaTierUnavailableException(String.format(
-                    "Parquet stats value not representable for sort-key column \"%s\": %s",
-                    location.starRocksColumn.getName(), conversionFailure.getMessage()));
-        }
-        // String (BINARY+UTF8) chunk min/max are exact in practice: parquet-cpp and
-        // parquet-mr do not truncate chunk-level Statistics (parquet-mr's
-        // parquet.statistics.truncate.length defaults to Integer.MAX_VALUE; parquet-cpp
-        // drops stats past max_statistics_size, which the isEmpty() guard above already
-        // routes to data tier). Pre-split is a pure planning optimization: the BE routes
-        // every loaded row to a tablet by its true value, independent of these stats. So
-        // even under a hypothetical custom-truncating writer, a widened min/max can only
-        // skew split boundaries or trigger a conservative overlap fallback -- it can never
-        // misroute or drop data. All numeric/temporal stats are exact too, so this reader
-        // never marks a Parquet row group truncated.
-        return new RowGroupStatistics(
-                new Tuple(List.of(minVariant)),
-                new Tuple(List.of(maxVariant)),
-                rowCount,
-                /*truncated=*/ false);
+        // Parquet chunk stats are never truncated (see the class javadoc). Absent nulls the
+        // box tuple is a valid loose lexicographic bound of the row group; a null (which sorts
+        // below every value) can fall under minTuple, but data safety does not rely on the
+        // bound -- the BE routes every row by its true value, so a null-leading row lands in
+        // the leftmost tablet (see the class javadoc / the single-column meta tier).
+        return new RowGroupStatistics(new Tuple(minValues), new Tuple(maxValues), rowCount, /*truncated=*/ false);
     }
 
     private static Variant toVariant(Object parquetValue, SortKeyLocation location)

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -331,7 +331,7 @@ public final class ParquetRowGroupStatisticsReader {
                 // than aborting the load. NOTE: toVariant's date/datetime path also throws the
                 // checked MetaTierUnavailableException (out-of-window rejection); that is not a
                 // RuntimeException and intentionally propagates past this catch with its own
-                // message — do not widen this to catch (Exception).
+                // message -- do not widen this to catch (Exception).
                 throw new MetaTierUnavailableException(String.format(
                         "Parquet stats value not representable for sort-key column \"%s\": %s",
                         location.starRocksColumn.getName(), conversionFailure.getMessage()));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -333,11 +333,13 @@ public final class ParquetRowGroupStatisticsReader {
                         location.starRocksColumn.getName(), conversionFailure.getMessage()));
             }
         }
-        // Parquet chunk stats are never truncated (see the class javadoc). Absent nulls the
-        // box tuple is a valid loose lexicographic bound of the row group; a null (which sorts
-        // below every value) can fall under minTuple, but data safety does not rely on the
-        // bound -- the BE routes every row by its true value, so a null-leading row lands in
-        // the leftmost tablet (see the class javadoc / the single-column meta tier).
+        // Parquet chunk stats are never truncated (parquet-mr defaults truncate.length to
+        // Integer.MAX_VALUE and parquet-cpp drops oversized stats, which the isEmpty() guard
+        // above already routes to data tier). Absent nulls the box tuple is a valid loose
+        // lexicographic bound of the row group; a null (which sorts below every value) can fall
+        // under minTuple, but data safety does not rely on the bound -- the BE routes every row
+        // by its true value, so a null-leading row lands in the leftmost tablet (as in the
+        // single-column meta tier).
         return new RowGroupStatistics(new Tuple(minValues), new Tuple(maxValues), rowCount, /*truncated=*/ false);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -15,6 +15,8 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.io.ByteStreams;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
@@ -137,10 +139,12 @@ public final class ParquetRowGroupStatisticsReader {
                 ParquetMetadata metadata = reader.getFooter();
                 MessageType schema = metadata.getFileMetaData().getSchema();
                 Optional<ZoneOffset> loadOffset = MetaTierTemporalWindow.fixedLoadOffset(loadTimeZone);
-                // Read the raw footer column_orders at most once per file (a leaf that needs the
-                // check indexes into this list). null -> unknown order for every leaf -> those
-                // leaves defer to data tier via declaresTypeDefinedColumnOrder.
-                List<ColumnOrder> columnOrders = readColumnOrders(inputFile);
+                // Read the raw footer column_orders at most once per file, and only if some
+                // sort-key column actually needs it (byte-array DECIMAL / unsigned INT32 -- see
+                // requiresColumnOrderCheck); most keys never trigger it, so the extra footer read
+                // is memoized and stays unpaid for the common case. null -> unknown order for every
+                // leaf -> those leaves defer to data tier via declaresTypeDefinedColumnOrder.
+                Supplier<List<ColumnOrder>> columnOrders = Suppliers.memoize(() -> readColumnOrders(inputFile));
                 List<SortKeyLocation> locations = new ArrayList<>(sortKeyColumns.size());
                 for (Column sortKeyColumn : sortKeyColumns) {
                     locations.add(locateSortKeyColumn(schema, columnOrders, sortKeyColumn, loadOffset));
@@ -159,7 +163,7 @@ public final class ParquetRowGroupStatisticsReader {
         }
     }
 
-    private static SortKeyLocation locateSortKeyColumn(MessageType schema, List<ColumnOrder> columnOrders,
+    private static SortKeyLocation locateSortKeyColumn(MessageType schema, Supplier<List<ColumnOrder>> columnOrders,
             Column sortKeyColumn, Optional<ZoneOffset> loadOffset) throws MetaTierUnavailableException {
         String columnName = sortKeyColumn.getName();
         int fieldIndex = -1;
@@ -197,7 +201,7 @@ public final class ParquetRowGroupStatisticsReader {
         // declaresTypeDefinedColumnOrder). Only those leaves pay the extra raw-footer read.
         boolean typeDefinedColumnOrder = false;
         if (requiresColumnOrderCheck(parquetTypeName, logicalAnnotation)) {
-            typeDefinedColumnOrder = declaresTypeDefinedColumnOrder(columnOrders, leafColumnIndex(schema, path));
+            typeDefinedColumnOrder = declaresTypeDefinedColumnOrder(columnOrders.get(), leafColumnIndex(schema, path));
         }
         rejectIncompatibleTypeMapping(parquetTypeName, logicalAnnotation, typeDefinedColumnOrder, sortKeyColumn,
                 loadOffset);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitPipeline.java
@@ -22,7 +22,7 @@ import java.util.function.BooleanSupplier;
 
 /**
  * Runtime collaborators the coordinator needs to actually run pre-split: a
- * sampler-and-planner (tier routing lives here — meta tier first for any
+ * sampler-and-planner (tier routing lives here -- meta tier first for any
  * sort-key arity, data tier on {@link MetaTierUnavailableException}), the job
  * factory + admission step, and the post-submit FINISHED wait.
  *

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitPipeline.java
@@ -22,8 +22,8 @@ import java.util.function.BooleanSupplier;
 
 /**
  * Runtime collaborators the coordinator needs to actually run pre-split: a
- * sampler-and-planner (tier routing lives here — meta tier first when the sort
- * key has arity 1, data tier on {@link MetaTierUnavailableException}), the job
+ * sampler-and-planner (tier routing lives here — meta tier first for any
+ * sort-key arity, data tier on {@link MetaTierUnavailableException}), the job
  * factory + admission step, and the post-submit FINISHED wait.
  *
  * <p>Bundled into one interface so the integrating load path (D1 / D2) ships

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
@@ -19,6 +19,7 @@ import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.sql.ast.BrokerDesc;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
@@ -52,6 +53,24 @@ class BrokerLoadRowGroupStatisticsProviderTest {
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         Assertions.assertEquals(32L, totalRowCount(rowGroupStatistics));
+    }
+
+    @Test
+    void compositeSortKeyProjectsAllColumns() throws Exception {
+        Path parquetPath = writeCompositeParquet(/*rowCount=*/ 16);
+
+        SampleRequest request = compositeSampleRequest(
+                List.of(parquetFileGroup()),
+                List.of(List.of(brokerFileStatus(parquetPath))));
+
+        List<RowGroupStatistics> rowGroupStatistics = provider.fetch(request);
+
+        Assertions.assertFalse(rowGroupStatistics.isEmpty());
+        for (RowGroupStatistics rg : rowGroupStatistics) {
+            // arity 2 proves the provider forwarded the FULL sort-key list, not get(0).
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            Assertions.assertEquals(2, rg.getMaxTuple().getValues().size());
+        }
     }
 
     @Test
@@ -194,6 +213,17 @@ class BrokerLoadRowGroupStatisticsProviderTest {
                 (group, rowIndex) -> group.append("sort_key", valueOffset + rowIndex));
     }
 
+    private Path writeCompositeParquet(int rowCount) throws IOException {
+        return PresplitTestSupport.writeParquetFixture(
+                tempDirectory,
+                "message schema { required binary tenant (UTF8); required int64 position; }",
+                rowCount,
+                (group, rowIndex) -> {
+                    group.append("tenant", String.format("tenant-%02d", rowIndex / 4));
+                    group.append("position", (long) rowIndex);
+                });
+    }
+
     private Path writeBigintOrc(int rowCount, long valueOffset) throws IOException {
         return PresplitTestSupport.writeOrcFixture(
                 tempDirectory,
@@ -218,6 +248,19 @@ class BrokerLoadRowGroupStatisticsProviderTest {
                 new BrokerLoadScanContext(
                         brokerDesc, fileGroups, fileStatusesPerGroup, Mockito.mock(ComputeResource.class), "UTC"),
                 List.of(new Column("sort_key", IntegerType.BIGINT)),
+                Long.MAX_VALUE,
+                /*seed=*/ 0L);
+    }
+
+    private SampleRequest compositeSampleRequest(
+            List<BrokerFileGroup> fileGroups, List<List<TBrokerFileStatus>> fileStatusesPerGroup) {
+        BrokerDesc brokerDesc = Mockito.mock(BrokerDesc.class);
+        Mockito.when(brokerDesc.hasBroker()).thenReturn(false);
+        Mockito.when(brokerDesc.getProperties()).thenReturn(new HashMap<>());
+        return new SampleRequest(
+                new BrokerLoadScanContext(
+                        brokerDesc, fileGroups, fileStatusesPerGroup, Mockito.mock(ComputeResource.class), "UTC"),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
                 Long.MAX_VALUE,
                 /*seed=*/ 0L);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
@@ -57,7 +57,7 @@ class BrokerLoadRowGroupStatisticsProviderTest {
 
     @Test
     void compositeSortKeyProjectsAllColumns() throws Exception {
-        Path parquetPath = writeCompositeParquet(/*rowCount=*/ 16);
+        Path parquetPath = PresplitTestSupport.writeCompositeParquetFixture(tempDirectory, /*rowCount=*/ 16);
 
         SampleRequest request = compositeSampleRequest(
                 List.of(parquetFileGroup()),
@@ -211,17 +211,6 @@ class BrokerLoadRowGroupStatisticsProviderTest {
                 "message schema { required int64 sort_key; }",
                 rowCount,
                 (group, rowIndex) -> group.append("sort_key", valueOffset + rowIndex));
-    }
-
-    private Path writeCompositeParquet(int rowCount) throws IOException {
-        return PresplitTestSupport.writeParquetFixture(
-                tempDirectory,
-                "message schema { required binary tenant (UTF8); required int64 position; }",
-                rowCount,
-                (group, rowIndex) -> {
-                    group.append("tenant", String.format("tenant-%02d", rowIndex / 4));
-                    group.append("position", (long) rowIndex);
-                });
     }
 
     private Path writeBigintOrc(int rowCount, long valueOffset) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadRowGroupStatisticsProviderTest.java
@@ -74,6 +74,25 @@ class BrokerLoadRowGroupStatisticsProviderTest {
     }
 
     @Test
+    void nonIdentityFileGroupFallsBackToDataTier() throws Exception {
+        // A per-group SET/explicit-column-list (like WHERE / columns_from_path / negative / hadoop
+        // funcs) maps or filters the sort key, so the raw footer column diverges from the loaded
+        // value. The meta path must reject it before reading footers (reusing the data tier's guard)
+        // and fall back rather than emit skewed boundaries -- this is the shape composite keys reached
+        // once the up-front composite gate was removed.
+        Path parquetPath = writeBigintParquet(/*rowCount=*/ 8, /*valueOffset=*/ 0L);
+        BrokerFileGroup nonIdentityGroup = Mockito.mock(BrokerFileGroup.class);
+        Mockito.when(nonIdentityGroup.getFileFormat()).thenReturn("parquet");
+        Mockito.when(nonIdentityGroup.getColumnExprList())
+                .thenReturn(List.of(Mockito.mock(com.starrocks.sql.ast.ImportColumnDesc.class)));
+
+        SampleRequest request = bigintSampleRequest(
+                List.of(nonIdentityGroup), List.of(List.of(brokerFileStatus(parquetPath))));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () -> provider.fetch(request));
+    }
+
+    @Test
     void multipleFileGroupsAreAggregated() throws Exception {
         Path firstFile = writeBigintParquet(/*rowCount=*/ 16, /*valueOffset=*/ 0L);
         Path secondFile = writeBigintParquet(/*rowCount=*/ 24, /*valueOffset=*/ 1000L);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
@@ -112,6 +113,32 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
                 /*seed=*/ 0L);
 
         Assertions.assertThrows(MetaTierUnavailableException.class, () -> provider.fetch(request));
+    }
+
+    @Test
+    void compositeSortKeyProjectsAllColumns() throws Exception {
+        Path parquetPath = PresplitTestSupport.writeParquetFixture(
+                tempDirectory,
+                "message schema { required binary tenant (UTF8); required int64 position; }",
+                /*rowCount=*/ 16,
+                (group, rowIndex) -> {
+                    group.append("tenant", String.format("tenant-%02d", rowIndex / 4));
+                    group.append("position", (long) rowIndex);
+                });
+        TableFunctionTable sourceTable = mockTableFunctionTable("parquet", List.of(brokerFileStatus(parquetPath)));
+        SampleRequest request = new SampleRequest(
+                new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                Long.MAX_VALUE, /*seed=*/ 0L);
+
+        List<RowGroupStatistics> rowGroupStatistics = provider.fetch(request);
+
+        Assertions.assertFalse(rowGroupStatistics.isEmpty());
+        for (RowGroupStatistics rg : rowGroupStatistics) {
+            // arity 2 proves the provider forwarded the FULL sort-key list, not get(0).
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            Assertions.assertEquals(2, rg.getMaxTuple().getValues().size());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromFilesRowGroupStatisticsProviderTest.java
@@ -117,14 +117,7 @@ class InsertFromFilesRowGroupStatisticsProviderTest {
 
     @Test
     void compositeSortKeyProjectsAllColumns() throws Exception {
-        Path parquetPath = PresplitTestSupport.writeParquetFixture(
-                tempDirectory,
-                "message schema { required binary tenant (UTF8); required int64 position; }",
-                /*rowCount=*/ 16,
-                (group, rowIndex) -> {
-                    group.append("tenant", String.format("tenant-%02d", rowIndex / 4));
-                    group.append("position", (long) rowIndex);
-                });
+        Path parquetPath = PresplitTestSupport.writeCompositeParquetFixture(tempDirectory, /*rowCount=*/ 16);
         TableFunctionTable sourceTable = mockTableFunctionTable("parquet", List.of(brokerFileStatus(parquetPath)));
         SampleRequest request = new SampleRequest(
                 new InsertFromFilesScanContext(sourceTable, Mockito.mock(ComputeResource.class), "UTC"),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/OrcStripeStatisticsReaderTest.java
@@ -56,7 +56,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -87,7 +88,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex + 100);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("region_id", IntegerType.INT), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("region_id", IntegerType.INT)), null);
 
         long globalMin = Long.MAX_VALUE;
         long globalMax = Long.MIN_VALUE;
@@ -110,7 +112,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         Assertions.assertNotNull(stripeStatistics.get(0).getMinTuple());
@@ -125,7 +128,8 @@ class OrcStripeStatisticsReaderTest {
                         .setVal(batchRow, String.format("tenant-%02d", rowIndex).getBytes(StandardCharsets.UTF_8)));
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -154,7 +158,8 @@ class OrcStripeStatisticsReaderTest {
                         .setVal(batchRow, (longPrefix + rowIndex).getBytes(StandardCharsets.UTF_8)));
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         for (RowGroupStatistics stripe : stripeStatistics) {
@@ -179,7 +184,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)), null);
+                List.of(new Column("tenant", TypeFactory.createCharType(16))), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -210,7 +215,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("tenant", VarcharType.VARCHAR), null));
+                        List.of(new Column("tenant", VarcharType.VARCHAR)), null));
     }
 
     @Test
@@ -227,7 +232,7 @@ class OrcStripeStatisticsReaderTest {
         // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
         List<RowGroupStatistics> charStats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)), null);
+                List.of(new Column("tenant", TypeFactory.createCharType(16))), null);
         Assertions.assertFalse(charStats.isEmpty());
         for (RowGroupStatistics stripe : charStats) {
             Assertions.assertEquals("a", stripe.getMinTuple().getValues().get(0).getStringValue());
@@ -237,7 +242,7 @@ class OrcStripeStatisticsReaderTest {
         // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
         List<RowGroupStatistics> varcharStats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("tenant", VarcharType.VARCHAR), null);
+                List.of(new Column("tenant", VarcharType.VARCHAR)), null);
         Assertions.assertFalse(varcharStats.isEmpty());
         for (RowGroupStatistics stripe : varcharStats) {
             Assertions.assertTrue(stripe.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
@@ -256,7 +261,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("payload", IntegerType.BIGINT), null));
+                        List.of(new Column("payload", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -271,7 +276,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("region_id", VarcharType.VARCHAR), null));
+                        List.of(new Column("region_id", VarcharType.VARCHAR)), null));
     }
 
     @Test
@@ -285,7 +290,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("missing_sort_key", IntegerType.BIGINT), null));
+                        List.of(new Column("missing_sort_key", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -303,7 +308,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("sort_key", IntegerType.BIGINT), null));
+                        List.of(new Column("sort_key", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -319,7 +324,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("wide_value", IntegerType.TINYINT), null));
+                        List.of(new Column("wide_value", IntegerType.TINYINT)), null));
     }
 
     @Test
@@ -338,7 +343,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         long totalRowCount = 0L;
         for (RowGroupStatistics stripe : stripeStatistics) {
@@ -357,7 +363,8 @@ class OrcStripeStatisticsReaderTest {
                 (batch, batchRow, rowIndex) -> { });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         Assertions.assertTrue(stripeStatistics.isEmpty());
     }
@@ -372,7 +379,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = rowIndex);
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         String globalMin = null;
@@ -403,7 +411,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_day", IntegerType.BIGINT), null));
+                        List.of(new Column("event_day", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -419,7 +427,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stripeStatistics = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertFalse(stripeStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -443,7 +452,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = -1 - rowIndex);
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1969-12-31",
@@ -461,7 +471,8 @@ class OrcStripeStatisticsReaderTest {
                         ((LongColumnVector) batch.cols[0]).vector[batchRow] = -171499);
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1500-06-15",
@@ -483,7 +494,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         String globalMin = null;
@@ -519,7 +531,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals("1970-01-01 00:00:01.500123",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -542,7 +555,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), null));
+                        List.of(new Column("event_ts", DateType.DATETIME)), null));
     }
 
     @Test
@@ -562,7 +575,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("event_ts", DateType.DATETIME), "+08:00");
+                List.of(new Column("event_ts", DateType.DATETIME)), "+08:00");
 
         Assertions.assertFalse(stats.isEmpty());
         String globalMin = null;
@@ -594,7 +607,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("event_ts", DateType.DATETIME), "+08:00");
+                List.of(new Column("event_ts", DateType.DATETIME)), "+08:00");
 
         Assertions.assertEquals("1970-01-01 08:00:01.500123",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -616,7 +629,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "America/New_York"));
+                        List.of(new Column("event_ts", DateType.DATETIME)), "America/New_York"));
     }
 
     @Test
@@ -635,7 +648,7 @@ class OrcStripeStatisticsReaderTest {
 
         Assertions.assertEquals("1970-01-02 04:00:00",
                 OrcStripeStatisticsReader.read(PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "+08:00")
+                        List.of(new Column("event_ts", DateType.DATETIME)), "+08:00")
                         .get(0).getMinTuple().getValues().get(0).getStringValue());
     }
 
@@ -656,7 +669,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "+08:00"));
+                        List.of(new Column("event_ts", DateType.DATETIME)), "+08:00"));
     }
 
     @Test
@@ -674,7 +687,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", IntegerType.BIGINT), null));
+                        List.of(new Column("event_ts", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -694,7 +707,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1969-12-31 23:59:58",
@@ -724,7 +738,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         String min = stats.get(0).getMinTuple().getValues().get(0).getStringValue();
         Assertions.assertTrue(min.startsWith("1969-12-31 23:59:5"), "expected a pre-1970 datetime, got " + min);
@@ -748,7 +763,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         Assertions.assertEquals("1500-06-15 12:00:00",
@@ -771,7 +787,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), null));
+                        List.of(new Column("event_ts", DateType.DATETIME)), null));
     }
 
     @Test
@@ -785,7 +801,8 @@ class OrcStripeStatisticsReaderTest {
                 });
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
-                PresplitTestSupport.statusOf(orcPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertFalse(stats.isEmpty());
         long totalRowCount = 0L;
@@ -808,7 +825,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         // Assert on BigDecimal VALUE, not the exact string: ORC's decimal-stats round-trip may
         // normalize trailing-zero scale ("1.00" vs "1"). Both are accepted downstream because the
@@ -838,7 +855,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         // Value-based comparison (ORC may render scale as "1" vs "1.00"); proves signed order.
         BigDecimal globalMin = null;
@@ -872,7 +889,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2))), null);
 
         Assertions.assertFalse(stats.isEmpty());
         BigDecimal globalMin = null;
@@ -899,7 +916,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
+                        List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))), null));
     }
 
     @Test
@@ -913,7 +930,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2)), null));
+                        List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))), null));
     }
 
     @Test
@@ -927,7 +944,7 @@ class OrcStripeStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 OrcStripeStatisticsReader.read(
                         PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                        new Column("d", IntegerType.BIGINT), null));
+                        List.of(new Column("d", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -943,7 +960,7 @@ class OrcStripeStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
                 PresplitTestSupport.statusOf(orcPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         Assertions.assertFalse(stats.isEmpty());
         long totalRowCount = 0L;
@@ -953,6 +970,184 @@ class OrcStripeStatisticsReaderTest {
             totalRowCount += stripe.getRowCount();
         }
         Assertions.assertEquals(3L, totalRowCount);
+    }
+
+    @Test
+    void readsCompositeBoundingBoxAcrossColumns() throws Exception {
+        Path orcPath = writeOrc(
+                "struct<tenant:string,position:bigint>",
+                /*rowCount=*/ 64,
+                (batch, batchRow, rowIndex) -> {
+                    ((BytesColumnVector) batch.cols[0]).setVal(batchRow,
+                            String.format("tenant-%02d", rowIndex / 16).getBytes(StandardCharsets.UTF_8));
+                    ((LongColumnVector) batch.cols[1]).vector[batchRow] = rowIndex;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMinTenant = null;
+        long globalMinPos = Long.MAX_VALUE;
+        long globalMaxPos = Long.MIN_VALUE;
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertNotNull(rg.getMinTuple());
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            Assertions.assertEquals(2, rg.getMaxTuple().getValues().size());
+            String minTenant = rg.getMinTuple().getValues().get(0).getStringValue();
+            long minPos = Long.parseLong(rg.getMinTuple().getValues().get(1).getStringValue());
+            long maxPos = Long.parseLong(rg.getMaxTuple().getValues().get(1).getStringValue());
+            globalMinTenant = (globalMinTenant == null || minTenant.compareTo(globalMinTenant) < 0)
+                    ? minTenant : globalMinTenant;
+            globalMinPos = Math.min(globalMinPos, minPos);
+            globalMaxPos = Math.max(globalMaxPos, maxPos);
+        }
+        Assertions.assertEquals("tenant-00", globalMinTenant);
+        Assertions.assertEquals(0L, globalMinPos);
+        Assertions.assertEquals(63L, globalMaxPos);
+    }
+
+    @Test
+    void compositeRejectsWhenAnyColumnUnsupported() {
+        // A LARGEINT sort-key column is outside the meta-tier integer window (isIntegerType()
+        // excludes LARGEINT) -> whole file falls back to data tier. LARGEINT is DDL-legal, so
+        // this is a reachable rejection.
+        Assertions.assertThrows(MetaTierUnavailableException.class, () -> {
+            Path orcPath = writeOrc(
+                    "struct<tenant:string,position:bigint>",
+                    /*rowCount=*/ 8,
+                    (batch, batchRow, rowIndex) -> {
+                        ((BytesColumnVector) batch.cols[0]).setVal(batchRow,
+                                String.format("t-%02d", rowIndex).getBytes(StandardCharsets.UTF_8));
+                        ((LongColumnVector) batch.cols[1]).vector[batchRow] = rowIndex;
+                    });
+            OrcStripeStatisticsReader.read(
+                    PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                    List.of(new Column("tenant", VarcharType.VARCHAR),
+                            new Column("position", IntegerType.LARGEINT)),
+                    null);
+        });
+    }
+
+    @Test
+    void compositeEmitsNullTupleWhenAnyColumnHasNoStats() throws Exception {
+        // position column is entirely null -> its stats getNumberOfValues()==0 -> MISSING ->
+        // the whole stripe tuple is null.
+        Path orcPath = writeOrc(
+                "struct<tenant:string,position:bigint>",
+                /*rowCount=*/ 8,
+                (batch, batchRow, rowIndex) -> {
+                    ((BytesColumnVector) batch.cols[0]).setVal(batchRow,
+                            String.format("t-%02d", rowIndex).getBytes(StandardCharsets.UTF_8));
+                    LongColumnVector position = (LongColumnVector) batch.cols[1];
+                    position.noNulls = false;
+                    position.isNull[batchRow] = true;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertNull(rg.getMinTuple());
+            Assertions.assertNull(rg.getMaxTuple());
+        }
+    }
+
+    @Test
+    void compositeOrsTruncatedFlagAcrossColumnsRegardlessOfOrder() throws Exception {
+        // Column 0 (position) is entirely null -> MISSING; column 1 (tenant) holds a > 1024-byte
+        // value -> ORC retains only a truncated bound (getMinimum()/getMaximum() null) -> TRUNCATED.
+        // The MISSING column is scanned first, but scanning ALL columns before deciding must still
+        // OR in the later column's truncation, so the null-tuple stripe reports truncated=true.
+        String bigValue = "x".repeat(2000);
+        Path orcPath = writeOrc(
+                "struct<position:bigint,tenant:string>",
+                /*rowCount=*/ 4,
+                (batch, batchRow, rowIndex) -> {
+                    LongColumnVector position = (LongColumnVector) batch.cols[0];
+                    position.noNulls = false;
+                    position.isNull[batchRow] = true;
+                    ((BytesColumnVector) batch.cols[1]).setVal(batchRow,
+                            bigValue.getBytes(StandardCharsets.UTF_8));
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("position", IntegerType.BIGINT), new Column("tenant", VarcharType.VARCHAR)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        boolean anyTruncated = false;
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertNull(rg.getMinTuple());
+            anyTruncated |= rg.isTruncated();
+        }
+        Assertions.assertTrue(anyTruncated, "truncated flag must be OR-ed in from the later string column");
+    }
+
+    @Test
+    void readsCompositeDateThenIntBoundingBox() throws Exception {
+        // ORC mixed (DATE, INT) key. Assert AGGREGATE global min across stripes.
+        Path orcPath = writeOrc(
+                "struct<event_day:date,region:int>",
+                /*rowCount=*/ 8,
+                (batch, batchRow, rowIndex) -> {
+                    ((LongColumnVector) batch.cols[0]).vector[batchRow] =
+                            java.time.LocalDate.of(2024, 1, 1 + rowIndex).toEpochDay();
+                    ((LongColumnVector) batch.cols[1]).vector[batchRow] = rowIndex + 10;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE), new Column("region", IntegerType.INT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMinDate = null;
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            String minDate = rg.getMinTuple().getValues().get(0).getStringValue();
+            globalMinDate = (globalMinDate == null || minDate.compareTo(globalMinDate) < 0) ? minDate : globalMinDate;
+        }
+        Assertions.assertEquals("2024-01-01", globalMinDate);
+    }
+
+    @Test
+    void compositeUsesNonNullStripeMinMaxWhenALeadingColumnHasNulls() throws Exception {
+        // Parity with single-column: a partial-null column is NOT a fallback trigger; the reader
+        // uses the non-null stripe min/max. A stripe whose tenant is entirely null yields a null
+        // tuple (that column's getNumberOfValues()==0 -> MISSING), the existing all-null fallback.
+        Path orcPath = writeOrc(
+                "struct<tenant:string,position:bigint>",
+                /*rowCount=*/ 16,
+                (batch, batchRow, rowIndex) -> {
+                    BytesColumnVector tenant = (BytesColumnVector) batch.cols[0];
+                    if (rowIndex % 2 == 1) {
+                        tenant.setVal(batchRow, String.format("tenant-%03d", rowIndex).getBytes(StandardCharsets.UTF_8));
+                    } else {
+                        tenant.noNulls = false;
+                        tenant.isNull[batchRow] = true;
+                    }
+                    ((LongColumnVector) batch.cols[1]).vector[batchRow] = rowIndex;
+                });
+
+        List<RowGroupStatistics> stats = OrcStripeStatisticsReader.read(
+                PresplitTestSupport.statusOf(orcPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        for (RowGroupStatistics rg : stats) {
+            if (rg.getMinTuple() != null) {
+                Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+                Assertions.assertNotNull(rg.getMinTuple().getValues().get(0).getStringValue());
+            }
+        }
     }
 
     private Path writeOrc(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSamplerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetMetadataSamplerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.DUMMY_CONTEXT;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintTuple;
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.compositeTuple;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.varcharColumn;
 
 public class ParquetMetadataSamplerTest {
@@ -54,6 +55,17 @@ public class ParquetMetadataSamplerTest {
     private static RowGroupStatistics rowGroupAllNull(long rowCount) {
         Tuple nullTuple = new Tuple(List.of((Variant) new NullVariant(IntegerType.BIGINT)));
         return new RowGroupStatistics(nullTuple, nullTuple, rowCount, false);
+    }
+
+    private static SampleRequest compositeRequest() {
+        return new SampleRequest(
+                DUMMY_CONTEXT, List.of(varcharColumn("tenant"), bigintColumn("position")), 1024L, 0L);
+    }
+
+    private static RowGroupStatistics compositeRowGroup(
+            String minTenant, long minPos, String maxTenant, long maxPos, long rowCount) {
+        return new RowGroupStatistics(
+                compositeTuple(minTenant, minPos), compositeTuple(maxTenant, maxPos), rowCount, false);
     }
 
     /**
@@ -193,16 +205,38 @@ public class ParquetMetadataSamplerTest {
     }
 
     @Test
-    public void testCompositeSortKeyFallback() {
-        ParquetMetadataSampler sampler = new ParquetMetadataSampler(
-                new FakeProvider(List.of(rowGroup(0, 99, 100))));
-        SampleRequest request = new SampleRequest(
-                DUMMY_CONTEXT, List.of(bigintColumn("k"), varcharColumn("g")), 1024L, 0L);
+    public void placesCompositeQuantileBoundariesOnLeadingColumnSeparatedBands() throws Exception {
+        // 3 leading-column-disjoint bands ("a" < "b" < "c"), 100 rows each. tabletCount=3 ->
+        // boundaries at the minTuple of band b and band c.
+        List<RowGroupStatistics> rowGroups = List.of(
+                compositeRowGroup("a", 0, "a", 99, 100),
+                compositeRowGroup("b", 0, "b", 99, 100),
+                compositeRowGroup("c", 0, "c", 99, 100));
+        ParquetMetadataSampler sampler = new ParquetMetadataSampler(new FakeProvider(rowGroups));
+
+        BoundaryPlannerResult result = sampler.tryPlan(compositeRequest(), 3);
+
+        Assertions.assertFalse(result.isNoSplit());
+        List<Tuple> boundaries = result.getBoundaries();
+        Assertions.assertEquals(2, boundaries.size());
+        Assertions.assertEquals(compositeTuple("b", 0), boundaries.get(0));
+        Assertions.assertEquals(compositeTuple("c", 0), boundaries.get(1));
+    }
+
+    @Test
+    public void compositeFalseOverlapFromBoxInflationFallsBack() {
+        // A leading tenant value ("m") straddles the boundary and each group's position range is
+        // wide, so the per-column boxes overlap (box_B.min=("m",10) < box_A.max=("m",999)) even
+        // though the true lex-ranges are disjoint. overlapFraction=1.0 > 0.3 -> data-tier fallback.
+        List<RowGroupStatistics> rowGroups = List.of(
+                compositeRowGroup("a", 5, "m", 999, 100),
+                compositeRowGroup("m", 10, "z", 900, 100));
+        ParquetMetadataSampler sampler = new ParquetMetadataSampler(new FakeProvider(rowGroups));
 
         MetaTierUnavailableException exception = Assertions.assertThrows(MetaTierUnavailableException.class,
-                () -> sampler.tryPlan(request, 4));
-        Assertions.assertTrue(exception.getMessage().contains("composite sort key"),
-                "expected composite-key error, got: " + exception.getMessage());
+                () -> sampler.tryPlan(compositeRequest(), 4));
+        Assertions.assertTrue(exception.getMessage().contains("overlap"),
+                "expected overlap fallback, got: " + exception.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -57,7 +57,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("sort_key", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         long totalRowCount = 0L;
@@ -88,7 +89,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("tenant", String.format("tenant-%02d", rowIndex)));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("tenant", VarcharType.VARCHAR), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR)), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         String globalMin = null;
@@ -121,7 +123,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)), null);
+                List.of(new Column("tenant", TypeFactory.createCharType(16))), null);
 
         Assertions.assertFalse(rowGroupStatistics.isEmpty());
         String globalMin = null;
@@ -150,7 +152,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // CHAR target: min/max canonicalized to the prefix before the first NUL ("a"), no NUL kept.
         List<RowGroupStatistics> charStats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", TypeFactory.createCharType(16)), null);
+                List.of(new Column("tenant", TypeFactory.createCharType(16))), null);
         Assertions.assertFalse(charStats.isEmpty());
         for (RowGroupStatistics rowGroup : charStats) {
             Assertions.assertEquals("a", rowGroup.getMinTuple().getValues().get(0).getStringValue());
@@ -160,7 +162,7 @@ class ParquetRowGroupStatisticsReaderTest {
         // VARCHAR target: same NUL data keeps the raw bytes (BE does not strnlen a VARCHAR boundary).
         List<RowGroupStatistics> varcharStats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("tenant", VarcharType.VARCHAR), null);
+                List.of(new Column("tenant", VarcharType.VARCHAR)), null);
         Assertions.assertFalse(varcharStats.isEmpty());
         for (RowGroupStatistics rowGroup : varcharStats) {
             Assertions.assertTrue(rowGroup.getMinTuple().getValues().get(0).getStringValue().indexOf('\0') >= 0);
@@ -180,7 +182,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("opaque_bytes", VarcharType.VARCHAR), null));
+                        List.of(new Column("opaque_bytes", VarcharType.VARCHAR)), null));
     }
 
     @Test
@@ -191,7 +193,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("region_id", rowIndex + 100));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("region_id", IntegerType.INT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("region_id", IntegerType.INT)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("100", rowGroupStatistics.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -206,7 +209,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("flag", rowIndex % 2 == 0));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("flag", BooleanType.BOOLEAN), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("flag", BooleanType.BOOLEAN)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals(2L, rowGroupStatistics.get(0).getRowCount());
@@ -222,7 +226,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("missing_sort_key", IntegerType.BIGINT), null));
+                        List.of(new Column("missing_sort_key", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -237,7 +241,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("payload", IntegerType.BIGINT), null));
+                        List.of(new Column("payload", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -251,7 +255,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("region_id", VarcharType.VARCHAR), null));
+                        List.of(new Column("region_id", VarcharType.VARCHAR)), null));
     }
 
     @Test
@@ -270,7 +274,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("sort_key", IntegerType.BIGINT), null));
+                        List.of(new Column("sort_key", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -286,7 +290,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("wide_value", IntegerType.TINYINT), null));
+                        List.of(new Column("wide_value", IntegerType.TINYINT)), null));
     }
 
     @Test
@@ -300,7 +304,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("keepalive", (long) rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("sort_key", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("sort_key", IntegerType.BIGINT)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         RowGroupStatistics only = rowGroupStatistics.get(0);
@@ -320,7 +325,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertFalse(rowGroupStatistics.get(0).isTruncated());
@@ -342,7 +348,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", IntegerType.BIGINT), null));
+                        List.of(new Column("event_day", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -356,7 +362,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -1 - rowIndex));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("1969-12-31",
@@ -373,7 +380,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -171499));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("1500-06-15",
@@ -389,7 +397,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", -719162));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("0001-01-01",
@@ -407,7 +416,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", DateType.DATE), null));
+                        List.of(new Column("event_day", DateType.DATE)), null));
     }
 
     @Test
@@ -419,7 +428,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_day", 2932896));
 
         List<RowGroupStatistics> rowGroupStatistics = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_day", DateType.DATE), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
 
         Assertions.assertEquals(1, rowGroupStatistics.size());
         Assertions.assertEquals("9999-12-31",
@@ -437,7 +447,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_day", DateType.DATE), null));
+                        List.of(new Column("event_day", DateType.DATE)), null));
     }
 
     private static MessageType timestampSchema(LogicalTypeAnnotation.TimeUnit unit, boolean isAdjustedToUTC) {
@@ -464,7 +474,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", rowIndex * 1000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -483,7 +494,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
@@ -501,7 +513,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 1_500_000_500L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals("1970-01-01 00:00:01.500000",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -519,7 +532,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", -2000L + rowIndex * 1000L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("1969-12-31 23:59:58",
@@ -538,7 +552,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", -500L));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals("1969-12-31 23:59:59.500000",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -556,7 +571,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", millis));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("event_ts", DateType.DATETIME), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
 
         Assertions.assertEquals("1500-06-15 12:00:00",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -573,7 +589,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), null));
+                        List.of(new Column("event_ts", DateType.DATETIME)), null));
     }
 
     @Test
@@ -588,7 +604,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), null));
+                        List.of(new Column("event_ts", DateType.DATETIME)), null));
     }
 
     @Test
@@ -602,7 +618,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("event_ts", DateType.DATETIME), "+08:00");
+                List.of(new Column("event_ts", DateType.DATETIME)), "+08:00");
 
         Assertions.assertFalse(stats.isEmpty());
         String globalMin = null;
@@ -629,7 +645,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("event_ts", DateType.DATETIME), "+08:00");
+                List.of(new Column("event_ts", DateType.DATETIME)), "+08:00");
 
         Assertions.assertEquals("1970-01-01 08:00:01.500123",
                 stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -646,7 +662,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "America/New_York"));
+                        List.of(new Column("event_ts", DateType.DATETIME)), "America/New_York"));
     }
 
     @Test
@@ -660,7 +676,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", -14_400_000L));
         Assertions.assertEquals("1970-01-01 04:00:00",
                 ParquetRowGroupStatisticsReader.read(PresplitTestSupport.statusOf(plusPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "+08:00")
+                        List.of(new Column("event_ts", DateType.DATETIME)), "+08:00")
                         .get(0).getMinTuple().getValues().get(0).getStringValue());
 
         Path minusPath = writeParquet(
@@ -669,7 +685,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("event_ts", 7_200_000L));
         Assertions.assertEquals("1969-12-31 21:00:00",
                 ParquetRowGroupStatisticsReader.read(PresplitTestSupport.statusOf(minusPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "-05:00")
+                        List.of(new Column("event_ts", DateType.DATETIME)), "-05:00")
                         .get(0).getMinTuple().getValues().get(0).getStringValue());
     }
 
@@ -686,7 +702,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", DateType.DATETIME), "+08:00"));
+                        List.of(new Column("event_ts", DateType.DATETIME)), "+08:00"));
     }
 
     @Test
@@ -699,7 +715,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("event_ts", IntegerType.BIGINT), null));
+                        List.of(new Column("event_ts", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -712,7 +728,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -731,7 +747,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -750,7 +766,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("-2.00", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -768,7 +784,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
+                        List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))), null));
     }
 
     @Test
@@ -782,7 +798,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2)), null));
+                        List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2))), null));
     }
 
     @Test
@@ -796,7 +812,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", IntegerType.BIGINT), null));
+                        List.of(new Column("d", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -812,7 +828,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -848,7 +864,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -878,7 +894,7 @@ class ParquetRowGroupStatisticsReaderTest {
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
                 PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 2)), null);
+                List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 2))), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -900,7 +916,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)), null));
+                        List.of(new Column("d", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))), null));
     }
 
     @Test
@@ -937,7 +953,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 250 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.SMALLINT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("u", IntegerType.SMALLINT)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -952,7 +969,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 65530 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), List.of(new Column("u", IntegerType.INT)), null);
 
         Assertions.assertEquals("65530", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("65534", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
@@ -967,7 +984,8 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", (int) (3_000_000_000L + rowIndex)));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.BIGINT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("u", IntegerType.BIGINT)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertFalse(stats.get(0).isTruncated());
@@ -984,7 +1002,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("u", IntegerType.BIGINT), null));
+                        List.of(new Column("u", IntegerType.BIGINT)), null));
     }
 
     @Test
@@ -996,7 +1014,7 @@ class ParquetRowGroupStatisticsReaderTest {
         Assertions.assertThrows(MetaTierUnavailableException.class, () ->
                 ParquetRowGroupStatisticsReader.read(
                         PresplitTestSupport.statusOf(parquetPath), new Configuration(),
-                        new Column("u", IntegerType.INT), null));
+                        List.of(new Column("u", IntegerType.INT)), null));
     }
 
     @Test
@@ -1007,7 +1025,7 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 2_000_000_000 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.INT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(), List.of(new Column("u", IntegerType.INT)), null);
 
         Assertions.assertEquals(1, stats.size());
         Assertions.assertEquals("2000000000", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
@@ -1022,10 +1040,163 @@ class ParquetRowGroupStatisticsReaderTest {
                 (group, rowIndex) -> group.append("u", 100 + rowIndex));
 
         List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
-                PresplitTestSupport.statusOf(parquetPath), new Configuration(), new Column("u", IntegerType.TINYINT), null);
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("u", IntegerType.TINYINT)), null);
 
         Assertions.assertEquals("100", stats.get(0).getMinTuple().getValues().get(0).getStringValue());
         Assertions.assertEquals("104", stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void readsCompositeBoundingBoxAcrossColumns() throws Exception {
+        // (tenant VARCHAR, position BIGINT) composite sort key. tenant changes slowly,
+        // position ascends; the per-column footer stats compose a bounding-box tuple.
+        Path parquetPath = writeParquet(
+                "message schema { required binary tenant (UTF8); required int64 position; }",
+                /*rowCount=*/ 64,
+                (group, rowIndex) -> {
+                    group.append("tenant", String.format("tenant-%02d", rowIndex / 16));
+                    group.append("position", (long) rowIndex);
+                });
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMinTenant = null;
+        long globalMinPos = Long.MAX_VALUE;
+        long globalMaxPos = Long.MIN_VALUE;
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertNotNull(rg.getMinTuple());
+            Assertions.assertNotNull(rg.getMaxTuple());
+            // arity 2, in sort-key order (tenant, position)
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            Assertions.assertEquals(2, rg.getMaxTuple().getValues().size());
+            String minTenant = rg.getMinTuple().getValues().get(0).getStringValue();
+            String maxTenant = rg.getMaxTuple().getValues().get(0).getStringValue();
+            long minPos = Long.parseLong(rg.getMinTuple().getValues().get(1).getStringValue());
+            long maxPos = Long.parseLong(rg.getMaxTuple().getValues().get(1).getStringValue());
+            Assertions.assertTrue(minTenant.compareTo(maxTenant) <= 0);
+            Assertions.assertTrue(minPos <= maxPos);
+            globalMinTenant = (globalMinTenant == null || minTenant.compareTo(globalMinTenant) < 0)
+                    ? minTenant : globalMinTenant;
+            globalMinPos = Math.min(globalMinPos, minPos);
+            globalMaxPos = Math.max(globalMaxPos, maxPos);
+        }
+        Assertions.assertEquals("tenant-00", globalMinTenant);
+        Assertions.assertEquals(0L, globalMinPos);
+        Assertions.assertEquals(63L, globalMaxPos);
+    }
+
+    @Test
+    void compositeRejectsWhenAnyColumnUnsupported() {
+        // tenant maps fine, but a LARGEINT sort-key column is outside the meta-tier integer
+        // window (isIntegerType() is exactly {TINYINT, SMALLINT, INT, BIGINT}; LARGEINT is
+        // excluded) -> whole file falls back to data tier. LARGEINT is a real, DDL-legal sort
+        // key, so this is a reachable rejection (not an impossible-scenario test).
+        Assertions.assertThrows(MetaTierUnavailableException.class, () -> {
+            Path parquetPath = writeParquet(
+                    "message schema { required binary tenant (UTF8); required int64 position; }",
+                    /*rowCount=*/ 8,
+                    (group, rowIndex) -> {
+                        group.append("tenant", String.format("t-%02d", rowIndex));
+                        group.append("position", (long) rowIndex);
+                    });
+            ParquetRowGroupStatisticsReader.read(
+                    PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                    List.of(new Column("tenant", VarcharType.VARCHAR),
+                            new Column("position", IntegerType.LARGEINT)),
+                    null);
+        });
+    }
+
+    @Test
+    void compositeEmitsNullTupleWhenAnyColumnHasNoStats() throws Exception {
+        // position is all-null (optional, never appended) -> its chunk has hasNonNullValue()=false
+        // -> the whole row-group tuple is null (data-tier fallback downstream).
+        Path parquetPath = writeParquet(
+                "message schema { required binary tenant (UTF8); optional int64 position; }",
+                /*rowCount=*/ 8,
+                (group, rowIndex) -> group.append("tenant", String.format("t-%02d", rowIndex)));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertNull(rg.getMinTuple(), "any-column-missing must null the whole tuple");
+            Assertions.assertNull(rg.getMaxTuple());
+        }
+    }
+
+    @Test
+    void readsCompositeDateThenIntBoundingBox() throws Exception {
+        // Mixed (DATE, INT) key exercises per-column DATE-window gate + integer column together.
+        // Assert AGGREGATE global min/max across row groups (the writer may emit several; a
+        // per-row-group "min == 2024-01-01" assertion would be false for later row groups).
+        Path parquetPath = writeParquet(
+                "message schema { required int32 event_day (DATE); required int32 region; }",
+                /*rowCount=*/ 8,
+                (group, rowIndex) -> {
+                    group.append("event_day", (int) java.time.LocalDate.of(2024, 1, 1 + rowIndex).toEpochDay());
+                    group.append("region", rowIndex + 10);
+                });
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE), new Column("region", IntegerType.INT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        String globalMinDate = null;
+        long globalMinRegion = Long.MAX_VALUE;
+        for (RowGroupStatistics rg : stats) {
+            Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+            String minDate = rg.getMinTuple().getValues().get(0).getStringValue();
+            long minRegion = Long.parseLong(rg.getMinTuple().getValues().get(1).getStringValue());
+            globalMinDate = (globalMinDate == null || minDate.compareTo(globalMinDate) < 0) ? minDate : globalMinDate;
+            globalMinRegion = Math.min(globalMinRegion, minRegion);
+        }
+        Assertions.assertEquals("2024-01-01", globalMinDate);
+        Assertions.assertEquals(10L, globalMinRegion);
+    }
+
+    @Test
+    void compositeUsesNonNullFooterMinMaxWhenALeadingColumnHasNulls() throws Exception {
+        // Parity with the single-column meta tier: a partial-null column does NOT trigger a
+        // fallback -- the reader uses the non-null footer min/max. Data safety comes from the
+        // BE routing every row (incl. nulls) by its true value, not from the box being a
+        // strict lower bound. Here tenant is optional and null on even rows; the emitted box
+        // still carries the non-null tenant min ("tenant-000") and full position range.
+        Path parquetPath = writeParquet(
+                "message schema { optional binary tenant (UTF8); required int64 position; }",
+                /*rowCount=*/ 16,
+                (group, rowIndex) -> {
+                    if (rowIndex % 2 == 1) {
+                        group.append("tenant", String.format("tenant-%03d", rowIndex));
+                    }
+                    group.append("position", (long) rowIndex);
+                });
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("tenant", VarcharType.VARCHAR), new Column("position", IntegerType.BIGINT)),
+                null);
+
+        Assertions.assertFalse(stats.isEmpty());
+        for (RowGroupStatistics rg : stats) {
+            // A row group whose tenant chunk still has at least one non-null value produces a
+            // non-null arity-2 box; a row group whose tenant chunk is entirely null yields a
+            // null tuple (hasNonNullValue()==false), which is the existing all-null fallback.
+            if (rg.getMinTuple() != null) {
+                Assertions.assertEquals(2, rg.getMinTuple().getValues().size());
+                Assertions.assertNotNull(rg.getMinTuple().getValues().get(0).getStringValue());
+            }
+        }
     }
 
     private Path writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PresplitTestSupport.java
@@ -217,6 +217,23 @@ final class PresplitTestSupport {
     }
 
     /**
+     * Write a two-column composite-key Parquet fixture (tenant VARCHAR + position BIGINT):
+     * tenant changes every 4 rows, position ascends. Centralized here so the composite fixture
+     * shape lives in one place (like {@link #writeParquetFixture}) for the provider tests that
+     * exercise multi-column projection.
+     */
+    static Path writeCompositeParquetFixture(java.nio.file.Path tempDirectory, int rowCount) throws IOException {
+        return writeParquetFixture(
+                tempDirectory,
+                "message schema { required binary tenant (UTF8); required int64 position; }",
+                rowCount,
+                (group, rowIndex) -> {
+                    group.append("tenant", String.format("tenant-%02d", rowIndex / 4));
+                    group.append("position", (long) rowIndex);
+                });
+    }
+
+    /**
      * Resolve a local-filesystem {@link FileStatus} for a fixture {@link Path}. The footer readers
      * take a {@code FileStatus} (the load snapshots one), so reader tests pass their written fixture
      * through here.


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split turns an external Parquet/ORC load into tablet range boundaries for an `enable_range_distribution=true` target through two tiers: a cheap meta tier that reads footer statistics, and a data tier that issues a sampling sub-query. Until now the meta tier only handled single-column sort keys; a composite (multi-column) range-distribution sort key -- e.g. `DUPLICATE KEY(k1,k2) ORDER BY(k1,k2)` -- always fell back to the data-tier sub-query, paying its cost even when footer statistics would suffice.

## What I'm doing:

Extend the meta tier to composite sort keys. FE-only.

- Both footer readers (`ParquetRowGroupStatisticsReader`, `OrcStripeStatisticsReader`) now project ALL sort-key columns and compose a per-column bounding-box tuple per row group / stripe: `minTuple = (min c1, ..., min cN)`, `maxTuple = (max c1, ..., max cN)`. Each column runs its existing per-column type / window / offset gate unchanged; if any column lacks usable statistics the whole row group yields a null tuple (data-tier fallback), and no partial tuple is ever emitted.
- `MetaTierFormat.read` and the two `RowGroupStatisticsProvider`s now pass the full sort-key list.
- `ParquetMetadataSampler` no longer rejects composite keys up front. Its overlap detection and row-quantile boundary placement already operate on whole `Tuple`s via lexicographic `Tuple.compareTo` and are unchanged.

Correctness / safety: pre-split boundaries are advisory -- the BE routes every row to a tablet by its true value (`RangeRouter` / `PartionKeyComparator`, an arity-agnostic lexicographic tuple compare that matches FE `Tuple.compareTo`), so a bounding-box boundary can only shift a split point, never drop or misroute a row. Absent nulls the box is a valid loose lexicographic bound; a NULL sorts below every value, exactly as in the shipped single-column tier. Composite meta tier fires when row groups separate on a leading sort-key column (their boxes are then disjoint); otherwise the existing overlap-fraction check falls back to the data tier. This mirrors how the data tier already supported composite keys end-to-end. No BE / thrift / protobuf change is needed -- the wire format and BE routing were already N-column.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5