### PR TITLE
[Enhancement] Skip getTable() for root in SHOW ANALYZE STATUS/JOB

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeJobStmt.java
@@ -26,6 +26,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.statistic.AnalyzeJob;
+import com.starrocks.statistic.StatisticUtils;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -60,31 +61,38 @@ public class ShowAnalyzeJobStmt extends ShowStmt {
 
             if (!analyzeJob.isAnalyzeAllTable()) {
                 String tableName = analyzeJob.getTableName();
-                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                        .getTable(context, analyzeJob.getCatalogName(), dbName, tableName);
+                row.set(3, tableName);
 
-                if (table == null) {
-                    throw new MetaNotFoundException("No found table: " + tableName);
-                }
+                // root always holds every privilege, so the privilege check below is guaranteed to pass for it.
+                // getTable() is only needed here to feed that check and to recompute the collectible-column
+                // count for display - both skippable for root - so skip it entirely to avoid an expensive
+                // Glue/HMS lookup on every row of every poll (e.g. BYOC ops polling this SHOW statement as root).
+                if (StatisticUtils.isRootUser(context)) {
+                    if (null != columns && !columns.isEmpty()) {
+                        String str = String.join(",", columns);
+                        row.set(4, str.length() > 100 ? str.substring(0, 100) + "..." : str);
+                    }
+                } else {
+                    Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getTable(context, analyzeJob.getCatalogName(), dbName, tableName);
 
-                row.set(3, table.getName());
+                    if (table == null) {
+                        throw new MetaNotFoundException("No found table: " + tableName);
+                    }
 
-                // In new privilege framework(RBAC), user needs any action on the table to show analysis job on it,
-                // for jobs on entire instance or entire db, we just show it directly because there isn't a specified
-                // table to check privilege on.
-                try {
-                    Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
-                } catch (AccessDeniedException e) {
-                    return null;
-                }
+                    // In new privilege framework(RBAC), user needs any action on the table to show analysis job
+                    // on it, for jobs on entire instance or entire db, we just show it directly because there
+                    // isn't a specified table to check privilege on.
+                    try {
+                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), table);
+                    } catch (AccessDeniedException e) {
+                        return null;
+                    }
 
-                if (null != columns && !columns.isEmpty()
-                        && (columns.size() != table.getBaseSchema().size())) {
-                    String str = String.join(",", columns);
-                    if (str.length() > 100) {
-                        row.set(4, str.substring(0, 100) + "...");
-                    } else {
-                        row.set(4, str);
+                    if (null != columns && !columns.isEmpty()
+                            && (columns.size() != table.getBaseSchema().size())) {
+                        String str = String.join(",", columns);
+                        row.set(4, str.length() > 100 ? str.substring(0, 100) + "..." : str);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowAnalyzeStatusStmt.java
@@ -54,24 +54,33 @@ public class ShowAnalyzeStatusStmt extends ShowStmt {
         row.set(1, analyzeStatus.getCatalogName() + "." + analyzeStatus.getDbName());
         row.set(2, analyzeStatus.getTableName());
 
-        Table table;
-        // In new privilege framework(RBAC), user needs any action on the table to show analysis status for it.
-        try {
-            table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
-                    context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
-            if (table == null) {
-                throw new SemanticException("Table %s is not found", analyzeStatus.getTableName());
+        // root always holds every privilege, so the privilege check below is guaranteed to pass for it.
+        // getTable() is only needed here to feed that check and to recompute the collectible-column count
+        // for display - both skippable for root - so skip it entirely to avoid an expensive Glue/HMS lookup
+        // on every row of every poll (e.g. BYOC ops polling this SHOW statement as root).
+        if (StatisticUtils.isRootUser(context)) {
+            if (null != columns && !columns.isEmpty()) {
+                row.set(3, String.join(",", columns));
             }
-            Authorizer.checkAnyActionOnTableLikeObject(context, analyzeStatus.getDbName(), table);
-        } catch (Exception e) {
-            LOG.warn("Failed to check privilege for show analyze status for table {}.", analyzeStatus.getTableName(), e);
-            return null;
-        }
+        } else {
+            Table table;
+            try {
+                table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(
+                        context, analyzeStatus.getCatalogName(), analyzeStatus.getDbName(), analyzeStatus.getTableName());
+                if (table == null) {
+                    throw new SemanticException("Table %s is not found", analyzeStatus.getTableName());
+                }
+                Authorizer.checkAnyActionOnTableLikeObject(context, analyzeStatus.getDbName(), table);
+            } catch (Exception e) {
+                LOG.warn("Failed to check privilege for show analyze status for table {}.",
+                        analyzeStatus.getTableName(), e);
+                return null;
+            }
 
-        long totalCollectColumnsSize = StatisticUtils.getCollectibleColumns(table).size();
-        if (null != columns && !columns.isEmpty() && (columns.size() != totalCollectColumnsSize)) {
-            String str = String.join(",", columns);
-            row.set(3, str);
+            long totalCollectColumnsSize = StatisticUtils.getCollectibleColumns(table).size();
+            if (null != columns && !columns.isEmpty() && (columns.size() != totalCollectColumnsSize)) {
+                row.set(3, String.join(",", columns));
+            }
         }
 
         row.set(4, analyzeStatus.getType().name());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -483,6 +483,12 @@ public class StatisticUtils {
         }
     }
 
+    // root always holds every privilege, so privilege checks on root are guaranteed to pass.
+    // Callers on hot paths (e.g. SHOW ANALYZE STATUS/JOB) can use this to skip the privilege check itself.
+    public static boolean isRootUser(ConnectContext context) {
+        return context.getCurrentUserIdentity().equals(UserIdentity.ROOT);
+    }
+
     // Get all the columns in the table that can be collected.
     // The list will only contain:
     // 1. non-aggregated column

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -304,10 +304,16 @@ public class AnalyzeStmtTest {
                         "{}, Test Failed]",
                 ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), analyzeStatus).toString());
 
+        // root always holds every privilege and skips getTable() entirely for SHOW ANALYZE STATUS/JOB
+        // (avoids an expensive Glue/HMS lookup on every row), so a row referencing a table that no longer
+        // exists in the external catalog is still shown instead of being filtered out.
         AnalyzeStatus extenalAnalyzeStatus = new ExternalAnalyzeStatus(-1, "hive0", "partitioned_db",
                 "tx", "tx:xxxx", Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,
-                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.MIN);
-        Assertions.assertNull(ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), extenalAnalyzeStatus));
+                StatsConstants.ScheduleType.ONCE, Maps.newHashMap(), LocalDateTime.of(2020, 1, 1, 1, 1));
+        extenalAnalyzeStatus.setStatus(StatsConstants.ScheduleStatus.FINISH);
+        Assertions.assertEquals("[-1, hive0.partitioned_db, tx, ALL, FULL, ONCE, SUCCESS, " +
+                        "2020-01-01 01:01:00, , {}, ]",
+                ShowAnalyzeStatusStmt.showAnalyzeStatus(getConnectContext(), extenalAnalyzeStatus).toString());
 
         sql = "show histogram meta where updateTime = '2020-01-01 01:01:00'";
         ShowHistogramStatsMetaStmt showHistogramStatsMetaStmt = (ShowHistogramStatsMetaStmt) analyzeSuccess(sql);


### PR DESCRIPTION
## Why I'm doing:
`SHOW ANALYZE STATUS` and `SHOW ANALYZE JOB` resolve the underlying table for every row and run a privilege check before including that row in the output. `root` always holds every privilege, so the check is guaranteed to pass — but the `getTable()` call backing it still happens, and for external catalogs (Hive/Iceberg) that can mean a Glue/HMS round trip per row. In BYOC deployments, ops backends poll these `SHOW` statements as `root`, so this is pure overhead on every poll.

## What I'm doing:
- Added `StatisticUtils.isRootUser(context)`.
- In `ShowAnalyzeStatusStmt` and `ShowAnalyzeJobStmt`, root now skips `getTable()` entirely instead of just skipping the privilege check:

```
non-root:  getTable() -> privilege check -> render row (filtered out if table missing/denied)
root:      render row directly from the AnalyzeStatus/AnalyzeJob record, no getTable() at all
```

- Trade-off: for root, a row can still be shown after its table was dropped from the external catalog (previously filtered out via the `getTable()` failure). The column-count-vs-schema comparison used to decide between `ALL` and an explicit column list is skipped too, so root always sees the explicit list when one was recorded.
- Scope is intentionally limited to these two `SHOW` statements (not the `SHOW STATS META` family in `ShowExecutor`), matching where BYOC ops actually poll as root.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
