### PR TITLE
[Tool] image-rebuild-three-digit: gate centos7/rocky9 promote by branch version

### DIFF
--- a/.github/workflows/image-rebuild-three-digit.yml
+++ b/.github/workflows/image-rebuild-three-digit.yml
@@ -46,6 +46,8 @@ jobs:
     if: github.event.pull_request.merged == true
     outputs:
       thirdparty: ${{ steps.filter-info.outputs.thirdparty }}
+      centos7: ${{ steps.distro.outputs.centos7 }}
+      rocky9: ${{ steps.distro.outputs.rocky9 }}
     steps:
       - uses: dorny/paths-filter@v3
         id: linux-thirdparty-filter
@@ -68,6 +70,24 @@ jobs:
           fi
           echo "thirdparty=${thirdparty}" >> $GITHUB_OUTPUT
 
+      - name: Decide distros by version
+        id: distro
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # rocky9 replaces centos7 from 4.2 onward (CentOS 7 EOL):
+          #   < 4.2  -> ubuntu + centos7
+          #   >= 4.2 -> ubuntu + rocky9
+          # Without this, a three-digit branch promotes a distro whose per-PR
+          # source image was never built (e.g. rocky9 on branch-4.1.x), and
+          # elastic-update-image.sh's `imagetools create` fails with "not found".
+          ver=${BASE_REF#branch-}; major=${ver%%.*}; rest=${ver#*.}; minor=${rest%%.*}
+          if (( major > 4 || (major == 4 && minor >= 2) )); then
+            echo "centos7=false" >> $GITHUB_OUTPUT; echo "rocky9=true"  >> $GITHUB_OUTPUT
+          else
+            echo "centos7=true"  >> $GITHUB_OUTPUT; echo "rocky9=false" >> $GITHUB_OUTPUT
+          fi
+
   thirdparty-update-image:
     needs: thirdparty-filter
     runs-on: [self-hosted, normal]
@@ -89,11 +109,13 @@ jobs:
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER ubuntu
 
       - name: update image - centos7
+        if: needs.thirdparty-filter.outputs.centos7 == 'true'
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER centos7
 
       - name: update image - rocky9
+        if: needs.thirdparty-filter.outputs.rocky9 == 'true'
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
           ./bin/elastic-update-image.sh $BRANCH $PR_NUMBER rocky9


### PR DESCRIPTION
## Why I'm doing:
The post-merge `Thirdparty Update Image` job in `image-rebuild-three-digit.yml` runs `update image - centos7` **and** `update image - rocky9` unconditionally for every three-digit branch. rocky9 replaces centos7 from 4.2 onward (CentOS 7 EOL), so on `branch-4.1.x` / `4.0.x` / `3.5.x` the rocky9 per-PR source image is never built, and `elastic-update-image.sh`'s `docker buildx imagetools create` fails with `... not found`. (First surfaced by the pprof CVE thirdparty bump backported to branch-4.1.3 — the first thirdparty-touching PR to actually run this job on a three-digit branch; before that every run skipped the job because the PRs didn't touch `thirdparty/**`.)

## What I'm doing:
Add a `Decide distros by version` step to `thirdparty-filter` that maps the base branch to the correct distro set, and gate the two promote steps with `if:`:
- `< 4.2`  -> ubuntu + centos7
- `>= 4.2` -> ubuntu + rocky9
- ubuntu always runs

Version test (`major>4 || (major==4 && minor>=2)`): 4.1.3 / 4.0.13 / 3.5.19 -> centos7; 4.2.0 / 4.10.1 / 5.0.0 -> rocky9.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr
