### PR TITLE
[Enhancement] Record generation version on lake PK index sstables

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/lake_persistent_index.h"
 
+#include <unordered_map>
+
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
@@ -246,6 +248,10 @@ Status LakePersistentIndex::ingest_sst(const FileMetaPB& sst_meta, const Persist
     sstable_pb.set_filesize(sst_meta.size());
     sstable_pb.set_shared_rssid(rssid);
     sstable_pb.set_shared_version(version);
+    // Record the generation version (PersistentIndexSstablePB.generation_version):
+    // the version at which this ingested sstable becomes visible in this tablet.
+    // Coexists with shared_version (read-time projection) and does not affect it.
+    sstable_pb.set_generation_version(version);
     sstable_pb.set_encryption_meta(sst_meta.encryption_meta());
     // Preserve the shared flag from sst_meta. During tablet split cross-publish,
     // newly-ingested SSTs may be shared with sibling split tablets; losing this flag
@@ -873,7 +879,32 @@ Status LakePersistentIndex::apply_opcompaction(const TabletMetadataPtr& metadata
     return Status::OK();
 }
 
-Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
+void LakePersistentIndex::assign_generation_versions(PersistentIndexSstableMetaPB* new_meta,
+                                                     const PersistentIndexSstableMetaPB& prev_meta,
+                                                     int64_t generation_version) {
+    // Callers resolve |generation_version| to a real publish/reshard version first; a new file must
+    // never be stamped 0 ("unknown"). Benign if it ever slips through in release -- 0 is the
+    // conservative value consumers treat as retain -- so a debug assert suffices.
+    DCHECK_GT(generation_version, 0);
+    std::unordered_map<std::string, int64_t> prev_versions;
+    prev_versions.reserve(prev_meta.sstables_size());
+    for (const auto& s : prev_meta.sstables()) {
+        prev_versions.emplace(s.filename(), s.generation_version());
+    }
+    for (auto& s : *new_meta->mutable_sstables()) {
+        if (s.generation_version() != 0) {
+            continue;
+        }
+        auto it = prev_versions.find(s.filename());
+        if (it != prev_versions.end()) {
+            s.set_generation_version(it->second);
+        } else {
+            s.set_generation_version(generation_version);
+        }
+    }
+}
+
+Status LakePersistentIndex::commit(MetaFileBuilder* builder, int64_t generation_version) {
     if ((too_many_rebuild_files() || too_many_rebuild_rows()) && !_memtable->empty()) {
         // If we have too many files or rows need to be rebuilt,
         // we need to do flush to reduce index rebuild cost later.
@@ -896,6 +927,14 @@ Status LakePersistentIndex::commit(MetaFileBuilder* builder) {
             new_sstable_pb->CopyFrom(sstable_pb);
         }
     }
+    // generation_version == 0 means "use this publish's version"; a non-zero override is passed by
+    // the reshard flush (see UpdateManager::flush_pk_memtable). The builder still holds the
+    // previous persisted sstable_meta here (before finalize_sstable_meta below), which
+    // assign_generation_versions uses to carry existing versions forward.
+    if (generation_version == 0) {
+        generation_version = builder->tablet_meta()->version();
+    }
+    assign_generation_versions(&sstable_meta, builder->tablet_meta()->sstable_meta(), generation_version);
     builder->finalize_sstable_meta(sstable_meta);
     auto [file_cnt, row_cnt] = need_rebuild_counts(*builder->tablet_meta(), sstable_meta);
     _need_rebuild_file_cnt = file_cnt;

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -121,7 +121,7 @@ public:
 
     Status apply_opcompaction(const TabletMetadataPtr& metadata, const TxnLogPB_OpCompaction& op_compaction);
 
-    Status commit(MetaFileBuilder* builder);
+    Status commit(MetaFileBuilder* builder, int64_t generation_version = 0);
 
     Status load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);
@@ -137,6 +137,14 @@ public:
 
     static void pick_sstables_for_merge(const PersistentIndexSstableMetaPB& sstable_meta,
                                         std::vector<PersistentIndexSstablePB>* sstables, bool* merge_base_level);
+
+    // Assign the generation version (PersistentIndexSstablePB.generation_version) to each
+    // sstable in |new_meta|: a sstable that already carries a non-zero value is left
+    // untouched; a file present in |prev_meta| keeps its recorded value (a legacy 0 stays 0,
+    // so lake vacuum retention treats it conservatively); a file absent from |prev_meta| is
+    // new this publish and is stamped with |generation_version|.
+    static void assign_generation_versions(PersistentIndexSstableMetaPB* new_meta,
+                                           const PersistentIndexSstableMetaPB& prev_meta, int64_t generation_version);
 
     // Check if this rowset need to rebuild, return `True` means need to rebuild this rowset.
     static bool needs_rowset_rebuild(const RowsetMetadataPB& rowset, uint32_t rebuild_rss_id);

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -109,7 +109,8 @@ Status LakePrimaryIndex::ingest_sst(const FileMetaPB& sst_meta, const Persistent
     }
 }
 
-Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder) {
+Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
+                                int64_t generation_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_commit_latency_us");
     if (_persistent_index == nullptr) {
         return Status::OK();
@@ -117,7 +118,7 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
 
     auto* lake_persistent_index = dynamic_cast<LakePersistentIndex*>(_persistent_index.get());
     if (lake_persistent_index != nullptr) {
-        return lake_persistent_index->commit(builder);
+        return lake_persistent_index->commit(builder, generation_version);
     } else {
         return Status::InternalError("Persistent index is not a LakePersistentIndex.");
     }

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -67,7 +67,7 @@ public:
 
     Status apply_opcompaction(const TabletMetadataPtr& metadata, const TxnLogPB_OpCompaction& op_compaction);
 
-    Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder);
+    Status commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder, int64_t generation_version = 0);
 
     // Force any in-memory memtables of the cloud-native persistent index to
     // be flushed into sstables on shared storage. A no-op for LOCAL /

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -2665,6 +2665,8 @@ Status emit_legacy_shared_sstable_into_dest(TabletManager* tablet_manager, const
     RETURN_IF_ERROR(rebuild_legacy_shared_sstable(tablet_manager, new_metadata.id(), src_pb, ctx.metadata(),
                                                   new_metadata, *family_maps_ptr, &projected_pb));
     if (!projected_pb.filename().empty()) {
+        // Rebuilt = a brand-new physical file, first visible at the merge version.
+        projected_pb.set_generation_version(new_metadata.version());
         dest->Add()->Swap(&projected_pb);
     }
     return Status::OK();
@@ -2690,6 +2692,8 @@ Status emit_non_shared_legacy_sstable_into_dest(TabletManager* tablet_manager, c
         RETURN_IF_ERROR(rebuild_non_shared_legacy_sstable(tablet_manager, new_metadata.id(), src_pb, ctx,
                                                           ctx.metadata(), &rebuilt_pb));
         if (!rebuilt_pb.filename().empty()) {
+            // Rebuilt = a brand-new physical file, first visible at the merge version.
+            rebuilt_pb.set_generation_version(new_metadata.version());
             dest->Add()->Swap(&rebuilt_pb);
         }
         return Status::OK();
@@ -2741,7 +2745,8 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
         // the case where an old tablet accumulated post-split DML that never
         // reached shared storage before merge; see the symmetric call in
         // split_tablet for the pre-split side of the invariant.
-        ASSIGN_OR_RETURN(auto flushed_metadata, update_manager->flush_pk_memtable(ctx.metadata()));
+        ASSIGN_OR_RETURN(auto flushed_metadata,
+                         update_manager->flush_pk_memtable(ctx.metadata(), new_metadata->version()));
         ctx.set_metadata(std::move(flushed_metadata));
         if (!ctx.metadata()->has_sstable_meta()) continue;
 

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1547,7 +1547,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     // the "reshard inputs must have full sstable coverage" invariant; merge
     // does the post-split half in merge_sstables.
     ASSIGN_OR_RETURN(TabletMetadataPtr old_tablet_metadata,
-                     tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata));
+                     tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata, new_version));
 
     // Dispatch on FE-supplied new_tablet_ranges. When set, FE has computed the
     // K-1 boundaries externally (external boundaries / external boundaries); BE computes

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -235,7 +235,8 @@ void UpdateManager::unload_and_remove_primary_index(int64_t tablet_id) {
 
 DEFINE_FAIL_POINT(skip_lake_pk_index_flush);
 
-StatusOr<TabletMetadataPtr> UpdateManager::flush_pk_memtable(const TabletMetadataPtr& metadata) {
+StatusOr<TabletMetadataPtr> UpdateManager::flush_pk_memtable(const TabletMetadataPtr& metadata,
+                                                             int64_t generation_version) {
     // Test-only escape hatch: reshard unit tests build hand-crafted metadata with no real
     // in-memory PK memtable, so there is nothing to flush; skip the (index-loading) flush so
     // they exercise the metadata merge/split logic without materializing a real index.
@@ -283,7 +284,12 @@ StatusOr<TabletMetadataPtr> UpdateManager::flush_pk_memtable(const TabletMetadat
     // mutable_metadata->sstable_meta(). builder.finalize() is NOT called
     // here — this flush does not produce its own metadata version; the
     // returned metadata is consumed by the surrounding reshard publish.
-    RETURN_IF_ERROR(index_entry->value().commit(metadata, &builder));
+    // This flush runs at base_version, but its freshly-flushed sstables first become
+    // visible to the split/merge children at the reshard publish version, so pass that
+    // as generation_version to commit(): it stamps those (new) sstables with it while
+    // inherited sstables (already present in the pre-commit sstable_meta) keep their
+    // recorded versions. The metadata version is left untouched.
+    RETURN_IF_ERROR(index_entry->value().commit(metadata, &builder, generation_version));
 
     // Success: dismiss the failure cleanup and release the cache entry.
     // write_guard is released when it goes out of scope at function return.

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -221,7 +221,7 @@ public:
     // exclusion between publish_resharding_tablet and publish_version, so
     // the cached _data_version cannot advance past metadata->version()
     // during this call.
-    StatusOr<TabletMetadataPtr> flush_pk_memtable(const TabletMetadataPtr& metadata);
+    StatusOr<TabletMetadataPtr> flush_pk_memtable(const TabletMetadataPtr& metadata, int64_t generation_version);
 
     StatusOr<IndexEntry*> rebuild_primary_index(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
                                                 int64_t base_version, int64_t new_version,

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -1338,6 +1338,7 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_preserves_shared_flag_for_new_ss
         if (sst.filename() == sst_filename) {
             match_count++;
             EXPECT_TRUE(sst.shared()) << "sst_meta.shared=true must be preserved in committed sstable_meta";
+            EXPECT_EQ(1, sst.generation_version()) << "ingest_sst stamps the generation version (the ingest version)";
         }
     }
     EXPECT_EQ(match_count, 1);
@@ -1578,6 +1579,103 @@ TEST_F(LakePersistentIndexTest, test_load_dels_parallel_matches_single_pass) {
     ASSERT_EQ(serial.size(), parallel.size());
     for (size_t i = 0; i < serial.size(); ++i) {
         EXPECT_EQ(serial[i], parallel[i]) << "mismatch at key " << keys[i];
+    }
+}
+
+TEST(AssignGenerationVersionsTest, stamps_new_preserves_existing_and_legacy) {
+    PersistentIndexSstableMetaPB prev;
+    {
+        auto* s = prev.add_sstables();
+        s->set_filename("existing_v3.sst");
+        s->set_generation_version(3);
+    }
+    {
+        auto* s = prev.add_sstables();
+        s->set_filename("legacy_zero.sst"); // version unset == 0
+    }
+
+    PersistentIndexSstableMetaPB cur;
+    {
+        auto* s = cur.add_sstables();
+        s->set_filename("existing_v3.sst"); // reappears, version dropped by copy
+    }
+    {
+        auto* s = cur.add_sstables();
+        s->set_filename("legacy_zero.sst"); // legacy, still unset
+    }
+    {
+        auto* s = cur.add_sstables();
+        s->set_filename("fresh_new.sst"); // brand new this publish
+    }
+    {
+        auto* s = cur.add_sstables();
+        s->set_filename("ingested.sst");
+        s->set_generation_version(9); // producer already stamped, absent from prev
+    }
+    {
+        auto* s = cur.add_sstables();
+        s->set_filename("existing_v3.sst");
+        s->set_generation_version(7); // same filename as prev@3 but already non-zero
+    }
+
+    LakePersistentIndex::assign_generation_versions(&cur, prev, /*generation_version=*/100);
+
+    ASSERT_EQ(5, cur.sstables_size());
+    EXPECT_EQ(3, cur.sstables(0).generation_version());   // existing, local 0 -> carried from prev (3)
+    EXPECT_EQ(0, cur.sstables(1).generation_version());   // legacy 0 -> STAYS 0 (present in prev); vacuum retains
+    EXPECT_EQ(100, cur.sstables(2).generation_version()); // new (absent from prev) -> new version
+    EXPECT_EQ(9, cur.sstables(3).generation_version());   // producer-stamped non-zero -> preserved (absent from prev)
+    EXPECT_EQ(7, cur.sstables(4).generation_version());   // non-zero -> NEVER overwritten, even though prev has @3
+}
+
+TEST_F(LakePersistentIndexTest, test_commit_stamps_version) {
+    const int N = 100;
+    const int64_t publish_version = 7;
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+
+    using Key = uint64_t;
+    std::vector<Key> keys(N);
+    std::vector<Slice> key_slices;
+    std::vector<IndexValue> values;
+    key_slices.reserve(N);
+    values.reserve(N);
+    for (int j = 0; j < N; j++) {
+        keys[j] = j;
+        key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
+        values.emplace_back(j * 2);
+    }
+    index->prepare(EditVersion(publish_version, 0), 0);
+    std::vector<IndexValue> old_values(N);
+    ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
+    ASSERT_OK(index->flush_memtable(true));
+    ASSERT_OK(index->sync_flush_all_memtables(10000000));
+
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    auto meta = std::make_shared<TabletMetadata>();
+    meta->CopyFrom(*_tablet_metadata);
+    meta->set_version(publish_version);
+    MetaFileBuilder builder(tablet, meta);
+    ASSERT_OK(index->commit(&builder));
+
+    // A freshly-flushed sstable is stamped with the publish version.
+    ASSERT_GE(meta->sstable_meta().sstables_size(), 1);
+    for (const auto& s : meta->sstable_meta().sstables()) {
+        EXPECT_EQ(publish_version, s.generation_version()) << "freshly-flushed sstable must carry its publish version";
+    }
+
+    // Re-commit at a later version WITHOUT new data: existing sstables must keep
+    // their original version (no re-stamp), because they are present in
+    // the previous sstable_meta the builder carries forward.
+    auto meta2 = std::make_shared<TabletMetadata>();
+    meta2->CopyFrom(*meta); // carries the publish_version sstable_meta forward
+    meta2->set_version(publish_version + 10);
+    MetaFileBuilder builder2(tablet, meta2);
+    ASSERT_OK(index->commit(&builder2));
+    ASSERT_GE(meta2->sstable_meta().sstables_size(), 1);
+    for (const auto& s : meta2->sstable_meta().sstables()) {
+        EXPECT_EQ(publish_version, s.generation_version()) << "re-commit must not re-stamp an existing sstable";
     }
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -354,6 +354,34 @@ protected:
         return {c0_uid, c1_uid};
     }
 
+    // Build a single-rowset PK tablet with one two-column segment and NO sstable_meta, so
+    // flush_pk_memtable takes the cold rebuild-from-segment path (rebuild_rss_id==0 ->
+    // needs_rowset_rebuild) and produces exactly one fresh sstable. |seg_name|/|seg_size|
+    // come from a prior write_two_column_segment. No rowset_to_schema mapping is set: the
+    // rowset uses the tablet's main c0/c1 PK schema (the same schema the segment was written
+    // with), so no historical_schemas entry is needed.
+    std::shared_ptr<TabletMetadataPB> make_single_segment_pk_tablet(int64_t tablet_id, int64_t version,
+                                                                    const std::string& seg_name, uint64_t seg_size,
+                                                                    int num_rows) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(version);
+        meta->set_next_rowset_id(10);
+        set_two_column_pk_schema(meta.get(), /*schema_id=*/4001);
+        meta->set_enable_persistent_index(true);
+        meta->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        auto* rowset = meta->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(version);
+        rowset->set_num_rows(num_rows);
+        rowset->set_data_size(seg_size);
+        auto* sm = rowset->add_segment_metas();
+        sm->set_filename(seg_name);
+        sm->set_size(seg_size);
+        sm->set_num_rows(num_rows);
+        return meta;
+    }
+
     // Write a real Segment file with num_rows rows: c0 = [0..num_rows), c1 = source_value_of(c0).
     // Returns the segment file size on disk. The file is placed under
     // tablet_id's segment directory as |segment_name|.
@@ -3490,6 +3518,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
         sst->set_shared(true);
         sst->set_shared_rssid(1);
         sst->set_shared_version(1);
+        sst->set_generation_version(7); // generation version; merge projection must inherit this, not restamp it
         sst->set_max_rss_rowid((static_cast<uint64_t>(1) << 32) | 99);
         return meta;
     };
@@ -3535,6 +3564,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     EXPECT_EQ(merged->rowsets(0).id(), out_sst.shared_rssid());
     // rssid_offset should be 0 (shared_rssid path)
     EXPECT_EQ(0, out_sst.rssid_offset());
+    // Projection reuses the physical file, so its generation version is inherited via
+    // CopyFrom (not restamped with the merge version).
+    EXPECT_EQ(7, out_sst.generation_version());
     // max_rss_rowid high part should match projected shared_rssid
     EXPECT_EQ((static_cast<uint64_t>(out_sst.shared_rssid()) << 32) | 99, out_sst.max_rss_rowid());
 }
@@ -11023,6 +11055,171 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_remaps_private_segments) {
     }
     EXPECT_EQ(1u, files.count("a.idx"));
     EXPECT_EQ(1u, files.count("b.idx"));
+}
+
+// =============================================================================
+// PK-index sstable version stamping
+// =============================================================================
+//
+// The reshard PK-index flush runs at base_version but the freshly-flushed
+// sstables first become visible at the reshard publish (new_version). These
+// tests assert that a genuinely-new flushed sstable carries new_version (so an
+// incremental snapshot keyed on version>pre_version does not skip it) while the
+// returned metadata keeps base_version.
+
+// A tablet with a real PK segment and NO sstable_meta triggers a cold
+// rebuild-from-segment during flush_pk_memtable, producing exactly one fresh
+// sstable. Assert it is stamped with new_version and the returned metadata's
+// own version is restored to base_version.
+TEST_F(LakeTabletReshardTest, test_reshard_flush_stamps_fresh_sstable_with_new_version) {
+    // Unlike the other reshard tests, this one drives a REAL flush from a real segment, so
+    // disable the fixture-wide skip_lake_pk_index_flush fail point enabled in SetUp().
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    const int64_t base_version = 1;
+    const int64_t new_version = 5; // deliberately > base_version
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+
+    constexpr int kNumRows = 16;
+    const std::string seg_name = "seg_flush.dat";
+    const uint64_t seg_size = write_two_column_segment(tablet_id, seg_name, kNumRows, [](int r) { return r * 10; });
+
+    auto meta = make_single_segment_pk_tablet(tablet_id, base_version, seg_name, seg_size, kNumRows);
+    ASSERT_OK(put_tablet_metadata(meta));
+
+    ASSIGN_OR_ABORT(auto flushed, _update_manager->flush_pk_memtable(meta, new_version));
+
+    ASSERT_NE(flushed, nullptr);
+    EXPECT_EQ(base_version, flushed->version());           // returned metadata keeps base_version (restore)
+    ASSERT_EQ(1, flushed->sstable_meta().sstables_size()); // exactly one fresh sstable
+    EXPECT_EQ(new_version, flushed->sstable_meta().sstables(0).generation_version())
+            << "a freshly-flushed reshard sstable must carry the reshard publish version, else an "
+               "incremental snapshot keyed on version>pre_version would skip it (data loss)";
+}
+
+// Same rebuild-from-segment source, driven through the real split publish path,
+// guarding that tablet_splitter passes new_version to flush_pk_memtable.
+TEST_F(LakeTabletReshardTest, test_split_publish_stamps_fresh_sstable_with_new_version) {
+    // Unlike the other reshard tests, this one drives a REAL split-publish flush from a real
+    // segment, so disable the fixture-wide skip_lake_pk_index_flush fail point from SetUp().
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    const int64_t base_version = 1;
+    const int64_t new_version = 5;
+    const int64_t src_tablet = next_id();
+    const int64_t child0 = next_id();
+    const int64_t child1 = next_id();
+    prepare_tablet_dirs(src_tablet);
+    prepare_tablet_dirs(child0);
+    prepare_tablet_dirs(child1);
+
+    constexpr int kNumRows = 16;
+    const std::string seg_name = "seg_split.dat";
+    const uint64_t seg_size = write_two_column_segment(src_tablet, seg_name, kNumRows, [](int r) { return r * 10; });
+
+    auto meta = make_single_segment_pk_tablet(src_tablet, base_version, seg_name, seg_size, kNumRows);
+    ASSERT_OK(put_tablet_metadata(meta));
+
+    ReshardingTabletInfoPB resharding;
+    auto& si = *resharding.mutable_splitting_tablet_info();
+    si.set_old_tablet_id(src_tablet);
+    si.add_new_tablet_ids(child0);
+    si.add_new_tablet_ids(child1);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(1);
+    std::unordered_map<int64_t, TabletMetadataPtr> metadatas;
+    std::unordered_map<int64_t, TabletRangePB> ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, metadatas, ranges));
+
+    // Whatever children the split produced (K new tablets, or a 1-tablet identical
+    // fallback), every freshly-flushed PK sstable they inherit must carry new_version.
+    bool saw_sstable = false;
+    for (const auto& [tablet_id, cm] : metadatas) {
+        for (const auto& s : cm->sstable_meta().sstables()) {
+            saw_sstable = true;
+            EXPECT_EQ(new_version, s.generation_version())
+                    << "split-flushed sstable must carry the split publish version";
+        }
+    }
+    EXPECT_TRUE(saw_sstable) << "split should have produced a flushed PK sstable from the rebuilt index";
+}
+
+// MERGE rebuilds a legacy shared sstable into a NEW physical file; that new file
+// must carry the merge (new) version, not the source sstable's old version.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_sstable_rebuild_stamps_new_version) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    const std::string legacy_filename = "legacy_gv_rebuild.sst";
+    const auto legacy_path = _tablet_manager->sst_location(child_b, legacy_filename);
+    const uint64_t legacy_filesize =
+            write_legacy_pk_sstable(legacy_path, {{"k1", /*rssid=*/1, /*rowid=*/0}, {"k2", /*rssid=*/2, /*rowid=*/0}});
+
+    auto meta_a = std::make_shared<TabletMetadataPB>();
+    meta_a->set_id(child_a);
+    meta_a->set_version(base_version);
+    meta_a->set_next_rowset_id(11);
+    set_primary_key_schema(meta_a.get(), 1001);
+    {
+        auto* rs = meta_a->add_rowsets();
+        rs->set_id(10);
+        rs->set_version(1);
+        rs->set_num_rows(10);
+        rs->set_data_size(100);
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename("seg_a10.dat");
+        sm->set_size(100);
+    }
+
+    auto meta_b = std::make_shared<TabletMetadataPB>();
+    meta_b->set_id(child_b);
+    meta_b->set_version(base_version);
+    meta_b->set_next_rowset_id(3);
+    set_primary_key_schema(meta_b.get(), 1001);
+    for (uint32_t rs_id : {1u, 2u}) {
+        auto* rs = meta_b->add_rowsets();
+        rs->set_id(rs_id);
+        rs->set_version(1);
+        rs->set_num_rows(10);
+        rs->set_data_size(100);
+        auto* sm = rs->add_segment_metas();
+        sm->set_filename(fmt::format("seg_b{}.dat", rs_id));
+        sm->set_size(100);
+    }
+    auto* sst = meta_b->mutable_sstable_meta()->add_sstables();
+    sst->set_filename(legacy_filename);
+    sst->set_filesize(legacy_filesize);
+    sst->set_shared(true);
+    sst->set_max_rss_rowid((static_cast<uint64_t>(2) << 32) | 0);
+    sst->set_version(base_version); // OLD version; rebuild writes a NEW file -> must get new_version
+
+    EXPECT_OK(put_tablet_metadata(meta_a));
+    EXPECT_OK(put_tablet_metadata(meta_b));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
+    merging_info.add_old_tablet_ids(child_a);
+    merging_info.add_old_tablet_ids(child_b);
+    merging_info.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(2);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges));
+
+    auto merged = tablet_metadatas.at(merged_tablet);
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    const auto& out_sst = merged->sstable_meta().sstables(0);
+    EXPECT_NE(legacy_filename, out_sst.filename()) << "rebuild wrote a new file";
+    EXPECT_EQ(new_version, out_sst.generation_version()) << "rebuilt (new) file must carry the merge version";
 }
 
 // =============================================================================

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -63,10 +63,20 @@ message PersistentIndexSstablePB {
     optional PUniqueId fileset_id = 12;
     // Offset applied to rssid when reusing sstables across tablets (e.g., tablet merge).
     optional int32 rssid_offset = 13 [default = 0];
+    // The tablet metadata version at which this physical sstable file first
+    // became visible -- i.e. the new version of the publish (or reshard) that
+    // produced it. Stamped once when the file is first persisted and never
+    // changed afterward; CopyFrom inherits it across tablet split/merge so a
+    // shared file keeps its original value. A non-zero value is never
+    // overwritten. 0/unset means unknown -- e.g. a file created before this
+    // field existed stays 0, so consumers such as lake vacuum retention must
+    // treat 0 conservatively.
+    optional int64 generation_version = 14;
 }
 
 message PersistentIndexSstableMetaPB {
-    // sstables are ordered with the smaller version on the left.
+    // sstables are ordered by max_rss_rowid ascending (see
+    // LakePersistentIndex::commit and apply_opcompaction), not by any version.
     repeated PersistentIndexSstablePB sstables = 1;
 }
 


### PR DESCRIPTION
## Why I'm doing:

Shared-data (lake) range-distribution tables support tablet split/merge. A version-based incremental copy of physical files needs a reliable per-file version — the tablet metadata version at which the file first became visible. Segment (`rowset.version`, field 10), delvec (`version_to_file` key), and DCG (`DeltaColumnGroupVerPB.versions`) already carry one; the PK-index sstable did not. This adds the open-source infrastructure to populate it reliably.

## What I'm doing:

Add a new field `PersistentIndexSstablePB.generation_version` (ordinal 14) that records, for each physical PK-index sstable, the tablet metadata version at which it first became visible.

- `LakePersistentIndex::commit` is the single choke point that assigns versions, via the static helper `assign_generation_versions(new_meta, prev_meta, generation_version)`. It derives each file's version from the **previous persisted `sstable_meta`** — which the builder still holds before `finalize_sstable_meta` — rather than mutating live in-memory state:
  - a file already recorded in the previous meta keeps its recorded version, so a **legacy / pre-feature file (recorded as `0`) stays `0`** and a version-based consumer must treat `0` conservatively (e.g. lake vacuum retention retains it) — this avoids over-stamping a pre-existing file with a later version and vacuuming it prematurely;
  - a genuinely-new file (absent from the previous meta) is stamped with the generation version;
  - a non-zero value is never overwritten.

  This one choke point covers normal flush, all compaction variants, and `ingest_sst`. Because it reads the previous persisted metadata instead of mutating live state, it never re-stamps across publishes and needs no locking beyond `commit()`'s existing per-index lock. A `DCHECK` guards the resolved version as `> 0`.
- The split/merge PK-memtable flush runs `commit()` at `base_version`, so `flush_pk_memtable` threads the reshard version as an explicit `generation_version` parameter (which otherwise defaults to the builder's publish version). Freshly-flushed sstables are stamped it, and the returned metadata's own version is left untouched.
- Merge builds `sstable_meta` directly (bypasses `commit()`): rebuild outputs are new physical files stamped the merge version at their two emit sites, while projection paths reuse the physical file and inherit the version via `CopyFrom`.
- Use a **new proto field** (ordinal 14) rather than reusing the deprecated field 1, so a stale value written before this feature can never be misread as a generation version.

`0`/unset means unknown. This is open-source infrastructure only; the enterprise external-cluster-snapshot consumer is out of scope.

**Out of scope / follow-up:** cross-cluster **lake replication** (`lake_replication_txn_manager`) is intentionally not touched — it does a full-copy metadata replacement (`incremental_snapshot=false`), so its copied SSTs belong to a full baseline rather than the `version > pre_version` incremental path.

Tests (BE UTs): `assign_generation_versions` unit (new file → generation version; carry-forward from previous meta; **legacy `0` preserved**; non-zero never overwritten); `commit` stamping + no re-stamp on re-commit; `ingest_sst`; reshard fresh-flush → generation version with returned metadata kept at `base_version`; split publish; merge legacy-rebuild → merge version; merge projection inherits. Lake persistent-index + reshard suites pass; `clang-format` and BE module boundaries clean.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
