### PR TITLE
[Enhancement] Cut join_hash_table.cpp compile time

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -113,6 +113,7 @@ set(EXEC_JOIN_CORE_FILES
     join/join_hash_table_descriptor.cpp
     join/join_key_constructor.cpp
     join/join_hash_table.cpp
+    join/join_hash_map_factory.cpp
     join/join_hash_map_mapping_inst.cpp
     join/join_hash_map_linear_chained_inst.cpp
     join/join_hash_map_linear_chained_set_inst.cpp

--- a/be/src/exec/join/join_hash_map.h
+++ b/be/src/exec/join/join_hash_map.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "exec/join/join_hash_map_base.h"
 #include "exec/join/join_hash_table_descriptor.h"
 #include "exec/join/join_type_traits.h"
 
@@ -31,16 +32,16 @@ class ColumnRef;
 
 // When hash table is empty, specific its implemention.
 // TODO: Merge with JoinHashMap?
-class JoinHashMapForEmpty {
+class JoinHashMapForEmpty : public JoinHashMapAdapter<JoinHashMapForEmpty> {
 public:
     explicit JoinHashMapForEmpty(JoinHashTableItems* table_items, HashTableProbeState* probe_state)
             : _table_items(table_items), _probe_state(probe_state) {}
 
-    void build_prepare(RuntimeState* state) {}
-    void probe_prepare(RuntimeState* state) {}
-    void build(RuntimeState* state) {}
+    void build_prepare(RuntimeState* state) override {}
+    void probe_prepare(RuntimeState* state) override {}
+    void build(RuntimeState* state) override {}
     void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
-               bool* has_remain) {
+               bool* has_remain) override {
         DCHECK_EQ(0, _table_items->row_count);
         *has_remain = false;
         _probe_state->match_flag = JoinMatchFlag::ALL_MATCH_ONE;
@@ -65,7 +66,7 @@ public:
         }
         return;
     }
-    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) {
+    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) override {
         // For RIGHT ANTI-JOIN, RIGHT SEMI-JOIN, FULL OUTER-JOIN, right table is empty,
         // do nothing for probe_remain.
         DCHECK_EQ(0, _table_items->row_count);
@@ -180,7 +181,7 @@ private:
 //     then `JoinHashMapMethod::lookup_init` to initialize the chained buckets for each row.
 
 template <LogicalType LT, JoinKeyConstructorType CT, JoinHashMapMethodType MT>
-class JoinHashMap {
+class JoinHashMap : public JoinHashMapAdapter<JoinHashMap<LT, CT, MT>> {
 public:
     using CppType = typename RunTimeTypeTraits<LT>::CppType;
     using BuildKeyConstructor = typename JoinKeyConstructorTypeTraits<CT, LT>::BuildType;
@@ -190,13 +191,13 @@ public:
     explicit JoinHashMap(JoinHashTableItems* table_items, HashTableProbeState* probe_state)
             : _table_items(table_items), _probe_state(probe_state) {}
 
-    void build_prepare(RuntimeState* state);
-    void probe_prepare(RuntimeState* state);
+    void build_prepare(RuntimeState* state) override;
+    void probe_prepare(RuntimeState* state) override;
 
-    void build(RuntimeState* state);
+    void build(RuntimeState* state) override;
     void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
-               bool* has_remain);
-    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain);
+               bool* has_remain) override;
+    void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) override;
     template <bool is_remain>
     void lazy_output(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk);
 
@@ -334,5 +335,20 @@ private:
     JoinHashTableItems* _table_items = nullptr;
     HashTableProbeState* _probe_state = nullptr;
 };
+
+// Factory whose definition lives in join_hash_map.hpp and is explicitly instantiated in the
+// join_hash_map_*_inst.cpp files. Callers (JoinHashTable::build) only see this declaration, so
+// they never have to complete the heavy polymorphic JoinHashMap<...> types just to create one.
+template <LogicalType LT, JoinKeyConstructorType CT, JoinHashMapMethodType MT>
+std::unique_ptr<JoinHashMapBase> make_join_hash_map(JoinHashTableItems* table_items, HashTableProbeState* probe_state);
+
+// Runtime factory table (defined in join_hash_map_factory.cpp, populated by the
+// join_hash_map_*_inst.cpp files at static init). Lets JoinHashTable::build() select a
+// concrete hash map by (key-constructor-unary, method-unary) without naming any concrete
+// JoinHashMap<LT, CT, MT> in build.cpp.
+using JoinHashMapFactoryFn = std::unique_ptr<JoinHashMapBase> (*)(JoinHashTableItems*, HashTableProbeState*);
+void register_join_hash_map_factory(JoinKeyConstructorUnaryType cut, JoinHashMapMethodUnaryType mut,
+                                    JoinHashMapFactoryFn fn);
+JoinHashMapFactoryFn find_join_hash_map_factory(JoinKeyConstructorUnaryType cut, JoinHashMapMethodUnaryType mut);
 
 } // namespace starrocks

--- a/be/src/exec/join/join_hash_map.hpp
+++ b/be/src/exec/join/join_hash_map.hpp
@@ -1959,4 +1959,9 @@ void JoinHashMap<LT, CT, MT>::_build_index_output(ChunkPtr* chunk) {
     (*chunk)->append_column(_probe_state->build_index_column, Chunk::HASH_JOIN_BUILD_INDEX_SLOT_ID);
 }
 
+template <LogicalType LT, JoinKeyConstructorType CT, JoinHashMapMethodType MT>
+std::unique_ptr<JoinHashMapBase> make_join_hash_map(JoinHashTableItems* table_items, HashTableProbeState* probe_state) {
+    return std::make_unique<JoinHashMap<LT, CT, MT>>(table_items, probe_state);
+}
+
 } // namespace starrocks

--- a/be/src/exec/join/join_hash_map_asof_inst.cpp
+++ b/be/src/exec/join/join_hash_map_asof_inst.cpp
@@ -18,11 +18,24 @@
 
 namespace starrocks {
 
+// Force-link anchor: referenced from join_hash_map_factory.cpp so this TU (and its
+// static-initializer factory registrations) is pulled from the static library.
+int join_hash_map_inst_anchor_asof = 0;
+
 #define DEF_JOIN_MAP(LT, CT, MT) JoinHashMap<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>
-#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                       \
-    template class DEF_JOIN_MAP(LT, CT, MT);                                                        \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*); \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);
+#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                            \
+    template class DEF_JOIN_MAP(LT, CT, MT);                                                             \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*);      \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);     \
+    template std::unique_ptr<JoinHashMapBase>                                                            \
+    make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>(JoinHashTableItems*,   \
+                                                                                  HashTableProbeState*); \
+    [[maybe_unused]] static const bool _jhm_reg_##LT##_##CT##_##MT =                                     \
+            (register_join_hash_map_factory(                                                             \
+                     JoinKeyConstructorTypeTraits<JoinKeyConstructorType::CT, LT>::unary_type,           \
+                     JoinHashMapMethodTypeTraits<JoinHashMapMethodType::MT, LT>::unary_type,             \
+                     &make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>),    \
+             true);
 
 INSTANTIATE_JOIN_HASH_MAP(TYPE_INT, ONE_KEY, LINEAR_CHAINED_ASOF)
 INSTANTIATE_JOIN_HASH_MAP(TYPE_BIGINT, ONE_KEY, LINEAR_CHAINED_ASOF)

--- a/be/src/exec/join/join_hash_map_base.h
+++ b/be/src/exec/join/join_hash_map_base.h
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "column/column.h"
+#include "column/vectorized_fwd.h"
+
+namespace starrocks {
+
+class RuntimeState;
+struct JoinHashTableItems;
+struct HashTableProbeState;
+
+// Runtime-polymorphic interface over the concrete JoinHashMap<LT, CT, MT> instantiations
+// (and JoinHashMapForEmpty). Previously JoinHashTable stored an ~80-alternative
+// std::variant and dispatched every operation through std::visit; that forced each
+// std::visit site to instantiate the generic visitor for all ~80 heavy JoinHashMap<...>
+// types in the caller TU, which dominated compile time (~1500s for join_hash_table.cpp).
+//
+// With this interface, JoinHashTable holds a single unique_ptr<JoinHashMapBase> and every
+// operation is one ordinary virtual call. The per-type dispatch information (the vtable)
+// is emitted where each concrete type is already explicitly instantiated (the
+// join_hash_map_*_inst.cpp files), so the heavy instantiation stays there instead of being
+// re-done at every call site. All dispatch is at chunk granularity, so the extra virtual
+// call is negligible at runtime.
+class JoinHashMapBase {
+public:
+    virtual ~JoinHashMapBase() = default;
+
+    virtual void build_prepare(RuntimeState* state) = 0;
+    virtual void probe_prepare(RuntimeState* state) = 0;
+    virtual void build(RuntimeState* state) = 0;
+    virtual void probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
+                       bool* has_remain) = 0;
+    virtual void probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* has_remain) = 0;
+
+    // `lazy_output<is_remain>` is a compile-time-parameterized member template; a virtual
+    // function cannot be a template, so the two instantiations are exposed as two entry points.
+    virtual void lazy_output_for_remain(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) = 0;
+    virtual void lazy_output_for_probe(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) = 0;
+
+    // Construct a fresh instance of the SAME concrete type, bound to the given items/state.
+    // Replaces the `make_unique<same-concrete-type>(...)` that clone_readable_table and
+    // reset_probe_state used to do inside a std::visit lambda.
+    virtual std::unique_ptr<JoinHashMapBase> clone(JoinHashTableItems* table_items,
+                                                   HashTableProbeState* probe_state) const = 0;
+};
+
+// CRTP adapter that supplies the boilerplate glue (the two lazy_output entry points and
+// clone) once for every concrete hash map, forwarding to the concrete type's own
+// `lazy_output<bool>` template and constructor. Concrete classes still override the five
+// core operations (build_prepare/probe_prepare/build/probe/probe_remain) directly.
+template <class Derived>
+class JoinHashMapAdapter : public JoinHashMapBase {
+public:
+    void lazy_output_for_remain(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) final {
+        static_cast<Derived*>(this)->template lazy_output<true>(state, probe_chunk, result_chunk);
+    }
+    void lazy_output_for_probe(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) final {
+        static_cast<Derived*>(this)->template lazy_output<false>(state, probe_chunk, result_chunk);
+    }
+    std::unique_ptr<JoinHashMapBase> clone(JoinHashTableItems* table_items,
+                                           HashTableProbeState* probe_state) const final {
+        return std::make_unique<Derived>(table_items, probe_state);
+    }
+};
+
+} // namespace starrocks

--- a/be/src/exec/join/join_hash_map_bucket_chained_inst.cpp
+++ b/be/src/exec/join/join_hash_map_bucket_chained_inst.cpp
@@ -18,11 +18,24 @@
 
 namespace starrocks {
 
+// Force-link anchor: referenced from join_hash_map_factory.cpp so this TU (and its
+// static-initializer factory registrations) is pulled from the static library.
+int join_hash_map_inst_anchor_bucket_chained = 0;
+
 #define DEF_JOIN_MAP(LT, CT, MT) JoinHashMap<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>
-#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                       \
-    template class DEF_JOIN_MAP(LT, CT, MT);                                                        \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*); \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);
+#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                            \
+    template class DEF_JOIN_MAP(LT, CT, MT);                                                             \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*);      \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);     \
+    template std::unique_ptr<JoinHashMapBase>                                                            \
+    make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>(JoinHashTableItems*,   \
+                                                                                  HashTableProbeState*); \
+    [[maybe_unused]] static const bool _jhm_reg_##LT##_##CT##_##MT =                                     \
+            (register_join_hash_map_factory(                                                             \
+                     JoinKeyConstructorTypeTraits<JoinKeyConstructorType::CT, LT>::unary_type,           \
+                     JoinHashMapMethodTypeTraits<JoinHashMapMethodType::MT, LT>::unary_type,             \
+                     &make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>),    \
+             true);
 
 INSTANTIATE_JOIN_HASH_MAP(TYPE_INT, ONE_KEY, BUCKET_CHAINED)
 INSTANTIATE_JOIN_HASH_MAP(TYPE_BIGINT, ONE_KEY, BUCKET_CHAINED)

--- a/be/src/exec/join/join_hash_map_factory.cpp
+++ b/be/src/exec/join/join_hash_map_factory.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Runtime factory table for JoinHashMap. Each join_hash_map_*_inst.cpp registers, at static
+// init, a `&make_join_hash_map<LT,CT,MT>` pointer keyed by (key-constructor-unary, method-unary).
+// JoinHashTable::build() then just looks the pointer up and calls it, so build.cpp never names a
+// concrete JoinHashMap<LT,CT,MT> and does not pay the ~8s-per-combo instantiation cost that a
+// compile-time dispatch incurs in a TU where those types are not otherwise instantiated.
+
+#include <unordered_map>
+
+#include "exec/join/join_hash_map.h"
+
+namespace starrocks {
+
+// The join_hash_map_*_inst.cpp TUs self-register their factories via static initializers, but
+// nothing else references them now that build() dispatches through JoinHashMapBase + this table,
+// so the linker would drop those objects. Reference one anchor from each below to force-link them.
+extern int join_hash_map_inst_anchor_bucket_chained;
+extern int join_hash_map_inst_anchor_linear_chained;
+extern int join_hash_map_inst_anchor_linear_chained_set;
+extern int join_hash_map_inst_anchor_asof;
+extern int join_hash_map_inst_anchor_mapping;
+
+namespace {
+[[gnu::used]] int* const g_join_hash_map_inst_link_anchors[] = {
+        &join_hash_map_inst_anchor_bucket_chained,
+        &join_hash_map_inst_anchor_linear_chained,
+        &join_hash_map_inst_anchor_linear_chained_set,
+        &join_hash_map_inst_anchor_asof,
+        &join_hash_map_inst_anchor_mapping,
+};
+} // namespace
+
+namespace {
+uint32_t factory_key(JoinKeyConstructorUnaryType cut, JoinHashMapMethodUnaryType mut) {
+    return (static_cast<uint32_t>(cut) << 16) | static_cast<uint32_t>(mut);
+}
+
+std::unordered_map<uint32_t, JoinHashMapFactoryFn>& factory_registry() {
+    static auto* registry = new std::unordered_map<uint32_t, JoinHashMapFactoryFn>();
+    return *registry;
+}
+} // namespace
+
+void register_join_hash_map_factory(JoinKeyConstructorUnaryType cut, JoinHashMapMethodUnaryType mut,
+                                    JoinHashMapFactoryFn fn) {
+    factory_registry()[factory_key(cut, mut)] = fn;
+}
+
+JoinHashMapFactoryFn find_join_hash_map_factory(JoinKeyConstructorUnaryType cut, JoinHashMapMethodUnaryType mut) {
+    (void)g_join_hash_map_inst_link_anchors;
+    const auto& registry = factory_registry();
+    const auto it = registry.find(factory_key(cut, mut));
+    return it == registry.end() ? nullptr : it->second;
+}
+
+} // namespace starrocks

--- a/be/src/exec/join/join_hash_map_linear_chained_inst.cpp
+++ b/be/src/exec/join/join_hash_map_linear_chained_inst.cpp
@@ -18,11 +18,24 @@
 
 namespace starrocks {
 
+// Force-link anchor: referenced from join_hash_map_factory.cpp so this TU (and its
+// static-initializer factory registrations) is pulled from the static library.
+int join_hash_map_inst_anchor_linear_chained = 0;
+
 #define DEF_JOIN_MAP(LT, CT, MT) JoinHashMap<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>
-#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                       \
-    template class DEF_JOIN_MAP(LT, CT, MT);                                                        \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*); \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);
+#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                            \
+    template class DEF_JOIN_MAP(LT, CT, MT);                                                             \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*);      \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);     \
+    template std::unique_ptr<JoinHashMapBase>                                                            \
+    make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>(JoinHashTableItems*,   \
+                                                                                  HashTableProbeState*); \
+    [[maybe_unused]] static const bool _jhm_reg_##LT##_##CT##_##MT =                                     \
+            (register_join_hash_map_factory(                                                             \
+                     JoinKeyConstructorTypeTraits<JoinKeyConstructorType::CT, LT>::unary_type,           \
+                     JoinHashMapMethodTypeTraits<JoinHashMapMethodType::MT, LT>::unary_type,             \
+                     &make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>),    \
+             true);
 
 INSTANTIATE_JOIN_HASH_MAP(TYPE_INT, ONE_KEY, LINEAR_CHAINED)
 INSTANTIATE_JOIN_HASH_MAP(TYPE_BIGINT, ONE_KEY, LINEAR_CHAINED)

--- a/be/src/exec/join/join_hash_map_linear_chained_set_inst.cpp
+++ b/be/src/exec/join/join_hash_map_linear_chained_set_inst.cpp
@@ -18,11 +18,24 @@
 
 namespace starrocks {
 
+// Force-link anchor: referenced from join_hash_map_factory.cpp so this TU (and its
+// static-initializer factory registrations) is pulled from the static library.
+int join_hash_map_inst_anchor_linear_chained_set = 0;
+
 #define DEF_JOIN_MAP(LT, CT, MT) JoinHashMap<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>
-#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                       \
-    template class DEF_JOIN_MAP(LT, CT, MT);                                                        \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*); \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);
+#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                            \
+    template class DEF_JOIN_MAP(LT, CT, MT);                                                             \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*);      \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);     \
+    template std::unique_ptr<JoinHashMapBase>                                                            \
+    make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>(JoinHashTableItems*,   \
+                                                                                  HashTableProbeState*); \
+    [[maybe_unused]] static const bool _jhm_reg_##LT##_##CT##_##MT =                                     \
+            (register_join_hash_map_factory(                                                             \
+                     JoinKeyConstructorTypeTraits<JoinKeyConstructorType::CT, LT>::unary_type,           \
+                     JoinHashMapMethodTypeTraits<JoinHashMapMethodType::MT, LT>::unary_type,             \
+                     &make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>),    \
+             true);
 
 INSTANTIATE_JOIN_HASH_MAP(TYPE_INT, ONE_KEY, LINEAR_CHAINED_SET)
 INSTANTIATE_JOIN_HASH_MAP(TYPE_BIGINT, ONE_KEY, LINEAR_CHAINED_SET)

--- a/be/src/exec/join/join_hash_map_mapping_inst.cpp
+++ b/be/src/exec/join/join_hash_map_mapping_inst.cpp
@@ -18,11 +18,24 @@
 
 namespace starrocks {
 
+// Force-link anchor: referenced from join_hash_map_factory.cpp so this TU (and its
+// static-initializer factory registrations) is pulled from the static library.
+int join_hash_map_inst_anchor_mapping = 0;
+
 #define DEF_JOIN_MAP(LT, CT, MT) JoinHashMap<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>
-#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                       \
-    template class DEF_JOIN_MAP(LT, CT, MT);                                                        \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*); \
-    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);
+#define INSTANTIATE_JOIN_HASH_MAP(LT, CT, MT)                                                            \
+    template class DEF_JOIN_MAP(LT, CT, MT);                                                             \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<true>(RuntimeState*, ChunkPtr*, ChunkPtr*);      \
+    template void DEF_JOIN_MAP(LT, CT, MT)::lazy_output<false>(RuntimeState*, ChunkPtr*, ChunkPtr*);     \
+    template std::unique_ptr<JoinHashMapBase>                                                            \
+    make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>(JoinHashTableItems*,   \
+                                                                                  HashTableProbeState*); \
+    [[maybe_unused]] static const bool _jhm_reg_##LT##_##CT##_##MT =                                     \
+            (register_join_hash_map_factory(                                                             \
+                     JoinKeyConstructorTypeTraits<JoinKeyConstructorType::CT, LT>::unary_type,           \
+                     JoinHashMapMethodTypeTraits<JoinHashMapMethodType::MT, LT>::unary_type,             \
+                     &make_join_hash_map<LT, JoinKeyConstructorType::CT, JoinHashMapMethodType::MT>),    \
+             true);
 
 INSTANTIATE_JOIN_HASH_MAP(TYPE_BOOLEAN, ONE_KEY, DIRECT_MAPPING)
 INSTANTIATE_JOIN_HASH_MAP(TYPE_TINYINT, ONE_KEY, DIRECT_MAPPING)

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -26,6 +26,7 @@
 #include "common/statusor.h"
 #include "common/system/cpu_info.h"
 #include "exec/join/join_hash_map_method.h"
+#include "exec/join/join_hash_table_descriptor.h"
 #include "exec/join/join_key_constructor.h"
 #include "exprs/column_ref.h"
 #include "runtime/descriptors.h"
@@ -343,27 +344,59 @@ std::pair<bool, JoinHashMapMethodUnaryType> JoinHashMapSelector::_try_use_linear
 }
 
 // ------------------------------------------------------------------------------------
-// JoinHashTable
+// JoinHashTable::build
 // ------------------------------------------------------------------------------------
 
-JoinHashTable JoinHashTable::clone_readable_table() {
-    JoinHashTable ht;
-
-    ht._is_empty_map = this->_is_empty_map;
-    ht._key_constructor_type = this->_key_constructor_type;
-    ht._hash_map_method_type = this->_hash_map_method_type;
-
-    ht._table_items = this->_table_items;
-    // Clone a new probe state.
-    ht._probe_state = std::make_unique<HashTableProbeState>(*this->_probe_state);
-
-    visit([&](const auto& hash_map) {
-        using HashMapType = std::decay_t<decltype(*hash_map)>;
-        ht._hash_map = std::make_unique<HashMapType>(ht._table_items.get(), ht._probe_state.get());
+Status JoinHashTable::build(RuntimeState* state, bool allow_build_empty_table) {
+    CancelableDefer defer = CancelableDefer([&]() {
+        _table_items->key_columns.clear();
+        _table_items->build_chunk->columns().clear();
+        _hash_map = {};
     });
 
-    return ht;
+    RETURN_IF_ERROR(_table_items->build_chunk->upgrade_if_overflow());
+    _table_items->has_large_column = _table_items->build_chunk->has_large_column();
+
+    // If the join key is column ref of build chunk, fetch from build chunk directly
+    size_t join_key_count = _table_items->join_keys.size();
+    for (size_t i = 0; i < join_key_count; i++) {
+        if (_table_items->join_keys[i].col_ref != nullptr) {
+            SlotId slot_id = _table_items->join_keys[i].col_ref->slot_id();
+            _table_items->key_columns[i] = _table_items->build_chunk->get_column_by_slot_id(slot_id);
+        }
+    }
+
+    RETURN_IF_ERROR(_upgrade_key_columns_if_overflow());
+
+    if (_table_items->row_count == 0 && allow_build_empty_table) {
+        _is_empty_map = true;
+        _hash_map = std::make_unique<JoinHashMapForEmpty>(_table_items.get(), _probe_state.get());
+    } else {
+        _is_empty_map = false;
+        std::tie(_key_constructor_type, _hash_map_method_type) =
+                JoinHashMapSelector::construct_key_and_determine_hash_map(state, _table_items.get());
+        // Look up the concrete factory registered by the join_hash_map_*_inst.cpp files and
+        // invoke it. build.cpp thus never names a concrete JoinHashMap<LT, CT, MT> and avoids the
+        // per-combo instantiation cost that a compile-time dispatch pays here.
+        JoinHashMapFactoryFn factory = find_join_hash_map_factory(_key_constructor_type, _hash_map_method_type);
+        if (factory == nullptr) {
+            return Status::InternalError("no join hash map factory registered for the selected key/method type");
+        }
+        _hash_map = factory(_table_items.get(), _probe_state.get());
+    }
+    // Dispatch is now a single virtual call rather than an ~80-way std::visit.
+    _hash_map->build_prepare(state);
+    _hash_map->probe_prepare(state);
+    _hash_map->build(state);
+    FAIL_POINT_TRIGGER_EXECUTE(hash_join_build_bad_alloc, { throw std::bad_alloc(); });
+    defer.cancel();
+
+    return Status::OK();
 }
+
+// ------------------------------------------------------------------------------------
+// JoinHashTable
+// ------------------------------------------------------------------------------------
 
 void JoinHashTable::set_probe_profile(RuntimeProfile::Counter* search_ht_timer,
                                       RuntimeProfile::Counter* output_probe_column_timer,
@@ -378,26 +411,6 @@ void JoinHashTable::set_probe_profile(RuntimeProfile::Counter* search_ht_timer,
 
 float JoinHashTable::get_keys_per_bucket() const {
     return _table_items->get_keys_per_bucket();
-}
-
-std::string JoinHashTable::get_hash_map_type() const {
-    if (const bool has_not_built = visit([&](const auto& map) { return map == nullptr; }); has_not_built) {
-        return "NONE";
-    }
-
-    if (_is_empty_map) {
-        return "EMPTY";
-    }
-
-    return dispatch_join_hash_map(
-            _key_constructor_type, _hash_map_method_type,
-            [&]<JoinKeyConstructorUnaryType CUT, JoinHashMapMethodUnaryType MUT>() {
-                static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
-                static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
-                static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::map_method_type;
-                return fmt::format("{}-{}-{}", join_key_constructor_type_to_string(CT),
-                                   join_hash_map_method_type_to_string(MT), logical_type_to_string(LT));
-            });
 }
 
 void JoinHashTable::close() {
@@ -625,85 +638,6 @@ int64_t JoinHashTable::mem_usage() const {
     }
     usage += _table_items->build_slice.size() * sizeof(Slice);
     return usage;
-}
-
-Status JoinHashTable::build(RuntimeState* state, bool allow_build_empty_table) {
-    CancelableDefer defer = CancelableDefer([&]() {
-        _table_items->key_columns.clear();
-        _table_items->build_chunk->columns().clear();
-        _hash_map = {};
-    });
-
-    RETURN_IF_ERROR(_table_items->build_chunk->upgrade_if_overflow());
-    _table_items->has_large_column = _table_items->build_chunk->has_large_column();
-
-    // If the join key is column ref of build chunk, fetch from build chunk directly
-    size_t join_key_count = _table_items->join_keys.size();
-    for (size_t i = 0; i < join_key_count; i++) {
-        if (_table_items->join_keys[i].col_ref != nullptr) {
-            SlotId slot_id = _table_items->join_keys[i].col_ref->slot_id();
-            _table_items->key_columns[i] = _table_items->build_chunk->get_column_by_slot_id(slot_id);
-        }
-    }
-
-    RETURN_IF_ERROR(_upgrade_key_columns_if_overflow());
-
-    if (_table_items->row_count == 0 && allow_build_empty_table) {
-        _is_empty_map = true;
-        _hash_map = std::make_unique<JoinHashMapForEmpty>(_table_items.get(), _probe_state.get());
-    } else {
-        _is_empty_map = false;
-        std::tie(_key_constructor_type, _hash_map_method_type) =
-                JoinHashMapSelector::construct_key_and_determine_hash_map(state, _table_items.get());
-        auto create_hash_map = [&]<JoinKeyConstructorUnaryType CUT, JoinHashMapMethodUnaryType MUT>() {
-            static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
-            if constexpr (LT != JoinHashMapMethodUnaryTypeTraits<MUT>::logical_type) {
-                return Status::InvalidArgument(
-                        strings::Substitute("Join key logical type {} does not match hash map logical type {}",
-                                            static_cast<int>(CUT), static_cast<int>(MUT)));
-            } else {
-                static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
-                static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::map_method_type;
-                _hash_map = std::make_unique<JoinHashMap<LT, CT, MT>>(_table_items.get(), _probe_state.get());
-                return Status::OK();
-            }
-        };
-        RETURN_IF_ERROR(dispatch_join_hash_map(_key_constructor_type, _hash_map_method_type, create_hash_map));
-    }
-    visit([&](auto& hash_map) {
-        hash_map->build_prepare(state);
-        hash_map->probe_prepare(state);
-        hash_map->build(state);
-        FAIL_POINT_TRIGGER_EXECUTE(hash_join_build_bad_alloc, { throw std::bad_alloc(); });
-    });
-    defer.cancel();
-
-    return Status::OK();
-}
-
-void JoinHashTable::reset_probe_state(RuntimeState* state) {
-    visit([&](const auto& hash_map) {
-        auto new_hash_map = std::make_unique<std::decay_t<decltype(*hash_map)>>(_table_items.get(), _probe_state.get());
-        new_hash_map->probe_prepare(state);
-        _hash_map = std::move(new_hash_map);
-    });
-}
-
-Status JoinHashTable::probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
-                            bool* eos) {
-    visit([&](const auto& hash_map) { hash_map->probe(state, key_columns, probe_chunk, chunk, eos); });
-    if (_table_items->has_large_column) {
-        RETURN_IF_ERROR((*chunk)->downgrade());
-    }
-    return Status::OK();
-}
-
-Status JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
-    visit([&](const auto& hash_map) { hash_map->probe_remain(state, chunk, eos); });
-    if (_table_items->has_large_column) {
-        RETURN_IF_ERROR((*chunk)->downgrade());
-    }
-    return Status::OK();
 }
 
 void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_columns) {
@@ -977,9 +911,77 @@ void JoinHashTable::_remove_duplicate_index_for_full_outer_join(Filter* filter) 
     }
 }
 
+std::string JoinHashTable::get_hash_map_type() const {
+    if (_hash_map == nullptr) {
+        return "NONE";
+    }
+
+    if (_is_empty_map) {
+        return "EMPTY";
+    }
+
+    return dispatch_join_hash_map(
+            _key_constructor_type, _hash_map_method_type,
+            [&]<JoinKeyConstructorUnaryType CUT, JoinHashMapMethodUnaryType MUT>() {
+                static constexpr auto LT = JoinKeyConstructorUnaryTypeTraits<CUT>::logical_type;
+                static constexpr auto CT = JoinKeyConstructorUnaryTypeTraits<CUT>::key_constructor_type;
+                static constexpr auto MT = JoinHashMapMethodUnaryTypeTraits<MUT>::map_method_type;
+                return fmt::format("{}-{}-{}", join_key_constructor_type_to_string(CT),
+                                   join_hash_map_method_type_to_string(MT), logical_type_to_string(LT));
+            });
+}
+
+JoinHashTable JoinHashTable::clone_readable_table() {
+    JoinHashTable ht;
+
+    ht._is_empty_map = this->_is_empty_map;
+    ht._key_constructor_type = this->_key_constructor_type;
+    ht._hash_map_method_type = this->_hash_map_method_type;
+
+    ht._table_items = this->_table_items;
+    // Clone a new probe state.
+    ht._probe_state = std::make_unique<HashTableProbeState>(*this->_probe_state);
+
+    // Clone a fresh hash map of the same concrete type, bound to the cloned items/state.
+    if (_hash_map != nullptr) {
+        ht._hash_map = _hash_map->clone(ht._table_items.get(), ht._probe_state.get());
+    }
+
+    return ht;
+}
+
+void JoinHashTable::reset_probe_state(RuntimeState* state) {
+    if (_hash_map == nullptr) {
+        return;
+    }
+    _hash_map = _hash_map->clone(_table_items.get(), _probe_state.get());
+    _hash_map->probe_prepare(state);
+}
+
+Status JoinHashTable::probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk,
+                            bool* eos) {
+    _hash_map->probe(state, key_columns, probe_chunk, chunk, eos);
+    if (_table_items->has_large_column) {
+        RETURN_IF_ERROR((*chunk)->downgrade());
+    }
+    return Status::OK();
+}
+
+Status JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
+    _hash_map->probe_remain(state, chunk, eos);
+    if (_table_items->has_large_column) {
+        RETURN_IF_ERROR((*chunk)->downgrade());
+    }
+    return Status::OK();
+}
+
 template <bool is_remain>
 Status JoinHashTable::lazy_output(RuntimeState* state, ChunkPtr* probe_chunk, ChunkPtr* result_chunk) {
-    visit([&](const auto& hash_map) { hash_map->template lazy_output<is_remain>(state, probe_chunk, result_chunk); });
+    if constexpr (is_remain) {
+        _hash_map->lazy_output_for_remain(state, probe_chunk, result_chunk);
+    } else {
+        _hash_map->lazy_output_for_probe(state, probe_chunk, result_chunk);
+    }
     if (_table_items->has_large_column) {
         RETURN_IF_ERROR((*result_chunk)->downgrade());
     }

--- a/be/src/exec/join/join_hash_table.h
+++ b/be/src/exec/join/join_hash_table.h
@@ -16,6 +16,7 @@
 
 #include "common/runtime_profile.h"
 #include "exec/join/join_hash_map.h"
+#include "exec/join/join_hash_map_base.h"
 
 namespace starrocks {
 
@@ -73,11 +74,6 @@ public:
     int64_t mem_usage() const;
 
 private:
-    template <class Visitor>
-    auto visit(Visitor&& visitor) const {
-        return std::visit(std::forward<Visitor>(visitor), _hash_map);
-    }
-
     void _init_probe_column(const HashTableParam& param);
     void _init_build_column(const HashTableParam& param);
     void _init_join_keys();
@@ -92,61 +88,10 @@ private:
     void _remove_duplicate_index_for_right_anti_join(Filter* filter);
     void _remove_duplicate_index_for_full_outer_join(Filter* filter);
 
-#define JoinHashMapForIntBigintKey(MT)                                                                                \
-    std::unique_ptr<JoinHashMap<TYPE_INT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,               \
-            std::unique_ptr<JoinHashMap<TYPE_BIGINT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,    \
-            std::unique_ptr<                                                                                          \
-                    JoinHashMap<TYPE_INT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::MT>>, \
-            std::unique_ptr<JoinHashMap<TYPE_BIGINT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE,                   \
-                                        JoinHashMapMethodType::MT>>
-
-#define JoinHashMapForSmallKey(MT)                                                                                  \
-    std::unique_ptr<JoinHashMap<TYPE_BOOLEAN, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,         \
-            std::unique_ptr<JoinHashMap<TYPE_TINYINT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>, \
-            std::unique_ptr<JoinHashMap<TYPE_SMALLINT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>
-
-#define JoinHashMapForNonSmallKey(MT)                                                                                  \
-    std::unique_ptr<JoinHashMap<TYPE_INT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,                \
-            std::unique_ptr<JoinHashMap<TYPE_BIGINT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,     \
-            std::unique_ptr<JoinHashMap<TYPE_LARGEINT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,   \
-            std::unique_ptr<JoinHashMap<TYPE_FLOAT, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,      \
-            std::unique_ptr<JoinHashMap<TYPE_DOUBLE, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,     \
-            std::unique_ptr<JoinHashMap<TYPE_DATE, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,       \
-            std::unique_ptr<JoinHashMap<TYPE_DATETIME, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,   \
-            std::unique_ptr<JoinHashMap<TYPE_DECIMALV2, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,  \
-            std::unique_ptr<JoinHashMap<TYPE_DECIMAL32, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,  \
-            std::unique_ptr<JoinHashMap<TYPE_DECIMAL64, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,  \
-            std::unique_ptr<JoinHashMap<TYPE_DECIMAL128, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>, \
-            std::unique_ptr<JoinHashMap<TYPE_VARCHAR, JoinKeyConstructorType::ONE_KEY, JoinHashMapMethodType::MT>>,    \
-                                                                                                                       \
-            std::unique_ptr<                                                                                           \
-                    JoinHashMap<TYPE_INT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE, JoinHashMapMethodType::MT>>,  \
-            std::unique_ptr<JoinHashMap<TYPE_BIGINT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE,                    \
-                                        JoinHashMapMethodType::MT>>,                                                   \
-            std::unique_ptr<JoinHashMap<TYPE_LARGEINT, JoinKeyConstructorType::SERIALIZED_FIXED_SIZE,                  \
-                                        JoinHashMapMethodType::MT>>,                                                   \
-                                                                                                                       \
-            std::unique_ptr<JoinHashMap<TYPE_VARCHAR, JoinKeyConstructorType::SERIALIZED, JoinHashMapMethodType::MT>>
-
-    using JoinHashMapVariant = std::variant<std::unique_ptr<JoinHashMapForEmpty>,
-                                            JoinHashMapForSmallKey(DIRECT_MAPPING),                //
-                                            JoinHashMapForNonSmallKey(BUCKET_CHAINED),             //
-                                            JoinHashMapForNonSmallKey(LINEAR_CHAINED),             //
-                                            JoinHashMapForNonSmallKey(LINEAR_CHAINED_SET),         //
-                                            JoinHashMapForNonSmallKey(LINEAR_CHAINED_ASOF),        //
-                                            JoinHashMapForIntBigintKey(RANGE_DIRECT_MAPPING),      //
-                                            JoinHashMapForIntBigintKey(RANGE_DIRECT_MAPPING_SET),  //
-                                            JoinHashMapForIntBigintKey(DENSE_RANGE_DIRECT_MAPPING) //
-                                            >;
-
-#undef JoinHashMapForNonSmallKey
-#undef JoinHashMapForSmallKey
-#undef JoinHashMapForIntBigintKey
-
     bool _is_empty_map = true;
     JoinKeyConstructorUnaryType _key_constructor_type;
     JoinHashMapMethodUnaryType _hash_map_method_type;
-    JoinHashMapVariant _hash_map;
+    std::unique_ptr<JoinHashMapBase> _hash_map;
 
     std::shared_ptr<JoinHashTableItems> _table_items;
     std::unique_ptr<HashTableProbeState> _probe_state = std::make_unique<HashTableProbeState>();


### PR DESCRIPTION
## Why I'm doing:

JoinHashTable dispatched every op through an ~80-alternative std::variant<unique_ptr<JoinHashMap<LT,CT,MT>>...> + std::visit, and created the concrete map via a compile-time CUT x MUT dispatch. Both forced build.cpp to instantiate all ~80 heavy JoinHashMap<> composite types (7 visit sites x 80, plus 80 make_unique combos), making it the single slowest BE translation unit (~1525s, ~47% of the cold-build wall).

Replace both with runtime polymorphism:
- Add JoinHashMapBase interface + JoinHashMapAdapter (CRTP) that forwards lazy_output<bool> and clone; JoinHashMap<> and JoinHashMapForEmpty now override build/probe/probe_remain/... and _hash_map becomes a unique_ptr<JoinHashMapBase>. Dispatch is one virtual call per chunk (runtime-neutral; the hot path was already indirect via std::visit).
- Move concrete creation into make_join_hash_map<> factories, registered per (key-constructor-unary, method-unary) in the *_inst.cpp files (where those types are already instantiated) and looked up at runtime in build().

build.cpp no longer names any concrete JoinHashMap<>, so the visit and creation template-instantiation costs disappear. Behavior is unchanged; the real codegen stays distributed across the 5 *_inst.cpp files (~145s each, parallel). join_hash_table.cpp drops off the slowest-TU list entirely.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
