### PR TITLE
[Enhancement] Preserve real error status when async delta writer is stopped

### DIFF
--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -134,11 +134,11 @@ void AsyncDeltaWriter::write(const AsyncDeltaWriterRequest& req, AsyncDeltaWrite
     if (r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
         FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
-        if (_writer->get_err_status().ok()) {
-            task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
-        } else {
-            task.write_cb->run(_writer->get_err_status(), nullptr, &failed_info);
+        Status st = _writer->get_err_status();
+        if (st.ok()) {
+            st = Status::InternalError("fail to call execution_queue_execute");
         }
+        task.write_cb->run(st, nullptr, &failed_info);
     }
 }
 
@@ -173,11 +173,11 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     if (r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
         FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
-        if (_writer->get_err_status().ok()) {
-            task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
-        } else {
-            task.write_cb->run(_writer->get_err_status(), nullptr, &failed_info);
+        Status st = _writer->get_err_status();
+        if (st.ok()) {
+            st = Status::InternalError("fail to call execution_queue_execute");
         }
+        task.write_cb->run(st, nullptr, &failed_info);
     }
 }
 

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -134,7 +134,11 @@ void AsyncDeltaWriter::write(const AsyncDeltaWriterRequest& req, AsyncDeltaWrite
     if (r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
         FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
-        task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
+        if (_writer->get_err_status().ok()) {
+            task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
+        } else {
+            task.write_cb->run(_writer->get_err_status(), nullptr, &failed_info);
+        }
     }
 }
 
@@ -169,7 +173,11 @@ void AsyncDeltaWriter::commit(AsyncDeltaWriterCallback* cb) {
     if (r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
         FailedRowsetInfo failed_info{.tablet_id = _writer->tablet()->tablet_id(), .replicate_token = nullptr};
-        task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
+        if (_writer->get_err_status().ok()) {
+            task.write_cb->run(Status::InternalError("fail to call execution_queue_execute"), nullptr, &failed_info);
+        } else {
+            task.write_cb->run(_writer->get_err_status(), nullptr, &failed_info);
+        }
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

We saw such SQL exceptions:
```
SQL Exception: SQLState=null, ErrorCode=0, Message= SQL Exception [(conn=50369772) xxxx.cluster.local: fail to call execution_queue_execute: BE:10232] in 
```

Instead of real failures of `execution_queue_execute()`, we suspect the queue was stopped by the time `AsyncDeltaWriter::write()` / `AsyncDeltaWriter::commit()` was called. This could happen because `write()`/`commit()` and `AsyncDeltaWriter::abort()` are called by different threads. 

In the above case, such SQL exceptions mask the real cause of a query failure. 

## What I'm doing:

Surface the writer's error status when there's one.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
