### PR TITLE
[BugFix] Persist the rewrite's own schema for range-rewrite shadow tablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
@@ -333,11 +333,11 @@ public abstract class LakeOnlineRewriteJobBase
     /**
      * Seam invoked lock-free after the shadow index tablets are built (PENDING stage 2) and before the
      * PENDING -&gt; WAITING_TXN commit, so a subclass can write each shadow tablet's version-1 metadata on
-     * the compute nodes. Default no-op: the replace-flavored range rewrite lets the compute node lazily
-     * materialize version-1 metadata on first read. The additive rollup overrides this: its shadow shards
-     * share the base index's per-partition storage path, so without an explicit CreateReplicaTask the
-     * compute node would lazily materialize a rollup tablet's version-1 metadata from the base index's
-     * shared initial-metadata template and read the BASE schema (wrong sort-key arity). Runs while the job
+     * the compute nodes. Default no-op. Both the range rewrite and the additive rollup override this:
+     * their shadow shards share the base index's per-partition storage path, so without an explicit
+     * CreateReplicaTask the compute node would lazily materialize a shadow tablet's version-1 metadata
+     * from the base index's shared initial-metadata template and read the BASE schema (a stale sort-key
+     * arity), which breaks the reshard/pre-split boundary validation. Runs while the job
      * is still PENDING (before the WAITING_TXN journal), so a failure leaves the job re-runnable: the
      * runPendingJob cleanup drops the orphaned shards and a retry rebuilds the shadow fresh. Must throw
      * AlterCancelException on failure.
@@ -406,8 +406,8 @@ public abstract class LakeOnlineRewriteJobBase
                 planPartitionShadow(plan, table, cachedDbName);
             }
 
-            // Write each shadow tablet's version-1 metadata on the compute nodes (default no-op; the
-            // additive rollup persists its own schema here). Still lock-free and still PENDING, so on any
+            // Write each shadow tablet's version-1 metadata on the compute nodes (default no-op; the range
+            // rewrite and the additive rollup persist their own schema here). Still lock-free and still PENDING, so on any
             // failure the finally below drops the orphaned shards and a retry rebuilds the shadow fresh.
             createShadowTabletMetadata(pendingPlans);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
@@ -24,19 +24,24 @@ import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.lake.Utils;
@@ -50,11 +55,19 @@ import com.starrocks.qe.QueryState;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
+import com.starrocks.thrift.TTabletType;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
@@ -330,19 +343,150 @@ public abstract class LakeOnlineRewriteJobBase
     protected void afterJobSettled(boolean cancelled) {
     }
 
+    // ---- shadow-index config for the per-tablet CreateReplicaTask (createShadowTabletMetadata) --------
+    // Each subclass supplies its own shadow-index schema/key config; the shared createShadowTabletMetadata
+    // below builds the tablet schema from these so the persisted sort-key arity matches the promoted index.
+    protected abstract List<Column> getShadowSchema();
+
+    protected abstract KeysType getShadowKeysType();
+
+    protected abstract List<Integer> getShadowSortKeyIdxes();
+
+    protected abstract List<Integer> getShadowSortKeyUniqueIds();
+
+    protected abstract short getShadowShortKeyColumnCount();
+
+    /** A short label for the shadow ("rollup" / "range-rewrite") used in log and error text. */
+    protected abstract String shadowKindLabel();
+
     /**
-     * Seam invoked lock-free after the shadow index tablets are built (PENDING stage 2) and before the
-     * PENDING -&gt; WAITING_TXN commit, so a subclass can write each shadow tablet's version-1 metadata on
-     * the compute nodes. Default no-op. Both the range rewrite and the additive rollup override this:
-     * their shadow shards share the base index's per-partition storage path, so without an explicit
-     * CreateReplicaTask the compute node would lazily materialize a shadow tablet's version-1 metadata
-     * from the base index's shared initial-metadata template and read the BASE schema (a stale sort-key
-     * arity), which breaks the reshard/pre-split boundary validation. Runs while the job
-     * is still PENDING (before the WAITING_TXN journal), so a failure leaves the job re-runnable: the
-     * runPendingJob cleanup drops the orphaned shards and a retry rebuilds the shadow fresh. Must throw
-     * AlterCancelException on failure.
+     * Write each shadow tablet's version-1 metadata on its compute node, carrying the shadow index's OWN
+     * schema (its sort key), so the reshard/pre-split boundary validation reads the shadow's sort-key
+     * arity rather than the base index's. Both range subclasses build their shadow shards in the base
+     * index's shard group (shared per-partition storage path), so without this the compute node would
+     * lazily materialize a shadow tablet's version-1 metadata from the base index's shared
+     * initial-metadata template and read the BASE schema (a stale sort-key arity), which breaks the
+     * reshard/pre-split boundary validation.
+     *
+     * <p>Build one CreateReplicaTask per shadow tablet under a READ lock, then send and wait outside the
+     * lock (a network round-trip must not be held across the database lock). Tablet-creation optimization
+     * is forced off so each tablet writes its OWN per-tablet version-1 metadata instead of the shared
+     * template. Runs while the job is still PENDING (before the WAITING_TXN journal), so a failure leaves
+     * the job re-runnable: the runPendingJob cleanup drops the orphaned shards and a retry rebuilds the
+     * shadow fresh.
      */
     protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
+        long shadowTabletCount = plans.stream()
+                .filter(plan -> plan.shadowIndex != null)
+                .mapToLong(plan -> plan.shadowIndex.getTablets().size())
+                .sum();
+        if (shadowTabletCount == 0) {
+            return;
+        }
+
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>((int) shadowTabletCount);
+        AgentBatchTask batchTask;
+        // Build the tasks under a READ lock (stable table metadata + compute-node resolution), then send
+        // and wait outside the lock (a network round-trip must not be held across the database lock).
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            batchTask = buildShadowTabletCreateTasks(table, plans, countDownLatch);
+        }
+
+        LakeRollupJob.sendAgentTaskAndWait(batchTask, countDownLatch,
+                Config.tablet_create_timeout_second * shadowTabletCount);
+    }
+
+    /**
+     * Build one {@link CreateReplicaTask} per shadow tablet, each carrying the shadow index's own tablet
+     * schema (its sort key) and its per-tablet range. The caller holds the database read lock. Split out
+     * so a unit test can assert the emitted tablet schema without a compute-node round-trip.
+     */
+    @VisibleForTesting
+    AgentBatchTask buildShadowTabletCreateTasks(@NotNull OlapTable table, List<PendingPartitionPlan> plans,
+                                                MarkedCountDownLatch<Long, Long> countDownLatch)
+            throws AlterCancelException {
+        AgentBatchTask batchTask = new AgentBatchTask();
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        long gtid = getNextGtid();
+
+        // The shadow index meta is not registered on the table until PENDING stage 3, so build the
+        // MaterializedIndexMeta from this job's shadow config -- identical to what registerShadowIndexMeta
+        // will register -- and derive the tablet schema (with the shadow's own sort key) from it.
+        MaterializedIndexMeta shadowIndexMeta = new MaterializedIndexMeta(
+                shadowIndexMetaId, getShadowSchema(), 0 /* schemaVersion */, 0 /* schemaHash */,
+                getShadowShortKeyColumnCount(), TStorageType.COLUMN, getShadowKeysType(), null /* defineStmt */,
+                getShadowSortKeyIdxes(), getShadowSortKeyUniqueIds());
+        TTabletSchema tabletSchema =
+                SchemaInfo.fromMaterializedIndex(table, shadowIndexMetaId, shadowIndexMeta).toTabletSchema();
+        String shadowKind = shadowKindLabel();
+
+        for (PendingPartitionPlan plan : plans) {
+            if (plan.shadowIndex == null) {
+                continue;
+            }
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(plan.physicalPartitionId);
+            if (physicalPartition == null) {
+                throw new AlterCancelException("partition " + plan.physicalPartitionId
+                        + " was dropped while creating " + shadowKind + " shadow tablets");
+            }
+            TStorageMedium storageMedium = table.getPartitionInfo()
+                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+
+            // The schema file is created once per partition, with the first tablet.
+            boolean createSchemaFile = true;
+            for (Tablet shadowTablet : plan.shadowIndex.getTablets()) {
+                long shadowTabletId = shadowTablet.getId();
+                ComputeNode computeNode = null;
+                try {
+                    computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, shadowTabletId);
+                } catch (ErrorReportException e) {
+                    // computeNode stays null -> handled below.
+                }
+                if (computeNode == null) {
+                    throw new AlterCancelException(
+                            "no alive compute node to create " + shadowKind + " shadow tablet " + shadowTabletId);
+                }
+                countDownLatch.addMark(computeNode.getId(), shadowTabletId);
+
+                CreateReplicaTask task = CreateReplicaTask.newBuilder()
+                        .setNodeId(computeNode.getId())
+                        .setDbId(dbId)
+                        .setTableId(tableId)
+                        .setPartitionId(plan.physicalPartitionId)
+                        .setIndexId(shadowIndexMetaId)
+                        .setTabletId(shadowTabletId)
+                        .setVersion(Partition.PARTITION_INIT_VERSION)
+                        .setStorageMedium(storageMedium)
+                        .setLatch(countDownLatch)
+                        .setEnablePersistentIndex(table.enablePersistentIndex())
+                        .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
+                        // Carry the table's flat-json config: this per-tablet metadata replaces the shared
+                        // base template (which had it), so without this a flat-json-enabled table's shadow
+                        // tablets would lose the derivation -- as every other create-replica path sets it.
+                        .setFlatJsonConfig(table.getFlatJsonConfig())
+                        .setTabletType(TTabletType.TABLET_TYPE_LAKE)
+                        .setCompressionType(table.getCompressionType())
+                        // The compute node overwrites the tablet schema's compression level with this
+                        // request field (defaults to 0), so set it explicitly to preserve a table's
+                        // configured non-default compression level -- as every other create-replica path does.
+                        .setCompressionLevel(table.getCompressionLevel())
+                        .setCreateSchemaFile(createSchemaFile)
+                        .setTabletSchema(tabletSchema)
+                        // Force per-tablet version-1 metadata: with the optimization on the compute node
+                        // would write the shared initial-metadata template, which belongs to the base index
+                        // sharing this partition storage path. Per-tablet metadata both fixes the stale
+                        // schema read and avoids clobbering the base template.
+                        .setEnableTabletCreationOptimization(false)
+                        .setGtid(gtid)
+                        .setCompactionStrategy(table.getCompactionStrategy())
+                        .setRange(shadowTablet.getRange())
+                        .build();
+                createSchemaFile = false;
+                batchTask.addTask(task);
+            }
+        }
+        return batchTask;
     }
 
     // ---- PENDING ---------------------------------------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
@@ -33,9 +33,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -43,23 +41,13 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ParseUtil;
-import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
-import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
-import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.KeysType;
-import com.starrocks.system.ComputeNode;
-import com.starrocks.task.AgentBatchTask;
-import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
-import com.starrocks.thrift.TTabletSchema;
-import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -247,132 +235,34 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
         plan.shadowIndex = shadowIndex;
     }
 
-    /**
-     * Write each range-rewrite shadow tablet's version-1 metadata on its compute node, carrying the NEW
-     * (rewritten) schema and its sort key, so the reshard/pre-split boundary validation reads the new
-     * sort-key arity rather than the base index's. The rewrite shadow shares the base index's
-     * per-partition storage path, so without this the compute node would lazily materialize the tablet's
-     * version-1 metadata from the base index's shared initial-metadata template and read the BASE schema
-     * (stale sort-key arity), which makes a subsequent load's pre-split fall back to identical.
-     *
-     * <p>Mirrors {@link LakeRangeRollupJob}: build one CreateReplicaTask per shadow tablet under a READ
-     * lock, then send and wait outside the lock (a network round-trip must not be held across the
-     * database lock). Tablet-creation optimization is forced off so each tablet writes its OWN per-tablet
-     * version-1 metadata instead of the shared initial-metadata template that belongs to the base index.
-     */
     @Override
-    protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
-        long shadowTabletCount = plans.stream()
-                .filter(plan -> plan.shadowIndex != null)
-                .mapToLong(plan -> plan.shadowIndex.getTablets().size())
-                .sum();
-        if (shadowTabletCount == 0) {
-            return;
-        }
-
-        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>((int) shadowTabletCount);
-        AgentBatchTask batchTask;
-        // Build the tasks under a READ lock (stable table metadata + compute-node resolution), then send
-        // and wait outside the lock (a network round-trip must not be held across the database lock).
-        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
-            OlapTable table = getTableOrThrow();
-            batchTask = buildShadowTabletCreateTasks(table, plans, countDownLatch);
-        }
-
-        LakeRollupJob.sendAgentTaskAndWait(batchTask, countDownLatch,
-                Config.tablet_create_timeout_second * shadowTabletCount);
+    protected List<Column> getShadowSchema() {
+        return newSchema;
     }
 
-    /**
-     * Build one {@link CreateReplicaTask} per range-rewrite shadow tablet, each carrying the new index's
-     * own tablet schema (its sort key) and its per-tablet range. The caller holds the database read lock.
-     * Split out so a unit test can assert the emitted tablet schema without a compute-node round-trip.
-     */
-    @VisibleForTesting
-    AgentBatchTask buildShadowTabletCreateTasks(@NotNull OlapTable table, List<PendingPartitionPlan> plans,
-                                                MarkedCountDownLatch<Long, Long> countDownLatch)
-            throws AlterCancelException {
-        AgentBatchTask batchTask = new AgentBatchTask();
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        long gtid = getNextGtid();
+    @Override
+    protected KeysType getShadowKeysType() {
+        return newKeysType;
+    }
 
-        // The shadow index meta is not registered on the table until PENDING stage 3, so build the
-        // MaterializedIndexMeta from this job's new-schema config -- identical to what
-        // registerShadowIndexMeta will register -- and derive the tablet schema (with the new sort key)
-        // from it.
-        MaterializedIndexMeta newIndexMeta = new MaterializedIndexMeta(
-                shadowIndexMetaId, newSchema, 0 /* schemaVersion */, 0 /* schemaHash */,
-                shadowShortKeyColumnCount, TStorageType.COLUMN, newKeysType, null /* defineStmt */,
-                newSortKeyIdxes, newSortKeyUniqueIds);
-        TTabletSchema tabletSchema =
-                SchemaInfo.fromMaterializedIndex(table, shadowIndexMetaId, newIndexMeta).toTabletSchema();
+    @Override
+    protected List<Integer> getShadowSortKeyIdxes() {
+        return newSortKeyIdxes;
+    }
 
-        for (PendingPartitionPlan plan : plans) {
-            if (plan.shadowIndex == null) {
-                continue;
-            }
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(plan.physicalPartitionId);
-            if (physicalPartition == null) {
-                throw new AlterCancelException("partition " + plan.physicalPartitionId
-                        + " was dropped while creating range-rewrite shadow tablets");
-            }
-            TStorageMedium storageMedium = table.getPartitionInfo()
-                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+    @Override
+    protected List<Integer> getShadowSortKeyUniqueIds() {
+        return newSortKeyUniqueIds;
+    }
 
-            // The schema file is created once per partition, with the first tablet.
-            boolean createSchemaFile = true;
-            for (Tablet shadowTablet : plan.shadowIndex.getTablets()) {
-                long shadowTabletId = shadowTablet.getId();
-                ComputeNode computeNode = null;
-                try {
-                    computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, shadowTabletId);
-                } catch (ErrorReportException e) {
-                    // computeNode stays null -> handled below.
-                }
-                if (computeNode == null) {
-                    throw new AlterCancelException(
-                            "no alive compute node to create range-rewrite shadow tablet " + shadowTabletId);
-                }
-                countDownLatch.addMark(computeNode.getId(), shadowTabletId);
+    @Override
+    protected short getShadowShortKeyColumnCount() {
+        return shadowShortKeyColumnCount;
+    }
 
-                CreateReplicaTask task = CreateReplicaTask.newBuilder()
-                        .setNodeId(computeNode.getId())
-                        .setDbId(dbId)
-                        .setTableId(tableId)
-                        .setPartitionId(plan.physicalPartitionId)
-                        .setIndexId(shadowIndexMetaId)
-                        .setTabletId(shadowTabletId)
-                        .setVersion(Partition.PARTITION_INIT_VERSION)
-                        .setStorageMedium(storageMedium)
-                        .setLatch(countDownLatch)
-                        .setEnablePersistentIndex(table.enablePersistentIndex())
-                        .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
-                        // Carry the table's flat-json config: this per-tablet metadata replaces the shared
-                        // base template (which had it), so without this a flat-json-enabled table's shadow
-                        // tablets would lose the derivation -- as every other create-replica path sets it.
-                        .setFlatJsonConfig(table.getFlatJsonConfig())
-                        .setTabletType(TTabletType.TABLET_TYPE_LAKE)
-                        .setCompressionType(table.getCompressionType())
-                        // The compute node overwrites the tablet schema's compression level with this
-                        // request field (defaults to 0), so set it explicitly to preserve a table's
-                        // configured non-default compression level -- as every other create-replica path does.
-                        .setCompressionLevel(table.getCompressionLevel())
-                        .setCreateSchemaFile(createSchemaFile)
-                        .setTabletSchema(tabletSchema)
-                        // Force per-tablet version-1 metadata: with the optimization on the compute node
-                        // would write the shared initial-metadata template, which belongs to the base index
-                        // sharing this partition storage path. Per-tablet metadata both fixes the stale
-                        // schema read and avoids clobbering the base template.
-                        .setEnableTabletCreationOptimization(false)
-                        .setGtid(gtid)
-                        .setCompactionStrategy(table.getCompactionStrategy())
-                        .setRange(shadowTablet.getRange())
-                        .build();
-                createSchemaFile = false;
-                batchTask.addTask(task);
-            }
-        }
-        return batchTask;
+    @Override
+    protected String shadowKindLabel() {
+        return "range-rewrite";
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
@@ -33,7 +33,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -41,13 +43,23 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ParseUtil;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
+import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletSchema;
+import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -233,6 +245,130 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
         plan.boundaries = boundaries;
         plan.shadowTabletCount = shadowTabletCount;
         plan.shadowIndex = shadowIndex;
+    }
+
+    /**
+     * Write each range-rewrite shadow tablet's version-1 metadata on its compute node, carrying the NEW
+     * (rewritten) schema and its sort key, so the reshard/pre-split boundary validation reads the new
+     * sort-key arity rather than the base index's. The rewrite shadow shares the base index's
+     * per-partition storage path, so without this the compute node would lazily materialize the tablet's
+     * version-1 metadata from the base index's shared initial-metadata template and read the BASE schema
+     * (stale sort-key arity), which makes a subsequent load's pre-split fall back to identical.
+     *
+     * <p>Mirrors {@link LakeRangeRollupJob}: build one CreateReplicaTask per shadow tablet under a READ
+     * lock, then send and wait outside the lock (a network round-trip must not be held across the
+     * database lock). Tablet-creation optimization is forced off so each tablet writes its OWN per-tablet
+     * version-1 metadata instead of the shared initial-metadata template that belongs to the base index.
+     */
+    @Override
+    protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
+        long shadowTabletCount = plans.stream()
+                .filter(plan -> plan.shadowIndex != null)
+                .mapToLong(plan -> plan.shadowIndex.getTablets().size())
+                .sum();
+        if (shadowTabletCount == 0) {
+            return;
+        }
+
+        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>((int) shadowTabletCount);
+        AgentBatchTask batchTask;
+        // Build the tasks under a READ lock (stable table metadata + compute-node resolution), then send
+        // and wait outside the lock (a network round-trip must not be held across the database lock).
+        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
+            OlapTable table = getTableOrThrow();
+            batchTask = buildShadowTabletCreateTasks(table, plans, countDownLatch);
+        }
+
+        LakeRollupJob.sendAgentTaskAndWait(batchTask, countDownLatch,
+                Config.tablet_create_timeout_second * shadowTabletCount);
+    }
+
+    /**
+     * Build one {@link CreateReplicaTask} per range-rewrite shadow tablet, each carrying the new index's
+     * own tablet schema (its sort key) and its per-tablet range. The caller holds the database read lock.
+     * Split out so a unit test can assert the emitted tablet schema without a compute-node round-trip.
+     */
+    @VisibleForTesting
+    AgentBatchTask buildShadowTabletCreateTasks(@NotNull OlapTable table, List<PendingPartitionPlan> plans,
+                                                MarkedCountDownLatch<Long, Long> countDownLatch)
+            throws AlterCancelException {
+        AgentBatchTask batchTask = new AgentBatchTask();
+        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        long gtid = getNextGtid();
+
+        // The shadow index meta is not registered on the table until PENDING stage 3, so build the
+        // MaterializedIndexMeta from this job's new-schema config -- identical to what
+        // registerShadowIndexMeta will register -- and derive the tablet schema (with the new sort key)
+        // from it.
+        MaterializedIndexMeta newIndexMeta = new MaterializedIndexMeta(
+                shadowIndexMetaId, newSchema, 0 /* schemaVersion */, 0 /* schemaHash */,
+                shadowShortKeyColumnCount, TStorageType.COLUMN, newKeysType, null /* defineStmt */,
+                newSortKeyIdxes, newSortKeyUniqueIds);
+        TTabletSchema tabletSchema =
+                SchemaInfo.fromMaterializedIndex(table, shadowIndexMetaId, newIndexMeta).toTabletSchema();
+
+        for (PendingPartitionPlan plan : plans) {
+            if (plan.shadowIndex == null) {
+                continue;
+            }
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(plan.physicalPartitionId);
+            if (physicalPartition == null) {
+                throw new AlterCancelException("partition " + plan.physicalPartitionId
+                        + " was dropped while creating range-rewrite shadow tablets");
+            }
+            TStorageMedium storageMedium = table.getPartitionInfo()
+                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+
+            // The schema file is created once per partition, with the first tablet.
+            boolean createSchemaFile = true;
+            for (Tablet shadowTablet : plan.shadowIndex.getTablets()) {
+                long shadowTabletId = shadowTablet.getId();
+                ComputeNode computeNode = null;
+                try {
+                    computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, shadowTabletId);
+                } catch (ErrorReportException e) {
+                    // computeNode stays null -> handled below.
+                }
+                if (computeNode == null) {
+                    throw new AlterCancelException(
+                            "no alive compute node to create range-rewrite shadow tablet " + shadowTabletId);
+                }
+                countDownLatch.addMark(computeNode.getId(), shadowTabletId);
+
+                CreateReplicaTask task = CreateReplicaTask.newBuilder()
+                        .setNodeId(computeNode.getId())
+                        .setDbId(dbId)
+                        .setTableId(tableId)
+                        .setPartitionId(plan.physicalPartitionId)
+                        .setIndexId(shadowIndexMetaId)
+                        .setTabletId(shadowTabletId)
+                        .setVersion(Partition.PARTITION_INIT_VERSION)
+                        .setStorageMedium(storageMedium)
+                        .setLatch(countDownLatch)
+                        .setEnablePersistentIndex(table.enablePersistentIndex())
+                        .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
+                        .setTabletType(TTabletType.TABLET_TYPE_LAKE)
+                        .setCompressionType(table.getCompressionType())
+                        // The compute node overwrites the tablet schema's compression level with this
+                        // request field (defaults to 0), so set it explicitly to preserve a table's
+                        // configured non-default compression level -- as every other create-replica path does.
+                        .setCompressionLevel(table.getCompressionLevel())
+                        .setCreateSchemaFile(createSchemaFile)
+                        .setTabletSchema(tabletSchema)
+                        // Force per-tablet version-1 metadata: with the optimization on the compute node
+                        // would write the shared initial-metadata template, which belongs to the base index
+                        // sharing this partition storage path. Per-tablet metadata both fixes the stale
+                        // schema read and avoids clobbering the base template.
+                        .setEnableTabletCreationOptimization(false)
+                        .setGtid(gtid)
+                        .setCompactionStrategy(table.getCompactionStrategy())
+                        .setRange(shadowTablet.getRange())
+                        .build();
+                createSchemaFile = false;
+                batchTask.addTask(task);
+            }
+        }
+        return batchTask;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
@@ -347,6 +347,10 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
                         .setLatch(countDownLatch)
                         .setEnablePersistentIndex(table.enablePersistentIndex())
                         .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
+                        // Carry the table's flat-json config: this per-tablet metadata replaces the shared
+                        // base template (which had it), so without this a flat-json-enabled table's shadow
+                        // tablets would lose the derivation -- as every other create-replica path sets it.
+                        .setFlatJsonConfig(table.getFlatJsonConfig())
                         .setTabletType(TTabletType.TABLET_TYPE_LAKE)
                         .setCompressionType(table.getCompressionType())
                         // The compute node overwrites the tablet schema's compression level with this

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRollupJob.java
@@ -33,11 +33,8 @@ import com.starrocks.alter.reshard.presplit.TabletPreSplitCoordinator;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
-import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
@@ -45,25 +42,15 @@ import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.Tuple;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Range;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ParseUtil;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
-import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
-import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.KeysType;
-import com.starrocks.system.ComputeNode;
-import com.starrocks.task.AgentBatchTask;
-import com.starrocks.task.CreateReplicaTask;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
-import com.starrocks.thrift.TTabletSchema;
-import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -355,128 +342,34 @@ public class LakeRangeRollupJob extends LakeOnlineRewriteJobBase {
         return DefaultPreSplitPipeline.buildTabletRanges(boundaries);
     }
 
-    /**
-     * Write each rollup shadow tablet's version-1 metadata on its compute node, carrying the ROLLUP's own
-     * schema (its ORDER BY sort key), so the reshard/pre-split boundary validation reads the rollup's
-     * sort-key arity rather than the base index's. The rollup shadow shards share the base index's
-     * per-partition storage path, so without this the compute node would lazily materialize the tablet's
-     * version-1 metadata from the base index's shared initial-metadata template and read the BASE schema.
-     *
-     * <p>Mirrors {@link LakeRollupJob}'s create-replica-and-wait: build one CreateReplicaTask per shadow
-     * tablet under a READ lock, then send and wait outside the lock. Two differences from the plain
-     * (non-range) rollup: (1) the tablet schema carries the rollup's own sort key (arity matches the
-     * rollup ORDER BY), not a null sort key; (2) tablet-creation optimization is forced off so each tablet
-     * writes its OWN per-tablet version-1 metadata instead of the shared initial-metadata template, which
-     * belongs to the base index sharing this partition storage path.
-     */
     @Override
-    protected void createShadowTabletMetadata(List<PendingPartitionPlan> plans) throws AlterCancelException {
-        long shadowTabletCount = plans.stream()
-                .filter(plan -> plan.shadowIndex != null)
-                .mapToLong(plan -> plan.shadowIndex.getTablets().size())
-                .sum();
-        if (shadowTabletCount == 0) {
-            return;
-        }
-
-        MarkedCountDownLatch<Long, Long> countDownLatch = new MarkedCountDownLatch<>((int) shadowTabletCount);
-        AgentBatchTask batchTask;
-        // Build the tasks under a READ lock (stable table metadata + compute-node resolution), then send
-        // and wait outside the lock (a network round-trip must not be held across the database lock).
-        try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.READ)) {
-            OlapTable table = getTableOrThrow();
-            batchTask = buildShadowTabletCreateTasks(table, plans, countDownLatch);
-        }
-
-        LakeRollupJob.sendAgentTaskAndWait(batchTask, countDownLatch,
-                Config.tablet_create_timeout_second * shadowTabletCount);
+    protected List<Column> getShadowSchema() {
+        return rollupSchema;
     }
 
-    /**
-     * Build one {@link CreateReplicaTask} per rollup shadow tablet, each carrying the rollup's own tablet
-     * schema (its sort key) and its per-tablet range. The caller holds the database read lock. Split out
-     * so a unit test can assert the emitted tablet schema without a compute-node round-trip.
-     */
-    @VisibleForTesting
-    AgentBatchTask buildShadowTabletCreateTasks(@NotNull OlapTable table, List<PendingPartitionPlan> plans,
-                                                MarkedCountDownLatch<Long, Long> countDownLatch)
-            throws AlterCancelException {
-        AgentBatchTask batchTask = new AgentBatchTask();
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
-        long gtid = getNextGtid();
+    @Override
+    protected KeysType getShadowKeysType() {
+        return rollupKeysType;
+    }
 
-        // The rollup shadow index meta is not registered on the table until PENDING stage 3, so build the
-        // MaterializedIndexMeta from this job's rollup config -- identical to what registerShadowIndexMeta
-        // will register -- and derive the tablet schema (with the rollup's own sort key) from it.
-        MaterializedIndexMeta rollupIndexMeta = new MaterializedIndexMeta(
-                shadowIndexMetaId, rollupSchema, 0 /* schemaVersion */, 0 /* schemaHash */,
-                shadowShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, null /* defineStmt */,
-                rollupSortKeyIdxes, rollupSortKeyUniqueIds);
-        TTabletSchema tabletSchema =
-                SchemaInfo.fromMaterializedIndex(table, shadowIndexMetaId, rollupIndexMeta).toTabletSchema();
+    @Override
+    protected List<Integer> getShadowSortKeyIdxes() {
+        return rollupSortKeyIdxes;
+    }
 
-        for (PendingPartitionPlan plan : plans) {
-            if (plan.shadowIndex == null) {
-                continue;
-            }
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(plan.physicalPartitionId);
-            if (physicalPartition == null) {
-                throw new AlterCancelException("partition " + plan.physicalPartitionId
-                        + " was dropped while creating rollup shadow tablets");
-            }
-            TStorageMedium storageMedium = table.getPartitionInfo()
-                    .getDataProperty(physicalPartition.getParentId()).getStorageMedium();
+    @Override
+    protected List<Integer> getShadowSortKeyUniqueIds() {
+        return rollupSortKeyUniqueIds;
+    }
 
-            // The schema file is created once per partition, with the first tablet.
-            boolean createSchemaFile = true;
-            for (Tablet shadowTablet : plan.shadowIndex.getTablets()) {
-                long shadowTabletId = shadowTablet.getId();
-                ComputeNode computeNode = null;
-                try {
-                    computeNode = warehouseManager.getComputeNodeAssignedToTablet(computeResource, shadowTabletId);
-                } catch (ErrorReportException e) {
-                    // computeNode stays null -> handled below.
-                }
-                if (computeNode == null) {
-                    throw new AlterCancelException(
-                            "no alive compute node to create rollup shadow tablet " + shadowTabletId);
-                }
-                countDownLatch.addMark(computeNode.getId(), shadowTabletId);
+    @Override
+    protected short getShadowShortKeyColumnCount() {
+        return shadowShortKeyColumnCount;
+    }
 
-                CreateReplicaTask task = CreateReplicaTask.newBuilder()
-                        .setNodeId(computeNode.getId())
-                        .setDbId(dbId)
-                        .setTableId(tableId)
-                        .setPartitionId(plan.physicalPartitionId)
-                        .setIndexId(shadowIndexMetaId)
-                        .setTabletId(shadowTabletId)
-                        .setVersion(Partition.PARTITION_INIT_VERSION)
-                        .setStorageMedium(storageMedium)
-                        .setLatch(countDownLatch)
-                        .setEnablePersistentIndex(table.enablePersistentIndex())
-                        .setPrimaryIndexCacheExpireSec(table.primaryIndexCacheExpireSec())
-                        .setTabletType(TTabletType.TABLET_TYPE_LAKE)
-                        .setCompressionType(table.getCompressionType())
-                        // The compute node overwrites the tablet schema's compression level with this
-                        // request field (defaults to 0), so set it explicitly to preserve a table's
-                        // configured non-default compression level -- as every other create-replica path does.
-                        .setCompressionLevel(table.getCompressionLevel())
-                        .setCreateSchemaFile(createSchemaFile)
-                        .setTabletSchema(tabletSchema)
-                        // Force per-tablet version-1 metadata: with the optimization on the compute node
-                        // would write the shared initial-metadata template, which belongs to the base index
-                        // sharing this partition storage path. Per-tablet metadata both fixes the wrong
-                        // schema read and avoids clobbering the base template.
-                        .setEnableTabletCreationOptimization(false)
-                        .setGtid(gtid)
-                        .setCompactionStrategy(table.getCompactionStrategy())
-                        .setRange(shadowTablet.getRange())
-                        .build();
-                createSchemaFile = false;
-                batchTask.addTask(task);
-            }
-        }
-        return batchTask;
+    @Override
+    protected String shadowKindLabel() {
+        return "rollup";
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
@@ -20,6 +20,7 @@ import com.starrocks.alter.reshard.presplit.SampleSet;
 import com.starrocks.alter.reshard.presplit.Sampler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MvId;
@@ -197,6 +198,9 @@ public class LakeRangeRewriteSchemaChangeJobTest {
     public void testCreateShadowTabletMetadataEmitsRewriteSchema() throws Exception {
         // A non-default compression level so the create task must carry it through, not level 0.
         table.setCompressionLevel(7);
+        // A flat-json config so the create task must carry it through (the per-tablet metadata replaces
+        // the shared base template that would otherwise have supplied it).
+        table.setFlatJsonConfig(new FlatJsonConfig(true, 0.5, 0.5, 100));
 
         // Rewrite to the single column k2 (arity 1), narrower than the base (k1, k2) (arity 2).
         LakeRangeRewriteSchemaChangeJob job = newSingleColumnJob(stubSampler(List.of()));
@@ -233,6 +237,12 @@ public class LakeRangeRewriteSchemaChangeJobTest {
             // must carry the table's configured level (7), not the builder default (0).
             Assertions.assertEquals(7, req.getCompression_level(),
                     "create task must carry the table's configured compression level, not the default");
+            // The per-tablet metadata replaces the shared base template, so it must carry the table's
+            // flat-json config; without it a flat-json-enabled table's shadow tablets lose the derivation.
+            Assertions.assertTrue(req.isSetFlat_json_config(),
+                    "create task must carry the table's flat-json config");
+            Assertions.assertTrue(req.getFlat_json_config().isFlat_json_enable(),
+                    "flat-json config must reflect the table's enabled setting");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
@@ -1775,6 +1775,38 @@ public class LakeRangeRewriteSchemaChangeJobTest {
         @Override
         protected void validateRewriteConfig() {
         }
+
+        // This stub never builds shadow tablets (planPartitionShadow is a no-op), so createShadowTabletMetadata
+        // early-returns and the shadow-config getters below are never actually read.
+        @Override
+        protected List<Column> getShadowSchema() {
+            return List.of();
+        }
+
+        @Override
+        protected KeysType getShadowKeysType() {
+            return KeysType.DUP_KEYS;
+        }
+
+        @Override
+        protected List<Integer> getShadowSortKeyIdxes() {
+            return List.of();
+        }
+
+        @Override
+        protected List<Integer> getShadowSortKeyUniqueIds() {
+            return List.of();
+        }
+
+        @Override
+        protected short getShadowShortKeyColumnCount() {
+            return (short) 0;
+        }
+
+        @Override
+        protected String shadowKindLabel() {
+            return "optimize";
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter;
 
+import com.starrocks.alter.LakeOnlineRewriteJobBase.PendingPartitionPlan;
 import com.starrocks.alter.reshard.presplit.Estimates;
 import com.starrocks.alter.reshard.presplit.SampleSet;
 import com.starrocks.alter.reshard.presplit.Sampler;
@@ -32,14 +33,23 @@ import com.starrocks.catalog.Tuple;
 import com.starrocks.catalog.Variant;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.CreateReplicaTask;
+import com.starrocks.thrift.TCreateTabletReq;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState;
@@ -88,6 +98,25 @@ public class LakeRangeRewriteSchemaChangeJobTest {
         GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
         table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), "t_range");
+
+        // createShadowTabletMetadata now writes each shadow tablet's version-1 metadata via a
+        // CreateReplicaTask, so the runPendingJob state-machine tests below must resolve a compute node and
+        // must not perform a real send/wait round-trip. Resolve every tablet to an alive node and no-op the
+        // send/wait; the dedicated createShadowTabletMetadata tests override these as needed.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                ComputeNode cn = new ComputeNode(1000L, "127.0.0.1", 9050);
+                cn.setAlive(true);
+                return cn;
+            }
+        };
+        new MockUp<LakeRollupJob>() {
+            @Mock
+            public static void sendAgentTaskAndWait(AgentBatchTask batchTask,
+                    MarkedCountDownLatch<Long, Long> countDownLatch, long timeoutSeconds) {
+            }
+        };
     }
 
     @AfterEach
@@ -127,6 +156,119 @@ public class LakeRangeRewriteSchemaChangeJobTest {
         return new Tuple(List.of(
                 Variant.of(IntegerType.INT, Integer.toString(k2)),
                 Variant.of(IntegerType.INT, Integer.toString(k1))));
+    }
+
+    /**
+     * Builds a job whose new sort key is the single column k2 (arity 1), narrower than the base
+     * (k1, k2) (arity 2) -- the arity-changing rewrite whose shadow tablets must persist the new arity.
+     */
+    private LakeRangeRewriteSchemaChangeJob newSingleColumnJob(Sampler sampler) {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        long shadowIndexMetaId = GlobalStateMgr.getCurrentState().getNextId();
+        LakeRangeRewriteSchemaChangeJob job = new LakeRangeRewriteSchemaChangeJob(
+                jobId, db.getId(), table.getId(), table.getName(), 3600_000L);
+        // New schema = base schema (column set unchanged); new sort key = the single column k2.
+        List<Column> baseSchema = table.getSchemaByIndexMetaId(table.getBaseIndexMetaId());
+        job.setNewSchema(new ArrayList<>(baseSchema));
+        job.setNewKeysType(KeysType.DUP_KEYS);
+        // k2 is at index 1 in the unchanged schema (k1, k2, v1) -> new sort key idxes = [1], arity 1.
+        job.setNewSortKeyIdxes(List.of(1));
+        job.setNewSortKeyColumns(List.of(baseSchema.get(1)));
+        job.setShadowIndex(shadowIndexMetaId, table.getBaseIndexMetaId(),
+                SchemaChangeHandler.SHADOW_NAME_PREFIX + table.getName(), (short) 1);
+        job.setSampler(sampler);
+        return job;
+    }
+
+    /** Create a PendingPartitionPlan for the first physical partition of the test table. */
+    private PendingPartitionPlan newPendingPlan(PhysicalPartition physicalPartition) {
+        MaterializedIndex baseIndex = physicalPartition.getLatestIndex(table.getBaseIndexMetaId());
+        return new PendingPartitionPlan(
+                physicalPartition.getId(),
+                baseIndex,
+                baseIndex.getShardGroupId(),
+                table.getPartition(physicalPartition.getParentId()).getName(),
+                baseIndex.getDataSize(),
+                table.getName(),
+                physicalPartition);
+    }
+
+    @Test
+    public void testCreateShadowTabletMetadataEmitsRewriteSchema() throws Exception {
+        // A non-default compression level so the create task must carry it through, not level 0.
+        table.setCompressionLevel(7);
+
+        // Rewrite to the single column k2 (arity 1), narrower than the base (k1, k2) (arity 2).
+        LakeRangeRewriteSchemaChangeJob job = newSingleColumnJob(stubSampler(List.of()));
+
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        job.planPartitionShadow(plan, table, DB_NAME);
+        Assertions.assertNotNull(plan.shadowIndex);
+        Assertions.assertTrue(plan.shadowIndex.getTablets().size() >= 1);
+
+        MarkedCountDownLatch<Long, Long> latch =
+                new MarkedCountDownLatch<>(plan.shadowIndex.getTablets().size());
+        AgentBatchTask batchTask = job.buildShadowTabletCreateTasks(table, List.of(plan), latch);
+
+        List<AgentTask> tasks = batchTask.getAllTasks();
+        Assertions.assertEquals(plan.shadowIndex.getTablets().size(), tasks.size(),
+                "one CreateReplicaTask per range-rewrite shadow tablet");
+        List<Integer> baseSortKeyIdxes = table.getIndexMetaByMetaId(table.getBaseIndexMetaId()).getSortKeyIdxes();
+        Assertions.assertEquals(2, baseSortKeyIdxes.size(), "base index sort key must be (k1, k2), arity 2");
+
+        for (AgentTask agentTask : tasks) {
+            Assertions.assertInstanceOf(CreateReplicaTask.class, agentTask);
+            TCreateTabletReq req = ((CreateReplicaTask) agentTask).toThrift();
+            // The emitted tablet schema is the new one: single-column sort key [1] (k2), NOT the base's
+            // (k1, k2) arity 2. Asserting [1] proves both the new arity and the correct column.
+            Assertions.assertEquals(List.of(1), req.getTablet_schema().getSort_key_idxes(),
+                    "shadow tablet must carry the new sort-key indexes (k2 -> [1]), not the base's (k1, k2)");
+            Assertions.assertEquals(job.getShadowIndexMetaId(), req.getTablet_schema().getId(),
+                    "tablet schema id must be the shadow index meta id");
+            // Per-tablet version-1 metadata (optimization off) so the base's shared template is not used.
+            Assertions.assertFalse(req.isEnable_tablet_creation_optimization(),
+                    "tablet-creation optimization must be off so per-tablet metadata is written");
+            // The compute node overwrites the schema's compression level with this request field, so it
+            // must carry the table's configured level (7), not the builder default (0).
+            Assertions.assertEquals(7, req.getCompression_level(),
+                    "create task must carry the table's configured compression level, not the default");
+        }
+    }
+
+    @Test
+    public void testCreateShadowTabletMetadataSkipsWhenNoShadowTablets() {
+        LakeRangeRewriteSchemaChangeJob job = newSingleColumnJob(stubSampler(List.of()));
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        // A plan whose shadow index was never built contributes no tablets, so the method returns early
+        // without acquiring the database lock or sending any create task.
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        Assertions.assertNull(plan.shadowIndex);
+        Assertions.assertDoesNotThrow(() -> job.createShadowTabletMetadata(List.of(plan)));
+    }
+
+    @Test
+    public void testBuildShadowTabletCreateTasksThrowsWithoutComputeNode() throws Exception {
+        // No alive compute node for the shadow tablet -> resolution throws, and the job aborts the alter.
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                throw ErrorReportException.report(ErrorCode.ERR_NO_NODES_IN_WAREHOUSE, tabletId);
+            }
+        };
+
+        LakeRangeRewriteSchemaChangeJob job = newSingleColumnJob(stubSampler(List.of()));
+        PhysicalPartition physicalPartition = table.getPhysicalPartitions().iterator().next();
+        PendingPartitionPlan plan = newPendingPlan(physicalPartition);
+        job.planPartitionShadow(plan, table, DB_NAME);
+        Assertions.assertNotNull(plan.shadowIndex);
+
+        MarkedCountDownLatch<Long, Long> latch =
+                new MarkedCountDownLatch<>(plan.shadowIndex.getTablets().size());
+        AlterCancelException ex = Assertions.assertThrows(AlterCancelException.class,
+                () -> job.buildShadowTabletCreateTasks(table, List.of(plan), latch));
+        Assertions.assertTrue(ex.getMessage().contains("no alive compute node"),
+                "abort message must name the missing compute node, was: " + ex.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRollupJobTest.java
@@ -20,6 +20,7 @@ import com.starrocks.alter.reshard.presplit.SampleSet;
 import com.starrocks.alter.reshard.presplit.Sampler;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
@@ -357,6 +358,9 @@ public class LakeRangeRollupJobTest {
 
         // Configure a non-default compression level so the create task must carry it through, not level 0.
         table.setCompressionLevel(7);
+        // A flat-json config so the create task must carry it through (the per-tablet metadata replaces
+        // the shared base template that would otherwise have supplied it).
+        table.setFlatJsonConfig(new FlatJsonConfig(true, 0.5, 0.5, 100));
 
         List<Column> baseSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         Column colK1 = baseSchema.get(0);
@@ -396,6 +400,12 @@ public class LakeRangeRollupJobTest {
             // carry the table's configured level (7), not the builder default (0).
             assertEquals(7, req.getCompression_level(),
                     "create task must carry the table's configured compression level, not the default");
+            // The per-tablet metadata replaces the shared base template, so it must carry the table's
+            // flat-json config; without it a flat-json-enabled table's shadow tablets lose the derivation.
+            assertTrue(req.isSetFlat_json_config(),
+                    "create task must carry the table's flat-json config");
+            assertTrue(req.getFlat_json_config().isFlat_json_enable(),
+                    "flat-json config must reflect the table's enabled setting");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

On a shared-data (cloud-native) range-distribution table, a sort-key-arity-changing
`ALTER TABLE ... ORDER BY(...)` (handled by `LakeRangeRewriteSchemaChangeJob`) persisted the BASE
index's schema onto its rewrite SHADOW TABLETS instead of the new (rewritten) schema. Any code that
reads such a tablet's stored schema therefore sees the base index's `sort_key_idxes` (the base sort-key
arity), not the rewritten one.

The concrete symptom: after the rewrite promotes the shadow to the visible index, a subsequent bulk
load's Sample-Based Tablet Pre-Split derives its boundary-tuple arity from the CURRENT visible index
(the new sort key) but the tablet's stored schema still carries the OLD arity. The external-boundaries
tablet-split validation (`tablet_splitter.cpp`, `tuple.values_size() != sort_key_idxes.size()`) then
rejects the boundaries and the split falls back to identical -- pre-split silently no-ops
(`external_boundaries_fallback_total` increments). This is the same defect class as the range-rollup
schema fix.

## What I'm doing:

Root cause: `LakeRangeRewriteSchemaChangeJob` (via `LakeTableAlterJobV2Builder.buildRangeShadowIndex`)
allocates the rewrite shadow tablets in the BASE index's shard group and never writes their own
version-1 metadata. The shadow shares the base index's per-partition storage path, so the compute node
lazily materializes each shadow tablet's version-1 metadata from the base index's shared
initial-metadata template (which carries the base schema). The rewrite's internal INSERT cannot repair
this: the shadow index's schema version is 0, so the compute node's `update_metadata_schema` version
gate (`new_schema_version > old_schema_version`) never adopts the write's schema. The non-range schema
change (`LakeTableSchemaChangeJob`) and the range rollup (`LakeRangeRollupJob`) do not have this problem
because they send a `CreateReplicaTask` per shadow tablet with an explicit `TTabletSchema`.

Fix: override the `LakeOnlineRewriteJobBase.createShadowTabletMetadata` seam on
`LakeRangeRewriteSchemaChangeJob` to send one `CreateReplicaTask` per rewrite shadow tablet carrying the
rewrite's OWN tablet schema (built from the job's new-schema config, so the persisted sort-key arity
matches the promoted index), with tablet-creation optimization disabled so each tablet writes its own
version-1 metadata instead of the shared base template. Mirrors the range-rollup path.
`LakeMvSortKeyRewriteJob`, which extends this job and overrides neither the seam nor the shadow-index
registration, inherits the fix for the same reason. Two now-inaccurate base-class comments (which
claimed the replace-flavored rewrite was safe to lazily materialize) are corrected.

## Behavior change

No. This corrects a persisted-metadata defect that only affects the reshard / tablet-split read path
after a sort-key-changing range rewrite (the rewrite's data write already sorts rows by the new key).
No SQL syntax, config, or interface change.

## Tests

- FE unit test `LakeRangeRewriteSchemaChangeJobTest`: a new case asserts each rewrite shadow tablet's
  `CreateReplicaTask` carries a `TTabletSchema` whose sort-key indexes are the NEW sort key (arity 1 for
  a single-column `ORDER BY(k2)` over a two-column base `ORDER BY(k1, k2)`), the shadow index meta id,
  tablet-creation optimization off, and the table's configured compression level; plus the empty-plans
  early-return and no-alive-compute-node abort cases. Existing state-machine tests keep passing via a
  `@BeforeEach` scaffold (resolve an alive compute node + no-op send/wait). `LakeRangeRewriteSchemaChangeJobTest`
  50/50, and the sibling/inheriting suites `LakeMvSortKeyRewriteJobTest` 18/18, `RangeKeyColumnRoutingTest`
  16/16, `RangeDistributionGuardTest` 31/31, `LakeRangeRollupJobTest` 17/17 all pass; checkstyle 0.
- TSP shared-data end-to-end (1 FE + 3 CN): a range table whose sort key is changed by
  `ALTER TABLE ... ORDER BY(...)` to a different arity, then loaded via `INSERT ... SELECT * FROM FILES(...)`.
  Before the fix the post-rewrite load's pre-split falls back to identical
  (`external_boundaries_fallback_total` increments, no split); after the fix the load splits 1 -> N with
  `external_boundaries_fallback_total` Delta = 0 and correct COUNT/MIN/MAX. (Result to be attached.)

Note: this feature (`LakeRangeRewriteSchemaChangeJob`) is main-only, so this fix is not backported.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
