### PR TITLE
[Enhancement] Normalize shared-data primary-key metadata to the cloud-native persistent index on FE load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -130,6 +130,15 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
                     String.valueOf(persistentIndexType));
             table.getTableProperty().buildPersistentIndexType();
+            if (isReplay) {
+                // Replaying a legacy alter log is metadata-only (no BE task is sent) and could
+                // re-apply a disabled/LOCAL persistent index, undoing the image-load migration in
+                // OlapTable.gsonPostProcess(). Re-normalize shared-data primary-key tables to the
+                // cloud-native index. On the live path we intentionally leave the values as-is so the
+                // FE catalog stays consistent with the BE task payload that was already built from
+                // them; the BE independently normalizes tablet metadata on load.
+                table.normalizeCloudNativePersistentIndex();
+            }
         }
         if (metaType == TTabletMetaType.ENABLE_FILE_BUNDLING) {
             table.setFileBundling(enableFileBundling);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1738,6 +1738,26 @@ public class OlapTable extends Table {
         }
 
         lastSchemaUpdateTime = new AtomicLong(-1);
+
+        // Keep the FE metadata of shared-data primary-key tables on the cloud-native persistent
+        // index after an image load (mirrors the BE normalization). See the method for details.
+        normalizeCloudNativePersistentIndex();
+    }
+
+    // Shared-data primary-key tables only support the cloud-native persistent index; the local-disk
+    // and in-memory indexes are deprecated (enforced on CREATE/ALTER by OlapTableFactory and
+    // SchemaChangeHandler, and on the BE by normalize_tablet_metadata_after_load). Upgrade any table
+    // created before that restriction so the FE metadata matches what the BE actually runs, keeping
+    // SHOW CREATE TABLE and FE-driven tablet tasks consistent. Idempotent; touches shared-data
+    // primary-key tables only. Invoked both on image load (gsonPostProcess) and on lake alter-meta
+    // replay (LakeTableAlterMetaJob.updateCatalog), so a legacy alter log cannot leave the table on
+    // a deprecated index type after startup.
+    public void normalizeCloudNativePersistentIndex() {
+        if (tableProperty != null && isCloudNativeTable() && getKeysType() == KeysType.PRIMARY_KEYS
+                && (!enablePersistentIndex() || getPersistentIndexType() != TPersistentIndexType.CLOUD_NATIVE)) {
+            setEnablePersistentIndex(true);
+            setPersistentIndexType(TPersistentIndexType.CLOUD_NATIVE);
+        }
     }
 
     public OlapTable selectiveCopy(Collection<String> reservedPartitions, boolean resetState, IndexExtState extState) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -49,6 +49,7 @@ import com.starrocks.thrift.TBatchGetTabletMetadataRequest;
 import com.starrocks.thrift.TBatchGetTabletMetadataResponse;
 import com.starrocks.thrift.TGetTabletMetadataRequest;
 import com.starrocks.thrift.TGetTabletMetadataResponse;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletRange;
 import com.starrocks.utframe.UtFrameUtils;
@@ -305,6 +306,25 @@ public class CreateLakeTableTest {
 
             Assertions.assertNotEquals(0, resultSet.getResultRows().size());
         }
+    }
+
+    @Test
+    public void testGsonPostProcessNormalizesLegacyLocalPkIndex() throws Exception {
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.legacy_local_pk\n" +
+                        "(c0 int, c1 string)\n" +
+                        "PRIMARY KEY(c0)\n" +
+                        "distributed by hash(c0) buckets 1;"));
+        LakeTable lakeTable = getLakeTable("lake_test", "legacy_local_pk");
+        // Simulate a table created before the cloud-native-only restriction: force its FE metadata
+        // back to the deprecated LOCAL persistent index.
+        lakeTable.setEnablePersistentIndex(true);
+        lakeTable.setPersistentIndexType(TPersistentIndexType.LOCAL);
+        Assertions.assertEquals(TPersistentIndexType.LOCAL, lakeTable.getPersistentIndexType());
+        // A metadata reload (gsonPostProcess) must upgrade it back to the cloud-native index.
+        lakeTable.gsonPostProcess();
+        Assertions.assertTrue(lakeTable.enablePersistentIndex());
+        Assertions.assertEquals(TPersistentIndexType.CLOUD_NATIVE, lakeTable.getPersistentIndexType());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Shared-data (cloud-native) primary-key tables only support the cloud-native persistent index — CREATE/ALTER enforce it on the FE (PR #75940) and the BE normalizes tablet metadata on load (PR #76260). But a table **created before** that restriction still carries `persistent_index_type=LOCAL` (or a disabled persistent index) in the FE metadata, so `SHOW CREATE TABLE` and FE-driven tablet tasks disagree with what the BE actually runs.

## What I'm doing:

Upgrade such tables in `OlapTable.gsonPostProcess()`: for a **cloud-native primary-key** table whose metadata reports a non-cloud-native / disabled persistent index, set `enable_persistent_index=true` and `persistent_index_type=CLOUD_NATIVE`. This mirrors the BE's `normalize_tablet_metadata_after_load()` and is a one-time, idempotent migration that persists to the next image. Only shared-data primary-key tables are touched; shared-nothing tables (which still support the local persistent index) are unaffected.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
