### PR TITLE
[Enhancement] Add coalesce stat propagation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -967,6 +967,8 @@ public class ExpressionStatisticCalculator {
                     minValue = left.getMinValue();
                     maxValue = left.getMaxValue();
                     break;
+                case FunctionSet.COALESCE:
+                    return calcCoalesceStats(List.of(left, right), callOperator);
                 case FunctionSet.WEEK:
                     minValue = 0;
                     maxValue = 53;
@@ -1019,6 +1021,62 @@ public class ExpressionStatisticCalculator {
             transformHistogramForBinary(callOperator, left, right).ifPresent(builder::setHistogram);
             return builder.build();
 
+        }
+
+        private ColumnStatistic calcCoalesceStats(List<ColumnStatistic> inputs, CallOperator callOperator) {
+            double nullsFraction = inputs.stream()
+                    .mapToDouble(ColumnStatistic::getNullsFraction)
+                    .reduce(1.0, (accumulator, nullFraction) -> accumulator * nullFraction);
+            double distinctValues = Math.min(rowCount,
+                    inputs.stream().mapToDouble(ColumnStatistic::getDistinctValuesCount).sum());
+            double coalesceMin = Double.NEGATIVE_INFINITY;
+            double coalesceMax = Double.POSITIVE_INFINITY;
+            if (callOperator.getChildren().stream().allMatch(c -> c.getType().isNumericType())) {
+                coalesceMin = inputs.stream()
+                        .mapToDouble(ColumnStatistic::getMinValue).min().orElse(Double.NEGATIVE_INFINITY);
+                coalesceMax = inputs.stream()
+                        .mapToDouble(ColumnStatistic::getMaxValue).max().orElse(Double.POSITIVE_INFINITY);
+            }
+            return ColumnStatistic.builder()
+                    .setMinValue(coalesceMin)
+                    .setMaxValue(coalesceMax)
+                    .setNullsFraction(nullsFraction)
+                    .setAverageRowSize(callOperator.getType().getTypeSize())
+                    .setDistinctValuesCount(distinctValues)
+                    .setHistogram(new Histogram(Collections.emptyList(), buildCoalesceMcv(inputs)))
+                    .build();
+        }
+
+        private Map<String, Long> buildCoalesceMcv(List<ColumnStatistic> inputs) {
+            Map<String, Long> coalesceMcv = new HashMap<>();
+            long maxRows = Math.round(rowCount);
+            long mcvTotalRowsAccountedFor = 0;
+            double weight = 1.0;
+            for (ColumnStatistic input : inputs) {
+                final double nullsFraction = input.getNullsFraction();
+                final var histogram = input.getHistogram();
+                if (nullsFraction < 1 && histogram != null && histogram.getMCV() != null) {
+                    for (final var entry : histogram.getMCV().entrySet()) {
+                        long scaled = Math.round(entry.getValue() * weight);
+                        if (scaled <= 0) {
+                            continue;
+                        }
+                        if (mcvTotalRowsAccountedFor + scaled >= maxRows) {
+                            coalesceMcv.merge(entry.getKey(), maxRows - mcvTotalRowsAccountedFor, Long::sum);
+                            return coalesceMcv;
+                        }
+                        coalesceMcv.merge(entry.getKey(), scaled, Long::sum);
+                        mcvTotalRowsAccountedFor += scaled;
+                    }
+                }
+                // A never-null column means every later column is unreachable.
+                if (nullsFraction == 0) {
+                    break;
+                }
+                weight *= nullsFraction;
+            }
+
+            return coalesceMcv;
         }
 
         private ColumnStatistic calculateDateTruncStats(CallOperator callOperator, ColumnStatistic dateStatistic) {
@@ -1155,6 +1213,8 @@ public class ExpressionStatisticCalculator {
             double averageRowSize;
             double nullsFraction;
             switch (callOperator.getFnName().toLowerCase()) {
+                case FunctionSet.COALESCE:
+                    return calcCoalesceStats(childColumnStatisticList, callOperator);
                 case FunctionSet.IF:
                     final var condStat = childColumnStatisticList.get(0);
                     final var thenStat = childColumnStatisticList.get(1);
@@ -1684,7 +1744,6 @@ public class ExpressionStatisticCalculator {
 
             return ColumnStatistic.unknown();
         }
-
 
         private static ColumnStatistic getArrayMapLambdaStats(CallOperator callOperator,
                                                               LambdaFunctionOperator lambda,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
@@ -164,6 +163,7 @@ public class ExpressionStatisticCalculator {
             }
             return builder.build();
         }
+
         @Override
         public ColumnStatistic visitCompoundPredicate(CompoundPredicateOperator operator, Void context) {
             if (inputStatistics == null || Double.isNaN(inputStatistics.getOutputRowCount())) {
@@ -269,14 +269,13 @@ public class ExpressionStatisticCalculator {
             return builder.build();
         }
 
-
-
         private static double clampFraction(double value) {
             if (Double.isNaN(value)) {
                 return 0.0;
             }
             return Math.max(0.0, Math.min(1.0, value));
         }
+
         @Override
         public ColumnStatistic visitBinaryPredicate(BinaryPredicateOperator operator, Void context) {
             // Constant binary predicates can be introduced after the normal scalar constant-folding pass,
@@ -337,7 +336,6 @@ public class ExpressionStatisticCalculator {
                         .ifPresent(falseOp -> mcvs.put(falseOp.toString(), falseRows));
             }
 
-
             if (!mcvs.isEmpty()) {
                 builder.setHistogram(new Histogram(Collections.emptyList(), mcvs));
             }
@@ -382,6 +380,7 @@ public class ExpressionStatisticCalculator {
                     return Optional.empty();
             }
         }
+
         @Override
         public ColumnStatistic visitCaseWhenOperator(CaseWhenOperator caseWhenOperator, Void context) {
             // 1. compute children column statistics
@@ -419,7 +418,6 @@ public class ExpressionStatisticCalculator {
         @Override
         public ColumnStatistic visitIsNullPredicate(IsNullPredicateOperator operator, Void context) {
             final var inputStat = operator.getChild(0).accept(this, context);
-
 
             Map<String, Long> mcvs = new HashMap<>();
             if (!inputStat.isUnknown()) {
@@ -1050,23 +1048,35 @@ public class ExpressionStatisticCalculator {
         private Map<String, Long> buildCoalesceMcv(List<ColumnStatistic> inputs) {
             Map<String, Long> coalesceMcv = new HashMap<>();
             long maxRows = Math.round(rowCount);
+            List<Map.Entry<String, Double>> contributions = collectWeightedCoalesceMcv(inputs);
             long mcvTotalRowsAccountedFor = 0;
+            for (int i = 0; i < contributions.size(); i++) {
+                final var contribution = contributions.get(i);
+                long scaled = Math.round(contribution.getValue());
+                if (scaled <= 0) {
+                    continue;
+                }
+                if (mcvTotalRowsAccountedFor + scaled >= maxRows) {
+                    scaleRemainingMcvs(contributions.subList(i, contributions.size()),
+                            maxRows - mcvTotalRowsAccountedFor, coalesceMcv);
+                    return coalesceMcv;
+                }
+                coalesceMcv.merge(contribution.getKey(), scaled, Long::sum);
+                mcvTotalRowsAccountedFor += scaled;
+            }
+
+            return coalesceMcv;
+        }
+
+        private List<Map.Entry<String, Double>> collectWeightedCoalesceMcv(List<ColumnStatistic> inputs) {
+            List<Map.Entry<String, Double>> contributions = new ArrayList<>();
             double weight = 1.0;
             for (ColumnStatistic input : inputs) {
                 final double nullsFraction = input.getNullsFraction();
                 final var histogram = input.getHistogram();
                 if (nullsFraction < 1 && histogram != null && histogram.getMCV() != null) {
                     for (final var entry : histogram.getMCV().entrySet()) {
-                        long scaled = Math.round(entry.getValue() * weight);
-                        if (scaled <= 0) {
-                            continue;
-                        }
-                        if (mcvTotalRowsAccountedFor + scaled >= maxRows) {
-                            coalesceMcv.merge(entry.getKey(), maxRows - mcvTotalRowsAccountedFor, Long::sum);
-                            return coalesceMcv;
-                        }
-                        coalesceMcv.merge(entry.getKey(), scaled, Long::sum);
-                        mcvTotalRowsAccountedFor += scaled;
+                        contributions.add(Map.entry(entry.getKey(), entry.getValue() * weight));
                     }
                 }
                 // A never-null column means every later column is unreachable.
@@ -1075,8 +1085,24 @@ public class ExpressionStatisticCalculator {
                 }
                 weight *= nullsFraction;
             }
+            return contributions;
+        }
 
-            return coalesceMcv;
+        private void scaleRemainingMcvs(List<Map.Entry<String, Double>> remaining, long remainingBudget,
+                                        Map<String, Long> targetMcv) {
+            if (remainingBudget <= 0) {
+                return;
+            }
+            double totalWeighted = remaining.stream().mapToDouble(Map.Entry::getValue).sum();
+            if (totalWeighted <= 0) {
+                return;
+            }
+            for (final var entry : remaining) {
+                long scaled = Math.round(remainingBudget * entry.getValue() / totalWeighted);
+                if (scaled > 0) {
+                    targetMcv.merge(entry.getKey(), scaled, Long::sum);
+                }
+            }
         }
 
         private ColumnStatistic calculateDateTruncStats(CallOperator callOperator, ColumnStatistic dateStatistic) {
@@ -1497,7 +1523,7 @@ public class ExpressionStatisticCalculator {
          * For x +/- const we will:
          * - transform MCV keys by applying the exact operation
          * - shift bucket bounds for x +/- const when the mapping is monotonic (x +/- const)
-         *   (for const - x we transform buckets by reversing order)
+         * (for const - x we transform buckets by reversing order)
          */
         private Optional<Histogram> transformHistogramForBinary(
                 CallOperator callOperator, ColumnStatistic leftStats, ColumnStatistic rightStats) {
@@ -1573,9 +1599,9 @@ public class ExpressionStatisticCalculator {
                             : deltaOpt.getAsDouble();
                     if (baseHist.getBuckets() != null) {
                         newBuckets = baseHist.getBuckets().stream()
-                            .map(b -> new Bucket(b.getLower() + bucketShift, b.getUpper() + bucketShift,
-                                    b.getCount(), b.getUpperRepeats()))
-                            .collect(Collectors.toList());
+                                .map(b -> new Bucket(b.getLower() + bucketShift, b.getUpper() + bucketShift,
+                                        b.getCount(), b.getUpperRepeats()))
+                                .collect(Collectors.toList());
                     }
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1032,7 +1032,8 @@ public class ExpressionStatisticCalculator {
                             .sum());
             double coalesceMin = Double.NEGATIVE_INFINITY;
             double coalesceMax = Double.POSITIVE_INFINITY;
-            if (callOperator.getChildren().stream().allMatch(c -> c.getType().isNumericType())) {
+            final Type resultType = callOperator.getType();
+            if (resultType.isNumericType() || resultType.isDateType() || resultType.isTime()) {
                 coalesceMin = inputs.stream()
                         .filter(s -> s.getNullsFraction() < 1.0)
                         .mapToDouble(ColumnStatistic::getMinValue).min().orElse(Double.NEGATIVE_INFINITY);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1035,14 +1035,19 @@ public class ExpressionStatisticCalculator {
                 coalesceMax = inputs.stream()
                         .mapToDouble(ColumnStatistic::getMaxValue).max().orElse(Double.POSITIVE_INFINITY);
             }
-            return ColumnStatistic.builder()
+            Map<String, Long> mcv = buildCoalesceMcv(inputs);
+            ColumnStatistic.Builder builder = ColumnStatistic.builder()
                     .setMinValue(coalesceMin)
                     .setMaxValue(coalesceMax)
                     .setNullsFraction(nullsFraction)
                     .setAverageRowSize(callOperator.getType().getTypeSize())
-                    .setDistinctValuesCount(distinctValues)
-                    .setHistogram(new Histogram(Collections.emptyList(), buildCoalesceMcv(inputs)))
-                    .build();
+                    .setDistinctValuesCount(distinctValues);
+
+            if (!mcv.isEmpty()) {
+                builder.setHistogram(new Histogram(Collections.emptyList(), buildCoalesceMcv(inputs)));
+            }
+
+            return builder.build();
         }
 
         private Map<String, Long> buildCoalesceMcv(List<ColumnStatistic> inputs) {
@@ -1075,7 +1080,12 @@ public class ExpressionStatisticCalculator {
                 final double nullsFraction = input.getNullsFraction();
                 final var histogram = input.getHistogram();
                 if (nullsFraction < 1 && histogram != null && histogram.getMCV() != null) {
-                    for (final var entry : histogram.getMCV().entrySet()) {
+                    for (final var entry : histogram.getMCV().entrySet().stream()
+                            .sorted((a, b) -> {
+                                int cmp = Long.compare(b.getValue(), a.getValue());
+                                return cmp != 0 ? cmp : a.getKey().compareTo(b.getKey());
+                            })
+                            .collect(Collectors.toList())) {
                         contributions.add(Map.entry(entry.getKey(), entry.getValue() * weight));
                     }
                 }
@@ -1098,9 +1108,9 @@ public class ExpressionStatisticCalculator {
                 return;
             }
             for (final var entry : remaining) {
-                long scaled = Math.round(remainingBudget * entry.getValue() / totalWeighted);
+                double scaled = Math.floor(remainingBudget * entry.getValue() / totalWeighted);
                 if (scaled > 0) {
-                    targetMcv.merge(entry.getKey(), scaled, Long::sum);
+                    targetMcv.merge(entry.getKey(), (long) scaled, Long::sum);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1026,13 +1026,18 @@ public class ExpressionStatisticCalculator {
                     .mapToDouble(ColumnStatistic::getNullsFraction)
                     .reduce(1.0, (accumulator, nullFraction) -> accumulator * nullFraction);
             double distinctValues = Math.min(rowCount,
-                    inputs.stream().mapToDouble(ColumnStatistic::getDistinctValuesCount).sum());
+                    inputs.stream()
+                            .filter(s -> s.getNullsFraction() < 1.0)
+                            .mapToDouble(ColumnStatistic::getDistinctValuesCount)
+                            .sum());
             double coalesceMin = Double.NEGATIVE_INFINITY;
             double coalesceMax = Double.POSITIVE_INFINITY;
             if (callOperator.getChildren().stream().allMatch(c -> c.getType().isNumericType())) {
                 coalesceMin = inputs.stream()
+                        .filter(s -> s.getNullsFraction() < 1.0)
                         .mapToDouble(ColumnStatistic::getMinValue).min().orElse(Double.NEGATIVE_INFINITY);
                 coalesceMax = inputs.stream()
+                        .filter(s -> s.getNullsFraction() < 1.0)
                         .mapToDouble(ColumnStatistic::getMaxValue).max().orElse(Double.POSITIVE_INFINITY);
             }
             Map<String, Long> mcv = buildCoalesceMcv(inputs);
@@ -1044,7 +1049,7 @@ public class ExpressionStatisticCalculator {
                     .setDistinctValuesCount(distinctValues);
 
             if (!mcv.isEmpty()) {
-                builder.setHistogram(new Histogram(Collections.emptyList(), buildCoalesceMcv(inputs)));
+                builder.setHistogram(new Histogram(Collections.emptyList(), mcv));
             }
 
             return builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1025,20 +1025,18 @@ public class ExpressionStatisticCalculator {
             double nullsFraction = inputs.stream()
                     .mapToDouble(ColumnStatistic::getNullsFraction)
                     .reduce(1.0, (accumulator, nullFraction) -> accumulator * nullFraction);
+            List<ColumnStatistic> reachableInputs = reachableCoalesceInputs(inputs);
             double distinctValues = Math.min(rowCount,
-                    inputs.stream()
-                            .filter(s -> s.getNullsFraction() < 1.0)
+                    reachableInputs.stream()
                             .mapToDouble(ColumnStatistic::getDistinctValuesCount)
                             .sum());
             double coalesceMin = Double.NEGATIVE_INFINITY;
             double coalesceMax = Double.POSITIVE_INFINITY;
             final Type resultType = callOperator.getType();
             if (resultType.isNumericType() || resultType.isDateType() || resultType.isTime()) {
-                coalesceMin = inputs.stream()
-                        .filter(s -> s.getNullsFraction() < 1.0)
+                coalesceMin = reachableInputs.stream()
                         .mapToDouble(ColumnStatistic::getMinValue).min().orElse(Double.NEGATIVE_INFINITY);
-                coalesceMax = inputs.stream()
-                        .filter(s -> s.getNullsFraction() < 1.0)
+                coalesceMax = reachableInputs.stream()
                         .mapToDouble(ColumnStatistic::getMaxValue).max().orElse(Double.POSITIVE_INFINITY);
             }
             Map<String, Long> mcv = buildCoalesceMcv(inputs);
@@ -1054,6 +1052,20 @@ public class ExpressionStatisticCalculator {
             }
 
             return builder.build();
+        }
+
+        private List<ColumnStatistic> reachableCoalesceInputs(List<ColumnStatistic> inputs) {
+            List<ColumnStatistic> reachable = new ArrayList<>();
+            for (ColumnStatistic input : inputs) {
+                final double nullsFraction = input.getNullsFraction();
+                if (nullsFraction < 1.0) {
+                    reachable.add(input);
+                }
+                if (nullsFraction == 0) {
+                    break;
+                }
+            }
+            return reachable;
         }
 
         private Map<String, Long> buildCoalesceMcv(List<ColumnStatistic> inputs) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -984,6 +984,45 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testCoalesceIgnoresArgsAfterGuaranteedNonNullColumn() {
+        // Given COALESCE(nonNullCol, highNdvCol) where the first argument is guaranteed non-null
+        // CASE WHEN an earlier argument can never be null THEN later arguments are unreachable and
+        //      contribute nothing to NDV or the min/max range END
+
+        final int rowCount = 10000;
+        final double nonNullFraction = 0.0;
+        final double highNdvNullFraction = 0.3;
+
+        // The result is exactly nonNullCol, so its NDV and range are the output's; highNdvCol is ignored.
+        final double expectedDistinctValues = 10;
+        final double expectedMin = 5;
+        final double expectedMax = 15;
+        final double expectedNullFraction = 0.0;
+
+        final ColumnRefOperator nonNullCol = new ColumnRefOperator(0, IntegerType.INT, "nonNullCol", true);
+        final ColumnRefOperator highNdvCol = new ColumnRefOperator(1, IntegerType.INT, "highNdvCol", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(nonNullCol, ColumnStatistic.builder()
+                        .setMinValue(5).setMaxValue(15)
+                        .setNullsFraction(nonNullFraction).setAverageRowSize(4).setDistinctValuesCount(10).build())
+                .addColumnStatistic(highNdvCol, ColumnStatistic.builder()
+                        .setMinValue(-100).setMaxValue(100000)
+                        .setNullsFraction(highNdvNullFraction).setAverageRowSize(4).setDistinctValuesCount(1000).build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.INT,
+                Lists.newArrayList(nonNullCol, highNdvCol));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(expectedDistinctValues, actualStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(expectedMin, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actualStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(expectedNullFraction, actualStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
     public void testCoalescePropagatesDateRangeWhenOneInputIsFullyNull() {
         // Given COALESCE(fullyNullDate, dateCol) over DATETIME inputs
         // CASE WHEN one input is fully null THEN min/max come from the reachable (non-null) date input END

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -984,6 +984,107 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testCoalescePropagatesDateRangeWhenOneInputIsFullyNull() {
+        // Given COALESCE(fullyNullDate, dateCol) over DATETIME inputs
+        // CASE WHEN one input is fully null THEN min/max come from the reachable (non-null) date input END
+
+        final int rowCount = 100;
+        final double fullyNullFraction = 1.0;
+        final double dateColNullFraction = 0.2;
+        final double dateColMin =
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2021-09-01", DateUtils.DATE_FORMATTER_UNIX));
+        final double dateColMax =
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("2022-07-01", DateUtils.DATE_FORMATTER_UNIX));
+
+        final double expectedMin = dateColMin;
+        final double expectedMax = dateColMax;
+
+        final ColumnRefOperator fullyNullDate = new ColumnRefOperator(0, DateType.DATETIME, "fullyNullDate", true);
+        final ColumnRefOperator dateCol = new ColumnRefOperator(1, DateType.DATETIME, "dateCol", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(fullyNullDate, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY).setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(fullyNullFraction).setAverageRowSize(8).setDistinctValuesCount(0).build())
+                .addColumnStatistic(dateCol, ColumnStatistic.builder()
+                        .setMinValue(dateColMin).setMaxValue(dateColMax)
+                        .setNullsFraction(dateColNullFraction).setAverageRowSize(8).setDistinctValuesCount(50).build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, DateType.DATETIME,
+                Lists.newArrayList(fullyNullDate, dateCol));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(expectedMin, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actualStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(0.2, actualStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testCoalescePropagatesTimeRangeWhenOneInputIsFullyNull() {
+        // Given COALESCE(fullyNullTime, timeCol) over TIME inputs (TIME min/max are seconds-of-day)
+        // CASE WHEN one input is fully null THEN min/max come from the reachable (non-null) time input END
+
+        final int rowCount = 100;
+        final double fullyNullFraction = 1.0;
+        final double timeColNullFraction = 0.2;
+        final double timeColMin = 3600;   // 01:00:00
+        final double timeColMax = 7200;   // 02:00:00
+
+        final double expectedMin = timeColMin;
+        final double expectedMax = timeColMax;
+
+        final ColumnRefOperator fullyNullTime = new ColumnRefOperator(0, DateType.TIME, "fullyNullTime", true);
+        final ColumnRefOperator timeCol = new ColumnRefOperator(1, DateType.TIME, "timeCol", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(fullyNullTime, ColumnStatistic.builder()
+                        .setMinValue(Double.NEGATIVE_INFINITY).setMaxValue(Double.POSITIVE_INFINITY)
+                        .setNullsFraction(fullyNullFraction).setAverageRowSize(8).setDistinctValuesCount(0).build())
+                .addColumnStatistic(timeCol, ColumnStatistic.builder()
+                        .setMinValue(timeColMin).setMaxValue(timeColMax)
+                        .setNullsFraction(timeColNullFraction).setAverageRowSize(8).setDistinctValuesCount(50).build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, DateType.TIME,
+                Lists.newArrayList(fullyNullTime, timeCol));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(expectedMin, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actualStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(0.2, actualStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testCoalesceLeavesRangeInfiniteWhenResultTypeIsNotSupported() {
+        // Given COALESCE(left, right) over VARCHAR inputs (result type is cannot be represented numerically)
+        // CASE WHEN the result type has no meaningful numeric range THEN min/max stay [-inf, +inf] END
+
+        final int rowCount = 100;
+        final ColumnRefOperator left = new ColumnRefOperator(0, VarcharType.VARCHAR, "left", true);
+        final ColumnRefOperator right = new ColumnRefOperator(1, VarcharType.VARCHAR, "right", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(left, ColumnStatistic.builder()
+                        .setMinValue(10).setMaxValue(20).setNullsFraction(0.2)
+                        .setAverageRowSize(16).setDistinctValuesCount(70).build())
+                .addColumnStatistic(right, ColumnStatistic.builder()
+                        .setMinValue(30).setMaxValue(40).setNullsFraction(0.5)
+                        .setAverageRowSize(16).setDistinctValuesCount(20).build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, VarcharType.VARCHAR,
+                Lists.newArrayList(left, right));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, actualStatistic.getMaxValue(), 0.001);
+    }
+
+    @Test
     public void testWeek() {
         ColumnRefOperator left = new ColumnRefOperator(0, DateType.DATETIME, "left", true);
         ColumnRefOperator right = new ColumnRefOperator(1, IntegerType.INT, "right", true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -743,7 +743,7 @@ public class ExpressionStatisticsCalculatorTest {
     @Test
     public void testCalculateMcvForKnownBinaryInputs() {
         // Given COALESCE(mcvLeft, mcvRight) where both inputs have MCV histograms
-        // CASE WHEN mcvLeft IS NOT NULL THEN mcvLeft ELSE mcvRight END
+        // CASE WHEN both inputs are NOT NULL THEN scale and weight MCV END
 
         final long rowCount = 1000;
         final double leftNullFraction = 0.3;
@@ -822,6 +822,135 @@ public class ExpressionStatisticsCalculatorTest {
                 .build();
         final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
                 Lists.newArrayList(input1, input2, input3));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertNotNull(actualStatistic.getHistogram());
+        Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
+    public void testCoalesceMcvScalingWhenMaxRowCountIsReached() {
+        // Given COALESCE(colA, colB)
+        // CASE WHEN accumulated MCV rows reach the row count THEN scale the remaining input's MCVs to fit END
+
+        final int rowCount = 300;
+        final double colANullFraction = 0.3;
+        final double colBNullFraction = 0.0;
+        final Map<String, Long> colAMcv = Map.of("a", 100L, "b", 100L);
+        final Map<String, Long> colBMcv = Map.of("c", 1000L, "d", 3000L);
+
+        final Map<String, Long> expectedMcv = Map.of(
+                "a", 100L,
+                "b", 100L,
+                "c", 25L,
+                "d", 75L);
+
+        final ColumnRefOperator colA = new ColumnRefOperator(0, IntegerType.INT, "colA", true);
+        final ColumnRefOperator colB = new ColumnRefOperator(1, IntegerType.INT, "colB", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(colA, ColumnStatistic.builder()
+                        .setNullsFraction(colANullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), colAMcv))
+                        .build())
+                .addColumnStatistic(colB, ColumnStatistic.builder()
+                        .setNullsFraction(colBNullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), colBMcv))
+                        .build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(colA, colB));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertNotNull(actualStatistic.getHistogram());
+        Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
+    public void testCoalesceMcvScalesRemainingInputsAcrossColumnsWhenRowCountReached() {
+        // Given COALESCE(input1, input2, input3)
+        // CASE WHEN the budget is reached mid-way THEN scale every remaining input's MCVs across columns END
+
+        final int rowCount = 100;
+        final double input1NullFraction = 0.5;
+        final double input2NullFraction = 0.5;
+        final double input3NullFraction = 0.0;
+        final Map<String, Long> input1Mcv = Map.of("P", 40L);
+        final Map<String, Long> input2Mcv = Map.of("B", 160L, "C", 240L);
+        final Map<String, Long> input3Mcv = Map.of("D", 160L);
+
+        final Map<String, Long> expectedMcv = Map.of(
+                "P", 40L,
+                "B", 20L,
+                "C", 30L,
+                "D", 10L);
+
+        final ColumnRefOperator input1 = new ColumnRefOperator(0, IntegerType.INT, "input1", true);
+        final ColumnRefOperator input2 = new ColumnRefOperator(1, IntegerType.INT, "input2", true);
+        final ColumnRefOperator input3 = new ColumnRefOperator(2, IntegerType.INT, "input3", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(input1, ColumnStatistic.builder()
+                        .setNullsFraction(input1NullFraction)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), input1Mcv))
+                        .build())
+                .addColumnStatistic(input2, ColumnStatistic.builder()
+                        .setNullsFraction(input2NullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), input2Mcv))
+                        .build())
+                .addColumnStatistic(input3, ColumnStatistic.builder()
+                        .setNullsFraction(input3NullFraction)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), input3Mcv))
+                        .build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(input1, input2, input3));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertNotNull(actualStatistic.getHistogram());
+        Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
+    public void testCoalesceMcvScalesDownFirstColumnWhenItAloneExceedsRowCount() {
+        // Given COALESCE(input1, input2) where input1 is never null so input2 is unreachable
+        // CASE WHEN the first input's MCVs alone exceed the row count THEN scale them down to fit END
+
+        final int rowCount = 100;
+        final double input1NullFraction = 0.0;
+        final double input2NullFraction = 0.0;
+        final Map<String, Long> input1Mcv = Map.of("A", 300L, "B", 100L);
+        final Map<String, Long> input2Mcv = Map.of("Z", 9999L);
+
+        final Map<String, Long> expectedMcv = Map.of(
+                "A", 75L,
+                "B", 25L);
+
+        final ColumnRefOperator input1 = new ColumnRefOperator(0, IntegerType.INT, "input1", true);
+        final ColumnRefOperator input2 = new ColumnRefOperator(1, IntegerType.INT, "input2", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(input1, ColumnStatistic.builder()
+                        .setNullsFraction(input1NullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), input1Mcv))
+                        .build())
+                .addColumnStatistic(input2, ColumnStatistic.builder()
+                        .setNullsFraction(input2NullFraction)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), input2Mcv))
+                        .build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(input1, input2));
 
         final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableList;
@@ -651,15 +650,15 @@ public class ExpressionStatisticsCalculatorTest {
         final double expectedMin = -100;                // min(leftMin, rightMin)
         final double expectedMax = 200.5;
 
-        final ColumnRefOperator leftInput = new ColumnRefOperator(2, IntegerType.INT, "left", true);
-        final ColumnRefOperator rightInput = new ColumnRefOperator(3, IntegerType.INT, "right", true);
+        final ColumnRefOperator leftInput = new ColumnRefOperator(2, FloatType.DOUBLE, "left", true);
+        final ColumnRefOperator rightInput = new ColumnRefOperator(3, FloatType.DOUBLE, "right", true);
         final Statistics statistics = Statistics.builder()
                 .setOutputRowCount(rowCount)
                 .addColumnStatistic(leftInput, new ColumnStatistic(leftMin, leftMax, leftNullFraction, 0, leftDistinctValues))
                 .addColumnStatistic(rightInput,
                         new ColumnStatistic(rightMin, rightMax, rightNullFraction, 0, rightDistinctValues))
                 .build();
-        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, FloatType.DOUBLE,
                 Lists.newArrayList(leftInput, rightInput));
 
         final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
@@ -956,6 +955,32 @@ public class ExpressionStatisticsCalculatorTest {
 
         Assertions.assertNotNull(actualStatistic.getHistogram());
         Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
+    public void testCoalesceLeavesHistogramUnsetWhenNoInputHasMcv() {
+        // Given COALESCE(left, right) where both inputs have known stats but no histogram/MCV
+        // CASE WHEN no input contributes any MCV THEN the histogram is left unset (not empty) END
+
+        final int rowCount = 100;
+        final ColumnRefOperator left = new ColumnRefOperator(0, IntegerType.INT, "left", true);
+        final ColumnRefOperator right = new ColumnRefOperator(1, IntegerType.INT, "right", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(left, ColumnStatistic.builder()
+                        .setMinValue(-100).setMaxValue(100).setNullsFraction(0.2)
+                        .setAverageRowSize(4).setDistinctValuesCount(70).build())
+                .addColumnStatistic(right, ColumnStatistic.builder()
+                        .setMinValue(0).setMaxValue(200).setNullsFraction(0.5)
+                        .setAverageRowSize(4).setDistinctValuesCount(20).build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(left, right));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertNull(actualStatistic.getHistogram());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -632,6 +632,204 @@ public class ExpressionStatisticsCalculatorTest {
     }
 
     @Test
+    public void testCoalesceReturnsCombinedStatisticsWhenBothInputsAreKnown() {
+        // Given COALESCE(left, right)
+        // CASE WHEN both inputs have known stats THEN calculate stats based on inputs END
+
+        final int rowCount = 100;
+        final int leftDistinctValues = 70;
+        final int rightDistinctValues = 20;
+        final double leftNullFraction = 0.2;
+        final double rightNullFraction = 0.5;
+        final int leftMin = -100;
+        final int leftMax = 100;
+        final int rightMin = 100;
+        final double rightMax = 200.5;
+
+        final double expectedDistinctValues = 90;
+        final double expectedNullFraction = 0.1;
+        final double expectedMin = -100;                // min(leftMin, rightMin)
+        final double expectedMax = 200.5;
+
+        final ColumnRefOperator leftInput = new ColumnRefOperator(2, IntegerType.INT, "left", true);
+        final ColumnRefOperator rightInput = new ColumnRefOperator(3, IntegerType.INT, "right", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(leftInput, new ColumnStatistic(leftMin, leftMax, leftNullFraction, 0, leftDistinctValues))
+                .addColumnStatistic(rightInput,
+                        new ColumnStatistic(rightMin, rightMax, rightNullFraction, 0, rightDistinctValues))
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(leftInput, rightInput));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(expectedNullFraction, actualStatistic.getNullsFraction(), 0.001);
+        Assertions.assertEquals(expectedDistinctValues, actualStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(expectedMin, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actualStatistic.getMaxValue(), 0.001);
+    }
+
+    @Test
+    public void testCoalesceReturnsUnknownWhenAnyInputIsUnknown() {
+        // Given COALESCE(left, right)
+        // CASE WHEN an input has unknown stats THEN output stats are also unknown END
+
+        final int rowCount = 100;
+        final ColumnRefOperator leftInput = new ColumnRefOperator(2, IntegerType.INT, "left", true);
+        final ColumnRefOperator rightInput = new ColumnRefOperator(3, IntegerType.INT, "right", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(leftInput, new ColumnStatistic(-100, 100, 0.2, 0, 70))
+                .addColumnStatistic(rightInput, ColumnStatistic.unknown())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(leftInput, rightInput));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertTrue(actualStatistic.isUnknown());
+    }
+
+    @Test
+    public void testCoalesceReturnsCombinedStatisticsWhenAllThreeInputsAreKnown() {
+        // Given COALESCE(input1, input2, input3)
+        // CASE WHEN more than two inputs where all have known stats THEN output stat is known END
+
+        final int rowCount = 100;
+        final int input1DistinctValues = 30;
+        final int input2DistinctValues = 20;
+        final int input3DistinctValues = 10;
+        final double input1NullFraction = 0.2;
+        final double input2NullFraction = 0.5;
+        final double input3NullFraction = 0.4;
+        final int input1Min = -100;
+        final int input1Max = 100;
+        final int input2Min = 100;
+        final int input2Max = 200;
+        final int input3Min = 0;
+        final int input3Max = 50;
+
+        final double expectedDistinctValues = 60;
+        final double expectedNullFraction = 0.04;
+        final double expectedMin = -100;
+        final double expectedMax = 200;
+
+        final ColumnRefOperator input1 = new ColumnRefOperator(0, IntegerType.INT, "input1", true);
+        final ColumnRefOperator input2 = new ColumnRefOperator(1, IntegerType.INT, "input2", true);
+        final ColumnRefOperator input3 = new ColumnRefOperator(2, IntegerType.INT, "input3", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(input1,
+                        new ColumnStatistic(input1Min, input1Max, input1NullFraction, 0, input1DistinctValues))
+                .addColumnStatistic(input2,
+                        new ColumnStatistic(input2Min, input2Max, input2NullFraction, 0, input2DistinctValues))
+                .addColumnStatistic(input3,
+                        new ColumnStatistic(input3Min, input3Max, input3NullFraction, 0, input3DistinctValues))
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(input1, input2, input3));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertFalse(actualStatistic.isUnknown());
+        Assertions.assertEquals(expectedNullFraction, actualStatistic.getNullsFraction(), 0.001);
+        Assertions.assertEquals(expectedDistinctValues, actualStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(expectedMin, actualStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(expectedMax, actualStatistic.getMaxValue(), 0.001);
+    }
+
+    @Test
+    public void testCalculateMcvForKnownBinaryInputs() {
+        // Given COALESCE(mcvLeft, mcvRight) where both inputs have MCV histograms
+        // CASE WHEN mcvLeft IS NOT NULL THEN mcvLeft ELSE mcvRight END
+
+        final long rowCount = 1000;
+        final double leftNullFraction = 0.3;
+        final double rightNullFraction = 0.5;
+        final Map<String, Long> leftMcv = Map.of("A", 400L, "B", 200L);
+        final Map<String, Long> rightMcv = Map.of("X", 300L, "A", 100L);
+
+        // Left MCVs pass through unscaled; right MCVs are scaled by the left null fraction (0.3) and merged by key.
+        final Map<String, Long> expectedMcv = Map.of(
+                "A", 430L,
+                "B", 200L,
+                "X", 90L);
+
+        final ColumnRefOperator mcvLeft = new ColumnRefOperator(4, IntegerType.INT, "mcvLeft", true);
+        final ColumnRefOperator mcvRight = new ColumnRefOperator(5, IntegerType.INT, "mcvRight", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(mcvLeft, ColumnStatistic.builder()
+                        .setNullsFraction(leftNullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), leftMcv))
+                        .build())
+                .addColumnStatistic(mcvRight, ColumnStatistic.builder()
+                        .setNullsFraction(rightNullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), rightMcv))
+                        .build())
+                .build();
+        final CallOperator coalesce =
+                new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT, Lists.newArrayList(mcvLeft, mcvRight));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertNotNull(actualStatistic.getHistogram());
+        Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
+    public void testCoalesceMcvCalculationWithMissingMcv() {
+        // Given COALESCE(input1, input2, input3)
+        // CASE WHEN one input has no mcv THEN mcv calculation does not account for the missing input END
+
+        final long rowCount = 1000;
+        final double input1NullFraction = 0.3;
+        final double input2NullFraction = 0.5;
+        final double input3NullFraction = 0.2;
+        final Map<String, Long> input1Mcv = Map.of("A", 400L, "B", 200L);
+        final Map<String, Long> input3Mcv = Map.of("Y", 50L);
+
+        // input1 passes through unscaled; input2 has no histogram so it adds nothing, but its null fraction
+        // still scales later inputs, so input3 is scaled by 0.3 * 0.5 = 0.15.
+        final Map<String, Long> expectedMcv = Map.of(
+                "A", 400L,
+                "B", 200L,
+                "Y", 8L);
+
+        final ColumnRefOperator input1 = new ColumnRefOperator(0, IntegerType.INT, "input1", true);
+        final ColumnRefOperator input2 = new ColumnRefOperator(1, IntegerType.INT, "input2", true);
+        final ColumnRefOperator input3 = new ColumnRefOperator(2, IntegerType.INT, "input3", true);
+        final Statistics statistics = Statistics.builder()
+                .setOutputRowCount(rowCount)
+                .addColumnStatistic(input1, ColumnStatistic.builder()
+                        .setNullsFraction(input1NullFraction)
+                        .setDistinctValuesCount(2)
+                        .setHistogram(new Histogram(Collections.emptyList(), input1Mcv))
+                        .build())
+                .addColumnStatistic(input2, ColumnStatistic.builder()
+                        .setNullsFraction(input2NullFraction)
+                        .setDistinctValuesCount(5)
+                        .build())
+                .addColumnStatistic(input3, ColumnStatistic.builder()
+                        .setNullsFraction(input3NullFraction)
+                        .setDistinctValuesCount(1)
+                        .setHistogram(new Histogram(Collections.emptyList(), input3Mcv))
+                        .build())
+                .build();
+        final CallOperator coalesce = new CallOperator(FunctionSet.COALESCE, IntegerType.BIGINT,
+                Lists.newArrayList(input1, input2, input3));
+
+        final ColumnStatistic actualStatistic = ExpressionStatisticCalculator.calculate(coalesce, statistics);
+
+        Assertions.assertNotNull(actualStatistic.getHistogram());
+        Assertions.assertEquals(expectedMcv, actualStatistic.getHistogram().getMCV());
+    }
+
+    @Test
     public void testWeek() {
         ColumnRefOperator left = new ColumnRefOperator(0, DateType.DATETIME, "left", true);
         ColumnRefOperator right = new ColumnRefOperator(1, IntegerType.INT, "right", true);


### PR DESCRIPTION
## Why I'm doing:
Column statistics (including MCVs) are not calculated for the coalesce function. This is detrimental to the query optimizer's performance. 

## What I'm doing:
Propagating column statistics for coalesce function based on its input. The implemented method assumes that the coalesce inputs are not correlated.

For COALESCE(c0, c1, …, cn), the output takes each row's value from the first non-null input. To propagate the most-common-values, each input column's MCV entries are weighted by that column's reachability — the probability that all earlier inputs were null — and then the combined set is scaled so the total row count never exceeds the maximum row count.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
