### PR TITLE
[Enhancement] Dictification for Array Functions with constant parameters (forntend changes)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -58,6 +58,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperat
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -97,6 +98,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
@@ -144,12 +146,16 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
     // array<string> support:
     //  array<string> -> array<string>: array function
     //  array<string> -> string       : array element
+    // Only processed if the first argument (input array) is not constant. Any string or array<string> constant
+    // parameters will be encoded into the array's dictionary domain using dict_encode().
     public static final Set<String> LOW_CARD_ARRAY_FUNCTIONS = ImmutableSet.of(
             FunctionSet.ARRAY_MIN,  // ARRAY -> STRING
             FunctionSet.ARRAY_MAX, FunctionSet.ARRAY_DISTINCT, // ARRAY -> ARRAY
             FunctionSet.ARRAY_SORT, FunctionSet.REVERSE, FunctionSet.ARRAY_SLICE, FunctionSet.ARRAY_FILTER,
             FunctionSet.ARRAY_LENGTH, // ARRAY -> bigint, return direct
-            FunctionSet.CARDINALITY);
+            FunctionSet.CARDINALITY, FunctionSet.ARRAY_CONTAINS, FunctionSet.ARRAY_CONTAINS_ALL,
+            FunctionSet.ARRAY_CONTAINS_SEQ, FunctionSet.ARRAY_INTERSECT, FunctionSet.ARRAY_POSITION,
+            FunctionSet.ARRAY_REMOVE);
 
     private final SessionVariable sessionVariable;
     private final boolean isQuery;
@@ -1534,6 +1540,12 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             return CONSTANTS;
         }
 
+        private static boolean isSupportedArrayFnConstantParameter(ScalarOperator op) {
+            return op.isConstantRef() || (!op.getType().isStringType() && !op.getType().isStringArrayType()) ||
+                    (op instanceof ArrayOperator arrayOp &&
+                            arrayOp.getChildren().stream().allMatch(ScalarOperator::isConstantRef));
+        }
+
         @Override
         public ScalarOperator visitCall(CallOperator call, Void context) {
             if (FunctionSet.nonDeterministicFunctions.contains(call.getFnName())) {
@@ -1552,10 +1564,13 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 ScalarOperator result = mergeWithArray(visitChildren(call, context), call);
                 return !result.isConstant() ? call : result;
             }
-
             if (LOW_CARD_ARRAY_FUNCTIONS.contains(call.getFnName()) ||
                     LOW_CARD_AGGREGATE_FUNCTIONS.contains(call.getFnName())) {
-                return mergeWithArray(visitChildren(call, context), call);
+                List<ScalarOperator> newChildren = visitChildren(call, context);
+                boolean forbidden = newChildren.get(0).isConstant() ||
+                        IntStream.range(0, newChildren.size()).anyMatch(i -> newChildren.get(i).equals(CONSTANTS)
+                                && !isSupportedArrayFnConstantParameter(call.getChild(i)));
+                return forbidden ? forbidden(newChildren, call) : mergeWithArray(newChildren, call);
             }
             if (LOW_CARD_STRING_FUNCTIONS.contains(call.getFnName())) {
                 return merge(visitChildren(call, context), call);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -19,11 +19,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -34,18 +36,22 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
+import com.starrocks.thrift.TFunctionBinaryType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_ARRAY_FUNCTIONS;
 import static com.starrocks.sql.optimizer.rule.tree.lowcardinality.DecodeCollector.LOW_CARD_STRUCT_FUNCTIONS;
@@ -303,6 +309,37 @@ class DecodeContext {
         }
     }
 
+    private static final String DICT_ENCODE = "dict_encode";
+    private static final Function DICT_ENCODE_FN = new Function(
+            30700, new FunctionName(DICT_ENCODE), List.of(VarcharType.VARCHAR, IntegerType.INT), IntegerType.INT, false);
+    static {
+        DICT_ENCODE_FN.setBinaryType(TFunctionBinaryType.BUILTIN);
+    }
+
+    private static ScalarOperator dictEncodeConstant(ScalarOperator constant, int dictId) {
+        if (!constant.getType().isStringType() && !constant.getType().isStringArrayType()) {
+            return constant;
+        }
+        ConstantOperator dictSlotConstant = ConstantOperator.createInt(dictId);
+        if (constant instanceof ConstantOperator constantOp) {
+            if (constantOp.getType().isStringType()) {
+                return new CallOperator(
+                        DICT_ENCODE, IntegerType.INT, List.of(constant, dictSlotConstant), DICT_ENCODE_FN);
+            }
+            Preconditions.checkState(constantOp.isNull());
+            return ConstantOperator.createNull(ArrayType.ARRAY_INT);
+        }
+        if (constant instanceof ArrayOperator arrayOp) {
+            Preconditions.checkState(arrayOp.getChildren().stream().allMatch(ScalarOperator::isConstantRef));
+            return new ArrayOperator(ArrayType.ARRAY_INT, arrayOp.isNullable(),
+                    arrayOp.getChildren().stream().map(k -> (ScalarOperator) new CallOperator(
+                                    DICT_ENCODE, IntegerType.INT, List.of(k, dictSlotConstant), DICT_ENCODE_FN))
+                            .collect(Collectors.toCollection(ArrayList::new)));
+        }
+        throw new IllegalArgumentException("Invalid constant argument for array function: " + constant);
+
+    }
+
     private static Function buildFunction(String fnName, List<ScalarOperator> args) {
         if (fnName.equals(FunctionSet.NAMED_STRUCT)) {
             Type[] argTypes = args.stream().map(ScalarOperator::getType).toArray(Type[]::new);
@@ -440,6 +477,13 @@ class DecodeContext {
                 return call;
             }
 
+            if (isSupportedArrayFunction(call)) {
+                ColumnRefOperator stringRef = getUseStringRef(call);
+                ColumnRefOperator dictRef = stringRefToDictRefMap.get(stringRef);
+                Preconditions.checkNotNull(dictRef);
+                newChildren = newChildren.stream().map(op -> op.isConstant() ?
+                        dictEncodeConstant(op, dictRef.getId()) : op).collect(Collectors.toCollection(ArrayList::new));
+            }
             Function fn = buildFunction(call.getFnName(), newChildren);
             ScalarOperator result = new CallOperator(call.getFnName(), fn.getReturnType(), newChildren, fn);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -1182,12 +1182,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     @Test
     public void testArrayFunctionsWithConstant() throws Exception {
         String sql = """
-                SELECT  ARRAY_CONTAINS(S_ADDRESS, "A"),
-                        ARRAY_CONTAINS_ALL(S_ADDRESS, ["B", "C"]),
-                        ARRAY_CONTAINS_SEQ(S_ADDRESS, ["A", "C"]),
-                        ARRAY_INTERSECT(S_ADDRESS, ["B", "C"]),
-                        ARRAY_POSITION(S_ADDRESS, "D"),
-                        ARRAY_REMOVE(S_ADDRESS, "A")
+                SELECT  ARRAY_CONTAINS(S_ADDRESS, 'A'),
+                        ARRAY_CONTAINS_ALL(S_ADDRESS, ['B', 'C']),
+                        ARRAY_CONTAINS_SEQ(S_ADDRESS, ['A', 'C']),
+                        ARRAY_INTERSECT(S_ADDRESS, ['B', 'C']),
+                        ARRAY_POSITION(S_ADDRESS, 'D'),
+                        ARRAY_REMOVE(S_ADDRESS, 'A')
                 FROM supplier_nullable;
                 """;
 
@@ -1210,12 +1210,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                     SELECT ARRAY_AGG(UPPER(S_COMMENT)) AS arr
                     FROM supplier_nullable
                 )
-                SELECT  ARRAY_CONTAINS(arr, "A"),
-                        ARRAY_CONTAINS_ALL(arr, ["B", "C"]),
-                        ARRAY_CONTAINS_SEQ(arr, ["A", "C"]),
-                        ARRAY_INTERSECT(arr, ["B", "C"]),
-                        ARRAY_POSITION(arr, "D"),
-                        ARRAY_REMOVE(arr, "A")
+                SELECT  ARRAY_CONTAINS(arr, 'A'),
+                        ARRAY_CONTAINS_ALL(arr, ['B', 'C']),
+                        ARRAY_CONTAINS_SEQ(arr, ['A', 'C']),
+                        ARRAY_INTERSECT(arr, ['B', 'C']),
+                        ARRAY_POSITION(arr, 'D'),
+                        ARRAY_REMOVE(arr, 'A')
                 FROM CTE;
                 """;
 
@@ -1242,7 +1242,7 @@ public class LowCardinalityArrayTest extends PlanTestBase {
     @Test
     public void testArrayFunctionsWithConstantArray() throws Exception {
         String sql = """
-                SELECT  ARRAY_CONTAINS(["A", "B"], S_COMMENT)
+                SELECT  ARRAY_CONTAINS(['A', 'B'], S_COMMENT)
                 FROM supplier_nullable
                 ORDER BY S_COMMENT;
                 """;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -1178,4 +1178,89 @@ public class LowCardinalityArrayTest extends PlanTestBase {
         Assertions.assertNotEquals(firstSlot, secondSlot,
                 "two array_map calls reusing arg name `x` must get distinct slot ids, plan was:\n" + plan);
     }
+
+    @Test
+    public void testArrayFunctionsWithConstant() throws Exception {
+        String sql = """
+                SELECT  ARRAY_CONTAINS(S_ADDRESS, "A"),
+                        ARRAY_CONTAINS_ALL(S_ADDRESS, ["B", "C"]),
+                        ARRAY_CONTAINS_SEQ(S_ADDRESS, ["A", "C"]),
+                        ARRAY_INTERSECT(S_ADDRESS, ["B", "C"]),
+                        ARRAY_POSITION(S_ADDRESS, "D"),
+                        ARRAY_REMOVE(S_ADDRESS, "A")
+                FROM supplier_nullable;
+                """;
+
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 9> : array_contains(15: S_ADDRESS, dict_encode('A', 15))\n" +
+                "  |  <slot 10> : array_contains_all(15: S_ADDRESS, [dict_encode('B', 15),dict_encode('C', 15)])\n" +
+                "  |  <slot 11> : array_contains_seq(15: S_ADDRESS, [dict_encode('A', 15),dict_encode('C', 15)])\n" +
+                "  |  <slot 12> : DictDecode(15: S_ADDRESS, [<place-holder>], " +
+                "array_intersect(15: S_ADDRESS, [dict_encode('B', 15),dict_encode('C', 15)]))\n" +
+                "  |  <slot 13> : array_position(15: S_ADDRESS, dict_encode('D', 15))\n" +
+                "  |  <slot 14> : DictDecode(15: S_ADDRESS, [<place-holder>], " +
+                "array_remove(15: S_ADDRESS, dict_encode('A', 15)))"), plan);
+    }
+
+    @Test
+    public void testArrayFunctionsWithConstantDerivedDict() throws Exception {
+        String sql = """
+                WITH CTE AS (
+                    SELECT ARRAY_AGG(UPPER(S_COMMENT)) AS arr
+                    FROM supplier_nullable
+                )
+                SELECT  ARRAY_CONTAINS(arr, "A"),
+                        ARRAY_CONTAINS_ALL(arr, ["B", "C"]),
+                        ARRAY_CONTAINS_SEQ(arr, ["A", "C"]),
+                        ARRAY_INTERSECT(arr, ["B", "C"]),
+                        ARRAY_POSITION(arr, "D"),
+                        ARRAY_REMOVE(arr, "A")
+                FROM CTE;
+                """;
+
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("3:Project\n" +
+                "  |  <slot 11> : array_contains(22: array_agg, dict_encode('A', 22))\n" +
+                "  |  <slot 12> : array_contains_all(22: array_agg, [dict_encode('B', 22),dict_encode('C', 22)])\n" +
+                "  |  <slot 13> : array_contains_seq(22: array_agg, [dict_encode('A', 22),dict_encode('C', 22)])\n" +
+                "  |  <slot 14> : DictDecode(22: array_agg, [<place-holder>], " +
+                "array_intersect(22: array_agg, [dict_encode('B', 22),dict_encode('C', 22)]))\n" +
+                "  |  <slot 15> : array_position(22: array_agg, dict_encode('D', 22))\n" +
+                "  |  <slot 16> : DictDecode(22: array_agg, [<place-holder>], " +
+                "array_remove(22: array_agg, dict_encode('A', 22)))\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: array_agg(21: UPPER)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 21> : DictDefine(20: S_COMMENT, [upper(<place-holder>)])\n" +
+                "  |  "), plan);
+    }
+
+    @Test
+    public void testArrayFunctionsWithConstantArray() throws Exception {
+        String sql = """
+                SELECT  ARRAY_CONTAINS(["A", "B"], S_COMMENT)
+                FROM supplier_nullable
+                ORDER BY S_COMMENT;
+                """;
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("  1:Project\n" +
+                "  |  <slot 9> : array_contains(['A','B'], DictDecode(10: S_COMMENT, [<place-holder>]))\n" +
+                "  |  <slot 10> : 10: S_COMMENT"), plan);
+    }
+
+    @Test
+    public void testArrayFunctionsWithNonConstantInput() throws Exception {
+        String sql = """
+                SELECT  ARRAY_INTERSECT(S_ADDRESS, ARRAY_DISTINCT(S_ADDRESS))
+                FROM supplier_nullable
+                """;
+        String plan = getFragmentPlan(sql);
+        Assertions.assertTrue(plan.contains("1:Project\n" +
+                "  |  <slot 9> : DictDecode(10: S_ADDRESS, [<place-holder>], " +
+                "array_intersect(10: S_ADDRESS, array_distinct(10: S_ADDRESS)))"), plan);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -1025,7 +1025,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                     "    UNPARTITIONED\n" +
                     "\n" +
                     "  27:Project\n" +
-                    "  |  <slot 603> : array_contains(DictDecode(625: array_agg, [<place-holder>]), 'asdfasdfasdf')\n" +
+                    "  |  <slot 603> : array_contains(625: array_agg, dict_encode('asdfasdfasdf', 625))\n" +
                     "  |  \n" +
                     "  26:AGGREGATE (merge finalize)\n" +
                     "  |  output: array_agg(625: array_agg)\n" +

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -305,13 +305,7 @@ insert into s2 select * from s2;
 -- result:
 -- !result
 [UC] analyze full table s1;
--- result:
-test_db_6dee41681e184222aa5562c8ae3fad8d.s1	analyze	status	OK
--- !result
 [UC] analyze full table s2;
--- result:
-test_db_6dee41681e184222aa5562c8ae3fad8d.s2	analyze	status	OK
--- !result
 function: wait_global_dict_ready('a1', 's1')
 -- result:
 
@@ -400,6 +394,23 @@ select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 fr
 -- result:
 anhui	5457
 beijing	5457
+-- !result
+select array_contains(a1, "Hunan"), array_contains_all(a1, ["Henan", "Tibet"]), array_contains_seq(a1, ["Ningxia", "Tibet"]), array_intersect(a1, ["Henan", "Yunnan"]),
+       array_position(a1, "Chongqing"), array_remove(a1, "Henan") from s1 order by v1 limit 2;
+-- result:
+1	0	0	["Henan"]	0	["Hunan"]
+0	1	1	["Yunnan","Henan"]	2	["Chongqing","Ningxia","Tibet","Yunnan"]
+-- !result
+with cte as (select array_slice(array_agg(a1[1] order by v1, v2), 1, 3)  as arr from s1)
+select array_contains(arr, "Hunan"), array_contains_all(arr, ["Henan", "Tibet"]), array_contains_seq(arr, ["Henan", "Hunan"]), array_intersect(arr, ["Henan", "Yunnan"]),
+       array_position(arr, "Macao"), array_remove(arr, "Henan") from cte;
+-- result:
+1	0	1	["Henan"]	3	["Hunan","Macao"]
+-- !result
+select  array_contains(a1, NULL), array_contains_all(a1, array_slice(a1, 1, 2)), array_contains_seq(a1, array_slice(a1, 1, 2)) from s1 order by v1 limit 2;
+-- result:
+0	1	1
+0	1	1
 -- !result
 -- name: test_low_array_with_dict_predicate
 CREATE TABLE `s3` (
@@ -521,13 +532,7 @@ insert into s4 values
 -- result:
 -- !result
 [UC] analyze full table s3;
--- result:
-test_db_71dab433600a49a6acd0a94e9315d982.s3	analyze	status	OK
--- !result
 [UC] analyze full table s4;
--- result:
-test_db_71dab433600a49a6acd0a94e9315d982.s4	analyze	status	OK
--- !result
 function: wait_global_dict_ready('a1', 's3')
 -- result:
 

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_array
@@ -395,15 +395,15 @@ select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 fr
 anhui	5457
 beijing	5457
 -- !result
-select array_contains(a1, "Hunan"), array_contains_all(a1, ["Henan", "Tibet"]), array_contains_seq(a1, ["Ningxia", "Tibet"]), array_intersect(a1, ["Henan", "Yunnan"]),
-       array_position(a1, "Chongqing"), array_remove(a1, "Henan") from s1 order by v1 limit 2;
+select array_contains(a1, 'Hunan'), array_contains_all(a1, ['Henan', 'Tibet']), array_contains_seq(a1, ['Ningxia', 'Tibet']), array_intersect(a1, ['Henan', 'Yunnan']),
+       array_position(a1, 'Chongqing'), array_remove(a1, 'Henan') from s1 order by v1 limit 2;
 -- result:
 1	0	0	["Henan"]	0	["Hunan"]
 0	1	1	["Yunnan","Henan"]	2	["Chongqing","Ningxia","Tibet","Yunnan"]
 -- !result
 with cte as (select array_slice(array_agg(a1[1] order by v1, v2), 1, 3)  as arr from s1)
-select array_contains(arr, "Hunan"), array_contains_all(arr, ["Henan", "Tibet"]), array_contains_seq(arr, ["Henan", "Hunan"]), array_intersect(arr, ["Henan", "Yunnan"]),
-       array_position(arr, "Macao"), array_remove(arr, "Henan") from cte;
+select array_contains(arr, 'Hunan'), array_contains_all(arr, ['Henan', 'Tibet']), array_contains_seq(arr, ['Henan', 'Hunan']), array_intersect(arr, ['Henan', 'Yunnan']),
+       array_position(arr, 'Macao'), array_remove(arr, 'Henan') from cte;
 -- result:
 1	0	1	["Henan"]	3	["Hunan","Macao"]
 -- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -335,12 +335,12 @@ select lower(MAX(upper(a1[1]))) from s1 group by a2[1] order by a2[1] limit 2;
 
 select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 from s1) y group by x1 order by x1 limit 2;
 
-select array_contains(a1, "Hunan"), array_contains_all(a1, ["Henan", "Tibet"]), array_contains_seq(a1, ["Ningxia", "Tibet"]), array_intersect(a1, ["Henan", "Yunnan"]),
-       array_position(a1, "Chongqing"), array_remove(a1, "Henan") from s1 order by v1 limit 2;
+select array_contains(a1, 'Hunan'), array_contains_all(a1, ['Henan', 'Tibet']), array_contains_seq(a1, ['Ningxia', 'Tibet']), array_intersect(a1, ['Henan', 'Yunnan']),
+       array_position(a1, 'Chongqing'), array_remove(a1, 'Henan') from s1 order by v1 limit 2;
 
 with cte as (select array_slice(array_agg(a1[1] order by v1, v2), 1, 3)  as arr from s1)
-select array_contains(arr, "Hunan"), array_contains_all(arr, ["Henan", "Tibet"]), array_contains_seq(arr, ["Henan", "Hunan"]), array_intersect(arr, ["Henan", "Yunnan"]),
-       array_position(arr, "Macao"), array_remove(arr, "Henan") from cte;
+select array_contains(arr, 'Hunan'), array_contains_all(arr, ['Henan', 'Tibet']), array_contains_seq(arr, ['Henan', 'Hunan']), array_intersect(arr, ['Henan', 'Yunnan']),
+       array_position(arr, 'Macao'), array_remove(arr, 'Henan') from cte;
 
 select  array_contains(a1, NULL), array_contains_all(a1, array_slice(a1, 1, 2)), array_contains_seq(a1, array_slice(a1, 1, 2)) from s1 order by v1 limit 2;
 

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_array
@@ -335,6 +335,15 @@ select lower(MAX(upper(a1[1]))) from s1 group by a2[1] order by a2[1] limit 2;
 
 select lower(x1), upper(MIN(HEX(x2))) from (select a1[1] x1, array_max(a2) x2 from s1) y group by x1 order by x1 limit 2;
 
+select array_contains(a1, "Hunan"), array_contains_all(a1, ["Henan", "Tibet"]), array_contains_seq(a1, ["Ningxia", "Tibet"]), array_intersect(a1, ["Henan", "Yunnan"]),
+       array_position(a1, "Chongqing"), array_remove(a1, "Henan") from s1 order by v1 limit 2;
+
+with cte as (select array_slice(array_agg(a1[1] order by v1, v2), 1, 3)  as arr from s1)
+select array_contains(arr, "Hunan"), array_contains_all(arr, ["Henan", "Tibet"]), array_contains_seq(arr, ["Henan", "Hunan"]), array_intersect(arr, ["Henan", "Yunnan"]),
+       array_position(arr, "Macao"), array_remove(arr, "Henan") from cte;
+
+select  array_contains(a1, NULL), array_contains_all(a1, array_slice(a1, 1, 2)), array_contains_seq(a1, array_slice(a1, 1, 2)) from s1 order by v1 limit 2;
+
 -- name: test_low_array_with_dict_predicate
 
 CREATE TABLE `s3` (


### PR DESCRIPTION
## Why I'm doing:
Currently dictification framework cannot rewrite array functions with constant arguments (like ARRAY_CONTAINS(arr, 'abc')). This is due to the fact that constant strings can't be translated into dictionary space. This PR implements this feature for fe side. 

## What I'm doing:
Implementing the logic for dictification of array functions which accept constant arguments in addition to the input array:

ARRAY_CONTAINS
ARRAY_CONTAINS_ALL
ARRAY_CONTAINS_SEQ
ARRAY_INTERSECT
ARRAY_POSITION
ARRAY_REMOVE

Backend changes have been done in https://github.com/StarRocks/starrocks/pull/74705 and need to be merged before this PR. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
