### PR TITLE
[Enhancement] Add FE metrics for ALTER TABLE column operations and duration (backport #76247)

### DIFF
--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -213,6 +213,23 @@ description: "Alphabetical s"
 - Type: Instantaneous
 - Description: Shared-data only. Number of shards currently assigned to this BE's StarOSWorker (size of the worker's local shard table). Updated synchronously inside `StarOSWorker::add_shard` and `StarOSWorker::remove_shard` (push-on-mutation), so the value reflects the last shard table mutation rather than being recomputed at scrape time. The gauge is not reset on BE shutdown and will retain its last value until the next mutation. Use it to observe shard distribution balance across BEs and to detect drift from the FE-side placement.
 
+## `starrocks_fe_alter_duration_ms`
+
+- Unit: ms
+- Type: Summary
+- Labels: `execution_mode` (`fse`, `legacy_fse`, or `rewrite`), `is_leader`
+- Description: Time in milliseconds to apply an ALTER TABLE change, per statement. Reported only by the Leader FE (`is_leader="true"`). Includes the 0.75/0.95/0.98/0.99/0.999 quantiles plus `_sum` and `_count`. The `execution_mode` label indicates how the change was applied:
+  - `fse`: the current Fast Schema Evolution (FSE), applied immediately while the statement runs.
+  - `legacy_fse`: the legacy FSE path, which runs in the background and is usually far slower. Occurs only in shared-data clusters with `cloud_native_fast_schema_evolution_v2` disabled (enabled by default, which uses `fse`).
+  - `rewrite`: the change had to physically rewrite the table data, which also runs in the background.
+
+## `starrocks_fe_alter_operation_total`
+
+- Unit: Count
+- Type: Cumulative
+- Labels: `type` (`add_column`, `drop_column`, or `modify_column`), `is_leader`
+- Description: Number of ALTER TABLE column operations, by type. A single statement can contain several operations — for example, `ADD COLUMN a, DROP COLUMN b` — and each is counted separately under its type. Renames, reorders, and comment-only changes are not counted. Reported only by the Leader FE (`is_leader="true"`).
+
 ## `starrocks_fe_clone_task_copy_bytes`
 
 - Unit: Bytes

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -213,6 +213,23 @@ description: "Alphabetical s"
 - タイプ: 瞬時値
 - 説明: 共有データモード専用。現在この BE の StarOSWorker に割り当てられている shard 数（worker のローカル shard テーブルのサイズ）。値は `StarOSWorker::add_shard` および `StarOSWorker::remove_shard` の内部で同期的に書き込まれ（mutation 時に push される方式）、メトリクス取得時に再計算されるわけではありません。したがって取得される値は、直近に発生した shard テーブルの変更結果を反映します。BE シャットダウン時に gauge はリセットされず、次回の mutation が発生するまで前回の値を保持します。BE 間の shard 分布バランスを観測したり、FE 側の配置結果との乖離を検出するために利用できます。
 
+## `starrocks_fe_alter_duration_ms`
+
+- 単位: ミリ秒
+- タイプ: サマリー
+- ラベル: `execution_mode` (`fse`、`legacy_fse`、または `rewrite`)、`is_leader`
+- 説明: ALTER TABLE の変更を適用するのにかかった時間 (ミリ秒)。ステートメント単位。報告するのは Leader FE (`is_leader="true"`) のみです。0.75、0.95、0.98、0.99、0.999 の分位値と `_sum`、`_count` を含みます。`execution_mode` ラベルは変更の適用方法を示します。
+  - `fse`: 現行の Fast Schema Evolution (FSE) で、ステートメント実行中に即座に完了します。
+  - `legacy_fse`: 旧来の FSE パスで、バックグラウンドで実行され通常はるかに遅くなります。`cloud_native_fast_schema_evolution_v2` が無効な共有データ (shared-data) クラスターでのみ発生します (デフォルトは有効で、その場合は `fse`)。
+  - `rewrite`: 変更のためにテーブルデータを物理的に書き換える必要があった場合 (例: 列の型変更) を示し、これもバックグラウンドで実行されます。
+
+## `starrocks_fe_alter_operation_total`
+
+- 単位: カウント
+- タイプ: 累積
+- ラベル: `type` (`add_column`、`drop_column`、または `modify_column`)、`is_leader`
+- 説明: ALTER TABLE の列操作の回数を、タイプ別に集計します。1 つのステートメントに複数の操作を含めることができ (例: `ADD COLUMN a, DROP COLUMN b`)、それぞれがタイプ別に個別にカウントされます。列名の変更、列順の変更、コメントのみの変更はカウントされません。報告するのは Leader FE (`is_leader="true"`) のみです。
+
 ## `starrocks_fe_clone_task_copy_bytes`
 
 - 単位: バイト

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -239,6 +239,23 @@ description: "Alphabetical s"
 - 类型：瞬时值
 - 描述：仅存算分离模式。当前分配给该 BE 的 StarOSWorker 的 shard 数量（即 worker 本地 shard 表的大小）。该值在 `StarOSWorker::add_shard` 与 `StarOSWorker::remove_shard` 内同步写入（mutation 时推送），不是在指标采集时重新计算；因此采集到的值反映的是最近一次 shard 表的变更结果。BE 关闭时该 gauge 不会被清零，会保留到下一次发生 mutation 为止。可用于观测各 BE 之间的 shard 分布均衡情况，并发现与 FE 端调度结果的偏差。
 
+## `starrocks_fe_alter_duration_ms`
+
+- 单位：毫秒
+- 类型：摘要
+- 标签：`execution_mode`（`fse`、`legacy_fse` 或 `rewrite`）、`is_leader`
+- 描述：应用一次 ALTER TABLE 变更的耗时（毫秒），按语句统计。仅由 Leader FE 上报（`is_leader="true"`）。包含 0.75、0.95、0.98、0.99、0.999 分位数及 `_sum`、`_count`。`execution_mode` 标签表示变更的应用方式：
+  - `fse`：当前的 Fast Schema Evolution（FSE），在语句执行期间立即完成。
+  - `legacy_fse`：旧版 FSE 路径，在后台执行，通常慢得多。仅出现在存算分离集群且表未开启 `cloud_native_fast_schema_evolution_v2` 时（默认开启，此时走 `fse`）。
+  - `rewrite`：该变更需要物理重写表数据（例如修改列类型），同样在后台执行。
+
+## `starrocks_fe_alter_operation_total`
+
+- 单位：计数
+- 类型：累积
+- 标签：`type`（`add_column`、`drop_column` 或 `modify_column`）、`is_leader`
+- 描述：ALTER TABLE 列操作的次数，按类型统计。一条语句可以包含多个操作——例如 `ADD COLUMN a, DROP COLUMN b`——每个操作按其类型分别计数。重命名、调整列顺序以及仅修改注释不计入。仅由 Leader FE 上报（`is_leader="true"`）。
+
 ## `starrocks_fe_clone_task_copy_bytes`
 
 - 单位：字节

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMetricRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMetricRegistry.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.metric.LeaderAwareCounterMetricLong;
+import com.starrocks.metric.LeaderAwareHistogramMetric;
+import com.starrocks.metric.Metric.MetricUnit;
+import com.starrocks.metric.MetricLabel;
+import com.starrocks.metric.MetricVisitor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry for ALTER TABLE metrics.
+ */
+public final class AlterMetricRegistry {
+
+    /** Alter operation type; the label value tags {@code alter_operation_total{type=...}}. */
+    public enum AlterOperationType {
+        ADD_COLUMN("add_column"),
+        DROP_COLUMN("drop_column"),
+        MODIFY_COLUMN("modify_column");
+
+        private final String labelValue;
+
+        AlterOperationType(String labelValue) {
+            this.labelValue = labelValue;
+        }
+
+        public String getLabelValue() {
+            return labelValue;
+        }
+    }
+
+    /** Alter execution mode; the label value tags {@code alter_duration_ms{execution_mode=...}}. */
+    public enum AlterExecutionMode {
+        // Synchronous, metadata-only fast schema evolution (shared-nothing, or shared-data FSE v2).
+        FAST_SCHEMA_EVOLUTION("fse"),
+        // Asynchronous lake schema-change job (LakeTableAsyncFastSchemaChangeJob); shared-data only.
+        LEGACY_FAST_SCHEMA_EVOLUTION("legacy_fse"),
+        // The change was applied by physically rewriting data (SchemaChangeJobV2 / LakeTableSchemaChangeJob).
+        REWRITE("rewrite");
+
+        private final String labelValue;
+
+        AlterExecutionMode(String labelValue) {
+            this.labelValue = labelValue;
+        }
+
+        public String getLabelValue() {
+            return labelValue;
+        }
+    }
+
+    private static volatile AlterMetricRegistry instance;
+
+    // One counter per alter operation type, created on first use and emitted via report().
+    private final Map<AlterOperationType, LeaderAwareCounterMetricLong> operationCounters = new ConcurrentHashMap<>();
+
+    // One duration histogram per execution mode, created on first use and emitted via report().
+    private final Map<AlterExecutionMode, LeaderAwareHistogramMetric> durationHistograms = new ConcurrentHashMap<>();
+
+    private AlterMetricRegistry() {
+    }
+
+    public static AlterMetricRegistry getInstance() {
+        AlterMetricRegistry inst = instance;
+        if (inst == null) {
+            synchronized (AlterMetricRegistry.class) {
+                if (instance == null) {
+                    instance = new AlterMetricRegistry();
+                }
+                inst = instance;
+            }
+        }
+        return inst;
+    }
+
+    /** Increment the alter operation counter for {@code type}. */
+    public void updateAlterOperation(AlterOperationType type) {
+        operationCounters.computeIfAbsent(type, t -> {
+            LeaderAwareCounterMetricLong counter = new LeaderAwareCounterMetricLong("alter_operation_total",
+                    MetricUnit.OPERATIONS, "Total number of ALTER TABLE operations, by type.");
+            counter.addLabel(new MetricLabel("type", t.getLabelValue()));
+            return counter;
+        }).increase(1L);
+    }
+
+    /** Observe an alter duration (ms) for {@code executionMode}. */
+    public void updateAlterDuration(AlterExecutionMode executionMode, long durationMs) {
+        durationHistograms.computeIfAbsent(executionMode, mode -> {
+            LeaderAwareHistogramMetric histogram = new LeaderAwareHistogramMetric("alter_duration_ms");
+            histogram.addLabel(new MetricLabel("execution_mode", mode.getLabelValue()));
+            return histogram;
+        }).update(durationMs);
+    }
+
+    @VisibleForTesting
+    public long getAlterOperationCount(AlterOperationType type) {
+        LeaderAwareCounterMetricLong counter = operationCounters.get(type);
+        return counter == null ? 0L : counter.getValue();
+    }
+
+    @VisibleForTesting
+    public long getAlterDurationCount(AlterExecutionMode executionMode) {
+        LeaderAwareHistogramMetric histogram = durationHistograms.get(executionMode);
+        return histogram == null ? 0L : histogram.getCount();
+    }
+
+    /** Emit the counters and duration histograms to the visitor. */
+    public void report(MetricVisitor visitor) {
+        for (LeaderAwareCounterMetricLong counter : operationCounters.values()) {
+            visitor.visit(counter);
+        }
+        for (LeaderAwareHistogramMetric histogram : durationHistograms.values()) {
+            visitor.visitHistogram(histogram);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -223,6 +223,16 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
+    protected void runFinishedRewritingJob() throws AlterCancelException {
+        super.runFinishedRewritingJob();
+        if (jobState == JobState.FINISHED) {
+            AlterMetricRegistry.getInstance().updateAlterDuration(
+                    AlterMetricRegistry.AlterExecutionMode.LEGACY_FAST_SCHEMA_EVOLUTION,
+                    finishedTimeMs - createTimeMs);
+        }
+    }
+
+    @Override
     public boolean isExpire() {
         boolean expiredByTime = super.isExpire();
         boolean expiredByHistorySchema = true;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -787,6 +787,11 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
 
         EditLog.waitInfinity(editLogFuture);
 
+        if (jobState == JobState.FINISHED) {
+            AlterMetricRegistry.getInstance().updateAlterDuration(
+                    AlterMetricRegistry.AlterExecutionMode.REWRITE, finishedTimeMs - createTimeMs);
+        }
+
         if (span != null) {
             span.end();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2253,10 +2253,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 // add column
                 fastSchemaEvolution &=
                         processAddColumn((AddColumnClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
+                AlterMetricRegistry.getInstance().updateAlterOperation(AlterMetricRegistry.AlterOperationType.ADD_COLUMN);
             } else if (alterClause instanceof AddColumnsClause) {
                 // add columns
                 fastSchemaEvolution &=
                         processAddColumns((AddColumnsClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
+                AlterMetricRegistry.getInstance().updateAlterOperation(AlterMetricRegistry.AlterOperationType.ADD_COLUMN);
             } else if (alterClause instanceof DropColumnClause) {
                 DropColumnClause dropColumnClause = (DropColumnClause) alterClause;
                 // check relative mvs with the modified column
@@ -2267,6 +2269,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 fastSchemaEvolution &=
                         processDropColumn((DropColumnClause) alterClause, olapTable, indexMetaIdToSchema,
                                 newIndexes);
+                AlterMetricRegistry.getInstance().updateAlterOperation(AlterMetricRegistry.AlterOperationType.DROP_COLUMN);
             } else if (alterClause instanceof ModifyColumnClause) {
                 ModifyColumnClause modifyColumnClause = (ModifyColumnClause) alterClause;
 
@@ -2294,6 +2297,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 // modify column
                 fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexMetaIdToSchema,
                                                            alterIndexMetaIdToIncrVarcharLenColNames);
+                AlterMetricRegistry.getInstance().updateAlterOperation(AlterMetricRegistry.AlterOperationType.MODIFY_COLUMN);
             } else if (alterClause instanceof ModifyColumnCommentClause) {
                 // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
                 if (alterClauses.size() > 1) {
@@ -3577,6 +3581,7 @@ public class SchemaChangeHandler extends AlterHandler {
      */
     private void updateCatalogForFastSchemaEvolution(SchemaChangeData schemaChangeData)
             throws DdlException, NotImplementedException {
+        long startMs = System.currentTimeMillis();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         long jobId = globalStateMgr.getNextId();
         // for schema change add/drop value column optimize, direct modify table meta.
@@ -3592,6 +3597,9 @@ public class SchemaChangeHandler extends AlterHandler {
         applyFastSchemaEvolutionMetaChange(schemaChangeData.getDatabase(), schemaChangeData.getTable(),
                 schemaChangeData.getNewIndexMetaIdToSchema(), schemaChangeData.getIndexes(), jobId,
                 indexMetaIdToNewSchemaId, false, -1);
+        AlterMetricRegistry.getInstance().updateAlterDuration(
+                AlterMetricRegistry.AlterExecutionMode.FAST_SCHEMA_EVOLUTION,
+                System.currentTimeMillis() - startMs);
     }
 
     private AlterJobV2 createFastSchemaEvolutionJobInSharedDataMode(SchemaChangeData schemaChangeData) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -856,6 +856,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
         EditLog.waitInfinity(journalTask);
 
+        if (jobState == JobState.FINISHED) {
+            AlterMetricRegistry.getInstance().updateAlterDuration(
+                    AlterMetricRegistry.AlterExecutionMode.REWRITE, finishedTimeMs - createTimeMs);
+        }
+
         LOG.info("schema change job finished: {}", jobId);
         this.span.end();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.AlterMetricRegistry;
 import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.backup.AbstractJob;
@@ -1449,6 +1450,8 @@ public final class MetricRepo {
         MergeCommitMetricRegistry.getInstance().visit(visitor);
 
         TransactionMetricRegistry.getInstance().report(visitor);
+
+        AlterMetricRegistry.getInstance().report(visitor);
 
         // node info
         visitor.getNodeInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMetricRegistryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMetricRegistryTest.java
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.alter.AlterMetricRegistry.AlterExecutionMode;
+import com.starrocks.alter.AlterMetricRegistry.AlterOperationType;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.metric.PrometheusMetricVisitor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Tests for {@link AlterMetricRegistry}, covering both writers end-to-end.
+ *
+ * <p>Extends {@link LakeFastSchemaChangeTestBase} so the shared-data lake paths are available and the
+ * cluster runs as leader (both metrics are leader-aware and report real values only on the leader).
+ * {@code isFastSchemaEvolutionV2()} returns {@code true}, so the inherited tests and
+ * {@link #executeAlterAndWaitFinish} exercise the synchronous FSE-v2 path; the asynchronous legacy
+ * path is driven manually in {@link #asyncLegacyJobRecordsLegacyFseDuration}, and the data-rewrite path
+ * in {@link #dataRewriteJobRecordsRewriteDuration}.
+ *
+ * <p>The registry singleton and its series are process-global, so assertions use before/after deltas,
+ * resilient to shared state across tests.
+ */
+public class AlterMetricRegistryTest extends LakeFastSchemaChangeTestBase {
+
+    @Override
+    protected boolean isFastSchemaEvolutionV2() {
+        return true;
+    }
+
+    // ---- counter ----
+
+    @Test
+    public void updateAlterOperationBumpsPerType() {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        for (AlterOperationType type : AlterOperationType.values()) {
+            long before = registry.getAlterOperationCount(type);
+            registry.updateAlterOperation(type);
+            Assertions.assertEquals(before + 1L, registry.getAlterOperationCount(type),
+                    "updateAlterOperation must bump " + type + " exactly once");
+        }
+    }
+
+    @Test
+    public void countsAddDropModifyThroughSchemaChangeHandler() throws Exception {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        createTable(connectContext,
+                "CREATE TABLE t_op (c0 INT, v0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 2 "
+                        + "PROPERTIES('cloud_native_fast_schema_evolution_v2'='true');");
+
+        long add0 = registry.getAlterOperationCount(AlterOperationType.ADD_COLUMN);
+        alterTable(connectContext, "ALTER TABLE t_op ADD COLUMN c1 BIGINT");
+        Assertions.assertEquals(add0 + 1, registry.getAlterOperationCount(AlterOperationType.ADD_COLUMN),
+                "ADD COLUMN must bump type=add_column");
+
+        long drop0 = registry.getAlterOperationCount(AlterOperationType.DROP_COLUMN);
+        alterTable(connectContext, "ALTER TABLE t_op DROP COLUMN c1");
+        Assertions.assertEquals(drop0 + 1, registry.getAlterOperationCount(AlterOperationType.DROP_COLUMN),
+                "DROP COLUMN must bump type=drop_column");
+
+        // The counter fires during analysis (in SchemaChangeHandler's per-clause loop), independent of the
+        // execution path the clause takes. On this shared-data v2 table an INT->BIGINT widening on a value
+        // column is fast-schema-evolution-eligible and applies synchronously, leaving the table NORMAL.
+        long mod0 = registry.getAlterOperationCount(AlterOperationType.MODIFY_COLUMN);
+        alterTable(connectContext, "ALTER TABLE t_op MODIFY COLUMN v0 BIGINT");
+        Assertions.assertEquals(mod0 + 1, registry.getAlterOperationCount(AlterOperationType.MODIFY_COLUMN),
+                "MODIFY COLUMN must bump type=modify_column");
+    }
+
+    // ---- emission (report -> MetricVisitor) ----
+
+    @Test
+    public void reportEmitsCounterAndHistogramSeries() {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        // Ensure at least one series exists for each label value.
+        registry.updateAlterOperation(AlterOperationType.ADD_COLUMN);
+        registry.updateAlterOperation(AlterOperationType.DROP_COLUMN);
+        registry.updateAlterOperation(AlterOperationType.MODIFY_COLUMN);
+        registry.updateAlterDuration(AlterExecutionMode.FAST_SCHEMA_EVOLUTION, 5L);
+        registry.updateAlterDuration(AlterExecutionMode.LEGACY_FAST_SCHEMA_EVOLUTION, 7L);
+        registry.updateAlterDuration(AlterExecutionMode.REWRITE, 9L);
+
+        PrometheusMetricVisitor visitor = new PrometheusMetricVisitor("starrocks_fe");
+        registry.report(visitor);
+        String out = visitor.build();
+
+        // Counter: one series per type, emitted by report() via visit(Metric). The counter is leader-aware,
+        // so it also carries an is_leader label; assert label-order-independently.
+        Assertions.assertTrue(out.contains("starrocks_fe_alter_operation_total{"), out);
+        Assertions.assertTrue(out.contains("type=\"add_column\""), out);
+        Assertions.assertTrue(out.contains("type=\"drop_column\""), out);
+        Assertions.assertTrue(out.contains("type=\"modify_column\""), out);
+        // The three counter series share a single HELP/TYPE header (deduped by metric name).
+        Assertions.assertEquals(1, countOccurrences(out, "# TYPE starrocks_fe_alter_operation_total"), out);
+
+        // Histogram: one set of quantile/_sum/_count lines per execution_mode, emitted via visitHistogram().
+        Assertions.assertTrue(out.contains("starrocks_fe_alter_duration_ms{quantile=\"0.75\""), out);
+        Assertions.assertTrue(out.contains("starrocks_fe_alter_duration_ms_count{"), out);
+        Assertions.assertTrue(out.contains("execution_mode=\"fse\""), out);
+        Assertions.assertTrue(out.contains("execution_mode=\"legacy_fse\""), out);
+        Assertions.assertTrue(out.contains("execution_mode=\"rewrite\""), out);
+        // The cluster runs as leader; assert is_leader="true" is bound to each family's series (not a single
+        // global match that one family could satisfy for both).
+        Assertions.assertTrue(anyLineContains(out, "starrocks_fe_alter_operation_total{", "is_leader=\"true\""), out);
+        Assertions.assertTrue(anyLineContains(out, "starrocks_fe_alter_duration_ms", "is_leader=\"true\""), out);
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+
+    /** True if some line of {@code haystack} contains both {@code a} and {@code b}. */
+    private static boolean anyLineContains(String haystack, String a, String b) {
+        for (String line : haystack.split("\n")) {
+            if (line.contains(a) && line.contains(b)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ---- duration histogram ----
+
+    @Test
+    public void syncFseRecordsFseDuration() throws Exception {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        LakeTable table = createTable(connectContext,
+                "CREATE TABLE t_sync (c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 2 "
+                        + "PROPERTIES('cloud_native_fast_schema_evolution_v2'='true');");
+        long before = registry.getAlterDurationCount(AlterExecutionMode.FAST_SCHEMA_EVOLUTION);
+        executeAlterAndWaitFinish(table, "ALTER TABLE t_sync ADD COLUMN c1 BIGINT", true);
+        Assertions.assertEquals(before + 1L,
+                registry.getAlterDurationCount(AlterExecutionMode.FAST_SCHEMA_EVOLUTION),
+                "synchronous FSE add-column must record one fse duration observation");
+    }
+
+    @Test
+    public void asyncLegacyJobRecordsLegacyFseDuration() throws Exception {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        LakeTable table = createTable(connectContext,
+                "CREATE TABLE t_legacy (c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 2 "
+                        + "PROPERTIES('cloud_native_fast_schema_evolution_v2'='false');");
+        long before = registry.getAlterDurationCount(AlterExecutionMode.LEGACY_FAST_SCHEMA_EVOLUTION);
+        alterTable(connectContext, "ALTER TABLE t_legacy ADD COLUMN c1 BIGINT");
+        runAsyncAlterToFinish(table);
+        Assertions.assertEquals(before + 1L,
+                registry.getAlterDurationCount(AlterExecutionMode.LEGACY_FAST_SCHEMA_EVOLUTION),
+                "async legacy FSE add-column must record one legacy_fse duration observation on FINISHED");
+    }
+
+    @Test
+    public void dataRewriteJobRecordsRewriteDuration() throws Exception {
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        LakeTable table = createTable(connectContext,
+                "CREATE TABLE t_rewrite (c0 INT, c1 VARCHAR(10)) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 2 "
+                        + "PROPERTIES('cloud_native_fast_schema_evolution_v2'='true');");
+        long before = registry.getAlterDurationCount(AlterExecutionMode.REWRITE);
+        // VARCHAR -> INT is not fast-schema-evolution eligible, so the change is applied by a data-rewrite
+        // schema-change job (LakeTableSchemaChangeJob), which records one rewrite observation on FINISHED.
+        executeAlterAndWaitFinish(table, "ALTER TABLE t_rewrite MODIFY COLUMN c1 INT", false);
+        Assertions.assertEquals(before + 1L, registry.getAlterDurationCount(AlterExecutionMode.REWRITE),
+                "data-rewrite schema change must record one rewrite duration observation on FINISHED");
+    }
+
+    /** Drive the single unfinished async schema-change job for {@code table} to FINISHED. */
+    private void runAsyncAlterToFinish(LakeTable table) throws Exception {
+        List<AlterJobV2> jobs = schemaChangeHandler.getUnfinishedAlterJobV2ByTableId(table.getId());
+        Assertions.assertEquals(1, jobs.size(), "expected exactly one async schema-change job");
+        AlterJobV2 job = jobs.get(0);
+        long deadline = System.currentTimeMillis() + 60_000;
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED
+                || table.getState() != OlapTable.OlapTableState.NORMAL) {
+            if (System.currentTimeMillis() > deadline) {
+                throw new RuntimeException("legacy FSE job did not finish; state=" + job.getJobState());
+            }
+            job.run();
+            Thread.sleep(100);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.metric;
 
+import com.starrocks.alter.AlterMetricRegistry;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.clone.TabletSchedCtx;
@@ -76,6 +77,24 @@ public class MetricRepoTest extends PlanTestBase {
         Assertions.assertTrue(StringUtils.isNotEmpty(json));
         Assertions.assertTrue(json.contains("test_metric"));
         Assertions.assertTrue(json.contains("brpc_pool_numactive"));
+    }
+
+    @Test
+    public void testAlterColumnMetricsExposure() {
+        // Record one series of each metric, then drive the real MetricRepo.getMetric() path to guard the
+        // AlterMetricRegistry.getInstance().report(visitor) wiring (removing it would silently drop both metrics).
+        AlterMetricRegistry registry = AlterMetricRegistry.getInstance();
+        registry.updateAlterOperation(AlterMetricRegistry.AlterOperationType.ADD_COLUMN);
+        registry.updateAlterDuration(AlterMetricRegistry.AlterExecutionMode.FAST_SCHEMA_EVOLUTION, 5L);
+
+        MetricVisitor visitor = new PrometheusMetricVisitor("");
+        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true, true);
+        MetricRepo.getMetric(visitor, params);
+        String output = visitor.build();
+
+        Assertions.assertTrue(output.contains("alter_operation_total{"), output);
+        Assertions.assertTrue(output.contains("alter_duration_ms"), output);
+        Assertions.assertTrue(output.contains("execution_mode=\"fse\""), output);
     }
 
     @Test


### PR DESCRIPTION
Manual backport of #76247 to `branch-4.1`. The Mergify auto-backport (#76331) failed to apply because `branch-4.1` does not contain the range-rewrite schema-change feature that surrounds the metric hook sites on `main`. This PR cherry-picks the squash commit and resolves the conflicts by hand.

**Conflict resolution (verified against `branch-4.1`):**
- `SchemaChangeHandler.java`: applied only this PR's changes (the four `updateAlterOperation` counter calls, `startMs`, and the `fse` duration block). Dropped the range-rewrite routing (`needsRangeRewriteSchemaChange` / `buildRoutedAddKeyColumnJob` / `buildRangeRewriteJob` / `createRangeRewriteJob`) that Mergify pulled in as context — those methods do not exist on `branch-4.1`. Kept `branch-4.1`'s `applyFastSchemaEvolutionMetaChange(..., false, -1)` signature and appended the duration hook after it.
- `SchemaChangeJobV2.java` / `LakeTableSchemaChangeJob.java`: kept `branch-4.1`'s `EditLog.waitInfinity(...)` and added the `rewrite` duration hook after it (guarded on `jobState == FINISHED`).
- `MetricRepoTest.java`: kept only `testAlterColumnMetricsExposure`; dropped `testSPMMetricsExposure` / `testPlanAdvisorMetricsExposure`, which belong to other PRs not present on `branch-4.1` and reference metrics 4.1 lacks.

Net change is `11 files, +434` — identical to the original squash commit.

**Verification:** FE build `SUCCESS`; `AlterMetricRegistryTest` (22) + `MetricRepoTest` (17) = 39/39 green on `branch-4.1`.

---

## Why I'm doing:

We want to understand how users actually use `ALTER TABLE ... <column op>` — which of add / drop / modify is most common — and how those changes are applied: the fast, metadata-only Fast Schema Evolution (FSE) path versus the slow path that physically rewrites data. This gives product and engineering real usage/adoption signal (including FSE v2 adoption in shared-data, and how often changes fall back to a data rewrite) instead of guesswork.

## What I'm doing:

Add two leader-aware (process-local) FE metrics, owned by a singleton `com.starrocks.alter.AlterMetricRegistry` and emitted through a `report(visitor)` hook wired into `MetricRepo.getMetric()`.

**Counter — `starrocks_fe_alter_operation_total{type=add_column|drop_column|modify_column, is_leader}`**

Incremented once per in-scope clause inside `SchemaChangeHandler.analyzeAndCreateJob`'s per-clause loop, at analysis time (independent of whether the resulting job later succeeds). A single statement can hold several operations — e.g. `ADD COLUMN a, DROP COLUMN b` — each counted under its type. Comment-only `MODIFY` (which returns before job creation) is excluded; renames and reorders are not counted.

**Histogram — `starrocks_fe_alter_duration_ms{execution_mode=fse|legacy_fse|rewrite, is_leader}`**

Time in milliseconds to apply an ALTER TABLE change, per statement:

- `fse`: the synchronous, metadata-only Fast Schema Evolution — shared-nothing, or shared-data with `cloud_native_fast_schema_evolution_v2` enabled (the default). Timed inline around `updateCatalogForFastSchemaEvolution`.
- `legacy_fse`: the shared-data asynchronous FSE path (`LakeTableAsyncFastSchemaChangeJob`), recorded when it reaches `FINISHED`. Occurs only when `cloud_native_fast_schema_evolution_v2` is disabled.
- `rewrite`: the change physically rewrote table data (e.g. a column type change), recorded when the data-rewrite schema-change job (`SchemaChangeJobV2` shared-nothing / `LakeTableSchemaChangeJob` shared-data) reaches `FINISHED`.

`legacy_fse` and `rewrite` are async wall-clock (include daemon queue + tablet propagation), while `fse` is the synchronous statement-thread latency — so `fse` versus the async modes is an order-of-magnitude indicator, not a like-for-like comparison (documented in the metric reference). The FSE fast path also builds a `SchemaChangeJobV2` purely as a history carrier and sets it `FINISHED` without ever running it, so it is not miscounted as `rewrite`.

Both metrics are leader-aware (carry `is_leader`, report 0 off-leader). Declared names omit the `starrocks_fe_` prefix (`PrometheusMetricVisitor` prepends it at scrape time). The `Alter*` vocabulary and metric names are intentionally generic so the registry can host more ALTER metrics later; this iteration tracks add/drop/modify column and the schema-change execution modes. Additive and backward-compatible — no existing metric or behavior changes and no new persisted state.

Docs for both metrics are in `docs/{en,zh,ja}/administration/management/monitoring/metric_details/s.md`.

### Tests

- `AlterMetricRegistryTest` — per-type counter bump; real ADD/DROP/MODIFY DDL through `SchemaChangeHandler` asserting per-`type` deltas; `report()` → Prometheus emission (all three `type` and all three `execution_mode` series, deduped HELP/TYPE, per-series `is_leader`); and end-to-end duration recording for `fse`, `legacy_fse`, and `rewrite` — the `rewrite` case drives a real data-rewrite `LakeTableSchemaChangeJob` to `FINISHED`.
- `MetricRepoTest.testAlterColumnMetricsExposure` — drives the real `MetricRepo.getMetric()` scrape path to guard the `report()` wiring (removing it would silently drop both metrics).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

(Additive only: two new leader-side monitoring metrics appear in the FE `/metrics` output. No existing metric, SQL surface, parameter, or persisted state changes.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wgZwYM3e53Jj41vb54dik