### PR TITLE
[BugFix] Force link int128 double cast wrapper (backport #76164)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -848,6 +848,7 @@ set(WL_LINK_DYNAMIC "-Wl,-Bdynamic")
 
 # Set starrocks libraries
 set(STARROCKS_LINK_LIBS
+    -Wl,-u,__wrap___floattidf
     ${WL_START_GROUP}
     Agent
     Common


### PR DESCRIPTION
## Why I'm doing:
We reproduced a BE SIGSEGV locally when running SQL cases that trigger `LARGEINT` to `DOUBLE` casts.
The crash stack shows that BE jumps to address `0x0` from the `__int128` to `double` cast path:
  ```text
  #0  0x0000000000000000 in ?? ()
  #1  starrocks::ImplicitToNumber::apply<__int128, double>
  #2  starrocks::CastFn<TYPE_LARGEINT, TYPE_DOUBLE>::cast_fn
  #3  starrocks::VectorizedCastExpr<TYPE_LARGEINT, TYPE_DOUBLE>::evaluate_checked
  #4  starrocks::Aggregator::evaluate_agg_input_column
```
StarRocks wraps the compiler-generated __floattidf helper with __wrap___floattidf. However, the wrapper implementation is built inside a static archive. With some linkers or linker behaviors, the weak reference generated after -wrap,__floattidf does not force the archive member that defines __wrap___floattidf to be extracted. As a result, starrocks_be may contain an unresolved weak wrapper symbol and crash when the cast path is executed.
## What I'm doing:
Force the linker to resolve `__wrap___floattidf` by adding `-Wl,-u,__wrap___floattidf` before StarRocks static libraries are scanned. This guarantees that the object defining the wrapper is linked into `starrocks_be`.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5

