### PR TITLE
[Enhancement] Push wildcard literal prefix down to S3 ListObjectsV2 for files() glob

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3418,7 +3418,7 @@ public class Config extends ConfigBase {
 
     /**
      * Whether to use the native AWS S3 SDK to resolve glob paths in the files() table function for
-     * S3 and S3-compatible object stores (s3/oss/cosn/ks3/obs/tos). Default is true. When true, the
+     * S3 and S3-compatible object stores (s3/s3a/s3n/oss/cosn/ks3/obs/tos). Default is true. When true, the
      * longest literal prefix of a wildcard is pushed down to S3 ListObjectsV2 instead of listing the
      * whole parent prefix via Hadoop globStatus, which is much faster when the prefix holds many
      * objects but few match. Set to false to fall back to the Hadoop globStatus path.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3416,6 +3416,16 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean azure_use_native_sdk = true;
 
+    /**
+     * Whether to use the native AWS S3 SDK to resolve glob paths in the files() table function for
+     * S3 and S3-compatible object stores (s3/oss/cosn/ks3/obs/tos). Default is true. When true, the
+     * longest literal prefix of a wildcard is pushed down to S3 ListObjectsV2 instead of listing the
+     * whole parent prefix via Hadoop globStatus, which is much faster when the prefix holds many
+     * objects but few match. Set to false to fall back to the Hadoop globStatus path.
+     */
+    @ConfField(mutable = true)
+    public static boolean s3_use_native_sdk_for_glob = true;
+
     @ConfField(mutable = true)
     public static boolean enable_experimental_rowstore = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/FileSystem.java
@@ -56,10 +56,10 @@ public interface FileSystem {
                 (scheme.equalsIgnoreCase(HdfsFsManager.WASB_SCHEME) || scheme.equalsIgnoreCase(HdfsFsManager.WASBS_SCHEME))) {
             // Use native Azure SDK is enabled and the scheme is wasb/wasbs
             return new AzBlobFileSystem(properties);
-        } else if (Config.s3_use_native_sdk_for_glob
-                && S3FileSystem.isSupportedScheme(scheme)
-                && S3FileSystem.canHandle(properties)) {
-            // Native S3 SDK glob for S3/S3-compatible object stores backed by an AWS cloud configuration.
+        } else if (Config.s3_use_native_sdk_for_glob && S3FileSystem.isSupportedScheme(scheme)) {
+            // Native S3 SDK glob for S3/S3-compatible object stores. Whether the properties actually
+            // resolve to an AWS configuration (and whether the pattern is eligible) is decided inside
+            // S3FileSystem.globList, which falls back to the Hadoop path otherwise.
             return new S3FileSystem(properties);
         } else {
             // HDFS-compatible implementation

--- a/fe/fe-core/src/main/java/com/starrocks/fs/FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/FileSystem.java
@@ -21,6 +21,7 @@ import com.starrocks.fs.azure.AzBlobFileSystem;
 import com.starrocks.fs.hdfs.HdfsFileSystemWrap;
 import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.fs.hdfs.WildcardURI;
+import com.starrocks.fs.s3.S3FileSystem;
 import com.starrocks.thrift.THdfsProperties;
 import org.apache.hadoop.fs.FileStatus;
 
@@ -55,6 +56,11 @@ public interface FileSystem {
                 (scheme.equalsIgnoreCase(HdfsFsManager.WASB_SCHEME) || scheme.equalsIgnoreCase(HdfsFsManager.WASBS_SCHEME))) {
             // Use native Azure SDK is enabled and the scheme is wasb/wasbs
             return new AzBlobFileSystem(properties);
+        } else if (Config.s3_use_native_sdk_for_glob
+                && S3FileSystem.isSupportedScheme(scheme)
+                && S3FileSystem.canHandle(properties)) {
+            // Native S3 SDK glob for S3/S3-compatible object stores backed by an AWS cloud configuration.
+            return new S3FileSystem(properties);
         } else {
             // HDFS-compatible implementation
             return new HdfsFileSystemWrap(properties);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1198,7 +1198,7 @@ public class HdfsFsManager {
             }
             return fileSystem;
         } catch (Exception e) {
-            LOG.error("errors while connect to " + path, e);
+            LOG.error("errors while connect to {}", path, e);
             throw new StarRocksException(e);
         } finally {
             fileSystem.getLock().unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1198,7 +1198,7 @@ public class HdfsFsManager {
             }
             return fileSystem;
         } catch (Exception e) {
-            LOG.error("errors while connect to {}", path, e);
+            LOG.error("error while connecting to {}", path, e);
             throw new StarRocksException(e);
         } finally {
             fileSystem.getLock().unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -19,7 +19,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.connector.share.credential.AwsCredentialUtil;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.aws.AwsCloudConfiguration;
@@ -41,6 +40,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -278,9 +278,20 @@ public class S3FileSystem implements FileSystem {
                         .build());
         String endpoint = awsCloudCredential.getEndpoint();
         if (endpoint != null && !endpoint.isEmpty()) {
-            builder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(endpoint));
+            builder.endpointOverride(resolveEndpointUri(endpoint, awsCloudConfiguration.getEnableSSL()));
         }
         return builder.build();
+    }
+
+    // Resolve the endpoint override URI. An explicit scheme in the endpoint wins; otherwise the
+    // scheme follows aws.s3.enable_ssl (http when SSL is disabled) so a plaintext S3-compatible
+    // endpoint (e.g. MinIO) is not first attempted over TLS and forced through the fallback path.
+    // Unlike AwsCredentialUtil.ensureSchemeInEndpoint, which always prepends https.
+    static URI resolveEndpointUri(String endpoint, boolean enableSSL) {
+        if (endpoint.contains("://")) {
+            return URI.create(endpoint);
+        }
+        return URI.create((enableSSL ? "https://" : "http://") + endpoint);
     }
 
     // Longest literal prefix of a component: everything before the first unescaped glob

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -1,0 +1,317 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.fs.s3;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.connector.share.credential.AwsCredentialUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.credential.aws.AwsCloudConfiguration;
+import com.starrocks.credential.aws.AwsCloudCredential;
+import com.starrocks.fs.FileSystem;
+import com.starrocks.fs.hdfs.HdfsFileSystemWrap;
+import com.starrocks.fs.hdfs.WildcardURI;
+import com.starrocks.thrift.THdfsProperties;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.GlobFilter;
+import org.apache.hadoop.fs.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A native S3 (and S3-compatible: oss/cosn/ks3/obs/tos) {@link FileSystem} implementation used to
+ * accelerate glob listing for the FILES() table function.
+ *
+ * <p>The Hadoop {@code S3AFileSystem.globStatus} path resolves a wildcard pattern by listing the
+ * parent "directory" of the first wildcard path component and filtering client-side. Because
+ * Hadoop's {@code Globber} splits the pattern on '/', the literal head inside a wildcard component
+ * (e.g. {@code 2026-06-24-13} in {@code sn-fstore/2026-06-24-13*}) is never pushed down as an S3
+ * {@code ListObjectsV2} prefix. For a bucket where the parent prefix holds millions of objects this
+ * enumerates the whole prefix even when only a handful match.
+ *
+ * <p>This implementation instead pushes the longest literal prefix of each wildcard component down
+ * into {@code ListObjectsV2(prefix=...)} so S3 returns only the matching keys, then applies a
+ * {@link GlobFilter} client-side to preserve Hadoop glob semantics (notably that {@code *} does not
+ * cross '/'). Only glob listing is overridden; {@link #getHdfsProperties} is delegated to
+ * {@link HdfsFileSystemWrap} so the backend read path is unchanged.
+ */
+public class S3FileSystem implements FileSystem {
+    private static final Logger LOG = LogManager.getLogger(S3FileSystem.class);
+
+    private static final String SEPARATOR = "/";
+    // Glob metacharacters recognized by Hadoop GlobPattern. Their presence marks a component as a
+    // wildcard; the literal prefix of a component is everything before the first of these.
+    private static final String GLOB_METACHARACTERS = "*?[{\\";
+
+    // S3-compatible schemes that Hadoop routes through S3AFileSystem (see HdfsFsManager.getFileSystem).
+    private static final Set<String> SUPPORTED_SCHEMES =
+            ImmutableSet.of("s3", "s3a", "s3n", "oss", "cosn", "ks3", "obs", "tos");
+
+    private final Map<String, String> properties;
+    // Reused for getHdfsProperties() and for the fallback glob path (exact paths / brace patterns).
+    private final HdfsFileSystemWrap fallback;
+
+    public S3FileSystem(Map<String, String> properties) {
+        this.properties = properties;
+        this.fallback = new HdfsFileSystemWrap(properties);
+    }
+
+    /**
+     * Whether the native S3 glob path can serve the given scheme.
+     */
+    public static boolean isSupportedScheme(String scheme) {
+        return scheme != null && SUPPORTED_SCHEMES.contains(scheme.toLowerCase());
+    }
+
+    /**
+     * Whether the given properties resolve to an AWS-style cloud configuration. When they do not
+     * (e.g. legacy {@code fs.oss.*} keys -> AliyunCloudConfiguration) the caller should fall back to
+     * the Hadoop path, since we build the client from {@link AwsCloudCredential}.
+     */
+    public static boolean canHandle(Map<String, String> properties) {
+        try {
+            CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            return cc instanceof AwsCloudConfiguration;
+        } catch (Exception e) {
+            LOG.warn("Failed to build cloud configuration for native S3 glob, will fall back to hadoop path", e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<FileStatus> globList(String path, boolean skipDir) throws StarRocksException {
+        WildcardURI uri = new WildcardURI(path);
+        String scheme = uri.getUri().getScheme();
+        String bucket = uri.getAuthority();
+        String keyPattern = stripLeadingSlash(uri.getPath());
+
+        // Fall back to the Hadoop globStatus path for cases the native prefix pushdown does not
+        // handle:
+        //   - brace expansion "{a,b}" (Hadoop expands it via GlobExpander; GlobFilter alone cannot),
+        //   - exact paths with no wildcard (Hadoop getFileStatus is a single efficient HEAD).
+        if (keyPattern.indexOf('{') >= 0 || !containsGlobWildcard(keyPattern)) {
+            return fallbackGlobList(path, skipDir);
+        }
+
+        long startTime = System.currentTimeMillis();
+        try (S3Client s3Client = createS3Client()) {
+            List<FileStatus> result = nativeGlobList(s3Client, scheme, bucket, keyPattern);
+            List<FileStatus> filtered = skipDir
+                    ? result.stream().filter(f -> !f.isDirectory()).collect(Collectors.toList())
+                    : result;
+            LOG.info("S3 native globList done, path={}, matched={}, costMs={}",
+                    path, filtered.size(), System.currentTimeMillis() - startTime);
+            return filtered;
+        } catch (Exception e) {
+            // Availability over optimization: any unexpected failure on the native path (e.g. an
+            // auth/region edge case the Hadoop path handles differently) falls back to globStatus so
+            // the query still succeeds. If the fallback also fails, its exception propagates.
+            LOG.warn("S3 native globList failed, falling back to hadoop globStatus. path: {}", path, e);
+            return fallbackGlobList(path, skipDir);
+        }
+    }
+
+    @Override
+    public THdfsProperties getHdfsProperties(String path) throws StarRocksException {
+        // BE read path must stay identical to the Hadoop-based implementation.
+        return fallback.getHdfsProperties(path);
+    }
+
+    // Delegates to the Hadoop globStatus path for patterns the native path does not handle.
+    protected List<FileStatus> fallbackGlobList(String path, boolean skipDir) throws StarRocksException {
+        return fallback.globList(path, skipDir);
+    }
+
+    /**
+     * Walk the pattern components the same way Hadoop's Globber does, but at each component that
+     * requires a listing, push the component's literal head into the S3 ListObjectsV2 prefix.
+     */
+    private List<FileStatus> nativeGlobList(S3Client s3Client, String scheme, String bucket, String keyPattern)
+            throws Exception {
+        List<String> components = getPathComponents(keyPattern);
+
+        // Candidate directory keys accumulated so far ("" == bucket root). Intermediate candidates
+        // are always directories; only terminal matches may be files.
+        List<String> candidateKeys = Lists.newArrayList("");
+        List<FileStatus> terminalResults = Lists.newArrayList();
+
+        for (int idx = 0; idx < components.size(); ++idx) {
+            String component = components.get(idx);
+            boolean isLast = idx == components.size() - 1;
+            GlobFilter globFilter = new GlobFilter(component);
+
+            if (candidateKeys.isEmpty()) {
+                break;
+            }
+
+            if (!isLast && !globFilter.hasPattern()) {
+                // Non-terminal literal component: assume it exists and just extend the prefix,
+                // mirroring the Globber optimization. A miss surfaces when a later listing is empty.
+                candidateKeys = candidateKeys.stream()
+                        .map(k -> k.isEmpty() ? component : k + SEPARATOR + component)
+                        .collect(Collectors.toList());
+                continue;
+            }
+
+            String literalHead = literalPrefixOf(component);
+            List<String> nextKeys = Lists.newArrayList();
+            for (String parentKey : candidateKeys) {
+                for (FileStatus child : listWithPrefix(s3Client, scheme, bucket, parentKey, literalHead)) {
+                    // Only directories can be recursed into for non-terminal components.
+                    if (!isLast && !child.isDirectory()) {
+                        continue;
+                    }
+                    // GlobFilter matches on the last path segment (getName()).
+                    if (!globFilter.accept(child.getPath())) {
+                        continue;
+                    }
+                    if (isLast) {
+                        terminalResults.add(child);
+                    } else {
+                        nextKeys.add(keyOf(child.getPath()));
+                    }
+                }
+            }
+            candidateKeys = nextKeys;
+        }
+
+        return terminalResults;
+    }
+
+    /**
+     * List entries directly under {@code parentKey} whose next path segment starts with
+     * {@code literalHead}, using a single S3 ListObjectsV2 with delimiter '/'. CommonPrefixes become
+     * directories, objects become files.
+     */
+    protected List<FileStatus> listWithPrefix(S3Client s3Client, String scheme, String bucket,
+                                              String parentKey, String literalHead) {
+        ListObjectsV2Request request = buildListObjectsRequest(bucket, parentKey, literalHead);
+        List<FileStatus> children = Lists.newArrayList();
+        for (ListObjectsV2Response page : s3Client.listObjectsV2Paginator(request)) {
+            collectPage(scheme, bucket, page, children);
+        }
+        return children;
+    }
+
+    // Build a ListObjectsV2 request scoped to entries directly under parentKey whose next segment
+    // starts with literalHead. Delimiter '/' lists a single hierarchy level.
+    static ListObjectsV2Request buildListObjectsRequest(String bucket, String parentKey, String literalHead) {
+        String prefix = parentKey.isEmpty() ? literalHead : parentKey + SEPARATOR + literalHead;
+        return ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .delimiter(SEPARATOR)
+                .build();
+    }
+
+    // Translate one ListObjectsV2 response page into FileStatus entries: CommonPrefixes become
+    // directories, objects become files, and "directory placeholder" objects (keys ending with '/')
+    // are dropped.
+    static void collectPage(String scheme, String bucket, ListObjectsV2Response page, List<FileStatus> out) {
+        for (CommonPrefix commonPrefix : page.commonPrefixes()) {
+            String dirKey = stripTrailingSlash(commonPrefix.prefix());
+            out.add(new FileStatus(0, true, 1, 1, 0, buildPath(scheme, bucket, dirKey)));
+        }
+        for (S3Object object : page.contents()) {
+            String key = object.key();
+            if (key.endsWith(SEPARATOR)) {
+                continue;
+            }
+            long size = object.size() == null ? 0L : object.size();
+            long mtime = object.lastModified() == null ? 0L : object.lastModified().toEpochMilli();
+            out.add(new FileStatus(size, false, 1, 1, mtime, buildPath(scheme, bucket, key)));
+        }
+    }
+
+    protected S3Client createS3Client() throws StarRocksException {
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        if (!(cc instanceof AwsCloudConfiguration)) {
+            throw new StarRocksException("Native S3 glob requires an AWS cloud configuration");
+        }
+        AwsCloudConfiguration awsCloudConfiguration = (AwsCloudConfiguration) cc;
+        AwsCloudCredential awsCloudCredential = awsCloudConfiguration.getAwsCloudCredential();
+
+        S3ClientBuilder builder = S3Client.builder()
+                .credentialsProvider(awsCloudCredential.generateAWSCredentialsProvider())
+                .region(awsCloudCredential.tryToResolveRegion())
+                .forcePathStyle(awsCloudConfiguration.getEnablePathStyleAccess());
+        String endpoint = awsCloudCredential.getEndpoint();
+        if (endpoint != null && !endpoint.isEmpty()) {
+            builder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(endpoint));
+        }
+        return builder.build();
+    }
+
+    // Split a key into non-empty path components, merging repeated slashes. E.g. "a//b/c" -> [a, b, c].
+    private static List<String> getPathComponents(String key) {
+        List<String> components = Lists.newArrayList();
+        for (String component : key.split(SEPARATOR)) {
+            if (!component.isEmpty()) {
+                components.add(component);
+            }
+        }
+        return components;
+    }
+
+    // Longest literal prefix of a component: everything before the first glob metacharacter.
+    private static String literalPrefixOf(String component) {
+        for (int i = 0; i < component.length(); ++i) {
+            if (GLOB_METACHARACTERS.indexOf(component.charAt(i)) >= 0) {
+                return component.substring(0, i);
+            }
+        }
+        return component;
+    }
+
+    private static boolean containsGlobWildcard(String key) {
+        for (int i = 0; i < key.length(); ++i) {
+            if (GLOB_METACHARACTERS.indexOf(key.charAt(i)) >= 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Build a full "scheme://bucket/key" path without re-parsing the key as a URI, so object keys
+    // containing characters like spaces or '%' are preserved verbatim.
+    private static Path buildPath(String scheme, String bucket, String key) {
+        return new Path(scheme, bucket, SEPARATOR + key);
+    }
+
+    private static String keyOf(Path path) {
+        return stripLeadingSlash(path.toUri().getPath());
+    }
+
+    private static String stripLeadingSlash(String s) {
+        return s.startsWith(SEPARATOR) ? s.substring(1) : s;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith(SEPARATOR) ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -15,6 +15,7 @@
 package com.starrocks.fs.s3;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.common.StarRocksException;
@@ -110,7 +111,9 @@ public class S3FileSystem implements FileSystem {
         WildcardURI uri = new WildcardURI(path);
         String scheme = uri.getUri().getScheme();
         String bucket = uri.getAuthority();
-        String keyPattern = stripLeadingSlash(uri.getPath());
+        // uri.getPath() is "" for a bucket-root path (s3://bucket) and null for a malformed opaque
+        // URI (s3:foo); normalize both to "" so they fall back to the Hadoop path instead of NPEing.
+        String keyPattern = stripLeadingSlash(Strings.nullToEmpty(uri.getPath()));
 
         // Fall back to the Hadoop globStatus path for cases the native prefix pushdown does not
         // handle:
@@ -273,14 +276,27 @@ public class S3FileSystem implements FileSystem {
         return builder.build();
     }
 
-    // Longest literal prefix of a component: everything before the first glob metacharacter.
+    // Longest literal prefix of a component: everything before the first unescaped glob
+    // metacharacter, with escapes resolved. A backslash escapes the next character, so "\X" is a
+    // literal X that is still part of the prefix (matching Hadoop GlobPattern). For example
+    // "part-\*abc*.parquet" yields "part-*abc", which can be pushed down as the ListObjectsV2 prefix.
     private static String literalPrefixOf(String component) {
+        StringBuilder head = new StringBuilder(component.length());
         for (int i = 0; i < component.length(); ++i) {
-            if (GLOB_METACHARACTERS.indexOf(component.charAt(i)) >= 0) {
-                return component.substring(0, i);
+            char c = component.charAt(i);
+            if (c == '\\') {
+                if (i + 1 >= component.length()) {
+                    break; // trailing backslash: stop, treat as end of the literal head
+                }
+                head.append(component.charAt(++i)); // the escaped char is a literal
+                continue;
             }
+            if (GLOB_METACHARACTERS.indexOf(c) >= 0) {
+                break; // first unescaped wildcard
+            }
+            head.append(c);
         }
-        return component;
+        return head.toString();
     }
 
     private static boolean containsGlobWildcard(String key) {

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.fs.s3;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.common.StarRocksException;
@@ -163,7 +164,7 @@ public class S3FileSystem implements FileSystem {
      */
     private List<FileStatus> nativeGlobList(S3Client s3Client, String scheme, String bucket, String keyPattern)
             throws Exception {
-        List<String> components = getPathComponents(keyPattern);
+        List<String> components = Splitter.on(SEPARATOR).omitEmptyStrings().splitToList(keyPattern);
 
         // Candidate directory keys accumulated so far ("" == bucket root). Intermediate candidates
         // are always directories; only terminal matches may be files.
@@ -272,17 +273,6 @@ public class S3FileSystem implements FileSystem {
         return builder.build();
     }
 
-    // Split a key into non-empty path components, merging repeated slashes. E.g. "a//b/c" -> [a, b, c].
-    private static List<String> getPathComponents(String key) {
-        List<String> components = Lists.newArrayList();
-        for (String component : key.split(SEPARATOR)) {
-            if (!component.isEmpty()) {
-                components.add(component);
-            }
-        }
-        return components;
-    }
-
     // Longest literal prefix of a component: everything before the first glob metacharacter.
     private static String literalPrefixOf(String component) {
         for (int i = 0; i < component.length(); ++i) {
@@ -295,7 +285,15 @@ public class S3FileSystem implements FileSystem {
 
     private static boolean containsGlobWildcard(String key) {
         for (int i = 0; i < key.length(); ++i) {
-            if (GLOB_METACHARACTERS.indexOf(key.charAt(i)) >= 0) {
+            char c = key.charAt(i);
+            // A backslash escapes the next character, so "\X" is a literal X, not a wildcard
+            // (matching Hadoop GlobPattern). Skip the escaped char so escaped-only patterns such as
+            // "part-\*.parquet" are treated as exact paths and fall back to the efficient HEAD path.
+            if (c == '\\') {
+                i++;
+                continue;
+            }
+            if (GLOB_METACHARACTERS.indexOf(c) >= 0) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -44,8 +44,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A native S3 (and S3-compatible: oss/cosn/ks3/obs/tos) {@link FileSystem} implementation used to
- * accelerate glob listing for the FILES() table function.
+ * A native S3 (and S3-compatible: s3a/s3n/oss/cosn/ks3/obs/tos) {@link FileSystem} implementation
+ * used to accelerate glob listing for the FILES() table function.
  *
  * <p>The Hadoop {@code S3AFileSystem.globStatus} path resolves a wildcard pattern by listing the
  * parent "directory" of the first wildcard path component and filtering client-side. Because
@@ -89,17 +89,18 @@ public class S3FileSystem implements FileSystem {
     }
 
     /**
-     * Whether the given properties resolve to an AWS-style cloud configuration. When they do not
-     * (e.g. legacy {@code fs.oss.*} keys -> AliyunCloudConfiguration) the caller should fall back to
-     * the Hadoop path, since we build the client from {@link AwsCloudCredential}.
+     * Build the cloud configuration and return it only when it is an AWS-style configuration. Returns
+     * null when the properties do not resolve to AWS credentials (e.g. legacy {@code fs.oss.*} keys ->
+     * AliyunCloudConfiguration) or when building fails, in which case the caller falls back to the
+     * Hadoop path. The returned object is reused to build the client, so the map is parsed only once.
      */
-    public static boolean canHandle(Map<String, String> properties) {
+    protected AwsCloudConfiguration tryGetAwsCloudConfiguration() {
         try {
             CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
-            return cc instanceof AwsCloudConfiguration;
+            return cc instanceof AwsCloudConfiguration ? (AwsCloudConfiguration) cc : null;
         } catch (Exception e) {
             LOG.warn("Failed to build cloud configuration for native S3 glob, will fall back to hadoop path", e);
-            return false;
+            return null;
         }
     }
 
@@ -118,14 +119,23 @@ public class S3FileSystem implements FileSystem {
             return fallbackGlobList(path, skipDir);
         }
 
+        // Resolve the cloud configuration once here (after the cheap pattern gate) and reuse it to
+        // build the client. Non-AWS configurations fall back to the Hadoop path.
+        AwsCloudConfiguration awsCloudConfiguration = tryGetAwsCloudConfiguration();
+        if (awsCloudConfiguration == null) {
+            return fallbackGlobList(path, skipDir);
+        }
+
         long startTime = System.currentTimeMillis();
-        try (S3Client s3Client = createS3Client()) {
+        try (S3Client s3Client = createS3Client(awsCloudConfiguration)) {
             List<FileStatus> result = nativeGlobList(s3Client, scheme, bucket, keyPattern);
             List<FileStatus> filtered = skipDir
                     ? result.stream().filter(f -> !f.isDirectory()).collect(Collectors.toList())
                     : result;
-            LOG.info("S3 native globList done, path={}, matched={}, costMs={}",
-                    path, filtered.size(), System.currentTimeMillis() - startTime);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("S3 native globList done, path={}, matched={}, costMs={}",
+                        path, filtered.size(), System.currentTimeMillis() - startTime);
+            }
             return filtered;
         } catch (Exception e) {
             // Availability over optimization: any unexpected failure on the native path (e.g. an
@@ -248,12 +258,7 @@ public class S3FileSystem implements FileSystem {
         }
     }
 
-    protected S3Client createS3Client() throws StarRocksException {
-        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
-        if (!(cc instanceof AwsCloudConfiguration)) {
-            throw new StarRocksException("Native S3 glob requires an AWS cloud configuration");
-        }
-        AwsCloudConfiguration awsCloudConfiguration = (AwsCloudConfiguration) cc;
+    protected S3Client createS3Client(AwsCloudConfiguration awsCloudConfiguration) {
         AwsCloudCredential awsCloudCredential = awsCloudConfiguration.getAwsCloudCredential();
 
         S3ClientBuilder builder = S3Client.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -137,6 +137,10 @@ public class S3FileSystem implements FileSystem {
             List<FileStatus> filtered = skipDir
                     ? result.stream().filter(f -> !f.isDirectory()).collect(Collectors.toList())
                     : result;
+            // S3 returns CommonPrefixes (dirs) and Contents (files) as separate groups; sort by path
+            // so the result order matches the Hadoop globStatus path (Globber does Arrays.sort) and is
+            // deterministic.
+            filtered.sort(null);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("S3 native globList done, path={}, matched={}, costMs={}",
                         path, filtered.size(), System.currentTimeMillis() - startTime);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/s3/S3FileSystem.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CommonPrefix;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
@@ -268,7 +269,9 @@ public class S3FileSystem implements FileSystem {
         S3ClientBuilder builder = S3Client.builder()
                 .credentialsProvider(awsCloudCredential.generateAWSCredentialsProvider())
                 .region(awsCloudCredential.tryToResolveRegion())
-                .forcePathStyle(awsCloudConfiguration.getEnablePathStyleAccess());
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(awsCloudConfiguration.getEnablePathStyleAccess())
+                        .build());
         String endpoint = awsCloudCredential.getEndpoint();
         if (endpoint != null && !endpoint.isEmpty()) {
             builder.endpointOverride(AwsCredentialUtil.ensureSchemeInEndpoint(endpoint));

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -17,6 +17,7 @@ package com.starrocks.fs.s3;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.credential.aws.AwsCloudConfiguration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.junit.jupiter.api.Test;
@@ -36,8 +37,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class S3FileSystemTest {
 
-    private static Map<String, String> emptyProps() {
-        return Maps.newHashMap();
+    // Properties that resolve to an AwsCloudConfiguration, so globList takes the native path
+    // (the real client is never built because createS3Client is overridden in the fake).
+    private static Map<String, String> awsProps() {
+        Map<String, String> props = Maps.newHashMap();
+        props.put("aws.s3.use_aws_sdk_default_behavior", "true");
+        return props;
     }
 
     private static FileStatus file(String key) {
@@ -65,12 +70,12 @@ public class S3FileSystemTest {
         boolean throwOnList = false;
 
         FakeS3FileSystem(Map<String, List<FileStatus>> canned) {
-            super(emptyProps());
+            super(awsProps());
             this.canned = canned;
         }
 
         @Override
-        protected S3Client createS3Client() {
+        protected S3Client createS3Client(AwsCloudConfiguration awsCloudConfiguration) {
             return null; // unused: listWithPrefix is overridden
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -175,6 +175,16 @@ public class S3FileSystemTest {
     }
 
     @Test
+    public void testEscapedWildcardFallsBack() throws StarRocksException {
+        // "\*" is a literal '*', not a wildcard, so this is an exact path and must not take the
+        // native listing path.
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.globList("s3://bucket/data/part-\\*.parquet", true);
+        assertTrue(fs.fellBack);
+        assertTrue(fs.pushedDown.isEmpty());
+    }
+
+    @Test
     public void testNativeFailureFallsBackToHadoop() throws StarRocksException {
         FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
         fs.throwOnList = true;

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -231,6 +231,16 @@ public class S3FileSystemTest {
     }
 
     @Test
+    public void testResolveEndpointUriHonorsSsl() {
+        // No scheme: follow enable_ssl.
+        assertEquals("https://minio:9000", S3FileSystem.resolveEndpointUri("minio:9000", true).toString());
+        assertEquals("http://minio:9000", S3FileSystem.resolveEndpointUri("minio:9000", false).toString());
+        // Explicit scheme in the endpoint wins regardless of enable_ssl.
+        assertEquals("http://minio:9000", S3FileSystem.resolveEndpointUri("http://minio:9000", true).toString());
+        assertEquals("https://minio:9000", S3FileSystem.resolveEndpointUri("https://minio:9000", false).toString());
+    }
+
+    @Test
     public void testBuildListObjectsRequestPushesNarrowPrefix() {
         ListObjectsV2Request request =
                 S3FileSystem.buildListObjectsRequest("mybucket", "sn-fstore", "2026-06-24-13");

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.fs.s3;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.StarRocksException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class S3FileSystemTest {
+
+    private static Map<String, String> emptyProps() {
+        return Maps.newHashMap();
+    }
+
+    private static FileStatus file(String key) {
+        return new FileStatus(10, false, 1, 1, 0, new Path("s3", "bucket", "/" + key));
+    }
+
+    private static FileStatus dir(String key) {
+        return new FileStatus(0, true, 1, 1, 0, new Path("s3", "bucket", "/" + key));
+    }
+
+    private static List<String> sortedNames(List<FileStatus> files) {
+        return files.stream().map(f -> f.getPath().getName()).sorted().collect(Collectors.toList());
+    }
+
+    /**
+     * Intercepts the per-level S3 listing so tests can assert the pushed-down prefix and feed canned
+     * children without contacting S3. Also records fallback delegation.
+     */
+    private static class FakeS3FileSystem extends S3FileSystem {
+        // Each entry is the [parentKey, literalHead] pushed down for one listing call.
+        final List<String[]> pushedDown = Lists.newArrayList();
+        // canned[prefix] -> children returned for that prefix (prefix = parentKey + "/" + literalHead).
+        final Map<String, List<FileStatus>> canned;
+        boolean fellBack = false;
+        boolean throwOnList = false;
+
+        FakeS3FileSystem(Map<String, List<FileStatus>> canned) {
+            super(emptyProps());
+            this.canned = canned;
+        }
+
+        @Override
+        protected S3Client createS3Client() {
+            return null; // unused: listWithPrefix is overridden
+        }
+
+        @Override
+        protected List<FileStatus> listWithPrefix(S3Client s3Client, String scheme, String bucket,
+                                                  String parentKey, String literalHead) {
+            pushedDown.add(new String[] {parentKey, literalHead});
+            if (throwOnList) {
+                throw new RuntimeException("simulated S3 listing failure");
+            }
+            String prefix = parentKey.isEmpty() ? literalHead : parentKey + "/" + literalHead;
+            return canned.getOrDefault(prefix, Lists.newArrayList());
+        }
+
+        @Override
+        protected List<FileStatus> fallbackGlobList(String path, boolean skipDir) {
+            fellBack = true;
+            return Lists.newArrayList();
+        }
+    }
+
+    @Test
+    public void testPrefixPushdownAndGlobFilter() throws StarRocksException {
+        Map<String, List<FileStatus>> canned = Maps.newHashMap();
+        // Simulate what S3 returns for prefix "sn-fstore/2026-06-24-1".
+        canned.put("sn-fstore/2026-06-24-1", Lists.newArrayList(
+                file("sn-fstore/2026-06-24-13"),
+                file("sn-fstore/2026-06-24-13x"),  // '?' matches exactly one char -> filtered out
+                file("sn-fstore/2026-06-24-19")));
+        FakeS3FileSystem fs = new FakeS3FileSystem(canned);
+
+        List<FileStatus> res = fs.globList("s3://bucket/sn-fstore/2026-06-24-1?", true);
+
+        // The literal head of the wildcard component is pushed down, not just the parent dir.
+        assertEquals(1, fs.pushedDown.size());
+        assertEquals("sn-fstore", fs.pushedDown.get(0)[0]);
+        assertEquals("2026-06-24-1", fs.pushedDown.get(0)[1]);
+        // GlobFilter is still applied client-side to honor '?' semantics.
+        assertEquals(Lists.newArrayList("2026-06-24-13", "2026-06-24-19"), sortedNames(res));
+    }
+
+    @Test
+    public void testMultiLevelWildcardPushesDownEachLevel() throws StarRocksException {
+        Map<String, List<FileStatus>> canned = Maps.newHashMap();
+        canned.put("logs/2026-", Lists.newArrayList(
+                dir("logs/2026-06"),
+                dir("logs/2026-07"),
+                file("logs/2026-note.txt")));      // a file at an intermediate level must not recurse
+        canned.put("logs/2026-06/13", Lists.newArrayList(
+                file("logs/2026-06/13-a.parquet"),
+                file("logs/2026-06/139.parquet")));
+        canned.put("logs/2026-07/13", Lists.newArrayList(
+                file("logs/2026-07/13-b.parquet")));
+        FakeS3FileSystem fs = new FakeS3FileSystem(canned);
+
+        List<FileStatus> res = fs.globList("s3://bucket/logs/2026-*/13*", true);
+
+        // Level 1 pushes down "2026-" under "logs"; level 2 pushes down "13" under each matched dir.
+        assertTrue(fs.pushedDown.stream()
+                .anyMatch(p -> p[0].equals("logs") && p[1].equals("2026-")));
+        assertTrue(fs.pushedDown.stream()
+                .anyMatch(p -> p[0].equals("logs/2026-06") && p[1].equals("13")));
+        assertTrue(fs.pushedDown.stream()
+                .anyMatch(p -> p[0].equals("logs/2026-07") && p[1].equals("13")));
+        assertEquals(Lists.newArrayList("13-a.parquet", "13-b.parquet", "139.parquet"), sortedNames(res));
+    }
+
+    @Test
+    public void testSkipDirFlag() throws StarRocksException {
+        Map<String, List<FileStatus>> canned = Maps.newHashMap();
+        canned.put("data/part", Lists.newArrayList(
+                file("data/part-0.parquet"),
+                dir("data/part-subdir")));
+        FakeS3FileSystem withDirs = new FakeS3FileSystem(canned);
+        List<FileStatus> all = withDirs.globList("s3://bucket/data/part*", false);
+        assertEquals(Lists.newArrayList("part-0.parquet", "part-subdir"), sortedNames(all));
+
+        FakeS3FileSystem skip = new FakeS3FileSystem(canned);
+        List<FileStatus> filesOnly = skip.globList("s3://bucket/data/part*", true);
+        assertEquals(Lists.newArrayList("part-0.parquet"), sortedNames(filesOnly));
+    }
+
+    @Test
+    public void testBracePatternFallsBack() throws StarRocksException {
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.globList("s3://bucket/data/part-{a,b}.parquet", true);
+        assertTrue(fs.fellBack);
+        assertTrue(fs.pushedDown.isEmpty());
+    }
+
+    @Test
+    public void testExactPathFallsBack() throws StarRocksException {
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.globList("s3://bucket/data/part-0.parquet", true);
+        assertTrue(fs.fellBack);
+        assertTrue(fs.pushedDown.isEmpty());
+    }
+
+    @Test
+    public void testNativeFailureFallsBackToHadoop() throws StarRocksException {
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.throwOnList = true;
+        fs.globList("s3://bucket/sn-fstore/2026-06-24-13*", true);
+        // The native path was attempted, then it fell back to the Hadoop globStatus path.
+        assertTrue(fs.pushedDown.size() >= 1);
+        assertTrue(fs.fellBack);
+    }
+
+    @Test
+    public void testBuildListObjectsRequestPushesNarrowPrefix() {
+        ListObjectsV2Request request =
+                S3FileSystem.buildListObjectsRequest("mybucket", "sn-fstore", "2026-06-24-13");
+        assertEquals("mybucket", request.bucket());
+        assertEquals("sn-fstore/2026-06-24-13", request.prefix());
+        assertEquals("/", request.delimiter());
+
+        // Root-level listing (empty parent) uses the literal head verbatim.
+        ListObjectsV2Request rootRequest = S3FileSystem.buildListObjectsRequest("mybucket", "", "logs-");
+        assertEquals("logs-", rootRequest.prefix());
+    }
+
+    @Test
+    public void testCollectPageParsesResponse() {
+        ListObjectsV2Response page = ListObjectsV2Response.builder()
+                .contents(
+                        S3Object.builder().key("sn-fstore/2026-06-24-13-a.parquet")
+                                .size(5L).lastModified(Instant.ofEpochMilli(1000)).build(),
+                        // directory placeholder object, must be skipped
+                        S3Object.builder().key("sn-fstore/2026-06-24-13/").size(0L).build())
+                .commonPrefixes(CommonPrefix.builder().prefix("sn-fstore/2026-06-24-13-dir/").build())
+                .build();
+
+        List<FileStatus> out = Lists.newArrayList();
+        S3FileSystem.collectPage("s3", "mybucket", page, out);
+
+        // File + common-prefix dir are returned; the "/"-suffixed placeholder object is dropped.
+        assertEquals(Lists.newArrayList("2026-06-24-13-a.parquet", "2026-06-24-13-dir"), sortedNames(out));
+        FileStatus dir = out.stream().filter(FileStatus::isDirectory).findFirst().orElseThrow();
+        assertEquals("s3://mybucket/sn-fstore/2026-06-24-13-dir", dir.getPath().toString());
+        FileStatus file = out.stream().filter(f -> !f.isDirectory()).findFirst().orElseThrow();
+        assertEquals(5, file.getLen());
+        assertEquals(1000, file.getModificationTime());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -175,11 +175,31 @@ public class S3FileSystemTest {
     }
 
     @Test
+    public void testEscapedLiteralIsPartOfPushedPrefix() throws StarRocksException {
+        // "\*" is a literal '*', so the literal head before the real wildcard is "part-*abc" and can
+        // be pushed down as the prefix (not just "part-").
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.globList("s3://bucket/dir/part-\\*abc*.parquet", true);
+        assertEquals(1, fs.pushedDown.size());
+        assertEquals("dir", fs.pushedDown.get(0)[0]);
+        assertEquals("part-*abc", fs.pushedDown.get(0)[1]);
+    }
+
+    @Test
     public void testEscapedWildcardFallsBack() throws StarRocksException {
         // "\*" is a literal '*', not a wildcard, so this is an exact path and must not take the
         // native listing path.
         FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
         fs.globList("s3://bucket/data/part-\\*.parquet", true);
+        assertTrue(fs.fellBack);
+        assertTrue(fs.pushedDown.isEmpty());
+    }
+
+    @Test
+    public void testBucketRootFallsBack() throws StarRocksException {
+        // s3://bucket has an empty path; it must fall back gracefully (no NPE, no native listing).
+        FakeS3FileSystem fs = new FakeS3FileSystem(Maps.newHashMap());
+        fs.globList("s3://bucket", true);
         assertTrue(fs.fellBack);
         assertTrue(fs.pushedDown.isEmpty());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/s3/S3FileSystemTest.java
@@ -144,6 +144,22 @@ public class S3FileSystemTest {
     }
 
     @Test
+    public void testResultsSortedByPath() throws StarRocksException {
+        // S3 returns dirs (CommonPrefixes) and files (Contents) as separate groups and in listing
+        // order; the result must be globally sorted by path, matching the Hadoop globStatus path.
+        Map<String, List<FileStatus>> canned = Maps.newHashMap();
+        canned.put("", Lists.newArrayList(
+                dir("orc1"), file("basic2.csv"), dir("orc0"), file("basic1.csv"), dir("parquet")));
+        FakeS3FileSystem fs = new FakeS3FileSystem(canned);
+
+        List<FileStatus> res = fs.globList("s3://bucket/*", false);
+
+        // Actual returned order (not re-sorted by the assertion) must already be sorted.
+        List<String> names = res.stream().map(f -> f.getPath().getName()).collect(Collectors.toList());
+        assertEquals(Lists.newArrayList("basic1.csv", "basic2.csv", "orc0", "orc1", "parquet"), names);
+    }
+
+    @Test
     public void testSkipDirFlag() throws StarRocksException {
         Map<String, List<FileStatus>> canned = Maps.newHashMap();
         canned.put("data/part", Lists.newArrayList(


### PR DESCRIPTION
  ## Why I'm doing:

  `SELECT count(*) FROM FILES("path" = "s3://bucket/prefix/2026-06-24-13*", ...)` can be
  extremely slow on the FE when the parent prefix (`s3://bucket/prefix/`) holds a huge number
  of objects (up to millions) even though only a few match the wildcard.

  Root cause: for S3/S3-compatible object stores the FE resolves the glob via Hadoop
  `S3AFileSystem.globStatus`. Hadoop's `Globber` splits the pattern on `/` and, at the first
  wildcard component, lists the parent "directory" and filters client-side. The literal head
  inside a wildcard component (e.g. `2026-06-24-13` in `2026-06-24-13*`) is never pushed down
  as a `ListObjectsV2` prefix, so S3 enumerates the whole parent prefix (paginated 1000 keys
  per request) and the FE discards almost everything.

  ## What I'm doing:

  Add a native S3 `FileSystem` implementation (`S3FileSystem`) that accelerates glob listing
  for the `files()` table function on S3 and S3-compatible stores
  (s3/s3a/s3n/oss/cosn/ks3/obs/tos):

  - Push the longest literal prefix of each wildcard component down into
    `ListObjectsV2(prefix=...)` so S3 returns only the matching keys, then apply a Hadoop
    `GlobFilter` client-side to preserve glob semantics (notably that `*` does not cross `/`).
  - Routing in `FileSystem.getFileSystem` is gated only on the object-store scheme + the config
    switch — deliberately cheap, with no cloud-config build at routing time. The remaining
    decisions are made inside `S3FileSystem.globList`, in cheap-to-expensive order:
      1. pattern gate — exact paths and brace `{a,b}` patterns fall back to the Hadoop
         `globStatus` path before any cloud-config is built;
      2. config gate — the cloud configuration is built once here; if it is not an
         `AwsCloudConfiguration` (e.g. legacy `fs.oss.*` keys) it falls back to the Hadoop path;
         otherwise the same object is reused to build the S3 client, so the property map is
         parsed only once on the fast path.
    Everything else (HDFS, Azure, GCS) keeps the existing Hadoop path via scheme routing.
  - `getHdfsProperties` is delegated to the Hadoop implementation, so the BE read path is
    unchanged.
  - Availability first: any unexpected failure on the native path logs a warning and falls back
    to the Hadoop `globStatus` path so the query still succeeds.
  - New mutable config `s3_use_native_sdk_for_glob` (default `true`) acts as a kill switch to
    fall back to the old behavior at runtime.

  The optimization only helps when a wildcard has a non-empty literal head; purely non-prefix
  patterns (e.g. `*.parquet`) cannot be pushed down to S3 and behave exactly as before (no
  regression). HDFS cannot benefit either, as it has no server-side prefix-listing API.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
