### PR TITLE
[BugFix] Keep OR-nested predicates when a branch is only partially bitmap-indexed

### DIFF
--- a/be/src/storage/rowset/bitmap_index_evaluator.cpp
+++ b/be/src/storage/rowset/bitmap_index_evaluator.cpp
@@ -47,6 +47,8 @@ struct BitmapIndexInitializer {
         }
 
         parent->_ctx.is_node_support_bitmap[&node] = true;
+        // A column predicate backed by a bitmap iterator is a fully-covered leaf.
+        parent->_ctx.is_node_fully_covered[&node] = true;
         auto& col_ctx = _get_or_create_column_context(bitmap_iter, cid, parent_node_ctx, parent_type);
         col_ctx.nodes.emplace_back(&node);
         return true;
@@ -58,8 +60,16 @@ struct BitmapIndexInitializer {
         auto& node_ctx = parent->_ctx.compound_node_to_context.emplace(&node, BitmapContext::CompoundNodeContext{})
                                  .first->second;
         bool has_bitmap_index = Type == CompoundNodeType::AND ? false : true;
+        // Fully covered iff every leaf in this subtree can use a bitmap index. Used later to decide whether
+        // predicates below an OR may be erased (only an exact, i.e. fully-covered, subtree is erasable there).
+        bool fully_covered = true;
         for (const auto& child : node.children()) {
             ASSIGN_OR_RETURN(const auto child_has_bitmap_index, child.visit(*this, &node_ctx, Type));
+            const bool child_fully_covered = child.visit([this](const auto& child_node) {
+                const auto it = parent->_ctx.is_node_fully_covered.find(&child_node);
+                return it != parent->_ctx.is_node_fully_covered.end() && it->second;
+            });
+            fully_covered &= child_fully_covered;
             if constexpr (Type == CompoundNodeType::AND) {
                 has_bitmap_index |= child_has_bitmap_index;
             } else {
@@ -70,6 +80,7 @@ struct BitmapIndexInitializer {
             }
         }
         parent->_ctx.is_node_support_bitmap[&node] = has_bitmap_index;
+        parent->_ctx.is_node_fully_covered[&node] = fully_covered;
         return has_bitmap_index;
     }
 
@@ -99,7 +110,10 @@ struct BitmapIndexInitializer {
 struct BitmapIndexSeeker {
     enum class ResultType : uint8_t { ALWAYS_FALSE, ALWAYS_TRUE, NOT_USED, OK };
 
-    StatusOr<ResultType> operator()(const PredicateAndNode& node) {
+    // `erasable` is true when a predicate matched here is guaranteed by the narrowed scan range, so it can be
+    // dropped from the residual tree. AND preserves it (an AND intersects, so each child is mandatory); it is
+    // only downgraded when descending into a not-fully-covered OR.
+    StatusOr<ResultType> operator()(const PredicateAndNode& node, bool erasable) {
         if (!parent->_ctx.is_node_support_bitmap[&node]) {
             return ResultType::NOT_USED;
         }
@@ -145,7 +159,7 @@ struct BitmapIndexSeeker {
         }
 
         for (const auto& child : node.compound_children()) {
-            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this, erasable));
             switch (res_type) {
             case ResultType::ALWAYS_FALSE:
                 parent->_ctx.nodes_to_erase.emplace(&node);
@@ -185,16 +199,23 @@ struct BitmapIndexSeeker {
             return ResultType::NOT_USED;
         }
 
-        parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+        if (erasable) {
+            parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+        }
 
         node_ctx.used = true;
         return ResultType::OK;
     }
 
-    StatusOr<ResultType> operator()(const PredicateOrNode& node) {
+    StatusOr<ResultType> operator()(const PredicateOrNode& node, bool erasable) {
         if (!parent->_ctx.is_node_support_bitmap[&node]) {
             return ResultType::NOT_USED;
         }
+
+        // A predicate below an OR may only be erased if this OR is fully covered by bitmap indexes. Otherwise
+        // the OR's bitmap is a superset (some branch is only partially indexed), and dropping any matched leaf
+        // would lose the per-branch correlation and admit false positives.
+        const bool child_erasable = erasable && parent->_ctx.is_node_fully_covered[&node];
 
         DCHECK(parent->_ctx.compound_node_to_context.find(&node) != parent->_ctx.compound_node_to_context.end());
         auto& node_ctx = parent->_ctx.compound_node_to_context[&node];
@@ -238,7 +259,7 @@ struct BitmapIndexSeeker {
         }
 
         for (const auto& child : node.compound_children()) {
-            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this));
+            ASSIGN_OR_RETURN(const auto res_type, child.visit(*this, child_erasable));
             switch (res_type) {
             case ResultType::ALWAYS_FALSE:
                 children_to_erase.emplace_back(&child);
@@ -278,7 +299,9 @@ struct BitmapIndexSeeker {
             return ResultType::NOT_USED;
         }
 
-        parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+        if (child_erasable) {
+            parent->_ctx.nodes_to_erase.insert(children_to_erase.begin(), children_to_erase.end());
+        }
 
         node_ctx.used = true;
         return ResultType::OK;
@@ -426,7 +449,9 @@ Status BitmapIndexEvaluator::evaluate(SparseRange<>& dst_scan_range, PredicateTr
     //  - Seek to the position of predicate's operand within
     //    bitmap index dictionary.
     // ---------------------------------------------------------
-    ASSIGN_OR_RETURN(const auto seek_res, _pred_tree.visit(BitmapIndexSeeker{this}));
+    // The root is an AND whose bitmap is intersected into the scan range, so predicates matched at the top
+    // level are erasable. Erasability is only revoked while descending through a not-fully-covered OR.
+    ASSIGN_OR_RETURN(const auto seek_res, _pred_tree.visit(BitmapIndexSeeker{this}, /*erasable=*/true));
     switch (seek_res) {
     case BitmapIndexSeeker::ResultType::ALWAYS_FALSE:
         dst_scan_range.clear();

--- a/be/src/storage/rowset/bitmap_index_evaluator.h
+++ b/be/src/storage/rowset/bitmap_index_evaluator.h
@@ -45,6 +45,10 @@ struct BitmapContext {
     /// and therefore do not modify the related PredicateTree, which may cause the address to change.
 
     std::unordered_map<const PredicateBaseNode*, bool> is_node_support_bitmap;
+    // A node is "fully covered" iff every leaf predicate in its subtree can use a bitmap index. Only a
+    // fully-covered subtree has an exact (not merely superset) bitmap, which is the precondition for
+    // erasing predicates that sit under an OR node. See BitmapIndexSeeker for how this gates erasure.
+    std::unordered_map<const PredicateBaseNode*, bool> is_node_fully_covered;
     // It ensures that `compound_node_to_context[node]` can be accessed after `is_node_support_bitmap[node]` is true.
     std::unordered_map<const PredicateBaseNode*, CompoundNodeContext> compound_node_to_context;
 

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_bitmap_index_partial_cover_or
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_bitmap_index_partial_cover_or
@@ -1,0 +1,70 @@
+-- name: test_bitmap_index_partial_cover_or @sequential
+-- Regression for the bitmap-index OR erasure bug: when an OR branch is only partially covered by a
+-- bitmap index -- (a=1 AND b=2) OR (a=2 AND b=3) with `a` bitmap-indexed and `b` not -- the indexed
+-- leaves must NOT be erased from the residual predicate. Before the fix, the residual collapsed to
+-- (b=2 OR b=3) over the scan range {a in (1,2)}, wrongly matching rows like (a=1,b=3) and (a=2,b=2).
+-- Keep the OR as a pushed-down predicate tree (do not rewrite it to a UNION), and isolate the bitmap
+-- index filter from the other index filters so the bitmap path is the only thing under test.
+set scan_or_to_union_limit = 1;
+-- result:
+-- !result
+update information_schema.be_configs set value="false" where name= "enable_index_segment_level_zonemap_filter";
+-- result:
+-- !result
+update information_schema.be_configs set value="false" where name= "enable_index_page_level_zonemap_filter";
+-- result:
+-- !result
+update information_schema.be_configs set value="false" where name= "enable_index_bloom_filter";
+-- result:
+-- !result
+CREATE TABLE t_or_bitmap (
+  id BIGINT NOT NULL,
+  a  INT    NOT NULL,
+  b  INT    NOT NULL,
+  INDEX idx_a (a) USING BITMAP
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_or_bitmap
+SELECT generate_series AS id, CAST(generate_series + 1000 AS INT) AS a, 100 AS b
+FROM TABLE(generate_series(1, 5000))
+UNION ALL SELECT 100001, 1, 2
+UNION ALL SELECT 100002, 2, 3
+UNION ALL SELECT 100003, 1, 3
+UNION ALL SELECT 100004, 2, 2;
+-- result:
+-- !result
+update information_schema.be_configs set value="true" where name= "enable_index_bitmap_filter";
+-- result:
+-- !result
+select count(1) from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3);
+-- result:
+2
+-- !result
+select id, a, b from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3) order by id;
+-- result:
+100001	1	2
+100002	2	3
+-- !result
+update information_schema.be_configs set value="false" where name= "enable_index_bitmap_filter";
+-- result:
+-- !result
+select count(1) from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3);
+-- result:
+2
+-- !result
+update information_schema.be_configs set value="true" where name= "enable_index_segment_level_zonemap_filter";
+-- result:
+-- !result
+update information_schema.be_configs set value="true" where name= "enable_index_page_level_zonemap_filter";
+-- result:
+-- !result
+update information_schema.be_configs set value="true" where name= "enable_index_bloom_filter";
+-- result:
+-- !result
+update information_schema.be_configs set value="true" where name= "enable_index_bitmap_filter";
+-- result:
+-- !result

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_bitmap_index_partial_cover_or
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_bitmap_index_partial_cover_or
@@ -1,0 +1,41 @@
+-- name: test_bitmap_index_partial_cover_or @sequential
+-- Regression for the bitmap-index OR erasure bug: when an OR branch is only partially covered by a
+-- bitmap index -- (a=1 AND b=2) OR (a=2 AND b=3) with `a` bitmap-indexed and `b` not -- the indexed
+-- leaves must NOT be erased from the residual predicate. Before the fix, the residual collapsed to
+-- (b=2 OR b=3) over the scan range {a in (1,2)}, wrongly matching rows like (a=1,b=3) and (a=2,b=2).
+-- Keep the OR as a pushed-down predicate tree (do not rewrite it to a UNION), and isolate the bitmap
+-- index filter from the other index filters so the bitmap path is the only thing under test.
+set scan_or_to_union_limit = 1;
+update information_schema.be_configs set value="false" where name= "enable_index_segment_level_zonemap_filter";
+update information_schema.be_configs set value="false" where name= "enable_index_page_level_zonemap_filter";
+update information_schema.be_configs set value="false" where name= "enable_index_bloom_filter";
+CREATE TABLE t_or_bitmap (
+  id BIGINT NOT NULL,
+  a  INT    NOT NULL,
+  b  INT    NOT NULL,
+  INDEX idx_a (a) USING BITMAP
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- One INSERT so every row shares a segment; >= 1000 distinct `a` values so the equality predicates
+-- a=1 / a=2 pass the bitmap selectivity gate (bitmap_max_filter_ratio=1 => cardinality must be >=1000).
+INSERT INTO t_or_bitmap
+SELECT generate_series AS id, CAST(generate_series + 1000 AS INT) AS a, 100 AS b
+FROM TABLE(generate_series(1, 5000))
+UNION ALL SELECT 100001, 1, 2
+UNION ALL SELECT 100002, 2, 3
+UNION ALL SELECT 100003, 1, 3
+UNION ALL SELECT 100004, 2, 2;
+-- bitmap enabled: must return the 2 truly-matching rows, not 4.
+update information_schema.be_configs set value="true" where name= "enable_index_bitmap_filter";
+select count(1) from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3);
+select id, a, b from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3) order by id;
+-- control: bitmap disabled must give the same answer.
+update information_schema.be_configs set value="false" where name= "enable_index_bitmap_filter";
+select count(1) from t_or_bitmap where (a = 1 and b = 2) or (a = 2 and b = 3);
+-- restore BE configs.
+update information_schema.be_configs set value="true" where name= "enable_index_segment_level_zonemap_filter";
+update information_schema.be_configs set value="true" where name= "enable_index_page_level_zonemap_filter";
+update information_schema.be_configs set value="true" where name= "enable_index_bloom_filter";
+update information_schema.be_configs set value="true" where name= "enable_index_bitmap_filter";


### PR DESCRIPTION
## Why I'm doing:

The bitmap index evaluator erased any column predicate whose bitmap range was applied, even when that predicate sat under an `OR` whose branch was only **partially** covered by bitmap indexes.

Because an `OR`'s bitmap is a union (a superset) of its branch bitmaps, dropping the indexed leaves loses the per-branch correlation and produces false positives. For example, `(a = 1 AND b = 2) OR (a = 2 AND b = 3)` with only `a` bitmap-indexed wrongly matched rows like `(a = 1, b = 3)` and `(a = 2, b = 2)`: the residual predicate collapsed to `(b = 2 OR b = 3)` over the scan range `{a in (1, 2)}`, so any row with `a in (1,2)` and `b in (2,3)` slipped through.

## What I'm doing:

Track a per-node "fully covered" flag (every leaf in the subtree is bitmap-indexed) and thread an `erasable` flag through the seeker. Erasability is preserved across `AND` nodes but revoked when descending into a not-fully-covered `OR`, so predicates below such an `OR` are retained in the residual tree.

Scan-range narrowing is unchanged (the union bitmap remains a valid superset), so partially covered `OR`s keep their filtering benefit without unsafe predicate erasure.

Adds a SQL regression test under `test_scan/test_pushdown_or_predicate` that isolates the bitmap-index path and asserts the bitmap-enabled result matches the bitmap-disabled control.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
