### PR TITLE
[BugFix] Retain lake vacuum files by version interval across tablet reshard

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -191,6 +191,9 @@ void MetaFileBuilder::append_dcg(uint32_t rssid,
             if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
                 file_meta.set_shared(dcg_ver.shared_files(i));
             }
+            if (i < dcg_ver.versions_size()) {
+                file_meta.set_version(dcg_ver.versions(i));
+            }
             _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
         }
     }
@@ -273,6 +276,9 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
         if (del_meta.has_shared()) {
             del_file_with_rid.set_shared(del_meta.shared());
         }
+        // Freshly created del file: stamp its creation version so lake vacuum can retain it by its
+        // own version after it is later transferred onto a higher-versioned compaction output rowset.
+        del_file_with_rid.set_version(rowset->version());
         rowset->add_del_files()->CopyFrom(del_file_with_rid);
     }
     // if rowset don't contain segment files, still inc next_rowset_id
@@ -280,7 +286,14 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
     // collect trash files: replaced partial-update segments and their segment-name-keyed .vi files
     for (const auto& orphan_file : orphan_files) {
         DCHECK(is_segment(orphan_file.name()) || is_vector_index(orphan_file.name()));
-        _tablet_meta->mutable_orphan_files()->Add()->CopyFrom(orphan_file);
+        auto* added_orphan = _tablet_meta->mutable_orphan_files()->Add();
+        added_orphan->CopyFrom(orphan_file);
+        // These replaced segment/.vi files are produced by this txn's partial-update rewrite, so
+        // their creation version is the metadata version being built. Respect an accurate version if
+        // the producer already set one.
+        if (!added_orphan->has_version()) {
+            added_orphan->set_version(_tablet_meta->version());
+        }
     }
     if (!_tablet_meta->rowset_to_schema().empty()) {
         auto schema_id = _tablet_meta->schema().id();
@@ -301,6 +314,9 @@ void MetaFileBuilder::apply_column_mode_partial_update(const TxnLogPB_OpWrite& o
         // sibling tablets. The orphan FileMetaPB only carries `shared`, so encode bundling into it
         // too, otherwise vacuum deletes the shared bundle file while a sibling still references it.
         file_meta.set_shared(segment_meta.shared() || segment_meta.has_bundle_file_offset());
+        // These segments are produced and discarded within this txn, so their creation version is
+        // the metadata version being built.
+        file_meta.set_version(_tablet_meta->version());
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }
@@ -502,6 +518,7 @@ void MetaFileBuilder::apply_drop_index(const TxnLogPB_OpDropIndex& op) {
                     file_meta.set_name(entry.index_file());
                     if (entry.has_file_size()) file_meta.set_size(entry.file_size());
                     if (entry.has_shared_file()) file_meta.set_shared(entry.shared_file());
+                    file_meta.set_version(entry.version());
                     _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
                 }
             }
@@ -636,6 +653,7 @@ void MetaFileBuilder::remove_compacted_sst(const TxnLogPB_OpCompaction& op_compa
             }
         }
         file_meta.set_shared(shared);
+        file_meta.set_version(input_sstable.generation_version());
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }
@@ -652,7 +670,12 @@ void MetaFileBuilder::remove_lcrm_file(const TxnLogPB_OpCompaction& op_compactio
     // tablet metadata GC process, which runs periodically and handles failures gracefully.
     // This approach is safe, non-blocking, and handles distributed cleanup correctly.
     if (op_compaction.has_lcrm_file()) {
-        _tablet_meta->add_orphan_files()->CopyFrom(op_compaction.lcrm_file());
+        auto* added = _tablet_meta->add_orphan_files();
+        added->CopyFrom(op_compaction.lcrm_file());
+        // The mapper file is produced and orphaned by this compaction and is never referenced by any
+        // visible tablet metadata, so its creation version is the metadata version being built.
+        // Stamping it lets vacuum reclaim it instead of over-retaining it under a covering snapshot.
+        added->set_version(_tablet_meta->version());
     }
 }
 
@@ -737,6 +760,9 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
                 if (dcg.shared_files_size() > 0) {
                     file_meta.set_shared(dcg.shared_files(i));
                 }
+                if (i < dcg.versions_size()) {
+                    file_meta.set_version(dcg.versions(i));
+                }
                 // Put useless `.cols` files into orphan files
                 _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
             }
@@ -761,6 +787,7 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
                     file_meta.set_name(entry.index_file());
                     if (entry.has_file_size()) file_meta.set_size(entry.file_size());
                     if (entry.has_shared_file()) file_meta.set_shared(entry.shared_file());
+                    file_meta.set_version(entry.version());
                     _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
                 }
             }
@@ -866,6 +893,9 @@ void MetaFileBuilder::apply_opcompaction_with_conflict(const TxnLogPB_OpCompacti
         // tablets. Encode bundling into the orphan's `shared` flag so vacuum's alive-check protects
         // it instead of deleting a bundle file a sibling still references.
         file_meta.set_shared(segment_meta.shared() || segment_meta.has_bundle_file_offset());
+        // These segments are produced and discarded within this txn, so their creation version is
+        // the metadata version being built.
+        file_meta.set_version(_tablet_meta->version());
         _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
     }
 }
@@ -982,6 +1012,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         if (refered_versions.find(itr->first) == refered_versions.end()) {
             VLOG(2) << "Remove delvec file record from delvec meta, version: " << itr->first
                     << ", file: " << itr->second.name();
+            itr->second.set_version(itr->first);
             _tablet_meta->mutable_orphan_files()->Add(std::move(itr->second));
             itr = _tablet_meta->mutable_delvec_meta()->mutable_version_to_file()->erase(itr);
         } else {
@@ -1005,6 +1036,7 @@ void MetaFileBuilder::_sstable_meta_clean_after_alter_type() {
             file_meta.set_name(sstable.filename());
             file_meta.set_size(sstable.filesize());
             file_meta.set_shared(sstable.shared());
+            file_meta.set_version(sstable.generation_version());
             _tablet_meta->mutable_orphan_files()->Add(std::move(file_meta));
         }
         // Clear the SSTable metadata.
@@ -1370,6 +1402,8 @@ Status MetaFileBuilder::set_final_rowset() {
             del_file_with_rid.set_encryption_meta(del.encryption_meta());
         }
         del_file_with_rid.set_shared(del.shared());
+        // Freshly created del file: stamp its creation version (see apply_opwrite).
+        del_file_with_rid.set_version(rowset->version());
         rowset->add_del_files()->CopyFrom(del_file_with_rid);
     }
 
@@ -1379,7 +1413,14 @@ Status MetaFileBuilder::set_final_rowset() {
     // Collect orphan files: replaced partial-update segments and their segment-name-keyed .vi files
     for (const auto& orphan_file : _pending_rowset_data.orphan_files) {
         DCHECK(is_segment(orphan_file.name()) || is_vector_index(orphan_file.name()));
-        _tablet_meta->mutable_orphan_files()->Add()->CopyFrom(orphan_file);
+        auto* added_orphan = _tablet_meta->mutable_orphan_files()->Add();
+        added_orphan->CopyFrom(orphan_file);
+        // These replaced segment/.vi files are produced by this txn's partial-update rewrite, so
+        // their creation version is the metadata version being built. Respect an accurate version if
+        // the producer already set one.
+        if (!added_orphan->has_version()) {
+            added_orphan->set_version(_tablet_meta->version());
+        }
     }
 
     // Handle schema mapping (same logic as apply_opwrite)

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1465,6 +1465,7 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts, Tab
                 fm.set_name(e.index_file());
                 if (e.has_file_size()) fm.set_size(e.file_size());
                 if (tgt_shared) fm.set_shared(true);
+                fm.set_version(e.version());
             }
         }
         if (ver.entries_size() == 0) continue;

--- a/be/src/storage/lake/tablet_retain_info.cpp
+++ b/be/src/storage/lake/tablet_retain_info.cpp
@@ -14,52 +14,23 @@
 
 #include "storage/lake/tablet_retain_info.h"
 
-#include "common/status.h"
-#include "storage/lake/tablet_manager.h"
-#include "storage/lake/tablet_metadata.h"
-
 namespace starrocks::lake {
 
-Status TabletRetainInfo::init(int64_t tablet_id, const std::unordered_set<int64_t>& retain_versions,
-                              TabletManager* tablet_mgr) {
-    _tablet_id = tablet_id;
-    for (const auto& version : retain_versions) {
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false);
-        if (!res.status().ok()) {
-            return res.status();
-        }
-        auto metadata = std::move(res).value();
-        for (const auto& rowset : metadata->rowsets()) {
-            _rowset_ids.insert(rowset.id());
-        }
-
-        for (const auto& [_, dcg] : (*metadata).dcg_meta().dcgs()) {
-            for (const auto& column_file : dcg.column_files()) {
-                _files.insert(column_file);
-            }
-        }
-        for (const auto& [_, file] : (*metadata).delvec_meta().version_to_file()) {
-            _files.insert(file.name());
-        }
-        for (const auto& sstable : (*metadata).sstable_meta().sstables()) {
-            _files.insert(sstable.filename());
-        }
-
-        _versions.insert(version);
-    }
-    return Status::OK();
+void TabletRetainInfo::init(const std::unordered_set<int64_t>& retain_versions) {
+    _retain_versions = retain_versions;
 }
 
-bool TabletRetainInfo::contains_file(const std::string& file_name) const {
-    return _files.find(file_name) != _files.end();
+bool TabletRetainInfo::retained_by_version(int64_t create_version, int64_t remove_version) const {
+    for (auto version : _retain_versions) {
+        if (create_version <= version && version < remove_version) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool TabletRetainInfo::contains_version(int64_t version) const {
-    return _versions.find(version) != _versions.end();
-}
-
-bool TabletRetainInfo::contains_rowset(uint32_t rowset_id) const {
-    return _rowset_ids.find(rowset_id) != _rowset_ids.end();
+    return _retain_versions.find(version) != _retain_versions.end();
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_retain_info.h
+++ b/be/src/storage/lake/tablet_retain_info.h
@@ -15,41 +15,40 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <unordered_set>
-
-namespace starrocks {
-class Status;
-}
 
 namespace starrocks::lake {
 
-class TabletManager;
-
 /*
- * TabletRetainInfo is used to collect all files name, rowsets id for the specifed versions
- * that used in vacuum process to determine which files(data or meta) can be deleted.
+ * TabletRetainInfo carries the set of tablet metadata versions that lake vacuum must retain for a
+ * partition (e.g. versions pinned by a cluster snapshot). It answers two questions used while
+ * collecting garbage:
+ *   - whether a tablet metadata file at a given version must be kept (contains_version);
+ *   - whether a data file must be kept because it was live at a retained version
+ *     (retained_by_version), decided purely from the file's own [create, remove) version interval.
+ *
+ * It deliberately reads no per-version tablet metadata: a retained version may predate the tablet
+ * (e.g. a split/merge child asked to retain a pre-reshard version it never had), so reading it would
+ * fail with NotFound. Keying on the file's own version instead makes the decision independent of
+ * both that read and the per-file `shared` flag (which reshard does not set uniformly).
 */
 class TabletRetainInfo {
 public:
     TabletRetainInfo() = default;
     ~TabletRetainInfo() = default;
 
-    Status init(int64_t tablet_id, const std::unordered_set<int64_t>& retain_versions, TabletManager* tablet_mgr);
+    void init(const std::unordered_set<int64_t>& retain_versions);
 
-    bool contains_file(const std::string& file_name) const;
+    // Whether a data file created at |create_version| and removed at |remove_version| was live at
+    // some retained version, i.e. there exists a retained version V with
+    // create_version <= V < remove_version. A |create_version| of 0 means "unknown" and is treated
+    // as the earliest possible version, so the file is retained conservatively.
+    bool retained_by_version(int64_t create_version, int64_t remove_version) const;
 
     bool contains_version(int64_t version) const;
 
-    bool contains_rowset(uint32_t rowset_id) const;
-
-    int64_t tablet_id() const { return _tablet_id; }
-
 private:
-    int64_t _tablet_id;
-    std::unordered_set<int64_t> _versions;
-    std::unordered_set<std::string> _files;
-    std::unordered_set<uint32_t> _rowset_ids;
+    std::unordered_set<int64_t> _retain_versions;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -234,6 +234,9 @@ void collect_dcg_orphan_files(const DeltaColumnGroupMetadataPB& old_dcg_meta,
             if (dcg_ver.shared_files_size() > 0 && i < dcg_ver.shared_files_size()) {
                 file_meta.set_shared(dcg_ver.shared_files(i));
             }
+            if (i < dcg_ver.versions_size()) {
+                file_meta.set_version(dcg_ver.versions(i));
+            }
             metadata->mutable_orphan_files()->Add(std::move(file_meta));
         }
     }
@@ -256,6 +259,7 @@ void collect_idg_orphan_files(const IndexDeltaGroupMetadataPB& old_idg_meta,
             file_meta.set_name(entry.index_file());
             if (entry.has_file_size()) file_meta.set_size(entry.file_size());
             file_meta.set_shared(entry.shared_file());
+            file_meta.set_version(entry.version());
             metadata->mutable_orphan_files()->Add(std::move(file_meta));
         }
     }
@@ -310,6 +314,7 @@ public:
                 file_meta.set_name(sstable.filename());
                 file_meta.set_size(sstable.filesize());
                 file_meta.set_shared(sstable.shared());
+                file_meta.set_version(sstable.generation_version());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             _metadata->clear_sstable_meta();
@@ -636,7 +641,12 @@ private:
         // Cleanup orphan lcrm files from merged large rowset split subtasks
         // These files are no longer valid after merging (segment IDs changed)
         for (const auto& lcrm_file : op_parallel.orphan_lcrm_files()) {
-            _metadata->add_orphan_files()->CopyFrom(lcrm_file);
+            auto* added = _metadata->add_orphan_files();
+            added->CopyFrom(lcrm_file);
+            // Transient mapper file produced and orphaned by this compaction, never referenced by
+            // visible metadata; stamp its creation version so vacuum can reclaim it rather than
+            // over-retaining it under a covering snapshot.
+            added->set_version(_new_version);
         }
 
         return Status::OK();
@@ -826,6 +836,7 @@ private:
                 file_meta.set_name(file.name());
                 file_meta.set_size(file.size());
                 file_meta.set_shared(file.shared());
+                file_meta.set_version(version);
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             // Clear sstable_meta and add to orphan files.
@@ -835,6 +846,7 @@ private:
                 file_meta.set_name(sstable.filename());
                 file_meta.set_size(sstable.filesize());
                 file_meta.set_shared(sstable.shared());
+                file_meta.set_version(sstable.generation_version());
                 _metadata->mutable_orphan_files()->Add(std::move(file_meta));
             }
             collect_dcg_orphan_files(old_dcg_meta, new_referenced_files, _metadata.get());

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -165,28 +165,6 @@ static bool is_shared_segment(const RowsetMetadataPB& rowset, int index) {
     return segment_meta.has_bundle_file_offset() || segment_meta.shared();
 }
 
-// Delete .vi files for segments in a rowset using segment_metas metadata.
-// A .vi is a per-segment sidecar whose lifetime follows its owning segment. When the
-// segment is shared across split siblings, its .vi must be routed through the
-// refcounting shared-file deleter so it is not deleted while a sibling still references
-// the segment (mirrors the segment routing in collect_garbage_files).
-static Status delete_rowset_vi_files(AsyncFileDeleter* deleter, AsyncSharedFileDeleter* shared_file_deleter,
-                                     const std::string& base_dir, int64_t tablet_id, const RowsetMetadataPB& rowset) {
-    for (int i = 0; i < rowset.segment_metas_size(); ++i) {
-        const auto& segment_meta = rowset.segment_metas(i);
-        const bool shared_file = is_shared_segment(rowset, i);
-        for (int64_t vi_id : segment_meta.vector_index_ids()) {
-            auto vi_path = join_path(base_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id));
-            if (shared_file && shared_file_deleter != nullptr) {
-                RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
-            } else {
-                RETURN_IF_ERROR(deleter->delete_file(vi_path));
-            }
-        }
-    }
-    return Status::OK();
-}
-
 const char* const kDuplicateFilesError =
         "Duplicate files were returned from the remote storage. The most likely cause is an S3 or HDFS API "
         "compatibility issue with your remote storage implementation.";
@@ -323,35 +301,58 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
                                     AsyncFileDeleter* deleter, AsyncSharedFileDeleter* shared_file_deleter,
                                     int64_t* garbage_data_size, const TabletRetainInfo& retain_info) {
     for (const auto& rowset : metadata.compaction_inputs()) {
-        if (retain_info.contains_rowset(rowset.id())) {
-            continue;
-        }
-
-        for (int i = 0; i < rowset.segment_metas_size(); ++i) {
-            const bool shared_file = is_shared_segment(rowset, i);
-            if (shared_file && shared_file_deleter != nullptr) {
-                RETURN_IF_ERROR(
-                        shared_file_deleter->delete_file(join_path(base_dir, rowset.segment_metas(i).filename())));
-            } else {
-                RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, rowset.segment_metas(i).filename())));
+        // A rowset's segments share the rowset's creation version, so retain them together by
+        // rowset.version(). The one compaction path that would break this equality is lake
+        // partial-segment compaction, which carries OLDER segments forward into a higher-versioned
+        // output rowset, so rowset.version() overstates those carried segments' creation version. That
+        // path is config-gated (enable_lake_compaction_use_partial_segments, off by default), non-PK
+        // only, and being retired in favor of parallel compaction, so it is deliberately not
+        // special-cased here. CAUTION: if it is ever enabled, this can under-retain -- delete a carried
+        // segment that an older retained snapshot still needs -- and the fix is to give those carried
+        // segments their own persisted creation version to key on here instead of rowset.version().
+        if (!retain_info.retained_by_version(rowset.version(), metadata.version())) {
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                const auto& segment_meta = rowset.segment_metas(i);
+                const bool shared_file = is_shared_segment(rowset, i);
+                if (shared_file && shared_file_deleter != nullptr) {
+                    RETURN_IF_ERROR(shared_file_deleter->delete_file(join_path(base_dir, segment_meta.filename())));
+                } else {
+                    RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, segment_meta.filename())));
+                }
+                // A .vi is a per-segment sidecar whose lifetime follows its segment: delete it with
+                // the segment, routed the same way (shared segment -> shared-file deleter).
+                for (int64_t vi_id : segment_meta.vector_index_ids()) {
+                    auto vi_path = join_path(base_dir, gen_vector_index_filename_for_segment(segment_meta, vi_id));
+                    if (shared_file && shared_file_deleter != nullptr) {
+                        RETURN_IF_ERROR(shared_file_deleter->delete_file(vi_path));
+                    } else {
+                        RETURN_IF_ERROR(deleter->delete_file(vi_path));
+                    }
+                }
             }
+            // rowset.data_size() is the segment payload; count it toward reclaimed bytes only when the
+            // segments are actually deleted, so deleting only a del file (segments retained under a
+            // snapshot) does not inflate the metric. segment_metas may omit per-file size, so this
+            // stays a rowset-level estimate.
+            *garbage_data_size += rowset.data_size();
         }
-        // Delete associated .vi files using per-segment vector index metadata. A shared
-        // segment's .vi follows the segment, so route it through the shared-file deleter.
-        RETURN_IF_ERROR(delete_rowset_vi_files(deleter, shared_file_deleter, base_dir, metadata.id(), rowset));
 
+        // Del files can carry a version different from their rowset's: a cloud-native PK compaction
+        // transfers older del files onto a higher-versioned output rowset, so retain them per file.
         for (const auto& del_file : rowset.del_files()) {
+            if (retain_info.retained_by_version(del_file.version(), metadata.version())) {
+                continue;
+            }
             if (del_file.shared() && shared_file_deleter != nullptr) {
                 RETURN_IF_ERROR(shared_file_deleter->delete_file(join_path(base_dir, del_file.name())));
             } else {
                 RETURN_IF_ERROR(deleter->delete_file(join_path(base_dir, del_file.name())));
             }
         }
-        *garbage_data_size += rowset.data_size();
     }
 
     for (const auto& file : metadata.orphan_files()) {
-        if (retain_info.contains_file(file.name())) {
+        if (retain_info.retained_by_version(file.version(), metadata.version())) {
             continue;
         }
 
@@ -623,7 +624,7 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     int64_t max_vacuum_version = 0;
     for (auto& tablet_info : tablet_infos) {
         TabletRetainInfo tablet_retain_info;
-        RETURN_IF_ERROR(tablet_retain_info.init(tablet_info.tablet_id(), retain_versions, tablet_mgr));
+        tablet_retain_info.init(retain_versions);
 
         int64_t tablet_vacuumed_version = 0;
         AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);

--- a/be/test/storage/lake/tablet_retain_info_test.cpp
+++ b/be/test/storage/lake/tablet_retain_info_test.cpp
@@ -16,178 +16,60 @@
 
 #include <gtest/gtest.h>
 
-#include "base/testutil/assert.h"
-#include "json2pb/json_to_pb.h"
-#include "storage/lake/join_path.h"
-#include "storage/lake/metacache.h"
-#include "storage/lake/tablet_metadata.h"
-#include "test_util.h"
-
 namespace starrocks::lake {
 
-class LakeTabletRetainInfoTest : public TestBase {
-public:
-    LakeTabletRetainInfoTest() : TestBase(kTestDir) {}
+// A data file created at |create| and removed at |remove| is retained iff some retained version V
+// satisfies create <= V < remove (i.e. the file was live at V).
+TEST(LakeTabletRetainInfoTest, retained_by_version_interval) {
+    TabletRetainInfo info;
+    info.init(/*retain_versions=*/{5});
 
-    void SetUp() override { clear_and_init_test_dir(); }
+    EXPECT_TRUE(info.retained_by_version(/*create=*/5, /*remove=*/6));   // create == V, V < remove
+    EXPECT_TRUE(info.retained_by_version(/*create=*/3, /*remove=*/6));   // create < V < remove
+    EXPECT_TRUE(info.retained_by_version(/*create=*/5, /*remove=*/100)); // wide live interval
 
-    void TearDown() override {
-        remove_test_dir_ignore_error();
-        _tablet_mgr->prune_metacache();
-    }
+    EXPECT_FALSE(info.retained_by_version(/*create=*/6, /*remove=*/10)); // created after V
+    EXPECT_FALSE(info.retained_by_version(/*create=*/3, /*remove=*/5));  // removed at V (V not < remove)
+    EXPECT_FALSE(info.retained_by_version(/*create=*/3, /*remove=*/4));  // interval entirely below V
+}
 
-protected:
-    constexpr static const char* const kTestDir = "./lake_tablet_retain_info_test";
+// An unset/0 creation version means "unknown, assume earliest": retained whenever some pinned
+// version is below the removal version (safe conservative retain, never a false delete).
+TEST(LakeTabletRetainInfoTest, retained_by_version_unknown_create_version) {
+    TabletRetainInfo info;
+    info.init({5});
 
-    void create_data_file(const std::string& name) {
-        auto full_path = join_path(join_path(kTestDir, kSegmentDirectoryName), name);
-        ASSIGN_OR_ABORT(auto f, FileSystem::Default()->new_writable_file(full_path));
-        ASSERT_OK(f->append("aaaa"));
-        ASSERT_OK(f->close());
-    }
+    EXPECT_TRUE(info.retained_by_version(/*create=*/0, /*remove=*/6));  // some pinned V (5) < remove
+    EXPECT_FALSE(info.retained_by_version(/*create=*/0, /*remove=*/5)); // no pinned V < remove(==5)
+    EXPECT_FALSE(info.retained_by_version(/*create=*/0, /*remove=*/4)); // no pinned V < remove
+}
 
-    template <class ProtobufMessage>
-    std::shared_ptr<ProtobufMessage> json_to_pb(const std::string& json) {
-        auto message = std::make_shared<ProtobufMessage>();
-        std::string error;
-        CHECK(json2pb::JsonToProtoMessage(json, message.get(), &error)) << error;
-        return message;
-    }
-};
+TEST(LakeTabletRetainInfoTest, retained_by_version_multiple_versions) {
+    TabletRetainInfo info;
+    info.init({5, 20});
 
-// NOLINTNEXTLINE
-TEST_F(LakeTabletRetainInfoTest, test_tablet_retain_info_normal) {
-    create_data_file("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec");
-    create_data_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat");
-    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat");
-    create_data_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst");
-    create_data_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat");
+    EXPECT_TRUE(info.retained_by_version(0, 6));   // covers V=5
+    EXPECT_TRUE(info.retained_by_version(10, 21)); // covers V=20
+    EXPECT_TRUE(info.retained_by_version(0, 100)); // covers both
+    EXPECT_FALSE(info.retained_by_version(6, 20)); // between: 5<6, and 20 is not < 20
+}
 
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-        "id": 666,
-        "version": 1
-        }
-        )DEL")));
+TEST(LakeTabletRetainInfoTest, retained_by_version_empty_retain_set) {
+    TabletRetainInfo info;
+    info.init({});
 
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-            "id": 666,
-            "version": 2,
-            "rowsets": [
-                {
-                    "id": 100,
-                    "data_size": 200,
-                    "segment_metas": [
-                        {
-                            "filename": "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat",
-                            "size": 100
-                        },
-                        {
-                            "filename": "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat",
-                            "size": 100
-                        }
-                    ]
-                }
-            ],
-            "delvec_meta": {
-                "version_to_file": [
-                    {
-                        "key": 2,
-                        "value": {
-                            "name": "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec",
-                            "size": 23
-                        }
-                    }
-                ],
-                "delvecs": [
-                    {
-                        "key": 10,
-                        "value": {
-                            "version": 4,
-                            "offset": 0,
-                            "size": 23
-                        }
-                    }
-                ]
-            },
-            "sstable_meta": {
-                "sstables": [
-                    {
-                        "filename": "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"
-                    }
-                ]
-            },
-            "prev_garbage_version": 0,
-            "commit_time": 2
-        }
-        )DEL")));
+    EXPECT_FALSE(info.retained_by_version(0, 1000));
+    EXPECT_FALSE(info.retained_by_version(1, 2));
+}
 
-    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
-        {
-            "id": 666,
-            "version": 3,
-            "rowsets": [
-                {
-                    "id": 101,
-                    "data_size": 100,
-                    "segment_metas": [
-                        {
-                            "filename": "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat",
-                            "size": 100
-                        }
-                    ]
-                }
-            ],
-            "compaction_inputs": [
-                {
-                    "data_size": 200,
-                    "segment_metas": [
-                        {
-                            "filename": "00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat",
-                            "size": 100
-                        },
-                        {
-                            "filename": "00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat",
-                            "size": 100
-                        }
-                    ]
-                }
-            ],
-            "orphan_files": [
-                {
-                    "name": "00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec",
-                    "size": 23
-                },
-                {
-                    "name": "0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst",
-                    "size": 24
-                }
-            ],
-            "prev_garbage_version": 0,
-            "commit_time": 3
-        }
-        )DEL")));
+TEST(LakeTabletRetainInfoTest, contains_version) {
+    TabletRetainInfo info;
+    info.init({2, 5});
 
-    TabletRetainInfo tablet_retain_info = TabletRetainInfo();
-    std::unordered_set<int64_t> set;
-    set.insert(2);
-    tablet_retain_info.init(666, set, _tablet_mgr.get());
-
-    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_27dc159f-6bfc-4a3a-9d9c-c97c10bb2e11.dat"));
-    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b582.dat"));
-    EXPECT_TRUE(tablet_retain_info.contains_file("00000000000159e3_3ea06130-ccac-4110-9de8-4813512c60da.delvec"));
-    EXPECT_TRUE(tablet_retain_info.contains_file("0000000000011111_9ae981b3-7d4b-49e9-9723-d7f752686155.sst"));
-    EXPECT_FALSE(tablet_retain_info.contains_file("00000000000159e4_a542395a-bff5-48a7-a3a7-2ed05691b583.dat"));
-
-    EXPECT_FALSE(tablet_retain_info.contains_version(1));
-    EXPECT_TRUE(tablet_retain_info.contains_version(2));
-    EXPECT_FALSE(tablet_retain_info.contains_version(3));
-
-    EXPECT_TRUE(tablet_retain_info.contains_rowset(100));
-    EXPECT_FALSE(tablet_retain_info.contains_rowset(101));
-
-    EXPECT_TRUE(tablet_retain_info.tablet_id() == 666);
+    EXPECT_TRUE(info.contains_version(2));
+    EXPECT_TRUE(info.contains_version(5));
+    EXPECT_FALSE(info.contains_version(1));
+    EXPECT_FALSE(info.contains_version(3));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -3090,6 +3090,279 @@ TEST_P(LakeVacuumTest, test_vacuum_version_control) {
     }
 }
 
+// A range-distribution reshard child's retain_versions may reference a pre-reshard version the
+// child never had (its earliest metadata is the reshard publish version). The version-interval
+// retain must: (a) not fail with NotFound -- it never reads {child}_V.meta; (b) keep a pre-reshard
+// segment that was live at the pinned version, purely by its recorded version and WITHOUT relying
+// on the `shared` flag (identical-tablet inherited files are not marked shared); and (c) still
+// vacuum the child's own post-pin garbage.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_retain_version_below_tablet_earliest) {
+    // A: created pre-reshard at version 3, inherited by the child (shared=false), compacted out at v6.
+    create_data_file("00000000000159e4_aaaaaaaa-0000-0000-0000-000000000003.dat");
+    // B: created by the child at version 6 (> pinned 3), compacted out at v7 -> collectable garbage.
+    create_data_file("00000000000159e4_bbbbbbbb-0000-0000-0000-000000000006.dat");
+    // C: live rowset segment.
+    create_data_file("00000000000159e4_cccccccc-0000-0000-0000-000000000006.dat");
+
+    // Child's earliest metadata is version 6 (the reshard publish version); no version <= 5 exists.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 700,
+            "version": 6,
+            "rowsets": [
+                { "id": 60, "version": 6, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_cccccccc-0000-0000-0000-000000000006.dat", "size": 100 } ] }
+            ],
+            "compaction_inputs": [
+                { "id": 30, "version": 3, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_aaaaaaaa-0000-0000-0000-000000000003.dat", "size": 100, "shared": false } ] }
+            ],
+            "prev_garbage_version": 0,
+            "commit_time": 100
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 700,
+            "version": 7,
+            "rowsets": [
+                { "id": 60, "version": 6, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_cccccccc-0000-0000-0000-000000000006.dat", "size": 100 } ] }
+            ],
+            "compaction_inputs": [
+                { "id": 61, "version": 6, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_bbbbbbbb-0000-0000-0000-000000000006.dat", "size": 100 } ] }
+            ],
+            "prev_garbage_version": 6,
+            "commit_time": 200
+        }
+        )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(700);
+    info->set_min_version(6);
+    request.set_min_retain_version(7);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    request.add_retain_versions(3); // pre-reshard version the child never had
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    // (a) whole RPC succeeds instead of aborting on NotFound.
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // (b) pre-reshard segment pinned by version 3 is retained, though shared=false.
+    EXPECT_TRUE(file_exist("00000000000159e4_aaaaaaaa-0000-0000-0000-000000000003.dat"));
+    // (c) the child's own post-pin garbage (created at version 6, > 3) is vacuumed.
+    EXPECT_FALSE(file_exist("00000000000159e4_bbbbbbbb-0000-0000-0000-000000000006.dat"));
+    // live rowset segment untouched.
+    EXPECT_TRUE(file_exist("00000000000159e4_cccccccc-0000-0000-0000-000000000006.dat"));
+}
+
+// Compaction-input retention: a rowset's SEGMENTS are retained by the rowset's version -- kept when a
+// pinned snapshot version falls in [rowset.version, tablet.version), reclaimed otherwise. DEL files are
+// retained by their OWN version instead, because a cloud-native PK compaction transfers older del files
+// onto a higher-versioned output rowset. A snapshot pins version 5.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_compaction_input_retention_by_version) {
+    create_data_file("00000000000159e4_11110000-0000-0000-0000-000000000003.dat"); // rowset created v3, pinned
+    create_data_file("00000000000159e4_22220000-0000-0000-0000-000000000008.dat"); // rowset created v8, not pinned
+    create_data_file("00000000000159e4_33330000-0000-0000-0000-000000000003.del"); // transferred del, created v3
+    create_data_file("00000000000159e4_44440000-0000-0000-0000-000000000008.del"); // fresh del, created v8
+    create_data_file("00000000000159e4_55550000-0000-0000-0000-000000000010.dat"); // live
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 950,
+            "version": 10,
+            "rowsets": [
+                { "id": 100, "version": 10, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_55550000-0000-0000-0000-000000000010.dat", "size": 100 } ] }
+            ],
+            "compaction_inputs": [
+                { "id": 90, "version": 3, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_11110000-0000-0000-0000-000000000003.dat", "size": 100 } ] },
+                { "id": 91, "version": 8, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_22220000-0000-0000-0000-000000000008.dat", "size": 100 } ],
+                  "del_files": [
+                      { "name": "00000000000159e4_33330000-0000-0000-0000-000000000003.del", "version": 3 },
+                      { "name": "00000000000159e4_44440000-0000-0000-0000-000000000008.del", "version": 8 }
+                  ] }
+            ],
+            "prev_garbage_version": 0,
+            "commit_time": 100
+        }
+        )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(950);
+    info->set_min_version(8);
+    request.set_min_retain_version(10);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    request.add_retain_versions(5); // pins version 5
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // Segment of the version-3 rowset is retained: the pin (5) lies in [3, 10).
+    EXPECT_TRUE(file_exist("00000000000159e4_11110000-0000-0000-0000-000000000003.dat"));
+    // Segment of the version-8 rowset is reclaimed: the pin (5) is not in [8, 10).
+    EXPECT_FALSE(file_exist("00000000000159e4_22220000-0000-0000-0000-000000000008.dat"));
+    // Del files are retained by their own version: v3 (<= pinned 5) survives, v8 (> pinned 5) is reclaimed.
+    EXPECT_TRUE(file_exist("00000000000159e4_33330000-0000-0000-0000-000000000003.del"));
+    EXPECT_FALSE(file_exist("00000000000159e4_44440000-0000-0000-0000-000000000008.del"));
+    EXPECT_TRUE(file_exist("00000000000159e4_55550000-0000-0000-0000-000000000010.dat"));
+}
+
+// Orphan files carry a stamped creation version; the interval retain keeps exactly the orphan files
+// that were live at a pinned version and deletes newer ones -- no {tablet}_V.meta read needed.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_orphan_file_version_interval) {
+    create_data_file("00000000000159e3_dddddddd-0000-0000-0000-000000000003.delvec"); // created v3, pinned
+    create_data_file("00000000000159e3_eeeeeeee-0000-0000-0000-000000000006.delvec"); // created v6, not pinned
+    create_data_file("00000000000159e4_ffffffff-0000-0000-0000-000000000007.dat");    // live
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 800,
+            "version": 7,
+            "rowsets": [
+                { "id": 70, "version": 7, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_ffffffff-0000-0000-0000-000000000007.dat", "size": 100 } ] }
+            ],
+            "orphan_files": [
+                { "name": "00000000000159e3_dddddddd-0000-0000-0000-000000000003.delvec", "size": 23, "version": 3 },
+                { "name": "00000000000159e3_eeeeeeee-0000-0000-0000-000000000006.delvec", "size": 23, "version": 6 }
+            ],
+            "prev_garbage_version": 0,
+            "commit_time": 100
+        }
+        )DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_delete_txn_log(false);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(800);
+    info->set_min_version(7);
+    request.set_min_retain_version(7);
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(12345);
+    request.add_retain_versions(3);
+    vacuum(_tablet_mgr.get(), request, &response);
+
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // orphan created at version 3 was live at pinned version 3 -> retained.
+    EXPECT_TRUE(file_exist("00000000000159e3_dddddddd-0000-0000-0000-000000000003.delvec"));
+    // orphan created at version 6 (> pinned 3) -> deleted.
+    EXPECT_FALSE(file_exist("00000000000159e3_eeeeeeee-0000-0000-0000-000000000006.delvec"));
+    EXPECT_TRUE(file_exist("00000000000159e4_ffffffff-0000-0000-0000-000000000007.dat"));
+}
+
+// Old-format tablet metadata predates the FileMetaPB.version field and may also carry unset
+// `version` on (compaction-input) rowsets, so both read as 0. The interval retain treats an unset
+// (0) creation version as "created at the earliest version": such files are conservatively retained
+// under a snapshot that pins any older version (never a false delete), and are reclaimed normally
+// when no snapshot pins them. This locks down the backward-compat behavior of the switch from the
+// old filename-based retain to the version-interval retain.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_legacy_unset_version_fields) {
+    // Tablet 900 -- pinned by a snapshot at an old version: legacy unset-version files are kept.
+    create_data_file("00000000000159e4_aa000000-0000-0000-0000-000000000000.dat");    // compaction input (no version)
+    create_data_file("00000000000159e3_bb000000-0000-0000-0000-000000000000.delvec"); // orphan (no version)
+    create_data_file("00000000000159e4_cc000000-0000-0000-0000-000000000000.dat");    // live
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 900,
+            "version": 8,
+            "rowsets": [
+                { "id": 90, "version": 8, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_cc000000-0000-0000-0000-000000000000.dat", "size": 100 } ] }
+            ],
+            "compaction_inputs": [
+                { "id": 80, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_aa000000-0000-0000-0000-000000000000.dat", "size": 100 } ] }
+            ],
+            "orphan_files": [
+                { "name": "00000000000159e3_bb000000-0000-0000-0000-000000000000.delvec", "size": 23 }
+            ],
+            "prev_garbage_version": 0,
+            "commit_time": 100
+        }
+        )DEL")));
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(900);
+        info->set_min_version(8);
+        request.set_min_retain_version(8);
+        request.set_grace_timestamp(::time(nullptr) + 3600);
+        request.set_min_active_txn_id(12345);
+        request.add_retain_versions(5); // snapshot pins an old version the legacy files predate
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        // unset version reads as 0 -> conservatively retained under the snapshot (no false delete).
+        EXPECT_TRUE(file_exist("00000000000159e4_aa000000-0000-0000-0000-000000000000.dat"));
+        EXPECT_TRUE(file_exist("00000000000159e3_bb000000-0000-0000-0000-000000000000.delvec"));
+        EXPECT_TRUE(file_exist("00000000000159e4_cc000000-0000-0000-0000-000000000000.dat"));
+    }
+
+    // Tablet 901 -- identical legacy layout but no snapshot pins it: garbage is reclaimed normally.
+    create_data_file("00000000000159e4_dd000000-0000-0000-0000-000000000000.dat");    // compaction input (no version)
+    create_data_file("00000000000159e3_ee000000-0000-0000-0000-000000000000.delvec"); // orphan (no version)
+    create_data_file("00000000000159e4_ff000000-0000-0000-0000-000000000000.dat");    // live
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 901,
+            "version": 8,
+            "rowsets": [
+                { "id": 91, "version": 8, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_ff000000-0000-0000-0000-000000000000.dat", "size": 100 } ] }
+            ],
+            "compaction_inputs": [
+                { "id": 81, "data_size": 100,
+                  "segment_metas": [ { "filename": "00000000000159e4_dd000000-0000-0000-0000-000000000000.dat", "size": 100 } ] }
+            ],
+            "orphan_files": [
+                { "name": "00000000000159e3_ee000000-0000-0000-0000-000000000000.delvec", "size": 23 }
+            ],
+            "prev_garbage_version": 0,
+            "commit_time": 100
+        }
+        )DEL")));
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(901);
+        info->set_min_version(8);
+        request.set_min_retain_version(8);
+        request.set_grace_timestamp(::time(nullptr) + 3600);
+        request.set_min_active_txn_id(12345);
+        // no retain_versions: nothing pins these versions.
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        // no snapshot -> legacy garbage (unset version) reclaimed normally.
+        EXPECT_FALSE(file_exist("00000000000159e4_dd000000-0000-0000-0000-000000000000.dat"));
+        EXPECT_FALSE(file_exist("00000000000159e3_ee000000-0000-0000-0000-000000000000.delvec"));
+        EXPECT_TRUE(file_exist("00000000000159e4_ff000000-0000-0000-0000-000000000000.dat"));
+    }
+}
+
 // Test: vacuum deletes .vi files for compaction_inputs using segment_metas
 // NOLINTNEXTLINE
 TEST_P(LakeVacuumTest, test_vacuum_vi_files_in_compaction_inputs) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -91,6 +91,11 @@ message FileMetaPB {
     // Whether this file shared by multiple tablets
     optional bool shared = 3 [default=false];
     optional bytes encryption_meta = 4;
+    // The tablet metadata version at which the file was created. Stamped when the file is moved into
+    // orphan_files so lake vacuum can tell whether the file was live at a snapshot-retained version
+    // without reading that version's tablet metadata. Unset (0) means "creation version unknown" and
+    // is treated conservatively (retained under any covering retain version).
+    optional int64 version = 5;
 }
 
 message DelvecMetadataPB {
@@ -188,6 +193,13 @@ message DelfileWithRowsetId {
     optional bytes encryption_meta = 4;
     // Whether this file shared by multiple tablets
     optional bool shared = 5 [default=false];
+    // The tablet metadata version at which this del file was created. Stamped once at creation and
+    // carried verbatim by CopyFrom when the del file is transferred to a compaction output rowset or
+    // inherited across tablet split/merge, so it reflects the ORIGINAL creation version even after
+    // the containing rowset is re-versioned. Lake vacuum uses it to tell whether the del file was
+    // live at a snapshot-retained version. Unset (0) means "creation version unknown" and is treated
+    // conservatively (retained under any covering retain version).
+    optional int64 version = 6;
 }
 
 message SegmentMetadataPB {


### PR DESCRIPTION
## Why I'm doing:

Shared-data range-distribution tables support tablet split/merge. When a cluster snapshot pins a
pre-reshard version `V` and the partition is then split/merged, the FE vacuum daemon enumerates the
partition's current (post-reshard child) tablets and ships the retained-version set (including `V`)
to the BE. A child tablet's earliest metadata is the reshard publish version (`> V`), so it has no
`{child}_{V}.meta`.

`TabletRetainInfo::init` read `{tablet}_{V}.meta` for every retained version to build its protect set.
For a child, `V` returns `NotFound`, so `init` failed. `vacuum_tablet_metadata` calls `init` under
`RETURN_IF_ERROR` **before any deletion**, so the whole partition's vacuum RPC failed every cycle,
`lastSuccVacuumVersion` never advanced, and expired metadata / data files / txn logs accumulated for
as long as the snapshot existed — an auto-vacuum stall / storage leak.

Naively skipping the `NotFound` version is unsafe: the incremental vacuum can delete a pre-reshard
segment that the snapshot still needs (the grace-time clamp that protects automated snapshots does
not hold for a finished manual / external snapshot), and only-suppressing *shared* file cleanup is
also unsafe because the reshard "identical tablet" path does not mark its inherited files `shared`,
so they route through the regular deleter.

## What I'm doing:

Decide vacuum retention by **version interval** instead of by reading the pinned version's metadata.

A garbage file must be kept iff it was live at a retained version, i.e. there is a retained version
`V` with `create_version <= V < remove_version`, where `remove_version` is the metadata version that
moved the file into `compaction_inputs` / `orphan_files`.

- `TabletRetainInfo` now holds only the retained-version set. It reads **no** per-version metadata, so
  the `NotFound` failure mode cannot occur by construction. It exposes
  `retained_by_version(create_version, remove_version)` (data-file liveness) and `contains_version(v)`
  (tablet-metadata-file retention, unchanged). The old metadata read and the
  `contains_file`/`contains_rowset` name/id sets are removed.
- Segments are retained by their rowset's creation version (`RowsetMetadataPB.version`, preserved
  through split `CopyFrom` and compaction).
- Del files can be transferred by a cloud-native PK compaction onto a higher-versioned output rowset,
  so they carry a new **optional `DelfileWithRowsetId.version`**, stamped at creation and retained per
  file (independent of the containing rowset's version).
- Orphan files carry a new **optional `FileMetaPB.version`**, stamped from the source object's own
  version at each orphaning site (dcg `versions[i]`, delvec `version_to_file` key, sstable `generation_version`,
  idg entry `version`; same-txn transient segment orphans are stamped with the metadata version being
  built). An unset/0 version means "unknown → retain conservatively", never a false delete.
- `collect_garbage_files` uses `retained_by_version(candidate.version(), metadata.version())`. Because
  the decision is keyed on version rather than the per-file `shared` flag, it correctly protects both
  shared and exclusive/identical inherited files.

Note for reviewers: this changes the internal vacuum retain mechanism and adds two backward-compatible
optional fields (`FileMetaPB.version` and `DelfileWithRowsetId.version`) to the storage metadata proto.
There is **no** user-facing SQL / config /
API / metric change, so this is classified as a bug fix (behavior change: No). Range distribution is a
new, new-tables-only feature with no on-disk compatibility burden.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5



