### PR TITLE
[BugFix] Persist the rollup's own schema for range-rollup shadow tablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
@@ -316,6 +316,21 @@ public abstract class LakeOnlineRewriteJobBase
     protected void afterJobSettled(boolean cancelled) {
     }
 
+    /**
+     * Seam invoked lock-free after the shadow index tablets are built (PENDING stage 2) and before the
+     * PENDING -&gt; WAITING_TXN commit, so a subclass can write each shadow tablet's version-1 metadata on
+     * the compute nodes. Default no-op: the replace-flavored range rewrite lets the compute node lazily
+     * materialize version-1 metadata on first read. The additive rollup overrides this: its shadow shards
+     * share the base index's per-partition storage path, so without an explicit CreateReplicaTask the
+     * compute node would lazily materialize a rollup tablet's version-1 metadata from the base index's
+     * shared initial-metadata template and read the BASE schema (wrong sort-key arity). Runs while the job
+     * is still PENDING (before the WAITING_TXN journal), so a failure leaves the job re-runnable: the
+     * runPendingJob cleanup drops the orphaned shards and a retry rebuilds the shadow fresh. Must throw
+     * AlterCancelException on failure.
+     */
+    protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
+    }
+
     // ---- PENDING ---------------------------------------------------------------------------------
 
     @Override
@@ -376,6 +391,11 @@ public abstract class LakeOnlineRewriteJobBase
             for (PendingPartitionPlan plan : pendingPlans) {
                 planPartitionShadow(plan, table, cachedDbName);
             }
+
+            // Write each shadow tablet's version-1 metadata on the compute nodes (default no-op; the
+            // additive rollup persists its own schema here). Still lock-free and still PENDING, so on any
+            // failure the finally below drops the orphaned shards and a retry rebuilds the shadow fresh.
+            createShadowTabletMetadata(pendingPlans);
 
             // Stage 3 (WRITE-lock commit): re-fetch and re-validate the table (TOCTOU: it may have been
             // dropped/altered while the lock was released), then install the built shadow indexes, journal

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
@@ -33,8 +33,11 @@ import com.starrocks.alter.reshard.presplit.TabletPreSplitCoordinator;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -42,15 +45,25 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
+import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -340,6 +353,126 @@ public class LakeRangeRollupJob extends LakeOnlineRewriteJobBase {
             return singleRange;
         }
         return DefaultPreSplitPipeline.buildTabletRanges(boundaries);
+    }
+
+    /**
+     * Write each rollup shadow tablet's version-1 metadata on its compute node, carrying the ROLLUP's own
+     * schema (its ORDER BY sort key), so the reshard/pre-split boundary validation reads the rollup's
+     * sort-key arity rather than the base index's. The rollup shadow shards share the base index's
+     * per-partition storage path, so without this the compute node would lazily materialize the tablet's
+     * version-1 metadata from the base index's shared initial-metadata template and read the BASE schema.
+     *
+     * <p>Mirrors {@link LakeRollupJob}'s create-replica-and-wait: build one CreateReplicaTask per shadow
+     * tablet under a READ lock, then send and wait outside the lock. Two differences from the plain
+     * (non-range) rollup: (1) the tablet schema carries the rollup's own sort key (arity matches the
+     * rollup ORDER BY), not a null sort key; (2) tablet-creation optimization is forced off so each tablet
+     * writes its OWN per-tablet version-1 metadata instead of the shared initial-metadata template, which
+     * belongs to the base index sharing this partition storage path.
+     */
+    @Override
+    protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
+        long shadowTabletCount = plans.stream()
+                .filter(plan -> plan.shadowIndex != null)
+                .mapToLong(plan -> plan.shadowIndex.getTablets().size())
+                .sum();
+        if (shadowTabletCount == 0) {
+            return;
+        }
+
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>((int) shadowTabletCount);
+        AgentBatchTask batchTask;
+        // Build the tasks under a READ lock (stable table metadata + compute-node resolution), then send
+        // and wait outside the lock (a network round-trip must not be held across the database lock).
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            batchTask = buildShadowTabletCreateTasks(table, plans, countDownLatch);
+        }
+
+        LakeRollupJob.sendAgentTaskAndWait(batchTask, countDownLatch,
+                Config.tablet_create_timeout_second * shadowTabletCount);
+    }
+
+    /**
+     * Build one {@link CreateReplicaTask} per rollup shadow tablet, each carrying the rollup's own tablet
+     * schema (its sort key) and its per-tablet range. The caller holds the database read lock. Split out
+     * so a unit test can assert the emitted tablet schema without a compute-node round-trip.
+     */
+    @VisibleForTesting
+    AgentBatchTask buildShadowTabletCreateTasks(@NotNull OlapTable table, List<PendingPartitionPlan> plans,
+                                                MarkedCountDownLatch<Long, Long> countDownLatch)
+            throws AlterCancelException {
+        AgentBatchTask batchTask = new AgentBatchTask();
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        long gtid = getNextGtid();
+
+        // The rollup shadow index meta is not registered on the table until PENDING stage 3, so build the
+        // MaterializedIndexMeta from this job's rollup config -- identical to what registerShadowIndexMeta
+        // will register -- and derive the tablet schema (with the rollup's own sort key) from it.
+        MaterializedIndexMeta rollupIndexMeta = new MaterializedIndexMeta(
+                shadowIndexMetaId, rollupSchema, 0 /* schemaVersion */, 0 /* schemaHash */,
+                shadowShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, null /* defineStmt */,
+                rollupSortKeyIdxes, rollupSortKeyUniqueIds);
+        TTabletSchema tabletSchema =
+                SchemaInfo.fromMaterializedIndex(table, shadowIndexMetaId, rollupIndexMeta).toTabletSchema();
+
+        for (PendingPartitionPlan plan : plans) {
+            if (plan.shadowIndex == null) {
+                continue;
+            }
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(plan.physicalPartitionId);
+            if (physicalPartition == null) {
+                throw new AlterCancelException("partition " + plan.physicalPartitionId
+                        + " was dropped while creating rollup shadow tablets");
+            }
+            TStorageMedium storageMedium = table.getPartitionInfo()
+                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+
+            // The schema file is created once per partition, with the first tablet.
+            boolean createSchemaFile = true;
+            for (Tablet shadowTablet : plan.shadowIndex.getTablets()) {
+                long shadowTabletId = shadowTablet.getId();
+                ComputeNode computeNode = null;
+                try {
+                    computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, shadowTabletId);
+                } catch (ErrorReportException e) {
+                    // computeNode stays null -> handled below.
+                }
+                if (computeNode == null) {
+                    throw new AlterCancelException(
+                            "no alive compute node to create rollup shadow tablet " + shadowTabletId);
+                }
+                countDownLatch.addMark(computeNode.getId(), shadowTabletId);
+
+                CreateReplicaTask task = CreateReplicaTask.newBuilder()
+                        .setNodeId(computeNode.getId())
+                        .setDbId(dbId)
+                        .setTableId(tableId)
+                        .setPartitionId(plan.physicalPartitionId)
+                        .setIndexId(shadowIndexMetaId)
+                        .setTabletId(shadowTabletId)
+                        .setVersion(Partition.PARTITION_INIT_VERSION)
+                        .setStorageMedium(storageMedium)
+                        .setLatch(countDownLatch)
+                        .setEnablePersistentIndex(table.enablePersistentIndex())
+                        .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
+                        .setTabletType(TTabletType.TABLET_TYPE_LAKE)
+                        .setCompressionType(table.getCompressionType())
+                        .setCreateSchemaFile(createSchemaFile)
+                        .setTabletSchema(tabletSchema)
+                        // Force per-tablet version-1 metadata: with the optimization on the compute node
+                        // would write the shared initial-metadata template, which belongs to the base index
+                        // sharing this partition storage path. Per-tablet metadata both fixes the wrong
+                        // schema read and avoids clobbering the base template.
+                        .setEnableTabletCreationOptimization(false)
+                        .setGtid(gtid)
+                        .setCompactionStrategy(table.getCompactionStrategy())
+                        .setRange(shadowTablet.getRange())
+                        .build();
+                createSchemaFile = false;
+                batchTask.addTask(task);
+            }
+        }
+        return batchTask;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
@@ -457,6 +457,10 @@ public class LakeRangeRollupJob extends LakeOnlineRewriteJobBase {
                         .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
                         .setTabletType(TTabletType.TABLET_TYPE_LAKE)
                         .setCompressionType(table.getCompressionType())
+                        // The compute node overwrites the tablet schema's compression level with this
+                        // request field (defaults to 0), so set it explicitly to preserve a table's
+                        // configured non-default compression level -- as every other create-replica path does.
+                        .setCompressionLevel(table.getCompressionLevel())
                         .setCreateSchemaFile(createSchemaFile)
                         .setTabletSchema(tabletSchema)
                         // Force per-tablet version-1 metadata: with the optimization on the compute node

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
@@ -29,6 +29,8 @@ import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.proc.RollupProcDir;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
@@ -63,7 +65,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LakeRangeRollupJobTest {
@@ -393,6 +397,46 @@ public class LakeRangeRollupJobTest {
             assertEquals(7, req.getCompression_level(),
                     "create task must carry the table's configured compression level, not the default");
         }
+    }
+
+    @Test
+    public void testCreateShadowTabletMetadataSkipsWhenNoShadowTablets() {
+        Column colK1 = table.getSchemaByIndexMetaId(baseIndexMetaId).get(0);
+        LakeRangeRollupJob job = newConfiguredRollupJob(List.of(colK1));
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        // A plan whose shadow index was never built contributes no tablets, so the method returns early
+        // without acquiring the database lock or sending any create task.
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        assertNull(plan.shadowIndex);
+        assertDoesNotThrow(() -> job.createShadowTabletMetadata(List.of(plan)));
+    }
+
+    @Test
+    public void testBuildShadowTabletCreateTasksThrowsWithoutComputeNode() throws Exception {
+        // No alive compute node for the shadow tablet -> resolution throws, and the job aborts the alter.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, tabletId);
+            }
+        };
+
+        Column colK1 = table.getSchemaByIndexMetaId(baseIndexMetaId).get(0);
+        LakeRangeRollupJob job = newConfiguredRollupJob(List.of(colK1));
+        // Empty sample -> a single full-range shadow tablet; planning does not resolve per-tablet nodes.
+        job.setSampler(stubSamplerReturning(List.of()));
+
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        job.planPartitionShadow(plan, table, DB_NAME);
+        assertNotNull(plan.shadowIndex);
+
+        MarkedCountDownLatch<Long, Long> latch =
+                new MarkedCountDownLatch<>(plan.shadowIndex.getTablets().size());
+        AlterCancelException ex = assertThrows(AlterCancelException.class,
+                () -> job.buildShadowTabletCreateTasks(table, List.of(plan), latch));
+        assertTrue(ex.getMessage().contains("no alive compute node"),
+                "abort message must name the missing compute node, was: " + ex.getMessage());
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
@@ -31,14 +31,24 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.proc.RollupProcDir;
 import com.starrocks.common.util.ParseUtil;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.CreateReplicaTask;
+import com.starrocks.thrift.TCreateTabletReq;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -319,6 +329,62 @@ public class LakeRangeRollupJobTest {
         assertTrue(plan.shadowTabletCount >= 1);
         for (Tablet t : plan.shadowIndex.getTablets()) {
             assertNotNull(t.getRange());
+        }
+    }
+
+    /**
+     * The rollup shadow tablets must be created with a CreateReplicaTask carrying the ROLLUP's OWN tablet
+     * schema (its single-column sort key), NOT the base index's schema (whose sort key is (k1, k2), arity
+     * 2). Without this the compute node lazily materializes the rollup tablet's version-1 metadata from
+     * the base index's shared initial-metadata template and reads the base sort-key arity, which breaks the
+     * reshard/pre-split boundary validation.
+     */
+    @Test
+    public void testCreateShadowTabletMetadataEmitsRollupSchema() throws Exception {
+        // Resolve every rollup shadow tablet to a single alive compute node.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                ComputeNode cn = new ComputeNode(1000L, "127.0.0.1", 9050);
+                cn.setAlive(true);
+                return cn;
+            }
+        };
+
+        List<Column> baseSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        Column colK1 = baseSchema.get(0);
+        // Rollup sort key is the single column k1 (arity 1), narrower than the base's (k1, k2) (arity 2).
+        LakeRangeRollupJob job = newConfiguredRollupJob(List.of(colK1));
+        // Empty sample -> a single full-range shadow tablet (K=1); enough to assert the emitted schema.
+        job.setSampler(stubSamplerReturning(List.of()));
+
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        job.planPartitionShadow(plan, table, DB_NAME);
+        assertNotNull(plan.shadowIndex);
+        assertTrue(plan.shadowIndex.getTablets().size() >= 1);
+
+        MarkedCountDownLatch<Long, Long> latch =
+                new MarkedCountDownLatch<>(plan.shadowIndex.getTablets().size());
+        AgentBatchTask batchTask = job.buildShadowTabletCreateTasks(table, List.of(plan), latch);
+
+        List<AgentTask> tasks = batchTask.getAllTasks();
+        assertEquals(plan.shadowIndex.getTablets().size(), tasks.size(),
+                "one CreateReplicaTask per rollup shadow tablet");
+        List<Integer> baseSortKeyIdxes = table.getIndexMetaByMetaId(baseIndexMetaId).getSortKeyIdxes();
+        assertEquals(2, baseSortKeyIdxes.size(), "base index sort key must be (k1, k2), arity 2");
+
+        for (AgentTask agentTask : tasks) {
+            assertInstanceOf(CreateReplicaTask.class, agentTask);
+            TCreateTabletReq req = ((CreateReplicaTask) agentTask).toThrift();
+            // The emitted tablet schema is the rollup's own: single-column sort key [0], NOT the base's.
+            assertEquals(List.of(0), req.getTablet_schema().getSort_key_idxes(),
+                    "rollup shadow tablet must carry the rollup's own sort-key indexes, not the base's");
+            assertEquals(job.getShadowIndexMetaId(), req.getTablet_schema().getId(),
+                    "tablet schema id must be the rollup shadow index meta id");
+            // Per-tablet version-1 metadata (optimization off) so the base's shared template is not used.
+            assertFalse(req.isEnable_tablet_creation_optimization(),
+                    "tablet-creation optimization must be off so per-tablet metadata is written");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
@@ -351,6 +351,9 @@ public class LakeRangeRollupJobTest {
             }
         };
 
+        // Configure a non-default compression level so the create task must carry it through, not level 0.
+        table.setCompressionLevel(7);
+
         List<Column> baseSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         Column colK1 = baseSchema.get(0);
         // Rollup sort key is the single column k1 (arity 1), narrower than the base's (k1, k2) (arity 2).
@@ -385,6 +388,10 @@ public class LakeRangeRollupJobTest {
             // Per-tablet version-1 metadata (optimization off) so the base's shared template is not used.
             assertFalse(req.isEnable_tablet_creation_optimization(),
                     "tablet-creation optimization must be off so per-tablet metadata is written");
+            // The compute node overwrites the schema's compression level with this request field, so it must
+            // carry the table's configured level (7), not the builder default (0).
+            assertEquals(7, req.getCompression_level(),
+                    "create task must carry the table's configured compression level, not the default");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

On a shared-data (cloud-native) range-distribution table, a range rollup added via
`ALTER TABLE ... ADD ROLLUP r (...) ORDER BY(...)` (created by `LakeRangeRollupJob`)
has its rollup SHADOW TABLETS persist the BASE index's schema instead of the rollup's
own. As a result, any code that reads the rollup tablet's stored schema sees the base
index's `sort_key_idxes` (the base sort-key arity) rather than the rollup's own sort
key.

The concrete symptom: the external-boundaries tablet-split validation
(`compute_split_ranges_from_external_boundaries`) reads the rollup tablet's stored
schema `sort_key_idxes()` and checks the boundary tuple arity against it. Because the
stored schema is the base's, a rollup whose sort-key arity differs from the base's is
rejected (`tuple arity != sort_key arity`) and the split falls back to identical -- the
rollup never splits. Verified on a shared-data cluster: a range table with a
single-column rollup (`ORDER BY(k2)`) on a two-column base (`ORDER BY(k1, k2)`) always
fell back; a two-column rollup coincidentally passed (its arity matched the base's).

## What I'm doing:

Root cause: `LakeRangeRollupJob` (via `buildRangeShadowIndex`) allocates the rollup
shadow tablets in the BASE index's shard group and never writes their own version-1
metadata / schema. The shard storage path is per-partition, so the CN lazily
materializes the rollup tablet's version-1 metadata from the base index's shared
initial-metadata template (which carries the base schema) instead of the rollup's own
schema. The non-range rollup path (`LakeRollupJob`) does not have this problem because
it sends a `CreateReplicaTask` per rollup tablet with an explicit `TTabletSchema`, so
each rollup tablet writes its own version-1 metadata.

Fix: make `LakeRangeRollupJob` write each rollup shadow tablet's own version-1 metadata
via a `CreateReplicaTask`, mirroring `LakeRollupJob`, but with the rollup's OWN schema
(built from the rollup shadow `MaterializedIndexMeta`, so it carries the rollup's own
sort key and arity, and each tablet's range). Tablet-creation optimization is disabled
for these tasks so the per-tablet metadata is actually written (with it on, the CN would
fall back to the base's shared template).

## Behavior change

No. This corrects a persisted-metadata defect that only affects the reshard / tablet-split
read path (the rollup's data write path already tags shadow writes with the rollup index
id, so rollup data is written correctly). No SQL syntax, config, or interface change.

## Tests

- FE unit test `LakeRangeRollupJobTest`: a new case asserts each rollup shadow tablet's
  `CreateReplicaTask` carries a `TTabletSchema` whose sort-key indexes are the rollup's
  OWN (arity 1 for a single-column `ORDER BY`), not the base's. `LakeRangeRollupJobTest`
  15/15 and the sibling `LakeRangeRewriteSchemaChangeJobTest` 46/46 pass; checkstyle 0.
- TSP shared-data end-to-end (1 FE + 3 CN): a range table with a single-column rollup,
  loaded via `INSERT ... SELECT * FROM FILES(...)`. After this fix the tablet pre-split
  splits BOTH the base index (1 -> 2 tablets) AND the rollup index (1 -> 2 tablets),
  with `external_boundaries_fallback_total = 0` across all CNs, and COUNT/MIN/MAX/SUM
  correct on both the base and the rollup (rollup carries all rows with correct values).

Note: this feature (`LakeRangeRollupJob`) is main-only, so this fix is not backported.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
