### PR TITLE
[BugFix] Resolve sparse segment_idx rssids in lake GLM late-materialization 

### DIFF
--- a/be/src/connector/lake/lake_global_late_materialization_context.cpp
+++ b/be/src/connector/lake/lake_global_late_materialization_context.cpp
@@ -39,13 +39,32 @@ lake::RowsetPtr LakeScanLazyMaterializationContext::get_rowset(const std::vector
     lake::RowsetPtr target;
     int32_t segment_id = 0;
 
+    // Resolve an rssid (rowset id + a segment's segment_idx) back to its rowset and the segment's
+    // PHYSICAL position in segment_metas. segment_idx is NOT necessarily dense over [0, num_segments):
+    // a tablet split keeps only the segments a child owns while preserving each kept segment's
+    // ORIGINAL segment_idx (so the inherited cloud-native PK-index rssids stay stable), which leaves
+    // gaps -- e.g. a child that drops the low-key segment keeps segments with segment_idx {1,2} while
+    // segment_metas_size()==2. Matching by segment_idx and returning the physical position is therefore
+    // required: the old dense `rssid - rowset.id()` offset would fail to resolve the top segment
+    // (rssid == id+2 falls outside [id, id+2)), surfacing as "not found lake rssid", and would resolve a
+    // surviving lower rssid to the wrong physical segment. See issue #75993.
+    const auto urssid = static_cast<uint32_t>(rssid);
     for (const auto& rowset : rowsets) {
         const auto& rowset_meta = rowset->metadata();
         const uint32_t rssid_base = rowset_meta.id();
-        size_t num_segment = rowset_meta.segment_metas_size();
-        if (rssid_base <= rssid && rssid < rssid_base + num_segment) {
-            segment_id = rssid - rssid_base;
-            target = rowset;
+        // Fast reject: the rssid must fall in this rowset's owned rssid span
+        // [id, id + get_rowset_id_step) = [id, id + max_segment_idx + 1).
+        if (urssid < rssid_base || urssid >= rssid_base + lake::get_rowset_id_step(rowset_meta)) {
+            continue;
+        }
+        for (int i = 0; i < rowset_meta.segment_metas_size(); ++i) {
+            if (rssid_base + lake::get_segment_idx(rowset_meta, i) == urssid) {
+                segment_id = i;
+                target = rowset;
+                break;
+            }
+        }
+        if (target != nullptr) {
             break;
         }
     }

--- a/be/test/connector/lake/lake_global_late_materialization_context_test.cpp
+++ b/be/test/connector/lake/lake_global_late_materialization_context_test.cpp
@@ -36,6 +36,23 @@ lake::RowsetPtr make_lake_rowset(int num_segments, ObjectPool* pool) {
     return std::make_shared<lake::Rowset>(nullptr, next_id++, std::move(meta), 0, nullptr);
 }
 
+// Build a lake::RowsetPtr with an explicit rowset id and explicit per-segment segment_idx values,
+// so the rowset's rssids are `rowset_id + segment_idx` (not the dense positional index). This mirrors
+// what a tablet split produces on a child that keeps only a subset of a rowset's segments while
+// preserving each kept segment's ORIGINAL segment_idx (issue #75993).
+lake::RowsetPtr make_lake_rowset_with_seg_idxs(uint32_t rowset_id, const std::vector<uint32_t>& seg_idxs,
+                                               ObjectPool* pool) {
+    auto meta = pool->add(new RowsetMetadataPB());
+    meta->set_id(rowset_id);
+    meta->set_num_rows(100);
+    for (uint32_t idx : seg_idxs) {
+        auto* sm = meta->add_segment_metas();
+        sm->set_filename("seg_" + std::to_string(idx) + ".dat");
+        sm->set_segment_idx(idx);
+    }
+    return std::make_shared<lake::Rowset>(nullptr, /*tablet_id=*/1, std::move(meta), 0, nullptr);
+}
+
 std::vector<BaseRowsetSharedPtr> as_base(const std::vector<lake::RowsetPtr>& rowsets) {
     std::vector<BaseRowsetSharedPtr> result;
     for (const auto& rowset : rowsets) {
@@ -90,6 +107,66 @@ TEST(LakeScanLazyMaterializationContextTest, GetRowsetFirstSegment) {
     ASSERT_NE(nullptr, result);
     EXPECT_EQ(rowset.get(), result.get());
     EXPECT_EQ(0, segment_idx);
+}
+
+// Sparse segment_idx after a tablet split: a child keeps segments with segment_idx {1, 2}
+// (physical positions 0, 1) while segment_metas_size()==2. get_rowset must resolve each rssid by
+// its real (rowset.id + segment_idx) and return the segment's PHYSICAL position. The pre-fix dense
+// logic (`rssid_base <= rssid < rssid_base + num_segments`, segment = rssid - rssid_base) would miss
+// rssid id+2 (falls outside [id, id+2)) -> "not found lake rssid" -- and resolve id+1 to the wrong
+// physical position. Regression guard for issue #75993.
+TEST(LakeScanLazyMaterializationContextTest, GetRowsetSparseSegmentIdx) {
+    LakeScanLazyMaterializationContext ctx;
+    ObjectPool pool;
+    // rowset id=1000, kept segments segment_idx {1, 2} (low-key segment 0 dropped by the split).
+    auto rs = make_lake_rowset_with_seg_idxs(1000, {1, 2}, &pool);
+    ctx.capture_rowsets(7, /*version=*/1, as_base({rs}));
+
+    int32_t seg_idx = -1;
+    // rssid id+1 -> physical position 0.
+    auto got = ctx.get_rowset(7, 1001, &seg_idx);
+    ASSERT_NE(nullptr, got);
+    EXPECT_EQ(rs.get(), got.get());
+    EXPECT_EQ(0, seg_idx);
+
+    // rssid id+2 -> physical position 1 (the case the pre-fix code failed to resolve).
+    seg_idx = -1;
+    got = ctx.get_rowset(7, 1002, &seg_idx);
+    ASSERT_NE(nullptr, got);
+    EXPECT_EQ(rs.get(), got.get());
+    EXPECT_EQ(1, seg_idx);
+
+    // rssid id+0: segment_idx 0 was dropped, so no segment owns it -> unresolved.
+    seg_idx = -1;
+    EXPECT_EQ(nullptr, ctx.get_rowset(7, 1000, &seg_idx));
+
+    // rssid beyond the rowset's owned span [id, id + max_segment_idx + 1) -> unresolved.
+    EXPECT_EQ(nullptr, ctx.get_rowset(7, 1003, &seg_idx));
+}
+
+// Multiple rowsets, one dense and one sparse: each rssid resolves to the correct rowset + position.
+TEST(LakeScanLazyMaterializationContextTest, GetRowsetMixedDenseAndSparse) {
+    LakeScanLazyMaterializationContext ctx;
+    ObjectPool pool;
+    auto dense = make_lake_rowset_with_seg_idxs(2000, {0, 1}, &pool);  // span [2000, 2002)
+    auto sparse = make_lake_rowset_with_seg_idxs(3000, {2, 3}, &pool); // span [3000, 3004)
+    ctx.capture_rowsets(9, /*version=*/1, as_base({dense, sparse}));
+
+    int32_t seg_idx = -1;
+    EXPECT_EQ(dense.get(), ctx.get_rowset(9, 2000, &seg_idx).get());
+    EXPECT_EQ(0, seg_idx);
+    EXPECT_EQ(dense.get(), ctx.get_rowset(9, 2001, &seg_idx).get());
+    EXPECT_EQ(1, seg_idx);
+
+    EXPECT_EQ(sparse.get(), ctx.get_rowset(9, 3002, &seg_idx).get());
+    EXPECT_EQ(0, seg_idx);
+    EXPECT_EQ(sparse.get(), ctx.get_rowset(9, 3003, &seg_idx).get());
+    EXPECT_EQ(1, seg_idx);
+
+    // Gaps between/around the owned spans resolve to nothing.
+    EXPECT_EQ(nullptr, ctx.get_rowset(9, 2002, &seg_idx));
+    EXPECT_EQ(nullptr, ctx.get_rowset(9, 3000, &seg_idx));
+    EXPECT_EQ(nullptr, ctx.get_rowset(9, 3001, &seg_idx));
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

On a shared-data RANGE PK table, global lazy-materialization (GLM) resolves a scan-emitted
row locator `rssid` back to its rowset + segment via
`LakeScanLazyMaterializationContext::get_rowset()`. That resolver assumed each rowset owns the
**dense** rssid range `[rowset.id, rowset.id + segment_metas_size)` and derived the segment as
`rssid - rowset.id`.

The assumption breaks after a tablet **SPLIT**. A split child keeps only the segments it owns and
**preserves each kept segment's original `segment_idx`** (so the inherited cloud-native PK-index
rssids stay stable), which leaves gaps — e.g. a child that drops the low-key segment keeps segments
with `segment_idx {1, 2}` while `segment_metas_size() == 2`. The scan tags those rows with
`rssid = rowset.id + get_segment_idx()` (sparse), but `get_rowset` checked `rssid < rowset.id + 2`, so:

- the top segment (`rssid == id+2`) resolved to no rowset → the row's late materialization failed
  with **`not found lake rssid`** (before #75889's null guard, a CN SIGSEGV);
- a surviving lower rssid could resolve to the **wrong physical segment position**, returning wrong data.

This is the actual root cause of the `not found lake rssid` errors seen on split children — the defect
is in the read/resolution path, not in the PK-index contents.

## What I'm doing:

Fix `LakeScanLazyMaterializationContext::get_rowset()` to be sparse-`segment_idx`-aware: match the
rssid against each segment's real `rowset.id + get_segment_idx(i)` and return the segment's **physical
position `i`**, with a fast reject on the rowset's owned span `[id, id + get_rowset_id_step)`.

This resolves sparse rssids correctly **without losing any row**, at the true source of the error, so
no write-side PK-index rewrite or entry drop is needed. Range-only in effect because hash-bucket
tablets never split; the OLAP path is unaffected (it allocates dense dynamic rssids).

> Supersedes the earlier base-level SST-merge reconcile approach on this branch: that dropped index
> entries on the write side using the *same* dense-interval assumption, which masked the symptom while
> risking dropping valid sparse-`segment_idx` entries. This PR fixes the resolver directly instead.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

### Verification

Added a unit test (`glm_manager_tablet_adaptor_test.cpp`) that builds a split-shaped lake rowset with
sparse `segment_idx {1, 2}` and asserts `get_rowset` resolves `id+1`→position 0 and `id+2`→position 1
(the case the pre-fix dense logic missed → `not found lake rssid`), plus a mixed dense/sparse
multi-rowset case and the unresolved-gap cases.
