### PR TITLE
[BugFix] Honor CREATE TABLE IF NOT EXISTS on Iceberg REST catalogs (backport #76307)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -257,7 +257,7 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         return normal.createTable(stmt);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -259,7 +259,7 @@ public interface ConnectorMetadata {
         return Lists.newArrayList();
     }
 
-    default boolean createTable(CreateTableStmt stmt) throws DdlException {
+    default boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         throw new StarRocksConnectorException("This connector doesn't support creating tables");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -267,7 +267,7 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         String dbName = stmt.getDbName();
         String tableName = stmt.getTableName();
 
@@ -284,7 +284,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         }
         Map<String, String> createTableProperties = IcebergApiConverter.rebuildCreateTableProperties(properties);
 
-        return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);
+        try {
+            return icebergCatalog.createTable(dbName, tableName, schema, partitionSpec, tableLocation, createTableProperties);
+        } catch (org.apache.iceberg.exceptions.AlreadyExistsException e) {
+            throw new AlreadyExistsException("Table Already Exists: " + tableName);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -250,7 +250,7 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public boolean createTable(CreateTableStmt stmt) throws DdlException {
+    public boolean createTable(CreateTableStmt stmt) throws DdlException, AlreadyExistsException {
         requireNonNull(stmt.getEngineName(), "engine name is null");
         Table.TableType type = Table.TableType.deserialize(stmt.getEngineName().toUpperCase());
         return metadataMap.get(type).createTable(stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -297,7 +297,15 @@ public class MetadataMgr {
                     }
                 }
             }
-            return connectorMetadata.get().createTable(stmt);
+            try {
+                return connectorMetadata.get().createTable(stmt);
+            } catch (AlreadyExistsException e) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, stmt.getTableName());
+                }
+                LOG.info("create table[{}] which already exists", stmt.getTableName());
+                return false;
+            }
         } else {
             throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }
@@ -354,7 +362,15 @@ public class MetadataMgr {
                     ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
                 }
             }
-            return connectorMetadata.get().createTable(stmt);
+            try {
+                return connectorMetadata.get().createTable(stmt);
+            } catch (AlreadyExistsException e) {
+                if (!stmt.isSetIfNotExists()) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_TABLE_EXISTS_ERROR, tableName);
+                }
+                LOG.info("create temporary table[{}] which already exists in session[{}]", tableName, sessionId);
+                return false;
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -75,6 +75,7 @@ import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ColumnRenameClause;
+import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ModifyColumnClause;
@@ -110,6 +111,8 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
@@ -371,6 +374,67 @@ public class IcebergMetadataTest extends TableTestBase {
                 () -> metadata.createDb("TEST_PROBE", new HashMap<>()));
         Assertions.assertTrue(e.getMessage().contains("TEST_PROBE"),
                 "translated message should carry the database name, but was: " + e.getMessage());
+    }
+
+    @Test
+    public void testCreateTableTranslatesConnectorAlreadyExists(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) {
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        new Expectations() {
+            {
+                stmt.getDbName();
+                result = "db";
+                minTimes = 0;
+                stmt.getTableName();
+                result = "tbl";
+                minTimes = 0;
+                stmt.getColumns();
+                result = Lists.newArrayList(new Column("id", Type.INT));
+                minTimes = 0;
+                stmt.getPartitionDesc();
+                result = null;
+                minTimes = 0;
+
+                icebergHiveCatalog.createTable(anyString, anyString, (Schema) any,
+                        (PartitionSpec) any, anyString, (Map<String, String>) any);
+                result = new org.apache.iceberg.exceptions.AlreadyExistsException("Table already exists: db.tbl");
+                times = 1;
+            }
+        };
+        AlreadyExistsException e = assertThrows(AlreadyExistsException.class,
+                () -> metadata.createTable(stmt));
+        Assertions.assertTrue(e.getMessage().contains("tbl"),
+                "translated message should carry the table name, but was: " + e.getMessage());
+    }
+
+    @Test
+    public void testCreateTableReturnsConnectorResult(
+            @Mocked IcebergHiveCatalog icebergHiveCatalog, @Mocked CreateTableStmt stmt) throws Exception {
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
+        new Expectations() {
+            {
+                stmt.getDbName();
+                result = "db";
+                minTimes = 0;
+                stmt.getTableName();
+                result = "tbl";
+                minTimes = 0;
+                stmt.getColumns();
+                result = Lists.newArrayList(new Column("id", Type.INT));
+                minTimes = 0;
+                stmt.getPartitionDesc();
+                result = null;
+                minTimes = 0;
+
+                icebergHiveCatalog.createTable(anyString, anyString, (Schema) any,
+                        (PartitionSpec) any, anyString, (Map<String, String>) any);
+                result = true;
+                times = 1;
+            }
+        };
+        Assertions.assertTrue(metadata.createTable(stmt));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -164,7 +164,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHiveConnector() throws DdlException {
+    public void testRouteToHiveConnector() throws DdlException, AlreadyExistsException {
         HiveTable hiveTable = new HiveTable();
 
         new Expectations() {
@@ -234,7 +234,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException {
+    public void testRouteToIcebergConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
         Table icebergTable = new IcebergTable();
 
         new Expectations() {
@@ -330,7 +330,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToHudiConnector() throws DdlException {
+    public void testRouteToHudiConnector() throws DdlException, AlreadyExistsException {
         HudiTable hudiTable = new HudiTable();
 
         new Expectations() {
@@ -405,7 +405,7 @@ public class UnifiedMetadataTest {
     }
 
     @Test
-    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException {
+    public void testRouteToDeltaLakeConnector(@Mocked HiveTable hiveTable) throws DdlException, AlreadyExistsException {
         Table deltaLakeTable = new DeltaLakeTable();
 
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -15,6 +15,9 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
@@ -33,6 +36,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.CreateTemporaryTableStmt;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -49,6 +53,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -277,6 +282,93 @@ public class MetadataMgrTest {
         createTableStmt.setIfNotExists();
         Assertions.assertFalse(metadataMgr.createTable(AnalyzeTestUtil.getConnectContext(), createTableStmt));
         AnalyzeTestUtil.getStarRocksAssert().dropCatalog("iceberg_catalog");
+    }
+
+    @Test
+    public void testCreateTableHonorsConnectorAlreadyExists(@Mocked ConnectorMetadata connectorMetadata) throws Exception {
+        String catalogName = "iceberg_catalog_metadata_mgr_already_exists";
+        ConnectContext context = AnalyzeTestUtil.getConnectContext();
+        MetadataMgr metadataMgr = context.getGlobalStateMgr().getMetadataMgr();
+
+        CreateTableStmt createTableStmt = new CreateTableStmt(false, true,
+                new TableName(catalogName, "iceberg_db", "iceberg_table"),
+                Collections.emptyList(), "iceberg", null, null, null, null, null, null);
+
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getOptionalMetadata(catalogName);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+
+                metadataMgr.getDb((ConnectContext) any, catalogName, "iceberg_db");
+                result = new com.starrocks.catalog.Database();
+                minTimes = 0;
+
+                metadataMgr.tableExists((ConnectContext) any, catalogName, "iceberg_db", "iceberg_table");
+                result = false;
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
+                connectorMetadata.createTable((CreateTableStmt) any);
+                result = new AlreadyExistsException("Table Already Exists: iceberg_table");
+                minTimes = 0;
+            }
+        };
+
+        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
+        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTable(context, createTableStmt));
+        Assertions.assertTrue(e.getMessage().contains("iceberg_table"));
+
+        // With IF NOT EXISTS, the create becomes a no-op that returns false.
+        createTableStmt.setIfNotExists();
+        Assertions.assertFalse(metadataMgr.createTable(context, createTableStmt));
+    }
+
+    @Test
+    public void testCreateTemporaryTableHonorsConnectorAlreadyExists(
+            @Mocked ConnectorMetadata connectorMetadata,
+            @Mocked LocalMetastore localMetastore,
+            @Mocked TemporaryTableMgr temporaryTableMgr) throws Exception {
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+
+        CreateTemporaryTableStmt stmt = new CreateTemporaryTableStmt(false, false,
+                new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, "test_db", "test_tbl"),
+                Collections.emptyList(), null, null, null, null, null, null,
+                Collections.emptyMap(), Collections.emptyMap(), null, null, null);
+        stmt.setSessionId(UUIDUtil.genUUID());
+
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.getOptionalMetadata(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
+                localMetastore.getDb("test_db");
+                result = new com.starrocks.catalog.Database();
+                minTimes = 0;
+
+                temporaryTableMgr.tableExists((UUID) any, anyLong, "test_tbl");
+                result = false;
+                minTimes = 0;
+
+                connectorMetadata.createTable((CreateTableStmt) any);
+                result = new AlreadyExistsException("Table Already Exists: test_tbl");
+                minTimes = 0;
+            }
+        };
+
+        // Without IF NOT EXISTS, the connector-level AlreadyExistsException surfaces as ERR_TABLE_EXISTS_ERROR.
+        DdlException e = assertThrows(DdlException.class, () -> metadataMgr.createTemporaryTable(stmt));
+        Assertions.assertTrue(e.getMessage().contains("test_tbl"));
+
+        // With IF NOT EXISTS, the create becomes a no-op that returns false.
+        stmt.setIfNotExists();
+        Assertions.assertFalse(metadataMgr.createTemporaryTable(stmt));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Backport of #76307 (`Honor CREATE TABLE IF NOT EXISTS on Iceberg REST catalogs`) to `branch-3.5`.

On Iceberg catalogs (notably the REST catalog), `CREATE TABLE IF NOT EXISTS <tbl>` can fail with an error when the table already exists, instead of being silently ignored as the `IF NOT EXISTS` clause promises. The Iceberg client throws its own `org.apache.iceberg.exceptions.AlreadyExistsException`, which is unrelated to StarRocks' `com.starrocks.common.AlreadyExistsException`; under concurrent creation of the same table the live `tableExists()` pre-check is bypassed by a TOCTOU race, and the untranslated connector exception leaks through and defeats the `IF NOT EXISTS` clause.

This is the same exception-translation gap already fixed for `CREATE DATABASE IF NOT EXISTS` on this branch in #75019 (backport of #75017).

## What I'm doing:

Translate the connector-level `org.apache.iceberg.exceptions.AlreadyExistsException` thrown by `icebergCatalog.createTable()` into StarRocks' `com.starrocks.common.AlreadyExistsException` in `IcebergMetadata.createTable()`, and honor `IF NOT EXISTS` in `MetadataMgr` (return `false` when set, otherwise report `ERR_TABLE_EXISTS_ERROR`). Same fix as #<MAIN_PR>, manually adapted to the 3.5 connector API:

- 3.5's `createTable` has no `ConnectContext` parameter, and the Iceberg delegate takes 6 args (no `context`, no `sortOrder`); the signatures/call sites differ from the main branch, so this is a manual backport rather than a clean cherry-pick. The translation logic itself is identical.
- Threads the checked `AlreadyExistsException` through the connector chain (`ConnectorMetadata`, `CatalogConnectorMetadata`, `UnifiedMetadata`); `MetadataMgr.createTable()` / `createTemporaryTable()` catch it, so the exception is absorbed and callers are unaffected.
- Added a unit test `testCreateTableTranslatesConnectorAlreadyExists` mirroring the existing `testCreateDbTranslatesConnectorAlreadyExists`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

