### PR TITLE
[BugFix] Fix Arrow Flight Prepared Statement Forwarding

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.CloseSessionRequest;
 import org.apache.arrow.flight.CloseSessionResult;
@@ -61,6 +62,7 @@ import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.auth2.BearerCredentialWriter;
 import org.apache.arrow.flight.grpc.CredentialCallOption;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
+import org.apache.arrow.flight.sql.FlightSqlUtils;
 import org.apache.arrow.flight.sql.SqlInfoBuilder;
 import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.memory.BufferAllocator;
@@ -189,7 +191,8 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
                 // When proxy is enabled and token is from another FE, forward the request
                 if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
-                    forwardActionToRemoteFE(token, request, listener);
+                    forwardActionToRemoteFE(token, FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType(),
+                            request, listener);
                     return;
                 }
 
@@ -232,7 +235,8 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         // When proxy is enabled and token is from another FE, forward the request
         if (isProxyEnabled() && !sessionManager.isLocalToken(token)) {
             EXECUTOR.submit(() -> {
-                forwardActionToRemoteFE(token, request, listener);
+                forwardActionToRemoteFE(token, FlightSqlUtils.FLIGHT_SQL_CLOSE_PREPARED_STATEMENT.getType(),
+                        request, listener);
             });
             return;
         }
@@ -718,11 +722,17 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     /**
      * Forward an action to the FE that issued the token.
      *
+     * <p>The {@code actionType} is the Flight SQL action-type string that the remote FE's {@code doAction} dispatcher
+     * matches on (e.g. {@code "CreatePreparedStatement"}), NOT the protobuf message name. It is supplied by the caller,
+     * which statically knows which action it is issuing.
+     *
      * @param token The bearer token containing the FE host
+     * @param actionType The Flight SQL action-type string (see {@link FlightSqlUtils})
      * @param request The protobuf action request to forward
      * @param listener The listener to receive results
      */
-    private void forwardActionToRemoteFE(String token, Message request, StreamListener<Result> listener) {
+    private void forwardActionToRemoteFE(String token, String actionType, Message request,
+                                         StreamListener<Result> listener) {
         String feHost = ArrowFlightSqlSessionManager.extractFeHost(token);
         if (feHost == null) {
             listener.onError(CallStatus.INVALID_ARGUMENT
@@ -738,9 +748,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             FlightClient client = getOrCreateClient(nodeKey, feHost, fePort);
             CredentialCallOption authOption = new CredentialCallOption(new BearerCredentialWriter(token));
 
-            org.apache.arrow.flight.Action action = new org.apache.arrow.flight.Action(
-                    request.getDescriptorForType().getFullName(),
-                    Any.pack(request).toByteArray());
+            Action action = new Action(actionType, Any.pack(request).toByteArray());
 
             Iterator<Result> results = client.doAction(action, authOption);
             while (results.hasNext()) {
@@ -748,8 +756,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             }
             listener.onCompleted();
 
-            LOG.info("[ARROW] Forwarded action {} to remote FE {}:{}",
-                    request.getDescriptorForType().getName(), feHost, fePort);
+            LOG.info("[ARROW] Forwarded action {} to remote FE {}:{}", actionType, feHost, fePort);
 
         } catch (Exception e) {
             LOG.warn("[ARROW] Failed to forward action to remote FE {}:{}", feHost, fePort, e);

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -55,6 +55,7 @@ import org.apache.arrow.flight.SetSessionOptionsRequest;
 import org.apache.arrow.flight.SetSessionOptionsResult;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
+import org.apache.arrow.flight.sql.FlightSqlUtils;
 import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ReadChannel;
@@ -1049,7 +1050,13 @@ public class ArrowFlightSqlServiceImplTest {
             testService.createPreparedStatement(createReq, callContext, listener);
             Thread.sleep(500);
 
-            verify(mockFeClient).doAction(any(org.apache.arrow.flight.Action.class), any());
+            // The forwarded action must carry the Flight SQL action-type string ("CreatePreparedStatement"),
+            // not the protobuf message name, otherwise the remote FE rejects it as "Unrecognized request".
+            ArgumentCaptor<org.apache.arrow.flight.Action> actionCaptor =
+                    ArgumentCaptor.forClass(org.apache.arrow.flight.Action.class);
+            verify(mockFeClient).doAction(actionCaptor.capture(), any());
+            assertEquals(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType(),
+                    actionCaptor.getValue().getType());
             verify(listener).onNext(mockResult);
             verify(listener).onCompleted();
         }
@@ -1088,7 +1095,13 @@ public class ArrowFlightSqlServiceImplTest {
             testService.closePreparedStatement(closeReq, callContext, listener);
             Thread.sleep(500);
 
-            verify(mockFeClient).doAction(any(org.apache.arrow.flight.Action.class), any());
+            // The forwarded action must carry the Flight SQL action-type string ("ClosePreparedStatement"),
+            // not the protobuf message name, otherwise the remote FE rejects it as "Unrecognized request".
+            ArgumentCaptor<org.apache.arrow.flight.Action> actionCaptor =
+                    ArgumentCaptor.forClass(org.apache.arrow.flight.Action.class);
+            verify(mockFeClient).doAction(actionCaptor.capture(), any());
+            assertEquals(FlightSqlUtils.FLIGHT_SQL_CLOSE_PREPARED_STATEMENT.getType(),
+                    actionCaptor.getValue().getType());
             verify(listener).onCompleted();
         }
     }


### PR DESCRIPTION
## Why I'm doing:
When behind a round-robin load balancer, a `CreatePreparedStatement/ClosePreparedStatement` that lands on a different FE than the one holding the session is forwarded with the protobuf message name (`arrow.flight.protocol.sql.ActionCreatePreparedStatementRequest`) as the action type instead of the Flight SQL action type (`CreatePreparedStatement`), so the remote FE rejects it as `Unrecognized request` and every ADBC client that opens with a prepared statement fails.
## What I'm doing:
Passing the correct Flight SQL action-type string from each call site into `forwardActionToRemoteFE` so the forwarded doAction matches the remote FE's dispatcher.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
