### PR TITLE
[Tool] fix connector library link order for thirdparty deps

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -540,6 +540,30 @@ endif()
 
 include(${SRC_DIR}/exprs_ext/extension_targets.cmake)
 
+# Concrete connectors reach the BE binary only as transitive PRIVATE deps of
+# ModuleBootstrap/Exec, which CMake places after the thirdparty group. List every
+# connector ModuleBootstrap pulls (guarded by the same options) ahead of it.
+set (DIRECT_CONNECTOR_LINK_LIBS
+    Connector
+    ConnectorLake
+    ConnectorFile
+    ConnectorHive
+    ConnectorIceberg
+    ConnectorCacheStats
+)
+if (WITH_CONNECTOR_BENCHMARK)
+    list(APPEND DIRECT_CONNECTOR_LINK_LIBS ConnectorBenchmark)
+endif()
+if (WITH_CONNECTOR_ELASTICSEARCH)
+    list(APPEND DIRECT_CONNECTOR_LINK_LIBS ConnectorElasticsearch)
+endif()
+if (WITH_CONNECTOR_JDBC)
+    list(APPEND DIRECT_CONNECTOR_LINK_LIBS ConnectorJDBC)
+endif()
+if (WITH_CONNECTOR_MYSQL)
+    list(APPEND DIRECT_CONNECTOR_LINK_LIBS ConnectorMySQL)
+endif()
+
 # Set starrocks libraries
 set(STARROCKS_LINK_LIBS
     HttpService
@@ -554,6 +578,10 @@ set(STARROCKS_LINK_LIBS
     ${WL_WHOLE_ARCHIVE_PREFIX} ${EXPR_EXTENSION_LIBS} ${WL_WHOLE_ARCHIVE_SUFFIX}
     ${WL_END_GROUP}
     Storage
+    # Connectors depend on the format libs and thirdparty archives below; keep ahead.
+    ${WL_START_GROUP}
+    ${DIRECT_CONNECTOR_LINK_LIBS}
+    ${WL_END_GROUP}
     # The concrete format libraries must be linked ahead of the thirdparty
     # dependency group below (which owns avro/avrocpp/arrow/orc). Linking only
     # the Formats aggregate lets CMake append its concrete members after that
@@ -875,17 +903,6 @@ set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS}
 if (WITH_GCOV)
     set(STARROCKS_LINK_LIBS ${STARROCKS_LINK_LIBS} --coverage)
 endif()
-
-# Broad test and benchmark executables directly exercise concrete connector implementations.
-# Keep these explicit: PRIVATE dependencies of shared BE modules are intentionally not propagated
-# when ENABLE_MULTI_DYNAMIC_LIBS is enabled.
-set (DIRECT_CONNECTOR_LINK_LIBS
-    Connector
-    ConnectorLake
-    ConnectorFile
-    ConnectorHive
-    ConnectorIceberg
-)
 
 # Set libraries for test. TestUtil is UT-only and intentionally stays out of
 # STARROCKS_LINK_LIBS so normal BE, format-lib, and benchmark builds do not


### PR DESCRIPTION
## Why I'm doing:

The daily release / benchmark BE build (`starrocks_benchmark_main_cloud`) fails at the final link of `starrocks_be` with a flood of undefined references to thirdparty symbols:

```
[100%] Linking CXX executable /root/starrocks/be/output/lib/starrocks_be
be/src/connector/file/scanner/parquet_reader.cpp:216: undefined reference to 'parquet::ParquetFileReader::Open(...)'
be/src/connector/file/scanner/avro_scanner.cpp:145: undefined reference to 'serdes_conf_new'
be/src/formats/avro/cpp/avro_reader.cpp:514: undefined reference to 'avro::DataFileReaderBase::close()'
be/src/formats/deletion_bitmap.cpp:28: undefined reference to 'roaring64_iterator_create'
be/src/formats/paimon/paimon_delete_file_builder.cpp:61: undefined reference to 'roaring64_bitmap_move_from_roaring32'
collect2: error: ld returned 1 exit status
```

Root cause: after the connector-module refactor (#76143 / #76232 / #76237 / #76238), the concrete connector modules (`Connector` / `ConnectorLake` / `ConnectorFile` / `ConnectorHive` / `ConnectorIceberg` / ...) reach the `starrocks_be` binary only as transitive PRIVATE deps of `ModuleBootstrap` / `Exec`. CMake appends those transitive deps **after** the thirdparty dependency group, so the connector objects (`parquet_reader`, `avro_scanner`, the iceberg/paimon/delta delete builders, `deletion_bitmap`) end up **behind** their thirdparty archives (avro/avrocpp, arrow/parquet, roaring) on the static link line, leaving their references unresolved.

Why the PR gates stayed green while the release build broke: the PR `BUILD` gate does fully link `starrocks_be`, but it runs on the **Ubuntu** toolchain image, which sets `STARROCKS_LINKER=lld` (`docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile`). lld resolves **backward references** into already-scanned archives by default (`--warn-backrefs` is off), so the misordered link line still succeeds silently. The release/benchmark build runs on the **CentOS 7** image, which has no lld: glibc 2.17 < 2.29 makes `be/CMakeLists.txt` force the **gold** linker, and gold (like GNU ld) does strict single-pass left-to-right archive scanning — the connector objects behind the thirdparty group fail with undefined references. (The BE UT gate additionally builds with `MAKE_TEST=ON`, which never links `starrocks_be` at all.)

So this class of link-order regression is invisible to the PR gates today. A follow-up worth considering: pass `-Wl,--warn-backrefs` to lld in the Ubuntu build so archive-order breakage fails in PR CI instead of in the CentOS release build.

This is the same class of link-order bug that #75841 fixed for the concrete format libraries.

## What I'm doing:

List the concrete connector modules explicitly in `STARROCKS_LINK_LIBS`, ahead of the format libraries and the thirdparty dependency group, mirroring the existing format-library fix. The list mirrors exactly the connector set `ModuleBootstrap` pulls: the six always-on connectors (including `ConnectorCacheStats`) plus the optional benchmark/Elasticsearch/JDBC/MySQL connectors under the same `WITH_CONNECTOR_*` guards. The `DIRECT_CONNECTOR_LINK_LIBS` definition is moved above `STARROCKS_LINK_LIBS` so it can be reused there; the test/benchmark link lists are left untouched (the now-redundant explicit copy is harmless for static libs and keeps the already-green test/bench link unchanged).

Fixes the release BE build break at `main`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
