### PR TITLE
[BugFix][CVE] Remove vulnerable stale transitive dependencies and enforce bans (backport #76097)

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -122,7 +122,14 @@ subprojects {
             implementation("com.qcloud.cos:hadoop-cos:3.3.0-8.3.2")
             implementation("com.qcloud:chdfs_hadoop_plugin_network:3.2")
             implementation("com.squareup.okhttp3:okhttp:4.10.0")
+            // keep on the same train as okhttp (tencentcloud-sdk declares 3.12.x)
+            implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
             implementation("com.squareup.okio:okio:3.4.0")
+            // okhttp 4.10.0 drags in okio-jvm 3.0.0 (CVE-2023-3635); keep it aligned with okio
+            implementation("com.squareup.okio:okio-jvm:3.4.0")
+            // tencentcloud-sdk below 3.1.1471 drags in EOL okhttp 2.7.5 (via hadoop-cos)
+            implementation("com.tencentcloudapi:tencentcloud-sdk-java-common:3.1.1471")
+            implementation("com.tencentcloudapi:tencentcloud-sdk-java-kms:3.1.1471")
             implementation("com.starrocks:fe-common:1.0.0")
             implementation("com.starrocks:hive-udf:1.0.0")
             implementation("com.starrocks:jprotobuf-starrocks:${project.ext["jprotobuf-starrocks.version"]}")
@@ -168,7 +175,8 @@ subprojects {
             implementation("org.apache.arrow:flight-sql-jdbc-driver:${project.ext["arrow.version"]}")
             implementation("org.apache.avro:avro:${project.ext["avro.version"]}")
             implementation("org.apache.commons:commons-dbcp2:2.9.0")
-            implementation("org.apache.commons:commons-lang3:3.9")
+            // 3.18.0 fixes CVE-2025-48924
+            implementation("org.apache.commons:commons-lang3:3.18.0")
             implementation("org.apache.commons:commons-pool2:2.3")
             implementation("org.apache.groovy:groovy-groovysh:4.0.9")
             implementation("org.apache.hadoop:hadoop-aliyun:${project.ext["hadoop.version"]}")
@@ -250,6 +258,18 @@ subprojects {
             implementation("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}")
             // dependency sync end
         }
+    }
+
+    // Mirror the Maven-side CVE exclusions/enforcer bans (see fe/pom.xml):
+    // these artifacts must never appear on any FE classpath.
+    configurations.all {
+        // superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs
+        exclude(group = "org.bouncycastle", module = "bcprov-jdk15on")
+        // EOL okhttp 2.x line (okhttp3 lives under com.squareup.okhttp3)
+        exclude(group = "com.squareup.okhttp")
+        // JSP engine, unused by FE; tomcat 9.0.93 carries CVE-2025-55754/CVE-2025-52434
+        exclude(group = "org.apache.tomcat")
+        exclude(group = "org.apache.tomcat.embed")
     }
 
     // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -47,7 +47,6 @@ under the License.
         <!-- jackson-annotations doesn't have 2.21.4 version released -->
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <spark.version>3.5.7</spark.version>
-        <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.15.2</parquet.version>
         <hadoop.version>3.4.3</hadoop.version>
         <gcs.connector.version>3.0.13</gcs.connector.version>
@@ -225,10 +224,11 @@ under the License.
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+            <!-- 3.18.0 fixes CVE-2025-48924 (ClassUtils.getClass StackOverflow) -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
+                <version>3.18.0</version>
             </dependency>
 
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-pool2 -->
@@ -550,10 +550,25 @@ under the License.
                 <version>4.10.0</version>
             </dependency>
 
+            <!-- keep on the same train as okhttp (tencentcloud-sdk declares 3.12.x) -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>logging-interceptor</artifactId>
+                <version>4.10.0</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.squareup.okio/okio -->
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+
+            <!-- pin okio-jvm to the same version as okio; okhttp 4.10.0 drags in
+                 okio-jvm 3.0.0 which is affected by CVE-2023-3635 -->
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-jvm</artifactId>
                 <version>3.4.0</version>
             </dependency>
 
@@ -1005,6 +1020,19 @@ under the License.
                 <version>3.3.0-8.3.2</version>
             </dependency>
 
+            <!-- hadoop-cos pulls tencentcloud-sdk 3.1.213 whose okhttp 2.7.5 is EOL;
+                 3.1.1471+ ships okhttp3, keeping COS client-side encryption usable -->
+            <dependency>
+                <groupId>com.tencentcloudapi</groupId>
+                <artifactId>tencentcloud-sdk-java-kms</artifactId>
+                <version>3.1.1471</version>
+            </dependency>
+            <dependency>
+                <groupId>com.tencentcloudapi</groupId>
+                <artifactId>tencentcloud-sdk-java-common</artifactId>
+                <version>3.1.1471</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.qcloud/chdfs_hadoop_plugin_network -->
             <dependency>
                 <groupId>com.qcloud</groupId>
@@ -1094,6 +1122,11 @@ under the License.
                     <exclusion>
                         <groupId>org.apache.hbase.thirdparty</groupId>
                         <artifactId>hbase-shaded-netty</artifactId>
+                    </exclusion>
+                    <!-- JSP engine, unused here; tomcat-jasper 9.0.93 carries open CVEs -->
+                    <exclusion>
+                        <groupId>org.apache.tomcat</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1252,6 +1285,12 @@ under the License.
                     <exclusion>
                         <groupId>org.lz4</groupId>
                         <artifactId>lz4-pure-java</artifactId>
+                    </exclusion>
+                    <!-- aliyun-java-auth drags in bcprov-jdk15on 1.70 (multiple CVEs);
+                         bcprov-jdk18on 1.84 on the classpath provides the same packages -->
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1575,6 +1614,45 @@ under the License.
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>ban-vulnerable-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs -->
+                                        <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                        <!-- EOL okhttp 2.x line -->
+                                        <exclude>com.squareup.okhttp:*</exclude>
+                                        <!-- okio-jvm below 3.4.0 is affected by CVE-2023-3635 -->
+                                        <exclude>com.squareup.okio:okio-jvm:[,3.4.0)</exclude>
+                                        <!-- commons-lang3 below 3.18.0 is affected by CVE-2025-48924 -->
+                                        <exclude>org.apache.commons:commons-lang3:[,3.18.0)</exclude>
+                                        <!-- JSP engine, unused by FE; 9.0.93 carries CVE-2025-55754/CVE-2025-52434 -->
+                                        <exclude>org.apache.tomcat:*</exclude>
+                                        <exclude>org.apache.tomcat.embed:*</exclude>
+                                        <!-- tencentcloud-sdk below 3.1.1471 drags in EOL okhttp 2.7.5 -->
+                                        <exclude>com.tencentcloudapi:*:[,3.1.1471)</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <reporting>
         <plugins>

--- a/java-extensions/odps-reader/pom.xml
+++ b/java-extensions/odps-reader/pom.xml
@@ -91,7 +91,21 @@
                     <artifactId>lz4-pure-java</artifactId>
                     <groupId>org.lz4</groupId>
                 </exclusion>
+                <!-- aliyun-java-auth drags in bcprov-jdk15on 1.70 (multiple CVEs);
+                     bcprov-jdk18on 1.84 on the classpath provides the same packages -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- aliyun-java-auth needs org.bouncycastle.*; the vulnerable bcprov-jdk15on
+             is excluded above, so ship bcprov-jdk18on in odps-reader-lib instead
+             (each BE reader has its own isolated classpath) -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
 
         <dependency>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -285,6 +285,12 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+                    <!-- json-simple 1.1.1 leaks junit 4.10 as a compile dependency
+                         (CVE-2020-15250); it must not ship in the runtime lib -->
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -440,6 +446,30 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <!-- 3.18.0 fixes CVE-2025-48924; udf-extensions bundles this into its
+                 jar-with-dependencies shipped under be/lib/jni-packages -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
+            <!-- hadoop-yarn-common drags in 2.12.7 copies of these; keep them
+                 aligned with the managed jackson version -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
             <!-- jackson -->
 
             <!-- apache arrow -->
@@ -571,6 +601,37 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>ban-vulnerable-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- superseded by bcprov-jdk18on; 1.70 carries multiple open CVEs -->
+                                        <exclude>org.bouncycastle:bcprov-jdk15on</exclude>
+                                        <!-- junit must never leak into runtime libs (CVE-2020-15250);
+                                             test scope stays allowed -->
+                                        <exclude>junit:junit:*:jar:compile</exclude>
+                                        <exclude>junit:junit:*:jar:runtime</exclude>
+                                        <!-- keep jackson-jaxrs aligned with the managed jackson version -->
+                                        <exclude>com.fasterxml.jackson.jaxrs:*:[,2.15.0)</exclude>
+                                        <!-- commons-lang3 below 3.18.0 is affected by CVE-2025-48924 -->
+                                        <exclude>org.apache.commons:commons-lang3:[,3.18.0)</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/java-extensions/udf-extensions/pom.xml
+++ b/java-extensions/udf-extensions/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Backport of #76097 to branch-4.0. Cherry-pick of `92d6b85dff6` with two trivial context-drift conflicts resolved in `fe/pom.xml` (kept the branch's parquet version, only removed the unreferenced `tomcat.version` property) and `fe/build.gradle.kts` (kept the branch's own `com.starrocks` constraint entries, inserted the okio-jvm/tencentcloud constraints). Verified on branch-4.0: full FE build passes with the enforcer gates active, FE starts clean, fe/lib physically drops bcprov-jdk15on-1.70 / okhttp-2.7.5 / tomcat-* 9.0.93 / okio-jvm-3.0.0 and picks up tencentcloud-sdk 3.1.1471 / commons-lang3 3.18.0; odps-reader-lib ships bcprov-jdk18on-1.84 only and the udf-extensions fat jar embeds commons-lang3 3.18.0.

--- Original PR description ---

## Why I'm doing:

A vulnerability scan against the release package showed several EOL/vulnerable artifacts physically shipping in `fe/lib` and `be/lib` **side by side with their fixed counterparts**, because unmanaged transitive dependencies leak through:

- `bcprov-jdk15on-1.70.jar` (multiple BC CVEs, e.g. CVE-2024-29857) next to `bcprov-jdk18on-1.84.jar`, via `odps-sdk-core -> aliyun-java-auth`
- `okhttp-2.7.5.jar` + `logging-interceptor-2.7.5.jar` (EOL 2.x line) next to okhttp 4.10.0, via `hadoop-cos -> tencentcloud-sdk-java-kms` 3.1.213
- `tomcat-* 9.0.93` (7 jars, CVE-2025-55754 / CVE-2025-52434) via `hudi-common -> hbase-server -> tomcat-jasper`; FE never runs JSP
- `okio-jvm-3.0.0.jar` (CVE-2023-3635) next to okio 3.4.0, resolved by okhttp 4.10.0
- `junit-4.10.jar` (CVE-2020-15250) leaking into the runtime hadoop lib via `hadoop-hdfs-httpfs -> json-simple 1.1.1` compile-scope leak
- `jackson-jaxrs-* 2.12.7` via `hadoop-yarn-common`, out of line with the managed jackson 2.21.4
- `commons-lang3` 3.9 (CVE-2025-48924, fixed in 3.18.0)

## What I'm doing:

Pom/gradle-only, no Java code changes:

1. **Exclude/converge the stale artifacts**: exclusions for bcprov-jdk15on, `org.apache.tomcat:*`, junit; pin `okio-jvm` 3.4.0 and manage `jackson-jaxrs-*` to `${jackson.version}`. On the FE flat classpath the existing `bcprov-jdk18on` 1.84 takes over; BE readers load from isolated per-module lib dirs, so odps-reader additionally declares `bcprov-jdk18on` explicitly.
2. **Bump commons-lang3 to 3.18.0** (also managed in java-extensions; `udf-extensions` bundled 3.9 into its jar-with-dependencies under `be/lib/jni-packages`).
3. **Add maven-enforcer `bannedDependencies` gates** in both fe and java-extensions root poms so a future dependency bump cannot silently re-introduce the removed artifacts (junit ban is compile/runtime scope only — test scope stays allowed). Also drops the unreferenced `tomcat.version` property.
4. **Mirror everything in the Gradle build** (fe/README-gradle.md promises the same artifacts).
5. **Eliminate okhttp 2.7.5 by upgrading the tencentcloud SDK instead of excluding it**: manage `tencentcloud-sdk-java-kms/common` at 3.1.1471, which ships okhttp3; converge `okhttp3:logging-interceptor` to 4.10.0. The enforcer rule is a version-range ban `com.tencentcloudapi:*:[,3.1.1471)` so the vulnerable SDK line stays banned while the fixed one is allowed.

**Note for reviewers (COS/tencentcloud)**: the KMS SDK is only consumed by COS *client-side* encryption (`COSEncryptionClient`/`QCLOUDKMS` generate/decrypt data keys); server-side encryption incl. SSE-KMS never calls it. The SDK upgrade keeps the capability working while the EOL okhttp 2.x line disappears. **No COS behavior change.**

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)