### PR TITLE
[Tool] DO NOT MERGE: TSP validation build for #76271 on pre-Arrow-24 base

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -53,6 +53,7 @@
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/index/vector/tenann/del_id_filter.h"
 #include "storage/index/vector/tenann/tenann_index_utils.h"
 #include "storage/index/vector/vector_index_reader.h"
@@ -4015,7 +4016,33 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         index_opts.segment_rows = num_rows();
 
         if (_inverted_index_ctx->inverted_index_iterators[cid] == nullptr) {
-            RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
+            // Column-mode partial update rewrites a column into a delta column group
+            // (.cols) file and leaves the base segment untouched, so the base segment's
+            // inverted index still reflects pre-update values. Mirror _apply_bitmap_index:
+            // take the index from the DCG segment when the column has been rewritten, so
+            // the index stays consistent with the data actually returned.
+            ASSIGN_OR_RETURN(std::shared_ptr<Segment> segment_ptr, _get_dcg_segment(ucid));
+            if (segment_ptr == nullptr) {
+                // find segment from delta column group failed, using main segment
+                segment_ptr = _segment;
+            } else {
+                std::shared_ptr<TabletIndex> index_meta;
+                RETURN_IF_ERROR(segment_ptr->tablet_schema().get_indexes_for_column(ucid, GIN, index_meta));
+                if (index_meta != nullptr) {
+                    ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(*index_meta));
+                    if (imp_type != InvertedImplementType::BUILTIN) {
+                        // Standalone (CLucene) inverted indexes are not produced by the DCG
+                        // writer, and the base segment's copy is stale for this column, so no
+                        // index is served. Ordinary predicates (e.g. equality) then evaluate
+                        // on the fresh column data. MATCH predicates cannot be evaluated
+                        // without an index and fail with an explicit error -- preferable to
+                        // silently filtering on pre-update values. Compaction rewrites the
+                        // base segment and restores index acceleration.
+                        continue;
+                    }
+                }
+            }
+            RETURN_IF_ERROR(segment_ptr->new_inverted_index_iterator(
                     ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts, index_opts));
             _inverted_index_ctx->has_inverted_index |= (_inverted_index_ctx->inverted_index_iterators[cid] != nullptr);
         }

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -54,6 +54,7 @@
 #include "storage/base/short_key_index.h"
 #include "storage/chunk_variant_helper.h"
 #include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/inverted_index_option.h"
 #include "storage/row_store_encoder.h"
 #include "storage/rowset/column_writer.h" // ColumnWriter
 #include "storage/rowset/json_column_writer.h"
@@ -200,6 +201,18 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         }
 
         RETURN_IF_ERROR(_tablet_schema->get_indexes_for_column(column.unique_id(), &opts.tablet_index));
+        if (opts.need_inverted_index && _opts.segment_file_mark.rowset_path_prefix.empty()) {
+            // Writers that produce auxiliary segments without a segment file mark (e.g. the
+            // column-mode partial update .cols writer) cannot derive a valid standalone index
+            // path: the path built below would be malformed and readers never look it up.
+            // Skip standalone (CLucene) index generation there instead of writing it to a
+            // bogus location; readers fall back to evaluating predicates on the data.
+            // Footer-inlined implementations (builtin) need no path and are kept.
+            ASSIGN_OR_RETURN(auto imp_type, get_inverted_imp_type(opts.tablet_index.at(GIN)));
+            if (imp_type != InvertedImplementType::BUILTIN) {
+                opts.need_inverted_index = false;
+            }
+        }
         if (opts.need_inverted_index) {
             opts.standalone_index_file_paths.emplace(
                     GIN, IndexDescriptor::inverted_index_file_path(_opts.segment_file_mark.rowset_path_prefix,

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -402,6 +402,10 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_delta
     WritableFileOptions opts{.sync_on_close = true};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
     SegmentWriterOptions writer_options;
+    // Deliberately no segment_file_mark: a mark would make standalone (CLucene) inverted
+    // indexes collide with the base segment's (same rowset id + segment id), so the
+    // SegmentWriter skips them for .cols files. Footer-inlined (builtin) inverted indexes
+    // are still written and served to readers through the DCG segment.
     auto segment_writer =
             std::make_unique<SegmentWriter>(std::move(wfile), rowsetid_segid.segment_id, tschema, writer_options);
     RETURN_IF_ERROR(segment_writer->init(false));
@@ -497,6 +501,10 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_segme
     WritableFileOptions opts{.sync_on_close = true};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
     SegmentWriterOptions writer_options;
+    // These are full-row segments appended to the rowset, so give the writer a real file
+    // mark: standalone (CLucene) inverted indexes land at the path readers derive from
+    // (rowset path, rowset id, segment id). Mirrors RowsetUpdateState's segment rewrite.
+    writer_options.segment_file_mark = {rowset->rowset_path(), rowset->rowset_id().to_string()};
     auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), segment_id, tablet_schema, writer_options);
     RETURN_IF_ERROR(segment_writer->init());
     return std::move(segment_writer);

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -42,7 +42,9 @@
 #include "storage/tablet_reader.h"
 #include "storage/tablet_reader_params.h"
 #include "storage/tablet_schema.h"
+#include "storage/types.h"
 #include "storage/update_manager.h"
+#include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/empty_iterator.h"
 #include "storage_primitive/union_iterator.h"
 
@@ -214,6 +216,118 @@ public:
                 CHECK_OK(writer->flush_chunk(*chunk));
             }
         }
+        RowsetSharedPtr partial_rowset = *writer->build();
+        partial_rowset->set_schema(tablet->tablet_schema());
+
+        return partial_rowset;
+    }
+
+    TabletSharedPtr create_tablet_with_gin_index(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.__set_len(255);
+        request.tablet_schema.columns.push_back(k3);
+
+        TOlapTableIndex gin_index;
+        gin_index.__set_index_id(1);
+        gin_index.__set_index_name("gin_v2");
+        gin_index.__set_columns({"v2"});
+        gin_index.__set_index_type(TIndexType::GIN);
+        gin_index.__set_common_properties({{"imp_lib", "builtin"}});
+        gin_index.__set_index_properties({{"parser", "none"}});
+        request.tablet_schema.__set_indexes({gin_index});
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+        _tablets.push_back(tablet);
+        return tablet;
+    }
+
+    RowsetSharedPtr create_str_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                      const std::function<std::string(int64_t)>& str_func) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+        auto cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->as_mutable_ptr()->append_datum(Datum(key));
+            cols[1]->as_mutable_ptr()->append_datum(Datum((int16_t)(key % 100 + 1)));
+            std::string v = str_func(key);
+            cols[2]->as_mutable_ptr()->append_datum(Datum(Slice(v)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        return *writer->build();
+    }
+
+    RowsetSharedPtr create_partial_str_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                              const std::function<std::string(int64_t)>& str_func,
+                                              std::vector<int32_t>& column_indexes,
+                                              const std::shared_ptr<TabletSchema>& partial_schema,
+                                              PartialUpdateMode mode = PartialUpdateMode::COLUMN_UPDATE_MODE) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = partial_schema;
+        writer_context.referenced_column_ids = column_indexes;
+        writer_context.full_tablet_schema = tablet->tablet_schema();
+        writer_context.is_partial_update = true;
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        writer_context.partial_update_mode = mode;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(partial_schema);
+
+        auto chunk = ChunkFactory::new_chunk(schema, keys.size());
+        for (int64_t key : keys) {
+            chunk->get_column_raw_ptr_by_index(0)->append_datum(Datum(key));
+            std::string v = str_func(key);
+            chunk->get_column_raw_ptr_by_index(1)->append_datum(Datum(Slice(v)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
         RowsetSharedPtr partial_rowset = *writer->build();
         partial_rowset->set_schema(tablet->tablet_schema());
 
@@ -1674,6 +1788,83 @@ TEST_P(RowsetColumnPartialUpdateTest, test_meta_reader_with_multiple_dcg_columns
     // 3. DCG file access with encryption (lines 262-269)
     auto status = collecter.open();
     // Success or failure is okay - we're testing code coverage
+}
+
+// Count rows matching `v2 == value` through a TabletReader scan, optionally letting the
+// GIN inverted index prune rows. Also re-checks every returned row against the predicate,
+// which catches the erased-predicate-without-recheck failure mode.
+static StatusOr<int64_t> count_rows_with_str_eq(const TabletSharedPtr& tablet, int64_t version, ColumnId cid,
+                                                const std::string& value, bool enable_gin_filter) {
+    Schema schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, version), schema);
+    RETURN_IF_ERROR(reader.prepare());
+    TabletReaderParams params;
+    params.enable_gin_filter = enable_gin_filter;
+    std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(get_type_info(TYPE_VARCHAR), cid, Slice(value)));
+    PredicateAndNode and_node;
+    and_node.add_child(PredicateColumnNode(pred.get()));
+    params.pred_tree = PredicateTree::create(std::move(and_node));
+    std::vector<ChunkIteratorPtr> seg_iters;
+    RETURN_IF_ERROR(reader.get_segment_iterators(params, &seg_iters));
+    int64_t rows = 0;
+    for (auto& iter : seg_iters) {
+        auto chunk = ChunkFactory::new_chunk(iter->schema(), 100);
+        while (true) {
+            chunk->reset();
+            auto st = iter->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            RETURN_IF_ERROR(st);
+            for (int r = 0; r < chunk->num_rows(); r++) {
+                if (chunk->columns()[cid]->get(r).get_slice().to_string() != value) {
+                    return Status::InternalError("returned row does not match the predicate");
+                }
+            }
+            rows += chunk->num_rows();
+        }
+        iter->close();
+    }
+    return rows;
+}
+
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_with_gin_index_check) {
+    // Column-mode partial update rewrites a column into a DCG (.cols) file while the base
+    // segment's inverted index still reflects pre-update values. The reader must serve the
+    // GIN index from the DCG segment, or GIN-filtered queries silently return wrong rows.
+    const int N = 100;
+    auto tablet = create_tablet_with_gin_index(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    int64_t version = 1;
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.emplace_back(create_str_rowset(tablet, keys, [](int64_t k) { return "old_" + std::to_string(k); }));
+    commit_rowsets(tablet, rowsets, version);
+
+    // GIN-accelerated read against the base segment works.
+    ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_5", true).value());
+
+    // Column-mode partial update: v2 = "new_<pk>" for the first half of the keys.
+    std::vector<int64_t> update_keys(keys.begin(), keys.begin() + N / 2);
+    std::vector<int32_t> column_indexes = {0, 2};
+    std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(tablet->tablet_schema(), column_indexes);
+    RowsetSharedPtr partial_rowset = create_partial_str_rowset(
+            tablet, update_keys, [](int64_t k) { return "new_" + std::to_string(k); }, column_indexes, partial_schema);
+    auto st = tablet->rowset_commit(++version, partial_rowset, 10000);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    for (bool gin_filter : {true, false}) {
+        // An updated row must be found by its new value ...
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "new_5", gin_filter).value());
+        // ... and must no longer be found by its old value.
+        ASSERT_EQ(0, count_rows_with_str_eq(tablet, version, 2, "old_5", gin_filter).value());
+        // Rows the update did not touch keep working.
+        ASSERT_EQ(1, count_rows_with_str_eq(tablet, version, 2, "old_60", gin_filter).value());
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,


### PR DESCRIPTION
Validation-only vehicle: #76271's fix cherry-picked onto 2f4ac8f67f2 (last main commit before the Arrow 24.0.0 thirdparty upgrade #75868), because the TSP build image's prebuilt thirdparty does not yet link current main (avrocpp/roaring64 undefined references). The 4 changed files are byte-identical between this base and current main, so cluster validation on this build is representative of #76271. Will be closed after validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)