### PR TITLE
[BugFix] Detect range-colocate joins in plan-feedback colocate detection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
@@ -19,8 +19,7 @@ import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.DistributionProperty;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
-import com.starrocks.sql.optimizer.base.HashDistributionDesc;
-import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionSpecHelper;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashJoinOperator;
@@ -60,17 +59,8 @@ public abstract class JoinTuningGuide implements TuningGuide {
     }
 
     protected boolean isColocateJoin(OptExpression optExpression) {
-        // through the required properties type check if it is colocate join
-        return optExpression.getRequiredProperties().stream().allMatch(
-                physicalPropertySet -> {
-                    if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
-                        return false;
-                    }
-                    HashDistributionDesc.SourceType hashSourceType =
-                            ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
-                                    .getHashDistributionDesc().getSourceType();
-                    return hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL);
-                });
+        return optExpression.getRequiredProperties().stream().allMatch(physicalPropertySet ->
+                DistributionSpecHelper.supportColocate(physicalPropertySet.getDistributionProperty().getSpec()));
     }
 
     protected boolean isShuffleJoin(OptExpression leftChild, OptExpression rightChild) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionSpecHelper.java
@@ -93,4 +93,19 @@ public final class DistributionSpecHelper {
                 new EquivalentDescriptor(tableId, Collections.emptyList());
         return new RangeDistributionSpec(colocateColumns, emptyEquiv);
     }
+
+    /**
+     * Whether a required distribution property carrying {@code spec} can be satisfied by a colocate
+     * join without a shuffle exchange: a hash-{@code LOCAL} spec (classic colocate) or a
+     * {@link RangeDistributionSpec} (range colocate).
+     */
+    public static boolean supportColocate(DistributionSpec spec) {
+        if (spec instanceof RangeDistributionSpec) {
+            return true;
+        }
+        if (spec instanceof HashDistributionSpec) {
+            return ((HashDistributionSpec) spec).getHashDistributionDesc().isLocal();
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -157,13 +157,13 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.base.DistributionCol;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionSpecHelper;
 import com.starrocks.sql.optimizer.base.EquivalentDescriptor;
 import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionDescBP;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
-import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -3380,22 +3380,8 @@ public class PlanFragmentBuilder {
         }
 
         private boolean isColocateJoin(OptExpression optExpression) {
-            // Colocate join detection: a required property is colocate when
-            // it is either a hash-LOCAL spec (classic colocate) or a
-            // RangeDistributionSpec (range colocate; scan-local by invariant).
-            return optExpression.getRequiredProperties().stream().allMatch(
-                    physicalPropertySet -> {
-                        DistributionSpec spec = physicalPropertySet.getDistributionProperty().getSpec();
-                        if (spec instanceof RangeDistributionSpec) {
-                            return true;
-                        }
-                        if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
-                            return false;
-                        }
-                        HashDistributionDesc.SourceType hashSourceType =
-                                ((HashDistributionSpec) spec).getHashDistributionDesc().getSourceType();
-                        return hashSourceType.equals(HashDistributionDesc.SourceType.LOCAL);
-                    });
+            return optExpression.getRequiredProperties().stream().allMatch(physicalPropertySet ->
+                    DistributionSpecHelper.supportColocate(physicalPropertySet.getDistributionProperty().getSpec()));
         }
 
         public boolean isShuffleJoin(OptExpression optExpression) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMPlan2SQLBuilder.java
@@ -25,10 +25,8 @@ import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
-import com.starrocks.sql.optimizer.base.HashDistributionDesc;
-import com.starrocks.sql.optimizer.base.HashDistributionSpec;
+import com.starrocks.sql.optimizer.base.DistributionSpecHelper;
 import com.starrocks.sql.optimizer.base.Ordering;
-import com.starrocks.sql.optimizer.base.RangeDistributionSpec;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.SortPhase;
@@ -728,26 +726,13 @@ public class SPMPlan2SQLBuilder {
                     return HintNode.HINT_JOIN_BUCKET;
                 }
             } else {
-                // Colocate detection mirrors PlanFragmentBuilder.isColocateJoin:
-                // either hash-LOCAL on every required property, or a
-                // RangeDistributionSpec on every required property (range
-                // colocate; scan-local by invariant). Mixed or non-matching
-                // specs fall through to HINT_JOIN_SHUFFLE.
-                boolean allRange = optExpression.getRequiredProperties().stream()
-                        .allMatch(p -> p.getDistributionProperty().getSpec() instanceof RangeDistributionSpec);
-                if (allRange) {
+                if (optExpression.getRequiredProperties().stream()
+                        .allMatch(p -> DistributionSpecHelper.supportColocate(p.getDistributionProperty().getSpec()))) {
                     return HintNode.HINT_JOIN_COLOCATE;
                 }
                 Preconditions.checkState(optExpression.getRequiredProperties().stream()
                         .allMatch(p -> p.getDistributionProperty().isShuffle()));
-                if (optExpression.getRequiredProperties().stream().allMatch(p -> {
-                    HashDistributionSpec spec = p.getDistributionProperty().getSpec().cast();
-                    return HashDistributionDesc.SourceType.LOCAL.equals(spec.getHashDistributionDesc().getSourceType());
-                })) {
-                    return HintNode.HINT_JOIN_COLOCATE;
-                } else {
-                    return HintNode.HINT_JOIN_SHUFFLE;
-                }
+                return HintNode.HINT_JOIN_SHUFFLE;
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/DistributionSpecHelperTest.java
@@ -31,8 +31,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link DistributionSpecHelper#buildRangeDistributionSpecSkeleton}.
@@ -260,5 +262,34 @@ class DistributionSpecHelperTest {
         assertEquals(map.get(colB).getId(), spec.getColocateColumns().get(1).getColId());
         assertEquals(TABLE_ID, spec.getEquivalentDescriptor().getTableId());
         assertEquals(DistributionSpec.DistributionType.RANGE_LOCAL, spec.getType());
+    }
+
+    @Test
+    void supportColocateTrueForRange() {
+        // Range-colocate is scan-local by invariant, so a range required property is always colocate.
+        EquivalentDescriptor descriptor = new EquivalentDescriptor(TABLE_ID, List.of(1L));
+        List<DistributionCol> cols = List.of(new DistributionCol(1, true));
+        descriptor.initDistributionUnionFind(cols);
+        assertTrue(DistributionSpecHelper.supportColocate(new RangeDistributionSpec(cols, descriptor)));
+    }
+
+    @Test
+    void supportColocateForHashDependsOnSourceType() {
+        List<DistributionCol> cols = List.of(new DistributionCol(1, true));
+        HashDistributionSpec local = new HashDistributionSpec(
+                new HashDistributionDesc(cols, HashDistributionDesc.SourceType.LOCAL));
+        HashDistributionSpec shuffleJoin = new HashDistributionSpec(
+                new HashDistributionDesc(cols, HashDistributionDesc.SourceType.SHUFFLE_JOIN));
+        assertTrue(DistributionSpecHelper.supportColocate(local), "hash-LOCAL is classic colocate");
+        assertFalse(DistributionSpecHelper.supportColocate(shuffleJoin),
+                "hash SHUFFLE_JOIN needs an exchange, not colocate");
+    }
+
+    @Test
+    void supportColocateFalseForNonColocateSpecs() {
+        assertFalse(DistributionSpecHelper.supportColocate(new RoundRobinDistributionSpec()));
+        assertFalse(DistributionSpecHelper.supportColocate(new ReplicatedDistributionSpec()));
+        assertFalse(DistributionSpecHelper.supportColocate(new GatherDistributionSpec()));
+        assertFalse(DistributionSpecHelper.supportColocate(AnyDistributionSpec.INSTANCE));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`JoinTuningGuide.isColocateJoin` (the plan-feedback / Plan Advisor tuning guide) only recognized
classic hash-`LOCAL` colocate joins. A range-colocate join carries `RangeDistributionSpec`
(`DistributionType.RANGE_LOCAL`) required properties, whose `isShuffle()` is `false`, so it was
misclassified as **non-colocate**. As a result the Plan Advisor silently skipped the colocate
build/probe-swap tuning guide for range-colocate joins — no wrong results and no crash (the
`isShuffle()` guard short-circuits before the `HashDistributionSpec` cast), just a missed
optimization.

This "is a required property a colocate join?" check was hand-rolled in three consumers
(`PlanFragmentBuilder`, `SPMPlan2SQLBuilder`, `JoinTuningGuide`), each with its own
`instanceof` / `SourceType` matching. When range-colocate join was added (#71860) the first two were
updated and this third one in the plan-feedback subsystem was missed — duplicated derived logic
drifting out of sync.

## What I'm doing:

Fix the detection and remove the duplication that caused it: extract the check into a single helper
`DistributionSpecHelper.supportColocate(DistributionSpec)` — a required property is colocate when its
spec is hash-`LOCAL` (classic colocate) or a `RangeDistributionSpec` (range colocate) — and route all
three consumers through it. Range-colocate joins are now correctly detected, and the check lives in
one place so it cannot drift again.

The behavior delta is confined to the range-colocate path, which is gated behind the off-by-default
experimental `enable_range_distribution` flag — no change under any default/released configuration.

Tests: `DistributionSpecHelperTest#supportColocate*` covers detection per spec (range / hash-`LOCAL` /
shuffle / other). Verified green together with the planner (`RangeColocateMixedJoinPlanTest`) and SPM
(`SPMPlan2SQLTest`) consumers that route through the helper.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: gated behind the off-by-default experimental `enable_range_distribution`; the Plan Advisor can now emit the colocate build/probe-swap guide for range-colocate joins

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
 
🤖 Generated with [Claude Code](https://claude.com/claude-code)
