### PR TITLE
[Enhancement] Cluster iceberg rewrite_manifests output by order-preserving partition ranges

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -30,9 +30,15 @@ import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.GenericManifestFile;
+import org.apache.iceberg.InternalData;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -60,6 +66,34 @@ public final class IcebergUtil {
 
     public static String fileName(String path) {
         return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    private static final Schema MANIFEST_PROJECTION =
+            ManifestFile.schema().select(
+                    "manifest_path",
+                    "manifest_length",
+                    "content",
+                    "partition_spec_id",
+                    "added_snapshot_id",
+                    "deleted_data_files_count");
+
+    /**
+     * Streams the manifest files of a snapshot. When the snapshot has a manifest list file,
+     * reads it directly (AVRO) with a narrow projection instead of materializing the full
+     * manifest list via snapshot.allManifests(); otherwise falls back to allManifests().
+     * Aligned with Iceberg FileCleanupStrategy.readManifests().
+     */
+    public static CloseableIterable<ManifestFile> readManifests(Snapshot snapshot, FileIO fileIO) {
+        if (snapshot.manifestListLocation() != null) {
+            return InternalData.read(
+                            FileFormat.AVRO, fileIO.newInputFile(snapshot.manifestListLocation()))
+                    .setRootType(GenericManifestFile.class)
+                    .project(MANIFEST_PROJECTION)
+                    .reuseContainers()
+                    .build();
+        } else {
+            return CloseableIterable.withNoopClose(snapshot.allManifests(fileIO));
+        }
     }
 
     public static class MinMaxValue {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -29,17 +29,12 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.ContentFile;
-import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.GenericManifestFile;
-import org.apache.iceberg.InternalData;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.FileIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +128,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
                 validFileNames.add(fileName(snapshot.manifestListLocation()));
             }
 
-            try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot, table.io())) {
+            try (CloseableIterable<ManifestFile> manifests = IcebergUtil.readManifests(snapshot, table.io())) {
                 for (ManifestFile manifest : manifests) {
                     if (!processedManifestFilePaths.add(manifest.path())) {
                         continue;
@@ -165,33 +160,6 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
         scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.hdfsEnvironment());
         return null;
-    }
-
-    /**
-     * Reads manifest files for a snapshot. When the snapshot has a manifest list file,
-     * reads from it directly (AVRO) for better efficiency; otherwise falls back to
-     * snapshot.allManifests(). Aligned with Iceberg FileCleanupStrategy.readManifests().
-     */
-    private static final Schema MANIFEST_PROJECTION =
-            ManifestFile.schema().select(
-                    "manifest_path",
-                    "manifest_length",
-                    "content",
-                    "partition_spec_id",
-                    "added_snapshot_id",
-                    "deleted_data_files_count");
-
-    private static CloseableIterable<ManifestFile> readManifests(Snapshot snapshot, FileIO fileIO) {
-        if (snapshot.manifestListLocation() != null) {
-            return InternalData.read(
-                            FileFormat.AVRO, fileIO.newInputFile(snapshot.manifestListLocation()))
-                    .setRootType(GenericManifestFile.class)
-                    .project(MANIFEST_PROJECTION)
-                    .reuseContainers()
-                    .build();
-        } else {
-            return CloseableIterable.withNoopClose(snapshot.allManifests(fileIO));
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -14,22 +14,37 @@
 
 package com.starrocks.connector.iceberg.procedure;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PartitionUtil;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.StructLikeWrapper;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
@@ -37,6 +52,7 @@ import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFA
 public class RewriteManifestsProcedure extends IcebergTableProcedure {
     private static final String PROCEDURE_NAME = "rewrite_manifests";
     private static final int MAX_MANIFEST_CLUSTERS = 100;
+    private static final int NULL_PARTITION_CLUSTER = -1;
 
     private static final RewriteManifestsProcedure INSTANCE = new RewriteManifestsProcedure();
 
@@ -65,8 +81,8 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
             return null;
         }
 
-        List<ManifestFile> manifests = currentSnapshot.allManifests(icebergTable.io());
-        if (manifests.isEmpty()) {
+        List<ManifestFile> dataManifests = currentSnapshot.dataManifests(icebergTable.io());
+        if (dataManifests.isEmpty()) {
             return null;
         }
 
@@ -76,28 +92,122 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
             manifestTargetSizeBytes = MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
         }
 
-        if (manifests.size() == 1 && manifests.get(0).length() < manifestTargetSizeBytes) {
+        if (dataManifests.size() == 1 && dataManifests.get(0).length() < manifestTargetSizeBytes) {
             return null;
         }
 
-        long totalManifestsSize = manifests.stream().mapToLong(ManifestFile::length).sum();
+        long totalManifestsSize = dataManifests.stream().mapToLong(ManifestFile::length).sum();
         // Having too many open manifest writers can potentially cause OOM on the coordinator
-        // Floor to at least 1 to avoid modulo-by-zero when totalManifestsSize is 0 (e.g., manifests report length 0)
-        long targetManifestClusters = Math.max(1, Math.min(
+        long targetManifestClusters = Math.min(
                 ((totalManifestsSize + manifestTargetSizeBytes - 1) / manifestTargetSizeBytes),
-                MAX_MANIFEST_CLUSTERS));
+                MAX_MANIFEST_CLUSTERS);
+
+        Types.StructType partitionType = icebergTable.spec().partitionType();
+        Map<Integer, PartitionSpec> specsById = icebergTable.specs();
+
+        // Assign each distinct top-level partition value an order-preserving bucket so that
+        // sorted-adjacent partitions land in the same manifest. This keeps each manifest's
+        // partition min/max range narrow (effective manifest pruning at read time) while bounding
+        // the number of concurrently open writers.
+        NavigableMap<Object, Integer> partitionValueToCluster;
+        if (icebergTable.spec().isPartitioned() && targetManifestClusters > 1) {
+            partitionValueToCluster = buildClusteredPartitionValues(
+                    icebergTable, currentSnapshot, (int) targetManifestClusters);
+        } else {
+            partitionValueToCluster = Collections.emptyNavigableMap();
+        }
 
         RewriteManifests rewriteManifests = context.transaction().rewriteManifests();
-        Types.StructType structType = icebergTable.spec().partitionType();
 
         rewriteManifests
                 .clusterBy(file -> {
-                    // Cluster by partitions for better locality when reading data files
-                    StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(file.partition());
-                    // Limit the number of clustering buckets to avoid creating too many small manifest files
-                    return Integer.toUnsignedLong(Objects.hash(partitionWrapper)) % targetManifestClusters;
+                    if (partitionValueToCluster.isEmpty()) {
+                        return 0;
+                    }
+                    PartitionSpec fileSpec = specsById.get(file.specId());
+                    if (fileSpec == null) {
+                        // Unknown spec: the partition spec evolved under a concurrent commit. Evolution
+                        // is rare, so abort and let the next maintenance run re-cluster against the new
+                        // spec rather than guessing an order for it.
+                        throw new StarRocksConnectorException(
+                                "rewrite_manifests aborted: the table's partition spec changed under a " +
+                                        "concurrent commit; it will be retried on the next maintenance run");
+                    }
+                    // Coerce into the current spec's partition type so files written under an older
+                    // partition spec still cluster correctly.
+                    StructLike partition =
+                            PartitionUtil.coercePartition(partitionType, fileSpec, file.partition());
+                    Object value = partition.get(0, Object.class);
+                    if (value == null) {
+                        return NULL_PARTITION_CLUSTER;
+                    }
+                    Integer cluster = partitionValueToCluster.get(value);
+                    if (cluster != null) {
+                        return cluster;
+                    }
+                    // Value not seen up front (typically a new partition added by a concurrent write to
+                    // the same spec). Slot it next to its sort-order neighbor.
+                    Map.Entry<Object, Integer> neighbor = partitionValueToCluster.floorEntry(value);
+                    if (neighbor == null) {
+                        neighbor = partitionValueToCluster.firstEntry();
+                    }
+                    return neighbor.getValue();
                 })
                 .commit();
         return null;
+    }
+
+    // Collect the distinct top-level partition values across all data manifests of the snapshot,
+    // sort them, and assign each a bucket in [0, targetClusters) grouping sorted-adjacent values
+    // into the same bucket. Clustering is limited to the top-level partition field because it is
+    // usually the most selective for read-time filters and keeps the distinct-value set small.
+    private static NavigableMap<Object, Integer> buildClusteredPartitionValues(
+            Table table, Snapshot snapshot, int targetClusters) {
+        PartitionSpec spec = table.spec();
+        Type.PrimitiveType firstFieldType =
+                spec.partitionType().fields().get(0).type().asPrimitiveType();
+        Comparator<Object> comparator = partitionValueComparator(firstFieldType);
+        Types.StructType partitionType = spec.partitionType();
+        Map<Integer, PartitionSpec> specsById = table.specs();
+        FileIO io = table.io();
+        List<ManifestFile> dataManifests = snapshot.dataManifests(io);
+        Iterable<CloseableIterable<DataFile>> perManifest = Iterables.transform(
+                dataManifests,
+                manifest -> (CloseableIterable<DataFile>)
+                        ManifestFiles.read(manifest, io, specsById).select(ImmutableList.of("partition")));
+
+        // Comparator-based dedup mirrors Iceberg's own equality for partition value types.
+        NavigableSet<Object> uniqueValues = new TreeSet<>(comparator);
+        try (CloseableIterable<DataFile> dataFiles = CloseableIterable.concat(perManifest)) {
+            for (DataFile file : dataFiles) {
+                StructLike partition = PartitionUtil.coercePartition(
+                        partitionType, specsById.get(file.specId()), file.partition());
+                Object value = partition.get(0, Object.class);
+                if (value != null) {
+                    uniqueValues.add(value);
+                }
+            }
+        } catch (IOException e) {
+            throw new StarRocksConnectorException(
+                    "Unable to read manifests while clustering partitions for snapshot " + snapshot.snapshotId(), e);
+        }
+
+        if (uniqueValues.isEmpty()) {
+            return Collections.emptyNavigableMap();
+        }
+
+        NavigableMap<Object, Integer> valueToCluster = new TreeMap<>(comparator);
+        int index = 0;
+        int size = uniqueValues.size();
+        for (Object value : uniqueValues) {
+            valueToCluster.put(value, (int) ((long) index * targetClusters / size));
+            index++;
+        }
+        return valueToCluster;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Comparator<Object> partitionValueComparator(Type.PrimitiveType type) {
+        return (Comparator<Object>) (Comparator<?>) Comparators.forType(type);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
@@ -47,6 +48,7 @@ import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutorService;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
@@ -126,7 +128,7 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
         NavigableMap<Object, Integer> partitionValueToCluster;
         if (icebergTable.spec().isPartitioned() && targetManifestClusters > 1) {
             partitionValueToCluster = buildClusteredPartitionValues(
-                    icebergTable, currentSnapshot, (int) targetManifestClusters);
+                    icebergTable, currentSnapshot, (int) targetManifestClusters, null);
         } else {
             partitionValueToCluster = Collections.emptyNavigableMap();
         }
@@ -176,7 +178,7 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
     // into the same bucket. Clustering is limited to the top-level partition field because it is
     // usually the most selective for read-time filters and keeps the distinct-value set small.
     private static NavigableMap<Object, Integer> buildClusteredPartitionValues(
-            Table table, Snapshot snapshot, int targetClusters) {
+            Table table, Snapshot snapshot, int targetClusters, ExecutorService scanExecutor) {
         PartitionSpec spec = table.spec();
         Type.PrimitiveType firstFieldType =
                 spec.partitionType().fields().get(0).type().asPrimitiveType();
@@ -190,9 +192,14 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
                 manifest -> (CloseableIterable<DataFile>)
                         ManifestFiles.read(manifest, io, specsById).select(ImmutableList.of("partition")));
 
-        // Comparator-based dedup mirrors Iceberg's own equality for partition value types.
+        // Read manifests in parallel when an executor is available. ParallelIterable produces items
+        // concurrently but is consumed single-threaded, so the TreeSet need not be thread-safe;
+        // without an executor, fall back to a sequential concatenation. Comparator-based dedup
+        // mirrors Iceberg's own equality for partition value types.
         NavigableSet<Object> uniqueValues = new TreeSet<>(comparator);
-        try (CloseableIterable<DataFile> dataFiles = CloseableIterable.concat(perManifest)) {
+        try (CloseableIterable<DataFile> dataFiles = scanExecutor != null
+                ? new ParallelIterable<>(perManifest, scanExecutor)
+                : CloseableIterable.concat(perManifest)) {
             for (DataFile file : dataFiles) {
                 StructLike partition = PartitionUtil.coercePartition(
                         partitionType, specsById.get(file.specId()), file.partition());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedure.java
@@ -18,9 +18,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionSpec;
@@ -81,8 +83,21 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
             return null;
         }
 
-        List<ManifestFile> dataManifests = currentSnapshot.dataManifests(icebergTable.io());
-        if (dataManifests.isEmpty()) {
+        long manifestCount = 0;
+        long totalManifestsSize = 0;
+        try (CloseableIterable<ManifestFile> manifests =
+                IcebergUtil.readManifests(currentSnapshot, icebergTable.io())) {
+            for (ManifestFile manifest : manifests) {
+                if (manifest.content() == ManifestContent.DATA) {
+                    manifestCount++;
+                    totalManifestsSize += manifest.length();
+                }
+            }
+        } catch (IOException e) {
+            throw new StarRocksConnectorException(
+                    "Unable to read manifests for snapshot " + currentSnapshot.snapshotId(), e);
+        }
+        if (manifestCount == 0) {
             return null;
         }
 
@@ -92,11 +107,10 @@ public class RewriteManifestsProcedure extends IcebergTableProcedure {
             manifestTargetSizeBytes = MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
         }
 
-        if (dataManifests.size() == 1 && dataManifests.get(0).length() < manifestTargetSizeBytes) {
+        if (manifestCount == 1 && totalManifestsSize < manifestTargetSizeBytes) {
             return null;
         }
 
-        long totalManifestsSize = dataManifests.stream().mapToLong(ManifestFile::length).sum();
         // Having too many open manifest writers can potentially cause OOM on the coordinator
         long targetManifestClusters = Math.min(
                 ((totalManifestsSize + manifestTargetSizeBytes - 1) / manifestTargetSizeBytes),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
@@ -120,7 +121,7 @@ public class RewriteManifestsProcedureTest {
     void testExecuteWithEmptyManifests() {
         RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.dataManifests(any())).thenReturn(Collections.emptyList());
+        when(snapshot.allManifests(any())).thenReturn(Collections.emptyList());
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -137,9 +138,10 @@ public class RewriteManifestsProcedureTest {
         RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
         ManifestFile smallManifest = Mockito.mock(ManifestFile.class);
         when(smallManifest.length()).thenReturn(100L);
+        when(smallManifest.content()).thenReturn(ManifestContent.DATA);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.dataManifests(any())).thenReturn(List.of(smallManifest));
+        when(snapshot.allManifests(any())).thenReturn(List.of(smallManifest));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -161,9 +163,11 @@ public class RewriteManifestsProcedureTest {
         ManifestFile m2 = Mockito.mock(ManifestFile.class);
         when(m1.length()).thenReturn(10 * 1024 * 1024L);
         when(m2.length()).thenReturn(10 * 1024 * 1024L);
+        when(m1.content()).thenReturn(ManifestContent.DATA);
+        when(m2.content()).thenReturn(ManifestContent.DATA);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.dataManifests(any())).thenReturn(List.of(m1, m2));
+        when(snapshot.allManifests(any())).thenReturn(List.of(m1, m2));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -192,9 +196,10 @@ public class RewriteManifestsProcedureTest {
         // One manifest larger than default target (8MB) still triggers rewrite
         ManifestFile largeManifest = Mockito.mock(ManifestFile.class);
         when(largeManifest.length()).thenReturn(10 * 1024 * 1024L);
+        when(largeManifest.content()).thenReturn(ManifestContent.DATA);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.dataManifests(any())).thenReturn(List.of(largeManifest));
+        when(snapshot.allManifests(any())).thenReturn(List.of(largeManifest));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/RewriteManifestsProcedureTest.java
@@ -17,25 +17,39 @@ package com.starrocks.connector.iceberg.procedure;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
+import com.starrocks.connector.iceberg.TestTables;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
+import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,6 +64,19 @@ import static org.mockito.Mockito.when;
 public class RewriteManifestsProcedureTest {
 
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+
+    private static final Schema SCHEMA =
+            new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "k2", Types.IntegerType.get()));
+    // Identity partition on an int column, so partition values have a natural order to cluster by.
+    private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("k2").build();
+
+    @TempDir
+    public File warehouse;
+
+    @AfterEach
+    public void clearNativeTables() {
+        TestTables.clearTables();
+    }
 
     @Test
     void testProcedureCreation() {
@@ -93,7 +120,7 @@ public class RewriteManifestsProcedureTest {
     void testExecuteWithEmptyManifests() {
         RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.allManifests(any())).thenReturn(Collections.emptyList());
+        when(snapshot.dataManifests(any())).thenReturn(Collections.emptyList());
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -112,7 +139,7 @@ public class RewriteManifestsProcedureTest {
         when(smallManifest.length()).thenReturn(100L);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.allManifests(any())).thenReturn(List.of(smallManifest));
+        when(snapshot.dataManifests(any())).thenReturn(List.of(smallManifest));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -136,7 +163,7 @@ public class RewriteManifestsProcedureTest {
         when(m2.length()).thenReturn(10 * 1024 * 1024L);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.allManifests(any())).thenReturn(List.of(m1, m2));
+        when(snapshot.dataManifests(any())).thenReturn(List.of(m1, m2));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -167,7 +194,7 @@ public class RewriteManifestsProcedureTest {
         when(largeManifest.length()).thenReturn(10 * 1024 * 1024L);
 
         Snapshot snapshot = Mockito.mock(Snapshot.class);
-        when(snapshot.allManifests(any())).thenReturn(List.of(largeManifest));
+        when(snapshot.dataManifests(any())).thenReturn(List.of(largeManifest));
 
         Table table = Mockito.mock(Table.class);
         when(table.currentSnapshot()).thenReturn(snapshot);
@@ -188,6 +215,96 @@ public class RewriteManifestsProcedureTest {
         verify(txn).rewriteManifests();
         verify(rewriteManifests).clusterBy(any());
         verify(rewriteManifests).commit();
+    }
+
+    @Test
+    void testPartitionedManifestsClusteredByOrderPreservingRange() throws Exception {
+        // 200 distinct partitions, cluster count capped at MAX_MANIFEST_CLUSTERS(=100),
+        // so the order-preserving assignment is bucket = rank * 100 / 200 = rank / 2.
+        int numPartitions = 200;
+        int expectedClusters = 100;
+
+        Function<DataFile, Object> clusterFn = runAndCaptureClusterFunction(numPartitions);
+
+        int[] buckets = new int[numPartitions];
+        for (int i = 0; i < numPartitions; i++) {
+            Object bucket = clusterFn.apply(dataFileForPartition(i));
+            assertNotNull(bucket);
+            buckets[i] = ((Number) bucket).intValue();
+        }
+
+        for (int i = 0; i < numPartitions; i++) {
+            // partition value equals its rank here, so the expected bucket is a pure function of i
+            assertEquals(i / 2, buckets[i], "partition k2=" + i + " landed in an unexpected bucket");
+            assertTrue(buckets[i] >= 0 && buckets[i] < expectedClusters, "bucket out of range: " + buckets[i]);
+            if (i > 0) {
+                // monotonic non-decreasing in partition-value order: the property a hash would break
+                assertTrue(buckets[i] >= buckets[i - 1], "bucketing is not order-preserving");
+            }
+        }
+        // grouping actually happened and stayed within the cap
+        assertEquals(expectedClusters, (int) Arrays.stream(buckets).distinct().count());
+    }
+
+    @Test
+    void testUnmappedPartitionValueSlotsIntoNeighborBucket() throws Exception {
+        int numPartitions = 10;
+        Function<DataFile, Object> clusterFn = runAndCaptureClusterFunction(numPartitions);
+        // A value not seen at planning time (e.g. a new partition from a concurrent write to the same
+        // spec) must not abort and must not be hash-scattered: an above-max value slots into the last
+        // known partition's bucket, preserving the order-preserving clustering.
+        Object maxBucket = clusterFn.apply(dataFileForPartition(numPartitions - 1));
+        Object unmappedBucket = clusterFn.apply(dataFileForPartition(9999));
+        assertNotNull(unmappedBucket);
+        assertEquals(maxBucket, unmappedBucket);
+    }
+
+    @Test
+    void testUnknownSpecAbortsRewrite() throws Exception {
+        Function<DataFile, Object> clusterFn = runAndCaptureClusterFunction(10);
+        // A file under a spec not seen at planning time (concurrent partition-spec evolution) aborts,
+        // deferring to the next maintenance run rather than guessing an order.
+        DataFile unknownSpecFile = Mockito.mock(DataFile.class);
+        when(unknownSpecFile.specId()).thenReturn(999);
+        assertThrows(StarRocksConnectorException.class, () -> clusterFn.apply(unknownSpecFile));
+    }
+
+    // Builds a real partitioned table with `numPartitions` single-file partitions, runs the
+    // procedure against it, and returns the clustering Function it hands to RewriteManifests.
+    // The manifest target size is forced to 1 byte so the cluster count is pinned to the cap.
+    private Function<DataFile, Object> runAndCaptureClusterFunction(int numPartitions) throws Exception {
+        TestTables.TestTable table = TestTables.create(warehouse, "t_range_" + numPartitions, SCHEMA, SPEC, 2);
+        AppendFiles append = table.newAppend();
+        for (int i = 0; i < numPartitions; i++) {
+            append.appendFile(dataFileForPartition(i));
+        }
+        append.commit();
+        table.updateProperties().set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "1").commit();
+
+        RewriteManifests rewriteManifests = Mockito.mock(RewriteManifests.class);
+        when(rewriteManifests.clusterBy(any())).thenReturn(rewriteManifests);
+        doNothing().when(rewriteManifests).commit();
+        Transaction txn = Mockito.mock(Transaction.class);
+        when(txn.rewriteManifests()).thenReturn(rewriteManifests);
+
+        IcebergTableProcedureContext context = createContext(table, txn);
+        RewriteManifestsProcedure procedure = RewriteManifestsProcedure.getInstance();
+        assertDoesNotThrow(() -> procedure.execute(context, Collections.emptyMap()));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Function<DataFile, Object>> captor = ArgumentCaptor.forClass(Function.class);
+        verify(rewriteManifests).clusterBy(captor.capture());
+        verify(rewriteManifests).commit();
+        return captor.getValue();
+    }
+
+    private static DataFile dataFileForPartition(int k2) {
+        return DataFiles.builder(SPEC)
+                .withPath("/path/to/data-k2-" + k2 + ".parquet")
+                .withFileSizeInBytes(10)
+                .withPartitionPath("k2=" + k2)
+                .withRecordCount(1)
+                .build();
     }
 
     private IcebergTableProcedureContext createContext(Table table, Transaction transaction) {

--- a/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests_partitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_rewrite_manifests_partitioned
@@ -1,0 +1,85 @@
+-- name: test_iceberg_rewrite_manifests_partitioned
+create external catalog iceberg_sql_test_${uuid0} properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
+    "enable_iceberg_metadata_cache" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (
+    k1 int,
+    p int
+)
+partition by (p)
+properties (
+    'location' = 'oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}',
+    'commit.manifest-merge.enabled' = 'false',
+    'commit.manifest.target-size-bytes' = '24000'
+);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 1);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 2);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (3, 3);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (4, 4);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (99, NULL);
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- result:
+5
+-- !result
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_manifests();
+-- result:
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- result:
+3
+-- !result
+select partitions[1].lower_bound as lo, partitions[1].upper_bound as hi from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests order by cast(partitions[1].lower_bound as int) nulls last;
+-- result:
+1	2
+3	4
+null	null
+-- !result
+select k1, p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+1	1
+2	2
+3	3
+4	4
+99	None
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where p = 3;
+-- result:
+1
+-- !result
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where p is null;
+-- result:
+1
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests_partitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_rewrite_manifests_partitioned
@@ -1,0 +1,50 @@
+-- name: test_iceberg_rewrite_manifests_partitioned
+create external catalog iceberg_sql_test_${uuid0} properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "iceberg.catalog.hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}",
+    "enable_iceberg_metadata_cache" = "true",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (
+    k1 int,
+    p int
+)
+partition by (p)
+properties (
+    'location' = 'oss://starrocks-ci-test/iceberg_db_${uuid0}/ice_tbl_${uuid0}',
+    'commit.manifest-merge.enabled' = 'false',
+    'commit.manifest.target-size-bytes' = '24000'
+);
+
+-- Five single-row appends => five data manifests, over four non-null partitions plus NULL.
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 1);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 2);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (3, 3);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (4, 4);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (99, NULL);
+
+-- Five manifests before clustering.
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+
+alter table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} execute rewrite_manifests();
+
+-- Clustered down to one manifest per bucket: {p=1,2},{p=3,4} and {p=NULL}.
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests;
+-- Each manifest's partition bound is a narrow, non-overlapping range (order-preserving clustering);
+-- the NULL-only manifest reports NULL bounds.
+select partitions[1].lower_bound as lo, partitions[1].upper_bound as hi from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0}$manifests order by cast(partitions[1].lower_bound as int) nulls last;
+
+-- Data is preserved; partition filters and the NULL partition still resolve correctly after clustering.
+select k1, p from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where p = 3;
+select count(1) from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where p is null;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

`rewrite_manifests` clustered data files into manifests with `hash(partition) % targetManifestClusters` (clusters capped at 100). When a table has more distinct partitions than clusters, partitions that are far apart in sort order hash into the same manifest, so each manifest's partition min/max bound spans the whole value range. Wide, overlapping bounds defeat manifest-level pruning at read time: a partition predicate can no longer skip manifests, which is the main benefit rewrite_manifests is supposed to preserve.

## What I'm doing:

Replace hash-mod clustering with order-preserving range bucketing. Collect the distinct top-level partition values of the snapshot, sort them with Iceberg's canonical comparator, and assign each an equal-width bucket so sorted-adjacent partitions land in the same manifest. Every manifest then covers a narrow, non-overlapping partition range, restoring effective manifest pruning while still bounding the number of concurrent manifest writers.

Details:
- NULL partitions cluster into their own manifest.
- Files written under an older partition spec are coerced into the current spec before clustering; an unknown spec (partition-spec evolution under a concurrent commit) aborts the run so the next maintenance pass re-clusters against the new spec.
- Values not seen during the up-front scan (e.g. a concurrent append to the same spec) fall into their sort-order neighbor bucket, preserving the ordering instead of polluting an unrelated bucket.
- Only data manifests are counted and clustered; delete manifests are left untouched.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
