### PR TITLE
[BugFix] Fix pinned-range map key mismatch that disabled MV bootstrap pinning for OLAP

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -340,7 +340,10 @@ public abstract class MVRefreshProcessor {
                 continue;
             }
             final TvrVersionRange pinned = TvrTableSnapshot.of(tvr.end());
-            pinnedMap.put(bti.getTableIdentifier(), pinned);
+            // Must key by Table#getTableIdentifier() to match every consumer (MVPCTRefreshPlanBuilder,
+            // PartitionDiffer#pinnedRangeFor). For native OLAP BaseTableInfo#getTableIdentifier() yields
+            // the table id but Table yields the name, so the old key silently missed every lookup.
+            pinnedMap.put(info.getBaseTable().getTableIdentifier(), pinned);
 
             if (info instanceof PCTTableSnapshotInfo) {
                 ((PCTTableSnapshotInfo) info).setPinnedRange(pinned);


### PR DESCRIPTION
## Why I'm doing:

`MVRefreshProcessor#setupPinnedRangesIfNeeded` builds the pinned-range map
keyed by `BaseTableInfo#getTableIdentifier()`, but every consumer of that map
looks entries up by `Table#getTableIdentifier()`:

- `MVPCTRefreshPlanBuilder` — `pinnedMap.get(table.getTableIdentifier())`
- `PartitionDiffer#pinnedRangeFor` — `pinnedRangeByTableIdentifier.get(table.getTableIdentifier())`

For native OLAP tables these two identifiers disagree: `BaseTableInfo`
returns `String.valueOf(tableId)` (the numeric id) while `Table` returns the
table name. As a result the lookup silently misses and the frozen snapshot is
never applied — neither to the refresh scan nor to partition diffing. External
tables (Iceberg/Hive) are unaffected because both sides return the same
identifier there.

## What I'm doing:

Key the pinned-range map by the resolved table's identifier
(`info.getBaseTable().getTableIdentifier()`) so the producer and every consumer
agree for all table types.

Fixes #issue: N/A — self-contained key-consistency fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

The pinned snapshot now actually takes effect for native OLAP base tables during
a pinned refresh (previously a no-op due to the key mismatch).

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
