### PR TITLE
[BugFix] Avoid query 404 from torn split reads and batch-publish intermediate versions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -613,7 +613,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                                       MaterializedIndex index,
                                       List<Tablet> tablets,
                                       List<TKeyRange> partitionRanges,
-                                      long localBeId) throws StarRocksException {
+                                      long localBeId,
+                                      long partitionVisibleVersion) throws StarRocksException {
         boolean enableQueryTabletAffinity =
                 ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isEnableQueryTabletAffinity();
         boolean skipDiskCache = ConnectContext.get() != null && ConnectContext.get().getSessionVariable().isSkipLocalDiskCache();
@@ -622,7 +623,9 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
         int schemaHash = olapTable.getSchemaHashByIndexMetaId(index.getMetaId());
         String schemaHashStr = String.valueOf(schemaHash);
         ConnectContext ctx = ConnectContext.get();
-        long visibleVersion = chooseScanVersion(physicalPartition.getVisibleVersion(), physicalPartition.getId(),
+        // Use the visibleVersion the caller captured together with the selected index, so a concurrent
+        // split cannot make us pair this index with a mismatched version (404 on a live tablet).
+        long visibleVersion = chooseScanVersion(partitionVisibleVersion, physicalPartition.getId(),
                 ctx == null ? null : ctx.getScanVersionOverride());
         scanPartitionVersions.put(physicalPartition.getId(), visibleVersion);
         String visibleVersionStr = String.valueOf(visibleVersion);
@@ -835,7 +838,16 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
 
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 final List<Tablet> tablets = Lists.newArrayList();
+                // Capture the selected index and the visible version together here and thread the captured
+                // version through to addScanRangeLocations, so the scan's version is the one paired with THIS
+                // index -- not re-read later, when a concurrent split may have advanced it. Read the index
+                // first, then the version: a split bumps the version (setVisibleVersion) before adding the
+                // child index, both under the catalog write lock, so index-then-version leaves only a
+                // sub-statement torn window whose sole outcome is (commitVersion, split parent) -- and the
+                // split parent stays readable at commitVersion until CLEANING (see the orphan-shard-group
+                // grace), making that rare pairing safe rather than a 404.
                 final MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(index.indexMetaId);
+                final long partitionVisibleVersion = physicalPartition.getVisibleVersion();
                 final Collection<Long> tabletIds = distributionPrune(selectedIndex, partition.getDistributionInfo());
                 LOG.debug("distribution prune tablets: {}", tabletIds);
 
@@ -853,7 +865,8 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 fillTabletId2BucketSeq(dispatch, selectedIndex, allTabletIds, tabletId2BucketSeq);
                 totalTabletsNum += selectedIndex.getTablets().size();
                 selectedTabletsNum += tablets.size();
-                addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, List.of(), localBeId);
+                addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, List.of(), localBeId,
+                        partitionVisibleVersion);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1048,7 +1048,12 @@ public class PlanFragmentBuilder {
                         }
                         selectedNonEmptyPartitionIds.add(partitionId);
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
+                        // Capture the selected index and the visible version together and thread the captured
+                        // version through to addScanRangeLocations (see OlapScanNode for the full rationale).
+                        // Read the index first, then the version: index-then-version bounds a concurrent
+                        // split's torn window to the safe (commitVersion, split parent) pairing.
                         final MaterializedIndex selectedIndex = physicalPartition.getLatestIndex(selectedIndexMetaId);
+                        final long partitionVisibleVersion = physicalPartition.getVisibleVersion();
                         totalTabletsNum += selectedIndex.getTablets().size();
                         List<Long> allTabletIds = selectedIndex.getTabletIdsInOrder();
                         OlapScanNode.fillTabletId2BucketSeq(
@@ -1056,7 +1061,7 @@ public class PlanFragmentBuilder {
                         List<Tablet> tablets =
                                 selectTabletIds.stream().map(selectedIndex::getTablet).collect(Collectors.toList());
                         scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, partitionRange,
-                                localBeId);
+                                localBeId, partitionVisibleVersion);
                     }
                 }
                 scanNode.setSelectedPartitionIds(Lists.newArrayList(selectedNonEmptyPartitionIds));

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -35,6 +35,8 @@ import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,6 +78,17 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
     }
 
     public void applyVisibleLog(TransactionState txnState, TableCommitInfo commitInfo, Database db) {
+        applyVisibleLog(txnState, commitInfo, db, false);
+    }
+
+    // deferVersionAdvance is set only on the batch-publish path. When true, this method does NOT advance the
+    // partition's visible version (nor run the per-txn continuity Precondition); it only does the per-txn
+    // bookkeeping (dataVersion, compaction score, reshard signal). applyVisibleLogBatch validates version
+    // continuity across the batch and advances each touched partition's visible version exactly once, at batch
+    // end, so lock-free query planning never samples an intermediate version whose BE .meta object was never
+    // materialized (BE materializes a single .meta bundle at the batch's final version).
+    private void applyVisibleLog(TransactionState txnState, TableCommitInfo commitInfo, Database db,
+            boolean deferVersionAdvance) {
         List<ColumnId> validDictCacheColumns = Lists.newArrayList();
         List<Long> dictCollectedVersions = Lists.newArrayList();
 
@@ -98,13 +111,17 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             long versionTime = partitionCommitInfo.getVersionTime();
             Quantiles compactionScore = partitionCommitInfo.getCompactionScore();
 
-            // The version of a replication transaction may not continuously
-            Preconditions.checkState(txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
-                    || txnState.isVersionOverwrite()
-                    || partitionCommitInfo.isDoubleWrite()
-                    || version == partition.getVisibleVersion() + 1);
-
-            partition.updateVisibleVersion(version, versionTime);
+            // In the batch-publish path the visible version is advanced once at batch end (see
+            // applyVisibleLogBatch), not here, so lock-free query planning never samples an intermediate
+            // version whose BE .meta object was never materialized.
+            if (!deferVersionAdvance) {
+                // The version of a replication transaction may not continuously
+                Preconditions.checkState(txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                        || txnState.isVersionOverwrite()
+                        || partitionCommitInfo.isDoubleWrite()
+                        || version == partition.getVisibleVersion() + 1);
+                partition.updateVisibleVersion(version, versionTime);
+            }
             if (txnState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
                 partition.setDataVersion(partitionCommitInfo.getDataVersion());
                 if (partitionCommitInfo.getVersionEpoch() > 0) {
@@ -213,9 +230,58 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
     }
 
     public void applyVisibleLogBatch(TransactionStateBatch txnStateBatch, Database db) {
+        // BE materializes a single .meta object at the batch's final version, so exposing an intermediate
+        // version to lock-free query planning would route a scan to a .meta that was never written (404).
+        // We therefore advance each touched partition's visible version exactly once, at the end, jumping
+        // straight from the batch's start to its final (materialized) new_version. Runs under the db write
+        // lock. Both the leader (finishTransactionBatch) and follower replay (replayUpsertTransactionStateBatch)
+        // reach here via updateCatalogAfterVisibleBatch, so the guarantee holds symmetrically on every FE that
+        // plans queries locally.
+        //
+        // Three passes so the failure path is side-effect-free: (1) validate per-partition version continuity
+        // across the whole batch, (2) apply each txn's per-txn bookkeeping with the version advance deferred,
+        // (3) advance each touched partition's visible version once. Validating before (2) ensures a malformed
+        // or replayed batch with a version gap is rejected WITHOUT partially updating the catalog (dataVersion,
+        // compaction/dict bookkeeping, tablet stats, reshard signal).
+        Map<Long, Long> finalVersion = new LinkedHashMap<>();
+        Map<Long, Long> finalVersionTime = new HashMap<>();
+        for (TransactionState txnState : txnStateBatch.getTransactionStates()) {
+            if (txnState.isShadowRewrite()) {
+                continue;
+            }
+            TableCommitInfo tableCommitInfo = txnState.getTableCommitInfo(txnStateBatch.getTableId());
+            for (PartitionCommitInfo pci : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
+                long partitionId = pci.getPhysicalPartitionId();
+                PhysicalPartition partition = table.getPhysicalPartition(partitionId);
+                if (partition == null) {
+                    continue;
+                }
+                long version = pci.getVersion();
+                // Per-partition version continuity within the batch: the first txn to touch a partition must
+                // start at visibleVersion+1 and each subsequent one steps by exactly 1. Replication /
+                // version-overwrite / double-write txns may legitimately be non-continuous and are exempt
+                // (mirrors the per-txn Precondition applyVisibleLog runs on the non-batch path).
+                boolean mayBeNonContinuous =
+                        txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                                || txnState.isVersionOverwrite() || pci.isDoubleWrite();
+                long expected = finalVersion.containsKey(partitionId)
+                        ? finalVersion.get(partitionId) + 1 : partition.getVisibleVersion() + 1;
+                Preconditions.checkState(mayBeNonContinuous || version == expected,
+                        "batch publish version not continuous: partition=" + partitionId
+                                + " expected=" + expected + " actual=" + version);
+                finalVersion.put(partitionId, version);
+                finalVersionTime.put(partitionId, pci.getVersionTime());
+            }
+        }
         for (TransactionState txnState : txnStateBatch.getTransactionStates()) {
             TableCommitInfo tableCommitInfo = txnState.getTableCommitInfo(txnStateBatch.getTableId());
-            applyVisibleLog(txnState, tableCommitInfo, db);
+            applyVisibleLog(txnState, tableCommitInfo, db, true);
+        }
+        for (Map.Entry<Long, Long> entry : finalVersion.entrySet()) {
+            PhysicalPartition partition = table.getPhysicalPartition(entry.getKey());
+            if (partition != null) {
+                partition.updateVisibleVersion(entry.getValue(), finalVersionTime.get(entry.getKey()));
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
@@ -94,7 +94,7 @@ public class ScanNodeComputeScanRangeTest {
         };
 
         Assertions.assertDoesNotThrow(() -> scanNode.addScanRangeLocations(partition, physicalPartition, selectedIndex,
-                selectedIndex.getTablets(), List.of(), -1));
+                selectedIndex.getTablets(), List.of(), -1, physicalPartition.getVisibleVersion()));
         Assertions.assertEquals(1, invokeCounter.get());
     }
 
@@ -159,5 +159,45 @@ public class ScanNodeComputeScanRangeTest {
                 OlapTableSink.createLocation(olapTable, partitionParam, false, computeResource, null));
         // 10 tablets share a single batched StarClient.getShardInfo call.
         Assertions.assertEquals(1, invokeCounter.get());
+    }
+
+    @Test
+    public void testFinalizeStatsThreadsCapturedVisibleVersion() {
+        // finalizeStats() -> getScanRangeLocations() -> computeTabletInfo() captures the selected index and
+        // the visible version together and threads that captured version into addScanRangeLocations, instead
+        // of re-reading getVisibleVersion() later where a concurrent split could have advanced it.
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(2));
+        Table table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "t1");
+        Assertions.assertNotNull(table);
+        desc.setTable(table);
+        OlapTable olapTable = (OlapTable) table;
+        OlapScanNode scanNode =
+                new OlapScanNode(new PlanNodeId(2), desc, "OlapScanNode", olapTable.getBaseIndexMetaId());
+        long partitionId = olapTable.getAllPartitionIds().get(0);
+        scanNode.setSelectedPartitionIds(List.of(partitionId));
+
+        AtomicInteger invokeCounter = new AtomicInteger(0);
+        new MockUp<StarClient>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(Invocation invocation, String serviceId, List<Long> shardIds,
+                                                long workerGroupId) throws StarClientException {
+                invokeCounter.incrementAndGet();
+                return invocation.proceed(serviceId, shardIds, workerGroupId);
+            }
+        };
+
+        Assertions.assertDoesNotThrow(scanNode::finalizeStats);
+        Assertions.assertTrue(invokeCounter.get() >= 1);
+    }
+
+    @Test
+    public void testExecPlanBuildsOlapScanRangesWithCapturedVersion() throws Exception {
+        // Building the exec plan runs PlanFragmentBuilder.visitPhysicalOlapScan, whose inline scan-range
+        // path captures the selected index and the visible version together and threads that captured
+        // version into addScanRangeLocations.
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        Assertions.assertNotNull(
+                UtFrameUtils.getPlanAndFragment(connectContext, "select * from test.t1").second);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanNodeComputeScanRangeTest.java
@@ -175,6 +175,9 @@ public class ScanNodeComputeScanRangeTest {
                 new OlapScanNode(new PlanNodeId(2), desc, "OlapScanNode", olapTable.getBaseIndexMetaId());
         long partitionId = olapTable.getAllPartitionIds().get(0);
         scanNode.setSelectedPartitionIds(List.of(partitionId));
+        // No predicate -> empty column filters -> distributionPrune scans all tablets (a null filter map
+        // would NPE inside HashDistributionPruner).
+        scanNode.setColumnFilters(Maps.newHashMap());
 
         AtomicInteger invokeCounter = new AtomicInteger(0);
         new MockUp<StarClient>() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -325,7 +325,8 @@ public class WarehouseManagerTest {
         Partition partition = new Partition(123, 456, "aaa", index, null);
         ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class,
                 () -> scanNode.addScanRangeLocations(partition, partition.getDefaultPhysicalPartition(),
-                        index, Collections.emptyList(), List.of(), 1));
+                        index, Collections.emptyList(), List.of(), 1,
+                        partition.getDefaultPhysicalPartition().getVisibleVersion()));
         Assertions.assertEquals("No alive backend or compute node in warehouse null.", ex.getMessage());
     }
 
@@ -401,11 +402,11 @@ public class WarehouseManagerTest {
         MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
         Partition partition = new Partition(123, 456, "aaa", index, null);
         scanNode.addScanRangeLocations(partition, partition.getDefaultPhysicalPartition(), index, Collections.emptyList(),
-                List.of(), 1);
+                List.of(), 1, partition.getDefaultPhysicalPartition().getVisibleVersion());
         // Since this is the second call to  addScanRangeLocations on the same OlapScanNode, we do not expect another call to
         // getAliveComputeNodes.
         scanNode.addScanRangeLocations(partition, partition.getDefaultPhysicalPartition(), index, Collections.emptyList(),
-                List.of(), 1);
+                List.of(), 1, partition.getDefaultPhysicalPartition().getVisibleVersion());
     }
 
     private OlapScanNode newOlapScanNode() {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -266,5 +268,61 @@ public class LakeTableTxnLogApplierTest extends LakeTableTestHelper {
         applier.applyVisibleLog(state, tableCommitInfo, /*unused*/null);
         Assertions.assertEquals(1, table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, table.getPartition(partitionId).getDefaultPhysicalPartition().getNextVersion());
+    }
+
+    @Test
+    public void testApplyVisibleLogBatchAdvancesVersionOnceToFinal() {
+        LakeTable table = buildLakeTable();
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        PhysicalPartition partition = table.getPartition(partitionId).getDefaultPhysicalPartition();
+
+        Assertions.assertEquals(1, partition.getVisibleVersion());
+
+        // A batch of 3 contiguous load txns (versions 2, 3, 4). The visible version -- what lock-free query
+        // planning reads -- is advanced only once, at batch end, straight to the batch's final materialized
+        // version, never stepped through an intermediate version whose .meta BE never wrote.
+        List<TransactionState> states = Lists.newArrayList();
+        for (long version = 2; version <= 4; version++) {
+            TransactionState state = newTransactionState();
+            state.setTransactionStatus(TransactionStatus.VISIBLE);
+            PartitionCommitInfo pci =
+                    new PartitionCommitInfo(physicalPartitionId, version, System.currentTimeMillis());
+            TableCommitInfo tci = new TableCommitInfo(tableId);
+            tci.addPartitionCommitInfo(pci);
+            state.putIdToTableCommitInfo(tableId, tci);
+            states.add(state);
+        }
+
+        applier.applyVisibleLogBatch(new TransactionStateBatch(states), /*unused*/ null);
+
+        Assertions.assertEquals(4, partition.getVisibleVersion());
+    }
+
+    @Test
+    public void testApplyVisibleLogBatchRejectsNonContiguousVersions() {
+        LakeTable table = buildLakeTable();
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        PhysicalPartition partition = table.getPartition(partitionId).getDefaultPhysicalPartition();
+
+        Assertions.assertEquals(1, partition.getVisibleVersion());
+
+        // Versions 2 then 4 -- skipping 3 -- must trip the per-partition continuity check. Because the
+        // version is advanced only at batch end (which never runs on failure), the partition's visible
+        // version is left untouched rather than stepped to a bogus value.
+        List<TransactionState> states = Lists.newArrayList();
+        for (long version : new long[] {2, 4}) {
+            TransactionState state = newTransactionState();
+            state.setTransactionStatus(TransactionStatus.VISIBLE);
+            PartitionCommitInfo pci =
+                    new PartitionCommitInfo(physicalPartitionId, version, System.currentTimeMillis());
+            TableCommitInfo tci = new TableCommitInfo(tableId);
+            tci.addPartitionCommitInfo(pci);
+            state.putIdToTableCommitInfo(tableId, tci);
+            states.add(state);
+        }
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> applier.applyVisibleLogBatch(new TransactionStateBatch(states), /*unused*/ null));
+        Assertions.assertEquals(1, partition.getVisibleVersion());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

On a shared-data RANGE PK table under concurrent tablet split + batch publish, a read query can 404 on a partition metadata object `.../meta/<tablet>_<version>.meta` that maps to no materialized state. Two independent mechanisms feed the same symptom:

1. **Torn (version, index) read during a split.** Lock-free query planning reads the tablet set (`PhysicalPartition.getLatestIndex()`) and the visible version (`getVisibleVersion()`) at two independent points. A concurrent split flips the partition from `(prevVersion, parentIndex)` to `(commitVersion, childIndex)` between them, so planning can pair the still-present parent index with the already-bumped commit version and route a scan to a `<tablet>_<version>.meta` that never existed.

2. **Unmaterialized intermediate version under batch publish.** With `lake_enable_batch_publish_version=true`, BE materializes one metadata object at the batch's final `new_version` and skips intermediate versions, while FE stepped `visibleVersion` per-txn through every intermediate (`LakeTableTxnLogApplier.applyVisibleLog` → `updateVisibleVersion`). A lock-free planner can sample an intermediate visible version whose `.meta` BE never wrote → 404.

## What I'm doing:

Both are fixed with two small, orthogonal, **lock-free** changes — no cached, derived `(version, index)` snapshot on `PhysicalPartition` (which would need a manual refresh at every version/index mutation site, an easy-to-miss invariant). Query planning stays lock-free.

- **Split — pair the scan version with the selected index** (commit 1). `OlapScanNode.computeTabletInfo` and the range-colocate path in `PlanFragmentBuilder.visitPhysicalOlapScan` now capture the selected index and the visible version together and thread the captured version through `addScanRangeLocations`, instead of re-reading `getVisibleVersion()` deep inside it (which widened the window). The two facts are read **index first, then version**. A split bumps the version (`setVisibleVersion`) before adding the child index, both inside one catalog-write-lock critical section (`SplitTabletJob.addNewMaterializedIndexes`), so reading `index → version` bounds the only remaining lock-free torn outcome to `(commitVersion, split-parent)`. The split publishes `commitVersion` on the parent tablets and the parent stays readable until `CLEANING` (the orphan-shard-group physical-deletion grace, #76195), so that rare sub-statement pairing returns correct data rather than a 404.

- **Batch — advance the visible version once, at batch end** (commit 2). `applyVisibleLogBatch` no longer steps `visibleVersion` per-txn. Each txn's per-txn bookkeeping (dataVersion, compaction score, reshard signal) still runs, but the visible version is validated for per-partition continuity and advanced **exactly once, at batch end** — jumping straight from the batch's start to its final materialized `new_version`, never through an unmaterialized intermediate. A lock-free reader therefore sees either the pre-batch or the final version, never an intermediate one. Runs under the db write lock; both the leader (`finishTransactionBatch`) and follower replay (`replayUpsertTransactionStateBatch`) reach it via `updateCatalogAfterVisibleBatch`, so the guarantee holds symmetrically on every FE that plans queries locally. Batch publish stays ON (no throughput regression).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

### Verification

- **Split** — `ScanNodeComputeScanRangeTest`: `testFinalizeStatsThreadsCapturedVisibleVersion` drives `finalizeStats() → getScanRangeLocations() → computeTabletInfo()`, and `testExecPlanBuildsOlapScanRangesWithCapturedVersion` builds an exec plan that runs `PlanFragmentBuilder.visitPhysicalOlapScan`'s inline scan-range path — both exercise the captured-version threading. Safety of the residual `(commitVersion, split-parent)` pairing relies on the parent-readability grace in #76195.
- **Batch** — `LakeTableTxnLogApplierTest`: `testApplyVisibleLogBatchAdvancesVersionOnceToFinal` asserts a 3-txn contiguous batch advances the partition to the final version only, and `testApplyVisibleLogBatchRejectsNonContiguousVersions` asserts a non-contiguous batch trips the continuity check without advancing.
- **End-to-end** — an earlier iteration of these fixes ran **224,605 queries with 0 `.meta` 404s** on a 3-CN shared-data cluster (RANGE PK table driven 1 → 300+ tablets under sustained ingest + a concurrent Q1–Q5 loop, batch publish ON), where the same workload hit the 404 within minutes without the fix. A re-run of the soak is recommended before merge.
