### PR TITLE
[Enhancement] Make routine load metadata alias optional

### DIFF
--- a/docs/en/loading/RoutineLoad.md
+++ b/docs/en/loading/RoutineLoad.md
@@ -428,10 +428,10 @@ This is useful for auditing (which topic/partition/offset a row came from), even
 #### Syntax
 
 ```SQL
-INCLUDE METADATA ( <metadata_key> AS <alias> [, <metadata_key> AS <alias> ...] )
+INCLUDE METADATA ( <metadata_key> [AS <alias>] [, <metadata_key> [AS <alias>] ...] )
 ```
 
-`INCLUDE METADATA` is a load property; place it among the other load properties (such as `COLUMNS` and `WHERE`), in any order, before the `PROPERTIES` and `FROM` clauses. `AS <alias>` is required, the alias must be unique within the clause, and it must not collide with a payload field, a destination-table column, or a reserved column name.
+`INCLUDE METADATA` is a load property; place it among the other load properties (such as `COLUMNS` and `WHERE`), in any order, before the `PROPERTIES` and `FROM` clauses. `AS <alias>` is optional. If it is omitted, the alias defaults to `<metadata_key>`. The alias must be unique within the clause, and it must not collide with a payload field, a destination-table column, or a reserved column name.
 
 #### Metadata keys
 
@@ -458,7 +458,7 @@ To read a single header/property value, use `element_at(<headers_alias>, '<name>
 #### Usage notes
 
 - `INCLUDE METADATA` is available for `format = json` (Kafka and Pulsar) and `format = avro` (Kafka only; Pulsar Routine Load does not support Avro). It is not supported for CSV, where one message can expand into many rows and per-message metadata would be ambiguous.
-- A metadata alias is an ordinary source column: reference it anywhere in the `COLUMNS` expressions. A payload field with the same name is never shadowed, because the alias is chosen explicitly.
+- A metadata alias is an ordinary source column: reference it anywhere in the `COLUMNS` expressions. If a payload field has the same name as a metadata key, specify a different alias with `AS <alias>` to avoid ambiguity.
 - `OFFSET` is Kafka-only and `MESSAGE_ID` is Pulsar-only; using a key unsupported by the source raises an error that lists the keys supported for that source.
 - `HEADERS`/`PROPERTIES` is a `MAP\<VARCHAR, VARCHAR>`. The source headers/properties are an ordered list that may repeat a key; duplicates collapse into the map with the last value winning (an `element_at(map, 'name')` lookup is likewise last-wins, and returns `NULL` when the key is absent). Values are raw bytes stored in VARCHAR as-is — there is no UTF-8 validation or decoding.
 

--- a/docs/ja/loading/RoutineLoad.md
+++ b/docs/ja/loading/RoutineLoad.md
@@ -428,10 +428,10 @@ JSON または Avro 形式のデータをロードする際、メッセージの
 #### 構文
 
 ```SQL
-INCLUDE METADATA ( <metadata_key> AS <alias> [, <metadata_key> AS <alias> ...] )
+INCLUDE METADATA ( <metadata_key> [AS <alias>] [, <metadata_key> [AS <alias>] ...] )
 ```
 
-`INCLUDE METADATA` はロードプロパティです。`COLUMNS` や `WHERE` などの他のロードプロパティと一緒に（順序は任意で）、`PROPERTIES` および `FROM` 句の前に配置します。`AS <alias>` は必須で、エイリアスは句内で一意であり、ペイロードフィールド、ターゲットテーブルのカラム、予約カラム名と衝突してはいけません。
+`INCLUDE METADATA` はロードプロパティです。`COLUMNS` や `WHERE` などの他のロードプロパティと一緒に（順序は任意で）、`PROPERTIES` および `FROM` 句の前に配置します。`AS <alias>` は任意です。省略した場合、エイリアスは `<metadata_key>` になります。エイリアスは句内で一意であり、ペイロードフィールド、ターゲットテーブルのカラム、予約カラム名と衝突してはいけません。
 
 #### メタデータキー
 
@@ -458,7 +458,7 @@ INCLUDE METADATA ( <metadata_key> AS <alias> [, <metadata_key> AS <alias> ...] )
 #### 使用上の注意
 
 - `INCLUDE METADATA` は `format = json`（Kafka および Pulsar）と `format = avro`（Kafka のみ。Pulsar Routine Load は Avro 非対応）で使用できます。1 つのメッセージが複数行に展開される場合があり、メッセージごとのメタデータが曖昧になるため、CSV ではサポートされません。
-- メタデータのエイリアスは通常のソースカラムです。`COLUMNS` 式の任意の場所で参照できます。エイリアスは明示的に選択されるため、同名のペイロードフィールドが隠されることはありません。
+- メタデータのエイリアスは通常のソースカラムです。`COLUMNS` 式の任意の場所で参照できます。ペイロードフィールドがメタデータキーと同じ名前の場合は、曖昧さを避けるために `AS <alias>` で別のエイリアスを指定してください。
 - `OFFSET` は Kafka 専用、`MESSAGE_ID` は Pulsar 専用です。ソースがサポートしないキーを使用すると、そのソースがサポートするキーを列挙したエラーが発生します。
 - `HEADERS`/`PROPERTIES` の型は `MAP\<VARCHAR, VARCHAR>` です。ソースの header/property は順序付きリストでキーが重複する場合があり、重複はマップに折りたたまれて最後の値が有効になります（`element_at(map, 'name')` ルックアップも同様に最後の値が有効で、キーが存在しない場合は `NULL` を返します）。値は生バイトとしてそのまま VARCHAR に格納され、UTF-8 の検証やデコードは行われません。
 

--- a/docs/zh/loading/RoutineLoad.md
+++ b/docs/zh/loading/RoutineLoad.md
@@ -415,10 +415,10 @@ StarRocks 支持导入所有类型的 Avro 数据。导入 Avro 数据至 StarRo
 #### 语法
 
 ```SQL
-INCLUDE METADATA ( <metadata_key> AS <alias> [, <metadata_key> AS <alias> ...] )
+INCLUDE METADATA ( <metadata_key> [AS <alias>] [, <metadata_key> [AS <alias>] ...] )
 ```
 
-`INCLUDE METADATA` 是一个导入属性；将它与其他导入属性（如 `COLUMNS` 和 `WHERE`）一起放置（顺序任意），位于 `PROPERTIES` 和 `FROM` 子句之前。`AS <alias>` 是必需的，别名在子句内必须唯一，且不能与消息体字段、目标表列或保留列名冲突。
+`INCLUDE METADATA` 是一个导入属性；将它与其他导入属性（如 `COLUMNS` 和 `WHERE`）一起放置（顺序任意），位于 `PROPERTIES` 和 `FROM` 子句之前。`AS <alias>` 是可选的；如果省略，别名默认为 `<metadata_key>`。别名在子句内必须唯一，且不能与消息体字段、目标表列或保留列名冲突。
 
 #### 元数据键
 
@@ -445,7 +445,7 @@ INCLUDE METADATA ( <metadata_key> AS <alias> [, <metadata_key> AS <alias> ...] )
 #### 使用说明
 
 - `INCLUDE METADATA` 适用于 `format = json`（Kafka 和 Pulsar）以及 `format = avro`（仅 Kafka；Pulsar Routine Load 不支持 Avro）。不支持 CSV，因为一条消息可能展开为多行，每条消息的元数据会产生歧义。
-- 元数据别名是普通的源列：可在 `COLUMNS` 表达式的任何位置引用。由于别名是显式选择的，同名的消息体字段不会被遮蔽。
+- 元数据别名是普通的源列：可在 `COLUMNS` 表达式的任何位置引用。如果消息体字段与元数据键同名，请通过 `AS <alias>` 指定不同的别名以避免歧义。
 - `OFFSET` 仅适用于 Kafka，`MESSAGE_ID` 仅适用于 Pulsar；对数据源使用不支持的键会报错，错误信息会列出该数据源支持的键。
 - `HEADERS`/`PROPERTIES` 的类型是 `MAP\<VARCHAR, VARCHAR>`。源端的 header/property 是一个有序列表，键可能重复；重复键折叠进 map 时最后的值生效（`element_at(map, 'name')` 查找同样是最后值生效，键不存在时返回 `NULL`）。值以原始字节按原样存入 VARCHAR——不做 UTF-8 校验或解码。
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMetadata.java
@@ -32,10 +32,10 @@ import java.util.Map;
 import java.util.Set;
 
 // Routine-load source metadata (INCLUDE METADATA clause).
-// INCLUDE METADATA (<KEY> AS <alias>, ...) binds per-message Kafka/Pulsar metadata to hidden source
+// INCLUDE METADATA (<KEY> [AS <alias>], ...) binds per-message Kafka/Pulsar metadata to hidden source
 // columns the BE scanner fills from the message rather than the payload, so a payload field named
-// like a metadata field is never shadowed. Each alias becomes a source column referenced by COLUMNS
-// exprs. The kinds mirror TStreamSourceMetaKind in PlanNodes.thrift.
+// like a metadata field is never shadowed. Each alias, or the metadata key when no alias is specified,
+// becomes a source column referenced by COLUMNS exprs. The kinds mirror TStreamSourceMetaKind in PlanNodes.thrift.
 public class RoutineLoadMetadata {
     private RoutineLoadMetadata() {
     }
@@ -140,7 +140,7 @@ public class RoutineLoadMetadata {
             }
             String alias = item.getAlias();
             if (alias == null || alias.isEmpty()) {
-                throw new DdlException("INCLUDE METADATA requires an alias (AS <name>) for key " + item.getKey());
+                throw new DdlException("INCLUDE METADATA has an empty alias for key " + item.getKey());
             }
             if (!seen.add(alias)) {
                 throw new DdlException("duplicate INCLUDE METADATA alias: " + alias);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ImportMetadataStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ImportMetadataStmt.java
@@ -19,10 +19,10 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
-// The INCLUDE METADATA (<key> AS <alias>, ...) clause of a routine-load statement. Each item binds a
+// The INCLUDE METADATA (<key> [AS <alias>], ...) clause of a routine-load statement. Each item binds a
 // source-metadata key (KEY, PARTITION, OFFSET, TIMESTAMP_MS, HEADERS, MESSAGE_ID, ...) to a hidden
-// source column named <alias> that COLUMNS exprs reference. The key is the raw text; it is validated
-// against the data source and mapped to a metadata kind in the analyzer
+// source column that COLUMNS exprs reference. When AS <alias> is omitted, the alias defaults to the key.
+// The key is the raw text; it is validated against the data source and mapped to a metadata kind in the analyzer
 // (see RoutineLoadMetadata.validateIncludeMetadata).
 public class ImportMetadataStmt extends StatementBase {
     public static class Item {
@@ -64,7 +64,7 @@ public class ImportMetadataStmt extends StatementBase {
         return items;
     }
 
-    // Renders the clause as it appears in CREATE ROUTINE LOAD, e.g. INCLUDE METADATA(KEY AS `k`, ...).
+    // Renders the clause with explicit aliases, e.g. INCLUDE METADATA(KEY AS `k`, ...).
     // Both RoutineLoadDesc.toSql (origStmt persistence) and SHOW CREATE ROUTINE LOAD render through this
     // single helper so the persisted and shown forms cannot drift. Keys are validated keywords emitted
     // as-is; the alias is rendered with the shared ParseUtil.backquote helper, so a reserved-word alias

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -10079,7 +10079,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             } else {
                 key = metaKeyContext.getText();
             }
-            String alias = ((Identifier) visit(itemContext.alias)).getValue();
+            String alias = itemContext.alias == null ? key : ((Identifier) visit(itemContext.alias)).getValue();
             items.add(new ImportMetadataStmt.Item(key, alias, createPos(itemContext)));
         }
         return new ImportMetadataStmt(items, createPos(context));

--- a/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/RoutineLoadDescTest.java
@@ -105,4 +105,25 @@ public class RoutineLoadDescTest {
                         " PROPERTIES (\"format\"=\"json\") FROM KAFKA (\"kafka_topic\" = \"my_topic\")", 0), null);
         Assertions.assertEquals("from", reservedReparsed.getMetadata().getItems().get(0).getAlias());
     }
+
+    @Test
+    public void testIncludeMetadataAliasOptional() throws Exception {
+        RoutineLoadDesc originLoad = CreateRoutineLoadStmt.getLoadDesc(new OriginStatementInfo(
+                "CREATE ROUTINE LOAD job ON tbl " +
+                        "INCLUDE METADATA(topic, KEY AS k), " +
+                        "COLUMNS(topic, k) " +
+                        "PROPERTIES (\"format\"=\"json\") " +
+                        "FROM KAFKA (\"kafka_topic\" = \"my_topic\")", 0), null);
+
+        Assertions.assertNotNull(originLoad.getMetadata());
+        Assertions.assertEquals(2, originLoad.getMetadata().getItems().size());
+        Assertions.assertEquals("topic", originLoad.getMetadata().getItems().get(0).getKey());
+        Assertions.assertEquals("topic", originLoad.getMetadata().getItems().get(0).getAlias());
+        Assertions.assertEquals("KEY", originLoad.getMetadata().getItems().get(1).getKey());
+        Assertions.assertEquals("k", originLoad.getMetadata().getItems().get(1).getAlias());
+
+        RoutineLoadDesc desc = new RoutineLoadDesc();
+        desc.setMetadata(originLoad.getMetadata());
+        Assertions.assertEquals("INCLUDE METADATA(topic AS `topic`, KEY AS `k`)", desc.toSql());
+    }
 }

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -1437,7 +1437,7 @@ includeMetadata
     ;
 
 metadataItem
-    : metaKey AS alias=identifier
+    : metaKey (AS alias=identifier)?
     ;
 
 metaKey


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

  Make INCLUDE METADATA accept metadata items without explicit AS aliases.
  When AS <alias> is omitted, use the metadata key as the alias and keep
  rendered SQL explicit with AS.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
