### PR TITLE
[Tool] unstable-case-review: add `runs` input to control consecutive-run count

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: 'main'
         type: string
+      runs:
+        description: 'Consecutive runs per case for the stability check (default 3; set 1 for a quick debug run)'
+        required: false
+        default: '3'
+        type: string
 
 permissions:
   checks: write
@@ -32,6 +37,9 @@ permissions:
 env:
   IS_INSPECTION: 'true'
   SHARE_PATH: /var/local/env
+  # Consecutive-run count for the stability check, consumed by ci-tool
+  # run-sql-tester.sh / elastic-ut-review.sh (default 3; 1 = quick debug).
+  REVIEW_RUNS: ${{ inputs.runs || '3' }}
 
 jobs:
   # ─── Info / gate ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why I'm doing:
The unstable-case-review stability check runs each case a fixed 3 consecutive times. There was no knob to run fewer (e.g. once) for a quick debug.

## What I'm doing:
Add a `workflow_dispatch` input `runs` (default `3`) and inject it as the `REVIEW_RUNS` env at workflow level. ci-tool's `run-sql-tester.sh` / `elastic-ut-review.sh` read `REVIEW_RUNS` (defaulting to 3) — see StarRocks/ci-tool#4686. Dispatch with `runs=1` for a single-pass debug run.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Default stays 3; only a non-default `runs` input changes behavior.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Not included
Pairs with StarRocks/ci-tool#4686 (which reads `REVIEW_RUNS`). Either can merge first — both default to 3, so no coordination risk.