### PR TITLE
[BugFix] Unschedule global RF timer in PipelineDriver destructor

### DIFF
--- a/be/src/exec/runtime/pipeline_driver.cpp
+++ b/be/src/exec/runtime/pipeline_driver.cpp
@@ -102,6 +102,10 @@ PipelineDriver::PipelineDriver()
           _driver_id(0) {}
 
 PipelineDriver::~PipelineDriver() noexcept {
+    // Queued or blocked drivers abandoned when the driver executor is closed during shutdown are
+    // destroyed without going through finalize(), so unschedule the global runtime-filter timer here
+    // as well; otherwise the timer thread may run a task whose owning shared_ptr is already gone.
+    _unschedule_global_rf_timer();
     if (_workgroup != nullptr) {
         _workgroup->decr_num_running_drivers();
     }
@@ -884,11 +888,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
 
     _update_driver_level_timer();
 
-    if (_global_rf_timer != nullptr) {
-        if (_pipeline_timer_context != nullptr) {
-            _pipeline_timer_context->unschedule_and_join(_global_rf_timer.get());
-        }
-    }
+    _unschedule_global_rf_timer();
 
     if (_driver_observer != nullptr) {
         _driver_observer->on_driver_finished(runtime_state);
@@ -937,6 +937,16 @@ void PipelineDriver::_update_global_rf_timer() {
     _global_rf_timer = std::move(timer);
     timespec abstime = butil::nanoseconds_from_now(_global_rf_wait_timeout_ns);
     WARN_IF_ERROR(_pipeline_timer_context->schedule(_global_rf_timer.get(), abstime), "schedule:");
+}
+
+void PipelineDriver::_unschedule_global_rf_timer() noexcept {
+    // Move the task out first so it stays alive while we synchronize with a callback that may already
+    // be running on the timer thread but has not yet taken its shared_from_this() reference. Otherwise
+    // doRun() could observe a zero use_count and throw std::bad_weak_ptr.
+    auto task = std::move(_global_rf_timer);
+    if (task != nullptr && _pipeline_timer_context != nullptr) {
+        _pipeline_timer_context->unschedule_and_join(task.get());
+    }
 }
 
 std::string PipelineDriver::_build_readable_string(bool use_raw_name) const {

--- a/be/src/exec/runtime/pipeline_driver.h
+++ b/be/src/exec/runtime/pipeline_driver.h
@@ -446,6 +446,7 @@ protected:
 
     // used in event scheduler
     void _update_global_rf_timer();
+    void _unschedule_global_rf_timer() noexcept;
 
     // Helper function to build readable string with option to use raw operator names
     std::string _build_readable_string(bool use_raw_name) const;

--- a/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
+++ b/be/test/exec/pipeline/schedule/pipeline_timer_test.cpp
@@ -28,6 +28,7 @@
 #include "butil/time.h"
 #include "common/brpc/brpc_stub_cache.h"
 #include "compute_env/pipeline/pipeline_timer_context.h"
+#include "exec/runtime/pipeline_driver.h"
 #include "exec_primitive/pipeline/primitives/pipeline_observer.h"
 #include "gtest/gtest.h"
 #include "runtime/runtime_state.h"
@@ -71,6 +72,18 @@ class LightProbe final : public LightTimerTask {
 public:
     void Run() override { ran.store(true, std::memory_order_release); }
     std::atomic<bool> ran{false};
+};
+
+// Reaches PipelineDriver's protected default constructor and its protected global-RF-timer members
+// so a test can drive the destructor cleanup path without standing up a full fragment.
+class TimerTestPipelineDriver final : public PipelineDriver {
+public:
+    TimerTestPipelineDriver() = default;
+
+    void register_global_rf_timer(PipelineTimerContextPtr context, std::shared_ptr<PipelineTimerTask> task) {
+        _pipeline_timer_context = std::move(context);
+        _global_rf_timer = std::move(task);
+    }
 };
 
 class CountingObserver final : public PipelineObserver {
@@ -301,6 +314,52 @@ TEST_F(PipelineTimerTaskTest, pipeline_timer_context_submits_batched_rf_timeout_
     EXPECT_EQ(observer2.source_count.load(std::memory_order_acquire), 1);
 
     context.clear_rf_timeout_tasks();
+}
+
+// A queued or blocked driver abandoned when the driver executor is closed during shutdown is
+// destroyed without going through finalize(). The destructor must still unschedule the global
+// runtime-filter timer, otherwise the timer thread runs a task whose owning shared_ptr is gone and
+// doRun()'s shared_from_this() throws std::bad_weak_ptr.
+TEST_F(PipelineTimerTaskTest, pipeline_driver_destructor_unschedules_global_rf_timer) {
+    auto context = std::make_shared<PipelineTimerContext>(&timer);
+    auto task = std::make_shared<ProbeTask>();
+    ASSERT_OK(context->schedule(task.get(), future_abstime(3600)));
+    ASSERT_NE(0, task->tid());
+
+    auto driver = std::make_unique<TimerTestPipelineDriver>();
+    driver->register_global_rf_timer(context, task);
+
+    // Intentionally skip finalize().
+    driver.reset();
+
+    // The destructor must already have removed the task; a second unschedule finds nothing.
+    EXPECT_EQ(-1, timer.unschedule(task.get()));
+}
+
+// The destructor must block until an already-running global RF timer task returns, mirroring
+// finalize()'s unschedule_and_join, so the task is never freed while doRun() is still executing.
+TEST_F(PipelineTimerTaskTest, pipeline_driver_destructor_waits_for_running_global_rf_timer) {
+    auto context = std::make_shared<PipelineTimerContext>(&timer);
+    auto task = std::make_shared<ProbeTask>();
+    task->block_until_released = true;
+    ASSERT_OK(context->schedule(task.get(), past_abstime()));
+    task->run_enter.acquire();
+
+    auto driver = std::make_unique<TimerTestPipelineDriver>();
+    driver->register_global_rf_timer(context, task);
+
+    std::atomic<bool> destructor_returned{false};
+    std::thread destructor([driver = std::move(driver), &destructor_returned]() mutable {
+        driver.reset();
+        destructor_returned.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(destructor_returned.load(std::memory_order_acquire));
+
+    task->run_gate.release();
+    destructor.join();
+    EXPECT_TRUE(destructor_returned.load(std::memory_order_acquire));
 }
 
 // LightTimerTask goes through a separate schedule/unschedule pair and lacks the


### PR DESCRIPTION
## Why I'm doing:

A BE/CN aborts during shutdown with `std::bad_weak_ptr`:

```
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  bad_weak_ptr
  ... starrocks::pipeline::RunTimerTask(void*)
  ... bthread::TimerThread::Task::run_and_delete()
  ... bthread::TimerThread::run()
```

The global runtime-filter timer (`RFScanWaitTimeout`) is owned solely by
`PipelineDriver::_global_rf_timer`, and it is only unscheduled in
`finalize()`. Queued or blocked drivers that are abandoned when the driver
executor is closed at shutdown are destroyed **without** going through
`finalize()`, so the bthread `TimerThread` — which keeps only a raw pointer to
the task — can still fire on a task whose last owning `shared_ptr` is already
gone. `PipelineTimerTask::doRun()` then calls `shared_from_this()` on the freed
object and throws `std::bad_weak_ptr`, aborting the process.

This is the abandoned-driver counterpart to the query-context-destruction race
fixed in #73082, which unscheduled only from `finalize()`. The throwing
`shared_from_this()` in `doRun()` was introduced when `PipelineTimerTask`
became `enable_shared_from_this` in #72058.

## What I'm doing:

- Extract the unschedule into `_unschedule_global_rf_timer()` and call it from
  **both** `finalize()` and `~PipelineDriver()`.
- The helper moves the `shared_ptr` into a local so the task stays alive across
  `unschedule_and_join()`, closing the window where a concurrently running
  `doRun()` could observe a zero `use_count`.
- Add unit tests: the destructor unschedules a pending global RF timer, and the
  destructor blocks until an in-flight timer task returns.

Verified: both changed translation units compile cleanly with the project
toolchain (gcc-12, `-std=gnu++23`), zero diagnostics.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
