### PR TITLE
[BugFix] Reject full-column ORDER BY that reorders key columns of a key-derived range-distribution table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1228,6 +1228,33 @@ public class SchemaChangeHandler extends AlterHandler {
         if (newSchema.size() != targetIndexSchema.size()) {
             throw new DdlException("Reorder stmt should contains all columns");
         }
+        // A full-column ORDER BY on a cloud-native range-distribution table whose sort key is key-derived
+        // (no explicit ORDER BY at creation, so getSortKeyIdxes() == null) reorders the schema and thus the
+        // key-derived range sort key. But this plain schema-change job copies each shadow tablet's range
+        // verbatim, so the stored boundary tuples stay in the OLD key-column space while the new sort key
+        // is the new key order; RangeDistributionPruner (FE) and RangeRouter (BE) then compare new-order
+        // key tuples against old-order boundaries -> silent wrong pruning / mis-routed loads. Reject a
+        // reorder that permutes the key columns. Changing the sort key via a subset
+        // "ALTER TABLE ... ORDER BY (<sort-key columns>)" routes through the range-rewrite path, which
+        // re-samples the K-tablet boundaries and is safe.
+        if (targetIndexMetaId == olapTable.getBaseIndexMetaId()
+                && olapTable.isCloudNativeTable() && olapTable.isRangeDistribution()
+                && olapTable.getIndexMetaByMetaId(olapTable.getBaseIndexMetaId()).getSortKeyIdxes() == null) {
+            List<String> newKeyOrder = newSchema.stream().filter(Column::isKey)
+                    .map(Column::getName).collect(Collectors.toList());
+            List<String> curKeyOrder = targetIndexSchema.stream().filter(Column::isKey)
+                    .map(Column::getName).collect(Collectors.toList());
+            boolean keyOrderChanged = newKeyOrder.size() != curKeyOrder.size();
+            for (int i = 0; !keyOrderChanged && i < newKeyOrder.size(); i++) {
+                keyOrderChanged = !newKeyOrder.get(i).equalsIgnoreCase(curKeyOrder.get(i));
+            }
+            if (keyOrderChanged) {
+                throw new DdlException("ALTER TABLE ORDER BY that reorders the key columns of a "
+                        + "range-distribution table is not supported: it would leave stale tablet range "
+                        + "boundaries. Change the sort key with ALTER TABLE ... ORDER BY (<sort-key "
+                        + "columns>) instead, which re-samples the tablet layout. Table: " + olapTable.getName());
+            }
+        }
         // replace the old column list
         indexMetaIdToSchema.put(targetIndexMetaId, newSchema);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeRewriteRoutingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeRewriteRoutingTest.java
@@ -107,6 +107,35 @@ public class RangeRewriteRoutingTest {
         assertInstanceOf(LakeRangeRewriteSchemaChangeJob.class, job);
     }
 
+    // (a') A FULL-column ORDER BY that permutes the key columns of a key-derived range table is rejected:
+    // it reorders the schema (shifting the key-derived range sort key) but the plain schema-change job
+    // copies tablet ranges verbatim, leaving stale boundaries. The subset form (a) is the supported way
+    // to re-sort (it re-samples via the rewrite job).
+    @Test
+    public void testFullReorderPermutingKeyColumnsRejectedForKeyDerivedRangeTable() throws Exception {
+        // No explicit ORDER BY at creation -> the range sort key is key-derived from KEY(k1, k2).
+        starRocksAssert.withTable("create table t_route_fullreorder (k1 int, k2 int, v1 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        DdlException e = assertThrowsDdlException(() ->
+                createJob("t_route_fullreorder", "alter table t_route_fullreorder order by (k2, k1, v1)"));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                e.getMessage().contains("reorders the key columns of a range-distribution table"),
+                "unexpected message: " + e.getMessage());
+    }
+
+    // (a'') A full-column ORDER BY that keeps the key order (reorders only value columns) does NOT shift
+    // the key-derived range sort key, so it is allowed (no reject).
+    @Test
+    public void testFullReorderKeepingKeyOrderAllowed() throws Exception {
+        starRocksAssert.withTable("create table t_route_fullreorder_vals (k1 int, k2 int, v1 int, v2 int)\n"
+                + "duplicate key(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        AlterJobV2 job = createJob("t_route_fullreorder_vals",
+                "alter table t_route_fullreorder_vals order by (k1, k2, v2, v1)");
+        org.junit.jupiter.api.Assertions.assertNotNull(job, "value-only full reorder must not be rejected");
+    }
+
     // (b) Lake range DUP table: MODIFY COLUMN keyness flip that shifts the (key-derived) sort key
     // routes to the rewrite job. DUP is used because all DUP columns carry the same (NONE)
     // aggregation type, so promoting a value column to a key is a valid schema change (an AGG


### PR DESCRIPTION
## Why I'm doing:

On a cloud-native range-distribution table whose sort key is key-derived (created without an explicit `ORDER BY`), a full-column `ALTER TABLE ... ORDER BY` that permutes the key columns takes the schema-reorder path (`processReorderColumn`). That reorders the schema — and thus the key-derived range sort key — but the plain lake schema-change job copies each shadow tablet's range verbatim instead of re-sampling. After the flip the sort key is the new key order while the stored boundary tuples are still in the old key-column space, so `RangeDistributionPruner` (FE) and `RangeRouter` (BE) compare new-order key tuples against old-order boundaries: silent wrong pruning and mis-routed loads, with no error. The subset `ORDER BY` form is routed to the range-rewrite job and re-samples, so only the full-column form slips through the `orderedColumns.size() != baseSchema.size()` dispatch. Reported by @banmoy while reviewing #76047.

## What I'm doing:

Reject the corrupting case: a full-column `ORDER BY` that permutes the key columns of a key-derived (`getSortKeyIdxes() == null`) cloud-native range-distribution table now fails with a clear message directing the user to the subset `ORDER BY (<sort-key columns>)` form, which re-samples the K-tablet boundaries. Cases that are already safe are unaffected: a full reorder that keeps the key order (reorders only value columns), tables created with an explicit `ORDER BY` (the sort key is remapped by name through a reorder), and non-range / non-cloud-native tables. Full support (routing the full reorder to a re-sampling rewrite job) is left as a follow-up enhancement.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
