### PR TITLE
[BugFix] Skip load spill clear_parent_path when no remote block used

### DIFF
--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -88,6 +88,11 @@ LoadSpillBlockManager::~LoadSpillBlockManager() {
 }
 
 Status LoadSpillBlockManager::clear_parent_path() {
+    // Skip cleanup if no remote block was ever acquired: a purely local spill never creates the
+    // remote parent directory, so acquiring a dir and issuing a remote delete would be wasted work.
+    if (!_used_remote_block.load(std::memory_order_relaxed)) {
+        return Status::OK();
+    }
     // _remote_dir_manager is initialized in init(), skip cleanup if init() was not called or failed
     Status status = Status::OK();
     if (_remote_dir_manager != nullptr) {
@@ -149,7 +154,13 @@ StatusOr<spill::BlockPtr> LoadSpillBlockManager::acquire_block(size_t block_size
     // Defer parent path deletion to LoadSpillBlockManager::~LoadSpillBlockManager(),
     // so the directory is only removed after all spill files have been cleaned up.
     opts.skip_parent_path_deletion = true;
-    return _block_manager->acquire_block(opts);
+    ASSIGN_OR_RETURN(auto block, _block_manager->acquire_block(opts));
+    if (block->is_remote()) {
+        // Remember that at least one remote block exists so clear_parent_path() knows the remote
+        // parent directory may need cleanup.
+        _used_remote_block.store(true, std::memory_order_relaxed);
+    }
+    return block;
 }
 
 // return Block to BlockManager

--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -93,6 +93,11 @@ Status LoadSpillBlockManager::clear_parent_path() {
     if (!_used_remote_block.load(std::memory_order_relaxed)) {
         return Status::OK();
     }
+    // Release all spill blocks first. Their backing files are removed synchronously by
+    // ~FileBlockContainer() (which was created with skip_parent_path_deletion=true, so it only
+    // deletes the block file, not the parent dir). Without this, delete_dir() below runs while the
+    // block files still exist, sees a non-empty directory, and leaves an orphaned <load_id>/ dir marker.
+    _block_container.reset();
     // _remote_dir_manager is initialized in init(), skip cleanup if init() was not called or failed
     Status status = Status::OK();
     if (_remote_dir_manager != nullptr) {

--- a/be/src/storage/lake/load_spill_block_manager.h
+++ b/be/src/storage/lake/load_spill_block_manager.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "exec/spill/block_manager.h"
 #include "exec/spill/dir_manager.h"
 #include "exec/spill/input_stream.h"
@@ -80,6 +82,8 @@ public:
     // Delete the remote spill parent directory (e.g. <remote_spill_path>/<load_id>).
     // Called in destructor after all spill blocks have been released, so that individual
     // container destructors only delete their own files and this method cleans up the directory.
+    // No-op (no remote acquire_dir/delete_dir) when no remote block was ever acquired, since a
+    // purely local spill never creates the remote parent directory.
     Status clear_parent_path();
 
     // acquire Block from BlockManager
@@ -101,6 +105,10 @@ private:
     std::unique_ptr<spill::BlockManager> _block_manager;       // Manager for blocks.
     std::unique_ptr<LoadSpillBlockContainer> _block_container; // Container for blocks.
     bool _initialized = false;                                 // Whether the manager is initialized.
+    // Set once any remote block is acquired. When it stays false, no remote parent directory was
+    // ever created, so clear_parent_path() can skip the remote acquire_dir + delete_dir calls.
+    // Atomic because blocks may be acquired concurrently by parallel flush threads.
+    std::atomic<bool> _used_remote_block{false};
 };
 
 } // namespace lake

--- a/be/test/storage/lake/load_spill_block_manager_test.cpp
+++ b/be/test/storage/lake/load_spill_block_manager_test.cpp
@@ -115,6 +115,41 @@ TEST_F(LoadSpillBlockManagerTest, test_destroy_does_not_clear_parent_path) {
     ASSERT_TRUE(status.ok()) << "Expected parent path to still exist after destroy, but got: " << status;
 }
 
+// Regression test: clear_parent_path() must delete the parent directory even when the spill blocks
+// are still held by the manager's block container (the real DeltaWriter flow, where blocks are
+// appended to block_container() and only released when the manager is torn down). Previously
+// clear_parent_path() called delete_dir() while the block files still existed, so delete_dir() saw a
+// non-empty directory and left an orphaned <load_id>/ dir marker behind.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_with_blocks_in_container) {
+    TUniqueId load_id;
+    load_id.hi = 23456;
+    load_id.lo = 78901;
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(load_id, 1, 1, kTestDir);
+    ASSERT_OK(block_manager->init());
+
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024, /*force_remote=*/true));
+    ASSERT_OK(block->append({Slice("test_data")}));
+    ASSERT_OK(block->flush());
+
+    // Mirror the production flow (SpillMemTableSink): a block group is created, the block is released
+    // and then handed to the manager's block container, and the caller drops its own reference. The
+    // block file therefore survives until the container is reset.
+    block_manager->block_container()->create_block_group();
+    ASSERT_OK(block_manager->release_block(block));
+    block_manager->block_container()->append_block(block);
+    block.reset();
+
+    std::string parent_path = std::string(kTestDir) + "/load_spill/" + print_id(load_id);
+    auto status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_OK(status);
+
+    // clear_parent_path() must release the container (deleting the block files) before delete_dir().
+    ASSERT_OK(block_manager->clear_parent_path());
+
+    status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_TRUE(status.is_not_found()) << "Expected parent path to be deleted, but got: " << status;
+}
+
 // Test that clear_parent_path() is a no-op when only local blocks were acquired.
 // A purely local spill never creates the remote parent directory, so clear_parent_path()
 // must skip the remote acquire_dir + delete_dir work and must not create anything.

--- a/be/test/storage/lake/load_spill_block_manager_test.cpp
+++ b/be/test/storage/lake/load_spill_block_manager_test.cpp
@@ -115,6 +115,34 @@ TEST_F(LoadSpillBlockManagerTest, test_destroy_does_not_clear_parent_path) {
     ASSERT_TRUE(status.ok()) << "Expected parent path to still exist after destroy, but got: " << status;
 }
 
+// Test that clear_parent_path() is a no-op when only local blocks were acquired.
+// A purely local spill never creates the remote parent directory, so clear_parent_path()
+// must skip the remote acquire_dir + delete_dir work and must not create anything.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_skipped_for_local_only) {
+    TUniqueId load_id;
+    load_id.hi = 12345;
+    load_id.lo = 67890;
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(load_id, 1, 1, kTestDir);
+    ASSERT_OK(block_manager->init());
+
+    // Acquire a local block only (force_remote=false) — the remote parent path is never created.
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024));
+    ASSERT_FALSE(block->is_remote());
+    ASSERT_OK(block->append({Slice("local_only")}));
+    ASSERT_OK(block->flush());
+
+    std::string parent_path = std::string(kTestDir) + "/load_spill/" + print_id(load_id);
+    ASSERT_TRUE(FileSystem::Default()->path_exists(parent_path).is_not_found());
+
+    ASSERT_OK(block_manager->release_block(block));
+    block.reset();
+
+    // No remote block was ever acquired, so clear_parent_path() returns OK without creating
+    // or touching the remote parent directory.
+    ASSERT_OK(block_manager->clear_parent_path());
+    ASSERT_TRUE(FileSystem::Default()->path_exists(parent_path).is_not_found());
+}
+
 // Test that clear_parent_path() is safe to call when init() was not called.
 TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_without_init) {
     auto block_manager = std::make_unique<LoadSpillBlockManager>(TUniqueId(), 1, 1, kTestDir);


### PR DESCRIPTION
## Why I'm doing:

`LoadSpillBlockManager::clear_parent_path()` is invoked unconditionally on the
`DeltaWriter` close path. Even when a load spills entirely to local storage and
never touches remote storage, it still issues a remote
`acquire_writable_dir()` followed by a `delete_dir()` against the object store.
For a local-only spill the remote parent directory was never created, so these
remote calls are pure overhead (extra object-store round-trips) with nothing to
clean up.

## What I'm doing:

Track whether any remote block was ever acquired:

- `acquire_block()` sets an atomic `_used_remote_block` flag when the block it
  returns is remote (either `force_remote` or a local-acquire fallback).
- `clear_parent_path()` returns early (no-op) when the flag is still false, so a
  purely local spill skips the remote `acquire_writable_dir` + `delete_dir`
  entirely.

The flag is atomic because blocks may be acquired concurrently by parallel
flush threads. Behavior is unchanged whenever any remote block exists — the
parent directory is still cleaned up exactly as before.

Added a UT (`test_clear_parent_path_skipped_for_local_only`) asserting that a
local-only spill never creates the remote parent directory and that
`clear_parent_path()` is a clean no-op.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
