### PR TITLE
[BugFix] Match Iceberg DELETE target scan node by table identity instead of synthetic id (backport #76013)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/IcebergPlannerUtils.java
@@ -14,14 +14,19 @@
 
 package com.starrocks.sql;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.iceberg.ScalarOperatorToIcebergExpr;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.PlanNode;
+import com.starrocks.planner.SlotId;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.ExecPlan;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Shared utilities for Iceberg DML planners (DeletePlanner, UpdatePlanner, future MergePlanner).
@@ -39,16 +44,75 @@ public class IcebergPlannerUtils {
      * snapshot when planned.
      */
     public static Long extractBaseSnapshotId(ExecPlan execPlan, IcebergTable targetTable) {
+        IcebergScanNode scanNode = findScanNodeFor(execPlan, targetTable);
+        return scanNode == null ? null : scanNode.getBaseSnapshotId().orElse(null);
+    }
+
+    /**
+     * Finds the {@link IcebergScanNode} in {@code execPlan} that reads {@code targetTable},
+     * matched by {@link IcebergTable#equals(Object)} — never by {@link IcebergTable#getId()},
+     * a synthetic id minted fresh on every external-table resolution, so the separately
+     * resolved DML target and scan-node table always differ in id.
+     * <p>
+     * A self-referential DML scans the target table more than once; among identity-equal
+     * candidates, the DML target is the scan producing the output row-locator slots
+     * ({@code _file}/{@code _pos} at output positions 0/1). Falls back to the first match
+     * when those slots cannot be resolved.
+     */
+    private static IcebergScanNode findScanNodeFor(ExecPlan execPlan, IcebergTable targetTable) {
         if (execPlan == null || execPlan.getScanNodes() == null || targetTable == null) {
             return null;
         }
+        List<IcebergScanNode> candidates = Lists.newArrayList();
         for (PlanNode node : execPlan.getScanNodes()) {
             if (node instanceof IcebergScanNode scanNode
-                    && scanNode.getIcebergTable().getId() == targetTable.getId()) {
-                return scanNode.getBaseSnapshotId().orElse(null);
+                    && scanNode.getIcebergTable().equals(targetTable)) {
+                candidates.add(scanNode);
+            }
+        }
+        if (candidates.size() <= 1) {
+            return candidates.isEmpty() ? null : candidates.get(0);
+        }
+        IcebergScanNode rowLocatorProducer = findRowLocatorProducingScan(execPlan, candidates);
+        return rowLocatorProducer != null ? rowLocatorProducer : candidates.get(0);
+    }
+
+    /**
+     * Returns the candidate scan whose tuple produces both output row-locator slots
+     * ({@code _file} at output position 0, {@code _pos} at position 1), or null when the
+     * slots cannot be resolved or no candidate produces them.
+     */
+    private static IcebergScanNode findRowLocatorProducingScan(ExecPlan execPlan,
+                                                               List<IcebergScanNode> candidates) {
+        List<Expr> outputExprs = execPlan.getOutputExprs();
+        if (outputExprs == null || outputExprs.size() < 2) {
+            return null;
+        }
+        SlotId fileSlotId = tryExtractSlotId(outputExprs.get(0));
+        SlotId posSlotId = tryExtractSlotId(outputExprs.get(1));
+        if (fileSlotId == null || posSlotId == null) {
+            return null;
+        }
+        for (IcebergScanNode scanNode : candidates) {
+            var slotIds = scanNode.getSlotIds(execPlan.getDescTbl());
+            if (slotIds.contains(fileSlotId.asInt()) && slotIds.contains(posSlotId.asInt())) {
+                return scanNode;
             }
         }
         return null;
+    }
+
+    /**
+     * Extracts the single slot id referenced by {@code expr}, unwrapping trivial casts;
+     * null when the expression does not reduce to exactly one slot.
+     */
+    static SlotId tryExtractSlotId(Expr expr) {
+        if (expr instanceof SlotRef slotRef) {
+            return slotRef.getSlotId();
+        }
+        List<SlotRef> slotRefs = Lists.newArrayList();
+        expr.collect(SlotRef.class, slotRefs);
+        return slotRefs.size() == 1 ? slotRefs.get(0).getSlotId() : null;
     }
 
     /**
@@ -59,22 +123,13 @@ public class IcebergPlannerUtils {
      */
     public static org.apache.iceberg.expressions.Expression buildIcebergFilterExpr(ExecPlan execPlan,
                                                                                      IcebergTable targetTable) {
-        if (execPlan == null || execPlan.getScanNodes() == null || targetTable == null) {
+        IcebergScanNode scanNode = findScanNodeFor(execPlan, targetTable);
+        if (scanNode == null) {
             return null;
         }
 
-        ScalarOperator predicate = null;
-        org.apache.iceberg.Schema nativeSchema = null;
-
-        for (PlanNode node : execPlan.getScanNodes()) {
-            if (node instanceof IcebergScanNode scanNode
-                    && scanNode.getIcebergTable().getId() == targetTable.getId()) {
-                predicate = scanNode.getIcebergJobPlanningPredicate();
-                nativeSchema = scanNode.getIcebergTable().getNativeTable().schema();
-                break;
-            }
-        }
-
+        ScalarOperator predicate = scanNode.getIcebergJobPlanningPredicate();
+        org.apache.iceberg.Schema nativeSchema = scanNode.getIcebergTable().getNativeTable().schema();
         if (predicate == null || nativeSchema == null) {
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDmlTargetScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDmlTargetScanTest.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.sql.IcebergPlannerUtils;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.apache.iceberg.BaseTable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies that the Iceberg DML target-scan lookup pulls the conflict-detection filter and
+ * base snapshot id from the scan node that actually feeds the DML (the one producing the
+ * output row-locator slots), not from an arbitrary same-table scan elsewhere in the plan.
+ */
+public class IcebergDmlTargetScanTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    // One shared native table: within a query, every resolution of the target reuses the same
+    // native Iceberg table (query-level IcebergMetadata cache), so all wrappers share it and
+    // IcebergTable.equals() (catalog + db + table identifier incl. UUID) sees one identity.
+    private static final org.apache.iceberg.Table SHARED_NATIVE_TABLE =
+            Mockito.mock(BaseTable.class, Mockito.RETURNS_DEEP_STUBS);
+
+    private static IcebergTable icebergTable(long syntheticId) {
+        // Same catalog identity, distinct synthetic ids: models the target table and a
+        // same-table scan resolved independently (CONNECTOR_ID_GENERATOR mints fresh ids).
+        return new IcebergTable(syntheticId, "t0_v2", "iceberg0", "resource", "unpartitioned_db",
+                "t0_v2", "", Lists.newArrayList(), SHARED_NATIVE_TABLE, Maps.newHashMap());
+    }
+
+    /**
+     * Deterministic guard for the scan order the SQL-level tests cannot force: when several
+     * scans share the target's catalog identity and the NON-target scan comes first in
+     * {@code getScanNodes()} (e.g. after a semi-join commutation), the lookup must still pick
+     * the scan producing the output row-locator slots.
+     */
+    @Test
+    public void testFindScanNodeForBindsRowLocatorProducingScan() throws Exception {
+        ExecPlan execPlan = new ExecPlan();
+        DescriptorTable descTbl = execPlan.getDescTbl();
+
+        // Subquery scan over the same physical table: plain data slots, no row locators.
+        TupleDescriptor subqueryTuple = descTbl.createTupleDescriptor("same-table-subquery-scan");
+        subqueryTuple.setTable(icebergTable(2L));
+        SlotDescriptor idSlot = descTbl.addSlotDescriptor(subqueryTuple);
+        idSlot.setColumn(new Column("id", IntegerType.INT));
+        idSlot.setIsMaterialized(true);
+        subqueryTuple.computeMemLayout();
+
+        // Target scan: produces the _file/_pos slots consumed by the DML sink.
+        TupleDescriptor targetTuple = descTbl.createTupleDescriptor("dml-target-scan");
+        targetTuple.setTable(icebergTable(3L));
+        SlotDescriptor fileSlot = descTbl.addSlotDescriptor(targetTuple);
+        fileSlot.setColumn(new Column(IcebergTable.FILE_PATH, VarcharType.VARCHAR));
+        fileSlot.setIsMaterialized(true);
+        SlotDescriptor posSlot = descTbl.addSlotDescriptor(targetTuple);
+        posSlot.setColumn(new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT));
+        posSlot.setIsMaterialized(true);
+        targetTuple.computeMemLayout();
+
+        IcebergScanNode subqueryScan = new IcebergScanNode(new PlanNodeId(0), subqueryTuple, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, null);
+        IcebergScanNode targetScan = new IcebergScanNode(new PlanNodeId(1), targetTuple, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, null);
+
+        // Adverse order: the non-target scan first.
+        execPlan.getScanNodes().add(subqueryScan);
+        execPlan.getScanNodes().add(targetScan);
+        execPlan.getOutputExprs().add(new SlotRef(fileSlot));
+        execPlan.getOutputExprs().add(new SlotRef(posSlot));
+
+        Method method = IcebergPlannerUtils.class.getDeclaredMethod(
+                "findScanNodeFor", ExecPlan.class, IcebergTable.class);
+        method.setAccessible(true);
+        Object found = method.invoke(null, execPlan, icebergTable(1L));
+        assertSame(targetScan, found,
+                "lookup must bind to the scan producing the output row-locator slots, not the first "
+                        + "same-identity scan in plan order");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The Iceberg DELETE/UPDATE planner locates the scan node that reads the target table to pull its plan-time base snapshot id and conflict-detection filter. Two problems break this lookup:

1. It matched the scan node's `IcebergTable` against the DML target by `IcebergTable.getId()`. That id is a synthetic value minted fresh on every external-table resolution (`CONNECTOR_ID_GENERATOR`), so the target and the scan node's table — the same physical table resolved separately — always carry different ids. The match silently finds nothing: the base snapshot id is lost (conflict detection falls back to the current snapshot, defeating the plan-time isolation window) and the conflict-detection filter is never set.
2. Even with a correct table-identity match, a self-referential DML (`DELETE FROM t WHERE id IN (SELECT ... FROM t ...)`) produces multiple scans of the same table in one plan, and identity alone cannot tell the target scan from the subquery scan; picking the wrong one attaches the subquery's predicate as the conflict filter and validates the wrong row set.

## What I'm doing:

1. **Match by table identity instead of the synthetic id**: a centralized `findScanNodeFor` lookup, shared by `extractBaseSnapshotId` and `buildIcebergFilterExpr`, matches scans with `IcebergTable.equals()` — the repository-wide external-table identity (catalog + database + table identifier including the Iceberg table UUID).
2. **Disambiguate multiple target-table scans by row-locator binding**: when more than one scan matches the target's identity, the lookup binds to the scan producing the output row-locator slots (`_file`/`_pos`, emitted by the DML analyzers at output positions 0 and 1 and consumed by the sink), falling back to the first identity match when the slots cannot be resolved. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
