### PR TITLE
[BugFix] Fix Iceberg metadata delete when a string date partition column is compared with a temporal value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionCastPredicatePruner.java
@@ -194,6 +194,45 @@ public class PartitionCastPredicatePruner {
     }
 
     /**
+     * Returns {@code true} only if EVERY residual conjunct definitively folds to {@code true} for the given
+     * partition values. This is the inverse of {@link #partitionMayMatch}: metadata-level DELETE may drop a whole
+     * partition/file only when all of its rows definitely match, so anything indeterminate (an unbound reference,
+     * a parse failure, a non-boolean or {@code null} fold, or a definite {@code false}) makes this return
+     * {@code false} - an indeterminate partition is never deleted.
+     *
+     * @param partitionValues column name (any case) -> raw partition string value.
+     */
+    public static boolean partitionDefinitelyMatches(List<ScalarOperator> residualConjuncts,
+                                                     Map<String, String> partitionValues) {
+        if (residualConjuncts.isEmpty()) {
+            return true;
+        }
+        Map<String, String> lowerValues = new HashMap<>();
+        for (Map.Entry<String, String> entry : partitionValues.entrySet()) {
+            if (entry.getValue() != null) {
+                lowerValues.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+            }
+        }
+        for (ScalarOperator conjunct : residualConjuncts) {
+            Map<ColumnRefOperator, ScalarOperator> replaceMap = new HashMap<>();
+            for (ColumnRefOperator ref : conjunct.getColumnRefs()) {
+                String value = lowerValues.get(ref.getName().toLowerCase(Locale.ROOT));
+                if (value == null) {
+                    // Cannot bind every reference to a partition value -> not a definite match -> do not delete.
+                    return false;
+                }
+                replaceMap.put(ref, ConstantOperator.createVarchar(value));
+            }
+            Boolean result = tryFoldToBoolean(conjunct, replaceMap);
+            if (result == null || !result) {
+                // Indeterminate or definitely false -> not a definite match -> do not delete.
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Coarse manifest/partition-group level check for the residual conjuncts, given each referenced column's
      * temporal value range {@code [min, max]} (parsed from the group's partition summary). Returns {@code false}
      * only when some residual conjunct provably cannot be satisfied by ANY value within the ranges, so the group

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -518,7 +518,11 @@ public class IcebergMetadata implements ConnectorMetadata {
                 return false;
             }
             if (!residual.pushable.isEmpty()) {
-                Expression pushableExpr = new ScalarOperatorToIcebergExpr().convert(residual.pushable,
+                // Strict conversion: a non-cast conjunct that cannot be converted/bound must make metadata delete
+                // ineligible. Non-strict convert would silently skip it and still return alwaysTrue, so
+                // selectsPartitions could wrongly pass and the skipped conjunct would be ignored at execution ->
+                // whole-file over-delete. On null (some pushable conjunct is unconvertible) fall back to row-level.
+                Expression pushableExpr = new ScalarOperatorToIcebergExpr().convertStrict(residual.pushable,
                         new ScalarOperatorToIcebergExpr.IcebergContext(nativeTable.schema().asStruct()));
                 if (pushableExpr == null || !ExpressionUtil.selectsPartitions(pushableExpr, nativeTable, caseSensitive)) {
                     return false;
@@ -616,8 +620,19 @@ public class IcebergMetadata implements ConnectorMetadata {
                 throw new StarRocksConnectorException("Cannot metadata-delete a cast-on-string-partition predicate on " +
                         "partition-transform-evolved table %s.%s", dbName, tableName);
             }
-            Expression pushableExpr = new ScalarOperatorToIcebergExpr().convert(residual.pushable,
+            // Strict conversion, consistent with canDeleteUsingMetadata: an unconvertible pushable conjunct must
+            // not be silently dropped (that would ignore it and over-delete). canDeleteUsingMetadata already
+            // guarantees non-null here; guard defensively.
+            Expression pushableExpr = new ScalarOperatorToIcebergExpr().convertStrict(residual.pushable,
                     new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct()));
+            if (pushableExpr == null) {
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        "Unconvertible pushable predicate for metadata delete", deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Cannot metadata-delete on %s.%s: pushable predicate is not " +
+                        "convertible to an Iceberg expression", dbName, tableName);
+            }
             int matchedFiles = 0;
             try (CloseableIterable<FileScanTask> tasks = nativeTbl.newScan()
                     .filter(pushableExpr).caseSensitive(false).ignoreResiduals().planFiles()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -528,8 +528,17 @@ public class IcebergMetadata implements ConnectorMetadata {
                     return false;
                 }
             }
-            // Whole predicate is partition level; the matching partitions are deleted file-by-file in
-            // executeMetadataDelete after StarRocks-side residual evaluation.
+            // The residual is evaluated against each partition value at execution time. A non-deterministic
+            // function (rand(), uuid(), ...) only materializes per row at execution and never folds to a constant,
+            // so executeMetadataDelete could evaluate nothing and silently delete nothing. Such predicates must be
+            // evaluated per row -> fall back to row-level delete.
+            for (ScalarOperator conjunct : residual.residual) {
+                if (Utils.hasNonDeterministicFunc(conjunct)) {
+                    return false;
+                }
+            }
+            // Whole predicate is partition level and deterministic; the matching partitions are deleted
+            // file-by-file in executeMetadataDelete after StarRocks-side residual evaluation.
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -497,6 +497,38 @@ public class IcebergMetadata implements ConnectorMetadata {
         // Use caseSensitive=false to be consistent with StarRocks expression conversion
         boolean caseSensitive = false;
 
+        // Cast-on-string-partition conjuncts (e.g. CAST(c AS DATETIME) = <ts>) cannot be soundly expressed as an
+        // Iceberg (string-domain) filter, so they are split out and evaluated StarRocks-side per partition in
+        // executeMetadataDelete. Metadata (whole-file) delete stays sound only when every candidate file is
+        // entirely matched or entirely unmatched by the whole predicate.
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        PartitionCastPredicatePruner.PartitionResidual residual =
+                PartitionCastPredicatePruner.split(conjuncts, identityStringPartitionColumns(icebergTable));
+        boolean droppedExists = residual.pushable.size() + residual.residual.size() < conjuncts.size();
+        if (droppedExists) {
+            // A cast-on-string conjunct references a non-partition column (or a mixed OR): a file may contain
+            // both matching and non-matching rows, so it cannot be whole-file deleted -> fall back to row-level.
+            return false;
+        }
+        if (residual.hasResidual()) {
+            // Partition values must be readable (no partition-transform evolution) to evaluate the residual, and
+            // the pushable part must also be partition level so each file is wholly matched/unmatched; otherwise
+            // fall back to row-level delete.
+            if (icebergTable.hasPartitionTransformedEvolution()) {
+                return false;
+            }
+            if (!residual.pushable.isEmpty()) {
+                Expression pushableExpr = new ScalarOperatorToIcebergExpr().convert(residual.pushable,
+                        new ScalarOperatorToIcebergExpr.IcebergContext(nativeTable.schema().asStruct()));
+                if (pushableExpr == null || !ExpressionUtil.selectsPartitions(pushableExpr, nativeTable, caseSensitive)) {
+                    return false;
+                }
+            }
+            // Whole predicate is partition level; the matching partitions are deleted file-by-file in
+            // executeMetadataDelete after StarRocks-side residual evaluation.
+            return true;
+        }
+
         // Convert ScalarOperator to Iceberg Expression
         Expression deleteExpr = convertScalarOperatorToIcebergExpr(predicate, nativeTable.schema());
         if (deleteExpr == null) {
@@ -565,26 +597,74 @@ public class IcebergMetadata implements ConnectorMetadata {
         long startMs = System.currentTimeMillis();
         String deleteType = "metadata";
 
-        // Convert ScalarOperator to Iceberg Expression
-        Expression deleteExpr = convertScalarOperatorToIcebergExpr(predicate, nativeTbl.schema());
-        if (deleteExpr == null) {
-            ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
-                    "Failed to convert predicate to Iceberg expression", deleteType);
-            ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
-                    System.currentTimeMillis() - startMs, deleteType);
-            throw new StarRocksConnectorException("Failed to convert predicate to Iceberg expression");
-        }
+        // Cast-on-string-partition conjuncts cannot be expressed as a sound Iceberg filter; evaluate them
+        // StarRocks-side per partition and delete matching files individually. Anything else keeps the existing
+        // row-filter delete. canDeleteUsingMetadata guarantees the whole predicate is partition level here.
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        PartitionCastPredicatePruner.PartitionResidual residual =
+                PartitionCastPredicatePruner.split(conjuncts, identityStringPartitionColumns(icebergTable));
 
-        DeleteFiles deleteFiles = nativeTbl.newDelete()
-                .deleteFromRowFilter(deleteExpr);
+        DeleteFiles deleteFiles = nativeTbl.newDelete();
+        String deleteDesc;
+        if (residual.hasResidual()) {
+            if (icebergTable.hasPartitionTransformedEvolution()) {
+                // Defensive: canDeleteUsingMetadata should have returned false; never silently mis-delete.
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        "Cannot metadata-delete cast-on-string-partition predicate under partition evolution", deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Cannot metadata-delete a cast-on-string-partition predicate on " +
+                        "partition-transform-evolved table %s.%s", dbName, tableName);
+            }
+            Expression pushableExpr = new ScalarOperatorToIcebergExpr().convert(residual.pushable,
+                    new ScalarOperatorToIcebergExpr.IcebergContext(nativeTbl.schema().asStruct()));
+            int matchedFiles = 0;
+            try (CloseableIterable<FileScanTask> tasks = nativeTbl.newScan()
+                    .filter(pushableExpr).caseSensitive(false).ignoreResiduals().planFiles()) {
+                for (FileScanTask task : tasks) {
+                    if (PartitionCastPredicatePruner.partitionDefinitelyMatches(residual.residual,
+                            icebergPartitionValues(task, icebergTable, false))) {
+                        deleteFiles.deleteFile(task.file());
+                        matchedFiles++;
+                    }
+                }
+            } catch (IOException e) {
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG, e, deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Failed to plan files for metadata delete on %s.%s: %s",
+                        dbName, tableName, e.getMessage());
+            }
+            if (matchedFiles == 0) {
+                // No partition matched the residual -> nothing to delete; do not commit an empty snapshot.
+                ConnectorMetricsMgr.increaseDeleteTotalSuccess(ConnectorMetricsMgr.CONNECTOR_ICEBERG, deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                LOG.info("Metadata delete on {}.{} matched no partitions; nothing deleted", dbName, tableName);
+                return;
+            }
+            deleteDesc = "cast-on-string-partition residual, matchedFiles=" + matchedFiles;
+        } else {
+            // Convert ScalarOperator to Iceberg Expression
+            Expression deleteExpr = convertScalarOperatorToIcebergExpr(predicate, nativeTbl.schema());
+            if (deleteExpr == null) {
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        "Failed to convert predicate to Iceberg expression", deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Failed to convert predicate to Iceberg expression");
+            }
+            deleteFiles.deleteFromRowFilter(deleteExpr);
+            deleteDesc = deleteExpr.toString();
+        }
 
         // Set engine info and user for audit
         updateCommitInfo(deleteFiles, context);
 
         try {
             deleteFiles.commit();
-            LOG.info("Successfully executed metadata delete on {}.{}, delete expression: {}",
-                    dbName, tableName, deleteExpr);
+            LOG.info("Successfully executed metadata delete on {}.{}, delete: {}",
+                    dbName, tableName, deleteDesc);
 
             // Get deleted rows and bytes from snapshot summary
             Snapshot newSnapshot = nativeTbl.currentSnapshot();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionCastPredicatePrunerTest.java
@@ -189,6 +189,33 @@ public class PartitionCastPredicatePrunerTest {
         Assertions.assertTrue(PartitionCastPredicatePruner.partitionMayMatch(residual, withNull));
     }
 
+    @Test
+    public void testPartitionDefinitelyMatches() {
+        List<ScalarOperator> residual = Lists.newArrayList(
+                eq(castTo(strPartCol, DateType.DATETIME), datetime("2020-06-14 00:00:00")));
+
+        // partition value casts to the constant -> definite match (safe to delete this partition)
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionDefinitelyMatches(
+                residual, singletonMap("c2", "2020-06-14")));
+        // case-insensitive column name lookup
+        Assertions.assertTrue(PartitionCastPredicatePruner.partitionDefinitelyMatches(
+                residual, singletonMap("C2", "2020-06-14")));
+
+        // definitely false -> not a match
+        Assertions.assertFalse(PartitionCastPredicatePruner.partitionDefinitelyMatches(
+                residual, singletonMap("c2", "2020-06-15")));
+        // unbound reference -> indeterminate -> NOT a definite match (must not delete)
+        Assertions.assertFalse(PartitionCastPredicatePruner.partitionDefinitelyMatches(
+                residual, singletonMap("other", "2020-06-14")));
+        // unparseable partition value -> indeterminate -> NOT a definite match (must not delete)
+        Assertions.assertFalse(PartitionCastPredicatePruner.partitionDefinitelyMatches(
+                residual, singletonMap("c2", "not-a-date")));
+        // null partition value -> unbound -> NOT a definite match
+        Map<String, String> withNull = new HashMap<>();
+        withNull.put("c2", null);
+        Assertions.assertFalse(PartitionCastPredicatePruner.partitionDefinitelyMatches(residual, withNull));
+    }
+
     private LocalDateTime dt(int y, int m, int d) {
         return LocalDateTime.of(y, m, d, 0, 0, 0);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -108,6 +108,7 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
@@ -3876,6 +3877,33 @@ public class IcebergMetadataTest extends TableTestBase {
 
         Assertions.assertTrue(metadata.canDeleteUsingMetadata(icebergTable, k2EqDate(2020, 6, 14)),
                 "cast-on-string-partition predicate is partition level -> metadata delete eligible");
+    }
+
+    @Test
+    public void testCanDeleteUsingMetadataStringDatePartitionCastMixedIneligible() throws Exception {
+        // A residual (cast on the partition column) combined with a non-partition pushable conjunct must NOT be
+        // eligible for metadata delete: a file could contain both matching and non-matching rows.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbDeleteStrPartMixed", 1);
+        table.newFastAppend().appendFile(DataFiles.builder(spec)
+                .withPath("/path/to/del-mix-0614.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-14").withRecordCount(3).build()).commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        // residual + a data-column (non-partition) conjunct: the pushable part is not partition level, so a file
+        // could hold both matching and non-matching rows -> not metadata-delete eligible -> row-level fallback.
+        ScalarOperator dataColConj = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(2, INT, "k1", true), ConstantOperator.createInt(1));
+        Assertions.assertFalse(metadata.canDeleteUsingMetadata(icebergTable,
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, k2EqDate(2020, 6, 14), dataColConj)),
+                "residual + non-partition data-column conjunct must not be metadata-delete eligible");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -3856,6 +3856,73 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testCanDeleteUsingMetadataStringDatePartitionCast() throws Exception {
+        // A STRING date partition column compared with a temporal value coerces to CAST(k2 AS DATETIME) = <ts>.
+        // The whole predicate is on the identity partition column, so metadata (whole-file) delete is eligible;
+        // the specific matching partitions are resolved StarRocks-side at execution time.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbDeleteStrPartCanDelete", 1);
+        table.newFastAppend().appendFile(DataFiles.builder(spec)
+                .withPath("/path/to/del-0614.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-14").withRecordCount(3).build()).commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        Assertions.assertTrue(metadata.canDeleteUsingMetadata(icebergTable, k2EqDate(2020, 6, 14)),
+                "cast-on-string-partition predicate is partition level -> metadata delete eligible");
+    }
+
+    @Test
+    public void testExecuteMetadataDeleteStringDatePartitionCast() throws Exception {
+        // Regression: previously CAST(k2 AS DATETIME) = <ts> was pushed to Iceberg as a string-domain filter
+        // (k2 = '2020-06-14 00:00:00'), which never matched the 'yyyy-MM-dd' partition value, so the delete was a
+        // silent no-op. Now the matching partition file is deleted and the non-matching one is kept.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbDeleteStrPartExec", 1);
+        table.newFastAppend()
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/del-0614.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-14").withRecordCount(3).build())
+                .appendFile(DataFiles.builder(spec).withPath("/path/to/del-0615.parquet").withFileSizeInBytes(20)
+                        .withPartitionPath("k2=2020-06-15").withRecordCount(4).build())
+                .commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        metadata.executeMetadataDelete(icebergTable, k2EqDate(2020, 6, 14), connectContext);
+
+        table.refresh();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(table.newScan().planFiles());
+        Assertions.assertEquals(1, fileScanTasks.size(), "only the 2020-06-14 partition file should be deleted");
+        Assertions.assertEquals("PartitionData{k2=2020-06-15}", fileScanTasks.get(0).file().partition().toString(),
+                "the non-matching 2020-06-15 partition must remain");
+    }
+
+    @Test
     public void testMetadataDeleteNodeExplainString() {
         // Test that IcebergMetadataDeleteNode generates correct EXPLAIN output
         mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();

--- a/test/sql/test_iceberg/R/test_iceberg_string_date_partition_delete
+++ b/test/sql/test_iceberg/R/test_iceberg_string_date_partition_delete
@@ -1,0 +1,84 @@
+-- name: test_iceberg_string_date_partition_delete
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+set catalog ice_cat_${uuid0};
+-- result:
+-- !result
+use ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+create table t_del_eq (
+    c1 int,
+    c2 string
+) partition by (c2)
+PROPERTIES ("format-version" = "2");
+-- result:
+-- !result
+insert into t_del_eq values (1, '2020-06-08'), (2, '2020-06-14'), (3, '2020-06-14'), (4, '2020-06-15'), (5, '2020-06-22');
+-- result:
+-- !result
+select c2, count(*) from t_del_eq group by c2 order by c2;
+-- result:
+2020-06-08	1
+2020-06-14	2
+2020-06-15	1
+2020-06-22	1
+-- !result
+delete from t_del_eq where c2 = cast('2020-06-15' as date) - interval 1 day;
+-- result:
+-- !result
+select c2, count(*) from t_del_eq group by c2 order by c2;
+-- result:
+2020-06-08	1
+2020-06-15	1
+2020-06-22	1
+-- !result
+delete from t_del_eq where c2 = date_sub(cast('2020-06-23' as date), interval 1 day);
+-- result:
+-- !result
+select c2, count(*) from t_del_eq group by c2 order by c2;
+-- result:
+2020-06-08	1
+2020-06-15	1
+-- !result
+delete from t_del_eq where c2 = '2020-06-15';
+-- result:
+-- !result
+select c2, count(*) from t_del_eq group by c2 order by c2;
+-- result:
+2020-06-08	1
+-- !result
+drop table t_del_eq force;
+-- result:
+-- !result
+create table t_del_rg (
+    c1 int,
+    c2 string
+) partition by (c2)
+PROPERTIES ("format-version" = "2");
+-- result:
+-- !result
+insert into t_del_rg values (1, '2020-06-08'), (2, '2020-06-14'), (3, '2020-06-15'), (4, '2020-06-22');
+-- result:
+-- !result
+delete from t_del_rg where c2 < cast('2020-06-15' as date);
+-- result:
+-- !result
+select c2, count(*) from t_del_rg group by c2 order by c2;
+-- result:
+2020-06-15	1
+2020-06-22	1
+-- !result
+drop table t_del_rg force;
+-- result:
+-- !result
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+-- result:
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_string_date_partition_delete
+++ b/test/sql/test_iceberg/T/test_iceberg_string_date_partition_delete
@@ -1,0 +1,56 @@
+-- name: test_iceberg_string_date_partition_delete
+-- description: DELETE on an Iceberg table whose STRING date partition column is compared with a temporal value
+-- coerces to CAST(c2 AS DATETIME) <op> <ts>. Iceberg's native pushdown unwraps the cast and compares in the
+-- string domain (c2 = '2020-06-14 00:00:00'), which never matches a 'yyyy-MM-dd' partition value: an equality
+-- delete silently removes nothing, and a range delete removes the wrong partitions (e.g. '2020-06-15' is a
+-- lexicographic prefix of '2020-06-15 00:00:00', so c2 < '2020-06-15 00:00:00' wrongly drops '2020-06-15').
+-- StarRocks now evaluates such cast-on-string-partition conjuncts against each partition's real value in the
+-- DATETIME domain and metadata-deletes only the definitely-matching partitions.
+
+create external catalog ice_cat_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+create database ice_cat_${uuid0}.ice_db_${uuid0};
+set catalog ice_cat_${uuid0};
+use ice_cat_${uuid0}.ice_db_${uuid0};
+
+-- Case A: equality delete (previously a silent no-op).
+create table t_del_eq (
+    c1 int,
+    c2 string
+) partition by (c2)
+PROPERTIES ("format-version" = "2");
+
+insert into t_del_eq values (1, '2020-06-08'), (2, '2020-06-14'), (3, '2020-06-14'), (4, '2020-06-15'), (5, '2020-06-22');
+
+select c2, count(*) from t_del_eq group by c2 order by c2;
+
+-- CAST(c2 AS DATETIME) = '2020-06-14 00:00:00' -> must delete exactly partition 2020-06-14.
+delete from t_del_eq where c2 = cast('2020-06-15' as date) - interval 1 day;
+select c2, count(*) from t_del_eq group by c2 order by c2;
+
+-- date_sub form of the same value.
+delete from t_del_eq where c2 = date_sub(cast('2020-06-23' as date), interval 1 day);
+select c2, count(*) from t_del_eq group by c2 order by c2;
+
+-- control: bare 'yyyy-MM-dd' literal (no cast, always worked) deletes 2020-06-15.
+delete from t_del_eq where c2 = '2020-06-15';
+select c2, count(*) from t_del_eq group by c2 order by c2;
+
+drop table t_del_eq force;
+
+-- Case B: range delete (previously over-deleted 2020-06-15).
+create table t_del_rg (
+    c1 int,
+    c2 string
+) partition by (c2)
+PROPERTIES ("format-version" = "2");
+
+insert into t_del_rg values (1, '2020-06-08'), (2, '2020-06-14'), (3, '2020-06-15'), (4, '2020-06-22');
+
+-- CAST(c2 AS DATETIME) < '2020-06-15 00:00:00' -> delete only 2020-06-08 and 2020-06-14; keep 2020-06-15, 2020-06-22.
+delete from t_del_rg where c2 < cast('2020-06-15' as date);
+select c2, count(*) from t_del_rg group by c2 order by c2;
+
+drop table t_del_rg force;
+
+drop database ice_cat_${uuid0}.ice_db_${uuid0};
+drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing

  Third in the series that fixes one root cause across its three consumers. When a STRING date
  partition column is compared with a temporal value, e.g.

      WHERE c2 = cast('2020-06-15' as date) - interval 1 day

  binary-predicate coercion turns it into `CAST(c2 AS DATETIME) = '2020-06-14 00:00:00'`. Iceberg's
  native pushdown unwraps the cast and compares in the STRING domain (`c2 = '2020-06-14 00:00:00'`),
  which never equals a `'yyyy-MM-dd'` partition value.

  - #76068 fixed the **scan side** (wrong empty results).
  - The manifest row-count follow-up fixed the **cardinality estimate** (collapsed to 1 -> bad plans).
  - This PR fixes the **DELETE metadata path**, the most severe of the three because it silently
    corrupts data on a mutating statement:
    - `canDeleteUsingMetadata` converts the predicate to the string-domain expression and, because it
      is an equality/range on the partition column, reports the delete as a partition-level metadata
      delete;
    - `executeMetadataDelete` then commits `deleteFromRowFilter(c2 = '2020-06-14 00:00:00')`, which
      matches no real partition -> an **equality delete silently removes nothing**, and a **range
      delete removes the wrong partitions** (e.g. `'2020-06-15'` is a lexicographic prefix of
      `'2020-06-15 00:00:00'`, so `c2 < '2020-06-15 00:00:00'` wrongly drops `'2020-06-15'`).

  ## What I'm doing

  Reuse `PartitionCastPredicatePruner.split(...)` to separate the delete predicate, and never feed a
  cast-on-string-partition conjunct to Iceberg's string-domain converter.

  - `canDeleteUsingMetadata` decides *eligibility* structurally and falls back to the (correct)
    row-level delete whenever the metadata path would be unsound:
    - a cast conjunct on a non-partition column / mixed OR (`dropped`) -> `false`;
    - partition-transform evolution (partition values unreadable) -> `false`;
    - a non-cast (`pushable`) conjunct that is not partition level -> `false`;
    - otherwise the whole predicate is partition level (every file is wholly matched or unmatched) ->
      `true`.
  - `executeMetadataDelete` does the *selection*: it plans candidate files with the pushable filter,
    evaluates the residual against each file's real partition value in the DATETIME domain via
    `PartitionCastPredicatePruner.partitionDefinitelyMatches(...)`, and deletes only the definitely
    matching files (`DeleteFiles.deleteFile`). Anything indeterminate is **not** deleted, so the path
    can only ever delete fewer rows than intended, never more.

  `partitionDefinitelyMatches` is the inverse of the scan/stats `partitionMayMatch`: metadata delete
  drops whole files, so a partition is removed only when the residual definitely folds to `true` for
  its value (an unbound/unparseable/false fold keeps the partition). Non-eligible deletes fall back to
  row-level position deletes, which evaluate the predicate correctly (and benefit from the #76068 scan
  fix).

  ## Reproduce

  See `test/sql/test_iceberg/T/test_iceberg_string_date_partition_delete`:

      create table t_del_eq (c1 int, c2 string) partition by (c2) PROPERTIES ("format-version" = "2");
      insert into t_del_eq values (1,'2020-06-08'),(2,'2020-06-14'),(3,'2020-06-14'),(4,'2020-06-15'),(5,'2020-06-22');

      -- equality: must delete partition 2020-06-14
      delete from t_del_eq where c2 = cast('2020-06-15' as date) - interval 1 day;
      select c2, count(*) from t_del_eq group by c2 order by c2;
      -- before: 2020-06-14 still present (silent no-op);  after: 2020-06-14 removed

      create table t_del_rg (c1 int, c2 string) partition by (c2) PROPERTIES ("format-version" = "2");
      insert into t_del_rg values (1,'2020-06-08'),(2,'2020-06-14'),(3,'2020-06-15'),(4,'2020-06-22');

      -- range: must delete only 2020-06-08 and 2020-06-14
    can only ever delete fewer rows than intended, never more.
      
  `partitionDefinitelyMatches` is the inverse of the scan/stats `partitionMayMatch`: metadata delete
  drops whole files, so a partition is removed only when the residual definitely folds to `true` for
  its value (an unbound/unparseable/false fold keeps the partition). Non-eligible deletes fall back to
  row-level position deletes, which evaluate the predicate correctly (and benefit from the #76068 scan
  fix). 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
