### PR TITLE
[BugFix] Carry predicateCommonOperators through PhysicalJoinOperator constructors

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/JoinTuningGuide.java
@@ -41,20 +41,18 @@ public abstract class JoinTuningGuide implements TuningGuide {
         if (needCommute) {
             joinType = JOIN_COMMUTATIVITY_MAP.get(joinOperator.getJoinType());
         }
+        // predicateCommonOperators is passed together with predicate: the predicate may reference common
+        // sub-expression columns that are only defined in predicateCommonOperators (see ScalarOperatorsReuseRule).
         PhysicalHashJoinOperator newJoinOperator = new PhysicalHashJoinOperator(
                 joinType,
                 joinOperator.getOnPredicate(),
                 joinOperator.getJoinHint(),
                 joinOperator.getLimit(),
                 joinOperator.getPredicate(),
+                joinOperator.getPredicateCommonOperators(),
                 joinOperator.getProjection(),
                 joinOperator.getSkewColumn(),
                 joinOperator.getSkewValues());
-        // The predicate may reference common sub-expression columns produced by ScalarOperatorsReuseRule
-        // (see predicateCommonOperators). Those columns are only defined in predicateCommonOperators, so it
-        // must be carried over together with the predicate. Otherwise the rebuilt join keeps a predicate that
-        // references undefined columns and the plan fails InputDependenciesChecker.
-        newJoinOperator.setPredicateCommonOperators(joinOperator.getPredicateCommonOperators());
         return newJoinOperator;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashJoinOperator.java
@@ -20,15 +20,17 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
-    private ScalarOperator skewColumn;
-    private List<ScalarOperator> skewValues;
+    private final ScalarOperator skewColumn;
+    private final List<ScalarOperator> skewValues;
     private Optional<PhysicalHashJoinOperator> skewJoinFriend = Optional.empty();
 
     // Only meaningful for skew join: 0=left child, 1=right child, -1=unknown/not skew join.
@@ -39,11 +41,13 @@ public class PhysicalHashJoinOperator extends PhysicalJoinOperator {
                                     String joinHint,
                                     long limit,
                                     ScalarOperator predicate,
+                                    Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators,
                                     Projection projection,
                                     ScalarOperator skewColumn,
                                     List<ScalarOperator> skewValues) {
 
-        super(OperatorType.PHYSICAL_HASH_JOIN, joinType, onPredicate, joinHint, limit, predicate, projection);
+        super(OperatorType.PHYSICAL_HASH_JOIN, joinType, onPredicate, joinHint, limit, predicate,
+                predicateCommonOperators, projection);
         this.skewColumn = skewColumn;
         this.skewValues = skewValues;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -23,9 +23,11 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -40,6 +42,7 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
                                    String joinHint,
                                    long limit,
                                    ScalarOperator predicate,
+                                   Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators,
                                    Projection projection) {
         super(operatorType);
         this.joinType = joinType;
@@ -47,6 +50,12 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
         this.joinHint = joinHint;
         this.limit = limit;
         this.predicate = predicate;
+        // predicateCommonOperators defines the common sub-expression columns that predicate may reference
+        // (produced by ScalarOperatorsReuseRule). It is coupled to predicate, so it is assigned right next to
+        // predicate here; every join subclass threads it through this constructor, which prevents a caller that
+        // rebuilds a join from keeping the predicate but silently dropping the columns it depends on (which
+        // would fail InputDependenciesChecker).
+        this.predicateCommonOperators = predicateCommonOperators;
         this.projection = projection;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMergeJoinOperator.java
@@ -21,8 +21,10 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.Map;
 import java.util.Objects;
 
 public class PhysicalMergeJoinOperator extends PhysicalJoinOperator {
@@ -32,8 +34,10 @@ public class PhysicalMergeJoinOperator extends PhysicalJoinOperator {
                                      String joinHint,
                                      long limit,
                                      ScalarOperator predicate,
+                                     Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators,
                                      Projection projection) {
-        super(OperatorType.PHYSICAL_MERGE_JOIN, joinType, onPredicate, joinHint, limit, predicate, projection);
+        super(OperatorType.PHYSICAL_MERGE_JOIN, joinType, onPredicate, joinHint, limit, predicate,
+                predicateCommonOperators, projection);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNestLoopJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalNestLoopJoinOperator.java
@@ -21,7 +21,10 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.Map;
 
 public class PhysicalNestLoopJoinOperator extends PhysicalJoinOperator {
 
@@ -30,8 +33,10 @@ public class PhysicalNestLoopJoinOperator extends PhysicalJoinOperator {
                                         String joinHint,
                                         long limit,
                                         ScalarOperator predicate,
+                                        Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators,
                                         Projection projection) {
-        super(OperatorType.PHYSICAL_NESTLOOP_JOIN, joinType, onPredicate, joinHint, limit, predicate, projection);
+        super(OperatorType.PHYSICAL_NESTLOOP_JOIN, joinType, onPredicate, joinHint, limit, predicate,
+                predicateCommonOperators, projection);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashJoinImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashJoinImplementationRule.java
@@ -54,6 +54,7 @@ public class HashJoinImplementationRule extends JoinImplementationRule {
                 joinOperator.getJoinHint(),
                 joinOperator.getLimit(),
                 joinOperator.getPredicate(),
+                joinOperator.getPredicateCommonOperators(),
                 joinOperator.getProjection(),
                 joinOperator.getSkewColumn(),
                 joinOperator.getSkewValues());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/MergeJoinImplementationRule.java
@@ -53,6 +53,7 @@ public class MergeJoinImplementationRule extends JoinImplementationRule {
                 joinOperator.getJoinHint(),
                 joinOperator.getLimit(),
                 joinOperator.getPredicate(),
+                joinOperator.getPredicateCommonOperators(),
                 joinOperator.getProjection());
         OptExpression result = OptExpression.create(physicalMergeJoin, input.getInputs());
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/NestLoopJoinImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/NestLoopJoinImplementationRule.java
@@ -83,6 +83,7 @@ public class NestLoopJoinImplementationRule extends JoinImplementationRule {
                 joinOperator.getJoinHint(),
                 joinOperator.getLimit(),
                 joinOperator.getPredicate(),
+                joinOperator.getPredicateCommonOperators(),
                 joinOperator.getProjection());
         OptExpression result = OptExpression.create(physicalNestLoopJoin, commutedExpr.getInputs());
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
@@ -224,12 +224,14 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
                     new PhysicalHashJoinOperator(originalShuffleJoinOperator.getJoinType(),
                             originalShuffleJoinOperator.getOnPredicate(), originalShuffleJoinOperator.getJoinHint(),
                             originalShuffleJoinOperator.getLimit(), originalShuffleJoinOperator.getPredicate(),
+                            originalShuffleJoinOperator.getPredicateCommonOperators(),
                             projectionOnJoin, skewSideJoinKeyExpr, nonNullSkewValues);
 
             PhysicalHashJoinOperator newBroadcastJoinOpt =
                     new PhysicalHashJoinOperator(originalShuffleJoinOperator.getJoinType(),
                             originalShuffleJoinOperator.getOnPredicate(), originalShuffleJoinOperator.getJoinHint(),
                             originalShuffleJoinOperator.getLimit(), originalShuffleJoinOperator.getPredicate(),
+                            originalShuffleJoinOperator.getPredicateCommonOperators(),
                             projectionOnJoin, skewSideJoinKeyExpr, nonNullSkewValues);
 
             // we have to let them know each other for runtime filter

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -278,8 +278,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         Projection newProjection = rewriteProjection(join.getProjection(), info.inputStringColumns);
 
         PhysicalHashJoinOperator newJoin = new PhysicalHashJoinOperator(
-                join.getJoinType(), newOnPredicate, join.getJoinHint(), join.getLimit(), newPredicate, newProjection,
-                join.getSkewColumn(), join.getSkewValues());
+                join.getJoinType(), newOnPredicate, join.getJoinHint(), join.getLimit(), newPredicate,
+                join.getPredicateCommonOperators(), newProjection, join.getSkewColumn(), join.getSkewValues());
         newJoin.setSkewJoinFriend(join.getSkewJoinFriend().orElse(null));
 
         return rewriteOptExpression(optExpression, newJoin, info.outputStringColumns);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinPredicateCommonOperatorsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinPredicateCommonOperatorsTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.physical;
+
+import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+// ScalarOperatorsReuseRule may extract a common sub-expression out of a physical operator's predicate into
+// predicateCommonOperators; the predicate then references columns that are defined only there. Every physical join
+// constructor must carry predicateCommonOperators together with predicate, so that a rebuilt join (e.g.
+// JoinTuningGuide, SkewShuffleJoinEliminationRule) does not keep the predicate while dropping the columns it depends
+// on, which would fail InputDependenciesChecker. These tests lock that invariant for all three join subclasses.
+class PhysicalJoinPredicateCommonOperatorsTest {
+
+    private static Map<ColumnRefOperator, ScalarOperator> commonOperators() {
+        ColumnRefOperator reuseCol = new ColumnRefOperator(100, IntegerType.BIGINT, "cse", true);
+        return Map.of(reuseCol, ConstantOperator.createBigint(1L));
+    }
+
+    private static ScalarOperator predicate() {
+        ColumnRefOperator reuseCol = new ColumnRefOperator(100, IntegerType.BIGINT, "cse", true);
+        return new BinaryPredicateOperator(BinaryType.EQ, reuseCol, ConstantOperator.createBigint(1L));
+    }
+
+    @Test
+    void hashJoinCarriesPredicateCommonOperators() {
+        Map<ColumnRefOperator, ScalarOperator> common = commonOperators();
+        PhysicalHashJoinOperator join = new PhysicalHashJoinOperator(
+                JoinOperator.INNER_JOIN, null, "", Operator.DEFAULT_LIMIT, predicate(), common, null, null, null);
+        assertSame(common, join.getPredicateCommonOperators());
+    }
+
+    @Test
+    void nestLoopJoinCarriesPredicateCommonOperators() {
+        Map<ColumnRefOperator, ScalarOperator> common = commonOperators();
+        PhysicalNestLoopJoinOperator join = new PhysicalNestLoopJoinOperator(
+                JoinOperator.INNER_JOIN, null, "", Operator.DEFAULT_LIMIT, predicate(), common, null);
+        assertSame(common, join.getPredicateCommonOperators());
+    }
+
+    @Test
+    void mergeJoinCarriesPredicateCommonOperators() {
+        Map<ColumnRefOperator, ScalarOperator> common = commonOperators();
+        PhysicalMergeJoinOperator join = new PhysicalMergeJoinOperator(
+                JoinOperator.INNER_JOIN, null, "", Operator.DEFAULT_LIMIT, predicate(), common, null);
+        assertSame(common, join.getPredicateCommonOperators());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/validate/TypeCheckerTest.java
@@ -74,6 +74,7 @@ class TypeCheckerTest {
                 null,
                 null,
                 null,
+                null,
                 null);
 
         OptExpression left = new OptExpression(new MockOperator(OperatorType.LOGICAL_VALUES));


### PR DESCRIPTION
## Why I'm doing:

  ScalarOperatorsReuseRule (physical rewrite phase) may extract a repeated sub-expression out of a physical join's post-join predicate into predicateCommonOperators; the rewritten predicate then references columns that are defined
  only in predicateCommonOperators.

  predicateCommonOperators was a settable field but was not passed through the join constructors, so any rule that rebuilds a join by hand-constructing new PhysicalHashJoinOperator(...) and copying getPredicate() would keep the
  predicate while silently dropping the columns it depends on. The rebuilt join then references undefined columns and the plan fails InputDependenciesChecker (The required cols {..} cannot obtain from input cols {..}).

  This was already hit and fixed narrowly in JoinTuningGuide (#75773) via a separate setPredicateCommonOperators call, but the same latent trap remained in SkewShuffleJoinEliminationRule: a skew shuffle join whose post-join predicate
  reuses a common sub-expression would drop predicateCommonOperators when the rule rebuilds it, producing the same InputDependenciesChecker failure.

## What I'm doing:

  Thread predicateCommonOperators through the PhysicalJoinOperator constructor, right next to predicate, so the coupled pair always travels together and every join subclass (PhysicalHashJoinOperator / PhysicalNestLoopJoinOperator /
  PhysicalMergeJoinOperator) carries it uniformly. Making it a required constructor argument means a caller that rebuilds a join can no longer forget it.

  - Add the parameter to PhysicalJoinOperator and all three subclass constructors.
  - Update all 8 construction sites to pass getPredicateCommonOperators():
    - SkewShuffleJoinEliminationRule (×2) — fixes the latent bug.
    - JoinTuningGuide.buildJoinOperator — pass via constructor and drop the now-redundant setPredicateCommonOperators call.
    - HashJoinImplementationRule / MergeJoinImplementationRule / NestLoopJoinImplementationRule / DecodeRewriter — pass through unchanged (value is null before the reuse rule runs, so behavior is preserved).
  - Add PhysicalJoinPredicateCommonOperatorsTest locking the invariant for all three join subclasses.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
