### PR TITLE
[UT] Add SQLTester cases for FILES() path pattern styles

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3371,6 +3371,17 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
                 "assert expect {} is not found in plan {}".format(expect, res["result"]),
             )
 
+    def assert_query_not_contains(self, query, *expects):
+        """
+        assert query result does not contain expect string
+        """
+        res = self.execute_sql(query, True)
+        for expect in expects:
+            tools.assert_true(
+                str(res["result"]).find(expect) < 0,
+                "assert expect {} is unexpectedly found in result {}".format(expect, res["result"]),
+            )
+
     def assert_query_contains_times(self, query, expect, expected_times: int):
         """
         Assert query result contains `expect` exactly `expected_times` times.

--- a/test/sql/test_files/R/test_files_path_patterns
+++ b/test/sql/test_files/R/test_files_path_patterns
@@ -36,6 +36,10 @@ function: assert_query_contains('select path, size, is_dir from files("path"="os
 -- result:
 None
 -- !result
+function: assert_query_not_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic1.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic2.csv')
+-- result:
+None
+-- !result
 function: assert_query_error_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic9*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'No files were found matching the pattern')
 -- result:
 None
@@ -56,7 +60,7 @@ function: assert_query_contains('select path, size, is_dir from files("path"="os
 -- result:
 None
 -- !result
-function: assert_query_contains('select count(*) from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '1')
+function: assert_query_not_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '2026-06-24-14-b.csv')
 -- result:
 None
 -- !result

--- a/test/sql/test_files/R/test_files_path_patterns
+++ b/test/sql/test_files/R/test_files_path_patterns
@@ -1,0 +1,67 @@
+-- name: test_files_path_patterns
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/path_patterns/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 52. OK num: 1(upload 1 files).
+-- !result
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic2.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 34. OK num: 1(upload 1 files).
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- result:
+None
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- result:
+None
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/*.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- result:
+None
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic?.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- result:
+None
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic1.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv')
+-- result:
+None
+-- !result
+function: assert_query_error_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic9*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'No files were found matching the pattern')
+-- result:
+None
+-- !result
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13-a.csv | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 52. OK num: 1(upload 1 files).
+-- !result
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic2.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-14-b.csv | grep -Pv "(average|elapsed)"
+-- result:
+0
+
+Succeed: Total num: 1, size: 34. OK num: 1(upload 1 files).
+-- !result
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '2026-06-24-13-a.csv')
+-- result:
+None
+-- !result
+function: assert_query_contains('select count(*) from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '1')
+-- result:
+None
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ > /dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_files/T/test_files_path_patterns
+++ b/test/sql/test_files/T/test_files_path_patterns
@@ -1,0 +1,29 @@
+-- name: test_files_path_patterns
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_files/path_patterns/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic2.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ | grep -Pv "(average|elapsed)"
+
+-- '*' matches any run of characters within a path segment
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- literal prefix followed by '*' (prefix is pushed down as the S3 ListObjectsV2 prefix)
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- '*' as a suffix match
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/*.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- '?' matches exactly one character
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic?.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
+-- exact single file, no wildcard (resolved via an efficient HEAD, not a listing)
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic1.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv')
+-- prefix glob with no match -> no files found
+function: assert_query_error_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic9*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'No files were found matching the pattern')
+
+-- ':' in a directory segment (e.g. a time-of-day prefix) plus a literal date prefix + '*'
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13-a.csv | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ./sql/test_files/csv_format/basic2.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-14-b.csv | grep -Pv "(average|elapsed)"
+-- the date prefix matches only the 2026-06-24-13 file
+function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '2026-06-24-13-a.csv')
+-- and excludes the 2026-06-24-14 file (exactly one match)
+function: assert_query_contains('select count(*) from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '1')
+
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ > /dev/null

--- a/test/sql/test_files/T/test_files_path_patterns
+++ b/test/sql/test_files/T/test_files_path_patterns
@@ -14,6 +14,8 @@ function: assert_query_contains('select path, size, is_dir from files("path"="os
 function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic?.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv', 'basic2.csv')
 -- exact single file, no wildcard (resolved via an efficient HEAD, not a listing)
 function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic1.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic1.csv')
+-- and the sibling file is not returned (would fail if it regressed to a directory listing)
+function: assert_query_not_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic1.csv", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'basic2.csv')
 -- prefix glob with no match -> no files found
 function: assert_query_error_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/basic9*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', 'No files were found matching the pattern')
 
@@ -22,8 +24,8 @@ shell: ossutil64 cp --force ./sql/test_files/csv_format/basic1.csv oss://${oss_b
 shell: ossutil64 cp --force ./sql/test_files/csv_format/basic2.csv oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-14-b.csv | grep -Pv "(average|elapsed)"
 -- the date prefix matches only the 2026-06-24-13 file
 function: assert_query_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '2026-06-24-13-a.csv')
--- and excludes the 2026-06-24-14 file (exactly one match)
-function: assert_query_contains('select count(*) from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '1')
+-- and excludes the sibling 2026-06-24-14 file
+function: assert_query_not_contains('select path, size, is_dir from files("path"="oss://${oss_bucket}/test_files/path_patterns/${uuid0}/06:00:00/2026-06-24-13*", "list_files_only"="true", "list_recursively"="false", "aws.s3.access_key"="${oss_ak}", "aws.s3.secret_key"="${oss_sk}", "aws.s3.endpoint"="${oss_endpoint}")', '2026-06-24-14-b.csv')
 
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_files/path_patterns/${uuid0}/ > /dev/null


### PR DESCRIPTION
  ## Why I'm doing:
  
  The existing `test_list_files` case only exercises `*` and prefix globs (`orc*`) for the
  FILES() table function. Common path-writing styles had no coverage: `?` single-character
  wildcards, `*.csv` suffix globs, exact single-file paths, no-match handling, and — the
  real-world motivator — paths that contain `:` in a directory segment (e.g. a time-of-day
  prefix like `06:00:00/`) combined with a literal date prefix such as `2026-06-24-13*`.
  These forms exercise the S3 native glob path added in #76210 (literal-prefix pushdown, the
  exact-path HEAD fast path, and the no-match error), so they are worth locking down.

  ## What I'm doing: 
  
  Add a new SQLTester case `test_files_path_patterns` (T/R pair under `test/sql/test_files/`)
  that stages CSV fixtures on OSS and checks each path style via `list_files_only=true`.
  Assertions use `assert_query_contains` / `assert_query_error_contains` (contains-style)
  rather than full-result matching, so they are insensitive to row order / exact sizes and
  stable across `-r` regeneration:
  
  - `*` (full segment), `basic*` (literal prefix + `*`), `*.csv` (suffix) → both files
  - `?` single character (`basic?.csv`) → both files
  - exact single file, no wildcard (`basic1.csv`) → that file
  - prefix glob with no match (`basic9*`) → "No files were found matching the pattern" error
  - `:` in a directory segment plus a literal date prefix (`06:00:00/2026-06-24-13*`):
    asserts the `2026-06-24-13` file is returned and that `count(*)` is exactly 1, i.e. the
    sibling `2026-06-24-14` file is correctly excluded by the pushed-down prefix

  Note: character classes `[...]` and brace expansion `{a,b}` are intentionally not covered                                                                                                                                      
  here — the `list_files_only` path normalizes via `new URI(path)`, which rejects `[`/`]`/`{`/`}`
  as illegal URI characters. That is a pre-existing limitation of `listFilesAndDirs`, independent
  of this test; it can be addressed separately.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
