### PR TITLE
[BugFix] Fix SparseRangeIterator::remaining_rows() undercounting after the first sub-range

### DIFF
--- a/be/src/storage_primitive/range.h
+++ b/be/src/storage_primitive/range.h
@@ -468,7 +468,7 @@ inline size_t SparseRangeIterator<T>::remaining_rows() const {
         return 0;
     }
     size_t res = 0;
-    auto range = Range<T>(_next_rowid, _range->_ranges[0].end());
+    auto range = Range<T>(_next_rowid, _range->_ranges[_index].end());
     res += range.span_size();
     for (size_t i = _index + 1; i < _range->_ranges.size(); i++) {
         res += _range->_ranges[i].span_size();

--- a/be/test/storage_primitive/range_test.cpp
+++ b/be/test/storage_primitive/range_test.cpp
@@ -204,4 +204,38 @@ TEST(SparseRangeIteratorTest, intersect_test) {
     }
 }
 
+TEST(SparseRangeIteratorTest, remaining_rows) {
+    // Three disjoint ranges, 10 + 20 + 20 = 50 rows in total.
+    SparseRange<> r1({{0, 10}, {20, 40}, {50, 70}});
+    SparseRangeIterator<> iter = r1.new_iterator();
+
+    // Fresh iterator: every row remains.
+    EXPECT_EQ(50u, iter.remaining_rows());
+
+    // Consume 5 rows inside the first range (still _index == 0).
+    (void)iter.next(5);
+    EXPECT_EQ(45u, iter.remaining_rows());
+
+    // Consume the remaining 5 rows of the first range; the iterator now sits at the
+    // start of the second range (_index == 1, _next_rowid == 20). This is the case the
+    // fix targets: the un-consumed part of the *current* range must be measured against
+    // _ranges[_index].end(), not _ranges[0].end(). The buggy version treated the current
+    // partial range as empty and returned 20 (dropping [20,40)'s 20 rows).
+    (void)iter.next(5);
+    EXPECT_EQ(40u, iter.remaining_rows());
+
+    // Advance 5 rows into the second range (_index == 1, _next_rowid == 25).
+    (void)iter.next(5);
+    EXPECT_EQ(35u, iter.remaining_rows());
+
+    // Finish the second range; now at the third range (_index == 2, _next_rowid == 50).
+    (void)iter.next(15);
+    EXPECT_EQ(20u, iter.remaining_rows());
+
+    // Drain the last range.
+    (void)iter.next(20);
+    EXPECT_FALSE(iter.has_more());
+    EXPECT_EQ(0u, iter.remaining_rows());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`SparseRangeIterator<T>::remaining_rows()` returns the wrong count once the iterator has advanced past its first sub-range. It measures the leading (partially consumed) sub-range against `_ranges[0].end()` — the end of the **first** sub-range — instead of `_ranges[_index].end()`, the end of the **current** sub-range.

The sub-ranges are disjoint and ascending, so whenever `_index > 0` the cursor `_next_rowid` is already at or beyond `_ranges[0].end()`. The `Range` constructor zeroes any range whose `begin >= end`, so that leading term collapses to an empty range and contributes `0`. The rows still remaining in the current sub-range are therefore dropped, and `remaining_rows()` under-reports. Because the result feeds `size_t` subtraction at the call site, the undercount can also underflow to a huge bogus value.

On the current main the only caller is `SegmentIterator::_try_to_update_ranges_by_runtime_filter()`, which computes `runtime_stats_filtered` when a runtime filter arrives mid-scan:

```cpp
size_t prev_size = _range_iter.remaining_rows();
_range_iter = _range_iter.intersection(r, &res);
...
_opts.stats->runtime_stats_filtered += (prev_size - _range_iter.remaining_rows());
```

## What I'm doing:
Measure the leading partial sub-range against the current sub-range's end (_ranges[_index].end()) instead of the first sub-range's end (_ranges[0].end()), so the un-consumed rows of the current sub-range are counted:

- auto range = Range<T>(_next_rowid, _range->_ranges[0].end());
+ auto range = Range<T>(_next_rowid, _range->_ranges[_index].end());
Add a SparseRangeIteratorTest.remaining_rows regression test that advances an iterator across three disjoint sub-ranges ([0,10) [20,40) [50,70)) and checks remaining_rows() at each position. At the _index > 0 checkpoints the pre-fix code returns 20 / 20 / 0 while the correct values are 40 / 35 / 20; the test fails before the fix and passes after.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
