### PR TITLE
[Tool] unstable-case-review: make probation-grant a `grant_probation` input (default off)

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: '3'
         type: string
+      grant_probation:
+        description: 'Open a PR moving now-passing blacklisted cases into PROBATION (default false; needs SYNC_PAT, i.e. CelerData)'
+        required: false
+        default: 'false'
+        type: string
 
 permissions:
   checks: write
@@ -309,13 +314,13 @@ jobs:
           retention-days: 14
 
       - name: Open PR granting probation eligibility
-        # Temporarily disabled: secrets.SYNC_PAT is not configured on
-        # this repo (the `SYNC_PAT` name lives in celerdata-enterprise),
-        # so `gh pr create` runs with an empty GH_TOKEN and fails. Also
-        # /var/lib/ci-tool is a shared dirty working tree on the runner.
-        # Re-enable after a working PAT is wired in and a clean-checkout
-        # safeguard is added to the step.
-        if: false
+        # Opt-in via the grant_probation input (default false = off, same as
+        # before). Needs SYNC_PAT (configured on CelerData) and the ubuntu/ai
+        # runners (CelerData only), so in practice this only fires on CelerData.
+        # The earlier blockers are resolved: SYNC_PAT is now set, and the
+        # runner's /var/lib/ci-tool is a bind-mount real dir so the per-job
+        # `cp` is a true isolated copy.
+        if: ${{ inputs.grant_probation == 'true' }}
         id: open_pr
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}


### PR DESCRIPTION
## Why I'm doing:
The review workflow's "Open PR granting probation eligibility" step was hardcoded `if: false`, so turning it on needed a code change each time. Its two original blockers are now resolved — SYNC_PAT is configured on CelerData, and the runner's `/var/lib/ci-tool` is a bind-mount real dir (the per-job `cp` is a true isolated copy, no source pollution).

## What I'm doing:
Replace the hardcoded `if: false` with a `workflow_dispatch` input **`grant_probation`** (default `'false'` — identical off-by-default behavior). Dispatch with `grant_probation=true` to open the probation-eligibility PR; no more code edits to toggle. Same pattern as `dry_run` (promote-demote) and `runs`. In practice it only fires on CelerData (SYNC_PAT + the ubuntu/ai runners live there).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(Default is off, same as the previous `if: false`; behavior only changes when a run explicitly passes `grant_probation=true`.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr