### PR TITLE
[BugFix] Fix BE crash in primary key auto-increment partial update apply

### DIFF
--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -165,14 +165,25 @@ Status SegmentRewriter::rewrite_auto_increment(const std::string& src_path, cons
     seg_options.chunk_size = num_rows;
     seg_options.temporary_data = true;
 
-    auto res = rowset->segments()[segment_id]->new_iterator(src_schema, seg_options);
-    auto& itr = res.value();
+    ASSIGN_OR_RETURN(auto itr, rowset->segments()[segment_id]->new_iterator(src_schema, seg_options));
 
     if (itr) {
         auto st = itr->get_next(read_chunk);
-        DCHECK_EQ(read_chunk->num_rows(), num_rows);
+        itr->close();
+        // Do NOT swallow the read error: a transient read failure (page crc / decompress / io) here would
+        // otherwise leave read_chunk short, and the downstream append_chunk would silently emit a segment whose
+        // key columns have fewer rows than the value columns (segment num_rows=0 while value columns=N).
+        TEST_SYNC_POINT_CALLBACK("SegmentRewriter::rewrite_auto_increment:get_next", &st);
+        RETURN_IF_ERROR(st);
+        TEST_SYNC_POINT_CALLBACK("SegmentRewriter::rewrite_auto_increment:read_chunk", read_chunk);
+        if (UNLIKELY(read_chunk->num_rows() != num_rows)) {
+            auto msg = "rewrite_auto_increment: read " + std::to_string(read_chunk->num_rows()) +
+                       " rows from partial segment " + src_path + " but expected " + std::to_string(num_rows) +
+                       " rows (partial-update/auto-increment segment read inconsistency)";
+            LOG(ERROR) << msg;
+            return Status::InternalError(msg);
+        }
     }
-    itr->close();
 
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path));

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -24,6 +24,7 @@
 #include "base/debug/trace.h"
 #include "base/failpoint/fail_point.h"
 #include "base/random/random.h"
+#include "base/testutil/sync_point.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "base/utility/pretty_printer.h"
@@ -5401,8 +5402,20 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();
         }
-        if ((*segment)->num_rows() == 0) {
-            continue;
+        uint32_t segment_num_rows = (*segment)->num_rows();
+        // Test hook: allow forcing a 0-row segment to exercise the integrity guard below.
+        TEST_SYNC_POINT_CALLBACK("TabletUpdates::get_column_values:segment_num_rows", &segment_num_rows);
+        if (segment_num_rows == 0) {
+            // A rssid appears here only with non-empty rowids resolved from the primary index, so a 0-row
+            // segment means the index/rowset-meta disagree with the on-disk segment data. Silently skipping
+            // would return short read columns and later crash in append_selective; fail loudly instead.
+            std::string msg = strings::Substitute(
+                    "segment $0 (rssid $1) has 0 rows but $2 rowids are requested in tablet $3; primary "
+                    "index/rowset-meta vs segment-data inconsistency (possibly a corrupt partial-update / "
+                    "auto-increment segment rewrite output)",
+                    seg_path, rssid, rowids.size(), _tablet.tablet_id());
+            LOG(ERROR) << msg;
+            return Status::Corruption(msg);
         }
         GetDeltaColumnContext ctx;
         RETURN_IF_ERROR(ctx.prepareGetDeltaColumnContext((*segment), _tablet.data_dir()->get_meta(),
@@ -5464,8 +5477,18 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();
         }
-        if ((*segment)->num_rows() == 0) {
-            return Status::OK();
+        uint32_t segment_num_rows = (*segment)->num_rows();
+        // Test hook: allow forcing a 0-row segment to exercise the integrity guard below.
+        TEST_SYNC_POINT_CALLBACK("TabletUpdates::get_column_values:auto_increment_segment_num_rows", &segment_num_rows);
+        if (segment_num_rows == 0) {
+            // Same integrity guard as the main read loop: a 0-row segment with resolved rowids means the
+            // primary index / rowset meta disagree with the on-disk segment data.
+            std::string msg = strings::Substitute(
+                    "auto-increment: segment $0 (rssid $1) has 0 rows but $2 rowids are requested in tablet $3 "
+                    "(primary index/rowset-meta vs segment-data inconsistency)",
+                    seg_path, rssid, rowids.size(), _tablet.tablet_id());
+            LOG(ERROR) << msg;
+            return Status::Corruption(msg);
         }
         GetDeltaColumnContext ctx;
         RETURN_IF_ERROR(ctx.prepareGetDeltaColumnContext((*segment), _tablet.data_dir()->get_meta(),

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "base/testutil/assert.h"
+#include "base/testutil/sync_point.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "common/config_compaction_fwd.h"
@@ -1025,6 +1026,139 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
 
     auto segment = *Segment::open(fs, FileInfo{dst_file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
+}
+
+// Regression test for the PK auto-increment partial-update 0-row-segment crash (write side / root cause).
+// rewrite_auto_increment must NOT swallow a failed read of the partial segment: the read status used to be
+// dropped (only a DCHECK guarded the row count, compiled out in release), leaving read_chunk short and letting
+// append_chunk emit a corrupt segment (segment num_rows=0 while value columns=N). The read error must surface.
+TEST_F(RowsetTest, SegmentRewriterAutoIncrementReadErrorTest) {
+    std::shared_ptr<TabletSchema> partial_tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_key_pb(3)});
+
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, partial_tablet_schema, &writer_context);
+    writer_context.writer_type = kHorizontal;
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+
+    int32_t chunk_size = 3000;
+    size_t num_rows = 3000;
+    {
+        std::vector<uint32_t> column_indexes{0, 1, 2};
+        auto schema = ChunkHelper::convert_schema(partial_tablet_schema, column_indexes);
+        auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
+        for (auto i = 0; i < num_rows / chunk_size + 1; ++i) {
+            chunk->reset();
+            auto cols = chunk->columns();
+            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+            }
+            std::unique_ptr<SegmentPB> seg_info = std::make_unique<SegmentPB>();
+            ASSERT_OK(rowset_writer->flush_chunk(*chunk, seg_info.get()));
+        }
+    }
+    RowsetSharedPtr rowset = rowset_writer->build().value();
+    rowset->load();
+    std::string file_name = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
+
+    std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
+    std::vector<uint32_t> read_column_ids{2, 3};
+    MutableColumns write_columns(read_column_ids.size());
+    for (auto i = 0; i < read_column_ids.size(); ++i) {
+        auto tablet_column = tablet_schema->column(read_column_ids[i]);
+        auto column = ChunkFactory::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+        write_columns[i] = column->clone_empty();
+        for (auto j = 0; j < num_rows; ++j) {
+            write_columns[i]->append_datum(Datum(static_cast<int32_t>(j + read_column_ids[i])));
+        }
+    }
+    AutoIncrementPartialUpdateState auto_increment_partial_update_state;
+    auto_increment_partial_update_state.init(rowset.get(), partial_tablet_schema, 2, 0);
+    auto_increment_partial_update_state.write_column.reset(std::move(write_columns[0]));
+    write_columns.erase(write_columns.begin());
+    auto dst_file_name = Rowset::segment_temp_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
+    std::vector<uint32_t> column_ids{3};
+
+    // Inject a failed read at the partial-segment get_next; rewrite_auto_increment must return the error.
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("SegmentRewriter::rewrite_auto_increment:get_next",
+                                          [](void* arg) { *(Status*)arg = Status::Corruption("injected read error"); });
+    auto st = SegmentRewriter::rewrite_auto_increment(file_name, dst_file_name, tablet_schema,
+                                                      auto_increment_partial_update_state, column_ids, &write_columns);
+    SyncPoint::GetInstance()->ClearCallBack("SegmentRewriter::rewrite_auto_increment:get_next");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ASSERT_FALSE(st.ok()) << "rewrite_auto_increment must not swallow a partial-segment read error";
+    ASSERT_TRUE(st.is_corruption()) << st.to_string();
+}
+
+// Covers the row-count guard in rewrite_auto_increment: if get_next succeeds but read_chunk comes back with
+// fewer rows than the segment (a short read), the rebuilt row would be malformed, so rewrite must reject it.
+TEST_F(RowsetTest, SegmentRewriterAutoIncrementRowCountMismatchTest) {
+    std::shared_ptr<TabletSchema> partial_tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_key_pb(3)});
+
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, partial_tablet_schema, &writer_context);
+    writer_context.writer_type = kHorizontal;
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+
+    int32_t chunk_size = 3000;
+    size_t num_rows = 3000;
+    {
+        std::vector<uint32_t> column_indexes{0, 1, 2};
+        auto schema = ChunkHelper::convert_schema(partial_tablet_schema, column_indexes);
+        auto chunk = ChunkFactory::new_chunk(schema, chunk_size);
+        for (auto i = 0; i < num_rows / chunk_size + 1; ++i) {
+            chunk->reset();
+            auto cols = chunk->columns();
+            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
+                cols[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
+                cols[1]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 1)));
+                cols[2]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j + 2)));
+            }
+            std::unique_ptr<SegmentPB> seg_info = std::make_unique<SegmentPB>();
+            ASSERT_OK(rowset_writer->flush_chunk(*chunk, seg_info.get()));
+        }
+    }
+    RowsetSharedPtr rowset = rowset_writer->build().value();
+    rowset->load();
+    std::string file_name = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
+
+    std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
+            {create_int_key_pb(1), create_int_key_pb(2), create_int_value_pb(3), create_int_value_pb(4)});
+    std::vector<uint32_t> read_column_ids{2, 3};
+    MutableColumns write_columns(read_column_ids.size());
+    for (auto i = 0; i < read_column_ids.size(); ++i) {
+        auto tablet_column = tablet_schema->column(read_column_ids[i]);
+        auto column = ChunkFactory::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+        write_columns[i] = column->clone_empty();
+        for (auto j = 0; j < num_rows; ++j) {
+            write_columns[i]->append_datum(Datum(static_cast<int32_t>(j + read_column_ids[i])));
+        }
+    }
+    AutoIncrementPartialUpdateState auto_increment_partial_update_state;
+    auto_increment_partial_update_state.init(rowset.get(), partial_tablet_schema, 2, 0);
+    auto_increment_partial_update_state.write_column.reset(std::move(write_columns[0]));
+    write_columns.erase(write_columns.begin());
+    auto dst_file_name = Rowset::segment_temp_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
+    std::vector<uint32_t> column_ids{3};
+
+    // get_next succeeds, but the read comes back short (empty read_chunk); rewrite must reject the row-count mismatch.
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("SegmentRewriter::rewrite_auto_increment:read_chunk",
+                                          [](void* arg) { ((Chunk*)arg)->reset(); });
+    auto st = SegmentRewriter::rewrite_auto_increment(file_name, dst_file_name, tablet_schema,
+                                                      auto_increment_partial_update_state, column_ids, &write_columns);
+    SyncPoint::GetInstance()->ClearCallBack("SegmentRewriter::rewrite_auto_increment:read_chunk");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ASSERT_FALSE(st.ok()) << "rewrite_auto_increment must reject a short partial-segment read";
+    ASSERT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(st.to_string().find("segment read inconsistency"), std::string::npos) << st.to_string();
 }
 
 TEST_F(RowsetTest, SegmentDeleteWriteTest) {

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -32,6 +32,7 @@
 #include "storage/manual_compaction.h"
 #include "storage/primary_key_dump.h"
 #include "storage/rowset/rowset_meta_manager.h"
+#include "storage/rowset_update_state.h"
 #include "storage/txn_manager.h"
 
 namespace starrocks {
@@ -3234,6 +3235,111 @@ TEST_F(TabletUpdatesTest, get_column_values_with_invalid_rssid) {
 
 TEST_F(TabletUpdatesTest, get_column_values_with_invalid_rssid_persistent_index) {
     test_get_column_values_with_invalid_rssid(true);
+}
+
+// Regression test for the read-side integrity guard of the PK auto-increment partial-update 0-row-segment crash.
+// When a resolved (valid) rssid points to a segment whose on-disk num_rows is 0 -- an index/rowset-meta vs
+// segment-data inconsistency, e.g. a corrupt partial-update/auto-increment rewrite -- get_column_values must fail
+// with Corruption instead of silently skipping the segment (which returned short read columns and later crashed
+// in append_selective). The 0-row condition cannot arise naturally, so it is injected via SyncPoint.
+TEST_F(TabletUpdatesTest, get_column_values_zero_row_segment) {
+    srand(GetCurrentTimeMicros());
+    auto tablet = create_tablet(rand(), rand());
+    DeferOp del_tablet([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(tablet->tablet_id());
+        (void)fs::remove_all(tablet->schema_hash_path());
+    });
+    const int N = 100;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(tablet->rowset_commit(2, create_rowset(tablet, keys)).ok());
+
+    // Use the real (valid) rssid of the committed rowset so we pass the rssid-range guards and reach the
+    // 0-row integrity check.
+    uint32_t rssid = 0;
+    {
+        std::vector<RowsetSharedPtr> rowsets;
+        EditVersion version;
+        ASSERT_TRUE(tablet->updates()->get_applied_rowsets(2, &rowsets, &version).ok());
+        ASSERT_FALSE(rowsets.empty());
+        rssid = rowsets[0]->rowset_meta()->get_rowset_seg_id();
+    }
+
+    std::vector<uint32_t> read_column_ids = {1, 2};
+    MutableColumns read_columns(read_column_ids.size());
+    const auto& tablet_schema = tablet->unsafe_tablet_schema_ref();
+    for (auto i = 0; i < read_column_ids.size(); i++) {
+        auto tablet_column = tablet_schema.column(read_column_ids[i]);
+        auto column = ChunkFactory::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+        read_columns[i] = column->clone_empty();
+    }
+    std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+    rowids_by_rssid[rssid] = {0, 1, 2};
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("TabletUpdates::get_column_values:segment_num_rows",
+                                          [](void* arg) { *(uint32_t*)arg = 0; });
+    auto st = tablet->updates()->get_column_values(read_column_ids, 0, false, rowids_by_rssid, &read_columns, nullptr,
+                                                   tablet->tablet_schema());
+    SyncPoint::GetInstance()->ClearCallBack("TabletUpdates::get_column_values:segment_num_rows");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ASSERT_FALSE(st.ok()) << "0-row segment with resolved rowids must fail loudly";
+    ASSERT_TRUE(st.is_corruption()) << st;
+}
+
+// Same integrity guard as get_column_values_zero_row_segment, but for the auto-increment default read path
+// (state != nullptr && with_default): a 0-row segment must yield Corruption, not a silent skip.
+TEST_F(TabletUpdatesTest, get_column_values_zero_row_segment_auto_increment) {
+    srand(GetCurrentTimeMicros());
+    auto tablet = create_tablet(rand(), rand());
+    DeferOp del_tablet([&]() {
+        auto tablet_mgr = StorageEngine::instance()->tablet_manager();
+        (void)tablet_mgr->drop_tablet(tablet->tablet_id());
+        (void)fs::remove_all(tablet->schema_hash_path());
+    });
+    const int N = 100;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_TRUE(tablet->rowset_commit(2, create_rowset(tablet, keys)).ok());
+
+    RowsetSharedPtr rowset;
+    {
+        std::vector<RowsetSharedPtr> rowsets;
+        EditVersion version;
+        ASSERT_TRUE(tablet->updates()->get_applied_rowsets(2, &rowsets, &version).ok());
+        ASSERT_FALSE(rowsets.empty());
+        rowset = rowsets[0];
+    }
+
+    // Drive the auto-increment default block: state != nullptr && with_default, with an empty rowids_by_rssid so
+    // the main read loop is skipped and control reaches the auto-increment default read.
+    AutoIncrementPartialUpdateState ai_state;
+    ai_state.init(rowset.get(), tablet->tablet_schema(), 0, 0);
+
+    std::vector<uint32_t> read_column_ids = {1};
+    MutableColumns read_columns(read_column_ids.size());
+    const auto& tablet_schema = tablet->unsafe_tablet_schema_ref();
+    for (auto i = 0; i < read_column_ids.size(); i++) {
+        auto tablet_column = tablet_schema.column(read_column_ids[i]);
+        auto column = ChunkFactory::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
+        read_columns[i] = column->clone_empty();
+    }
+    std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("TabletUpdates::get_column_values:auto_increment_segment_num_rows",
+                                          [](void* arg) { *(uint32_t*)arg = 0; });
+    auto st = tablet->updates()->get_column_values(read_column_ids, 0, /*with_default=*/true, rowids_by_rssid,
+                                                   &read_columns, &ai_state, tablet->tablet_schema());
+    SyncPoint::GetInstance()->ClearCallBack("TabletUpdates::get_column_values:auto_increment_segment_num_rows");
+    SyncPoint::GetInstance()->DisableProcessing();
+    ASSERT_FALSE(st.ok()) << "0-row segment on the auto-increment default path must fail loudly";
+    ASSERT_TRUE(st.is_corruption()) << st;
 }
 
 void TabletUpdatesTest::test_get_missing_version_ranges(const std::vector<int64_t>& versions,


### PR DESCRIPTION
## Why I'm doing:

For a primary-key table with an AUTO_INCREMENT column, a partial update that
omits that column applies through SegmentRewriter::rewrite_auto_increment, which
rebuilds the full segment from three sources: the keys / user-provided columns
re-read from the partial segment, the auto-increment column, and the missing
columns read from history.

rewrite_auto_increment swallowed the status of the partial-segment read: the
iterator was taken with StatusOr::value() (no ok() check) and get_next's status
was dropped (only a DCHECK guarded the row count, compiled out in release). A
transient read failure left read_chunk short, so the rebuilt segment recorded a
segment num_rows of 0 while its value columns still held N rows of real data.
The rowset meta and primary index kept the commit-time counts, so the
inconsistency stayed dormant until a later partial update of the same keys read
that segment via get_column_values, which silently skipped the 0-row segment,
returned an empty read column, and dereferenced a null source in
append_selective / SIMDGather (src=0x0) -- a crash that replays the pending
apply on every restart.

Shared-nothing only; the lake path (rewrite_auto_increment_lake)
already checks the read.


## What I'm doing:

Root cause (write side), be/src/storage/rowset/segment_rewriter.cpp:
- rewrite_auto_increment no longer swallows read errors: create the iterator
  with ASSIGN_OR_RETURN (an iterator-creation failure now returns cleanly
  instead of aborting in value()), propagate get_next's status, and always
  validate the read row count against the segment, with the expected/actual
  counts and segment path in the error. This mirrors rewrite_auto_increment_lake.
  Also closes a latent crash where itr->close() ran on a possibly-null iterator.

Read side (stops the crash on already-corrupt data),
be/src/storage/tablet_updates.cpp:
- get_column_values returns Status::Corruption instead of silently skipping when
  a resolved rssid points to a 0-row segment (both the main read loop and the
  auto-increment default block). Corruption is non-retryable, so the tablet
  enters error state (recoverable via clone) rather than an endless crash-loop.
  Generalizes #69617, which only guarded the rssid-underflow / out-of-range case.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
