### PR TITLE
[BugFix] Fix scan-teardown use-after-free on MorselQueueFactory

### DIFF
--- a/be/src/exec/runtime/fragment_context.h
+++ b/be/src/exec/runtime/fragment_context.h
@@ -206,6 +206,13 @@ private:
     std::unique_ptr<FragmentDictState> _fragment_dict_state;
     ExecNode* _plan = nullptr; // lives in _runtime_state->obj_pool()
     size_t _next_driver_id = 0;
+    // MorselQueueFactory must outlive the pipelines/operators declared below: a
+    // scan operator's ConnectorChunkSource::close() is invoked from ~ScanOperator
+    // during _pipelines teardown and calls back into the MorselQueueFactory via
+    // ScanOperatorFactory::morsel_queue_factory(). Declaring _morsel_queue_factories
+    // before _pipelines makes it destroyed after them, avoiding a use-after-free on
+    // non-EOF (cancel/error/limit) teardown paths.
+    MorselQueueFactoryMap _morsel_queue_factories;
     // Must outlive PipelineDriver observers owned by _pipelines.
     std::unique_ptr<EventScheduler> _event_scheduler;
     Pipelines _pipelines;
@@ -217,7 +224,6 @@ private:
     std::shared_ptr<PipelineTimerTask> _timeout_task = nullptr;
     std::shared_ptr<PipelineTimerTask> _report_state_task = nullptr;
 
-    MorselQueueFactoryMap _morsel_queue_factories;
     DriverLimiter::TokenPtr _driver_token = nullptr;
 
     std::unique_ptr<PassThroughChunkBufferGuard> _pass_through_chunk_buffer_guard;

--- a/be/test/exec/pipeline_fragment_context_exec_runtime_test.cpp
+++ b/be/test/exec/pipeline_fragment_context_exec_runtime_test.cpp
@@ -24,9 +24,11 @@
 #include "compute_env/workgroup/work_group_manager.h"
 #include "exec/runtime/fragment_context.h"
 #include "exec/runtime/fragment_context_manager.h"
+#include "exec/runtime/pipeline.h"
 #include "exec_primitive/pipeline/primitives/driver_executor.h"
 #include "exec_primitive/pipeline/primitives/driver_queue.h"
 #include "exec_primitive/pipeline/primitives/pipeline_metrics.h"
+#include "exec_primitive/pipeline/scan/morsel_queue_factory_base.h"
 #include "runtime/runtime_state.h"
 #include "runtime/service_contexts.h"
 
@@ -69,6 +71,50 @@ public:
     int audit_failure_count = 0;
     QueryContext* last_query_ctx = nullptr;
     FragmentContext* last_fragment_ctx = nullptr;
+};
+
+// Liveness tracker shared between the MorselQueueFactory stand-in and the
+// Pipeline stand-in so the pipeline teardown can observe factory liveness without
+// dereferencing freed memory itself.
+struct MorselFactoryLiveness {
+    bool factory_alive = true;
+    bool factory_destroyed_before_pipeline = false;
+};
+
+// Stands in for the MorselQueueFactory owned by FragmentContext::_morsel_queue_factories.
+// In production a scan operator's ConnectorChunkSource::close() calls into this
+// object during fragment teardown.
+class TrackingMorselQueueFactory final : public MorselQueueFactory {
+public:
+    explicit TrackingMorselQueueFactory(std::shared_ptr<MorselFactoryLiveness> live) : _live(std::move(live)) {}
+    ~TrackingMorselQueueFactory() override { _live->factory_alive = false; }
+
+    MorselQueue* create(int /*driver_sequence*/) override { return nullptr; }
+    size_t size() const override { return 0; }
+    size_t num_original_morsels() const override { return 0; }
+    bool is_shared() const override { return false; }
+    bool could_local_shuffle() const override { return false; }
+
+private:
+    std::shared_ptr<MorselFactoryLiveness> _live;
+};
+
+// Stands in for the operator subtree owned by FragmentContext::_pipelines. The
+// real teardown chain is ~PipelineDriver -> ~ScanOperator ->
+// ConnectorChunkSource::close() -> MorselQueueFactory::mark_split_source_morsel_finished();
+// this destructor observes whether the factory is still alive at that point.
+class TrackingPipeline final : public Pipeline {
+public:
+    explicit TrackingPipeline(std::shared_ptr<MorselFactoryLiveness> live)
+            : Pipeline(0, OpFactories{}, nullptr), _live(std::move(live)) {}
+    ~TrackingPipeline() override {
+        if (!_live->factory_alive) {
+            _live->factory_destroyed_before_pipeline = true;
+        }
+    }
+
+private:
+    std::shared_ptr<MorselFactoryLiveness> _live;
 };
 
 std::shared_ptr<FragmentContext> make_fragment_context(const TUniqueId& query_id, const TUniqueId& fragment_id) {
@@ -150,6 +196,34 @@ TEST(FragmentContextExecRuntimeTest, FailureAuditUsesInjectedExecutionServicesWi
     EXPECT_EQ(query_ctx, recording_executor->last_query_ctx);
     EXPECT_EQ(&fragment_ctx, recording_executor->last_fragment_ctx);
     manager.close();
+}
+
+// Regression test for the scan-teardown use-after-free that crashed CN nodes:
+// ConnectorChunkSource::close() runs from ~ScanOperator while FragmentContext's
+// _pipelines are being destroyed, and calls back into a MorselQueueFactory owned
+// by _morsel_queue_factories. The factory must therefore be destroyed AFTER the
+// pipelines, i.e. declared before them. This pins that ordering so a future
+// reshuffle of the member declarations cannot silently reintroduce the UAF.
+TEST(FragmentContextExecRuntimeTest, MorselQueueFactoryOutlivesPipelines) {
+    TUniqueId query_id;
+    query_id.hi = 10;
+    query_id.lo = 20;
+    TUniqueId fragment_id;
+    fragment_id.hi = 30;
+    fragment_id.lo = 40;
+
+    auto live = std::make_shared<MorselFactoryLiveness>();
+    {
+        auto fragment_ctx = make_fragment_context(query_id, fragment_id);
+        fragment_ctx->morsel_queue_factories().emplace(0, std::make_unique<TrackingMorselQueueFactory>(live));
+
+        Pipelines pipelines;
+        pipelines.emplace_back(std::make_shared<TrackingPipeline>(live));
+        fragment_ctx->set_pipelines(ExecutionGroups{}, std::move(pipelines));
+    } // ~FragmentContext destroys members in reverse declaration order here.
+
+    EXPECT_FALSE(live->factory_destroyed_before_pipeline)
+            << "MorselQueueFactory was destroyed before the pipelines; scan teardown would use-after-free";
 }
 
 } // namespace


### PR DESCRIPTION
## Why I'm doing:

CN/BE nodes crashed repeatedly with a use-after-free during query teardown.
The crash stack is consistently:

```
IndividualMorselQueueFactory::mark_split_source_morsel_finished
  <- ConnectorChunkSource::_report_split_source_morsel_finished_once
  <- ConnectorChunkSource::close
  <- ~ScanOperator <- ~PipelineDriver <- ~FragmentContext
```

`FragmentContext` destroys its members in reverse declaration order.
`_morsel_queue_factories` was declared *after* `_pipelines`, so it was
destroyed *first*. While `_pipelines` is then being torn down, a scan
operator's `ConnectorChunkSource::close()` (run from `~ScanOperator`)
calls back into the `MorselQueueFactory` via
`ScanOperatorFactory::mark_split_source_morsel_finished()` — dereferencing
an already-freed object.

The callback in `close()` was added by #69095 as a safety net so
split-source completion is still reported when a chunk source exits
through non-EOF paths (cancel / error / limit reached). On those teardown
paths the factory is gone, so the report becomes a UAF. It only reproduces
for lake/connector scans that use split-source morsels and tear the
fragment down without reaching EOF.

## What I'm doing:

Declare `_morsel_queue_factories` before `_pipelines` so it is destroyed
*after* the pipelines and their operators, matching the existing ordering
constraint already documented for `_event_scheduler`. This is a
member-declaration-order fix only; the relative order versus
`_runtime_state` / `_plan` is unchanged.

Add a regression test (`FragmentContextExecRuntimeTest.MorselQueueFactoryOutlivesPipelines`)
that installs a tracking `MorselQueueFactory` and a tracking `Pipeline`
into a `FragmentContext` and asserts the factory is still alive when the
pipeline is destroyed, pinning the destruction order so a future member
reshuffle cannot silently reintroduce the crash.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
