### PR TITLE
[BugFix] Serve GIN inverted index from DCG segment after column-mode partial update

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -53,6 +53,7 @@
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
@@ -4015,7 +4016,33 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         index_opts.segment_rows = num_rows();
 
         if (_inverted_index_ctx->inverted_index_iterators[cid] == nullptr) {
-            RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
+            // Column-mode partial update rewrites a column into a delta column group
+            // (.cols) file and leaves the base segment untouched, so the base segment's
+            // inverted index still reflects pre-update values. Mirror _apply_bitmap_index:
+            // take the index from the DCG segment when the column has been rewritten, so
+            // the index stays consistent with the data actually returned.
+            ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid));
+            if (segment_ptr == nullptr) {
+                // find segment from delta column group failed, using main segment
+                segment_ptr = _segment;
+            } else {
+                std::shared_ptr<TabletIndex> index_meta;
+                RETURN_IF_ERROR(segment_ptr->tablet_schema().get_indexes_for_column(ucid, GIN, index_meta));
+                if (index_meta != nullptr) {
+                    ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(*index_meta));
+                    if (imp_type != InvertedImplementType::BUILTIN) {
+                        // Standalone (CLucene) inverted indexes are not produced by the DCG
+                        // writer, and the base segment's copy is stale for this column, so no
+                        // index is served. Ordinary predicates (e.g. equality) then evaluate
+                        // on the fresh column data. MATCH predicates cannot be evaluated
+                        // without an index and fail with an explicit error -- preferable to
+                        // silently filtering on pre-update values. Compaction rewrites the
+                        // base segment and restores index acceleration.
+                        continue;
+                    }
+                }
+            }
+            RETURN_IF_ERROR(segment_ptr->new_inverted_index_iterator(
                     ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts, index_opts));
             _inverted_index_ctx->has_inverted_index |= (_inverted_index_ctx->inverted_index_iterators[cid] != nullptr);
         }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -54,6 +54,7 @@
 #include "storage/base/short_key_index.h"
 #include "storage/chunk_variant_helper.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/row_store_encoder.h"
 #include "storage/rowset/column_writer.h" // ColumnWriter
 #include "storage/rowset/json_column_writer.h"
@@ -200,6 +201,18 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         }
 
         RETURN_IF_ERROR(_tablet_schema->get_indexes_for_column(column.unique_id(), &opts.tablet_index));
+        if (opts.need_inverted_index && _opts.segment_file_mark.rowset_path_prefix.empty()) {
+            // Writers that produce auxiliary segments without a segment file mark (e.g. the
+            // column-mode partial update .cols writer) cannot derive a valid standalone index
+            // path: the path built below would be malformed and readers never look it up.
+            // Skip standalone (CLucene) index generation there instead of writing it to a
+            // bogus location; readers fall back to evaluating predicates on the data.
+            // Footer-inlined implementations (builtin) need no path and are kept.
+            ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(opts.tablet_index.at(GIN)));
+            if (imp_type != InvertedImplementType::BUILTIN) {
+                opts.need_inverted_index = false;
+            }
+        }
         if (opts.need_inverted_index) {
             opts.standalone_index_file_paths.emplace(
                     GIN, IndexDescriptor::inverted_index_file_path(_opts.segment_file_mark.rowset_path_prefix,

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -402,6 +402,10 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_delta
     WritableFileOptions opts{.sync_on_close = true};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
     SegmentWriterOptions writer_options;
+    // Deliberately no segment_file_mark: a mark would make standalone (CLucene) inverted
+    // indexes collide with the base segment's (same rowset id + segment id), so the
+    // SegmentWriter skips them for .cols files. Footer-inlined (builtin) inverted indexes
+    // are still written and served to readers through the DCG segment.
     auto segment_writer =
             std::make_unique<SegmentWriter>(std::move(wfile), rowsetid_segid.segment_id, tschema, writer_options);
     RETURN_IF_ERROR(segment_writer->init(false));
@@ -497,6 +501,10 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_segme
     WritableFileOptions opts{.sync_on_close = true};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
     SegmentWriterOptions writer_options;
+    // These are full-row segments appended to the rowset, so give the writer a real file
+    // mark: standalone (CLucene) inverted indexes land at the path readers derive from
+    // (rowset path, rowset id, segment id). Mirrors RowsetUpdateState's segment rewrite.
+    writer_options.segment_file_mark = {rowset->rowset_path(), rowset->rowset_id().to_string()};
     auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), segment_id, tablet_schema, writer_options);
     RETURN_IF_ERROR(segment_writer->init());
     return std::move(segment_writer);

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -222,7 +222,8 @@ public:
         return partial_rowset;
     }
 
-    TabletSharedPtr create_tablet_with_gin_index(int64_t tablet_id, int32_t schema_hash) {
+    TabletSharedPtr create_tablet_with_gin_index(int64_t tablet_id, int32_t schema_hash,
+                                                 const std::string& imp_lib = "builtin") {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
@@ -256,7 +257,7 @@ public:
         gin_index.__set_index_name("gin_v2");
         gin_index.__set_columns({"v2"});
         gin_index.__set_index_type(TIndexType::GIN);
-        gin_index.__set_common_properties({{"imp_lib", "builtin"}});
+        gin_index.__set_common_properties({{"imp_lib", imp_lib}});
         gin_index.__set_index_properties({{"parser", "none"}});
         request.tablet_schema.__set_indexes({gin_index});
 
@@ -1808,7 +1809,20 @@ static StatusOr<int64_t> count_rows_with_str_eq(const TabletSharedPtr& tablet, i
     RETURN_IF_ERROR(reader.get_segment_iterators(params, &seg_iters));
     int64_t rows = 0;
     for (auto& iter : seg_iters) {
-        auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
+        // Chunk column order follows the iterator's output schema, which is not necessarily
+        // keyed by ColumnId; resolve the value column's position by matching the field id.
+        const Schema& out_schema = iter->schema();
+        int value_pos = -1;
+        for (size_t i = 0; i < out_schema.num_fields(); i++) {
+            if (out_schema.field(i)->id() == cid) {
+                value_pos = static_cast<int>(i);
+                break;
+            }
+        }
+        if (value_pos < 0) {
+            return Status::InternalError("value column not present in scan output schema");
+        }
+        auto chunk = ChunkFactory::new_chunk(out_schema, 100);
         while (true) {
             chunk->reset();
             auto st = iter->get_next(chunk.get());
@@ -1817,7 +1831,7 @@ static StatusOr<int64_t> count_rows_with_str_eq(const TabletSharedPtr& tablet, i
             }
             RETURN_IF_ERROR(st);
             for (int r = 0; r < chunk->num_rows(); r++) {
-                if (chunk->columns()[cid]->get(r).get_slice().to_string() != value) {
+                if (chunk->columns()[value_pos]->get(r).get_slice().to_string() != value) {
                     return Status::InternalError("returned row does not match the predicate");
                 }
             }
@@ -1866,6 +1880,47 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_gin_index_check) {
         ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_60", gin_filter).value());
     }
 }
+
+#ifndef __APPLE__
+// CLucene (the shared-nothing default implementation) is not produced for DCG .cols files.
+// After a column-mode partial update on the indexed column, the base segment's CLucene index
+// is stale, so no index is served for the updated column: ordinary predicates must fall back
+// to evaluating on the fresh data and still return correct results. This exercises the
+// write-side skip (segment_writer.cpp) and the read-side CLucene branch (segment_iterator.cpp).
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_clucene_gin_index_check) {
+    const int N = 100;
+    auto tablet = create_tablet_with_gin_index(rand(), rand(), "clucene");
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.emplace_back(create_str_rowset(tablet, keys, [](int64_t k) { return "old_" + std::to_string(k); }));
+    commit_rowsets(tablet, rowsets, version);
+
+    // Base-segment CLucene index accelerates the pre-update read.
+    ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_5", true).value());
+
+    // Column-mode partial update: v2 = "new_<pk>" for the first half of the keys.
+    std::vector<int64_t> update_keys(keys.begin(), keys.begin() + N / 2);
+    std::vector<int32_t> column_indexes = {0, 2};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset = create_partial_str_rowset(
+            tablet, update_keys, [](int64_t k) { return "new_" + std::to_string(k); }, column_indexes, partial_schema);
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    for (bool gin_filter : {true, false}) {
+        // Updated rows resolve to the fresh value; the stale CLucene index is not consulted.
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "new_5", gin_filter).value());
+        ASSERT_EQ(0, count_rows_with_str_eq(tablet, version, 2, "old_5", gin_filter).value());
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_60", gin_filter).value());
+    }
+}
+#endif
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(RowsetColumnPartialUpdateParam{1}, RowsetColumnPartialUpdateParam{1024},

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -42,7 +42,9 @@
 #include "storage/tablet_reader.h"
 #include "storage/tablet_reader_params.h"
 #include "storage/tablet_schema.h"
+#include "storage/types.h"
 #include "storage/update_manager.h"
+#include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/empty_iterator.h"
 #include "storage_primitive/union_iterator.h"
 
@@ -214,6 +216,118 @@ public:
                 CHECK_OK(writer->flush_chunk(*chunk));
             }
         }
+        RowsetSharedPtr partial_rowset = *writer->build();
+        partial_rowset->set_schema(tablet->tablet_schema());
+
+        return partial_rowset;
+    }
+
+    TabletSharedPtr create_tablet_with_gin_index(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.__set_len(255);
+        request.tablet_schema.columns.push_back(k3);
+
+        TOlapTableIndex gin_index;
+        gin_index.__set_index_id(1);
+        gin_index.__set_index_name("gin_v2");
+        gin_index.__set_columns({"v2"});
+        gin_index.__set_index_type(TIndexType::GIN);
+        gin_index.__set_common_properties({{"imp_lib", "builtin"}});
+        gin_index.__set_index_properties({{"parser", "none"}});
+        request.tablet_schema.__set_indexes({gin_index});
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+        _tablets.push_back(tablet);
+        return tablet;
+    }
+
+    RowsetSharedPtr create_str_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                      const std::function<std::string(int64_t)>& str_func) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+        auto cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            std::string v = str_func(key);
+            cols[2]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_partial_str_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                              const std::function<std::string(int64_t)>& str_func,
+                                              std::vector<int32_t>& column_indexes,
+                                              const std::shared_ptr<TabletSchema>& partial_schema,
+                                              PartialUpdateMode mode = PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = partial_schema;
+        writer_context.referenced_column_ids = column_indexes;
+        writer_context.full_tablet_schema = tablet->tablet_schema();
+        writer_context.is_partial_update = true;
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        writer_context.partial_update_mode = mode;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(partial_schema);
+
+        auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+        for (int64_t key : keys) {
+            chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(key));
+            std::string v = str_func(key);
+            chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(Slice(v)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
         RowsetSharedPtr partial_rowset = *writer->build();
         partial_rowset->set_schema(tablet->tablet_schema());
 
@@ -1674,6 +1788,83 @@ TEST_P(RowsetColumnPartialUpdateTest, test_meta_reader_with_multiple_dcg_columns
     // 3. DCG file access with encryption (lines 262-269)
     auto status = collecter.open();
     // Success or failure is okay - we're testing code coverage
+}
+
+// Count rows matching `v2 == value` through a TabletReader scan, optionally letting the
+// GIN inverted index prune rows. Also re-checks every returned row against the predicate,
+// which catches the erased-predicate-without-recheck failure mode.
+static StatusOr<int64_t> count_rows_with_str_eq(const TabletSharedPtr& tablet, int64_t version, ColumnId cid,
+                                                const std::string& value, bool enable_gin_filter) {
+    Schema schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, version), schema);
+    RETURN_IF_ERROR(reader.prepare());
+    TabletReaderParams params;
+    params.enable_gin_filter = enable_gin_filter;
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_VARCHAR), cid, Slice(value)));
+    PredicateAndNode and_node;
+    and_node.add_child(PredicateColumnNode(pred.get()));
+    params.pred_tree = PredicateTree::create(std::move(and_node));
+    std::vector<ChunkIteratorPtr> seg_iters;
+    RETURN_IF_ERROR(reader.get_segment_iterators(params, &seg_iters));
+    int64_t rows = 0;
+    for (auto& iter : seg_iters) {
+        auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
+        while (true) {
+            chunk->reset();
+            auto st = iter->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            RETURN_IF_ERROR(st);
+            for (int r = 0; r < chunk->num_rows(); r++) {
+                if (chunk->columns()[cid]->get(r).get_slice().to_string() != value) {
+                    return Status::InternalError("returned row does not match the predicate");
+                }
+            }
+            rows += chunk->num_rows();
+        }
+        iter->close();
+    }
+    return rows;
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_gin_index_check) {
+    // Column-mode partial update rewrites a column into a DCG (.cols) file while the base
+    // segment's inverted index still reflects pre-update values. The reader must serve the
+    // GIN index from the DCG segment, or GIN-filtered queries silently return wrong rows.
+    const int N = 100;
+    auto tablet = create_tablet_with_gin_index(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.emplace_back(create_str_rowset(tablet, keys, [](int64_t k) { return "old_" + std::to_string(k); }));
+    commit_rowsets(tablet, rowsets, version);
+
+    // GIN-accelerated read against the base segment works.
+    ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_5", true).value());
+
+    // Column-mode partial update: v2 = "new_<pk>" for the first half of the keys.
+    std::vector<int64_t> update_keys(keys.begin(), keys.begin() + N / 2);
+    std::vector<int32_t> column_indexes = {0, 2};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset = create_partial_str_rowset(
+            tablet, update_keys, [](int64_t k) { return "new_" + std::to_string(k); }, column_indexes, partial_schema);
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    for (bool gin_filter : {true, false}) {
+        // An updated row must be found by its new value ...
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "new_5", gin_filter).value());
+        // ... and must no longer be found by its old value.
+        ASSERT_EQ(0, count_rows_with_str_eq(tablet, version, 2, "old_5", gin_filter).value());
+        // Rows the update did not touch keep working.
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_60", gin_filter).value());
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,


### PR DESCRIPTION
## Why I'm doing:

A GIN (inverted) index is allowed on PRIMARY KEY tables, and column-mode partial update is a PRIMARY KEY table feature, but the two silently corrupt query results when combined.

Column-mode partial update rewrites a column into a delta column group (`.cols`) file and leaves the base segment untouched, so the base segment's inverted index still reflects **pre-update values**. The read path, however, always resolved the GIN inverted index from the **base segment**: `SegmentIterator::_init_inverted_index_iterators` bound the iterator to the base segment while the column data was served from the DCG file. A GIN-filtered query then pruned rows with the stale index and erased the predicate without re-checking, silently returning wrong rows:

- rows matching the **old** value came back (displaying the new value that no longer matches the predicate);
- rows matching the **new** value were missed.

Bitmap and bloom filter indexes do not have this problem because their read paths are already DCG-aware (`_apply_bitmap_index` resolves the index through `_get_dcg_segment`). GIN was the only index read path still pinned to the base segment.

Two adjacent write-side defects in the same combination:

- The `.cols` DCG writer has no segment file mark, so a standalone (CLucene) inverted index derived a malformed path rooted at `/` — failing the load on non-root deployments and leaking an unreadable index directory otherwise.
- `RowsetColumnUpdateState::_prepare_segment_writer` (full-row segments produced by `COLUMN_UPSERT_MODE` inserts) also had no segment file mark, so its standalone CLucene index never landed at the path readers derive.

## What I'm doing:

Mirror `_apply_bitmap_index` in the GIN read path and fix the write-side path derivation:

1. **Read path (the core fix):** `_init_inverted_index_iterators` now resolves the inverted index from the DCG segment when the column has been rewritten by column-mode partial update, keeping index and data consistent. DCG segments already carry fresh footer-inlined (builtin) inverted indexes written by the partial update — they were just never read.
2. **CLucene on a DCG-overridden column:** standalone CLucene indexes are not produced for `.cols` files, so the iterator is skipped. Ordinary predicates (e.g. equality on an untokenized index) then evaluate correctly on the fresh column data, unaccelerated until compaction rebuilds the base segment. `MATCH` predicates cannot be evaluated without an index; they now fail with `MatchExpr`'s explicit error instead of silently filtering on pre-update values (fail-loud replaces silent wrong results for this corner).
3. **SegmentWriter:** skip standalone CLucene index emission when the writer has no segment file mark (the `.cols` writer) instead of writing to a malformed path. Footer-inlined (builtin) indexes are unaffected.
4. **`_prepare_segment_writer`:** pass a real segment file mark so standalone CLucene indexes of `COLUMN_UPSERT_MODE` full-row segments land at the reader-visible path, mirroring `RowsetUpdateState`'s segment rewrite.

Added a regression test (`RowsetColumnPartialUpdateTest.partial_update_with_gin_index_check`) that creates a PK tablet with a builtin GIN index (`parser=none`), performs a column-mode partial update on the indexed column, and verifies GIN-filtered reads: updated rows are found by their new value, no longer found by their old value, and untouched rows keep working. The helper also re-checks every returned row against the predicate, which catches the erased-predicate-without-recheck failure mode.

Fixes #na

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Behavior notes (all confined to the GIN × column-mode partial update combination, which today returns silently wrong results):
- builtin GIN (shared-data default): GIN-filtered queries now return correct results after a column-mode partial update, still index-accelerated.
- CLucene GIN (shared-nothing default) on a column rewritten by column-mode partial update: ordinary predicates fall back to evaluating on data (correct); `MATCH` fails with an explicit error instead of silently filtering on stale values, until compaction rebuilds the base segment.
- Column-mode partial update loads on CLucene-GIN tables no longer try to write a standalone index to a malformed path rooted at `/` (previously failed the load on non-root deployments).

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
