### PR TITLE
[UT] Fix flaky PublishVersionDaemonTest.testSharedNothingPublishWithThreadPool

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -23,6 +23,8 @@ import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.PublishVersionTask;
 import mockit.Expectations;
 import mockit.Mock;
@@ -244,6 +246,18 @@ public class PublishVersionDaemonTest {
             @Mock
             public ThreadPoolExecutor getTaskExecutor() {
                 return new SynchronousExecutor();
+            }
+        };
+
+        // Prevent AgentBatchTask from being dispatched to the shared background agent-task pool.
+        // Otherwise AgentBatchTask.run() would invoke methods on the @Mocked SystemInfoService
+        // (e.g. getBackend) from an uncontrolled daemon thread, racing with JMockit's mock
+        // lifecycle and causing flaky "Missing invocation" failures. This test only verifies
+        // publish bookkeeping, not agent task dispatch.
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+                // no-op
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:

`PublishVersionDaemonTest.testSharedNothingPublishWithThreadPool` is flaky, intermittently failing with:

```
Missing 1 invocation to:
com.starrocks.system.SystemInfoService#getBackend(1L)
Caused by: Missing invocations
    at com.starrocks.task.AgentBatchTask.run(AgentBatchTask.java:176)
    at java.base/java.lang.Thread.run(Thread.java:833)
```

Root cause: the test makes the publish executor synchronous via a `SynchronousExecutor` mock of `PublishVersionDaemon.getTaskExecutor()`, but the shared-nothing OLAP publish path (`PublishVersionDaemon.publishVersionForOlapTable`) still calls `AgentTaskExecutor.submit(batchTask)`, which dispatches the `AgentBatchTask` to a shared static daemon thread pool. That background thread runs `AgentBatchTask.run()` and invokes `getBackend(1L)` on the `@Mocked SystemInfoService` from an uncontrolled thread, racing with JMockit's mock lifecycle and producing nondeterministic "Missing invocation" failures.

## What I'm doing:

Mock `AgentTaskExecutor.submit` to a no-op inside the test so no background thread touches the mocked instances. The test only verifies publish bookkeeping (`finishTransaction` / `publishingTransactionIds` cleanup) — with `canTxnFinished` mocked to `true` and `finishTransaction` mocked via a `Delegate`, the agent-task dispatch is irrelevant to what the test asserts, so skipping it does not weaken coverage.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5