### PR TITLE
[UT] Fix iceberg iterator test npe

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ExternalResourceCleanupTest.java
@@ -767,6 +767,7 @@ public class ExternalResourceCleanupTest {
         org.apache.iceberg.Table nativeTbl = Mockito.mock(org.apache.iceberg.Table.class);
         org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(List.of());
         Mockito.when(nativeTbl.schema()).thenReturn(schema);
+        Mockito.when(nativeTbl.spec()).thenReturn(org.apache.iceberg.PartitionSpec.unpartitioned());
         Mockito.when(table.getNativeTable()).thenReturn(nativeTbl);
         Mockito.when(table.getCatalogDBName()).thenReturn("db");
         Mockito.when(table.getCatalogTableName()).thenReturn("tbl");


### PR DESCRIPTION
## Why I'm doing:

```
org.opentest4j.AssertionFailedError: Unexpected exception thrown: java.lang.reflect.InvocationTargetException
	at com.starrocks.connector.ExternalResourceCleanupTest.testIcebergMetadataIteratorThrowsIOException(ExternalResourceCleanupTest.java:832)
Caused by: java.lang.reflect.InvocationTargetException
	at com.starrocks.connector.ExternalResourceCleanupTest.lambda$testIcebergMetadataIteratorThrowsIOException$4(ExternalResourceCleanupTest.java:832)
	... 1 more
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.iceberg.PartitionSpec.fields()" because the return value of "org.apache.iceberg.Table.spec()" is null
	at com.starrocks.connector.iceberg.IcebergMetadata.identityStringPartitionColumns(IcebergMetadata.java:1333)
	at com.starrocks.connector.iceberg.IcebergMetadata.collectTableStatisticsAndCacheIcebergSplit(IcebergMetadata.java:1145)
	... 2 more
```

## What I'm doing:

Fix iceberg iterator test npe

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
