### PR TITLE
[Tool] unstable-case-review: pass --repo so it reviews the running repo's section

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -66,6 +66,7 @@ jobs:
 
           python3 bin/review-unstable-cases.py prepare \
             --json files/unstable_case.json \
+            --repo "${{ github.repository }}" \
             --branch "${BRANCH}" \
             --case-types "${CASE_TYPES}"
 
@@ -253,6 +254,7 @@ jobs:
 
           python3 bin/review-unstable-cases.py report \
             --json     files/unstable_case.json \
+            --repo     "${{ github.repository }}" \
             --branch   "${BRANCH}" \
             --commit   "${COMMIT_SHA}" \
             --case-types "${CASE_TYPES}" \


### PR DESCRIPTION
## Why I'm doing:
`review-unstable-cases.py` builds the blacklist section key as `<repo>-<branch>`, and `--repo` **defaults to `StarRocks/starrocks`**. The `unstable-case-review` workflow's `prepare` and `report` steps never passed `--repo`, so when the workflow runs on **CelerData** it reviewed the `StarRocks/starrocks-<branch>` section (226 cases) instead of `CelerData/celerdata-enterprise-<branch>` (211) — re-checking, and writing promotion/demotion into, the **wrong repo's blacklist**. (Confirmed live: the produced `probation.json` was keyed `StarRocks/starrocks-main` on a CelerData run.)

## What I'm doing:
Pass `--repo "${{ github.repository }}"` to both the `prepare` and `report` invocations, so the section key follows the repo the workflow actually runs in. This matches what `unstable-case-ai-analysis.yml` and `unstable-case-promote-demote.yml` already do.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

(On CelerData the review now targets the CelerData blacklist section instead of the StarRocks one.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr