### PR TITLE
[Enhancement] Implementing dictification for array functions with additional constant arguments (backend changes) (backport #74705)

### DIFF
--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -55,6 +55,7 @@ set(EXPR_FILES
   column_ref.cpp
   placeholder_ref.cpp
   dictmapping_expr.cpp
+  dict_functions.cpp
   compound_predicate.cpp
   condition_expr.cpp
   encryption_functions.cpp

--- a/be/src/exprs/dict_functions.cpp
+++ b/be/src/exprs/dict_functions.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/dict_functions.h"
+
+#include <cstdint>
+#include <string>
+
+#include "column/column_helper.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "runtime/global_dict/config.h"
+#include "runtime/global_dict/parser.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+namespace {
+struct EncodeDictState {
+    bool is_null = false;
+    DictId code = 0;
+};
+} // namespace
+
+Status DictFunctions::dict_encode_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
+    }
+    auto* state = new EncodeDictState();
+    context->set_function_state(scope, state);
+
+    if (!context->is_notnull_constant_column(1)) {
+        return Status::InternalError("dict_encode: dict_slot_id must be a non-null constant");
+    }
+    const int32_t slot_id = ColumnHelper::get_const_value<TYPE_INT>(context->get_constant_column(1));
+
+    if (!context->is_constant_column(0)) {
+        return Status::InternalError("dict_encode: value must be a constant");
+    }
+    if (!context->is_notnull_constant_column(0)) {
+        state->is_null = true;
+        return Status::OK();
+    }
+
+    RuntimeState* runtime_state = context->state();
+    if (runtime_state == nullptr) {
+        return Status::InternalError("dict_encode: null runtime state for slot " + std::to_string(slot_id));
+    }
+
+    const Slice value = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(0));
+    ASSIGN_OR_RETURN(state->code, runtime_state->mutable_dict_optimize_parser()->lookup_dict_code(slot_id, value));
+    return Status::OK();
+}
+
+Status DictFunctions::dict_encode_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        delete reinterpret_cast<EncodeDictState*>(context->get_function_state(scope));
+    }
+    return Status::OK();
+}
+
+StatusOr<ColumnPtr> DictFunctions::dict_encode(FunctionContext* context, const Columns& columns) {
+    auto* state = reinterpret_cast<EncodeDictState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (state == nullptr) {
+        return Status::InternalError("dict_encode: function state not initialized");
+    }
+    const size_t num_rows = columns[0]->size();
+    if (state->is_null) {
+        return ColumnHelper::create_const_null_column(num_rows);
+    }
+    return ColumnHelper::create_const_column<TYPE_INT>(state->code, num_rows);
+}
+
+} // namespace starrocks

--- a/be/src/exprs/dict_functions.h
+++ b/be/src/exprs/dict_functions.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exprs/function_context.h"
+#include "exprs/function_helper.h"
+
+namespace starrocks {
+
+class DictFunctions {
+public:
+    // dict_encode(value, dict_slot_id): translate a constant VARCHAR to its global-dictionary code
+    // for the column identified by dict_slot_id, resolved once from BE runtime state. Lets the
+    // low-cardinality rewrite pre-encode a constant operand so a dict-aware comparison runs directly
+    // on integer codes (e.g. array_contains(dict_array, dict_encode('foo', slot))).
+    //
+    //   value         VARCHAR constant.
+    //   dict_slot_id  INT constant: the global-dict column id whose dictionary to use.
+    //
+    // A value absent from the dictionary encodes to std::numeric_limits<DictId>::max() (a guaranteed-absent
+    // sentinel). This makes equality/membership comparisons against it behave correctly, but it must not be
+    // used for order comparison. A NULL input value encodes to NULL.
+    DEFINE_VECTORIZED_FN(dict_encode);
+
+    static Status dict_encode_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status dict_encode_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+};
+
+} // namespace starrocks

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -14,6 +14,8 @@
 
 #include "runtime/global_dict/parser.h"
 
+#include <limits>
+
 #include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_builder.h"
@@ -508,6 +510,26 @@ void DictOptimizeParser::rewrite_descriptor(RuntimeState* runtime_state, const s
             slot_desc = newSlot;
         }
     }
+}
+
+StatusOr<DictId> DictOptimizeParser::lookup_dict_code(SlotId slot_id, const Slice& value) {
+    if (_mutable_dict_maps == nullptr) {
+        return Status::InternalError("dict_encode: dict maps not initialized");
+    }
+    auto it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    if (it == _mutable_dict_maps->end()) {
+        RETURN_IF_ERROR(eval_dict_expr(slot_id));
+        it = _mutable_dict_maps->find(static_cast<uint32_t>(slot_id));
+    }
+    if (it == _mutable_dict_maps->end()) {
+        return Status::InternalError(fmt::format("dict_encode: global dictionary not found for slot {}", slot_id));
+    }
+
+    const GlobalDictMap& forward = it->second.first;
+    if (auto f = forward.find(value); f != forward.end()) {
+        return f->second;
+    }
+    return std::numeric_limits<DictId>::max();
 }
 
 } // namespace starrocks

--- a/be/src/runtime/global_dict/parser.h
+++ b/be/src/runtime/global_dict/parser.h
@@ -24,6 +24,7 @@
 #include "common/global_types.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "runtime/global_dict/types.h"
 
 namespace starrocks {
@@ -69,6 +70,11 @@ public:
     void close() noexcept;
 
     void check_could_apply_dict_optimize(ExprContext* expr_ctx, DictOptimizeContext* dict_opt_ctx);
+
+    // Look up `value`'s global-dict code for `slot_id`.
+    // Returns std::numeric_limits<DictId>::max() when `value` is not present,
+    // valid for equality/membership only.
+    StatusOr<DictId> lookup_dict_code(SlotId slot_id, const Slice& value);
 
     // For global dictionary optimized columns,
     // the type at the execution level is INT but at the storage level is TYPE_STRING/TYPE_CHAR,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -191,6 +191,7 @@ set(EXEC_FILES
         ./exprs/min_max_predicate_test.cpp
         ./exprs/in_const_predicate_test.cpp
         ./exprs/dict_expr_test.cpp
+        ./exprs/dict_functions_test.cpp
         ./formats/csv/array_converter_test.cpp
         ./formats/csv/boolean_converter_test.cpp
         ./formats/csv/csv_file_writer_test.cpp

--- a/be/test/exprs/dict_functions_test.cpp
+++ b/be/test/exprs/dict_functions_test.cpp
@@ -1,0 +1,103 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/dict_functions.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
+#include "runtime/global_dict/config.h"
+#include "runtime/global_dict/parser.h"
+#include "runtime/global_dict/types.h"
+#include "runtime/runtime_state.h"
+#include "runtime/types.h"
+#include "types/logical_type.h"
+#include "util/slice.h"
+
+namespace starrocks {
+
+class EncodeDictTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _dict_strings = {"a", "b", "c"};
+        GlobalDictMap forward;
+        RGlobalDictMap reverse;
+        for (size_t i = 0; i < _dict_strings.size(); ++i) {
+            auto code = static_cast<int32_t>(i + 1);
+            forward.emplace(Slice(_dict_strings[i]), code);
+            reverse.emplace(code, Slice(_dict_strings[i]));
+        }
+        GlobalDictMaps* dict_maps = _state.mutable_query_global_dict_map();
+        dict_maps->emplace(kSlotId, std::make_pair(std::move(forward), std::move(reverse)));
+        _state.mutable_dict_optimize_parser()->set_mutable_dict_maps(&_state, dict_maps);
+    }
+
+protected:
+    static constexpr int32_t kSlotId = 1;
+    static constexpr DictId kNoMatch = std::numeric_limits<DictId>::max();
+
+    std::unique_ptr<FunctionContext> makeContext(const TypeDescriptor& arg0_type, RuntimeState* rs,
+                                                 const Columns& constant_columns) {
+        std::vector<TypeDescriptor> arg_types = {arg0_type, TypeDescriptor(TYPE_INT)};
+        std::unique_ptr<FunctionContext> ctx(
+                FunctionContext::create_test_context(std::move(arg_types), TypeDescriptor(TYPE_INT)));
+        ctx->set_runtime_state(rs);
+        ctx->set_constant_columns(constant_columns);
+        return ctx;
+    }
+
+    std::vector<std::string> _dict_strings;
+    RuntimeState _state;
+};
+
+TEST_F(EncodeDictTest, scalar_value_in_dict) {
+    Columns columns = {ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("b"), 1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_EQ(2, ColumnHelper::get_const_value<TYPE_INT>(result));
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+TEST_F(EncodeDictTest, scalar_value_absent_uses_no_match_code) {
+    Columns columns = {ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("z"), 1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_EQ(kNoMatch, ColumnHelper::get_const_value<TYPE_INT>(result));
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+TEST_F(EncodeDictTest, scalar_null_value_returns_null) {
+    Columns columns = {ColumnHelper::create_const_null_column(1),
+                       ColumnHelper::create_const_column<TYPE_INT>(kSlotId, 1)};
+    auto ctx = makeContext(TypeDescriptor(TYPE_VARCHAR), &_state, columns);
+
+    ASSERT_TRUE(DictFunctions::dict_encode_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+    ColumnPtr result = DictFunctions::dict_encode(ctx.get(), columns).value();
+    EXPECT_TRUE(result->only_null());
+    ASSERT_TRUE(DictFunctions::dict_encode_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
+}
+
+} // namespace starrocks

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -423,6 +423,11 @@ vectorized_functions = [
     [30603, 'from_binary', True, True, 'VARCHAR', ['VARBINARY'], 'BinaryFunctions::from_binary',
      'BinaryFunctions::from_binary_prepare', 'BinaryFunctions::from_binary_close'],
 
+    # dict_encode(value, dict_slot_id): translate a constant to its global dictionary code (resolved
+    # once from BE runtime state), so a dict-aware comparison can run on codes. BE-only.
+    [30700, 'dict_encode', True, False, 'INT', ['VARCHAR', 'INT'], 'DictFunctions::dict_encode',
+     'DictFunctions::dict_encode_prepare', 'DictFunctions::dict_encode_close'],
+
     # 50xxx: timestamp functions
     [50008, 'year', True, False, 'SMALLINT', ['DATE'], 'TimeFunctions::yearV3'],
     [50009, 'year', True, False, 'SMALLINT', ['DATETIME'], 'TimeFunctions::yearV2'],

--- a/gensrc/script/gen_functions.py
+++ b/gensrc/script/gen_functions.py
@@ -69,6 +69,7 @@ ${license}
 
 #include "exprs/array_functions.h"
 #include "exprs/builtin_functions.h"
+#include "exprs/dict_functions.h"
 #include "exprs/map_functions.h"
 #include "exprs/struct_functions.h"
 #include "exprs/math_functions.h"
@@ -101,6 +102,7 @@ BuiltinFunctions::FunctionTables BuiltinFunctions::_fn_tables = {
 function_list = list()
 function_set = set()
 function_signature_set = set()
+FE_HIDDEN_FUNCTIONS = {'dict_encode'}
 
 
 def add_function(fn_data):
@@ -158,7 +160,8 @@ def generate_fe(path):
 
     value = dict()
     value["license"] = license_string
-    value["functions"] = "\n        ".join([gen_fe_fn(i) for i in function_list])
+    value["functions"] = "\n        ".join(
+        [gen_fe_fn(i) for i in function_list if i['name'] not in FE_HIDDEN_FUNCTIONS])
 
     content = java_template.substitute(value)
 


### PR DESCRIPTION
## Why I'm doing:
Currently dictification framework cannot rewrite array functions with constant arguments (like `ARRAY_CONTAINS(arr, 'abc')`).  This is due to the fact that constant strings can't be translated into dictionary space.  This PR implements the be changes for this feature. 


## What I'm doing:
Implementing `dict_encode(value, dict_slot_id)` function which translates a constant to its global-dictionary code for the column identified by dict_slot_id, resolved once from BE runtime state. It lets the low-cardinality rewrite pre-encode a constant operand so a dict-aware comparison can run directly on integer codes.
NOTE: This function is hidden from fe and can be only added to the plan by low cardinality framework.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

