### PR TITLE
[BugFix] Skip unloadable tables in describeTable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -933,7 +933,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         Database db = metadataMgr.getDb(context, catalogName, params.db);
 
         if (db != null) {
-            Table table = metadataMgr.getTable(context, catalogName, params.db, params.table_name);
+            Table table;
+            try {
+                table = metadataMgr.getTable(context, catalogName, params.db, params.table_name);
+            } catch (Exception e) {
+                // A single table may fail to load/resolve (e.g. an external view whose
+                // definition cannot be parsed by StarRocks). Skip it instead of failing the
+                // whole describeTable RPC, which would break information_schema.columns scans.
+                LOG.warn("Failed to describe table {}.{}, skip it", params.db, params.table_name, e);
+                return result;
+            }
             if (table == null) {
                 return result;
             }
@@ -973,7 +982,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(fullName);
             if (db != null) {
                 for (String tableName : db.getTableNamesViewWithLock()) {
-                    Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+                    Table table;
+                    try {
+                        table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), tableName);
+                    } catch (Exception e) {
+                        // A single table may fail to load/resolve; skip it instead of aborting
+                        // the whole scan, mirroring the AccessDeniedException handling below.
+                        LOG.warn("Failed to describe table {}.{}, skip it", fullName, tableName, e);
+                        continue;
+                    }
                     if (table == null) {
                         continue;
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -38,6 +38,7 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
@@ -54,6 +55,8 @@ import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.DropTableStmt;
@@ -1329,6 +1332,63 @@ public class FrontendServiceImplTest {
         Assertions.assertEquals(2, testDefaultValue.size());
         Assertions.assertEquals("CURRENT_TIMESTAMP", testDefaultValue.get(0).getColumnDesc().getColumnDefault());
         Assertions.assertEquals("2", testDefaultValue.get(1).getColumnDesc().getColumnDefault());
+    }
+
+    @Test
+    public void testDescribeTableSkipsUnloadableTable() throws Exception {
+        // A single table may fail to load/resolve (e.g. an external view whose definition
+        // cannot be parsed by StarRocks). describeTable must skip it and return an empty
+        // result instead of throwing, otherwise information_schema.columns scans break.
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                throw new StarRocksConnectorException("failed to parse hive view text");
+            }
+        };
+
+        starRocksAssert.useDatabase("test");
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TDescribeTableParams request = new TDescribeTableParams();
+        request.setDb("test");
+        request.setTable_name("unloadable_view");
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("root");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        request.setCurrent_user_ident(userIdentity);
+
+        TDescribeTableResult response = impl.describeTable(request);
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.getColumns().isEmpty(),
+                "describeTable should skip a table that fails to load and return no columns");
+    }
+
+    @Test
+    public void testDescribeWithoutDbAndTableSkipsUnloadableTable() throws Exception {
+        // The no-db/no-table path (e.g. "select * from information_schema.columns limit N")
+        // iterates over every table. A single table that fails to load/resolve must be
+        // skipped instead of aborting the whole scan.
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public Table getTable(String dbName, String tblName) {
+                throw new StarRocksConnectorException("failed to parse hive view text");
+            }
+        };
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TDescribeTableParams request = new TDescribeTableParams();
+        // Neither db nor table set -> routes to describeWithoutDbAndTable.
+        request.setLimit(10);
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("root");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        request.setCurrent_user_ident(userIdentity);
+
+        TDescribeTableResult response = impl.describeTable(request);
+        Assertions.assertNotNull(response);
+        Assertions.assertTrue(response.getColumns().isEmpty(),
+                "describeWithoutDbAndTable should skip tables that fail to load and return no columns");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

An `information_schema.columns` scan lists a schema's tables and then calls `describeTable` once per table. If a **single** table fails to load or resolve, `describeTable` let the exception escape the Thrift handler, so the whole RPC (and the user's query) failed with a confusing `Internal error processing describeTable` / `FE RPC failure`.

This is reproducible with a Hive view whose definition uses Spark-only syntax (e.g. `LATERAL VIEW stack(...)`) that the StarRocks parser cannot parse: `MetadataMgr.getTable` raises `StarRocksConnectorException("failed to parse hive view text")`.

The table-*listing* path uses the lightweight `getBasicTable()` (see #73488), which does not parse view definitions, so a bad external view passes listing and reaches `describeTable`, whose `getTable()` then parses and throws. As a result, one unparseable external object breaks the entire metadata scan for the schema. This is present on all maintained branches (3.5 / 4.0 / 4.1).

## What I'm doing:

Catch per-table load failures in both `describeTable` code paths (the db+table path and `describeWithoutDbAndTable`) and skip the table — log a warning and return no columns for it — mirroring the existing `AccessDeniedException` skip behavior. This restores the "skip the bad object" behavior at the correct layer, so one bad external object no longer breaks the whole `information_schema.columns` scan regardless of how the caller lists tables.

- Wrap `MetadataMgr.getTable` in try/catch in `FrontendServiceImpl.describeTable`
- Wrap `getTable` in try/catch in `describeWithoutDbAndTable`
- Add `FrontendServiceImplTest.testDescribeTableSkipsUnloadableTable`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
