### PR TITLE
[BugFix] Honor CREATE TABLE IF NOT EXISTS on Iceberg REST catalogs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -312,7 +312,7 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
-    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         return normal.createTable(context, stmt);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -319,7 +319,7 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
-    default boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+    default boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         throw new StarRocksConnectorException("This connector doesn't support creating tables");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -337,7 +337,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
 
@@ -356,8 +356,12 @@ public class IcebergMetadata implements ConnectorMetadata {
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
         SortOrder sortOrder = IcebergApiConverter.toIcebergSortOrder(schema, stmt.getOrderByElements());
 
-        return icebergCatalog.createTable(context, dbName, tableName, schema, partitionSpec, tableLocation,
-                sortOrder, createTableProperties);
+        try {
+            return icebergCatalog.createTable(context, dbName, tableName, schema, partitionSpec, tableLocation,
+                    sortOrder, createTableProperties);
+        } catch (org.apache.iceberg.exceptions.AlreadyExistsException e) {
+            throw new AlreadyExistsException("Table Already Exists: " + tableName);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -282,7 +282,7 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     }
 
     @Override
-    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(ConnectContext context, CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         requireNonNull(stmt.getEngineName(), "engine name is null");
         Table.TableType type = Table.TableType.deserialize(stmt.getEngineName().toUpperCase());
         return metadataMap.get(type).createTable(context, stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -309,7 +309,15 @@ public class MetadataMgr {
                     }
                 }
             }
-            return connectorMetadata.get().createTable(context, stmt);
+            try {
+                return connectorMetadata.get().createTable(context, stmt);
+            } catch (AlreadyExistsException e) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, stmt.getTableName());
+                }
+                LOG.info("create table[{}] which already exists", stmt.getTableName());
+                return false;
+            }
         } else {
             throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }
@@ -366,7 +374,15 @@ public class MetadataMgr {
                     ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
                 }
             }
-            return connectorMetadata.get().createTable(context, stmt);
+            try {
+                return connectorMetadata.get().createTable(context, stmt);
+            } catch (AlreadyExistsException e) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
+                }
+                LOG.info("create temporary table[{}] which already exists in session[{}]", tableName, sessionId);
+                return false;
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -86,6 +86,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnPosition;
 import com.starrocks.sql.ast.ColumnRenameClause;
+import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropPartitionColumnClause;
 import com.starrocks.sql.ast.DropTableStmt;
@@ -516,6 +517,67 @@ public class IcebergMetadataTest extends TableTestBase {
 
             metadata.createDb(connectContext, "iceberg_db", new HashMap<>());
         });
+    }
+
+    @Test
+    public void testCreateTableTranslatesConnectorAlreadyExists(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) {
+        new Expectations() {
+            {
+                stmt.getDbName();
+                result = "db";
+                minTimes = 0;
+                stmt.getTableName();
+                result = "tbl";
+                minTimes = 0;
+                stmt.getColumns();
+                result = Lists.newArrayList(new Column("id", IntegerType.INT));
+                minTimes = 0;
+                stmt.getPartitionDesc();
+                result = null;
+                minTimes = 0;
+
+                icebergHiveCatalog.createTable((ConnectContext) any, anyString, anyString, (Schema) any,
+                        (PartitionSpec) any, anyString, (SortOrder) any, (Map<String, String>) any);
+                result = new org.apache.iceberg.exceptions.AlreadyExistsException("Table already exists: db.tbl");
+                times = 1;
+            }
+        };
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        AlreadyExistsException e = assertThrows(AlreadyExistsException.class,
+                () -> metadata.createTable(connectContext, stmt));
+        Assertions.assertTrue(e.getMessage().contains("tbl"),
+                "translated message should carry the table name, but was: " + e.getMessage());
+    }
+
+    @Test
+    public void testCreateTableReturnsConnectorResult(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) throws Exception {
+        new Expectations() {
+            {
+                stmt.getDbName();
+                result = "db";
+                minTimes = 0;
+                stmt.getTableName();
+                result = "tbl";
+                minTimes = 0;
+                stmt.getColumns();
+                result = Lists.newArrayList(new Column("id", IntegerType.INT));
+                minTimes = 0;
+                stmt.getPartitionDesc();
+                result = null;
+                minTimes = 0;
+
+                icebergHiveCatalog.createTable((ConnectContext) any, anyString, anyString, (Schema) any,
+                        (PartitionSpec) any, anyString, (SortOrder) any, (Map<String, String>) any);
+                result = true;
+                times = 1;
+            }
+        };
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        Assertions.assertTrue(metadata.createTable(connectContext, stmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -171,7 +171,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHiveConnector() throws DdlException {
+    public void testRouteToHiveConnector() throws DdlException, AlreadyExistsException {
         HiveTable hiveTable = new HiveTable();
 
         new Expectations() {
@@ -241,7 +241,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException {
+    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
         Table icebergTable = new IcebergTable();
 
         new Expectations() {
@@ -337,7 +337,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHudiConnector() throws DdlException {
+    public void testRouteToHudiConnector() throws DdlException, AlreadyExistsException {
         HudiTable hudiTable = new HudiTable();
 
         new Expectations() {
@@ -412,7 +412,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException {
+    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
         Table deltaLakeTable = new DeltaLakeTable();
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
@@ -33,6 +35,10 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.CreateTemporaryTableStmt;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -49,6 +55,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -287,6 +294,98 @@ public class MetadataMgrTest {
         } finally {
             dropCatalogIfExists(catalogName);
         }
+    }
+
+    @Test
+    public void testCreateTableHonorsConnectorAlreadyExists(@Mocked ConnectorMetadata connectorMetadata) throws Exception {
+        String catalogName = "iceberg_catalog_metadata_mgr_already_exists";
+        ConnectContext context = AnalyzeTestUtil.getConnectContext();
+        MetadataMgr metadataMgr = context.getGlobalStateMgr().getMetadataMgr();
+
+        CreateTableStmt createTableStmt = new CreateTableStmt(false, true,
+                new TableRef(QualifiedName.of(Lists.newArrayList(catalogName, "iceberg_db", "iceberg_table")),
+                        null, NodePosition.ZERO),
+                Collections.emptyList(), "iceberg", null, null, null, null, null, null);
+
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getOptionalMetadata(catalogName);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, catalogName, "iceberg_db");
+                result = new com.starrocks.catalog.Database();
+                minTimes = 0;
+
+                metadataMgr.tableExists((ConnectContext) any, catalogName, "iceberg_db", "iceberg_table");
+                result = false;
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
+                connectorMetadata.createTable((ConnectContext) any, (CreateTableStmt) any);
+                result = new AlreadyExistsException("Table Already Exists: iceberg_table");
+                minTimes = 0;
+            }
+        };
+
+        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
+        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTable(context, createTableStmt));
+        Assertions.assertTrue(e.getMessage().contains("iceberg_table"));
+
+        // With IF NOT EXISTS, the create becomes a no-op that returns false.
+        createTableStmt.setIfNotExists();
+        Assertions.assertFalse(metadataMgr.createTable(context, createTableStmt));
+    }
+
+    @Test
+    public void testCreateTemporaryTableHonorsConnectorAlreadyExists(
+            @Mocked ConnectorMetadata connectorMetadata,
+            @Mocked LocalMetastore localMetastore,
+            @Mocked TemporaryTableMgr temporaryTableMgr) throws Exception {
+        ConnectContext context = AnalyzeTestUtil.getConnectContext();
+        MetadataMgr metadataMgr = context.getGlobalStateMgr().getMetadataMgr();
+
+        CreateTemporaryTableStmt stmt = new CreateTemporaryTableStmt(false, false,
+                new TableRef(QualifiedName.of(
+                        Lists.newArrayList(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, "test_db", "test_tbl")),
+                        null, NodePosition.ZERO),
+                Collections.emptyList(), null, null, null, null, null, null,
+                Collections.emptyMap(), Collections.emptyMap(), null,
+                Collections.emptyList(), Collections.emptyList(), NodePosition.ZERO);
+        stmt.setSessionId(UUIDUtil.genUUID());
+
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getOptionalMetadata(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
+                localMetastore.getDb("test_db");
+                result = new com.starrocks.catalog.Database();
+                minTimes = 0;
+
+                temporaryTableMgr.tableExists((UUID) any, anyLong, "test_tbl");
+                result = false;
+                minTimes = 0;
+
+                connectorMetadata.createTable((ConnectContext) any, (CreateTableStmt) any);
+                result = new AlreadyExistsException("Table Already Exists: test_tbl");
+                minTimes = 0;
+            }
+        };
+
+        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
+        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTemporaryTable(context, stmt));
+        Assertions.assertTrue(e.getMessage().contains("test_tbl"));
+
+        // With IF NOT EXISTS, the create becomes a no-op that returns false.
+        stmt.setIfNotExists();
+        Assertions.assertFalse(metadataMgr.createTemporaryTable(context, stmt));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Context: I run StarRocks with an Iceberg (REST) catalog in production. This is a follow-up to #75017 (`Honor CREATE DATABASE IF NOT EXISTS on Iceberg REST catalogs`, already backported to 3.5): I initially reported only the `CREATE DATABASE` case I had hit, and while further auditing the same exception-translation gap I found `CREATE TABLE IF NOT EXISTS` has the identical problem, which this PR fixes.

On Iceberg catalogs (notably the REST catalog), `CREATE TABLE IF NOT EXISTS <tbl>` can fail with an error when the table already exists, instead of being silently ignored as the `IF NOT EXISTS` clause promises.

The root cause is an exception-type mismatch at the StarRocks ↔ Iceberg boundary — the same class of bug already fixed for `CREATE DATABASE IF NOT EXISTS` in #75017. `MetadataMgr.createTable()` pre-checks existence with `tableExists()` and honors `IF NOT EXISTS` there. `tableExists()` is a live catalog probe, so a single sequential statement is correctly handled; but under concurrent creation of the same table there is a TOCTOU window where several statements pass the pre-check (table not yet created) and then race into the actual create. The Iceberg client (notably the REST catalog) then throws its own `org.apache.iceberg.exceptions.AlreadyExistsException` for the losers of the race, which is an unrelated class to StarRocks' `com.starrocks.common.AlreadyExistsException`. That connector-level exception leaks through unchanged, so the upper layer never recognizes it as "already exists" and the statement errors out.

Reproduced on StarRocks 4.1.1 + Iceberg REST catalog: 23 of 24 concurrent `CREATE TABLE IF NOT EXISTS` statements failed with a leaked `org.apache.iceberg.exceptions.AlreadyExistsException: Table already exists: ...` (a single serial statement is correctly a no-op, because the live pre-check catches it).

## What I'm doing:

Translate the connector-level `org.apache.iceberg.exceptions.AlreadyExistsException` thrown by `icebergCatalog.createTable()` into StarRocks' `com.starrocks.common.AlreadyExistsException`, carrying the table name in the message. This mirrors the `CREATE DATABASE IF NOT EXISTS` fix (#75017). The upper layer then recognizes the condition and honors `IF NOT EXISTS` (silently ignore) or reports a clean `ERR_TABLE_EXISTS_ERROR`.

- `IcebergMetadata.createTable()`: wrap the `createTable` call in try/catch and rethrow the Iceberg exception as StarRocks `AlreadyExistsException`.
- Thread the checked `AlreadyExistsException` through the connector chain so the translated exception can propagate: `ConnectorMetadata`, `CatalogConnectorMetadata`, `UnifiedMetadata`.
- `MetadataMgr.createTable()` / `createTemporaryTable()`: catch the translated exception and reuse the existing `IF NOT EXISTS` handling (return `false` when set, otherwise report `ERR_TABLE_EXISTS_ERROR`). The exception is absorbed here, so the DDL/statement executors and other callers are unaffected.
- Added a unit test `testCreateTableTranslatesConnectorAlreadyExists` that mocks the catalog to throw the Iceberg exception and asserts the translated StarRocks exception (type + message) is raised.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
