### PR TITLE
[BugFix] Bump table optimistic version on tablet split so concurrent queries re-plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -571,6 +571,18 @@ public class MergeTabletJob extends TabletReshardJob {
                             newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
                 }
             }
+
+            // Installing the new materialized indexes changes the partition's tablet layout:
+            // PhysicalPartition.getLatestIndex() now returns a different tablet set. A query that
+            // captured the old layout during planning (OlapScanNode fills scanTabletIds from
+            // getLatestIndex(), then mapTabletsToPartitions() re-reads it) would otherwise hard-fail
+            // at plan build ("Invalid tablet id ... may have been dropped") or hand a CN a stale
+            // tablet/version whose metadata object no longer exists. Bump the table's optimistic
+            // version so StatementPlanner's retry loop (OptimisticVersion.validateTableUpdate) detects
+            // the change and re-plans against the new layout. Mirrors SplitTabletJob's bump at the
+            // same commit point. This runs on both the leader (runRunningJob) and the replay path
+            // (replayCleaningJob), so followers re-plan too.
+            olapTable.lastSchemaUpdateTime.set(System.nanoTime());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -740,6 +740,18 @@ public class SplitTabletJob extends TabletReshardJob {
                             newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
                 }
             }
+
+            // Installing the new materialized indexes changes the partition's tablet layout:
+            // PhysicalPartition.getLatestIndex() now returns a different tablet set. A query that
+            // captured the old layout during planning (OlapScanNode fills scanTabletIds from
+            // getLatestIndex(), then mapTabletsToPartitions() re-reads it) would otherwise hard-fail
+            // at plan build ("Invalid tablet id ... may have been dropped") or hand a CN a stale
+            // tablet/version whose metadata object no longer exists. Bump the table's optimistic
+            // version so StatementPlanner's retry loop (OptimisticVersion.validateTableUpdate) detects
+            // the change and re-plans against the new layout. Mirrors MergePartitionJob's bump at its
+            // partition-replace commit point. This runs on both the leader (runRunningJob) and the
+            // replay path (replayCleaningJob), so followers re-plan too.
+            olapTable.lastSchemaUpdateTime.set(System.nanoTime());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -219,6 +219,34 @@ public class MergeTabletJobTest {
     }
 
     @Test
+    public void testRunMergeBumpsOptimisticVersion() throws Exception {
+        TabletReshardJob splitJob = createSplitTabletReshardJob();
+        splitJob.init();
+        splitJob.run();
+        splitJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, splitJob.getJobState());
+
+        long beforeMerge = table.lastSchemaUpdateTime.get();
+
+        TabletReshardJob mergeJob = createMergeTabletReshardJob();
+        Assertions.assertNotNull(mergeJob);
+        mergeJob.init();
+        mergeJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, mergeJob.getJobState());
+
+        // runRunningJob() -> addNewMaterializedIndexes() installs the merged index and changes the
+        // partition tablet layout. It must bump lastSchemaUpdateTime so a query planned concurrently
+        // is re-planned by StatementPlanner's retry loop against the new layout, instead of failing with
+        // "Invalid tablet id ... The tablet may have been dropped". This runs on the RUNNING step.
+        mergeJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, mergeJob.getJobState());
+
+        long afterMerge = table.lastSchemaUpdateTime.get();
+        Assertions.assertTrue(afterMerge > beforeMerge,
+                "merge must bump lastSchemaUpdateTime (before=" + beforeMerge + ", after=" + afterMerge + ")");
+    }
+
+    @Test
     public void testGettersAndParallelTablets() throws Exception {
         MergeTabletJob mergeJob = createMergeTabletReshardJob();
         Assertions.assertEquals(db.getId(), mergeJob.getDbId());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -152,6 +152,30 @@ public class SplitTabletJobTest {
     }
 
     @Test
+    public void testRunBumpsOptimisticVersion() throws Exception {
+        installLakeServiceMock(this::addDataDrivenRanges);
+
+        long beforeSplit = table.lastSchemaUpdateTime.get();
+
+        TabletReshardJob tabletReshardJob = createTabletReshardJob();
+        Assertions.assertNotNull(tabletReshardJob);
+        tabletReshardJob.init();
+        tabletReshardJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.RUNNING, tabletReshardJob.getJobState());
+
+        // runRunningJob() -> addNewMaterializedIndexes() installs the split-child indexes and changes
+        // the partition tablet layout. It must bump lastSchemaUpdateTime so a query planned concurrently
+        // is re-planned by StatementPlanner's retry loop against the new layout, instead of failing with
+        // "Invalid tablet id ... The tablet may have been dropped". This runs on the RUNNING step.
+        tabletReshardJob.run();
+        Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, tabletReshardJob.getJobState());
+
+        long afterSplit = table.lastSchemaUpdateTime.get();
+        Assertions.assertTrue(afterSplit > beforeSplit,
+                "split must bump lastSchemaUpdateTime (before=" + beforeSplit + ", after=" + afterSplit + ")");
+    }
+
+    @Test
     public void testFallbackToIdenticalTablet() throws Exception {
         installLakeServiceMock(this::addFallbackToIdenticalRanges);
 


### PR DESCRIPTION
## Why I'm doing:

During a tablet reshard (split) on a shared-data RANGE PK table, installing the new materialized indexes changes the partition's tablet layout. A query planned concurrently captures the old layout: `OlapScanNode.computeScanRangeLocations()` fills `scanTabletIds` from `PhysicalPartition.getLatestIndex()`, then `mapTabletsToPartitions()` re-reads `getLatestIndex()`. The split installs a new `MaterializedIndex` between the two reads, so a `scanTabletId` (a just-created split child) is absent from the rebuilt map and planning throws:

```
Invalid tablet id: '<id>'. The tablet may have been dropped. Selected partitions:[...]
```

`StatementPlanner`'s planning-retry loop should re-plan on concurrent metadata change, but its guard `OptimisticVersion.validateTableUpdate` only reacts to schema changes (`lastSchemaUpdateTime`) or `UPDATING_META` state — a tablet reshard bumps neither, so it rethrows instead of retrying.

## What I'm doing:

Bump `olapTable.lastSchemaUpdateTime` at the split's visible-commit point (`addNewMaterializedIndexes()`, which runs on both the leader path `runRunningJob()` and the replay path `replayCleaningJob()`), mirroring what `MergePartitionJob` already does at its partition-replace commit point. The existing retry loop then detects the change and re-plans against the new tablet layout instead of hard-failing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

### Verification

Reproduced on a shared-data RANGE PK lake table under sustained ingest with dynamic reshard splitting and a concurrent Q1–Q5 query load: the `Invalid tablet id` failure occurs deterministically in the split index-swap window. With this fix the planning-retry loop re-plans against the new tablet layout and the failure no longer occurs during concurrent splits.
