### PR TITLE
[Enhancement] Improve error messages for large column capacity limit checks

### DIFF
--- a/be/src/base/status.cpp
+++ b/be/src/base/status.cpp
@@ -277,7 +277,7 @@ std::string Status::code_as_string() const {
     case TStatusCode::JIT_COMPILE_ERROR:
         return "JIT compile error";
     case TStatusCode::CAPACITY_LIMIT_EXCEED:
-        return "Capaticy limit exceeded";
+        return "Capacity limit exceeded";
     case TStatusCode::SHUTDOWN:
         return "Shut down in progress";
     case TStatusCode::BIG_QUERY_CPU_SECOND_LIMIT_EXCEEDED:

--- a/be/src/exec/runtime/pipeline_driver.cpp
+++ b/be/src/exec/runtime/pipeline_driver.cpp
@@ -457,10 +457,11 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
 
                         if (UNLIKELY(config::pipeline_enable_large_column_checker)) {
                             if (capacity_exceed || maybe_chunk.value()->has_capacity_limit_reached()) {
+                                LOG(WARNING) << "Large column detected after " << i << "-th operator "
+                                             << curr_op->get_name() << " in " << to_readable_string();
                                 return Status::CapacityLimitExceed(
-                                        fmt::format("Large column detected at "
-                                                    "after {}-th operator {} in {}",
-                                                    i, curr_op->get_name(), to_readable_string()));
+                                        "Large column detected, please reduce rows per batch or the size of "
+                                        "string/array values");
                             }
                         }
 


### PR DESCRIPTION
## Why I'm doing:

When the large-column capacity checker trips, the error returned to the client
embedded internal diagnostics — the driver's raw pointer (`addr=this`) and the
full operator chain from `to_readable_string()`. That is internal debugging
information that should not reach end users, and it gives them nothing
actionable. Separately, the shared status string for `CAPACITY_LIMIT_EXCEED`
had a typo ("Capaticy").

## What I'm doing:

1. Fix the typo `Capaticy` -> `Capacity` in the shared status string
   (`code_as_string`), which is the common prefix for all
   `CapacityLimitExceed` results.
2. In the pipeline driver's large-column checker, keep the detailed diagnostics
   (operator index/name, query id, driver address, full operator chain) in
   `be.WARNING` for operators/developers, and return a concise, actionable
   message to the client instead:
   `Large column detected, please reduce rows per batch or the size of string/array values`

No functional change — the guard still trips on the same condition; only the
user-visible message text and the destination of the internal diagnostics change.

Fixes #76302

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
