### PR TITLE
[Enhancement] Extend Sample-Based Tablet Pre-Split to range tables with a rollup index

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutor.java
@@ -165,15 +165,37 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
         SampleSpec spec = resolveSampleSpec(request);
         double samplingRate = pickSamplingRate(spec.totalInputBytes());
         int rowLimit = pickRowLimit(request.getSampleByteLimit());
+        List<SecondaryIndexSpec> secondaryIndexSortKeys = request.getSecondaryIndexSortKeys();
         String sampleSql = buildSampleSql(
                 spec.fromClauseSql(), spec.whereClauseSqlOrNull(),
-                spec.sortKeyProjectionIdents(), spec.partitionProjectionIdents(),
+                spec.sortKeyProjectionIdents(), secondaryProjectionIdents(secondaryIndexSortKeys),
+                spec.partitionProjectionIdents(),
                 samplingRate, rowLimit, request.getSeed());
         List<TResultBatch> resultBatches = runSampleQuery(
                 sampleSql, spec.computeResource(), request.getQueryTimeoutSeconds());
-        Iterator<SampleRow> rowIterator =
-                decodeRows(resultBatches, spec.sortKeyColumns(), spec.partitionSourceColumns()).iterator();
+        Iterator<SampleRow> rowIterator = decodeRows(
+                resultBatches, spec.sortKeyColumns(), secondaryIndexSortKeys, spec.partitionSourceColumns())
+                .iterator();
         return new SampleExecution(rowIterator, new Estimates(spec.totalInputBytes(), 0L));
+    }
+
+    /**
+     * Flattens each {@link SecondaryIndexSpec}'s sort-key column names into
+     * backtick-quoted SQL identifiers, in spec order then per-spec column
+     * order. Empty when {@code secondaryIndexSortKeys} is empty, so the
+     * projection is byte-identical to the pre-multi-index SQL.
+     */
+    private static List<String> secondaryProjectionIdents(List<SecondaryIndexSpec> secondaryIndexSortKeys) {
+        if (secondaryIndexSortKeys.isEmpty()) {
+            return List.of();
+        }
+        List<String> idents = new ArrayList<>();
+        for (SecondaryIndexSpec secondaryIndexSpec : secondaryIndexSortKeys) {
+            for (Column column : secondaryIndexSpec.sortKey()) {
+                idents.add(SqlUtils.getIdentSql(column.getName()));
+            }
+        }
+        return idents;
     }
 
     static double pickSamplingRate(long totalFileBytes) {
@@ -211,9 +233,26 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
             String fromClauseSql, String whereClauseSqlOrNull,
             List<String> sortKeyProjectionIdents, List<String> partitionProjectionIdents,
             double samplingRate, int rowLimit, long seed) {
+        return buildSampleSql(fromClauseSql, whereClauseSqlOrNull, sortKeyProjectionIdents, List.of(),
+                partitionProjectionIdents, samplingRate, rowLimit, seed);
+    }
+
+    /**
+     * Extended overload additionally projecting {@code secondaryProjectionIdents}
+     * between the sort-key and partition-source slices, for the multi-index
+     * data-tier sampler. An empty {@code secondaryProjectionIdents} produces SQL
+     * byte-identical to the base overload above.
+     */
+    @VisibleForTesting
+    static String buildSampleSql(
+            String fromClauseSql, String whereClauseSqlOrNull,
+            List<String> sortKeyProjectionIdents, List<String> secondaryProjectionIdents,
+            List<String> partitionProjectionIdents,
+            double samplingRate, int rowLimit, long seed) {
         List<String> projected = new ArrayList<>(
-                sortKeyProjectionIdents.size() + partitionProjectionIdents.size());
+                sortKeyProjectionIdents.size() + secondaryProjectionIdents.size() + partitionProjectionIdents.size());
         projected.addAll(sortKeyProjectionIdents);
+        projected.addAll(secondaryProjectionIdents);
         projected.addAll(partitionProjectionIdents);
         String projection = String.join(", ", projected);
         long orderShuffleSeed = seed ^ 0x5A5A5A5A5A5A5A5AL;
@@ -299,6 +338,7 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
     private List<SampleRow> decodeRows(
             List<TResultBatch> resultBatches,
             List<Column> sortKeyColumns,
+            List<SecondaryIndexSpec> secondaryIndexSortKeys,
             List<Column> partitionSourceColumns) throws StarRocksException {
         List<SampleRow> rows = new ArrayList<>();
         if (resultBatches == null) {
@@ -310,7 +350,7 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
                 continue;
             }
             for (ByteBuffer rowBuffer : batchRows) {
-                rows.add(decodeRow(rowBuffer, sortKeyColumns, partitionSourceColumns));
+                rows.add(decodeRow(rowBuffer, sortKeyColumns, secondaryIndexSortKeys, partitionSourceColumns));
             }
         }
         return rows;
@@ -318,12 +358,15 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
 
     /**
      * Decode one HTTP_PROTOCAL JSON row ({@code {"data":[<val0>, ...]}}) into a
-     * {@link SampleRow}. The JSON array carries
-     * {@code sortKeyColumns.size() + partitionSourceColumns.size()} cells in
-     * projection order: the first slice fills the row's sort-key tuple, the
-     * trailing slice fills its partition-source tuple. When
-     * {@code partitionSourceColumns} is empty the trailing slice is empty and
-     * the row collapses to the pre-extension single-tuple shape.
+     * {@link SampleRow}. The JSON array carries {@code sortKeyColumns.size() +
+     * <sum of each secondary spec's sort-key size> + partitionSourceColumns.size()}
+     * cells in projection order: the first slice fills the row's sort-key
+     * tuple, the middle slice fills one id-tagged {@link IndexTuple} per
+     * {@link SecondaryIndexSpec} (in spec order), and the trailing slice fills
+     * its partition-source tuple. When {@code secondaryIndexSortKeys} is empty
+     * the middle slice is empty and, combined with an empty
+     * {@code partitionSourceColumns}, the row collapses to the pre-extension
+     * single-tuple shape.
      *
      * <p>Nullable columns accept JSON nulls and decode to
      * {@link com.starrocks.catalog.NullVariant}; non-nullable columns surface a
@@ -335,22 +378,38 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
     private SampleRow decodeRow(
             ByteBuffer rowBuffer,
             List<Column> sortKeyColumns,
+            List<SecondaryIndexSpec> secondaryIndexSortKeys,
             List<Column> partitionSourceColumns) throws StarRocksException {
-        int expectedArity = sortKeyColumns.size() + partitionSourceColumns.size();
+        int secondaryArity = 0;
+        for (SecondaryIndexSpec secondaryIndexSpec : secondaryIndexSortKeys) {
+            secondaryArity += secondaryIndexSpec.sortKey().size();
+        }
+        int expectedArity = sortKeyColumns.size() + secondaryArity + partitionSourceColumns.size();
         JsonArray dataArray = extractDataArray(rowBuffer, expectedArity);
         List<Variant> sortKeyValues = new ArrayList<>(sortKeyColumns.size());
         for (int columnIndex = 0; columnIndex < sortKeyColumns.size(); columnIndex++) {
             sortKeyValues.add(decodeCell(
                     dataArray.get(columnIndex), sortKeyColumns.get(columnIndex), COLUMN_ROLE_SORT_KEY));
         }
+        List<IndexTuple> secondaryIndexTuples = new ArrayList<>(secondaryIndexSortKeys.size());
+        int cursor = sortKeyColumns.size();
+        for (SecondaryIndexSpec secondaryIndexSpec : secondaryIndexSortKeys) {
+            List<Column> indexSortKey = secondaryIndexSpec.sortKey();
+            List<Variant> indexValues = new ArrayList<>(indexSortKey.size());
+            for (Column column : indexSortKey) {
+                indexValues.add(decodeCell(dataArray.get(cursor), column, COLUMN_ROLE_SECONDARY_INDEX));
+                cursor++;
+            }
+            secondaryIndexTuples.add(new IndexTuple(secondaryIndexSpec.indexMetaId(), indexValues));
+        }
         List<Variant> partitionSourceValues = new ArrayList<>(partitionSourceColumns.size());
         for (int columnIndex = 0; columnIndex < partitionSourceColumns.size(); columnIndex++) {
             partitionSourceValues.add(decodeCell(
-                    dataArray.get(sortKeyColumns.size() + columnIndex),
+                    dataArray.get(cursor + columnIndex),
                     partitionSourceColumns.get(columnIndex),
                     COLUMN_ROLE_PARTITION_SOURCE));
         }
-        return new SampleRow(sortKeyValues, partitionSourceValues);
+        return new SampleRow(sortKeyValues, partitionSourceValues, secondaryIndexTuples);
     }
 
     /**
@@ -410,6 +469,7 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
     }
 
     private static final String COLUMN_ROLE_SORT_KEY = "sort-key";
+    private static final String COLUMN_ROLE_SECONDARY_INDEX = "secondary-index";
     private static final String COLUMN_ROLE_PARTITION_SOURCE = "partition-source";
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.load.BrokerFileGroup;
@@ -26,6 +27,7 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
@@ -155,8 +157,29 @@ public final class BrokerLoadPreSplitHook {
                 MetaUtils.getRangeDistributionColumns(targetTable),
                 targetTable.getPartitionInfo().getPartitionColumns(targetTable.getIdToColumn()),
                 sumFileBytes(fileStatuses),
-                computeResource);
+                computeResource,
+                buildSecondaryIndexSpecs(targetTable));
         PreSplitFlow.dispatch(database, targetTable, prepared, LoadKind.BROKER_LOAD, shouldAbort, context);
+    }
+
+    /**
+     * Builds one {@link SecondaryIndexSpec} per visible rollup index of {@code targetTable}
+     * (every visible index except the base), each carrying its own sort key, so the
+     * multi-partition data-tier sampler can project and sample every visible index
+     * alongside the base sort key.
+     *
+     * <p>Package-private (not private) so the unit test can drive it directly.
+     */
+    static List<SecondaryIndexSpec> buildSecondaryIndexSpecs(OlapTable targetTable) {
+        List<SecondaryIndexSpec> specs = new ArrayList<>();
+        for (MaterializedIndexMeta meta : targetTable.getVisibleIndexMetas()) {
+            if (meta.getIndexMetaId() == targetTable.getBaseIndexMetaId()) {
+                continue;
+            }
+            specs.add(new SecondaryIndexSpec(meta.getIndexMetaId(),
+                    MetaUtils.getRangeDistributionColumns(targetTable, meta.getIndexMetaId())));
+        }
+        return specs;
     }
 
     private static long sumFileBytes(List<List<TBrokerFileStatus>> fileStatuses) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -49,9 +49,11 @@ import java.util.stream.Collectors;
 
 /**
  * Production {@link PreSplitPipeline} composing the FE-side sampler tiers,
- * {@link BoundaryPlanner}, {@link SplitTabletJobFactory#forExternalBoundaries},
- * and {@link TabletReshardJobMgr}. Constructor-injected dependencies keep the
- * class testable without static mocking.
+ * {@link BoundaryPlanner}, and {@link TabletReshardJobMgr}. The job itself comes
+ * from {@link SplitTabletJobFactory#forExternalBoundaries} when a single visible
+ * index is split, or {@link SplitTabletJobFactory#forExternalBoundariesMultiTablet}
+ * when multiple visible indexes are split together. Constructor-injected
+ * dependencies keep the class testable without static mocking.
  *
  * <p>Tier routing: meta tier ({@link ParquetMetadataSampler#tryPlan}) is invoked
  * first. {@link MetaTierUnavailableException} switches the run to data tier
@@ -99,8 +101,9 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
     private final long fileTotalBytes;
     private final Duration pollInterval;
     private final Clock clock;
-    // The triggering load's compute resource, carried into SplitTabletJobFactory.forExternalBoundaries
-    // so pre-split shards are scheduled in the load's warehouse. May be null (falls back to default).
+    // The triggering load's compute resource, carried into the SplitTabletJobFactory job (forExternalBoundaries
+    // or forExternalBoundariesMultiTablet) so pre-split shards are scheduled in the load's warehouse.
+    // May be null (falls back to default).
     private final ComputeResource loadComputeResource;
 
     public DefaultPreSplitPipeline(

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -225,15 +225,15 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
                 new Estimates(fileTotalBytes, 0L), activeComputeNodeCount);
 
         Map<Long, List<TabletRange>> oldTabletIdToRanges = new LinkedHashMap<>();
-        for (int i = 0; i < indexTargets.size(); i++) {
-            IndexPreSplitTarget indexTarget = indexTargets.get(i);
+        for (IndexPreSplitTarget indexTarget : indexTargets) {
             SampleRequest indexRequest = new SampleRequest(request.getScanContext(), indexTarget.sortKey(),
                     request.getSampleByteLimit(), request.getSeed());
             TierOutcome outcome = planBoundariesWithFallback(indexRequest, requestedTabletCount, deadline);
             if (outcome.result().isNoSplit()) {
                 continue;
             }
-            if (i == 0) {
+            if (oldTabletIdToRanges.isEmpty()) {
+                // first index that produced cuts -> record load-level tier/boundary metrics once
                 recordTierUsed(outcome.tier());
                 recordBoundariesPlanned(outcome.result().getBoundaries().size());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -19,12 +19,15 @@ import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -35,10 +38,14 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
 
 /**
  * Production {@link PreSplitPipeline} composing the FE-side sampler tiers,
@@ -88,7 +95,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
     private final TabletReshardJobMgr tabletReshardJobManager;
     private final Database database;
     private final OlapTable table;
-    private final long oldTabletId;
+    private final List<IndexPreSplitTarget> indexTargets;
     private final long fileTotalBytes;
     private final Duration pollInterval;
     private final Clock clock;
@@ -102,7 +109,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
             TabletReshardJobMgr tabletReshardJobManager,
             Database database,
             OlapTable table,
-            long oldTabletId,
+            List<IndexPreSplitTarget> indexTargets,
             long fileTotalBytes,
             Duration pollInterval,
             Clock clock,
@@ -112,9 +119,10 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         this.tabletReshardJobManager = Objects.requireNonNull(tabletReshardJobManager, "tabletReshardJobManager");
         this.database = Objects.requireNonNull(database, "database");
         this.table = Objects.requireNonNull(table, "table");
-        Preconditions.checkArgument(oldTabletId > 0, "oldTabletId must be > 0, was %s", oldTabletId);
+        Preconditions.checkArgument(indexTargets != null && !indexTargets.isEmpty(),
+                "indexTargets must be non-empty");
         Preconditions.checkArgument(fileTotalBytes >= 0, "fileTotalBytes must be >= 0, was %s", fileTotalBytes);
-        this.oldTabletId = oldTabletId;
+        this.indexTargets = indexTargets;
         this.fileTotalBytes = fileTotalBytes;
         this.pollInterval = Objects.requireNonNull(pollInterval, "pollInterval");
         this.clock = Objects.requireNonNull(clock, "clock");
@@ -148,8 +156,8 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
      * defensively. Unpartitioned tables retain the meta-tier-first routing.
      */
     public static DefaultPreSplitPipeline forLoadKind(
-            Database database, OlapTable table, long oldTabletId, long fileTotalBytes, LoadKind loadKind,
-            ComputeResource loadComputeResource) {
+            Database database, OlapTable table, List<IndexPreSplitTarget> indexTargets, long fileTotalBytes,
+            LoadKind loadKind, ComputeResource loadComputeResource) {
         MetaTierSampler metaTierSampler;
         if (loadKind == LoadKind.INSERT_FROM_TABLE || table.getPartitionInfo().isPartitioned()) {
             // INSERT_FROM_TABLE always uses the data tier: an OLAP source table has no
@@ -173,7 +181,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         TabletReshardJobMgr tabletReshardJobManager = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
         return new DefaultPreSplitPipeline(
                 metaTierSampler, dataTierSampler, tabletReshardJobManager,
-                database, table, oldTabletId, fileTotalBytes,
+                database, table, indexTargets, fileTotalBytes,
                 DEFAULT_POLL_INTERVAL, Clock.systemUTC(), loadComputeResource);
     }
 
@@ -213,22 +221,64 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         int requestedTabletCount = TabletPreSplitCoordinator.selectTabletCount(
                 new Estimates(fileTotalBytes, 0L), activeComputeNodeCount);
 
-        TierOutcome outcome = planBoundariesWithFallback(request, requestedTabletCount, deadline);
-        if (outcome.result.isNoSplit()) {
+        Map<Long, List<TabletRange>> oldTabletIdToRanges = new LinkedHashMap<>();
+        for (int i = 0; i < indexTargets.size(); i++) {
+            IndexPreSplitTarget indexTarget = indexTargets.get(i);
+            SampleRequest indexRequest = new SampleRequest(request.getScanContext(), indexTarget.sortKey(),
+                    request.getSampleByteLimit(), request.getSeed());
+            TierOutcome outcome = planBoundariesWithFallback(indexRequest, requestedTabletCount, deadline);
+            if (outcome.result().isNoSplit()) {
+                continue;
+            }
+            if (i == 0) {
+                recordTierUsed(outcome.tier());
+                recordBoundariesPlanned(outcome.result().getBoundaries().size());
+            }
+            oldTabletIdToRanges.put(indexTarget.oldTabletId(), buildTabletRanges(outcome.result().getBoundaries()));
+        }
+        if (oldTabletIdToRanges.isEmpty()) {
             return Optional.empty();
         }
-
-        recordTierUsed(outcome.tier);
-        recordBoundariesPlanned(outcome.result.getBoundaries().size());
-
-        List<TabletRange> tabletRanges = buildTabletRanges(outcome.result.getBoundaries());
-        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
-                database, table, oldTabletId, tabletRanges);
+        // Final authoritative re-check: a rollup could have become visible (or dropped) between the target
+        // snapshot and here. Re-resolve the visible index-id set under a brief READ lock; if it no longer
+        // equals the planned set, skip pre-split (never submit a base-only partial). The factory's own READ
+        // lock + table-state check + admission CAS cover the residual micro-window; a base-only split is
+        // data-safe regardless (BE routes by true value), so this re-check is an extra safeguard on top
+        // of that, not the sole defense.
+        Set<Long> expectedIndexMetaIds = indexTargets.stream().map(IndexPreSplitTarget::indexMetaId)
+                .collect(Collectors.toSet());
+        if (!currentVisibleIndexMetaIds(database, table).equals(expectedIndexMetaIds)) {
+            return Optional.empty();
+        }
+        TabletReshardJob job;
+        if (oldTabletIdToRanges.size() == 1) {
+            Map.Entry<Long, List<TabletRange>> only = oldTabletIdToRanges.entrySet().iterator().next();
+            job = SplitTabletJobFactory.forExternalBoundaries(database, table, only.getKey(), only.getValue());
+        } else {
+            job = SplitTabletJobFactory.forExternalBoundariesMultiTablet(database, table, oldTabletIdToRanges);
+        }
         // Carry the triggering load's warehouse so the job's shard creation + publish run there.
         if (loadComputeResource != null) {
             job.setWarehouseId(loadComputeResource.getWarehouseId());
         }
         return Optional.of(new PreparedReshardJob(job));
+    }
+
+    /**
+     * Re-resolves {@code table}'s currently-visible index-meta-id set under a brief intensive READ
+     * lock. Used by {@link #preSubmit} to detect a rollup that became visible (or was dropped)
+     * between the eligibility-target snapshot and job assembly.
+     */
+    private static Set<Long> currentVisibleIndexMetaIds(Database database, OlapTable table) {
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(database.getId(), table.getId(), LockType.READ);
+        try {
+            return table.getVisibleIndexMetas().stream()
+                    .map(MaterializedIndexMeta::getIndexMetaId)
+                    .collect(Collectors.toSet());
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(database.getId(), table.getId(), LockType.READ);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
@@ -33,6 +34,7 @@ import com.starrocks.thrift.TBrokerFileStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,8 +82,30 @@ final class FilesPreSplitSource implements InsertPreSplitSource {
         List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(target);
         List<Column> partitionColumns =
                 target.getPartitionInfo().getPartitionColumns(target.getIdToColumn());
+        List<SecondaryIndexSpec> secondaryIndexSpecs = buildSecondaryIndexSpecs(target);
         return new PreSplitFlow.Prepared(scanContext, sortKeyColumns, partitionColumns,
-                sumFileBytes(sourceTable), context.getCurrentComputeResource());
+                sumFileBytes(sourceTable), context.getCurrentComputeResource(), secondaryIndexSpecs);
+    }
+
+    /**
+     * Builds one {@link SecondaryIndexSpec} per visible rollup index of {@code target}
+     * (every visible index except the base), each carrying its own sort key, so the
+     * multi-partition data-tier sampler can project and sample every visible index
+     * alongside the base sort key.
+     *
+     * <p>Package-private (not private) so the unit test can drive it directly without
+     * mocking the full FILES resolution chain that precedes it.
+     */
+    static List<SecondaryIndexSpec> buildSecondaryIndexSpecs(OlapTable target) {
+        List<SecondaryIndexSpec> specs = new ArrayList<>();
+        for (MaterializedIndexMeta meta : target.getVisibleIndexMetas()) {
+            if (meta.getIndexMetaId() == target.getBaseIndexMetaId()) {
+                continue;
+            }
+            specs.add(new SecondaryIndexSpec(meta.getIndexMetaId(),
+                    MetaUtils.getRangeDistributionColumns(target, meta.getIndexMetaId())));
+        }
+        return specs;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/IndexPreSplitTarget.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/IndexPreSplitTarget.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.catalog.Column;
+
+import java.util.List;
+
+/**
+ * Resolved single-tablet pre-split target for one visible index (base or
+ * rollup) of a range-distribution table's unique physical partition.
+ *
+ * @param indexMetaId stable meta id of the index, matches the key in
+ *                     {@code OlapTable.indexMetaIdToMeta} across reshard
+ *                     (unlike the physical index id, which changes).
+ * @param oldTabletId the index's single base-index-tablet-per-partition
+ *                     tablet id before the split.
+ * @param sortKey     the index's own sort-key columns, resolved via
+ *                     {@link com.starrocks.sql.common.MetaUtils#getRangeDistributionColumns(
+ *                     com.starrocks.catalog.OlapTable, long)}.
+ */
+record IndexPreSplitTarget(long indexMetaId, long oldTabletId, List<Column> sortKey) {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/IndexTuple.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/IndexTuple.java
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.catalog.Variant;
+
+import java.util.List;
+
+/**
+ * One secondary index's sampled sort-key tuple, tagged with the owning
+ * index's meta id. A {@link SampleRow} carries zero or more of these -- one
+ * per {@link SecondaryIndexSpec} in the originating {@link SampleRequest} --
+ * so a downstream multi-index grouper can derive per-index split boundaries
+ * from the same sampled row set instead of re-sampling per index.
+ */
+public record IndexTuple(long indexMetaId, List<Variant> values) {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHook.java
@@ -18,6 +18,7 @@ import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
@@ -39,6 +40,7 @@ import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -164,9 +166,10 @@ public final class InsertPreSplitHook {
      *       value (has a default, is nullable, auto-increment, or generated) —
      *       mirrors InsertAnalyzer's "must be explicitly mentioned" rule, so a list
      *       missing a required column is skipped rather than resharded;</li>
-     *   <li>every range-distribution (sort) key column is present — an omitted key
-     *       is defaulted for every row, collapsing the data on that key and making
-     *       split boundaries degenerate.</li>
+     *   <li>every range-distribution (sort) key column of EVERY visible index (base
+     *       plus any rollup) is present -- an omitted key is defaulted for every row,
+     *       collapsing the data on that key and making split boundaries degenerate
+     *       for whichever index the omitted column belongs to.</li>
      * </ul>
      *
      * <p>Source-specific column/source alignment is still checked later in each
@@ -205,12 +208,30 @@ public final class InsertPreSplitHook {
                 return false;   // a required column is missing from the list
             }
         }
-        for (Column sortKey : sortKeyColumns) {
+        for (Column sortKey : unionOfVisibleIndexSortKeyColumns(target, sortKeyColumns)) {
             if (!listed.contains(sortKey.getName().toLowerCase())) {
                 return false;   // a sort-key column is missing -> degenerate split
             }
         }
         return true;
+    }
+
+    /**
+     * Union of {@code baseSortKeyColumns} with every OTHER visible index's (rollup)
+     * sort-key columns. A target column list must cover every visible index's sort
+     * key, not just the base one -- an omitted rollup key still collapses that
+     * index's data on split, even when the base split is fine.
+     */
+    private static List<Column> unionOfVisibleIndexSortKeyColumns(
+            OlapTable target, List<Column> baseSortKeyColumns) {
+        List<Column> union = new ArrayList<>(baseSortKeyColumns);
+        for (MaterializedIndexMeta meta : target.getVisibleIndexMetas()) {
+            if (meta.getIndexMetaId() == target.getBaseIndexMetaId()) {
+                continue;
+            }
+            union.addAll(MetaUtils.getRangeDistributionColumns(target, meta.getIndexMetaId()));
+        }
+        return union;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouper.java
@@ -38,9 +38,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Groups a {@link SampleSet}'s rows into per-target-partition buckets ready
@@ -82,13 +84,19 @@ public final class PartitionSampleGrouper {
      * @param dbId            db id for the intensive lock scope
      * @param totalFileBytes  total bytes of the load's input (per {@code Estimates});
      *                        used to apportion {@code estimatedBytes} across groups
+     * @param sampledSecondaryIndexMetaIds  authoritative secondary index-id set the
+     *                        sampler projected ({@link SampleSet#getSecondaryIndexMetaIds()});
+     *                        an existing partition whose currently-resolved secondary
+     *                        index-id set differs is dropped as ineligible (a rollup
+     *                        appeared or vanished since the sample)
      * @return list of {@link PartitionSamples} sorted by sample-count descending
      *         (heaviest first), capped at
      *         {@link Config#tablet_pre_split_max_partitions_per_load}; possibly
      *         empty
      */
     public static List<PartitionSamples> group(SampleSet samples, OlapTable table, ConnectContext ctx,
-                                               long dbId, long totalFileBytes) {
+                                               long dbId, long totalFileBytes,
+                                               Set<Long> sampledSecondaryIndexMetaIds) {
         List<Tuple> partitionSourceTuples = samples.getPartitionSourceTuples();
         if (partitionSourceTuples.isEmpty()) {
             // Sampler did not project partition source columns (target was unpartitioned).
@@ -128,7 +136,13 @@ public final class PartitionSampleGrouper {
                 group = new RawGroup(formatted);
                 rawGroups.put(formatted, group);
             }
-            group.rows.add(new SampleRow(sortKeyTuples.get(rowIndex).getValues(), partitionSourceTuple));
+            // Carry the id-tagged secondary-index tuples through only when the sampler
+            // projected them; getSecondaryIndexTuples() is empty for single-index targets,
+            // so never index into it in that case.
+            List<IndexTuple> secondaryIndexTuples = samples.getSecondaryIndexTuples().isEmpty()
+                    ? List.of() : samples.getSecondaryIndexTuples().get(rowIndex);
+            group.rows.add(new SampleRow(
+                    sortKeyTuples.get(rowIndex).getValues(), partitionSourceTuple, secondaryIndexTuples));
         }
 
         if (rawGroups.isEmpty()) {
@@ -230,6 +244,20 @@ public final class PartitionSampleGrouper {
                     PreSplitMetrics.recordEligibilitySkip(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
                     continue;
                 }
+                // Resolve every visible index (base + rollups) and confirm the resolved
+                // secondary index-id set still matches what the sampler projected. A
+                // rollup that appeared or vanished since the sample, or a rollup that no
+                // longer resolves (multi-tablet / non-scalar sort key), drops the whole
+                // partition -- the authoritative re-check runs again at plan time. The base
+                // oldTabletId stays on PartitionSamples; per-index targets are re-resolved
+                // at plan time, not carried from here.
+                List<IndexPreSplitTarget> indexTargets =
+                        PreSplitTargets.resolveVisibleIndexTargets(table, physicalPartition);
+                if (indexTargets == null
+                        || !resolvedSecondaryIndexMetaIds(indexTargets).equals(sampledSecondaryIndexMetaIds)) {
+                    PreSplitMetrics.recordEligibilitySkip(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
+                    continue;
+                }
                 long oldTabletId = baseIndex.getTablets().get(0).getId();
                 resolved.add(new PartitionSamples(
                         group.formattedValues, group.partitionName, true,
@@ -243,6 +271,18 @@ public final class PartitionSampleGrouper {
         // already explain why each group was dropped. There WERE groups; they were
         // ineligible, not empty. Return the (possibly empty) heaviest-first list.
         return resolved;
+    }
+
+    /**
+     * The secondary (non-base) index-meta ids of a base-first
+     * {@link IndexPreSplitTarget} list -- the base is always {@code targets.get(0)}.
+     */
+    private static Set<Long> resolvedSecondaryIndexMetaIds(List<IndexPreSplitTarget> indexTargets) {
+        Set<Long> secondaryIds = new HashSet<>();
+        for (int i = 1; i < indexTargets.size(); i++) {
+            secondaryIds.add(indexTargets.get(i).indexMetaId());
+        }
+        return secondaryIds;
     }
 
     private static List<String> formatPartitionTuple(List<Variant> partitionSourceTuple,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -40,7 +40,9 @@ import java.util.function.BooleanSupplier;
  *   <li>{@link #dispatch} — partitioned-vs-unpartitioned routing, including the
  *       automatic-partition gate that conservatively skips manually
  *       list/range-partitioned targets (those cannot pre-create partitions from
- *       sampled values).</li>
+ *       sampled values), and the INSERT-from-table rollup descope (a rollup's sort
+ *       key cannot be remapped to source columns, so a multi-index target skips
+ *       before sampling for that load kind only).</li>
  *   <li>{@link #runSinglePartitionFlow} — resolve the unique partition + base
  *       tablet, build a {@link DefaultPreSplitPipeline}, submit via
  *       {@link TabletPreSplitCoordinator#submitAsynchronously}, then sync-await
@@ -79,6 +81,11 @@ final class PreSplitFlow {
 
     static void dispatch(Database database, OlapTable target, Prepared prepared,
                          LoadKind loadKind, BooleanSupplier shouldAbort, ConnectContext context) {
+        if (loadKind == LoadKind.INSERT_FROM_TABLE && target.getVisibleIndexMetas().size() > 1) {
+            // INSERT-from-table cannot remap a divergent rollup sort key to source columns (descoped).
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
+            return;
+        }
         if (target.getPartitionInfo().isPartitioned()) {
             // Manually list/range-partitioned targets do not support pre-creating partitions
             // from sampled values; skip conservatively, let the load proceed.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -25,7 +25,9 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -137,13 +139,19 @@ final class PreSplitFlow {
         if (samples == null) {
             return;
         }
+        // The authoritative secondary index-id set the sampler projected. The grouper drops any
+        // partition whose currently-resolved rollup set differs, and the coordinator re-checks the
+        // same set immediately before planning each partition.
+        Set<Long> sampledSecondaryIndexMetaIds = new HashSet<>(samples.getSecondaryIndexMetaIds());
         List<PartitionSamples> groups = PartitionSampleGrouper.group(
-                samples, table, context, database.getId(), prepared.estimatedBytes());
+                samples, table, context, database.getId(), prepared.estimatedBytes(),
+                sampledSecondaryIndexMetaIds);
         if (groups.isEmpty()) {
             return;
         }
         PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                database, table, groups, activeComputeNodeCount, context, prepared.computeResource());
+                database, table, groups, activeComputeNodeCount, context, prepared.computeResource(),
+                sampledSecondaryIndexMetaIds);
         LOG.info("Sample-Based Tablet Pre-Split ({}, multi-partition) outcome for table {}: {}",
                 loadKind, table.getName(), outcome);
         if (outcome instanceof PreSplitOutcome.SubmittedCombined submittedCombined) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -72,11 +72,22 @@ final class PreSplitFlow {
      * Source-resolved inputs the flow needs. sortKeyColumns / partitionColumns are TARGET
      * columns (boundary planning + per-row partition projection); estimatedBytes sizes the
      * requested tablet count; computeResource sizes the active CN count; scanContext carries
-     * the source-specific scan inputs.
+     * the source-specific scan inputs; secondaryIndexSpecs names every OTHER visible index
+     * (rollup) whose sort key the multi-partition data-tier sampler should project alongside
+     * the base sort key -- empty for single-index targets and for INSERT-from-table (descoped).
      */
     record Prepared(ScanContext scanContext, List<Column> sortKeyColumns,
                     List<Column> partitionColumns, long estimatedBytes,
-                    ComputeResource computeResource) {
+                    ComputeResource computeResource, List<SecondaryIndexSpec> secondaryIndexSpecs) {
+
+        /**
+         * Backward-compatible constructor for callers with no rollup to project;
+         * defaults secondaryIndexSpecs to empty.
+         */
+        Prepared(ScanContext scanContext, List<Column> sortKeyColumns,
+                List<Column> partitionColumns, long estimatedBytes, ComputeResource computeResource) {
+            this(scanContext, sortKeyColumns, partitionColumns, estimatedBytes, computeResource, List.of());
+        }
     }
 
     static void dispatch(Database database, OlapTable target, Prepared prepared,
@@ -144,8 +155,8 @@ final class PreSplitFlow {
     static SampleSet runDataTierSampler(OlapTable table, Prepared prepared, LoadKind loadKind) {
         try {
             SampleRequest request = new SampleRequest(
-                    prepared.scanContext(), prepared.sortKeyColumns(), prepared.partitionColumns(),
-                    Config.tablet_pre_split_sample_byte_limit, /*seed*/ 0L)
+                    prepared.scanContext(), prepared.sortKeyColumns(), prepared.secondaryIndexSpecs(),
+                    prepared.partitionColumns(), Config.tablet_pre_split_sample_byte_limit, /*seed*/ 0L)
                     .withQueryTimeoutSeconds((int) Config.tablet_pre_split_pre_submit_timeout_seconds);
             Sampler sampler = new ReservoirSampler(DefaultPreSplitPipeline.sampleSubqueryExecutorFor(loadKind));
             return sampler.sample(request);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -106,7 +106,7 @@ final class PreSplitFlow {
         }
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                target.database(), target.olapTable(), target.oldTabletId(), prepared.estimatedBytes(), loadKind,
+                target.database(), target.olapTable(), target.indexTargets(), prepared.estimatedBytes(), loadKind,
                 prepared.computeResource());
         PreSplitOutcome outcome = TabletPreSplitCoordinator.submitAsynchronously(
                 target.database(), target.olapTable(), target.partitionId(), prepared.scanContext(),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -117,6 +117,13 @@ final class PreSplitFlow {
         if (target == null) {
             return;
         }
+        if (loadKind == LoadKind.INSERT_FROM_TABLE && target.indexTargets().size() > 1) {
+            // Authoritative re-check on the resolved index set: a rollup that became visible after the
+            // dispatch-time descope gate must not be sampled with the base-only INSERT-from-table source
+            // mapping. Skip pre-split (load proceeds) -- INSERT-from-table with a rollup is out of scope.
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
+            return;
+        }
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
                 target.database(), target.olapTable(), target.indexTargets(), prepared.estimatedBytes(), loadKind,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitTargets.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitTargets.java
@@ -17,11 +17,13 @@ package com.starrocks.alter.reshard.presplit;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.sql.common.MetaUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -42,8 +44,10 @@ import java.util.List;
  * <p><b>Two slices</b>:
  * <ul>
  *   <li>{@link #findEligibleTable} — table-only structural gate (range
- *       distribution, NORMAL state, no MV/rollup, supported sort key) used
- *       by the multi-partition coordinator's defensive re-check. Returns the
+ *       distribution, NORMAL state, every visible index has a supported sort
+ *       key) used by the multi-partition coordinator's defensive re-check.
+ *       A visible rollup no longer disqualifies the table by itself; its own
+ *       sort key must still be non-empty and scalar. Returns the
  *       failing {@link SkipReason}, or {@code null} when the table is eligible;
  *       the caller records it. The multi-partition coordinator does
  *       per-partition checks on its own under a short READ lock after
@@ -61,10 +65,17 @@ final class PreSplitTargets {
     }
 
     /**
-     * Resolved single-partition single-tablet target bundle. Both hooks pass
-     * this through to the coordinator as one value.
+     * Resolved single-partition target bundle: one {@link IndexPreSplitTarget} per
+     * visible index (base index first), all sharing the same partition. Both hooks
+     * pass this through to the coordinator as one value.
      */
-    record EligibleTarget(Database database, OlapTable olapTable, long partitionId, long oldTabletId) {
+    record EligibleTarget(Database database, OlapTable olapTable, long partitionId,
+                          List<IndexPreSplitTarget> indexTargets) {
+
+        /** The base index's old tablet id -- derived so existing single-tablet read sites keep compiling. */
+        long oldTabletId() {
+            return indexTargets.get(0).oldTabletId();
+        }
     }
 
     /**
@@ -94,19 +105,18 @@ final class PreSplitTargets {
         if (table.getState() != OlapTable.OlapTableState.NORMAL) {
             return SkipReason.TABLE_NOT_NORMAL;
         }
-        if (table.getVisibleIndexMetas().size() != 1) {
-            return SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP;
-        }
-        // Mirrors TabletPreSplitCoordinator.areSortKeyColumnsSupported: every
-        // sort-key column must be scalar; deeper per-column validation runs
-        // at plan time.
-        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table);
-        if (sortKeyColumns.isEmpty()) {
-            return SkipReason.UNSUPPORTED_SORT_KEY;
-        }
-        for (Column column : sortKeyColumns) {
-            if (!column.getType().isScalarType()) {
+        // Every visible index (base or rollup) must have its own supported sort key.
+        // Mirrors TabletPreSplitCoordinator.areSortKeyColumnsSupported: every sort-key
+        // column must be scalar; deeper per-column validation runs at plan time.
+        for (MaterializedIndexMeta meta : table.getVisibleIndexMetas()) {
+            List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table, meta.getIndexMetaId());
+            if (sortKeyColumns.isEmpty()) {
                 return SkipReason.UNSUPPORTED_SORT_KEY;
+            }
+            for (Column column : sortKeyColumns) {
+                if (!column.getType().isScalarType()) {
+                    return SkipReason.UNSUPPORTED_SORT_KEY;
+                }
             }
         }
         return null;
@@ -130,7 +140,9 @@ final class PreSplitTargets {
      *         missing — records {@link SkipReason#METADATA_NOT_RESOLVED} (e.g. an
      *         alter raced the load); or when the partition has zero or multiple
      *         base-index tablets — records {@link SkipReason#MULTIPLE_BASE_INDEX_TABLETS}
-     *         (the common case on a re-load against an already-split partition).
+     *         (the common case on a re-load against an already-split partition); or when
+     *         a visible rollup fails per-index resolution (multi-tablet, empty, or
+     *         non-scalar sort key) -- records {@link SkipReason#HAS_MATERIALIZED_VIEW_OR_ROLLUP}.
      */
     static EligibleTarget findEligibleTarget(Database database, OlapTable olapTable) {
         PhysicalPartition uniquePartition = findUniquePhysicalPartition(olapTable);
@@ -143,13 +155,72 @@ final class PreSplitTargets {
             PreSplitMetrics.recordEligibilitySkip(SkipReason.METADATA_NOT_RESOLVED);
             return null;
         }
-        List<Tablet> baseTablets = baseIndex.getTablets();
-        if (baseTablets.size() != 1) {
+        if (baseIndex.getTablets().size() != 1) {
             PreSplitMetrics.recordEligibilitySkip(SkipReason.MULTIPLE_BASE_INDEX_TABLETS);
             return null;
         }
-        long baseTabletId = baseTablets.get(0).getId();
-        return new EligibleTarget(database, olapTable, uniquePartition.getId(), baseTabletId);
+        List<IndexPreSplitTarget> indexTargets = resolveVisibleIndexTargets(olapTable, uniquePartition);
+        if (indexTargets == null) {
+            PreSplitMetrics.recordEligibilitySkip(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
+            return null;
+        }
+        return new EligibleTarget(database, olapTable, uniquePartition.getId(), indexTargets);
+    }
+
+    /**
+     * Resolves every visible index of {@code table}'s {@code partition} into an
+     * {@link IndexPreSplitTarget}, base index first.
+     *
+     * @return the base-first list, or {@code null} when any visible index (base or
+     *         rollup) has other-than-one tablet, an empty sort key, or a non-scalar
+     *         sort-key column. Row-count emptiness is intentionally NOT checked here --
+     *         that stays a separate per-partition gate the caller applies on its own.
+     */
+    static List<IndexPreSplitTarget> resolveVisibleIndexTargets(OlapTable table, PhysicalPartition partition) {
+        List<MaterializedIndex> visibleIndices =
+                partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
+        IndexPreSplitTarget baseTarget = null;
+        List<IndexPreSplitTarget> rollupTargets = new ArrayList<>();
+        for (MaterializedIndex index : visibleIndices) {
+            IndexPreSplitTarget target = resolveIndexTarget(table, index);
+            if (target == null) {
+                return null;
+            }
+            if (index.getMetaId() == table.getBaseIndexMetaId()) {
+                baseTarget = target;
+            } else {
+                rollupTargets.add(target);
+            }
+        }
+        if (baseTarget == null) {
+            return null;
+        }
+        List<IndexPreSplitTarget> orderedTargets = new ArrayList<>(1 + rollupTargets.size());
+        orderedTargets.add(baseTarget);
+        orderedTargets.addAll(rollupTargets);
+        return orderedTargets;
+    }
+
+    /**
+     * Resolves one visible index into an {@link IndexPreSplitTarget}, or {@code null}
+     * when it has other-than-one tablet, an empty sort key, or a non-scalar sort-key
+     * column.
+     */
+    private static IndexPreSplitTarget resolveIndexTarget(OlapTable table, MaterializedIndex index) {
+        List<Tablet> tablets = index.getTablets();
+        if (tablets.size() != 1) {
+            return null;
+        }
+        List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(table, index.getMetaId());
+        if (sortKeyColumns.isEmpty()) {
+            return null;
+        }
+        for (Column column : sortKeyColumns) {
+            if (!column.getType().isScalarType()) {
+                return null;
+            }
+        }
+        return new IndexPreSplitTarget(index.getMetaId(), tablets.get(0).getId(), sortKeyColumns);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ReservoirSampler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ReservoirSampler.java
@@ -64,9 +64,11 @@ public final class ReservoirSampler implements Sampler {
         SampleSubqueryExecutor.SampleExecution execution = executor.execute(request);
         long byteLimit = request.getSampleByteLimit();
         Iterator<SampleRow> rowIterator = execution.rows();
+        List<Long> secondaryIndexMetaIds = secondaryIndexMetaIds(request.getSecondaryIndexSortKeys());
 
         List<Tuple> sortKeyTuples = new ArrayList<>();
         List<Tuple> partitionSourceTuples = new ArrayList<>();
+        List<List<IndexTuple>> secondaryIndexTuples = new ArrayList<>();
         long accumulatedBytes = 0L;
 
         while (rowIterator.hasNext()) {
@@ -81,9 +83,13 @@ public final class ReservoirSampler implements Sampler {
             // distinguishes the unpartitioned path from the partitioned one here.
             List<Variant> sortKeyValues = row.sortKeyTuple();
             List<Variant> partitionSourceValues = row.partitionSourceTuple();
+            List<IndexTuple> rowSecondaryIndexTuples = row.secondaryIndexTuples();
             long rowBytes = estimateRowBytes(sortKeyValues);
             if (!partitionSourceValues.isEmpty()) {
                 rowBytes += estimateRowBytes(partitionSourceValues);
+            }
+            for (IndexTuple indexTuple : rowSecondaryIndexTuples) {
+                rowBytes += estimateRowBytes(indexTuple.values());
             }
             // Always admit the first row so a single oversize row doesn't return an empty
             // SampleSet; for subsequent rows enforce the soft limit.
@@ -96,16 +102,41 @@ public final class ReservoirSampler implements Sampler {
             if (!partitionSourceValues.isEmpty()) {
                 partitionSourceTuples.add(new Tuple(ImmutableList.copyOf(partitionSourceValues)));
             }
+            if (!secondaryIndexMetaIds.isEmpty()) {
+                secondaryIndexTuples.add(ImmutableList.copyOf(rowSecondaryIndexTuples));
+            }
             accumulatedBytes += rowBytes;
         }
 
         if (sortKeyTuples.isEmpty()) {
-            return SampleSet.EMPTY;
+            if (secondaryIndexMetaIds.isEmpty()) {
+                return SampleSet.EMPTY;
+            }
+            // A zero-row sample of a request WITH secondary specs still carries the
+            // authoritative id set -- SampleSet.EMPTY has none, which would defeat the
+            // downstream id-set check.
+            return new SampleSet(
+                    List.of(), List.of(), secondaryIndexMetaIds, List.of(), execution.estimates());
         }
-        // partitionSourceTuples is either empty (executor projected no partition-source
-        // columns) or filled 1:1 with sortKeyTuples. The mid-stream byte-limit break
-        // preserves this invariant because the two lists are appended together per row.
-        return new SampleSet(sortKeyTuples, partitionSourceTuples, execution.estimates());
+        // partitionSourceTuples/secondaryIndexTuples are either empty (executor projected
+        // no partition-source columns / request carried no secondary specs) or filled 1:1
+        // with sortKeyTuples. The mid-stream byte-limit break preserves this invariant
+        // because the lists are appended together per row.
+        return new SampleSet(
+                sortKeyTuples, partitionSourceTuples, secondaryIndexMetaIds, secondaryIndexTuples,
+                execution.estimates());
+    }
+
+    /** Extracts the authoritative secondary index-id set, in the request's declared spec order. */
+    private static List<Long> secondaryIndexMetaIds(List<SecondaryIndexSpec> secondaryIndexSortKeys) {
+        if (secondaryIndexSortKeys.isEmpty()) {
+            return List.of();
+        }
+        List<Long> metaIds = new ArrayList<>(secondaryIndexSortKeys.size());
+        for (SecondaryIndexSpec secondaryIndexSpec : secondaryIndexSortKeys) {
+            metaIds.add(secondaryIndexSpec.indexMetaId());
+        }
+        return metaIds;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRequest.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * so each index can be split per predicted partition from the same sample.
  * They flow through to the per-row secondary-index tuples in
  * {@link SampleSet#getSecondaryIndexTuples()}. Empty when the target has no
- * rollup (no projection extension, no tuple population) — existing callers
+ * rollup (no projection extension, no tuple population) -- existing callers
  * use the shorter constructors and see no behavior change.
  */
 public final class SampleRequest {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRequest.java
@@ -33,10 +33,19 @@ import java.util.Objects;
  * boundaries. Empty for unpartitioned targets (no projection extension, no
  * tuple population) — existing callers use the four-arg constructor and see
  * no behavior change.
+ *
+ * <p>{@code secondaryIndexSortKeys} names additional visible indexes (rollups)
+ * whose sort keys should be projected and sampled alongside the base sort key,
+ * so each index can be split per predicted partition from the same sample.
+ * They flow through to the per-row secondary-index tuples in
+ * {@link SampleSet#getSecondaryIndexTuples()}. Empty when the target has no
+ * rollup (no projection extension, no tuple population) — existing callers
+ * use the shorter constructors and see no behavior change.
  */
 public final class SampleRequest {
     private final ScanContext scanContext;
     private final List<Column> sortKey;
+    private final List<SecondaryIndexSpec> secondaryIndexSortKeys;
     private final List<Column> partitionSourceColumns;
     private final long sampleByteLimit;
     private final long seed;
@@ -46,7 +55,7 @@ public final class SampleRequest {
 
     public SampleRequest(ScanContext scanContext, List<Column> sortKey,
                          List<Column> partitionSourceColumns, long sampleByteLimit, long seed) {
-        this(scanContext, sortKey, partitionSourceColumns, sampleByteLimit, seed, /*queryTimeoutSeconds=*/ 0);
+        this(scanContext, sortKey, ImmutableList.of(), partitionSourceColumns, sampleByteLimit, seed);
     }
 
     /**
@@ -57,10 +66,25 @@ public final class SampleRequest {
         this(scanContext, sortKey, ImmutableList.of(), sampleByteLimit, seed);
     }
 
-    private SampleRequest(ScanContext scanContext, List<Column> sortKey, List<Column> partitionSourceColumns,
+    /**
+     * Constructor additionally carrying {@code secondaryIndexSortKeys} for the
+     * multi-index data-tier sampler; the shorter constructors above default it
+     * to an empty list.
+     */
+    public SampleRequest(ScanContext scanContext, List<Column> sortKey,
+                         List<SecondaryIndexSpec> secondaryIndexSortKeys,
+                         List<Column> partitionSourceColumns, long sampleByteLimit, long seed) {
+        this(scanContext, sortKey, secondaryIndexSortKeys, partitionSourceColumns, sampleByteLimit, seed,
+                /*queryTimeoutSeconds=*/ 0);
+    }
+
+    private SampleRequest(ScanContext scanContext, List<Column> sortKey,
+                          List<SecondaryIndexSpec> secondaryIndexSortKeys,
+                          List<Column> partitionSourceColumns,
                           long sampleByteLimit, long seed, int queryTimeoutSeconds) {
         this.scanContext = Objects.requireNonNull(scanContext, "scanContext");
         Objects.requireNonNull(sortKey, "sortKey");
+        Objects.requireNonNull(secondaryIndexSortKeys, "secondaryIndexSortKeys");
         Objects.requireNonNull(partitionSourceColumns, "partitionSourceColumns");
         Preconditions.checkArgument(!sortKey.isEmpty(), "sortKey must be non-empty");
         Preconditions.checkArgument(sampleByteLimit > 0,
@@ -68,6 +92,7 @@ public final class SampleRequest {
         Preconditions.checkArgument(queryTimeoutSeconds >= 0,
                 "queryTimeoutSeconds must be non-negative, was %s", queryTimeoutSeconds);
         this.sortKey = ImmutableList.copyOf(sortKey);
+        this.secondaryIndexSortKeys = ImmutableList.copyOf(secondaryIndexSortKeys);
         this.partitionSourceColumns = ImmutableList.copyOf(partitionSourceColumns);
         this.sampleByteLimit = sampleByteLimit;
         this.seed = seed;
@@ -76,11 +101,12 @@ public final class SampleRequest {
 
     /**
      * Returns a copy with the sampling sub-query's wall-clock cap set to
-     * {@code queryTimeoutSeconds}; all other fields carry through. Used by the
-     * data-tier pipeline to bound the sample to the remaining pre-submit budget.
+     * {@code queryTimeoutSeconds}; all other fields, including
+     * {@code secondaryIndexSortKeys}, carry through. Used by the data-tier
+     * pipeline to bound the sample to the remaining pre-submit budget.
      */
     public SampleRequest withQueryTimeoutSeconds(int queryTimeoutSeconds) {
-        return new SampleRequest(scanContext, sortKey, partitionSourceColumns,
+        return new SampleRequest(scanContext, sortKey, secondaryIndexSortKeys, partitionSourceColumns,
                 sampleByteLimit, seed, queryTimeoutSeconds);
     }
 
@@ -90,6 +116,10 @@ public final class SampleRequest {
 
     public List<Column> getSortKey() {
         return sortKey;
+    }
+
+    public List<SecondaryIndexSpec> getSecondaryIndexSortKeys() {
+        return secondaryIndexSortKeys;
     }
 
     public List<Column> getPartitionSourceColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleRow.java
@@ -22,29 +22,46 @@ import java.util.Objects;
 /**
  * One row of a data-tier sample. Carries the sort-key tuple
  * {@link BoundaryPlanner} consumes, plus an optional partition-source tuple a
- * downstream multi-partition grouper consumes. The partition-source tuple is
- * empty when the target is unpartitioned (the executor projects only the sort
- * key and the request's {@code partitionSourceColumns} is empty), and is
- * non-empty when the request supplied partition-source columns.
+ * downstream multi-partition grouper consumes, plus zero or more secondary-
+ * index tuples a downstream multi-index grouper consumes. The
+ * partition-source tuple is empty when the target is unpartitioned (the
+ * executor projects only the sort key and the request's
+ * {@code partitionSourceColumns} is empty), and is non-empty when the request
+ * supplied partition-source columns. {@code secondaryIndexTuples} is empty
+ * when the request carried no {@link SecondaryIndexSpec}s, and otherwise
+ * carries one {@link IndexTuple} per spec, in the request's declared order.
  *
- * <p>Existing single-tuple callers use {@link #ofSortKey}; the record's full
- * constructor is reserved for callers that already know both tuples (the
- * partitioned-target data-tier executor).
+ * <p>Existing single-tuple callers use {@link #ofSortKey}; the two-tuple
+ * constructor is reserved for callers that already know both the sort-key and
+ * partition-source tuples but not secondary-index tuples (defaults them to
+ * empty); the canonical three-tuple constructor is for the multi-index
+ * data-tier executor.
  */
-public record SampleRow(List<Variant> sortKeyTuple, List<Variant> partitionSourceTuple) {
+public record SampleRow(
+        List<Variant> sortKeyTuple, List<Variant> partitionSourceTuple, List<IndexTuple> secondaryIndexTuples) {
 
     public SampleRow {
         Objects.requireNonNull(sortKeyTuple, "sortKeyTuple");
         Objects.requireNonNull(partitionSourceTuple, "partitionSourceTuple");
+        Objects.requireNonNull(secondaryIndexTuples, "secondaryIndexTuples");
+    }
+
+    /**
+     * Backwards-compatible constructor for callers that know the sort-key and
+     * partition-source tuples but not secondary-index tuples; defaults
+     * {@code secondaryIndexTuples} to an empty list.
+     */
+    public SampleRow(List<Variant> sortKeyTuple, List<Variant> partitionSourceTuple) {
+        this(sortKeyTuple, partitionSourceTuple, List.of());
     }
 
     /**
      * Backwards-compatible factory for callers that only have a sort-key tuple;
-     * defaults {@code partitionSourceTuple} to an empty list. Used by the
-     * unpartitioned-target executor path and by test fixtures that pre-date
-     * partition-source projection.
+     * defaults {@code partitionSourceTuple} and {@code secondaryIndexTuples} to
+     * empty lists. Used by the unpartitioned-target executor path and by test
+     * fixtures that pre-date partition-source / secondary-index projection.
      */
     public static SampleRow ofSortKey(List<Variant> sortKeyTuple) {
-        return new SampleRow(sortKeyTuple, List.of());
+        return new SampleRow(sortKeyTuple, List.of(), List.of());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleSet.java
@@ -19,8 +19,10 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.Tuple;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Output of a {@link Sampler}. The tuple lists are defensively copied at
@@ -34,14 +36,28 @@ import java.util.Objects;
  * tuple list: same size as {@code tuples} (1:1 by index) when populated, or
  * empty when the underlying request projected no partition-source columns.
  *
- * <p>{@link #EMPTY} represents a successful sample of zero rows — distinct
- * from "sampler failed", which the sampler signals by throwing.
+ * <p>{@code secondaryIndexMetaIds} is the AUTHORITATIVE secondary index-id set,
+ * taken from the originating {@link SampleRequest}'s specs in projection
+ * order; it is present even for a zero-row sample, so downstream code checks
+ * id-set membership against this list rather than inspecting rows.
+ * {@code secondaryIndexTuples} carries the parallel per-row secondary-index
+ * tuple list: empty when {@code secondaryIndexMetaIds} is empty, otherwise the
+ * same size as {@code tuples} (including zero), with every present row's
+ * {@link IndexTuple} id-set equal to {@code secondaryIndexMetaIds} (exactly
+ * one per id, no duplicates, no unknown ids) — a short or malformed row is
+ * rejected at construction rather than silently dropped downstream.
+ *
+ * <p>{@link #EMPTY} represents a successful sample of zero rows with no
+ * secondary indexes — distinct from "sampler failed", which the sampler
+ * signals by throwing.
  */
 public final class SampleSet {
     public static final SampleSet EMPTY = new SampleSet(Collections.emptyList(), Estimates.ZERO);
 
     private final List<Tuple> tuples;
     private final List<Tuple> partitionSourceTuples;
+    private final List<Long> secondaryIndexMetaIds;
+    private final List<List<IndexTuple>> secondaryIndexTuples;
     private final Estimates estimates;
 
     public SampleSet(List<Tuple> tuples, Estimates estimates) {
@@ -49,14 +65,53 @@ public final class SampleSet {
     }
 
     public SampleSet(List<Tuple> tuples, List<Tuple> partitionSourceTuples, Estimates estimates) {
+        this(tuples, partitionSourceTuples, Collections.emptyList(), Collections.emptyList(), estimates);
+    }
+
+    public SampleSet(List<Tuple> tuples, List<Tuple> partitionSourceTuples,
+                     List<Long> secondaryIndexMetaIds, List<List<IndexTuple>> secondaryIndexTuples,
+                     Estimates estimates) {
         Objects.requireNonNull(tuples, "tuples");
         Objects.requireNonNull(partitionSourceTuples, "partitionSourceTuples");
+        Objects.requireNonNull(secondaryIndexMetaIds, "secondaryIndexMetaIds");
+        Objects.requireNonNull(secondaryIndexTuples, "secondaryIndexTuples");
         Preconditions.checkArgument(
                 partitionSourceTuples.isEmpty() || partitionSourceTuples.size() == tuples.size(),
                 "partitionSourceTuples must be either empty or the same size as tuples (%s vs %s)",
                 partitionSourceTuples.size(), tuples.size());
+        if (secondaryIndexMetaIds.isEmpty()) {
+            Preconditions.checkArgument(secondaryIndexTuples.isEmpty(),
+                    "secondaryIndexTuples must be empty when secondaryIndexMetaIds is empty, had %s row(s)",
+                    secondaryIndexTuples.size());
+        } else {
+            Preconditions.checkArgument(secondaryIndexTuples.size() == tuples.size(),
+                    "secondaryIndexTuples must be the same size as tuples when secondaryIndexMetaIds is "
+                            + "non-empty (%s vs %s)",
+                    secondaryIndexTuples.size(), tuples.size());
+            Set<Long> expectedIds = new HashSet<>(secondaryIndexMetaIds);
+            for (int rowIndex = 0; rowIndex < secondaryIndexTuples.size(); rowIndex++) {
+                List<IndexTuple> rowTuples = Objects.requireNonNull(
+                        secondaryIndexTuples.get(rowIndex), "secondaryIndexTuples row " + rowIndex);
+                Set<Long> rowIds = new HashSet<>();
+                for (IndexTuple indexTuple : rowTuples) {
+                    Objects.requireNonNull(indexTuple, "secondaryIndexTuples row " + rowIndex + " entry");
+                    Preconditions.checkArgument(rowIds.add(indexTuple.indexMetaId()),
+                            "secondaryIndexTuples row %s carries a duplicate index id %s",
+                            rowIndex, indexTuple.indexMetaId());
+                }
+                Preconditions.checkArgument(rowIds.equals(expectedIds),
+                        "secondaryIndexTuples row %s carries index ids %s but expected exactly %s",
+                        rowIndex, rowIds, expectedIds);
+            }
+        }
         this.tuples = ImmutableList.copyOf(tuples);
         this.partitionSourceTuples = ImmutableList.copyOf(partitionSourceTuples);
+        this.secondaryIndexMetaIds = ImmutableList.copyOf(secondaryIndexMetaIds);
+        ImmutableList.Builder<List<IndexTuple>> secondaryIndexTuplesBuilder = ImmutableList.builder();
+        for (List<IndexTuple> rowTuples : secondaryIndexTuples) {
+            secondaryIndexTuplesBuilder.add(ImmutableList.copyOf(rowTuples));
+        }
+        this.secondaryIndexTuples = secondaryIndexTuplesBuilder.build();
         this.estimates = Objects.requireNonNull(estimates, "estimates");
     }
 
@@ -71,6 +126,26 @@ public final class SampleSet {
      */
     public List<Tuple> getPartitionSourceTuples() {
         return partitionSourceTuples;
+    }
+
+    /**
+     * Parallel-by-index secondary-index tuple lists, one inner list per sampled
+     * row. Empty when {@link #getSecondaryIndexMetaIds()} is empty; otherwise
+     * the same size as {@link #getTuples()} (including zero for a zero-row
+     * sample).
+     */
+    public List<List<IndexTuple>> getSecondaryIndexTuples() {
+        return secondaryIndexTuples;
+    }
+
+    /**
+     * The authoritative secondary index-id set, taken from the originating
+     * {@link SampleRequest}'s specs in projection order. Present even for a
+     * zero-row sample — callers should check id-set membership against this
+     * list rather than inspecting rows.
+     */
+    public List<Long> getSecondaryIndexMetaIds() {
+        return secondaryIndexMetaIds;
     }
 
     public Estimates getEstimates() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SampleSet.java
@@ -44,11 +44,11 @@ import java.util.Set;
  * tuple list: empty when {@code secondaryIndexMetaIds} is empty, otherwise the
  * same size as {@code tuples} (including zero), with every present row's
  * {@link IndexTuple} id-set equal to {@code secondaryIndexMetaIds} (exactly
- * one per id, no duplicates, no unknown ids) — a short or malformed row is
+ * one per id, no duplicates, no unknown ids) -- a short or malformed row is
  * rejected at construction rather than silently dropped downstream.
  *
  * <p>{@link #EMPTY} represents a successful sample of zero rows with no
- * secondary indexes — distinct from "sampler failed", which the sampler
+ * secondary indexes -- distinct from "sampler failed", which the sampler
  * signals by throwing.
  */
 public final class SampleSet {
@@ -141,7 +141,7 @@ public final class SampleSet {
     /**
      * The authoritative secondary index-id set, taken from the originating
      * {@link SampleRequest}'s specs in projection order. Present even for a
-     * zero-row sample — callers should check id-set membership against this
+     * zero-row sample -- callers should check id-set membership against this
      * list rather than inspecting rows.
      */
     public List<Long> getSecondaryIndexMetaIds() {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpec.java
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.catalog.Column;
+
+import java.util.List;
+
+/**
+ * One visible secondary index (rollup) whose sort key the multi-partition
+ * data-tier sampler should project and sample alongside the base sort key.
+ * Carried on {@link SampleRequest#getSecondaryIndexSortKeys()}; the
+ * {@code indexMetaId} tags the resulting {@link IndexTuple} so it can be
+ * routed back to the correct index downstream.
+ */
+public record SecondaryIndexSpec(long indexMetaId, List<Column> sortKey) {
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
@@ -112,6 +112,9 @@ final class TablePreSplitSource implements InsertPreSplitSource {
                 mapping.sortKeySourceColumnNames(), mapping.partitionSourceColumnNames(),
                 wherePredicateSql, context.getCurrentComputeResource());
         long estimatedBytes = Math.max(0L, resolvedSource.sourceTable().getDataSize());
+        // INSERT-from-table cannot remap a rollup's sort key to source columns, so the
+        // dispatch gate already skips multi-index targets for this load kind; secondaryIndexSpecs
+        // stays empty here via the backward-compatible Prepared constructor.
         return new PreSplitFlow.Prepared(scanContext, sortKeyColumns, partitionColumns,
                 estimatedBytes, context.getCurrentComputeResource());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -110,9 +110,6 @@ public final class TabletPreSplitCoordinator {
         if (table.getState() != OlapTable.OlapTableState.NORMAL) {
             return skipEligibility(SkipReason.TABLE_NOT_NORMAL);
         }
-        if (table.getVisibleIndexMetas().size() != 1) {
-            return skipEligibility(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
-        }
         if (!areSortKeyColumnsSupported(table)) {
             return skipEligibility(SkipReason.UNSUPPORTED_SORT_KEY);
         }
@@ -130,6 +127,9 @@ public final class TabletPreSplitCoordinator {
         }
         if (baseIndex.getRowCount() > 0) {
             return skipEligibility(SkipReason.PARTITION_NOT_EMPTY);
+        }
+        if (PreSplitTargets.resolveVisibleIndexTargets(table, partition) == null) {
+            return skipEligibility(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
         }
 
         return new PreSplitOutcome.Eligible();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -24,9 +24,9 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.TimeoutException;
@@ -43,11 +43,13 @@ import org.apache.logging.log4j.Logger;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -589,11 +591,13 @@ public final class TabletPreSplitCoordinator {
      */
     public static PreSplitOutcome submitForPartitionsCombined(
             Database database, OlapTable table, List<PartitionSamples> partitionSamplesList,
-            int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource) {
+            int activeComputeNodeCount, ConnectContext ctx, ComputeResource loadComputeResource,
+            Set<Long> sampledSecondaryIndexMetaIds) {
         Objects.requireNonNull(database, "database");
         Objects.requireNonNull(table, "table");
         Objects.requireNonNull(partitionSamplesList, "partitionSamplesList");
         Objects.requireNonNull(ctx, "ctx");
+        Objects.requireNonNull(sampledSecondaryIndexMetaIds, "sampledSecondaryIndexMetaIds");
         Preconditions.checkArgument(activeComputeNodeCount >= 1,
                 "activeComputeNodeCount must be >= 1, was %s", activeComputeNodeCount);
 
@@ -607,14 +611,14 @@ public final class TabletPreSplitCoordinator {
         // Phase 2: per-partition pre-create + plan, accumulating into oldTabletIdToRanges.
         // perPartitionResults is parallel-by-input bookkeeping: Skipped(reason) for dropped
         // entries, Submitted(null) sentinel for entries that fed the combined job.
-        List<Column> sortKey = MetaUtils.getRangeDistributionColumns(table);
         Map<Long, List<TabletRange>> oldTabletIdToRanges = new LinkedHashMap<>();
         List<PreSplitOutcome> perPartitionResults = new ArrayList<>(partitionSamplesList.size());
 
         for (PartitionSamples entry : partitionSamplesList) {
             PreSplitMetrics.recordPartitionCounted();
             PreSplitOutcome perPartition = planOnePartition(
-                    database, table, entry, sortKey, activeComputeNodeCount, ctx, oldTabletIdToRanges);
+                    database, table, entry, activeComputeNodeCount, ctx,
+                    sampledSecondaryIndexMetaIds, oldTabletIdToRanges);
             perPartitionResults.add(perPartition);
         }
 
@@ -658,10 +662,19 @@ public final class TabletPreSplitCoordinator {
      * sentinel; on any per-partition failure, returns a {@link PreSplitOutcome.Skipped}
      * carrying the specific reason. Throwables are caught and mapped — the
      * caller iterates the full list regardless of one entry's outcome.
+     *
+     * <p>Every visible index (base + rollups) is re-resolved and planned inside a
+     * LOCAL {@code {oldTabletId -> ranges}} map; the local map is merged into the
+     * combined {@code oldTabletIdToRanges} only after ALL indexes planned
+     * successfully. Any throw discards the local map, so a base-only remnant never
+     * leaks into the combined submit. A no-cut index is simply omitted from the
+     * local map; if EVERY index is no-cut the partition returns
+     * {@link SkipReason#NO_USEFUL_CUTS}.
      */
     private static PreSplitOutcome planOnePartition(
-            Database database, OlapTable table, PartitionSamples entry, List<Column> sortKey,
+            Database database, OlapTable table, PartitionSamples entry,
             int activeComputeNodeCount, ConnectContext ctx,
+            Set<Long> sampledSecondaryIndexMetaIds,
             Map<Long, List<TabletRange>> oldTabletIdToRanges) {
         try {
             if (!entry.existsInCatalog()) {
@@ -688,27 +701,43 @@ public final class TabletPreSplitCoordinator {
                 }
             }
 
-            // Brief intensive READ lock for post-create re-resolve. Lock is acquired BEFORE the
-            // try block so a throw from the lock call does not run the finally release.
-            ResolvedPartition resolved = resolveUnderReadLock(database, table, entry.partitionName());
-            if (resolved == null) {
+            // Always re-resolve the partition's full visible-index target list immediately before
+            // planning (existing AND pre-created partitions): the factory does NOT enforce
+            // one-tablet-per-index, so a concurrent split could otherwise leak stale targets. A
+            // resolved secondary index-id set that no longer equals the sampled set drops the
+            // partition here rather than submitting a base-only partial.
+            List<IndexPreSplitTarget> resolvedTargets =
+                    resolveUnderReadLock(database, table, entry.partitionName(), sampledSecondaryIndexMetaIds);
+            if (resolvedTargets == null) {
                 PreSplitMetrics.recordEligibilitySkip(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
                 return new PreSplitOutcome.Skipped(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
             }
 
             int requestedTabletCount = selectTabletCount(
                     new Estimates(entry.estimatedBytes(), 0L), activeComputeNodeCount);
-            SampleSet sampleSet = buildSampleSet(entry);
-            BoundaryPlannerResult planResult = BoundaryPlanner.planRowQuantileBoundaries(
-                    sampleSet, requestedTabletCount, sortKey);
-            if (planResult.isNoSplit()) {
+            // Plan every index into a LOCAL map first; merge only on full success so a throw
+            // mid-way never leaves a base-only remnant in the combined map. targets.get(0) is the
+            // base (resolveVisibleIndexTargets returns base first); the rest are rollups matched
+            // to each row's IndexTuple by indexMetaId, never by list position.
+            Map<Long, List<TabletRange>> local = new LinkedHashMap<>();
+            for (int i = 0; i < resolvedTargets.size(); i++) {
+                IndexPreSplitTarget target = resolvedTargets.get(i);
+                Long secondaryIndexMetaId = i == 0 ? null : target.indexMetaId();
+                SampleSet sampleSet = buildSampleSet(entry, secondaryIndexMetaId);
+                BoundaryPlannerResult planResult = BoundaryPlanner.planRowQuantileBoundaries(
+                        sampleSet, requestedTabletCount, target.sortKey());
+                if (planResult.isNoSplit()) {
+                    continue;
+                }
+                local.put(target.oldTabletId(),
+                        DefaultPreSplitPipeline.buildTabletRanges(planResult.getBoundaries()));
+            }
+            if (local.isEmpty()) {
                 PreSplitMetrics.recordEligibilitySkip(SkipReason.NO_USEFUL_CUTS);
                 return new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS);
             }
 
-            List<TabletRange> tabletRanges = DefaultPreSplitPipeline.buildTabletRanges(
-                    planResult.getBoundaries());
-            oldTabletIdToRanges.put(resolved.oldTabletId, tabletRanges);
+            oldTabletIdToRanges.putAll(local);
             // Submitted(null) is a "fed-into-combined-submit" sentinel; promoted at the outer
             // level when the combined job is admitted.
             return new PreSplitOutcome.Submitted(null);
@@ -726,12 +755,19 @@ public final class TabletPreSplitCoordinator {
     }
 
     /**
-     * Acquire an intensive table READ lock, re-resolve the partition's
-     * default physical partition + base index, verify single-tablet + empty,
-     * and return the discovered oldTabletId. Returns {@code null} when any
-     * eligibility check fails (caller maps to PARTITION_NOT_ELIGIBLE_POST_CREATE).
+     * Acquire an intensive table READ lock and re-resolve the partition's FULL
+     * visible-index target list (base first) via
+     * {@link PreSplitTargets#resolveVisibleIndexTargets}. Verifies the base index
+     * is empty (its row count is not checked by the resolver) and that the
+     * resolved secondary index-id set still equals {@code sampledSecondaryIndexMetaIds}.
+     * Runs for BOTH existing and pre-created partitions -- always re-resolve
+     * immediately before planning, because the factory does NOT enforce
+     * one-tablet-per-index and a stale target from the grouper snapshot must be
+     * rejected here. Returns {@code null} when any check fails (caller maps to
+     * PARTITION_NOT_ELIGIBLE_POST_CREATE).
      */
-    private static ResolvedPartition resolveUnderReadLock(Database database, OlapTable table, String partitionName) {
+    private static List<IndexPreSplitTarget> resolveUnderReadLock(
+            Database database, OlapTable table, String partitionName, Set<Long> sampledSecondaryIndexMetaIds) {
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(database.getId(), table.getId(), LockType.READ);
         try {
@@ -744,14 +780,24 @@ public final class TabletPreSplitCoordinator {
                 return null;
             }
             MaterializedIndex baseIndex = physicalPartition.getIndex(table.getBaseIndexMetaId());
-            if (baseIndex == null) {
+            if (baseIndex == null || baseIndex.getRowCount() > 0) {
+                // resolveVisibleIndexTargets covers base tablet count + sort key, but intentionally
+                // not row-count emptiness -- gate that here before resolving the full index set.
                 return null;
             }
-            List<Tablet> tablets = baseIndex.getTablets();
-            if (tablets.size() != 1 || baseIndex.getRowCount() > 0) {
+            List<IndexPreSplitTarget> targets =
+                    PreSplitTargets.resolveVisibleIndexTargets(table, physicalPartition);
+            if (targets == null) {
                 return null;
             }
-            return new ResolvedPartition(physicalPartition.getId(), tablets.get(0).getId());
+            Set<Long> resolvedSecondaryIndexMetaIds = new HashSet<>();
+            for (int i = 1; i < targets.size(); i++) {
+                resolvedSecondaryIndexMetaIds.add(targets.get(i).indexMetaId());
+            }
+            if (!resolvedSecondaryIndexMetaIds.equals(sampledSecondaryIndexMetaIds)) {
+                return null;
+            }
+            return targets;
         } finally {
             locker.unLockTableWithIntensiveDbLock(database.getId(), table.getId(), LockType.READ);
         }
@@ -759,19 +805,38 @@ public final class TabletPreSplitCoordinator {
 
     /**
      * Project the entry's {@link SampleRow} list into a {@link SampleSet} the
-     * {@link BoundaryPlanner} consumes — only the sort-key tuples and a
-     * zero-byte {@link Estimates} are needed here (estimatedBytes already
-     * drove K_i selection).
+     * {@link BoundaryPlanner} consumes for one index. When
+     * {@code secondaryIndexMetaId} is {@code null} the base sort-key tuples are
+     * used; otherwise each row's {@link IndexTuple} whose {@code indexMetaId}
+     * matches is selected (matched by id, never by list position). Only the
+     * per-index tuples and a zero-byte {@link Estimates} are needed here
+     * (estimatedBytes already drove K_i selection).
      */
-    private static SampleSet buildSampleSet(PartitionSamples entry) {
+    private static SampleSet buildSampleSet(PartitionSamples entry, Long secondaryIndexMetaId) {
         List<SampleRow> rows = entry.samples();
-        List<Tuple> sortKeyTuples = new ArrayList<>(rows.size());
+        List<Tuple> tuples = new ArrayList<>(rows.size());
         for (SampleRow row : rows) {
-            sortKeyTuples.add(new Tuple(row.sortKeyTuple()));
+            List<Variant> values = secondaryIndexMetaId == null
+                    ? row.sortKeyTuple() : indexTupleValues(row, secondaryIndexMetaId);
+            tuples.add(new Tuple(values));
         }
-        return new SampleSet(sortKeyTuples, Estimates.ZERO);
+        return new SampleSet(tuples, Estimates.ZERO);
     }
 
-    /** One partition's post-create resolution: stable IDs the coordinator passes to the factory. */
-    private record ResolvedPartition(long physicalPartitionId, long oldTabletId) { }
+    /**
+     * The values of the row's {@link IndexTuple} tagged with {@code indexMetaId}.
+     * The grouper carries exactly one tuple per sampled secondary index, so a
+     * missing match signals a corrupt sample and is thrown as a RuntimeException
+     * that {@link #planOnePartition} maps to SAMPLE_FAILED (the whole partition,
+     * never a base-only remnant).
+     */
+    private static List<Variant> indexTupleValues(SampleRow row, long indexMetaId) {
+        for (IndexTuple indexTuple : row.secondaryIndexTuples()) {
+            if (indexTuple.indexMetaId() == indexMetaId) {
+                return indexTuple.values();
+            }
+        }
+        throw new IllegalStateException(
+                "sample row is missing a secondary-index tuple for index " + indexMetaId);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutorTest.java
@@ -14,12 +14,19 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import java.util.List;
+
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.jsonResultBatch;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -67,5 +74,103 @@ class AbstractSqlSampleSubqueryExecutorTest {
 
         verify(context).setCurrentWarehouseId(7L);
         verify(sessionVariable, never()).setQueryTimeoutS(anyInt());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Secondary-index (multi-index) projection + decode tests. Driven through
+    // InternalPartitionSampleSubqueryExecutor -- a concrete AbstractSqlSampleSubqueryExecutor
+    // subclass in this package -- since these seams (buildSampleSql's secondary slice,
+    // decodeRow's cumulative-arity secondary decode) are shared scaffolding exercised
+    // via execute(), not overridden per subclass.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void projectsSecondaryIndexColumns() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+        SecondaryIndexSpec rollupOne = new SecondaryIndexSpec(101L, List.of(bigintColumn("r1")));
+        SecondaryIndexSpec rollupTwo = new SecondaryIndexSpec(102L, List.of(bigintColumn("r2a"), bigintColumn("r2b")));
+
+        executor.execute(partitionRequest("db", "tbl", "p1",
+                List.of("k"), List.of(rollupOne, rollupTwo), List.of("dt"), 0L,
+                List.of(bigintColumn("k")), List.of(bigintColumn("dt"))));
+
+        Assertions.assertTrue(capturedSql.toString().contains("SELECT `k`, `r1`, `r2a`, `r2b`, `dt` FROM"),
+                "projection must be sort-key, then each secondary spec's sort key in spec order, "
+                        + "then partition-source: " + capturedSql);
+    }
+
+    @Test
+    void decodesSecondaryTuplesTaggedByMetaId() throws Exception {
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> List.of(
+                        jsonResultBatch("{\"data\":[\"1\", \"10\", \"20\", \"21\", \"99\"]}")));
+        SecondaryIndexSpec rollupOne = new SecondaryIndexSpec(101L, List.of(bigintColumn("r1")));
+        SecondaryIndexSpec rollupTwo = new SecondaryIndexSpec(102L, List.of(bigintColumn("r2a"), bigintColumn("r2b")));
+
+        SampleSubqueryExecutor.SampleExecution execution = executor.execute(partitionRequest(
+                "db", "tbl", "p1", List.of("k"), List.of(rollupOne, rollupTwo), List.of("dt"), 0L,
+                List.of(bigintColumn("k")), List.of(bigintColumn("dt"))));
+
+        List<SampleRow> rows = Lists.newArrayList(execution.rows());
+        Assertions.assertEquals(1, rows.size());
+        SampleRow row = rows.get(0);
+        Assertions.assertEquals("1", row.sortKeyTuple().get(0).getStringValue());
+        Assertions.assertEquals("99", row.partitionSourceTuple().get(0).getStringValue());
+        Assertions.assertEquals(2, row.secondaryIndexTuples().size());
+        Assertions.assertEquals(101L, row.secondaryIndexTuples().get(0).indexMetaId());
+        Assertions.assertEquals(1, row.secondaryIndexTuples().get(0).values().size());
+        Assertions.assertEquals("10", row.secondaryIndexTuples().get(0).values().get(0).getStringValue());
+        Assertions.assertEquals(102L, row.secondaryIndexTuples().get(1).indexMetaId());
+        Assertions.assertEquals(2, row.secondaryIndexTuples().get(1).values().size());
+        Assertions.assertEquals("20", row.secondaryIndexTuples().get(1).values().get(0).getStringValue());
+        Assertions.assertEquals("21", row.secondaryIndexTuples().get(1).values().get(1).getStringValue());
+    }
+
+    @Test
+    void emptySecondaryProjectionAndDecodeUnchanged() throws Exception {
+        StringBuilder capturedSql = new StringBuilder();
+        InternalPartitionSampleSubqueryExecutor executor = new InternalPartitionSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of(jsonResultBatch("{\"data\":[\"10\", \"20\"]}"));
+                });
+
+        SampleSubqueryExecutor.SampleExecution execution = executor.execute(partitionRequest(
+                "db", "tbl", "p1", List.of("k"), List.of(), List.of("dt"), 0L,
+                List.of(bigintColumn("k")), List.of(bigintColumn("dt"))));
+
+        Assertions.assertTrue(capturedSql.toString().contains("SELECT `k`, `dt` FROM"),
+                "empty secondary specs must not alter the projection: " + capturedSql);
+        List<SampleRow> rows = Lists.newArrayList(execution.rows());
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertTrue(rows.get(0).secondaryIndexTuples().isEmpty(),
+                "no secondary specs -> empty secondaryIndexTuples, never null");
+        Assertions.assertEquals("10", rows.get(0).sortKeyTuple().get(0).getStringValue());
+        Assertions.assertEquals("20", rows.get(0).partitionSourceTuple().get(0).getStringValue());
+    }
+
+    private static SampleRequest partitionRequest(
+            String dbName,
+            String tableName,
+            String partitionName,
+            List<String> sortKeySourceColumnNames,
+            List<SecondaryIndexSpec> secondaryIndexSortKeys,
+            List<String> partitionSourceColumnNames,
+            long partitionSizeBytes,
+            List<Column> sortKeyColumns,
+            List<Column> partitionSourceColumns) {
+        ComputeResource computeResource = mock(ComputeResource.class);
+        InternalPartitionScanContext scanContext = new InternalPartitionScanContext(
+                dbName, tableName, partitionName,
+                sortKeySourceColumnNames, partitionSourceColumnNames,
+                partitionSizeBytes, computeResource);
+        return new SampleRequest(
+                scanContext, sortKeyColumns, secondaryIndexSortKeys, partitionSourceColumns,
+                /*sampleByteLimit=*/ Long.MAX_VALUE, /*seed=*/ 0L);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -598,6 +598,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         com.starrocks.catalog.MaterializedIndexMeta baseMeta = mock(com.starrocks.catalog.MaterializedIndexMeta.class);
         when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(table.getName()).thenReturn("partitioned_t");
         when(table.supportedAutomaticPartition()).thenReturn(true);
         PartitionInfo partitionInfo = mock(PartitionInfo.class);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -447,6 +447,46 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         }
     }
 
+    // ---------- Secondary index spec construction ----------
+
+    @Test
+    public void buildSecondaryIndexSpecsIncludesEveryRollupExceptBase() {
+        // A target with a base index (id 1) and one rollup (id 2) must produce exactly
+        // one SecondaryIndexSpec for the rollup, carrying its own (divergent) sort key.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        com.starrocks.catalog.MaterializedIndexMeta baseMeta =
+                mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        com.starrocks.catalog.MaterializedIndexMeta rollupMeta =
+                mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        List<Column> rollupSortKey = List.of(bigintColumn("r"));
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L)).thenReturn(rollupSortKey);
+
+            List<SecondaryIndexSpec> specs = BrokerLoadPreSplitHook.buildSecondaryIndexSpecs(table);
+
+            Assertions.assertEquals(1, specs.size(), "exactly one rollup spec expected");
+            Assertions.assertEquals(2L, specs.get(0).indexMetaId());
+            Assertions.assertEquals(rollupSortKey, specs.get(0).sortKey());
+        }
+    }
+
+    @Test
+    public void buildSecondaryIndexSpecsEmptyForSingleIndexTarget() {
+        // A single-index (base only) target must produce no secondary specs.
+        // mockPartitionedRangeTable's single visible index carries BASE_INDEX_META_ID;
+        // stub getBaseIndexMetaId() to match so the loop recognizes it as the base.
+        OlapTable table = mockPartitionedRangeTable();
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+
+        Assertions.assertTrue(BrokerLoadPreSplitHook.buildSecondaryIndexSpecs(table).isEmpty(),
+                "a single-index target must produce no secondary index specs");
+    }
+
     // The await-helper polling semantics (finished, aborted, disappeared, timeout)
     // are covered by InsertPreSplitHookFilesPartitionedTest's
     // awaitCombinedJobAllowingFallback* tests now that the helper lives on

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -164,10 +164,10 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             // Non-empty grouped list -> submitForPartitionsCombined is invoked.
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(Mockito.mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any(), any()))
                     .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -179,7 +179,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // Routing proof: partitioned tables MUST take the multi-partition path...
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), times(1));
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), times(1));
             // ...and MUST NOT fall through to the single-partition entry.
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
@@ -214,7 +214,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(Mockito.mock(PartitionSamples.class)));
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -226,7 +226,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // The automatic-partition gate must skip before either submit path.
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }
@@ -264,10 +264,10 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                 metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
                 grouper.when(() -> PartitionSampleGrouper.group(
                                 any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                                anyLong(), anyLong()))
+                                anyLong(), anyLong(), any()))
                         .thenReturn(List.of(Mockito.mock(PartitionSamples.class)));
                 coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                                any(), any(), anyList(), anyInt(), any(), any()))
+                                any(), any(), anyList(), anyInt(), any(), any(), any()))
                         .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
                 BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -316,9 +316,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // Sampler failed -> no grouping, no submit.
             grouper.verify(() -> PartitionSampleGrouper.group(
-                    any(), any(), any(), anyLong(), anyLong()), never());
+                    any(), any(), any(), anyLong(), anyLong(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 
@@ -350,9 +350,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                     mock(ComputeResource.class), () -> false);
 
             grouper.verify(() -> PartitionSampleGrouper.group(
-                    any(), any(), any(), anyLong(), anyLong()), never());
+                    any(), any(), any(), anyLong(), anyLong(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 
@@ -377,7 +377,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of());
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
@@ -389,9 +389,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
 
             // Grouper ran but returned empty -> no submit.
             grouper.verify(() -> PartitionSampleGrouper.group(
-                    any(), any(), any(), anyLong(), anyLong()), times(1));
+                    any(), any(), any(), anyLong(), anyLong(), any()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 
@@ -441,7 +441,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                     mock(ComputeResource.class), () -> false);
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -90,6 +90,8 @@ import static org.mockito.Mockito.when;
  */
 public class BrokerLoadPreSplitHookPartitionedTest {
 
+    private static final long BASE_INDEX_META_ID = 10L;
+
     private boolean savedConfigBrokerLoad;
     private boolean savedMetricHasInit;
 
@@ -158,6 +160,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(sampledRows))) {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
             // Non-empty grouped list -> submitForPartitionsCombined is invoked.
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
@@ -208,6 +211,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(sampledRows))) {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
                             anyLong(), anyLong()))
@@ -257,6 +261,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                                 return sampledRows;
                             }))) {
                 metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+                metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
                 grouper.when(() -> PartitionSampleGrouper.group(
                                 any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
                                 anyLong(), anyLong()))
@@ -300,6 +305,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class)))
                                 .thenThrow(new com.starrocks.common.StarRocksException("synthetic sample failure")))) {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
                     mockConnectContextWithSessionPreSplit(true),
@@ -334,6 +340,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class)))
                                 .thenThrow(new RuntimeException("synthetic runtime sample failure")))) {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
 
             BrokerLoadPreSplitHook.maybeRunPreSplit(
                     mockConnectContextWithSessionPreSplit(true),
@@ -367,6 +374,7 @@ public class BrokerLoadPreSplitHookPartitionedTest {
                 MockedConstruction<ReservoirSampler> ignored = Mockito.mockConstruction(ReservoirSampler.class,
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(sampledRows))) {
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(sortKey);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)).thenReturn(sortKey);
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
                             anyLong(), anyLong()))
@@ -534,8 +542,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
     /**
      * Mock a partitioned, range-distribution {@link OlapTable} that passes
      * every structural gate inside {@link PreSplitTargets#findEligibleTable}.
+     * The single visible index meta's id is fixed to {@link #BASE_INDEX_META_ID}.
      * The caller is responsible for ALSO stubbing
-     * {@code MetaUtils.getRangeDistributionColumns(table)} via
+     * {@code MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID)} via
      * {@link MockedStatic} when the test needs {@code findEligibleTable} to
      * return {@code null} (i.e. the table is actually eligible) — without that
      * stub the bare mock returns an empty sort-key list and the eligibility
@@ -546,7 +555,9 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
         when(table.isRangeDistribution()).thenReturn(true);
         when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(mock(com.starrocks.catalog.MaterializedIndexMeta.class)));
+        com.starrocks.catalog.MaterializedIndexMeta baseMeta = mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
         when(table.getName()).thenReturn("partitioned_t");
         when(table.supportedAutomaticPartition()).thenReturn(true);
         PartitionInfo partitionInfo = mock(PartitionInfo.class);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
@@ -200,7 +200,7 @@ public class BrokerLoadPreSplitHookTest {
             stubIndexSortKey(metaUtils, target, BASE_INDEX_META_ID, "k");
             stubIndexSortKey(metaUtils, target, ROLLUP_INDEX_META_ID, "k2");
             pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
-                            any(), any(), anyLong(), anyLong(), any(), any()))
+                            any(), any(), any(), anyLong(), any(), any()))
                     .thenReturn(mock(DefaultPreSplitPipeline.class));
             coordinator.when(() -> TabletPreSplitCoordinator.submitAsynchronously(
                             any(), any(), anyLong(), any(), any(), any(), anyInt()))

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -36,23 +37,31 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.assertHookDoesNotDelegate;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.mockConnectContextWithSessionPreSplit;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
  * Detection-side coverage for {@link BrokerLoadPreSplitHook}: each early-return
  * branch is exercised and asserted via {@code MockedStatic} to never reach
- * {@link TabletPreSplitCoordinator#submitAsynchronously}. The eligible-
- * delegation path needs a full FE fixture (catalog, tablet inverted index,
- * compute-resource warehouse) and is left to integration coverage.
+ * {@link TabletPreSplitCoordinator#submitAsynchronously}. The full eligible-
+ * delegation path (sampling through an admitted reshard job) needs a full FE
+ * fixture (catalog, tablet inverted index, compute-resource warehouse) and is
+ * left to integration coverage; the relaxed per-index gate (base + rollup)
+ * is covered here with {@link TabletPreSplitCoordinator} itself mocked out.
  */
 public class BrokerLoadPreSplitHookTest {
 
     private static final long BASE_INDEX_META_ID = 200L;
+    private static final long ROLLUP_INDEX_META_ID = 210L;
 
     private boolean savedConfigBrokerLoad;
 
@@ -170,6 +179,75 @@ public class BrokerLoadPreSplitHookTest {
         assertSinglePartitionResolveRecordsSkip(target, SkipReason.METADATA_NOT_RESOLVED);
     }
 
+    // ---- relaxed per-index gate: base + rollup ----
+
+    @Test
+    public void testEligibleRollupDelegatesToCoordinator() throws Exception {
+        // A base index plus a single eligible rollup (single-tablet, scalar sort key) must NOT
+        // be skipped for has_materialized_view_or_rollup and must reach the coordinator's
+        // submitAsynchronously -- the relaxed per-index gate (PreSplitTargets#resolveVisibleIndexTargets)
+        // lets it through where the old getVisibleIndexMetas().size() != 1 gate would have skipped.
+        OlapTable target = tableWithBaseAndRollup();
+        installBaseAndRollup(target, /*rollupTabletCount*/ 1);
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class);
+                MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<DefaultPreSplitPipeline> pipelineStatic = Mockito.mockStatic(DefaultPreSplitPipeline.class);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class)) {
+            stubIndexSortKey(metaUtils, target, BASE_INDEX_META_ID, "k");
+            stubIndexSortKey(metaUtils, target, ROLLUP_INDEX_META_ID, "k2");
+            pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
+                            any(), any(), anyLong(), anyLong(), any(), any()))
+                    .thenReturn(mock(DefaultPreSplitPipeline.class));
+            coordinator.when(() -> TabletPreSplitCoordinator.submitAsynchronously(
+                            any(), any(), anyLong(), any(), any(), any(), anyInt()))
+                    .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
+
+            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
+            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+
+            invokeHook(target, List.of(mock(BrokerFileGroup.class)), List.of(List.<TBrokerFileStatus>of()));
+
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
+                    any(), any(), anyLong(), any(), any(), any(), anyInt()), times(1));
+            Assertions.assertEquals(baseline,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
+                    "eligible base+rollup must not bump the has_materialized_view_or_rollup bucket");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+        }
+    }
+
+    @Test
+    public void testIneligibleRollupRecordsSkip() throws Exception {
+        // A rollup that fails per-index resolution (here: more than one tablet) must skip the
+        // whole target under has_materialized_view_or_rollup and never delegate.
+        OlapTable target = tableWithBaseAndRollup();
+        installBaseAndRollup(target, /*rollupTabletCount*/ 2);
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            stubIndexSortKey(metaUtils, target, BASE_INDEX_META_ID, "k");
+            stubIndexSortKey(metaUtils, target, ROLLUP_INDEX_META_ID, "k2");
+
+            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
+            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+
+            assertHookDoesNotDelegate(() ->
+                    invokeHook(target, List.of(mock(BrokerFileGroup.class)), List.of(List.<TBrokerFileStatus>of())));
+
+            Assertions.assertEquals(baseline + 1L,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
+                    "ineligible rollup must bump the has_materialized_view_or_rollup bucket");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+        }
+    }
+
     @Test
     public void testInternalThrowIsSwallowed() throws Exception {
         // Drive the outer try/catch by passing an OlapTable whose accessor
@@ -240,6 +318,62 @@ public class BrokerLoadPreSplitHookTest {
         when(partitionInfo.isPartitioned()).thenReturn(false);
         when(table.getPartitionInfo()).thenReturn(partitionInfo);
         return table;
+    }
+
+    /**
+     * Variant of {@link #tablePassingTableLevelGate} with a second visible index (a rollup)
+     * alongside the base, so {@link PreSplitTargets#findEligibleTable}'s per-index sort-key
+     * check runs against both. Per-partition shape (physical partitions, tablets per index) is
+     * left to {@link #installBaseAndRollup}.
+     */
+    private static OlapTable tableWithBaseAndRollup() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        when(table.isRangeDistribution()).thenReturn(true);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        PartitionInfo partitionInfo = mock(PartitionInfo.class);
+        when(partitionInfo.isPartitioned()).thenReturn(false);
+        when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        return table;
+    }
+
+    /**
+     * Installs {@code target}'s single physical partition with a single-tablet base index and a
+     * rollup index carrying {@code rollupTabletCount} tablets, both visible to
+     * {@link PreSplitTargets#resolveVisibleIndexTargets}.
+     */
+    private static void installBaseAndRollup(OlapTable target, int rollupTabletCount) {
+        MaterializedIndex baseIndex = mock(MaterializedIndex.class);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(baseIndex.getTablets()).thenReturn(List.of(mock(Tablet.class)));
+        when(baseIndex.getRowCount()).thenReturn(0L);
+
+        MaterializedIndex rollupIndex = mock(MaterializedIndex.class);
+        when(rollupIndex.getMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        List<Tablet> rollupTablets = new ArrayList<>(rollupTabletCount);
+        for (int i = 0; i < rollupTabletCount; i++) {
+            rollupTablets.add(mock(Tablet.class));
+        }
+        when(rollupIndex.getTablets()).thenReturn(rollupTablets);
+
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex, rollupIndex));
+        when(target.getPhysicalPartitions()).thenReturn(List.of(partition));
+    }
+
+    /** Stub {@code MetaUtils.getRangeDistributionColumns(target, indexMetaId)} to a single scalar column. */
+    private static void stubIndexSortKey(
+            MockedStatic<MetaUtils> metaUtils, OlapTable target, long indexMetaId, String columnName) {
+        metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(target, indexMetaId))
+                .thenReturn(List.of(PresplitTestSupport.bigintColumn(columnName)));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookTest.java
@@ -232,7 +232,9 @@ public class BrokerLoadPreSplitHookTest {
         when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
         when(table.isRangeDistribution()).thenReturn(true);
         when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(mock(MaterializedIndexMeta.class)));
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
         when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         PartitionInfo partitionInfo = mock(PartitionInfo.class);
         when(partitionInfo.isPartitioned()).thenReturn(false);
@@ -253,7 +255,7 @@ public class BrokerLoadPreSplitHookTest {
         boolean savedHasInit = MetricRepo.hasInit;
         MetricRepo.hasInit = true;
         try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(target))
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(target, BASE_INDEX_META_ID))
                     .thenReturn(List.of(PresplitTestSupport.bigintColumn("k")));
             String label = expectedReason.name().toLowerCase();
             long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
@@ -580,10 +580,10 @@ public class DefaultPreSplitPipelineTest {
     }
 
     @Test
-    public void preSubmit_recordsTierForBaseOnly() throws Exception {
+    public void preSubmit_recordsTierForFirstContributingIndexOnly() throws Exception {
         // Base yields 1 boundary, rollup yields 2 -- if tier/boundary recording ran per-index
-        // instead of base-only, the tier counter would bump by 2 and the histogram would also
-        // record the rollup's 2-boundary sample.
+        // instead of once for the first contributing index, the tier counter would bump by 2 and
+        // the histogram would also record the rollup's 2-boundary sample.
         stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
         BoundaryPlannerResult baseResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
         BoundaryPlannerResult rollupResult = new BoundaryPlannerResult(List.of(bigintTuple(10), bigintTuple(20)));
@@ -598,11 +598,11 @@ public class DefaultPreSplitPipelineTest {
         LongCounterMetric savedSamplerInvocations = MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS;
         MetricRepo.hasInit = true;
         MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED =
-                new MetricRegistry().histogram("presubmit_records_tier_for_base_only_test");
+                new MetricRegistry().histogram("presubmit_records_tier_for_first_contributing_index_test");
         // recordSamplerInvocation() (called unconditionally at the top of preSubmit) needs this
         // non-null once hasInit is forced true; MetricRepo.init() is never run in this bare test.
         MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS =
-                new LongCounterMetric("presubmit_records_tier_for_base_only_test_invocations",
+                new LongCounterMetric("presubmit_records_tier_for_first_contributing_index_test_invocations",
                         MetricUnit.REQUESTS, "test-local sampler invocations");
         try {
             String tierLabel = DefaultPreSplitPipeline.TIER_LABEL_META_TIER;
@@ -620,11 +620,67 @@ public class DefaultPreSplitPipelineTest {
 
             Assertions.assertEquals(baselineTierCount + 1,
                     MetricRepo.COUNTER_TABLET_PRE_SPLIT_TIER_USED.getMetric(tierLabel).getValue().longValue(),
-                    "tier_used must be recorded exactly once (base only), not once per index");
+                    "tier_used must be recorded exactly once (first contributing index), not once per index");
             Assertions.assertEquals(1, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getCount(),
-                    "boundaries_planned must be recorded exactly once (base only)");
+                    "boundaries_planned must be recorded exactly once (first contributing index)");
             Assertions.assertEquals(1, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getSnapshot().getMax(),
                     "the recorded boundary count must be the base's (1), not the rollup's (2)");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+            MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED = savedHistogram;
+            MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS = savedSamplerInvocations;
+        }
+    }
+
+    @Test
+    public void preSubmit_baseNoCutsRollupCuts_recordsTierForRollup() throws Exception {
+        // The base's own sort key yields NO_SPLIT while the rollup still produces cuts -- a
+        // real (rollup-only) job is submitted, and the rollup must be the one recorded as the
+        // first contributing index (not zero recordings, since it is not literally index 0).
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult rollupResult = new BoundaryPlannerResult(List.of(bigintTuple(10), bigintTuple(20)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) ->
+                request.getSortKey().equals(BASE_SORT_KEY) ? BoundaryPlannerResult.NO_SPLIT : rollupResult;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        Histogram savedHistogram = MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED;
+        LongCounterMetric savedSamplerInvocations = MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS;
+        MetricRepo.hasInit = true;
+        MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED =
+                new MetricRegistry().histogram("presubmit_base_no_cuts_rollup_cuts_test");
+        MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS =
+                new LongCounterMetric("presubmit_base_no_cuts_rollup_cuts_test_invocations",
+                        MetricUnit.REQUESTS, "test-local sampler invocations");
+        try {
+            String tierLabel = DefaultPreSplitPipeline.TIER_LABEL_META_TIER;
+            long baselineTierCount = MetricRepo.COUNTER_TABLET_PRE_SPLIT_TIER_USED.getMetric(tierLabel).getValue();
+
+            TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+            try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+                mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
+                                eq(database), eq(table), eq(ROLLUP_TABLET_ID), any()))
+                        .thenReturn(fakeJob);
+
+                DefaultPreSplitPipeline pipeline =
+                        newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+                Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                        pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+                Assertions.assertTrue(prepared.isPresent(),
+                        "rollup-only cuts must still submit (allowed base-no-cut/rollup-cut)");
+                mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
+            }
+
+            Assertions.assertEquals(baselineTierCount + 1,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_TIER_USED.getMetric(tierLabel).getValue().longValue(),
+                    "tier_used must be recorded once for the rollup, the first (and only) contributing index");
+            Assertions.assertEquals(1, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getCount(),
+                    "boundaries_planned must be recorded once for the rollup, not skipped");
+            Assertions.assertEquals(2, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getSnapshot().getMax(),
+                    "the recorded boundary count must be the rollup's (2)");
         } finally {
             MetricRepo.hasInit = savedHasInit;
             MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED = savedHistogram;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
@@ -14,21 +14,28 @@
 
 package com.starrocks.alter.reshard.presplit;
 
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
 import com.starrocks.alter.reshard.SplitTabletJobFactory;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.metric.LongCounterMetric;
+import com.starrocks.metric.Metric.MetricUnit;
+import com.starrocks.metric.MetricRepo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -36,7 +43,9 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,14 +53,21 @@ import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.DUMMY_CON
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintTuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DefaultPreSplitPipelineTest {
 
     private static final long OLD_TABLET_ID = 9000L;
+    private static final long ROLLUP_TABLET_ID = 9100L;
+    private static final long BASE_INDEX_META_ID = 1L;
+    private static final long ROLLUP_INDEX_META_ID = 2L;
+    private static final List<Column> BASE_SORT_KEY = List.of(bigintColumn("ts"));
+    private static final List<Column> ROLLUP_SORT_KEY = List.of(bigintColumn("ts2"));
     private static final long FILE_TOTAL_BYTES = 1024L;
     private static final int ACTIVE_COMPUTE_NODES = 3;
     private static final Duration PRE_SUBMIT_TIMEOUT = Duration.ofSeconds(30);
@@ -73,12 +89,16 @@ public class DefaultPreSplitPipelineTest {
         Config.tablet_reshard_max_split_count = 1024;
 
         database = mock(Database.class);
+        when(database.getId()).thenReturn(500L);
         table = mock(OlapTable.class);
         when(table.getName()).thenReturn("t");
+        when(table.getId()).thenReturn(600L);
         tabletReshardJobManager = mock(TabletReshardJobMgr.class);
 
-        Column sortColumn = bigintColumn("ts");
-        sampleRequest = new SampleRequest(DUMMY_CONTEXT, List.of(sortColumn), 16L * DebugUtil.MEGABYTE, 0L);
+        sampleRequest = new SampleRequest(DUMMY_CONTEXT, BASE_SORT_KEY, 16L * DebugUtil.MEGABYTE, 0L);
+        // Default single-index shape (matches singleBaseTarget()); tests covering a base+rollup
+        // target list restub this via stubVisibleIndexMetas.
+        stubVisibleIndexMetas(BASE_INDEX_META_ID);
     }
 
     @AfterEach
@@ -88,10 +108,36 @@ public class DefaultPreSplitPipelineTest {
     }
 
     private DefaultPreSplitPipeline newPipeline(MetaTierSampler metaTierSampler, Sampler dataTierSampler, Clock clock) {
+        return newPipeline(singleBaseTarget(), metaTierSampler, dataTierSampler, clock);
+    }
+
+    private DefaultPreSplitPipeline newPipeline(List<IndexPreSplitTarget> indexTargets,
+            MetaTierSampler metaTierSampler, Sampler dataTierSampler, Clock clock) {
         return new DefaultPreSplitPipeline(
                 metaTierSampler, dataTierSampler, tabletReshardJobManager,
-                database, table, OLD_TABLET_ID, FILE_TOTAL_BYTES,
+                database, table, indexTargets, FILE_TOTAL_BYTES,
                 POLL_INTERVAL, clock, null);
+    }
+
+    private static List<IndexPreSplitTarget> singleBaseTarget() {
+        return List.of(new IndexPreSplitTarget(BASE_INDEX_META_ID, OLD_TABLET_ID, BASE_SORT_KEY));
+    }
+
+    private static List<IndexPreSplitTarget> baseAndRollupTargets() {
+        return List.of(
+                new IndexPreSplitTarget(BASE_INDEX_META_ID, OLD_TABLET_ID, BASE_SORT_KEY),
+                new IndexPreSplitTarget(ROLLUP_INDEX_META_ID, ROLLUP_TABLET_ID, ROLLUP_SORT_KEY));
+    }
+
+    /** Stubs {@code table.getVisibleIndexMetas()} to the given index-meta ids, base first. */
+    private void stubVisibleIndexMetas(long... indexMetaIds) {
+        List<MaterializedIndexMeta> metas = new ArrayList<>();
+        for (long indexMetaId : indexMetaIds) {
+            MaterializedIndexMeta meta = mock(MaterializedIndexMeta.class);
+            when(meta.getIndexMetaId()).thenReturn(indexMetaId);
+            metas.add(meta);
+        }
+        when(table.getVisibleIndexMetas()).thenReturn(metas);
     }
 
     @Test
@@ -368,6 +414,224 @@ public class DefaultPreSplitPipelineTest {
         Assertions.assertTrue(ranges.get(1).getRange().isMaximum());
     }
 
+    // ---------- preSubmit: unified per-index plan ----------
+
+    @Test
+    public void preSubmit_singleIndex_usesSingleTabletFactory() throws Exception {
+        // A single-index target list (base only, matching the pre-existing shape) must still
+        // route through forExternalBoundaries, never forExternalBoundariesMultiTablet.
+        BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) -> metaTierResult;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), eq(OLD_TABLET_ID), any()))
+                    .thenReturn(fakeJob);
+
+            DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isPresent());
+            Assertions.assertSame(fakeJob, prepared.get().payload());
+            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
+        }
+    }
+
+    @Test
+    public void preSubmit_baseAndRollup_splitsBothViaMultiTablet() throws Exception {
+        // Both the base and a rollup produce cuts -> the {oldTabletId -> ranges} map has two
+        // entries -> forExternalBoundariesMultiTablet, never the single-tablet factory.
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) -> metaTierResult;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                            eq(database), eq(table), mapCaptor.capture()))
+                    .thenReturn(fakeJob);
+
+            DefaultPreSplitPipeline pipeline = newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isPresent());
+            Assertions.assertSame(fakeJob, prepared.get().payload());
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(2, map.size());
+            Assertions.assertTrue(map.containsKey(OLD_TABLET_ID));
+            Assertions.assertTrue(map.containsKey(ROLLUP_TABLET_ID));
+            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), anyLong(), any()), never());
+        }
+    }
+
+    @Test
+    public void preSubmit_rollupNoCuts_usesSingleTabletFactoryForBase() throws Exception {
+        // The rollup's own sort key yields NO_SPLIT while the base still produces cuts -- the
+        // map ends up with only the base entry, so the single-tablet factory is used (a
+        // base-only submit is allowed).
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) ->
+                request.getSortKey().equals(BASE_SORT_KEY) ? metaTierResult : BoundaryPlannerResult.NO_SPLIT;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), eq(OLD_TABLET_ID), any()))
+                    .thenReturn(fakeJob);
+
+            DefaultPreSplitPipeline pipeline = newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isPresent(), "base-only cuts must still submit (allowed base-only)");
+            Assertions.assertSame(fakeJob, prepared.get().payload());
+            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
+        }
+    }
+
+    @Test
+    public void preSubmit_baseMetaTierRollupDataTier_bothPlanned() throws Exception {
+        // Per-index tier independence: the base's sort key reaches meta tier, the rollup's own
+        // sort key is meta-tier-unavailable and falls back to data tier -- both still contribute
+        // cuts to the combined map.
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) -> {
+            if (request.getSortKey().equals(BASE_SORT_KEY)) {
+                return metaTierResult;
+            }
+            throw new MetaTierUnavailableException("test: rollup meta tier unavailable");
+        };
+        Sampler dataTier = request -> new SampleSet(
+                List.of(bigintTuple(10), bigintTuple(20), bigintTuple(30), bigintTuple(40)),
+                new Estimates(FILE_TOTAL_BYTES, 4L));
+
+        TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                            eq(database), eq(table), mapCaptor.capture()))
+                    .thenReturn(fakeJob);
+
+            DefaultPreSplitPipeline pipeline = newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isPresent());
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(2, map.size(),
+                    "per-index tier independence: both base (meta) and rollup (data) must contribute cuts");
+            Assertions.assertTrue(map.containsKey(OLD_TABLET_ID));
+            Assertions.assertTrue(map.containsKey(ROLLUP_TABLET_ID));
+        }
+    }
+
+    @Test
+    public void preSubmit_visibleIndexAppearedAfterSnapshot_skips() throws Exception {
+        // The eligibility snapshot only captured the base index, but a rollup has since become
+        // visible on the live table -- the final id-set re-check must detect the mismatch and
+        // skip entirely (never a base-only partial submit).
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) -> metaTierResult;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isEmpty(), "a visible-index-set mismatch must skip, never a base-only submit");
+            mocked.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void preSubmit_noIndexCuts_returnsEmpty() throws Exception {
+        MetaTierSampler metaTier = (request, requestedTabletCount) -> BoundaryPlannerResult.NO_SPLIT;
+        Sampler dataTier = request -> {
+            throw new AssertionError("data tier must not be invoked when meta tier returns NO_SPLIT");
+        };
+
+        try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+            DefaultPreSplitPipeline pipeline = newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+            Optional<PreSplitPipeline.PreparedReshardJob> prepared =
+                    pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+
+            Assertions.assertTrue(prepared.isEmpty());
+            mocked.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void preSubmit_recordsTierForBaseOnly() throws Exception {
+        // Base yields 1 boundary, rollup yields 2 -- if tier/boundary recording ran per-index
+        // instead of base-only, the tier counter would bump by 2 and the histogram would also
+        // record the rollup's 2-boundary sample.
+        stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
+        BoundaryPlannerResult baseResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
+        BoundaryPlannerResult rollupResult = new BoundaryPlannerResult(List.of(bigintTuple(10), bigintTuple(20)));
+        MetaTierSampler metaTier = (request, requestedTabletCount) ->
+                request.getSortKey().equals(BASE_SORT_KEY) ? baseResult : rollupResult;
+        Sampler dataTier = request -> {
+            throw new StarRocksException("dataTier should not be called");
+        };
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        Histogram savedHistogram = MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED;
+        LongCounterMetric savedSamplerInvocations = MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS;
+        MetricRepo.hasInit = true;
+        MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED =
+                new MetricRegistry().histogram("presubmit_records_tier_for_base_only_test");
+        // recordSamplerInvocation() (called unconditionally at the top of preSubmit) needs this
+        // non-null once hasInit is forced true; MetricRepo.init() is never run in this bare test.
+        MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS =
+                new LongCounterMetric("presubmit_records_tier_for_base_only_test_invocations",
+                        MetricUnit.REQUESTS, "test-local sampler invocations");
+        try {
+            String tierLabel = DefaultPreSplitPipeline.TIER_LABEL_META_TIER;
+            long baselineTierCount = MetricRepo.COUNTER_TABLET_PRE_SPLIT_TIER_USED.getMetric(tierLabel).getValue();
+
+            TabletReshardJob fakeJob = mock(TabletReshardJob.class);
+            try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
+                mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+                        .thenReturn(fakeJob);
+
+                DefaultPreSplitPipeline pipeline =
+                        newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
+                pipeline.preSubmit(sampleRequest, ACTIVE_COMPUTE_NODES, PRE_SUBMIT_TIMEOUT);
+            }
+
+            Assertions.assertEquals(baselineTierCount + 1,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_TIER_USED.getMetric(tierLabel).getValue().longValue(),
+                    "tier_used must be recorded exactly once (base only), not once per index");
+            Assertions.assertEquals(1, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getCount(),
+                    "boundaries_planned must be recorded exactly once (base only)");
+            Assertions.assertEquals(1, MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED.getSnapshot().getMax(),
+                    "the recorded boundary count must be the base's (1), not the rollup's (2)");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+            MetricRepo.HISTO_TABLET_PRE_SPLIT_BOUNDARIES_PLANNED = savedHistogram;
+            MetricRepo.COUNTER_TABLET_PRE_SPLIT_SAMPLER_INVOCATIONS = savedSamplerInvocations;
+        }
+    }
+
     @Test
     public void forLoadKindInsertFromTableSinglePartitionForcesDataTier() {
         // Unpartitioned OlapTable; forLoadKind with INSERT_FROM_TABLE must install a
@@ -378,7 +642,7 @@ public class DefaultPreSplitPipelineTest {
         when(table.getPartitionInfo()).thenReturn(partitionInfo);
 
         DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                database, table, OLD_TABLET_ID, FILE_TOTAL_BYTES, LoadKind.INSERT_FROM_TABLE, null);
+                database, table, singleBaseTarget(), FILE_TOTAL_BYTES, LoadKind.INSERT_FROM_TABLE, null);
 
         Assertions.assertThrows(MetaTierUnavailableException.class,
                 () -> pipeline.getMetaTierSamplerForTest().tryPlan(sampleRequest, 3),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookColumnListTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookColumnListTest.java
@@ -15,10 +15,14 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.common.MetaUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.List;
@@ -127,6 +131,30 @@ public class InsertPreSplitHookColumnListTest {
     public void sortKeyMatchIsCaseInsensitive() {
         Assertions.assertTrue(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
                 insertWithTargetColumns(List.of("K", "V")), tableWithBaseColumns("k", "v"), requiredColumns("k")));
+    }
+
+    @Test
+    public void columnListOmittingRollupKey_notPreSplitSafe() {
+        // base index (id 1): sort key k, plus v. A visible rollup (id 2) sorts on a
+        // divergent column r. A target list covering the base sort key but omitting
+        // the rollup's sort key must be rejected -- the rollup split would collapse
+        // its data on r even though the base split on k is fine.
+        OlapTable table = tableWithBaseColumns("k", "v");
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L))
+                    .thenReturn(requiredColumns("r"));
+
+            Assertions.assertFalse(InsertPreSplitHook.targetColumnListIsPreSplitSafe(
+                    insertWithTargetColumns(List.of("k", "v")), table, requiredColumns("k")),
+                    "a target column list omitting a divergent rollup sort key must not be pre-split safe");
+        }
     }
 
     // ---- targetColumnListIsFullIdentity (INSERT-from-table gate) ----

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -121,8 +121,10 @@ public class InsertPreSplitHookFilesPartitionedTest {
             when(globalState.getTabletReshardJobMgr()).thenReturn(mock(TabletReshardJobMgr.class));
             gsm.when(GlobalStateMgr::getCurrentState).thenReturn(globalState);
 
+            List<IndexPreSplitTarget> indexTargets = List.of(
+                    new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 99L, List.of(bigintColumn("ts"))));
             DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                    database, table, /*oldTabletId*/ 99L, /*fileTotalBytes*/ 1024L,
+                    database, table, indexTargets, /*fileTotalBytes*/ 1024L,
                     LoadKind.INSERT_FROM_FILES, null);
 
             // Drive the partitioned meta-tier sampler directly via reflection over the
@@ -159,8 +161,10 @@ public class InsertPreSplitHookFilesPartitionedTest {
             when(globalState.getTabletReshardJobMgr()).thenReturn(mock(TabletReshardJobMgr.class));
             gsm.when(GlobalStateMgr::getCurrentState).thenReturn(globalState);
 
+            List<IndexPreSplitTarget> indexTargets = List.of(
+                    new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 99L, List.of(bigintColumn("ts"))));
             DefaultPreSplitPipeline pipeline = DefaultPreSplitPipeline.forLoadKind(
-                    database, table, /*oldTabletId*/ 99L, /*fileTotalBytes*/ 1024L,
+                    database, table, indexTargets, /*fileTotalBytes*/ 1024L,
                     LoadKind.INSERT_FROM_FILES, null);
 
             java.lang.reflect.Field metaField = DefaultPreSplitPipeline.class.getDeclaredField("metaTierSampler");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -21,6 +21,7 @@ import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.TableFunctionTable;
@@ -31,6 +32,7 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -243,6 +245,45 @@ public class InsertPreSplitHookFilesPartitionedTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }
+    }
+
+    // ---------- Secondary index spec construction ----------
+
+    @Test
+    public void buildSecondaryIndexSpecsIncludesEveryRollupExceptBase() {
+        // A target with a base index (id 1) and one rollup (id 2) must produce exactly
+        // one SecondaryIndexSpec for the rollup, carrying its own (divergent) sort key.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        List<Column> rollupSortKey = List.of(bigintColumn("r"));
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L)).thenReturn(rollupSortKey);
+
+            List<SecondaryIndexSpec> specs = FilesPreSplitSource.buildSecondaryIndexSpecs(table);
+
+            Assertions.assertEquals(1, specs.size(), "exactly one rollup spec expected");
+            Assertions.assertEquals(2L, specs.get(0).indexMetaId());
+            Assertions.assertEquals(rollupSortKey, specs.get(0).sortKey());
+        }
+    }
+
+    @Test
+    public void buildSecondaryIndexSpecsEmptyForSingleIndexTarget() {
+        // A single-index (base only) target must produce no secondary specs.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
+
+        Assertions.assertTrue(FilesPreSplitSource.buildSecondaryIndexSpecs(table).isEmpty(),
+                "a single-index target must produce no secondary index specs");
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -234,14 +234,14 @@ public class InsertPreSplitHookFilesPartitionedTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
 
             PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_FILES,
                     () -> false, mock(ConnectContext.class));
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.assertHookDoesNotDelegate;
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.mockConnectContextWithSessionPreSplit;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -256,7 +257,8 @@ public class InsertPreSplitHookFilesTest {
             // flow would reach submitAsynchronously if the MV gate were removed.
             targets.when(() -> PreSplitTargets.findEligibleTarget(database, mv))
                     .thenReturn(new PreSplitTargets.EligibleTarget(database, mv, /*partitionId*/ 11L,
-                            /*oldTabletId*/ 22L));
+                            List.of(new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 22L,
+                                    List.of(bigintColumn("sort_col"))))));
             pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
                     any(), any(), anyLong(), anyLong(), any(), any()))
                     .thenReturn(mock(DefaultPreSplitPipeline.class));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -260,7 +260,7 @@ public class InsertPreSplitHookFilesTest {
                             List.of(new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 22L,
                                     List.of(bigintColumn("sort_col"))))));
             pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
-                    any(), any(), anyLong(), anyLong(), any(), any()))
+                    any(), any(), any(), anyLong(), any(), any()))
                     .thenReturn(mock(DefaultPreSplitPipeline.class));
 
             InsertPreSplitHook.maybeRunPreSplit(stmt, context);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesTest.java
@@ -268,7 +268,7 @@ public class InsertPreSplitHookFilesTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -723,7 +723,7 @@ public class InsertPreSplitHookTableTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
 
         /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -81,6 +81,8 @@ import static org.mockito.Mockito.when;
  */
 public class InsertPreSplitHookTableTest {
 
+    private static final long BASE_INDEX_META_ID = 10L;
+
     private boolean savedConfigInsertFromTable;
 
     @BeforeEach
@@ -641,7 +643,10 @@ public class InsertPreSplitHookTableTest {
             when(target.isCloudNativeTableOrMaterializedView()).thenReturn(true);
             when(target.isRangeDistribution()).thenReturn(true);
             when(target.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-            when(target.getVisibleIndexMetas()).thenReturn(List.of(mock(com.starrocks.catalog.MaterializedIndexMeta.class)));
+            com.starrocks.catalog.MaterializedIndexMeta baseMeta = mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+            when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+            when(target.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
+            when(target.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
             when(target.getBaseSchemaWithoutGeneratedColumn()).thenReturn(columnsOf(targetColumns));
             PartitionInfo targetPartitionInfo = mock(PartitionInfo.class);
             when(targetPartitionInfo.isPartitioned()).thenReturn(false);
@@ -703,6 +708,8 @@ public class InsertPreSplitHookTableTest {
                     .thenReturn(normalizedRef);
 
             metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(target))
+                    .thenReturn(List.of(bigintColumn("k")));
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(eq(target), eq(BASE_INDEX_META_ID)))
                     .thenReturn(List.of(bigintColumn("k")));
             metaUtils.when(() -> MetaUtils.getSessionAwareTable(any(), eq(targetDb), any())).thenReturn(target);
             metaUtils.when(() -> MetaUtils.getSessionAwareTable(any(), eq(sourceDb), any())).thenReturn(sourceTable);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PartitionSampleGrouperTest.java
@@ -16,6 +16,7 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -47,6 +48,7 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -180,7 +182,7 @@ public class PartitionSampleGrouperTest {
                 rowWithPartitionCells(Variant.of(IntegerType.INT, "1"))));
 
         try (MockedConstruction<Locker> ignored = Mockito.mockConstruction(Locker.class)) {
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
             assertTrue(out.isEmpty());
         }
 
@@ -214,7 +216,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-28", "p20260528");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(3, out.size());
             assertEquals(5, out.get(0).samples().size());
@@ -241,7 +243,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size());
             assertEquals(10, out.get(0).samples().size());
@@ -272,7 +274,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
 
-            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             analyzerUtils.verify(() -> AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
                     eq(table), eq(List.of(List.of("2026-05-26"))), eq(false), any()), times(1));
@@ -294,7 +296,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size());
             AddPartitionClause clause = out.get(0).analyzedClause();
@@ -321,7 +323,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size());
             PartitionSamples ps = out.get(0);
@@ -346,7 +348,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size());
             PartitionSamples ps = out.get(0);
@@ -370,7 +372,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertTrue(out.isEmpty(), "non-empty existing partition must be dropped");
         }
@@ -394,7 +396,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertTrue(out.isEmpty(), "multi-tablet existing partition must be dropped");
             assertEquals(ineligibleBaseline + 1L,
@@ -424,7 +426,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertTrue(out.isEmpty(), "stale catalog must drop the group");
             assertEquals(baseline + 1L, eligibilitySkipCount(SkipReason.STALE_CATALOG_STATE));
@@ -452,7 +454,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertTrue(out.isEmpty(), "stale catalog must drop the group");
             assertEquals(baseline + 1L, eligibilitySkipCount(SkipReason.STALE_CATALOG_STATE));
@@ -488,7 +490,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-28", "p20260528");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(3, out.size());
             assertEquals(5, out.get(0).samples().size());
@@ -520,7 +522,7 @@ public class PartitionSampleGrouperTest {
             // 2026-05-27 -> succeeds
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size());
             assertEquals("p20260527", out.get(0).partitionName());
@@ -535,7 +537,7 @@ public class PartitionSampleGrouperTest {
         SampleSet samples = sampleSetOf(Collections.emptyList());
 
         try (MockedConstruction<Locker> ignored = Mockito.mockConstruction(Locker.class)) {
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
             assertTrue(out.isEmpty());
         }
     }
@@ -548,7 +550,7 @@ public class PartitionSampleGrouperTest {
         Tuple sortOnly = tuple(Variant.of(IntegerType.INT, "1"));
         SampleSet samples = new SampleSet(List.of(sortOnly), Estimates.ZERO);
 
-        List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+        List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
         assertTrue(out.isEmpty());
     }
 
@@ -581,7 +583,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-28", "p20260528");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(2, out.size());
             assertEquals(5, out.get(0).samples().size());
@@ -613,7 +615,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-27", "p20260527");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(2, out.size());
             assertEquals(baseline,
@@ -658,7 +660,7 @@ public class PartitionSampleGrouperTest {
                         })) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
         }
 
         assertEquals(1, lockCalls.get(), "exactly one intensive READ lock must be acquired");
@@ -693,7 +695,7 @@ public class PartitionSampleGrouperTest {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26 01:00:00", "p20260526");
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26 23:00:00", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(1, out.size(), "two raw values resolving to one partition must merge into one entry");
             assertEquals("p20260526", out.get(0).partitionName());
@@ -759,7 +761,7 @@ public class PartitionSampleGrouperTest {
                         return clause;
                     });
 
-            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
         }
 
         assertEquals(2, analyzeCalls.get(), "analyze must run for both distinct raw values");
@@ -805,7 +807,7 @@ public class PartitionSampleGrouperTest {
                 stubAnalyzerToReturnClauseFor(analyzerUtils, table, date, "p" + date.replace("-", ""));
             }
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertEquals(2, out.size(), "cap=2 must keep exactly the two heaviest groups");
             assertTrue(getPartitionCalls.get() <= 2,
@@ -838,7 +840,7 @@ public class PartitionSampleGrouperTest {
                 MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
             stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
 
-            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES);
+            List<PartitionSamples> out = PartitionSampleGrouper.group(samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of());
 
             assertTrue(out.isEmpty(), "non-empty existing partition must be dropped");
             assertEquals(ineligibleBaseline + 1L,
@@ -846,6 +848,68 @@ public class PartitionSampleGrouperTest {
                     "non-empty existing partition must bump PARTITION_NOT_ELIGIBLE_POST_CREATE");
             assertEquals(emptyBaseline, eligibilitySkipCount(SkipReason.GROUPER_EMPTY),
                     "an ineligible-but-present group must NOT bump GROUPER_EMPTY");
+        }
+    }
+
+    @Test
+    public void carriesSecondaryIndexTuplesIntoGroupedRows() {
+        // A sample carrying a secondary (rollup) index tuple must pass the id-tagged
+        // IndexTuple through into every grouped SampleRow. Verified against the
+        // pre-create branch (no partition installed) so the conditional carry is
+        // isolated from the catalog re-resolve.
+        long rollupMetaId = 4001L;
+        Column dateCol = new Column("d", DateType.DATE);
+        OlapTable table = stubTable(List.of(dateCol));
+
+        List<Tuple> sortTuples = List.of(tuple(Variant.of(IntegerType.INT, "7")));
+        List<Tuple> partitionTuples = List.of(tuple(Variant.of(DateType.DATE, "2026-05-26")));
+        List<List<IndexTuple>> secondaryTuples = List.of(List.of(
+                new IndexTuple(rollupMetaId, List.of(Variant.of(IntegerType.INT, "70")))));
+        SampleSet samples = new SampleSet(sortTuples, partitionTuples,
+                List.of(rollupMetaId), secondaryTuples, Estimates.ZERO);
+
+        try (MockedStatic<AnalyzerUtils> analyzerUtils = Mockito.mockStatic(AnalyzerUtils.class);
+                MockedConstruction<AlterTableClauseAnalyzer> alterCtor =
+                        Mockito.mockConstruction(AlterTableClauseAnalyzer.class, (mockObj, ctx) -> { });
+                MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
+            stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
+
+            List<PartitionSamples> out = PartitionSampleGrouper.group(
+                    samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of(rollupMetaId));
+
+            assertEquals(1, out.size());
+            List<IndexTuple> carried = out.get(0).samples().get(0).secondaryIndexTuples();
+            assertEquals(1, carried.size(), "the rollup IndexTuple must be carried into the grouped row");
+            assertEquals(rollupMetaId, carried.get(0).indexMetaId());
+        }
+    }
+
+    @Test
+    public void dropsPartitionWhenResolvedSecondaryIdSetDiffersFromSampled() {
+        // The sampler projected a rollup (id 4001) but the existing partition resolves
+        // to base only -> the resolved secondary id set ({}) differs from the sampled
+        // set ({4001}) -> drop as PARTITION_NOT_ELIGIBLE_POST_CREATE.
+        Column dateCol = new Column("d", DateType.DATE);
+        OlapTable table = stubTable(List.of(dateCol));
+        installPartitionWithTablets(table, "p20260526", 9001L, List.of(8001L), /*rowCount*/ 0L);
+
+        MetricRepo.hasInit = true;
+        long baseline = eligibilitySkipCount(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
+
+        SampleSet samples = sampleSetOf(List.of(tuple(Variant.of(DateType.DATE, "2026-05-26"))));
+
+        try (MockedStatic<AnalyzerUtils> analyzerUtils = Mockito.mockStatic(AnalyzerUtils.class);
+                MockedConstruction<AlterTableClauseAnalyzer> alterCtor =
+                        Mockito.mockConstruction(AlterTableClauseAnalyzer.class, (mockObj, ctx) -> { });
+                MockedConstruction<Locker> lockerCtor = Mockito.mockConstruction(Locker.class)) {
+            stubAnalyzerToReturnClauseFor(analyzerUtils, table, "2026-05-26", "p20260526");
+
+            List<PartitionSamples> out = PartitionSampleGrouper.group(
+                    samples, table, null, DB_ID, TOTAL_FILE_BYTES, Set.of(4001L));
+
+            assertTrue(out.isEmpty(),
+                    "a resolved secondary id set differing from the sampled set must drop the partition");
+            assertEquals(baseline + 1L, eligibilitySkipCount(SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE));
         }
     }
 
@@ -869,6 +933,13 @@ public class PartitionSampleGrouperTest {
         PartitionInfo info = mock(PartitionInfo.class);
         when(info.getPartitionColumns(any())).thenReturn(partitionColumns);
         when(table.getPartitionInfo()).thenReturn(info);
+        // Base index meta so MetaUtils.getRangeDistributionColumns resolves a scalar sort key
+        // when the grouper re-resolves the partition's visible-index targets under its READ lock.
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(baseMeta.getSchema()).thenReturn(List.of(new Column("k", IntegerType.BIGINT)));
+        when(baseMeta.getSortKeyIdxes()).thenReturn(List.of(0));
+        when(table.getIndexMetaByMetaId(BASE_INDEX_META_ID)).thenReturn(baseMeta);
         return table;
     }
 
@@ -913,7 +984,10 @@ public class PartitionSampleGrouperTest {
         }
         when(baseIndex.getTablets()).thenReturn(tablets);
         when(baseIndex.getRowCount()).thenReturn(rowCount);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(physicalPartition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        when(physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
         when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
         when(table.getPartition(partitionName)).thenReturn(partition);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -18,10 +18,12 @@ import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
@@ -176,6 +178,47 @@ public class PreSplitFlowTest {
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
                     any(), any(), anyList(), anyInt(), any(), any()), never());
+        }
+    }
+
+    @Test
+    public void dispatchInsertFromTableWithRollupSkipsBeforeSampling() {
+        // INSERT-from-table cannot remap a divergent rollup sort key to source columns, so a
+        // target with more than one visible index (base + rollup) must skip before sampling /
+        // grouping / pre-create -- regardless of partition shape. The gate is the FIRST line of
+        // dispatch, so none of the multi-partition scaffolding below (sampler, grouper) ever runs.
+        Database database = mock(Database.class);
+        when(database.getId()).thenReturn(7L);
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        when(table.getVisibleIndexMetas()).thenReturn(
+                List.of(mock(MaterializedIndexMeta.class), mock(MaterializedIndexMeta.class)));
+        PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try (MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class);
+                MockedConstruction<ReservoirSampler> sampler = Mockito.mockConstruction(ReservoirSampler.class)) {
+            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
+            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+
+            PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_TABLE,
+                    () -> false, mock(ConnectContext.class));
+
+            Assertions.assertTrue(sampler.constructed().isEmpty(), "the data-tier sampler must never be constructed");
+            grouper.verify(() -> PartitionSampleGrouper.group(
+                    any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class), anyLong(), anyLong()),
+                    never());
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
+                    any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    any(), any(), anyList(), anyInt(), any(), any()), never());
+            Assertions.assertEquals(baseline + 1L,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
+                    "INSERT-from-table with a rollup must bump the has_materialized_view_or_rollup bucket");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -105,7 +105,7 @@ public class PreSplitFlowTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 
@@ -127,17 +127,17 @@ public class PreSplitFlowTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any(), any()))
                     .thenReturn(new PreSplitOutcome.Skipped(SkipReason.NO_USEFUL_CUTS));
 
             PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_FILES,
                     () -> false, mock(ConnectContext.class));
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), times(1));
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), times(1));
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
         }
@@ -168,7 +168,7 @@ public class PreSplitFlowTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
 
             PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_FILES,
@@ -177,7 +177,7 @@ public class PreSplitFlowTest {
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
         }
     }
 
@@ -208,12 +208,12 @@ public class PreSplitFlowTest {
 
             Assertions.assertTrue(sampler.constructed().isEmpty(), "the data-tier sampler must never be constructed");
             grouper.verify(() -> PartitionSampleGrouper.group(
-                    any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class), anyLong(), anyLong()),
+                    any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class), anyLong(), anyLong(), any()),
                     never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
                     any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
             coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any()), never());
+                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
             Assertions.assertEquals(baseline + 1L,
                     MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
                     "INSERT-from-table with a rollup must bump the has_materialized_view_or_rollup bucket");
@@ -301,10 +301,10 @@ public class PreSplitFlowTest {
                         (sampler, ctx) -> when(sampler.sample(any(SampleRequest.class))).thenReturn(samples))) {
             grouper.when(() -> PartitionSampleGrouper.group(
                             any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
-                            anyLong(), anyLong()))
+                            anyLong(), anyLong(), any()))
                     .thenReturn(List.of(mock(PartitionSamples.class)));
             coordinator.when(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                            any(), any(), anyList(), anyInt(), any(), any()))
+                            any(), any(), anyList(), anyInt(), any(), any(), any()))
                     .thenReturn(new PreSplitOutcome.SubmittedCombined(combinedJob, List.of()));
 
             PreSplitFlow.runMultiPartitionFlow(database, table, prepared,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -422,7 +422,7 @@ public class PreSplitFlowTest {
     private static DefaultPreSplitPipeline stubPipelineFactory(MockedStatic<DefaultPreSplitPipeline> pipelineStatic) {
         DefaultPreSplitPipeline pipeline = mock(DefaultPreSplitPipeline.class);
         pipelineStatic.when(() -> DefaultPreSplitPipeline.forLoadKind(
-                        any(), any(), anyLong(), anyLong(), any(), any()))
+                        any(), any(), any(), anyLong(), any(), any()))
                 .thenReturn(pipeline);
         return pipeline;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -370,7 +370,9 @@ public class PreSplitFlowTest {
             MockedStatic<PreSplitTargets> targets, Database database, OlapTable table) {
         targets.when(() -> PreSplitTargets.findEligibleTarget(database, table))
                 .thenReturn(new PreSplitTargets.EligibleTarget(
-                        database, table, /*partitionId*/ 11L, /*oldTabletId*/ 22L));
+                        database, table, /*partitionId*/ 11L,
+                        List.of(new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 22L,
+                                List.of(bigintColumn("sort_col"))))));
     }
 
     /** Stub DefaultPreSplitPipeline.forLoadKind to return a mock pipeline, returning it for verification. */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -279,6 +279,42 @@ public class PreSplitFlowTest {
         }
     }
 
+    @Test
+    public void singleFlowSkipsInsertFromTableWhenResolvedIndexTargetsHaveRollup() {
+        // Race regression: the dispatch-time descope gate reads target.getVisibleIndexMetas()
+        // before findEligibleTarget resolves the authoritative indexTargets. If a rollup becomes
+        // visible in between, the RESOLVED indexTargets can have 2 entries (base + rollup) even
+        // though the table had a single visible index at dispatch time. runSinglePartitionFlow
+        // must re-check the resolved set and skip -- not sample the rollup with the base-only
+        // INSERT-from-table source mapping.
+        Database database = mock(Database.class);
+        OlapTable table = mockTable(/*partitioned*/ false, /*automatic*/ false);
+        PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+
+        boolean savedHasInit = MetricRepo.hasInit;
+        MetricRepo.hasInit = true;
+        try (MockedStatic<PreSplitTargets> targets = Mockito.mockStatic(PreSplitTargets.class);
+                MockedStatic<TabletPreSplitCoordinator> coordinator =
+                        Mockito.mockStatic(TabletPreSplitCoordinator.class)) {
+            stubEligibleTargetWithRollup(targets, database, table);
+            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
+            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+
+            PreSplitFlow.runSinglePartitionFlow(database, table, prepared,
+                    LoadKind.INSERT_FROM_TABLE, () -> false);
+
+            coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
+                    any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
+            coordinator.verify(() -> TabletPreSplitCoordinator.awaitFinishedAllowingFallback(
+                    any(), any(), any(), any(), any()), never());
+            Assertions.assertEquals(baseline + 1L,
+                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
+                    "resolved rollup on INSERT-from-table must bump the has_materialized_view_or_rollup bucket");
+        } finally {
+            MetricRepo.hasInit = savedHasInit;
+        }
+    }
+
     // ---------- multi-partition flow await ----------
 
     @Test
@@ -416,6 +452,23 @@ public class PreSplitFlowTest {
                         database, table, /*partitionId*/ 11L,
                         List.of(new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 22L,
                                 List.of(bigintColumn("sort_col"))))));
+    }
+
+    /**
+     * Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target with a
+     * rollup (base + one rollup index target) for {@code table} -- simulates a rollup that
+     * became visible after the dispatch-time descope gate read the visible-index count.
+     */
+    private static void stubEligibleTargetWithRollup(
+            MockedStatic<PreSplitTargets> targets, Database database, OlapTable table) {
+        targets.when(() -> PreSplitTargets.findEligibleTarget(database, table))
+                .thenReturn(new PreSplitTargets.EligibleTarget(
+                        database, table, /*partitionId*/ 11L,
+                        List.of(
+                                new IndexPreSplitTarget(/*indexMetaId*/ 1L, /*oldTabletId*/ 22L,
+                                        List.of(bigintColumn("sort_col"))),
+                                new IndexPreSplitTarget(/*indexMetaId*/ 2L, /*oldTabletId*/ 33L,
+                                        List.of(bigintColumn("sort_col"))))));
     }
 
     /** Stub DefaultPreSplitPipeline.forLoadKind to return a mock pipeline, returning it for verification. */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitTargetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitTargetsTest.java
@@ -39,21 +39,27 @@ import static org.mockito.Mockito.when;
 /**
  * Unit tests for {@link PreSplitTargets#findEligibleTable}, the table-level
  * structural eligibility gate shared by both load hooks and the multi-partition
- * coordinator's defensive re-check.
+ * coordinator's defensive re-check, plus {@link PreSplitTargets#findEligibleTarget}
+ * and {@link PreSplitTargets#resolveVisibleIndexTargets}.
  *
- * <p>Each test stubs an {@link OlapTable} that passes every check up to the one
- * under test, then asserts the gate returns exactly that branch's
- * {@link SkipReason}. The {@code null} (eligible) path is also pinned as a
- * positive control.
+ * <p>Each {@code findEligibleTable} test stubs an {@link OlapTable} that passes
+ * every check up to the one under test, then asserts the gate returns exactly
+ * that branch's {@link SkipReason}. The {@code null} (eligible) path is also
+ * pinned as a positive control.
  */
 public class PreSplitTargetsTest {
+
+    private static final long BASE_INDEX_META_ID = 10L;
+    private static final long ROLLUP_INDEX_META_ID = 20L;
 
     private static OlapTable tableThatPassesUpTo() {
         OlapTable table = mock(OlapTable.class);
         when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
         when(table.isRangeDistribution()).thenReturn(true);
         when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(mock(MaterializedIndexMeta.class)));
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
         return table;
     }
 
@@ -86,23 +92,11 @@ public class PreSplitTargetsTest {
     }
 
     @Test
-    public void rejectsTableWithMaterializedViewOrRollup() {
-        // More than one visible index meta means an MV / rollup is attached.
-        OlapTable table = mock(OlapTable.class);
-        when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
-        when(table.isRangeDistribution()).thenReturn(true);
-        when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(
-                mock(MaterializedIndexMeta.class), mock(MaterializedIndexMeta.class)));
-        Assertions.assertEquals(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP,
-                PreSplitTargets.findEligibleTable(mock(Database.class), table));
-    }
-
-    @Test
     public void rejectsEmptySortKey() {
         OlapTable table = tableThatPassesUpTo();
         try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table)).thenReturn(List.of());
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of());
             Assertions.assertEquals(SkipReason.UNSUPPORTED_SORT_KEY,
                     PreSplitTargets.findEligibleTable(mock(Database.class), table));
         }
@@ -113,7 +107,7 @@ public class PreSplitTargetsTest {
         OlapTable table = tableThatPassesUpTo();
         Column arrayColumn = new Column("arr", new ArrayType(IntegerType.INT));
         try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
                     .thenReturn(List.of(arrayColumn));
             Assertions.assertEquals(SkipReason.UNSUPPORTED_SORT_KEY,
                     PreSplitTargets.findEligibleTable(mock(Database.class), table));
@@ -121,15 +115,67 @@ public class PreSplitTargetsTest {
     }
 
     @Test
-    public void acceptsEligibleTable() {
+    public void findEligibleTable_singleIndex_ok() {
         // Positive control: range-distribution, NORMAL, single index, scalar sort key -> eligible (null).
         OlapTable table = tableThatPassesUpTo();
         Column scalarColumn = new Column("k", IntegerType.BIGINT);
         try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table))
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
                     .thenReturn(List.of(scalarColumn));
             Assertions.assertNull(PreSplitTargets.findEligibleTable(mock(Database.class), table),
                     "fully eligible table must return null (no skip reason)");
+        }
+    }
+
+    @Test
+    public void findEligibleTable_baseAndScalarRollup_ok() {
+        // A visible rollup with its own scalar sort key no longer disqualifies the table --
+        // the `getVisibleIndexMetas().size() != 1` gate is gone; every visible index's sort
+        // key is checked independently instead.
+        OlapTable table = mock(OlapTable.class);
+        when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        when(table.isRangeDistribution()).thenReturn(true);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        Column baseSortKey = new Column("k", IntegerType.BIGINT);
+        Column rollupSortKey = new Column("k2", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(baseSortKey));
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, ROLLUP_INDEX_META_ID))
+                    .thenReturn(List.of(rollupSortKey));
+            Assertions.assertNull(PreSplitTargets.findEligibleTable(mock(Database.class), table),
+                    "base + scalar-sort-key rollup must be eligible (null)");
+        }
+    }
+
+    @Test
+    public void findEligibleTable_rollupNonScalarSortKey_unsupported() {
+        // Base index is fine; the rollup's sort key has a non-scalar column -> UNSUPPORTED_SORT_KEY.
+        OlapTable table = mock(OlapTable.class);
+        when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
+        when(table.isRangeDistribution()).thenReturn(true);
+        when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        Column baseSortKey = new Column("k", IntegerType.BIGINT);
+        Column rollupArrayColumn = new Column("arr", new ArrayType(IntegerType.INT));
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(baseSortKey));
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, ROLLUP_INDEX_META_ID))
+                    .thenReturn(List.of(rollupArrayColumn));
+            Assertions.assertEquals(SkipReason.UNSUPPORTED_SORT_KEY,
+                    PreSplitTargets.findEligibleTable(mock(Database.class), table));
         }
     }
 
@@ -140,15 +186,16 @@ public class PreSplitTargetsTest {
      */
     private static OlapTable tableWithSinglePartition(int tabletCount) {
         OlapTable table = mock(OlapTable.class);
-        when(table.getBaseIndexMetaId()).thenReturn(10L);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         PhysicalPartition partition = mock(PhysicalPartition.class);
         when(partition.getId()).thenReturn(100L);
         when(table.getPhysicalPartitions()).thenReturn(List.of(partition));
         if (tabletCount < 0) {
-            when(partition.getIndex(10L)).thenReturn(null);
+            when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(null);
         } else {
             MaterializedIndex baseIndex = mock(MaterializedIndex.class);
-            when(partition.getIndex(10L)).thenReturn(baseIndex);
+            when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+            when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
             List<Tablet> tablets = new ArrayList<>();
             for (int i = 0; i < tabletCount; i++) {
                 Tablet tablet = mock(Tablet.class);
@@ -156,6 +203,8 @@ public class PreSplitTargetsTest {
                 tablets.add(tablet);
             }
             when(baseIndex.getTablets()).thenReturn(tablets);
+            when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                    .thenReturn(List.of(baseIndex));
         }
         return table;
     }
@@ -164,11 +213,16 @@ public class PreSplitTargetsTest {
     public void resolvesSinglePartitionSingleTabletTarget() {
         // Positive control: exactly one physical partition with one base tablet -> target.
         OlapTable table = tableWithSinglePartition(1);
-        PreSplitTargets.EligibleTarget target =
-                PreSplitTargets.findEligibleTarget(mock(Database.class), table);
-        Assertions.assertNotNull(target);
-        Assertions.assertEquals(100L, target.partitionId());
-        Assertions.assertEquals(1000L, target.oldTabletId());
+        Column sortKey = new Column("k", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(sortKey));
+            PreSplitTargets.EligibleTarget target =
+                    PreSplitTargets.findEligibleTarget(mock(Database.class), table);
+            Assertions.assertNotNull(target);
+            Assertions.assertEquals(100L, target.partitionId());
+            Assertions.assertEquals(1000L, target.oldTabletId());
+        }
     }
 
     @Test
@@ -221,5 +275,128 @@ public class PreSplitTargetsTest {
     private static long skipBucket(SkipReason reason) {
         return MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED
                 .getMetric(reason.name().toLowerCase()).getValue().longValue();
+    }
+
+    // ---------- resolveVisibleIndexTargets ----------
+
+    private static MaterializedIndex mockIndexWithOneTablet(long metaId, long tabletId) {
+        MaterializedIndex index = mock(MaterializedIndex.class);
+        when(index.getMetaId()).thenReturn(metaId);
+        Tablet tablet = mock(Tablet.class);
+        when(tablet.getId()).thenReturn(tabletId);
+        when(index.getTablets()).thenReturn(List.of(tablet));
+        return index;
+    }
+
+    @Test
+    public void resolveVisibleIndexTargets_baseOnly_resolvesSingleTarget() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndex baseIndex = mockIndexWithOneTablet(BASE_INDEX_META_ID, 1001L);
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
+
+        Column sortKey = new Column("k", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(sortKey));
+            List<IndexPreSplitTarget> targets = PreSplitTargets.resolveVisibleIndexTargets(table, partition);
+            Assertions.assertNotNull(targets);
+            Assertions.assertEquals(1, targets.size());
+            Assertions.assertEquals(BASE_INDEX_META_ID, targets.get(0).indexMetaId());
+            Assertions.assertEquals(1001L, targets.get(0).oldTabletId());
+            Assertions.assertEquals(List.of(sortKey), targets.get(0).sortKey());
+        }
+    }
+
+    @Test
+    public void resolveVisibleIndexTargets_baseAndRollup_baseFirst() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndex rollupIndex = mockIndexWithOneTablet(ROLLUP_INDEX_META_ID, 2001L);
+        MaterializedIndex baseIndex = mockIndexWithOneTablet(BASE_INDEX_META_ID, 1001L);
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        // Rollup listed before base in the source list -- base must still resolve first.
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(rollupIndex, baseIndex));
+
+        Column baseSortKey = new Column("k", IntegerType.BIGINT);
+        Column rollupSortKey = new Column("k2", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(baseSortKey));
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, ROLLUP_INDEX_META_ID))
+                    .thenReturn(List.of(rollupSortKey));
+            List<IndexPreSplitTarget> targets = PreSplitTargets.resolveVisibleIndexTargets(table, partition);
+            Assertions.assertNotNull(targets);
+            Assertions.assertEquals(2, targets.size());
+            Assertions.assertEquals(BASE_INDEX_META_ID, targets.get(0).indexMetaId(), "base index must be first");
+            Assertions.assertEquals(ROLLUP_INDEX_META_ID, targets.get(1).indexMetaId());
+        }
+    }
+
+    @Test
+    public void resolveVisibleIndexTargets_rollupMultiTablet_null() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndex baseIndex = mockIndexWithOneTablet(BASE_INDEX_META_ID, 1001L);
+        MaterializedIndex rollupIndex = mock(MaterializedIndex.class);
+        when(rollupIndex.getMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        when(rollupIndex.getTablets()).thenReturn(List.of(mock(Tablet.class), mock(Tablet.class)));
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex, rollupIndex));
+
+        Column baseSortKey = new Column("k", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(baseSortKey));
+            Assertions.assertNull(PreSplitTargets.resolveVisibleIndexTargets(table, partition),
+                    "a multi-tablet rollup must fail the whole resolution");
+        }
+    }
+
+    @Test
+    public void resolveVisibleIndexTargets_rollupNonScalarSortKey_null() {
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndex baseIndex = mockIndexWithOneTablet(BASE_INDEX_META_ID, 1001L);
+        MaterializedIndex rollupIndex = mockIndexWithOneTablet(ROLLUP_INDEX_META_ID, 2001L);
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex, rollupIndex));
+
+        Column baseSortKey = new Column("k", IntegerType.BIGINT);
+        Column rollupArrayColumn = new Column("arr", new ArrayType(IntegerType.INT));
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(baseSortKey));
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, ROLLUP_INDEX_META_ID))
+                    .thenReturn(List.of(rollupArrayColumn));
+            Assertions.assertNull(PreSplitTargets.resolveVisibleIndexTargets(table, partition),
+                    "a non-scalar rollup sort-key column must fail the whole resolution");
+        }
+    }
+
+    @Test
+    public void resolveVisibleIndexTargets_baseNonEmptyRowCount_stillResolves() {
+        // Row-count emptiness is a separate PARTITION_NOT_EMPTY gate elsewhere; the resolver
+        // itself must not reject a non-empty base index.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        MaterializedIndex baseIndex = mockIndexWithOneTablet(BASE_INDEX_META_ID, 1001L);
+        when(baseIndex.getRowCount()).thenReturn(999L);
+        PhysicalPartition partition = mock(PhysicalPartition.class);
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
+
+        Column sortKey = new Column("k", IntegerType.BIGINT);
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, BASE_INDEX_META_ID))
+                    .thenReturn(List.of(sortKey));
+            Assertions.assertNotNull(PreSplitTargets.resolveVisibleIndexTargets(table, partition),
+                    "row count must not be checked by the resolver");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ReservoirSamplerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ReservoirSamplerTest.java
@@ -237,4 +237,44 @@ public class ReservoirSamplerTest {
 
         Assertions.assertEquals(fullInput, result.getEstimates());
     }
+
+    @Test
+    public void testCountsSecondaryTupleBytes() throws Exception {
+        // Each cell's string value is 1 char wide. Row bytes = sortKey(1) + secondary(1) = 2.
+        // With byteLimit=3: row 0 is always admitted (2 bytes, accumulated=2); row 1 would push
+        // accumulated to 4 > 3, so only 1 row survives -- proving the secondary cell counted
+        // against the limit (without it, each row would be 1 byte and both would fit).
+        SecondaryIndexSpec secondarySpec = new SecondaryIndexSpec(7L, List.of(bigintColumn("r")));
+        SampleSubqueryExecutor executor = request -> {
+            List<SampleRow> rows = List.of(
+                    new SampleRow(bigintRow(0), List.of(), List.of(new IndexTuple(7L, bigintRow(1)))),
+                    new SampleRow(bigintRow(2), List.of(), List.of(new IndexTuple(7L, bigintRow(3)))));
+            return new SampleSubqueryExecutor.SampleExecution(rows.iterator(), new Estimates(1024L, 2L));
+        };
+        Sampler sampler = new ReservoirSampler(executor);
+        SampleRequest request = new SampleRequest(
+                DUMMY_CONTEXT, List.of(bigintColumn("k")), List.of(secondarySpec), List.of(), 3L, 0L);
+
+        SampleSet result = sampler.sample(request);
+
+        Assertions.assertEquals(1, result.getTuples().size(),
+                "secondary tuple bytes must count against the byte limit, stopping before the 2nd row");
+    }
+
+    @Test
+    public void testZeroRowsWithSecondarySpecsPreservesMetaIds() throws Exception {
+        SecondaryIndexSpec secondarySpec = new SecondaryIndexSpec(7L, List.of(bigintColumn("r")));
+        Sampler sampler = new ReservoirSampler(new FakeExecutor(Collections.emptyList(), Estimates.ZERO));
+        SampleRequest request = new SampleRequest(
+                DUMMY_CONTEXT, List.of(bigintColumn("k")), List.of(secondarySpec), List.of(), 1024L, 0L);
+
+        SampleSet result = sampler.sample(request);
+
+        Assertions.assertNotSame(SampleSet.EMPTY, result,
+                "zero-row sample WITH secondary specs must not collapse to the bare EMPTY constant "
+                        + "(it would drop the authoritative id set)");
+        Assertions.assertTrue(result.isEmpty());
+        Assertions.assertEquals(List.of(7L), result.getSecondaryIndexMetaIds());
+        Assertions.assertTrue(result.getSecondaryIndexTuples().isEmpty());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/SampleDtoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/SampleDtoTest.java
@@ -16,6 +16,8 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -97,5 +99,113 @@ public class SampleDtoTest {
 
         Assertions.assertEquals(1, sampleSet.getTuples().size());
         Assertions.assertEquals(new Estimates(4096L, 1L), sampleSet.getEstimates());
+    }
+
+    @Test
+    public void testSampleRequestDefaultConstructorsHaveEmptySecondaryIndexSortKeys() {
+        SampleRequest fourArg = new SampleRequest(DUMMY_CONTEXT, List.of(varcharColumn("k")), 1024L, 0L);
+        SampleRequest fiveArg = new SampleRequest(
+                DUMMY_CONTEXT, List.of(varcharColumn("k")), List.of(), 1024L, 0L);
+
+        Assertions.assertTrue(fourArg.getSecondaryIndexSortKeys().isEmpty());
+        Assertions.assertTrue(fiveArg.getSecondaryIndexSortKeys().isEmpty());
+    }
+
+    @Test
+    public void testSampleRequestWithQueryTimeoutSecondsPreservesSecondaryIndexSortKeys() {
+        SecondaryIndexSpec secondarySpec = new SecondaryIndexSpec(7L, List.of(varcharColumn("r")));
+        SampleRequest request = new SampleRequest(
+                DUMMY_CONTEXT, List.of(varcharColumn("k")), List.of(secondarySpec), List.of(), 1024L, 0L);
+
+        SampleRequest withTimeout = request.withQueryTimeoutSeconds(30);
+
+        Assertions.assertEquals(List.of(secondarySpec), withTimeout.getSecondaryIndexSortKeys());
+        Assertions.assertEquals(30, withTimeout.getQueryTimeoutSeconds());
+    }
+
+    @Test
+    public void testSampleRowOfSortKeyHasEmptySecondaryTuples() {
+        SampleRow row = SampleRow.ofSortKey(List.of(Variant.of(IntegerType.BIGINT, "1")));
+
+        Assertions.assertNotNull(row.secondaryIndexTuples());
+        Assertions.assertTrue(row.secondaryIndexTuples().isEmpty());
+        Assertions.assertTrue(row.partitionSourceTuple().isEmpty());
+    }
+
+    @Test
+    public void testSampleRowTwoArgConstructorDefaultsEmptySecondaryTuples() {
+        List<Variant> sortKeyTuple = List.of(Variant.of(IntegerType.BIGINT, "1"));
+        List<Variant> partitionSourceTuple = List.of(Variant.of(IntegerType.BIGINT, "2"));
+
+        SampleRow row = new SampleRow(sortKeyTuple, partitionSourceTuple);
+
+        Assertions.assertNotNull(row.secondaryIndexTuples());
+        Assertions.assertTrue(row.secondaryIndexTuples().isEmpty());
+        Assertions.assertEquals(sortKeyTuple, row.sortKeyTuple());
+        Assertions.assertEquals(partitionSourceTuple, row.partitionSourceTuple());
+    }
+
+    @Test
+    public void testSampleSetBaseOnlyGetSecondaryIndexTuplesAndMetaIdsEmpty() {
+        SampleSet twoArg = new SampleSet(List.of(bigintTuple(1L)), new Estimates(100L, 1L));
+        SampleSet threeArg = new SampleSet(List.of(bigintTuple(1L)), List.of(), new Estimates(100L, 1L));
+
+        Assertions.assertTrue(twoArg.getSecondaryIndexTuples().isEmpty());
+        Assertions.assertTrue(twoArg.getSecondaryIndexMetaIds().isEmpty());
+        Assertions.assertTrue(threeArg.getSecondaryIndexTuples().isEmpty());
+        Assertions.assertTrue(threeArg.getSecondaryIndexMetaIds().isEmpty());
+    }
+
+    @Test
+    public void testSampleSetWithSecondariesMetaIdsMatchSpecOrder() {
+        IndexTuple indexTupleA = new IndexTuple(5L, List.of(Variant.of(IntegerType.BIGINT, "10")));
+        IndexTuple indexTupleB = new IndexTuple(9L, List.of(Variant.of(IntegerType.BIGINT, "20")));
+        SampleSet sampleSet = new SampleSet(
+                List.of(bigintTuple(1L)), List.of(),
+                List.of(5L, 9L), List.of(List.of(indexTupleA, indexTupleB)),
+                new Estimates(100L, 1L));
+
+        Assertions.assertEquals(List.of(5L, 9L), sampleSet.getSecondaryIndexMetaIds());
+        Assertions.assertEquals(1, sampleSet.getSecondaryIndexTuples().size());
+        Assertions.assertEquals(List.of(indexTupleA, indexTupleB), sampleSet.getSecondaryIndexTuples().get(0));
+    }
+
+    @Test
+    public void testSampleSetWithSecondariesMetaIdsPresentEvenForZeroRowSample() {
+        SampleSet sampleSet = new SampleSet(List.of(), List.of(), List.of(5L), List.of(), Estimates.ZERO);
+
+        Assertions.assertTrue(sampleSet.isEmpty());
+        Assertions.assertEquals(List.of(5L), sampleSet.getSecondaryIndexMetaIds());
+        Assertions.assertTrue(sampleSet.getSecondaryIndexTuples().isEmpty());
+    }
+
+    @Test
+    public void testSampleSetMalformedSecondaryRowRejected() {
+        IndexTuple idFive = new IndexTuple(5L, List.of(Variant.of(IntegerType.BIGINT, "10")));
+
+        // Row is missing id 9 entirely (authoritative ids are {5, 9}).
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new SampleSet(
+                List.of(bigintTuple(1L)), List.of(),
+                List.of(5L, 9L), List.of(List.of(idFive)),
+                new Estimates(100L, 1L)));
+
+        // Row carries an id (42) outside the authoritative set ({5}).
+        IndexTuple unknownId = new IndexTuple(42L, List.of(Variant.of(IntegerType.BIGINT, "10")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new SampleSet(
+                List.of(bigintTuple(1L)), List.of(),
+                List.of(5L), List.of(List.of(unknownId)),
+                new Estimates(100L, 1L)));
+
+        // Row carries id 5 twice (duplicate within one row).
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new SampleSet(
+                List.of(bigintTuple(1L)), List.of(),
+                List.of(5L), List.of(List.of(idFive, idFive)),
+                new Estimates(100L, 1L)));
+
+        // Outer secondaryIndexTuples list is shorter than tuples (a missing row).
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new SampleSet(
+                List.of(bigintTuple(1L), bigintTuple(2L)), List.of(),
+                List.of(5L), List.of(List.of(idFive)),
+                new Estimates(100L, 1L)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -134,13 +134,14 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         when(table.isCloudNativeTableOrMaterializedView()).thenReturn(true);
         when(table.isRangeDistribution()).thenReturn(true);
         when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(mock(MaterializedIndexMeta.class)));
 
         Column sortKey = new Column("k", IntegerType.BIGINT);
         MaterializedIndexMeta indexMeta = mock(MaterializedIndexMeta.class);
+        when(indexMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(indexMeta.getSchema()).thenReturn(List.of(sortKey));
         when(indexMeta.getSortKeyIdxes()).thenReturn(List.of(0));
         when(table.getIndexMetaByMetaId(BASE_INDEX_META_ID)).thenReturn(indexMeta);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(indexMeta));
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -53,6 +53,7 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -91,8 +92,11 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
     private static final long TABLE_ID = 200L;
     private static final long BASE_INDEX_META_ID = 300L;
 
+    private static final long ROLLUP_INDEX_META_ID = 400L;
+
     private Database database;
     private OlapTable table;
+    private MaterializedIndexMeta baseIndexMeta;
 
     private boolean savedMetricHasInit;
     private LongCounterMetric savedPartitionsTotal;
@@ -136,12 +140,12 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         when(table.getState()).thenReturn(OlapTable.OlapTableState.NORMAL);
 
         Column sortKey = new Column("k", IntegerType.BIGINT);
-        MaterializedIndexMeta indexMeta = mock(MaterializedIndexMeta.class);
-        when(indexMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
-        when(indexMeta.getSchema()).thenReturn(List.of(sortKey));
-        when(indexMeta.getSortKeyIdxes()).thenReturn(List.of(0));
-        when(table.getIndexMetaByMetaId(BASE_INDEX_META_ID)).thenReturn(indexMeta);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(indexMeta));
+        baseIndexMeta = mock(MaterializedIndexMeta.class);
+        when(baseIndexMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+        when(baseIndexMeta.getSchema()).thenReturn(List.of(sortKey));
+        when(baseIndexMeta.getSortKeyIdxes()).thenReturn(List.of(0));
+        when(table.getIndexMetaByMetaId(BASE_INDEX_META_ID)).thenReturn(baseIndexMeta);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseIndexMeta));
     }
 
     @AfterEach
@@ -177,7 +181,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, /*activeComputeNodeCount*/ 3, freshConnectContext(), null);
+                    database, table, entries, /*activeComputeNodeCount*/ 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(3, mapCaptor.getValue().size());
@@ -222,7 +226,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, addPartitionsCalls.get());
@@ -257,7 +261,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, mapCaptor.getValue().size(), "only pGood feeds the combined submit");
@@ -287,7 +291,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenThrow(new StarRocksException("synthetic factory rejection"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
             verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr(), never())
@@ -315,7 +319,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
             doThrow(new StarRocksException("capacity exceeded")).when(mgr).addTabletReshardJob(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
         }
@@ -342,7 +346,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(1, mapCaptor.getValue().size());
@@ -381,7 +385,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, /*activeComputeNodeCount*/ 12, freshConnectContext(), null);
+                    database, table, entries, /*activeComputeNodeCount*/ 12, freshConnectContext(), null, Set.of());
 
             Map<Long, List<TabletRange>> map = mapCaptor.getValue();
             // K_1 = 24 (ceil(1000MB/50MB)=20 rounded up to a multiple of 12) -> 24 ranges.
@@ -439,7 +443,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertEquals(3, lockCalls.get(), "one intensive READ lock per partition");
             Assertions.assertEquals(3, unlockCalls.get(), "lock must be released after each partition");
@@ -459,7 +463,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.TABLE_NOT_NORMAL);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -490,7 +494,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertEquals(baseline + 3L,
                     MetricRepo.COUNTER_TABLET_PRE_SPLIT_PARTITIONS_TOTAL.getValue().longValue(),
@@ -517,7 +521,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     .thenThrow(new IllegalArgumentException("synthetic bad ranges"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.SUBMIT_FAILED);
             verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr(), never())
@@ -539,7 +543,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -570,7 +574,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             Assertions.assertEquals(0, addPartitionsCalls.get(),
@@ -595,7 +599,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             // Single entry dropped as PARTITION_NOT_ELIGIBLE_POST_CREATE -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
@@ -628,7 +632,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             // Only the single-tablet partition feeds the combined submit.
@@ -654,7 +658,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             // Single non-empty partition dropped -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
@@ -677,7 +681,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -703,7 +707,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
             factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
@@ -741,7 +745,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    database, table, entries, 3, freshConnectContext(), null);
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
             // Only pGood feeds the combined submit; pBoom was dropped.
@@ -751,6 +755,368 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
             PreSplitOutcome.SubmittedCombined combined = (PreSplitOutcome.SubmittedCombined) outcome;
             assertSkippedReason(combined.perPartitionResults().get(0), SkipReason.SAMPLE_FAILED);
             Assertions.assertInstanceOf(PreSplitOutcome.Submitted.class, combined.perPartitionResults().get(1));
+        }
+    }
+
+    // ---------- Multi-index (rollup) tests ----------
+
+    @Test
+    public void carriesIdTaggedTuplesAndResolvesAllIndexTablets() throws Exception {
+        // One partition with a base index + one rollup. The entry's rows carry an
+        // id-tagged rollup IndexTuple; resolveUnderReadLock resolves BOTH index
+        // tablets and planOnePartition splits both -> the combined map has the base
+        // tablet AND the rollup tablet.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100,
+                        /*baseCuts*/ true, new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Assertions.assertEquals(2, mapCaptor.getValue().size(), "base + rollup tablets both split");
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(21_001L), "base tablet split");
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(22_001L), "rollup tablet split");
+        }
+    }
+
+    @Test
+    public void splitsEveryIndexPerPartition() throws Exception {
+        // 2 indexes (base + rollup) x 2 partitions -> 4 combined-map entries.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        installPartitionWithIndices("p2", 11_002L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_002L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_002L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)),
+                rollupEntry("p2", 11_002L, 21_002L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(4, map.size(), "2 indexes x 2 partitions -> 4 tablet entries");
+            Assertions.assertTrue(map.keySet().containsAll(List.of(21_001L, 22_001L, 21_002L, 22_002L)));
+        }
+    }
+
+    @Test
+    public void baseNoCutsRollupCuts_rollupOnlyContribution() throws Exception {
+        // Base samples are all equal (no split) but the rollup samples cut -> only the
+        // rollup tablet contributes to the combined map.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100,
+                        /*baseCuts*/ false, new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Assertions.assertEquals(1, mapCaptor.getValue().size());
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(22_001L), "only the rollup tablet split");
+            Assertions.assertFalse(mapCaptor.getValue().containsKey(21_001L), "no-cut base is omitted");
+        }
+    }
+
+    @Test
+    public void allIndexesNoCuts_partitionSkippedNoUsefulCuts() throws Exception {
+        // Both base and rollup samples are all equal -> every index no-cut -> the local
+        // map is empty -> Skipped(NO_USEFUL_CUTS), the factory is never called.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100,
+                        /*baseCuts*/ false, new IndexSampleSpec(ROLLUP_INDEX_META_ID, false)));
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+                    never());
+        }
+    }
+
+    @Test
+    public void secondaryPlanningThrowsAfterBasePlanned_dropsWholePartition() throws Exception {
+        // pBad: base cuts and is planned into the LOCAL map, then the rollup planning
+        // throws (its rows carry no matching IndexTuple) -> the whole partition is
+        // dropped and the base-only remnant NEVER leaks into the combined map.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("pBad", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        installPartitionWithIndices("pGood", 11_002L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_002L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_002L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                // pBad carries NO secondary tuple, so the rollup buildSampleSet throws.
+                rollupEntry("pBad", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100, /*baseCuts*/ true),
+                rollupEntry("pGood", 11_002L, 21_002L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(2, map.size(), "only pGood's base + rollup feed the combined submit");
+            Assertions.assertTrue(map.containsKey(21_002L));
+            Assertions.assertTrue(map.containsKey(22_002L));
+            Assertions.assertFalse(map.containsKey(21_001L), "pBad base-only remnant must NOT leak");
+            Assertions.assertFalse(map.containsKey(22_001L));
+
+            PreSplitOutcome.SubmittedCombined combined = (PreSplitOutcome.SubmittedCombined) outcome;
+            assertSkippedReason(combined.perPartitionResults().get(0), SkipReason.SAMPLE_FAILED);
+            Assertions.assertInstanceOf(PreSplitOutcome.Submitted.class, combined.perPartitionResults().get(1));
+        }
+    }
+
+    @Test
+    public void projectionOrderDiffersFromCatalogOrder_stillCorrect() throws Exception {
+        // The catalog resolves the rollups in order [rollupA, rollupB], but each row's
+        // IndexTuple list is in the REVERSED order [rollupB, rollupA]. rollupA carries
+        // cutting values, rollupB carries all-equal values. Because matching is by
+        // indexMetaId (not list position), rollupA still splits and rollupB does not; a
+        // positional bug would swap them.
+        long rollupA = ROLLUP_INDEX_META_ID;
+        long rollupB = 500L;
+        wireVisibleRollups(rollupA, rollupB);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(rollupA, List.of(22_001L), 0L),
+                mockMaterializedIndex(rollupB, List.of(23_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100, /*baseCuts*/ true,
+                        new IndexSampleSpec(rollupB, /*cuts*/ false),
+                        new IndexSampleSpec(rollupA, /*cuts*/ true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(rollupA, rollupB));
+
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertTrue(map.containsKey(22_001L), "rollupA (cutting values, id-matched) must split");
+            Assertions.assertFalse(map.containsKey(23_001L), "rollupB (all-equal, id-matched) must not split");
+            Assertions.assertTrue(map.containsKey(21_001L), "base splits too");
+        }
+    }
+
+    @Test
+    public void singleIndexMultiPartition_unchanged() throws Exception {
+        // Base-only entries (empty secondary tuples) with an empty sampled secondary set
+        // exercise the conditional access path and produce today's base-only map.
+        installExistingPartition("p1", 11_001L, 21_001L, 0L);
+        installExistingPartition("p2", 11_002L, 21_002L, 0L);
+        List<PartitionSamples> entries = List.of(
+                existingEntry("p1", 11_001L, 21_001L, 100, 100L * DebugUtil.MEGABYTE),
+                existingEntry("p2", 11_002L, 21_002L, 100, 100L * DebugUtil.MEGABYTE));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
+
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(2, map.size(), "single-index target yields only the base tablets");
+            Assertions.assertTrue(map.keySet().containsAll(List.of(21_001L, 21_002L)));
+        }
+    }
+
+    @Test
+    public void rollupMultiTablet_dropsPartition() throws Exception {
+        // pBad's rollup carries 2 tablets -> resolveVisibleIndexTargets returns null ->
+        // the partition is dropped as PARTITION_NOT_ELIGIBLE_POST_CREATE. pGood's rollup
+        // is single-tablet and still contributes.
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("pBad", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L, 22_009L), 0L)));
+        installPartitionWithIndices("pGood", 11_002L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_002L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_002L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("pBad", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)),
+                rollupEntry("pGood", 11_002L, 21_002L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Assertions.assertEquals(2, mapCaptor.getValue().size(), "only pGood's base + rollup contribute");
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(21_002L));
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(22_002L));
+
+            PreSplitOutcome.SubmittedCombined combined = (PreSplitOutcome.SubmittedCombined) outcome;
+            assertSkippedReason(combined.perPartitionResults().get(0),
+                    SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
+        }
+    }
+
+    @Test
+    public void sampledSecondaryIdSetDiffersFromResolved_dropsPartition() throws Exception {
+        // The sampled secondary id set is {rollupA=400}, but the partition currently
+        // resolves rollupB=500 -> the sets differ -> resolveUnderReadLock drops the
+        // partition and the factory is never called.
+        long rollupB = 500L;
+        wireVisibleRollups(rollupB);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(rollupB, List.of(23_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                rollupEntry("p1", 11_001L, 21_001L, 100L * DebugUtil.MEGABYTE, 100, true,
+                        new IndexSampleSpec(ROLLUP_INDEX_META_ID, true)));
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
+
+            assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+                    never());
+        }
+    }
+
+    @Test
+    public void existingPartitionReResolvedBeforePlanning_staleTargetsRejected() throws Exception {
+        // A concurrent split made pStale's base index multi-tablet between the grouper
+        // snapshot and planning. resolveUnderReadLock re-resolves (the factory does not
+        // enforce one-tablet-per-index) and rejects the stale target; pGood contributes.
+        installPartitionWithTabletCount("pStale", 11_001L, /*tabletCount*/ 2, 0L);
+        installExistingPartition("pGood", 11_002L, 21_002L, 0L);
+        List<PartitionSamples> entries = List.of(
+                existingEntry("pStale", 11_001L, 21_001L, 100, 100L * DebugUtil.MEGABYTE),
+                existingEntry("pGood", 11_002L, 21_002L, 100, 100L * DebugUtil.MEGABYTE));
+
+        TabletReshardJob combinedJob = mock(TabletReshardJob.class);
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+                    eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
+
+            Assertions.assertInstanceOf(PreSplitOutcome.SubmittedCombined.class, outcome);
+            Assertions.assertEquals(1, mapCaptor.getValue().size(), "only pGood survives the re-resolve");
+            Assertions.assertTrue(mapCaptor.getValue().containsKey(21_002L));
+
+            PreSplitOutcome.SubmittedCombined combined = (PreSplitOutcome.SubmittedCombined) outcome;
+            assertSkippedReason(combined.perPartitionResults().get(0),
+                    SkipReason.PARTITION_NOT_ELIGIBLE_POST_CREATE);
+        }
+    }
+
+    @Test
+    public void visibleIndexAddedAfterSamplingSnapshot_partitionDropped() throws Exception {
+        // The sample saw a single index (empty sampled secondary set), but a rollup
+        // became visible by resolveUnderReadLock time -> the resolved secondary set
+        // {rollup} differs from {} -> the partition is dropped, NEVER as a base-only
+        // combined entry (the factory is never called).
+        wireVisibleRollups(ROLLUP_INDEX_META_ID);
+        installPartitionWithIndices("p1", 11_001L, List.of(
+                mockMaterializedIndex(BASE_INDEX_META_ID, List.of(21_001L), 0L),
+                mockMaterializedIndex(ROLLUP_INDEX_META_ID, List.of(22_001L), 0L)));
+        List<PartitionSamples> entries = List.of(
+                existingEntry("p1", 11_001L, 21_001L, 100, 100L * DebugUtil.MEGABYTE));
+
+        try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
+                MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
+                MockedConstruction<Locker> ignored = noopLockerCtor()) {
+
+            PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
+                    database, table, entries, 3, freshConnectContext(), null, Set.of());
+
+            assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+                    never());
         }
     }
 
@@ -833,11 +1199,14 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         PhysicalPartition physicalPartition = mock(PhysicalPartition.class);
         when(physicalPartition.getId()).thenReturn(physicalPartitionId);
         MaterializedIndex baseIndex = mock(MaterializedIndex.class);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
         Tablet tablet = mock(Tablet.class);
         when(tablet.getId()).thenReturn(tabletId);
         when(baseIndex.getTablets()).thenReturn(List.of(tablet));
         when(baseIndex.getRowCount()).thenReturn(rowCount);
         when(physicalPartition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        when(physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
         when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
         when(table.getPartition(name)).thenReturn(partition);
     }
@@ -853,6 +1222,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         PhysicalPartition physicalPartition = mock(PhysicalPartition.class);
         when(physicalPartition.getId()).thenReturn(physicalPartitionId);
         MaterializedIndex baseIndex = mock(MaterializedIndex.class);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
         List<Tablet> tablets = new ArrayList<>(tabletCount);
         for (int i = 0; i < tabletCount; i++) {
             Tablet tablet = mock(Tablet.class);
@@ -862,8 +1232,89 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         when(baseIndex.getTablets()).thenReturn(tablets);
         when(baseIndex.getRowCount()).thenReturn(rowCount);
         when(physicalPartition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        when(physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
         when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
         when(table.getPartition(name)).thenReturn(partition);
+    }
+
+    /** One index's per-row sample shape: which index the tuple is tagged with, and whether it cuts. */
+    private record IndexSampleSpec(long indexMetaId, boolean cuts) { }
+
+    /**
+     * Build a {@link PartitionSamples} whose rows carry a base sort-key tuple plus
+     * one id-tagged {@link IndexTuple} per {@code secondarySpecs}, in the given
+     * order (which may deliberately differ from catalog order). {@code cuts} rows
+     * carry ascending distinct BIGINT values (the planner produces useful cuts);
+     * otherwise every value is identical (the planner returns NO_SPLIT).
+     */
+    private static PartitionSamples rollupEntry(String name, long partitionId, long oldTabletId,
+                                                long estimatedBytes, int sampleCount, boolean baseCuts,
+                                                IndexSampleSpec... secondarySpecs) {
+        List<SampleRow> rows = new ArrayList<>(sampleCount);
+        for (int i = 0; i < sampleCount; i++) {
+            List<Variant> baseTuple = List.of(Variant.of(IntegerType.BIGINT, baseCuts ? Long.toString(i) : "42"));
+            List<IndexTuple> secondary = new ArrayList<>(secondarySpecs.length);
+            for (IndexSampleSpec spec : secondarySpecs) {
+                secondary.add(new IndexTuple(spec.indexMetaId(),
+                        List.of(Variant.of(IntegerType.BIGINT, spec.cuts() ? Long.toString(i) : "42"))));
+            }
+            rows.add(new SampleRow(baseTuple, List.of(), secondary));
+        }
+        return new PartitionSamples(
+                List.of("v_" + name), name, /*existsInCatalog*/ true,
+                partitionId, oldTabletId, /*analyzedClause*/ null, rows, estimatedBytes);
+    }
+
+    /** Mock a {@link MaterializedIndex} with the given meta id, tablet ids, and row count. */
+    private static MaterializedIndex mockMaterializedIndex(long metaId, List<Long> tabletIds, long rowCount) {
+        MaterializedIndex index = mock(MaterializedIndex.class);
+        when(index.getMetaId()).thenReturn(metaId);
+        List<Tablet> tablets = new ArrayList<>(tabletIds.size());
+        for (Long tabletId : tabletIds) {
+            Tablet tablet = mock(Tablet.class);
+            when(tablet.getId()).thenReturn(tabletId);
+            tablets.add(tablet);
+        }
+        when(index.getTablets()).thenReturn(tablets);
+        when(index.getRowCount()).thenReturn(rowCount);
+        return index;
+    }
+
+    /**
+     * Install a {@link Partition} whose default physical partition exposes the given
+     * visible indices (base index first). {@code resolveUnderReadLock} walks both
+     * {@code getIndex(baseIndexMetaId)} and {@code getLatestMaterializedIndices}.
+     */
+    private void installPartitionWithIndices(String name, long physicalPartitionId, List<MaterializedIndex> indices) {
+        Partition partition = mock(Partition.class);
+        PhysicalPartition physicalPartition = mock(PhysicalPartition.class);
+        when(physicalPartition.getId()).thenReturn(physicalPartitionId);
+        when(physicalPartition.getIndex(BASE_INDEX_META_ID)).thenReturn(indices.get(0));
+        when(physicalPartition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(indices);
+        when(partition.getDefaultPhysicalPartition()).thenReturn(physicalPartition);
+        when(table.getPartition(name)).thenReturn(partition);
+    }
+
+    /**
+     * Wire the base index meta plus one {@link MaterializedIndexMeta} per given rollup id
+     * (each with its own scalar sort key) so the real {@code MetaUtils.getRangeDistributionColumns}
+     * resolves every index and {@code table.getVisibleIndexMetas} reports base + rollups.
+     */
+    private void wireVisibleRollups(long... rollupMetaIds) {
+        List<MaterializedIndexMeta> metas = new ArrayList<>();
+        metas.add(baseIndexMeta);
+        for (long rollupMetaId : rollupMetaIds) {
+            Column rollupSortKey = new Column("k" + rollupMetaId, IntegerType.BIGINT);
+            MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+            when(rollupMeta.getIndexMetaId()).thenReturn(rollupMetaId);
+            when(rollupMeta.getSchema()).thenReturn(List.of(rollupSortKey));
+            when(rollupMeta.getSortKeyIdxes()).thenReturn(List.of(0));
+            when(table.getIndexMetaByMetaId(rollupMetaId)).thenReturn(rollupMeta);
+            metas.add(rollupMeta);
+        }
+        when(table.getVisibleIndexMetas()).thenReturn(metas);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorTest.java
@@ -52,6 +52,7 @@ public class TabletPreSplitCoordinatorTest {
 
     private static final long PARTITION_ID = 10001L;
     private static final long BASE_INDEX_META_ID = 200L;
+    private static final long ROLLUP_INDEX_META_ID = 201L;
 
     private Database database;
     private OlapTable table;
@@ -90,11 +91,16 @@ public class TabletPreSplitCoordinatorTest {
 
         database = mock(Database.class);
         baseIndex = mock(MaterializedIndex.class);
+        when(baseIndex.getMetaId()).thenReturn(BASE_INDEX_META_ID);
         when(baseIndex.getTablets()).thenReturn(List.of(mock(Tablet.class)));
         when(baseIndex.getRowCount()).thenReturn(0L);
 
         partition = mock(PhysicalPartition.class);
         when(partition.getIndex(BASE_INDEX_META_ID)).thenReturn(baseIndex);
+        // Default: base index only, visible to resolveVisibleIndexTargets. Tests that add a
+        // rollup override this via stubRollupIndex(...).
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex));
 
         table = mock(OlapTable.class);
         when(table.isRangeDistribution()).thenReturn(true);
@@ -127,6 +133,34 @@ public class TabletPreSplitCoordinatorTest {
         when(indexMeta.getSchema()).thenReturn(List.of(columns));
         when(indexMeta.getSortKeyIdxes()).thenReturn(sortKeyIdxes);
         when(table.getIndexMetaByMetaId(BASE_INDEX_META_ID)).thenReturn(indexMeta);
+    }
+
+    /**
+     * Add a visible rollup index (alongside the default base index) with {@code tabletCount}
+     * tablets and {@code sortKeyColumns} as its sort key, mirroring {@link #stubSortKeyColumns}
+     * for the base index. Overrides the default {@code partition.getLatestMaterializedIndices}
+     * stub so both indices are visible to {@link PreSplitTargets#resolveVisibleIndexTargets}.
+     */
+    private void stubRollupIndex(int tabletCount, Column... sortKeyColumns) {
+        List<Integer> sortKeyIdxes = new java.util.ArrayList<>(sortKeyColumns.length);
+        for (int columnIndex = 0; columnIndex < sortKeyColumns.length; columnIndex++) {
+            sortKeyIdxes.add(columnIndex);
+        }
+        MaterializedIndexMeta rollupIndexMeta = mock(MaterializedIndexMeta.class);
+        when(rollupIndexMeta.getSchema()).thenReturn(List.of(sortKeyColumns));
+        when(rollupIndexMeta.getSortKeyIdxes()).thenReturn(sortKeyIdxes);
+        when(table.getIndexMetaByMetaId(ROLLUP_INDEX_META_ID)).thenReturn(rollupIndexMeta);
+
+        MaterializedIndex rollupIndex = mock(MaterializedIndex.class);
+        when(rollupIndex.getMetaId()).thenReturn(ROLLUP_INDEX_META_ID);
+        List<Tablet> tablets = new java.util.ArrayList<>(tabletCount);
+        for (int tabletIndex = 0; tabletIndex < tabletCount; tabletIndex++) {
+            tablets.add(mock(Tablet.class));
+        }
+        when(rollupIndex.getTablets()).thenReturn(tablets);
+
+        when(partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(List.of(baseIndex, rollupIndex));
     }
 
     @AfterEach
@@ -216,12 +250,32 @@ public class TabletPreSplitCoordinatorTest {
     }
 
     @Test
-    public void testMaterializedViewOrRollupSkipped() {
-        // visibleIndexMetas.size() > 1 means at least one MV or rollup is attached.
-        when(table.getVisibleIndexMetas()).thenReturn(
-                List.of(mock(MaterializedIndexMeta.class), mock(MaterializedIndexMeta.class)));
+    public void maybeAct_baseAndEligibleRollup_eligible() {
+        // A visible rollup with its own single tablet and scalar sort key no longer
+        // disqualifies the table -- the getVisibleIndexMetas().size() != 1 gate is gone;
+        // resolveVisibleIndexTargets checks every visible index independently instead.
+        stubRollupIndex(/*tabletCount*/ 1, PresplitTestSupport.bigintColumn("k2"));
+
+        Assertions.assertInstanceOf(PreSplitOutcome.Eligible.class, invokeMaybeAct());
+    }
+
+    @Test
+    public void maybeAct_ineligibleRollup_skips() {
+        // A rollup that fails per-index resolution (here: more than one tablet) must
+        // still skip the whole target under HAS_MATERIALIZED_VIEW_OR_ROLLUP.
+        stubRollupIndex(/*tabletCount*/ 2, PresplitTestSupport.bigintColumn("k2"));
 
         assertSkipped(invokeMaybeAct(), SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
+    }
+
+    @Test
+    public void maybeAct_baseNonEmptyWithRollup_partitionNotEmpty() {
+        // The base-index row-count check must still gate ahead of the per-index rollup
+        // resolution, even when an otherwise-eligible rollup is present.
+        when(baseIndex.getRowCount()).thenReturn(42L);
+        stubRollupIndex(/*tabletCount*/ 1, PresplitTestSupport.bigintColumn("k2"));
+
+        assertSkipped(invokeMaybeAct(), SkipReason.PARTITION_NOT_EMPTY);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split previously excluded any range-distribution table that
carries a visible secondary materialized index (a rollup) via a hard
`getVisibleIndexMetas().size() != 1` eligibility gate. A bulk load into such a table
therefore got no pre-split: every index stayed a single tablet and the load wrote
serially. This change lets a bulk load into a range table with a rollup run in parallel,
like a hash-distributed table.

## What I'm doing:

Extend pre-split to split BOTH the base index and its rollup, each by boundaries sampled
from that index's own sort key, submitted as ONE combined reshard job.

FE-only. The BE / thrift / proto are unchanged: the External-Boundaries substrate
(`SplitTabletJobFactory.forExternalBoundariesMultiTablet`) already splits a multi-index
reshard job, so the change is entirely on the FE planning side -- resolve every visible
index's single tablet, sample the load source projecting each index's own sort key, plan
each index's boundaries, and feed all indexes' `oldTabletId -> ranges` into one job.

- On a shared-data range-distribution table a synchronous MV cannot be created, so the
  only visible secondary index is a routable range rollup that carries its own (possibly
  divergent) sort key; each index is sampled and planned by its own sort key.
- Split boundaries are advisory: the BE routes every row by its true value, so a
  per-index boundary can only shift where a split lands, never lose or misroute a row.
- Covers single-partition and multi-partition (auto-partition) loads for INSERT-from-FILES
  and Broker Load. Multi-partition planning is transactional per partition (all indexes of
  a partition split together or the partition is skipped), and secondary sample tuples are
  matched to their index by meta id, not by position.
- INSERT-from-table is intentionally skipped when the target has a rollup (its source is
  another table whose columns cannot be mapped to a divergent rollup sort key) -- a
  documented follow-up, not a partial split.
- The single-index (no-rollup) path is preserved exactly, and every sampling / planning /
  submit failure falls back to no-pre-split so the load always completes.

No new config, session variable, metric, thrift, or proto field.

Tests: full `com.starrocks.alter.reshard.presplit` FE unit package (34 classes) -- 624 run,
0 failures, 0 errors, 4 pre-existing skips; checkstyle 0. New coverage for the eligibility
relaxation, per-index planning on both the single- and multi-partition paths, transactional
all-or-nothing per partition, id-matched tuple pairing, the INSERT-from-table descope
(including a resolved-set race regression), and fail-safe fallbacks. A TSP shared-data
end-to-end run (base + rollup both split 1 -> N tablets, external-boundaries fallback = 0)
will be attached as a comment.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
