### PR TITLE
[BugFix] Bound and expose the Iceberg partition cache memory

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -147,8 +147,13 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                         }
                     }
                 });
-        this.partitionCache = newCacheBuilderWithMaximumSize(
-                icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE, DEFAULT_CACHE_NUM).build(
+        long partitionCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
+                icebergProperties.getIcebergPartitionCacheMemoryUsageRatio());
+        this.partitionCache = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE)
+                .executor(executorService)
+                .maximumWeight(partitionCacheSize)
+                .weigher((Weigher<IcebergTableName, Map<String, Partition>>) this::weighPartitionEntry)
+                .build(
                     new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableName, Map<String, Partition>>() {
                         @Override
                         public Map<String, Partition> load(IcebergTableName key) throws Exception {
@@ -650,6 +655,17 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return (int) size;
     }
 
+    // Each entry holds a whole table's partition map, which is unbounded in bytes (a table can have
+    // millions of partitions). Sample the partition values so weighing stays cheap on large maps.
+    private int weighPartitionEntry(IcebergTableName key, Map<String, Partition> partitions) {
+        long size = Estimator.estimate(key) + Estimator.estimate(partitions, 3);
+        if (size > Integer.MAX_VALUE) {
+            LOG.warn("Partition cache entry size for key {} is too large: {} bytes", key, size);
+            return Integer.MAX_VALUE;
+        }
+        return (int) size;
+    }
+
     private long estimateContentFilesSize(Set<? extends ContentFile<?>> files) {
         if (files == null || files.isEmpty()) {
             return 0L;
@@ -694,7 +710,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return Estimator.estimate(tables.asMap(), 10) +
                 Estimator.estimate(databases.asMap(), 10) +
                 estimateDataFileCacheSize() +
-                estimateDeleteFileCacheSize() + Estimator.estimate(metaFileCacheMap, 10);
+                estimateDeleteFileCacheSize() +
+                Estimator.estimate(partitionCache.asMap(), 10) +
+                Estimator.estimate(metaFileCacheMap, 10) +
+                Estimator.estimate(tableLatestAccessTime, 10) +
+                Estimator.estimate(tableLatestRefreshTime, 10) +
+                Estimator.estimate(tableRefreshLockMap, 10);
     }
 
     private long estimateDataFileCacheSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalogProperties.java
@@ -44,6 +44,7 @@ public class IcebergCatalogProperties {
     public static final String ICEBERG_DATA_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_data_file_cache_memory_usage_ratio";
     public static final String ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO = "iceberg_delete_file_cache_memory_usage_ratio";
     public static final String ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO = "iceberg_table_cache_memory_usage_ratio";
+    public static final String ICEBERG_PARTITION_CACHE_MEMORY_SIZE_RATIO = "iceberg_partition_cache_memory_usage_ratio";
 
     // internal config
     public static final String REFRESH_ICEBERG_MANIFEST_MIN_LENGTH = "refresh_iceberg_manifest_min_length";
@@ -67,6 +68,7 @@ public class IcebergCatalogProperties {
     private double icebergDataFileCacheMemoryUsageRatio;
     private double icebergDeleteFileCacheMemoryUsageRatio;
     private double icebergTableCacheMemoryUsageRatio;
+    private double icebergPartitionCacheMemoryUsageRatio;
     private long icebergTableCacheRefreshIntervalSec;
 
     public IcebergCatalogProperties(Map<String, String> catalogProperties) {
@@ -107,6 +109,8 @@ public class IcebergCatalogProperties {
                     properties, ICEBERG_DELETE_FILE_CACHE_MEMORY_SIZE_RATIO, 0.1);
         this.icebergTableCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
                     properties, ICEBERG_TABLE_CACHE_MEMORY_SIZE_RATIO, 0.1);
+        this.icebergPartitionCacheMemoryUsageRatio = PropertyUtil.propertyAsDouble(
+                    properties, ICEBERG_PARTITION_CACHE_MEMORY_SIZE_RATIO, 0.1);
         this.icebergManifestCacheWithColumnStatistics = PropertyUtil.propertyAsBoolean(
                 properties, ICEBERG_MANIFEST_CACHE_WITH_COLUMN_STATISTICS, true);
         this.refreshIcebergManifestMinLength = PropertyUtil.propertyAsLong(properties, REFRESH_ICEBERG_MANIFEST_MIN_LENGTH,
@@ -180,6 +184,10 @@ public class IcebergCatalogProperties {
 
     public double getIcebergTableCacheMemoryUsageRatio() {
         return icebergTableCacheMemoryUsageRatio;
+    }
+
+    public double getIcebergPartitionCacheMemoryUsageRatio() {
+        return icebergPartitionCacheMemoryUsageRatio;
     }
 
     public long getRefreshIcebergManifestMinLength() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -218,6 +218,38 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
+    public void testPartitionCacheCountedInEstimateSize(@Mocked IcebergCatalog icebergCatalog) {
+        PartitionSpec spec = Mockito.mock(PartitionSpec.class);
+        Mockito.when(spec.isUnpartitioned()).thenReturn(false);
+        Table nativeTable = createBaseTableWithManifests(1, 0, spec);
+        Map<String, Partition> partitionMap = new HashMap<>();
+        for (int i = 0; i < 1000; i++) {
+            partitionMap.put("dt=part-" + i, new Partition(1234L, 1L));
+        }
+        new Expectations() {
+            {
+                icebergCatalog.getTable((ConnectContext) any, "db", "test");
+                result = nativeTable;
+                minTimes = 0;
+                icebergCatalog.getPartitions((IcebergTable) any, anyLong, null);
+                result = partitionMap;
+                minTimes = 0;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        IcebergTable table = IcebergTable.builder().setSrTableName("test")
+                .setCatalogDBName("db").setCatalogTableName("test").setNativeTable(nativeTable).build();
+
+        long before = cachingIcebergCatalog.estimateSize();
+        cachingIcebergCatalog.getPartitions(table, 1L, null);
+        long after = cachingIcebergCatalog.estimateSize();
+        // partitionCache used to be excluded from estimateSize, so a full partition map was invisible.
+        Assertions.assertTrue(after > before,
+                "partitionCache must be counted in estimateSize; before=" + before + " after=" + after);
+    }
+
+    @Test
     public void testGetDB(@Mocked IcebergCatalog icebergCatalog, @Mocked Database db) {
         new Expectations() {
             {


### PR DESCRIPTION
## Why I'm doing:

`CachingIcebergCatalog`'s partition cache stores one whole-table partition map (`Map<String, Partition>`) per entry, but was bounded only by **entry count** (`maximumSize`), not bytes. A handful of tables with many partitions (a table can have millions) can therefore grow it without limit. It is also the **only** metadata cache left out of `estimateSize()`, so its footprint is invisible in `/api/memory_usage` and the minute-level memory logs.

This is a real growth path, not a corner case: materialized views over Iceberg tables track base-table partitions, so MV rewrite/refresh populates the partition cache across many base tables.

Alongside it, the auxiliary maps `tableLatestAccessTime` / `tableLatestRefreshTime` / `tableRefreshLockMap` were likewise absent from `estimateSize()`.

## What I'm doing:

- Add a weigher + `maximumWeight` bound to the partition cache, sized by a new catalog property `iceberg_partition_cache_memory_usage_ratio` (default `0.1`), mirroring the data/delete/table file caches. The weigher samples the partition values (sample size 3) so weighing stays cheap on large maps.
- Include the partition cache and the three auxiliary maps in `estimateSize()`, so their bytes are reported. This benefits from the recently merged Estimator container-overhead fix (#75971), which makes the estimate accurate.

Fixes #issue: N/A — FE memory-safety/observability fix for the Iceberg partition cache (no separate tracking issue).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

New catalog property `iceberg_partition_cache_memory_usage_ratio` (default 0.1). The partition cache is now bounded by memory weight instead of a fixed 100k entry count, so under memory pressure it may hold fewer entries than before; the ratio is tunable and can be raised to restore the previous footprint.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
