### PR TITLE
[BugFix] Fix operator precedence in the join shuffle-join output-property branch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -421,7 +421,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                         leftOnPredicateColumns, rightOnPredicateColumns);
 
             } else if ((leftDistributionDesc.isShuffle() || leftDistributionDesc.isShuffleEnforce()) &&
-                    (rightDistributionDesc.isShuffle()) || rightDistributionDesc.isShuffleEnforce()) {
+                    (rightDistributionDesc.isShuffle() || rightDistributionDesc.isShuffleEnforce())) {
                 // shuffle join
                 PhysicalPropertySet outputProperty = computeShuffleJoinOutputProperty(node.getJoinType(),
                         leftDistributionDesc.getDistributionCols(), rightDistributionDesc.getDistributionCols());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OutputPropertyDeriverRangeTest.java
@@ -69,6 +69,16 @@ class OutputPropertyDeriverRangeTest {
         return new OutputPropertyDeriver(null, null, childrenOutputProperties);
     }
 
+    // Non-null EMPTY requirements so that, if a child combo were ever misrouted
+    // into the shuffle-join branch, computeShuffleJoinOutputProperty returns
+    // PhysicalPropertySet.EMPTY (the requirements are not shuffle) and the method
+    // returns normally — reproducing a "silently derive a degenerate output"
+    // outcome rather than an incidental NPE, so a throw assertion is meaningful.
+    private static OutputPropertyDeriver newDeriverWithEmptyRequirements(
+            List<PhysicalPropertySet> childrenOutputProperties) {
+        return new OutputPropertyDeriver(null, PhysicalPropertySet.EMPTY, childrenOutputProperties);
+    }
+
     private static RangeDistributionSpec buildRangeSkeleton(long tableId, int... colIds) {
         EquivalentDescriptor descriptor = new EquivalentDescriptor(tableId, Collections.emptyList());
         List<DistributionCol> cols = Arrays.stream(colIds)
@@ -395,6 +405,60 @@ class OutputPropertyDeriverRangeTest {
         StarRocksPlannerException ex = invokeVisitPhysicalJoinExpectingThrow(deriver, node, context);
         assertTrue(ex.getMessage().contains("Children output property distribution error"),
                 "expected the children-distribution diagnostic, got: " + ex.getMessage());
+    }
+
+    // Shared body for the shuffle-join-branch precedence guards below. A
+    // (leftSource, SHUFFLE_ENFORCE) child combo whose leftSource is neither
+    // shuffle nor shuffle-enforce (LOCAL / BUCKET) is not a legal shuffle join,
+    // so the deriver must reject it with the clean children-distribution error.
+    // Follows the assertRangeJoinEmitsDominatedSide helper idiom above.
+    private void assertShuffleEnforceRightRejectsLeft(PhysicalHashJoinOperator node,
+            ExpressionContext context, HashDistributionDesc.SourceType leftSource) {
+        stubInnerJoinWithEmptyColumns(node, context);
+        OutputPropertyDeriver deriver = newDeriverWithEmptyRequirements(List.of(
+                propertyOf(buildHashSpec(leftSource, 1)),
+                propertyOf(buildHashSpec(HashDistributionDesc.SourceType.SHUFFLE_ENFORCE, 2))));
+
+        StarRocksPlannerException ex = invokeVisitPhysicalJoinExpectingThrow(deriver, node, context);
+        assertTrue(ex.getMessage().contains("Children output property distribution error"),
+                "expected the children-distribution diagnostic, got: " + ex.getMessage());
+    }
+
+    /**
+     * Operator-precedence regression guard for the shuffle-join branch.
+     *
+     * <p>A (LOCAL, SHUFFLE_ENFORCE) child combo is not a legal shuffle join: the
+     * left side is bucket-local. The intended guard —
+     * {@code (leftShuffle || leftEnforce) && (rightShuffle || rightEnforce)} —
+     * evaluates to false here, so the deriver must reject it with the clean
+     * children-distribution error.
+     *
+     * <p>Before the parentheses were added, {@code &&} bound tighter than
+     * {@code ||}, so the guard collapsed to
+     * {@code [(leftShuffle || leftEnforce) && rightShuffle] || rightEnforce}.
+     * With the right side SHUFFLE_ENFORCE the trailing {@code || rightEnforce}
+     * forced the branch true regardless of the left side, and this combo slipped
+     * into the shuffle-join branch, silently deriving a degenerate output
+     * property instead of throwing.
+     */
+    @Test
+    void visitPhysicalJoinThrowsOnLocalLeftShuffleEnforceRight(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) {
+        assertShuffleEnforceRightRejectsLeft(node, context, HashDistributionDesc.SourceType.LOCAL);
+    }
+
+    /**
+     * Same precedence guard as
+     * {@link #visitPhysicalJoinThrowsOnLocalLeftShuffleEnforceRight}, but with a
+     * BUCKET left side — the other left source type that is neither shuffle nor
+     * shuffle-enforce, so the correct guard also rejects it.
+     */
+    @Test
+    void visitPhysicalJoinThrowsOnBucketLeftShuffleEnforceRight(
+            @Mocked PhysicalHashJoinOperator node,
+            @Mocked ExpressionContext context) {
+        assertShuffleEnforceRightRejectsLeft(node, context, HashDistributionDesc.SourceType.BUCKET);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

In `OutputPropertyDeriver.visitPhysicalJoin`, the hash/hash "shuffle join" output-property branch guard relied on Java operator precedence (`&&` binds tighter than `||`):

```java
} else if ((leftDistributionDesc.isShuffle() || leftDistributionDesc.isShuffleEnforce()) &&
        (rightDistributionDesc.isShuffle()) || rightDistributionDesc.isShuffleEnforce()) {
```

so it parsed as `[(leftShuffle || leftEnforce) && rightShuffle] || rightEnforce` instead of the intended `(leftShuffle || leftEnforce) && (rightShuffle || rightEnforce)`.

The two groupings differ only when the right child is `SHUFFLE_ENFORCE` and the left child is `LOCAL` or `BUCKET`. In that case the buggy grouping enters the shuffle-join branch and silently derives a degenerate output property, whereas the intended grouping falls through to the final `else` and throws the clean `childrenDistributionError`.

**This divergent case is unreachable today, so there is no user-visible behavior change** (justification below). The fix aligns the code with its stated intent and hardens the deriver against a future change silently triggering the latent bug.

## What I'm doing:

- Add parentheses around the right-hand disjunction so the guard reads `(leftShuffle || leftEnforce) && (rightShuffle || rightEnforce)`.
- Add two direct-invocation regression tests in `OutputPropertyDeriverRangeTest` asserting the `(LOCAL, SHUFFLE_ENFORCE)` and `(BUCKET, SHUFFLE_ENFORCE)` combos now throw the clean `childrenDistributionError` (before the fix they silently returned a degenerate `PhysicalPropertySet.EMPTY`).

### Why the divergent case is unreachable (behavior-change: No)

`BUCKET` and `SHUFFLE_ENFORCE` are never an operator's derived output property — scans/aggs derive `LOCAL`/`SHUFFLE_AGG`, colocate and bucket joins derive `LOCAL`, shuffle joins derive `SHUFFLE_JOIN`; they exist only as properties `ChildOutputPropertyGuarantor` enforces on a join's children (and per `RequiredPropertyDeriver`/`HashDistributionSpec` they cannot even satisfy a join child's `SHUFFLE_JOIN` required property, so they never enter the guarantor as a raw child output). `EnforceAndCostTask` runs that guarantor on the same children-output-property list immediately before `OutputPropertyDeriver`, and no guarantor path leaves a `SHUFFLE_ENFORCE` right child paired with a `LOCAL`/`BUCKET` left child:

- the main hash/hash dispatch enforces the right child to `SHUFFLE_ENFORCE` only when the left child is shuffle;
- the shuffle/skew hint branch (which early-returns without the final `checkState`) enforces a `LOCAL` left to `SHUFFLE_ENFORCE`, and a `BUCKET` left cannot occur;
- the range fallback enforces both sides.

So the mis-parenthesization cannot change any reachable plan or query result.

### Test evidence

- `OutputPropertyDeriverRangeTest`: 15/15 pass. The 2 new tests fail on the pre-fix code (which silently returns `PhysicalPropertySet.EMPTY` for the divergent combo) and pass after the fix.
- `checkstyleMain` + `checkstyleTest`: green.

### Follow-up (not in this PR)

Optionally extract `HashDistributionDesc.isShuffleLike()` = `isShuffle() || isShuffleEnforce()` to collapse the compound boolean at its two use sites and remove the sharp edge that caused this bug; a separate `[Refactor]` on main (`PruneShuffleColumnRule` carries the De Morgan negation of the same predicate).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
