### PR TITLE
[BugFix] Fix Iceberg equality-delete under-application when a string date partition column is compared with a temporal value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1787,9 +1787,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         String tableName = icebergTable.getCatalogTableName();
         org.apache.iceberg.Table table = icebergTable.getNativeTable();
         List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+        // Cast-on-string-partition conjuncts (e.g. CAST(c AS DATETIME) = <ts>) are pruned unsoundly by Iceberg's
+        // string-domain comparison; pushing them here would drop equality-delete files whose 'yyyy-MM-dd' partition
+        // value never equals the rendered '...00:00:00' string, so the deletes would not be applied and already
+        // deleted rows would leak back into the result. Keep such conjuncts out of the pushed predicate and instead
+        // filter the returned delete files against their partition values StarRocks-side.
+        PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
+                scalarOperators, identityStringPartitionColumns(icebergTable));
         ScalarOperatorToIcebergExpr.IcebergContext icebergContext = new ScalarOperatorToIcebergExpr.IcebergContext(
                 table.schema().asStruct());
-        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(scalarOperators, icebergContext);
+        Expression icebergPredicate = new ScalarOperatorToIcebergExpr().convert(residual.pushable, icebergContext);
 
         StarRocksIcebergTableScanContext scanContext = new StarRocksIcebergTableScanContext(
                 catalogName, dbName, tableName, PlanMode.LOCAL, ConnectContext.get());
@@ -1803,7 +1810,55 @@ public class IcebergMetadata implements ConnectorMetadata {
             scan = scan.filter(icebergPredicate);
         }
 
-        return ((StarRocksIcebergTableScan) scan).getDeleteFiles(content);
+        Set<DeleteFile> deleteFiles = ((StarRocksIcebergTableScan) scan).getDeleteFiles(content);
+        if (residual.hasResidual()) {
+            // Keep a delete file unless its partition value definitely cannot satisfy the residual (partitionMayMatch
+            // drops only on a definitive false). Dropping a possibly-matching delete file would under-apply deletes,
+            // so this only prunes delete files from partitions that provably cannot match.
+            deleteFiles = deleteFiles.stream()
+                    .filter(f -> PartitionCastPredicatePruner.partitionMayMatch(
+                            residual.residual, deleteFilePartitionValues(f, icebergTable)))
+                    .collect(Collectors.toSet());
+        }
+        return deleteFiles;
+    }
+
+    // Raw string partition values for an equality/position delete file, keyed by (identity) partition column name,
+    // using the delete file's own partition spec (a delete file may predate the current spec). Returns an empty map
+    // on any decoding uncertainty (partition-transform evolution, dropped source column, non-PartitionData), which
+    // makes partitionMayMatch conservatively keep the file so a needed delete is never dropped.
+    private static Map<String, String> deleteFilePartitionValues(DeleteFile file, IcebergTable table) {
+        try {
+            org.apache.iceberg.Table nativeTable = table.getNativeTable();
+            PartitionSpec spec = nativeTable.specs().get(file.specId());
+            if (spec == null || !(file.partition() instanceof org.apache.iceberg.PartitionData)) {
+                return Collections.emptyMap();
+            }
+            org.apache.iceberg.PartitionData partitionData = (org.apache.iceberg.PartitionData) file.partition();
+            List<String> values = PartitionUtil.getIcebergPartitionValues(spec, partitionData, false);
+            Map<String, String> result = new HashMap<>();
+            int index = 0;
+            for (PartitionField field : spec.fields()) {
+                if (field.transform().isVoid()) {
+                    continue;
+                }
+                if (index >= values.size()) {
+                    break;
+                }
+                String value = values.get(index++);
+                if (!field.transform().isIdentity()) {
+                    continue;
+                }
+                String name = table.getPartitionSourceName(nativeTable.schema(), field);
+                if (name != null && value != null) {
+                    result.put(name, value);
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            LOG.debug("failed to decode delete file partition values, keep file: {}", file.path(), e);
+            return Collections.emptyMap();
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1838,8 +1838,14 @@ public class IcebergMetadata implements ConnectorMetadata {
             List<String> values = PartitionUtil.getIcebergPartitionValues(spec, partitionData, false);
             Map<String, String> result = new HashMap<>();
             int index = 0;
-            for (PartitionField field : spec.fields()) {
-                if (field.transform().isVoid()) {
+            List<PartitionField> fields = spec.fields();
+            for (int i = 0; i < fields.size(); i++) {
+                PartitionField field = fields.get(i);
+                // Stay aligned with getIcebergPartitionValues, which emits NO entry only for a void field whose
+                // slot is null. A void field with a non-null slot (possible under partition evolution) still has an
+                // entry, so it must consume one here; skipping it without consuming would shift every later value
+                // onto the wrong identity column and could prune a required delete file.
+                if (field.transform().isVoid() && partitionData.get(i) == null) {
                     continue;
                 }
                 if (index >= values.size()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -142,6 +142,8 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetricsModes;
@@ -1526,6 +1528,45 @@ public class IcebergMetadataTest extends TableTestBase {
         return new BinaryPredicateOperator(BinaryType.EQ,
                 new CastOperator(DATETIME, new ColumnRefOperator(3, VARCHAR, "k2", true)),
                 ConstantOperator.createDatetime(LocalDateTime.of(year, month, day, 0, 0, 0)));
+    }
+
+    @Test
+    public void testGetDeleteFilesStringDatePartitionCast() throws Exception {
+        // An equality-delete file lives in partition k2=2020-06-14. Previously getDeleteFiles pushed
+        // CAST(k2 AS DATETIME) = <ts> to Iceberg's string-domain scan filter, which pruned this delete file
+        // (its 'yyyy-MM-dd' partition value never equals the rendered '...00:00:00' string), so the equality
+        // delete was not applied and deleted rows leaked. It must now be kept.
+        PartitionSpec spec = PartitionSpec.builderFor(SCHEMA_J).identity("k2").build();
+        TestTables.TestTable table = create(SCHEMA_J, spec, "tbGetDeleteFiles", 2);
+        table.newFastAppend().appendFile(DataFiles.builder(spec)
+                .withPath("/path/to/gdf-0614.parquet").withFileSizeInBytes(20)
+                .withPartitionPath("k2=2020-06-14").withRecordCount(3).build()).commit();
+        DeleteFile eqDelete = FileMetadata.deleteFileBuilder(spec)
+                .ofEqualityDeletes(3)   // k2 field id
+                .withPath("/path/to/gdf-0614-eqdel.orc").withFormat(FileFormat.ORC)
+                .withFileSizeInBytes(10).withPartitionPath("k2=2020-06-14").withRecordCount(1).build();
+        table.newRowDelta().addDeletes(eqDelete).commit();
+        table.refresh();
+        List<Column> columns = Lists.newArrayList(
+                new Column("id", INT), new Column("k1", INT), new Column("k2", VARCHAR));
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", columns, table, Maps.newHashMap());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT,
+                new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG),
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+        long snapshotId = table.currentSnapshot().snapshotId();
+
+        // cast predicate matching the partition -> delete file kept (previously wrongly pruned in the string domain).
+        Set<DeleteFile> matched = metadata.getDeleteFiles(
+                icebergTable, snapshotId, k2EqDate(2020, 6, 14), FileContent.EQUALITY_DELETES);
+        Assertions.assertEquals(1, matched.size(),
+                "equality-delete file must not be pruned by a cast-on-string-partition predicate");
+
+        // cast predicate for a different date -> the 2020-06-14 delete file definitely cannot match -> pruned.
+        Set<DeleteFile> none = metadata.getDeleteFiles(
+                icebergTable, snapshotId, k2EqDate(2019, 1, 1), FileContent.EQUALITY_DELETES);
+        Assertions.assertTrue(none.isEmpty(),
+                "a definitely-non-matching partition's delete file should be pruned StarRocks-side");
     }
 
     @Test

--- a/test/sql/test_iceberg/R/test_iceberg_eq_delete_string_date_partition
+++ b/test/sql/test_iceberg/R/test_iceberg_eq_delete_string_date_partition
@@ -1,0 +1,27 @@
+-- name: test_iceberg_eq_delete_string_date_partition
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+set new_planner_optimize_timeout = 30000;
+-- result:
+-- !result
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part order by id, v;
+-- result:
+1	2020-06-14	200
+2	2020-06-22	300
+-- !result
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = cast('2020-06-15' as date) - interval 1 day order by id, v;
+-- result:
+1	2020-06-14	200
+-- !result
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = date_sub(cast('2020-06-15' as date), interval 1 day) order by id, v;
+-- result:
+1	2020-06-14	200
+-- !result
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = '2020-06-14' order by id, v;
+-- result:
+1	2020-06-14	200
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_eq_delete_string_date_partition
+++ b/test/sql/test_iceberg/T/test_iceberg_eq_delete_string_date_partition
@@ -1,0 +1,40 @@
+-- name: test_iceberg_eq_delete_string_date_partition
+-- description: MOR equality-delete read on a table whose STRING date partition column is compared with a temporal
+-- value. The predicate coerces to CAST(c2 AS DATETIME) <op> <ts>; getDeleteFiles must not push that cast to
+-- Iceberg's string-domain filter (it would prune the equality-delete file whose 'yyyy-MM-dd' partition value
+-- never equals the rendered '...00:00:00' string, so the delete would not be applied and a deleted row would
+-- leak back). See #76068 (scan) / #76107 (cardinality) for the same root cause on other paths.
+--
+-- Only Flink can write Iceberg equality-delete files, so the fixture below is created in advance (upsert mode
+-- keyed by (id, c2) produces one equality delete for id=1 in partition c2=2020-06-14). Create it once with:
+--
+--   CREATE DATABASE IF NOT EXISTS ice.iceberg_ci_db;
+--   CREATE TABLE ice.iceberg_ci_db.eq_del_str_date_part (
+--       id INT, c2 STRING, v INT,
+--       PRIMARY KEY (id, c2) NOT ENFORCED
+--   ) PARTITIONED BY (c2)
+--   WITH ('format-version'='2', 'write.upsert.enabled'='true');
+--   INSERT INTO ice.iceberg_ci_db.eq_del_str_date_part VALUES (1, '2020-06-14', 100);
+--   INSERT INTO ice.iceberg_ci_db.eq_del_str_date_part VALUES (1, '2020-06-14', 200);  -- upsert -> eq-delete of (1,100)
+--   INSERT INTO ice.iceberg_ci_db.eq_del_str_date_part VALUES (2, '2020-06-22', 300);
+--
+-- Logical content after the upserts: (1, 2020-06-14, 200) and (2, 2020-06-22, 300); the old (1, ..., 100) is
+-- removed by an equality delete in partition 2020-06-14.
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+set new_planner_optimize_timeout = 30000;
+
+-- baseline: equality delete is applied (no cast predicate) -> old value gone.
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part order by id, v;
+
+-- cast/interval form hitting the eq-deleted partition: must NOT leak the deleted v=100.
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = cast('2020-06-15' as date) - interval 1 day order by id, v;
+
+-- date_sub builtin form of the same value.
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = date_sub(cast('2020-06-15' as date), interval 1 day) order by id, v;
+
+-- control: bare 'yyyy-MM-dd' literal (no cast, always worked) must agree.
+select id, c2, v from iceberg_sql_test_${uuid0}.iceberg_ci_db.eq_del_str_date_part where c2 = '2020-06-14' order by id, v;
+
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing

  Fourth (and last) in the series fixing one root cause across its consumers. When a STRING date
  partition column is compared with a temporal value, e.g.

      WHERE c2 = cast('2020-06-15' as date) - interval 1 day

  binary-predicate coercion produces `CAST(c2 AS DATETIME) = '2020-06-14 00:00:00'`. Iceberg's native
  pushdown unwraps the cast and compares in the STRING domain, which never equals a `'yyyy-MM-dd'`
  partition value.

  - #76068 fixed the **scan side** (wrong empty results).
  - #76107 fixed the **manifest cardinality estimate** (collapsed to 1 -> bad plans).
  - The metadata-delete follow-up fixed **DELETE** (silent no-op / wrong partitions).
  - This PR fixes the **MOR equality-delete read path** (`getDeleteFiles`).

  `getDeleteFiles` pushed the whole predicate through the string-domain converter to filter the
  equality-delete-file scan. A `CAST(string_partition_col AS DATETIME) = <ts>` conjunct therefore
  pruned every equality-delete file whose `'yyyy-MM-dd'` partition value did not equal the rendered
  `'...00:00:00'` string. `IcebergEqualityDeleteRewriteRule` then derived no delete schemas, the
  equality-delete anti-join was not applied, and **already-deleted rows leaked back into the result**.
  Unlike the other paths, this is a silent correctness bug on reads (stale rows returned).

  ## What I'm doing

  Reuse `PartitionCastPredicatePruner`:

  - **Do not push** cast-on-string-partition conjuncts to the delete-file scan filter; only the
    non-cast (`pushable`) conjuncts are converted and pushed.
  - After planning, **filter the returned delete files StarRocks-side** by their partition values with
    `partitionMayMatch` (drops a delete file only when its partition value provably cannot satisfy the
    residual). Keeping a possibly-matching delete file is safe (a superset only over-applies equality
    deletes, which match by key and never remove non-matching rows); dropping a needed one is not, so
    the direction matches #76068's scan-side pruning.
  - Add `deleteFilePartitionValues(DeleteFile, table)`, which decodes a delete file's partition values
    using the file's own partition spec (a delete file may predate the current spec) and returns an
    empty map on any decoding uncertainty (partition-transform evolution, dropped source column, etc.),
    so `partitionMayMatch` conservatively keeps the file.

  ## Reproduce

  Equality-delete files can only be written by Flink (StarRocks/Spark write position deletes), so the
  fixture is created with a Flink upsert:

      -- Flink
      CREATE TABLE ice.db.t_eqdel (
          id INT, c2 STRING, v INT, PRIMARY KEY (id, c2) NOT ENFORCED
      ) PARTITIONED BY (c2) WITH ('format-version'='2', 'write.upsert.enabled'='true');
      INSERT INTO ice.db.t_eqdel VALUES (1, '2020-06-14', 100);
      INSERT INTO ice.db.t_eqdel VALUES (1, '2020-06-14', 200);  -- upsert -> equality delete of (1,100)
      INSERT INTO ice.db.t_eqdel VALUES (2, '2020-06-22', 300);

      -- StarRocks
      SELECT id, c2, v FROM t_eqdel WHERE c2 = cast('2020-06-15' as date) - interval 1 day ORDER BY id, v;
      -- before: 1|2020-06-14|100 AND 1|2020-06-14|200   (deleted v=100 leaks)
      -- after : 1|2020-06-14|200
      -- baseline (no predicate) and the bare-string 'c2 = 2020-06-14' already returned only v=200.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
