### PR TITLE
[BugFix] Fix Iceberg manifest data-file cache serving an incomplete file set (backport #76215)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -290,8 +291,10 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
             return entries;
         }
 
-        Set<DataFile> tmpDataFiles = Sets.newHashSet();
-        Set<DeleteFile> tmpDeleteFiles = Sets.newHashSet();
+        // Concurrent set: a plain HashSet mutated by the parallel manifest fill can report size()==expected
+        // while missing a file, letting an incomplete entry pass the read-side size check.
+        Set<DataFile> tmpDataFiles = ConcurrentHashMap.newKeySet();
+        Set<DeleteFile> tmpDeleteFiles = ConcurrentHashMap.newKeySet();
         if (shouldCacheDataFiles) {
             final Set<Integer> requestedColumnIds =
                     identifierFieldIds != null && !identifierFieldIds.isEmpty() ? identifierFieldIds : null;

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -607,6 +607,12 @@ public class StarRocksIcebergTableScan
         }
 
         if (files != null) {
+            if (!files.isEmpty()) {
+                // A non-empty entry that fails the count check is a corrupted/incomplete cache write, not a
+                // normal empty placeholder; log it so this failure path is no longer silent.
+                LOG.warn("Dropping incomplete Iceberg manifest cache entry {}: cached {} files, manifest expects {}",
+                        manifest.path(), files.size(), expectedLiveFilesCount(manifest));
+            }
             cache.invalidate(manifest.path());
         }
         return null;

--- a/fe/fe-core/src/test/java/org/apache/iceberg/StarRocksIcebergTableScanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/iceberg/StarRocksIcebergTableScanTest.java
@@ -105,6 +105,33 @@ public class StarRocksIcebergTableScanTest {
         Assertions.assertFalse(keep.contains(3), "non-key column dropped");
     }
 
+    // The on-read completeness check compares only cardinality, so a cache entry that lost one live file
+    // but is padded back to the expected size is served as "complete" and silently drops rows.
+    @Test
+    public void testCompletenessCheckIsContentBlindToSizeMatchingWrongFileSet() {
+        // Manifest advertises three live files; the true set is {f1, f2, f3}.
+        ManifestFile manifest = mockManifestFile("three-live-files-manifest", 1, 2);
+        DataFile f1 = Mockito.mock(DataFile.class);
+        DataFile f2 = Mockito.mock(DataFile.class);
+        DataFile f3 = Mockito.mock(DataFile.class);
+
+        // Corrupted entry: f3 is missing but a stale file pads the size back to three.
+        DataFile stale = Mockito.mock(DataFile.class);
+        Set<DataFile> corrupted = Set.of(f1, f2, stale);
+        Assertions.assertFalse(corrupted.contains(f3), "precondition: a genuine live file is absent");
+
+        Assertions.assertTrue(StarRocksIcebergTableScan.isCompleteCachedFiles(manifest, corrupted),
+                "size-only check accepts a wrong-content set of the expected size -- the check is content-blind");
+
+        @SuppressWarnings("unchecked")
+        Cache<String, Set<DataFile>> cache = Mockito.mock(Cache.class);
+        Mockito.when(cache.getIfPresent(manifest.path())).thenReturn(corrupted);
+
+        Set<DataFile> served = StarRocksIcebergTableScan.getCompleteCachedFiles(cache, manifest);
+        Assertions.assertSame(corrupted, served, "the corrupted entry is served to the query verbatim");
+        Mockito.verify(cache, Mockito.never()).invalidate(manifest.path());
+    }
+
     private ManifestFile mockManifestFile(String path, Integer existingFilesCount, Integer addedFilesCount) {
         ManifestFile manifest = Mockito.mock(ManifestFile.class);
         Mockito.when(manifest.path()).thenReturn(path);


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/11562

The FE Iceberg manifest data-file cache can serve a cached file set that is missing a live data file while still passing the read-side completeness check, so scan planning silently drops the file and the query returns a short result (e.g. `count(*)` under-counts by exactly one data file's rows). It reproduces intermittently right after a commit — when metadata-cache refresh, statistics collection and the first query fill the cache concurrently — and self-heals once the entry is evicted, so a serial re-run passes.

## What I'm doing:

`ManifestReader.fillCacheIfNeeded` accumulated the cached data files into a plain `HashSet`. That set can be mutated by the parallel manifest fill, and a concurrent mutation can leave `size()` reporting the expected live-file count while an element is actually lost. The read-side check `StarRocksIcebergTableScan.isCompleteCachedFiles` only compares `size()` against `existingFilesCount + addedFilesCount`, so a set whose size lies passes the check and the missing file is dropped from planning.

Because data files have unique paths, a *trustworthy* `size() == live count` already implies completeness, so the fix makes the size trustworthy rather than adding a content checksum:

- Accumulate into `ConcurrentHashMap.newKeySet()` so `size()` stays accurate under parallel fill; the existing size check then reliably rejects and refills an incomplete entry.
- Log a warning when a non-empty cache entry fails the completeness check, since that failure path was previously silent.

Added a unit test showing the size-only completeness check is content-blind (accepts an expected-size set that is missing a live file).

Fixes #issue: N/A — race in the FE Iceberg manifest data-file cache; found during Iceberg query testing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
<hr>This is an automatic backport of pull request #76215 done by [Mergify](https://mergify.com).



