### PR TITLE
[BugFix] Delete load spill blocks before removing the per-load spill dir

### DIFF
--- a/be/src/storage/lake/load_spill_block_manager.cpp
+++ b/be/src/storage/lake/load_spill_block_manager.cpp
@@ -88,6 +88,11 @@ LoadSpillBlockManager::~LoadSpillBlockManager() {
 }
 
 Status LoadSpillBlockManager::clear_parent_path() {
+    // Release all spill blocks first. Their backing files are removed synchronously by
+    // ~FileBlockContainer() (which was created with skip_parent_path_deletion=true, so it only
+    // deletes the block file, not the parent dir). Without this, delete_dir() below runs while the
+    // block files still exist, sees a non-empty directory, and leaves an orphaned <load_id>/ dir marker.
+    _block_container.reset();
     // _remote_dir_manager is initialized in init(), skip cleanup if init() was not called or failed
     Status status = Status::OK();
     if (_remote_dir_manager != nullptr) {

--- a/be/test/storage/lake/load_spill_block_manager_test.cpp
+++ b/be/test/storage/lake/load_spill_block_manager_test.cpp
@@ -86,6 +86,39 @@ TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path) {
     ASSERT_TRUE(status.is_not_found()) << "Expected parent path to be deleted, but got: " << status;
 }
 
+// Regression test: clear_parent_path() must delete the parent directory even when the spill blocks
+// are still held by the manager's block container (the real DeltaWriter flow, where blocks are
+// appended to block_container() and only released when the manager is torn down). Previously
+// clear_parent_path() called delete_dir() while the block files still existed, so delete_dir() saw a
+// non-empty directory and left an orphaned <load_id>/ dir marker behind.
+TEST_F(LoadSpillBlockManagerTest, test_clear_parent_path_with_blocks_in_container) {
+    TUniqueId load_id;
+    load_id.hi = 23456;
+    load_id.lo = 78901;
+    auto block_manager = std::make_unique<LoadSpillBlockManager>(load_id, 1, 1, kTestDir);
+    ASSERT_OK(block_manager->init());
+
+    ASSIGN_OR_ABORT(auto block, block_manager->acquire_block(1024, /*force_remote=*/true));
+    ASSERT_OK(block->append({Slice("test_data")}));
+    ASSERT_OK(block->flush());
+
+    // Mirror the production flow: the block is owned by the manager's block container, and the caller
+    // drops its own reference. The block file therefore survives until the container is reset.
+    block_manager->block_container()->append_block(block);
+    ASSERT_OK(block_manager->release_block(block));
+    block.reset();
+
+    std::string parent_path = std::string(kTestDir) + "/load_spill/" + print_id(load_id);
+    auto status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_OK(status);
+
+    // clear_parent_path() must release the container (deleting the block files) before delete_dir().
+    ASSERT_OK(block_manager->clear_parent_path());
+
+    status = FileSystem::Default()->iterate_dir(parent_path, [](std::string_view) -> bool { return true; });
+    ASSERT_TRUE(status.is_not_found()) << "Expected parent path to be deleted, but got: " << status;
+}
+
 // Test that destroying LoadSpillBlockManager does NOT clean up the spill parent directory.
 // The cleanup should be done explicitly via clear_parent_path() in DeltaWriter::close().
 TEST_F(LoadSpillBlockManagerTest, test_destroy_does_not_clear_parent_path) {


### PR DESCRIPTION
## Why I'm doing:

On shared-data primary key loads that spill to remote object storage, every load leaves an orphaned 0-byte `<remote_spill_path>/load_spill/<load_id>/` directory marker behind in the object store. They accumulate one-per-load and are only reclaimed later by GC/vacuum.

Root cause: `LoadSpillBlockManager::clear_parent_path()` (called from `DeltaWriterImpl::release_resources()`) calls `delete_dir()` while the spill blocks are still held by `_block_container`, so their backing files still exist. `delete_dir()` is a delete-empty-dir operation, sees a non-empty directory, returns `"not empty"`, and — because the status is intentionally ignored (best-effort, "cleared by GC later") — the dir marker is never removed. The block files are only deleted afterwards by `~FileBlockContainer()` when `~LoadSpillBlockManager()` resets the container, i.e. after the one-shot `clear_parent_path()` already gave up.

Verified on a branch-3.5 shared-data cluster: `clear_parent_path` logs `Failed to clear load spill parent path ... dir load_spill/<load_id> is not empty`, and the empty `<load_id>/` marker persists across loads (accumulating one per remote-spill load). The spill *data* files themselves are correctly hot-deleted during merge — only the empty dir marker leaks.

## What I'm doing:

Reset `_block_container` at the start of `clear_parent_path()` so the spill block files are deleted synchronously (via `~FileBlockContainer`, created with `skip_parent_path_deletion=true`) **before** `delete_dir()` runs. This honors the intent already documented on `acquire_block()`: the directory is only removed after all spill files are cleaned up.

Added a regression test (`test_clear_parent_path_with_blocks_in_container`) that mirrors the real DeltaWriter flow — the block is held by `block_container()` rather than released by the caller — and asserts the parent directory is deleted. Without the fix, `clear_parent_path()` returns `"not empty"` and the directory survives.

Note: the per-load spill directory was removed entirely on `main` by the zero-LIST load-spill refactor, so this issue and fix apply to **branch-3.5 only** (this PR targets branch-3.5 directly; there is no `main` counterpart to backport from).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

