### PR TITLE
[BugFix] Escape jsonpaths value in SHOW CREATE ROUTINE LOAD output (backport #75755)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1734,6 +1734,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         return gson.toJson(jobProperties);
     }
 
+    // Escape a value for embedding in a double-quoted SQL string literal: backslash first, then
+    // double quote. Pairs with the parser's escapeBackSlash() so the emitted DDL parses back to
+    // the original value. escapeJava is unsuitable here: it emits \\uXXXX for non-ASCII chars,
+    // which escapeBackSlash() cannot decode, silently corrupting e.g. CJK jsonpaths.
+    private static String escapeForDoubleQuotedSql(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
     public String jobPropertiesToSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("(\n");
@@ -1762,13 +1770,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         sb.append(getFormat()).append("\",\n");
 
         sb.append("\"").append(CreateRoutineLoadStmt.JSONPATHS).append("\"=\"");
-        sb.append(getJsonPaths()).append("\",\n");
+        sb.append(escapeForDoubleQuotedSql(getJsonPaths())).append("\",\n");
 
         sb.append("\"").append(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY).append("\"=\"");
         sb.append(isStripOuterArray()).append("\",\n");
 
         sb.append("\"").append(CreateRoutineLoadStmt.JSONROOT).append("\"=\"");
-        sb.append(getJsonRoot()).append("\",\n");
+        sb.append(escapeForDoubleQuotedSql(getJsonRoot())).append("\",\n");
 
         sb.append("\"").append(LoadStmt.STRICT_MODE).append("\"=\"");
         sb.append(isStrictMode()).append("\",\n");
@@ -1784,7 +1792,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
         if (getMergeCondition() != null) {
             sb.append("\"").append(LoadStmt.MERGE_CONDITION).append("\"=\"");
-            sb.append(getMergeCondition()).append("\",\n");
+            sb.append(escapeForDoubleQuotedSql(getMergeCondition())).append("\",\n");
         }
 
         sb.append("\"").append(CreateRoutineLoadStmt.TRIMSPACE).append("\"=\"");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadDDLTest.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import com.starrocks.sql.ast.CreateRoutineLoadStmt;
+import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+// The DDL generated for SHOW CREATE ROUTINE LOAD must be runnable: user-controlled property
+// values (jsonpaths, json_root, merge_condition) can contain double quotes and backslashes,
+// which must be escaped so the emitted statement parses back to the original values.
+public class ShowCreateRoutineLoadDDLTest {
+
+    private KafkaRoutineLoadJob jobWithProperties(Map<String, String> extraProperties) {
+        KafkaRoutineLoadJob job = new KafkaRoutineLoadJob(1L, "testJob", 10L, 20L, "127.0.0.1:9092", "topic1");
+        Map<String, String> jobProperties = Deencapsulation.getField(job, "jobProperties");
+        jobProperties.putAll(extraProperties);
+        return job;
+    }
+
+    // Embed jobPropertiesToSql() output in a full CREATE ROUTINE LOAD statement, parse it back,
+    // and return the raw job properties the parser recovered.
+    private Map<String, String> roundTrip(KafkaRoutineLoadJob job) {
+        String ddl = "CREATE ROUTINE LOAD testDb.testJob ON testTbl PROPERTIES " + job.jobPropertiesToSql() +
+                "FROM KAFKA (\"kafka_broker_list\"=\"127.0.0.1:9092\",\"kafka_topic\"=\"topic1\")";
+        List<StatementBase> stmts = SqlParser.parse(ddl, 32);
+        Assertions.assertEquals(1, stmts.size(), ddl);
+        CreateRoutineLoadStmt parsed = (CreateRoutineLoadStmt) stmts.get(0);
+        return parsed.getJobProperties();
+    }
+
+    @Test
+    public void testJsonPathsWithDoubleQuotesRoundTrip() {
+        String jsonPaths = "[\"$.id\", \"$.name\"]";
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(
+                CreateRoutineLoadStmt.FORMAT, "json",
+                CreateRoutineLoadStmt.JSONPATHS, jsonPaths));
+
+        // The emitted value must carry escaped quotes, not raw ones.
+        String propertiesSql = job.jobPropertiesToSql();
+        Assertions.assertTrue(propertiesSql.contains("\"jsonpaths\"=\"[\\\"$.id\\\", \\\"$.name\\\"]\""),
+                propertiesSql);
+
+        Assertions.assertEquals(jsonPaths, roundTrip(job).get(CreateRoutineLoadStmt.JSONPATHS));
+    }
+
+    @Test
+    public void testNonAsciiJsonPathsRoundTrip() {
+        // Non-ASCII path keys must survive unchanged; escapeJava-style \\uXXXX escaping would
+        // corrupt them because the parser's escapeBackSlash() cannot decode unicode escapes.
+        String jsonPaths = "[\"$.用户名\"]";
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(
+                CreateRoutineLoadStmt.FORMAT, "json",
+                CreateRoutineLoadStmt.JSONPATHS, jsonPaths));
+
+        Assertions.assertEquals(jsonPaths, roundTrip(job).get(CreateRoutineLoadStmt.JSONPATHS));
+    }
+
+    @Test
+    public void testJsonPathsWithBackslashRoundTrip() {
+        String jsonPaths = "[\"$.a\\b\"]";
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(
+                CreateRoutineLoadStmt.FORMAT, "json",
+                CreateRoutineLoadStmt.JSONPATHS, jsonPaths));
+
+        Assertions.assertEquals(jsonPaths, roundTrip(job).get(CreateRoutineLoadStmt.JSONPATHS));
+    }
+
+    @Test
+    public void testAdjacentBackslashQuoteRoundTrip() {
+        // A backslash immediately followed by a double quote is the trickiest interaction:
+        // the pair must escape to \\\" and decode back to \" rather than collapsing.
+        String jsonPaths = "[\"$.a\\\"b\"]";
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(
+                CreateRoutineLoadStmt.FORMAT, "json",
+                CreateRoutineLoadStmt.JSONPATHS, jsonPaths));
+
+        String propertiesSql = job.jobPropertiesToSql();
+        Assertions.assertTrue(propertiesSql.contains("\"jsonpaths\"=\"[\\\"$.a\\\\\\\"b\\\"]\""), propertiesSql);
+
+        Assertions.assertEquals(jsonPaths, roundTrip(job).get(CreateRoutineLoadStmt.JSONPATHS));
+    }
+
+    @Test
+    public void testJsonRootAndMergeConditionRoundTrip() {
+        String jsonRoot = "$.\"da\\ta\"";
+        String mergeCondition = "src.op = \"delete\"";
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(
+                CreateRoutineLoadStmt.FORMAT, "json",
+                CreateRoutineLoadStmt.JSONPATHS, "[\"$.id\"]",
+                CreateRoutineLoadStmt.JSONROOT, jsonRoot,
+                LoadStmt.MERGE_CONDITION, mergeCondition));
+
+        Map<String, String> parsed = roundTrip(job);
+        Assertions.assertEquals(jsonRoot, parsed.get(CreateRoutineLoadStmt.JSONROOT));
+        Assertions.assertEquals(mergeCondition, parsed.get(LoadStmt.MERGE_CONDITION));
+    }
+
+    @Test
+    public void testEmptyJsonPathsRoundTrip() {
+        KafkaRoutineLoadJob job = jobWithProperties(Map.of(CreateRoutineLoadStmt.FORMAT, "json"));
+
+        Assertions.assertEquals("", roundTrip(job).get(CreateRoutineLoadStmt.JSONPATHS));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #75755 (squashed commit `94637df`). Mergify's automatic backport failed with a cherry-pick conflict in `RoutineLoadJob.java` and auto-closed the original backport PR (#75770). Resubmitting with the conflict resolved.

The conflict was purely contextual: the three call-site edits (`jsonpaths`, `json_root`, `merge_condition`) applied cleanly, and the only conflicting hunk was the insertion point of the new `escapeForDoubleQuotedSql` helper, which main anchors after an unrelated `columnDescsToSql` method that does not exist on this branch. Resolution keeps only the `escapeForDoubleQuotedSql` helper; no unrelated code was pulled in. The resulting source and test are byte-identical to the merged change.

Original description:

`SHOW CREATE ROUTINE LOAD` emits the `jsonpaths` property value raw into a double-quoted SQL string. A real `jsonpaths` value contains double quotes, e.g. `["$.id", "$.name"]`, which terminate the enclosing `"..."` early and produce non-runnable DDL — copy/paste of the output fails to parse. The same generated DDL is used in replay/migration and tooling paths, so the job definition is effectively unrecoverable from the output. The sibling `json_root` and `merge_condition` properties have the same latent bug (a merge condition can legitimately contain a string literal like `src.op = "delete"`).

## What I'm doing:

Escape backslashes and double quotes in the `jsonpaths`, `json_root`, and `merge_condition` values in `RoutineLoadJob.jobPropertiesToSql()` via a small targeted helper (`\` first, then `"`).

A targeted escape is used instead of `StringEscapeUtils.escapeJava` (the convention used for `enclose`/`escape`) deliberately: `escapeJava` emits `\uXXXX` for non-ASCII characters, which the parser's `escapeBackSlash()` cannot decode. That would turn a CJK jsonpath like `["$.用户名"]` into a silently wrong path (loading NULLs) instead of failing loudly at parse time. The targeted escape round-trips all inputs exactly.

Added `ShowCreateRoutineLoadDDLTest` with round-trip tests: the emitted properties SQL is embedded into a full `CREATE ROUTINE LOAD` statement, parsed back, and the recovered values are asserted equal to the originals.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This is a backport pr

This is a manual backport of #75755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

