### PR TITLE
[Enhancement] Make the segment iterator reusable across scans

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -46,6 +46,7 @@ set(STORAGE_FILES
     segment_flush_executor.cpp
     segment_replicate_executor.cpp
     metadata_util.cpp
+    non_closing_chunk_iterator.cpp
     kv_store.cpp
     local_tablet_reader.cpp
     olap_server.cpp

--- a/be/src/storage/non_closing_chunk_iterator.cpp
+++ b/be/src/storage/non_closing_chunk_iterator.cpp
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/non_closing_chunk_iterator.h"
+
+#include <memory>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace starrocks {
+
+class NonClosingChunkIterator final : public ChunkIterator {
+public:
+    explicit NonClosingChunkIterator(ChunkIteratorPtr child)
+            : ChunkIterator(child->schema(), child->chunk_size()), _child(std::move(child)) {}
+
+    void close() override {}
+
+    size_t merged_rows() const override { return _child->merged_rows(); }
+
+    Status init_encoded_schema(ColumnIdToGlobalDictMap& dict_maps) override {
+        RETURN_IF_ERROR(ChunkIterator::init_encoded_schema(dict_maps));
+        return _child->init_encoded_schema(dict_maps);
+    }
+
+    Status init_output_schema(const std::unordered_set<uint32_t>& unused_output_column_ids) override {
+        RETURN_IF_ERROR(ChunkIterator::init_output_schema(unused_output_column_ids));
+        return _child->init_output_schema(unused_output_column_ids);
+    }
+
+protected:
+    Status do_get_next(Chunk* chunk) override { return _child->get_next(chunk); }
+    Status do_get_next(Chunk* chunk, std::vector<uint32_t>* rowid) override { return _child->get_next(chunk, rowid); }
+    Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override {
+        return _child->get_next(chunk, rssid_rowids);
+    }
+
+private:
+    ChunkIteratorPtr _child;
+};
+
+ChunkIteratorPtr new_non_closing_chunk_iterator(const ChunkIteratorPtr& child) {
+    return std::make_shared<NonClosingChunkIterator>(child);
+}
+
+} // namespace starrocks

--- a/be/src/storage/non_closing_chunk_iterator.h
+++ b/be/src/storage/non_closing_chunk_iterator.h
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage_primitive/chunk_iterator.h"
+
+namespace starrocks {
+
+// Wraps |child| as a per-scan iterator without taking ownership of its close
+// lifecycle. The slot owner must close |child| explicitly.
+ChunkIteratorPtr new_non_closing_chunk_iterator(const ChunkIteratorPtr& child);
+
+} // namespace starrocks

--- a/be/src/storage/rowset/bitmap_index_evaluator.cpp
+++ b/be/src/storage/rowset/bitmap_index_evaluator.cpp
@@ -414,6 +414,11 @@ void BitmapIndexEvaluator::close() {
 }
 
 Status BitmapIndexEvaluator::init(BitmapIndexIteratorSupplier&& supplier) {
+    close();
+    _closed = false;
+    _ctx = BitmapContext{};
+    _has_bitmap_index = false;
+    _bitmap_index_iterators.clear();
     _bitmap_index_iterators.resize(ChunkSchemaHelper::max_column_id(_schema) + 1, nullptr);
     ASSIGN_OR_RETURN(_has_bitmap_index,
                      _pred_tree.visit(BitmapIndexInitializer{this, supplier}, nullptr, CompoundNodeType::AND));

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -338,9 +338,7 @@ struct SegmentZoneMapPruner {
     const SegmentReadOptions& read_options;
 };
 
-StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const SegmentReadOptions& read_options) {
-    DCHECK(read_options.stats != nullptr);
-
+Status Segment::_prune_by_segment_zone_map(const SegmentReadOptions& read_options) {
     const auto pruned = config::enable_index_segment_level_zonemap_filter &&
                         read_options.pred_tree_for_zone_map.visit(SegmentZoneMapPruner{this, read_options});
     if (pruned) {
@@ -349,7 +347,13 @@ StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const Se
         }
         return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _segment_file_info.path));
     }
+    return Status::OK();
+}
 
+StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const SegmentReadOptions& read_options) {
+    DCHECK(read_options.stats != nullptr);
+
+    RETURN_IF_ERROR(_prune_by_segment_zone_map(read_options));
     return new_segment_iterator(shared_from_this(), schema, read_options);
 }
 
@@ -358,6 +362,17 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const Schema& schema, const Seg
         return Status::InvalidArgument("stats is null pointer");
     }
     return _new_iterator(schema, read_options);
+}
+
+StatusOr<ChunkIteratorPtr> Segment::new_reusable_iterator(const Schema& iterator_schema, const Schema& output_schema,
+                                                          const SegmentReadOptions& read_options,
+                                                          ChunkIteratorPtr* reusable_slot) {
+    if (read_options.stats == nullptr) {
+        return Status::InvalidArgument("stats is null pointer");
+    }
+    RETURN_IF_ERROR(_prune_by_segment_zone_map(read_options));
+    return new_reusable_segment_iterator(shared_from_this(), iterator_schema, output_schema, read_options,
+                                         reusable_slot);
 }
 
 Status Segment::new_inverted_index_iterator(uint32_t ucid, InvertedIndexIterator** iter, const SegmentReadOptions& opts,

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -108,6 +108,9 @@ public:
 
     // may return EndOfFile
     StatusOr<ChunkIteratorPtr> new_iterator(const Schema& schema, const SegmentReadOptions& read_options);
+    StatusOr<ChunkIteratorPtr> new_reusable_iterator(const Schema& iterator_schema, const Schema& output_schema,
+                                                     const SegmentReadOptions& read_options,
+                                                     ChunkIteratorPtr* reusable_slot);
 
     StatusOr<std::shared_ptr<Segment>> new_dcg_segment(const DeltaColumnGroup& dcg, uint32_t idx,
                                                        const TabletSchemaCSPtr& read_tablet_schema);
@@ -302,6 +305,7 @@ private:
                                               std::unordered_map<uint32_t, uint32_t>& column_id_to_footer_ordinal);
 
     StatusOr<ChunkIteratorPtr> _new_iterator(const Schema& schema, const SegmentReadOptions& read_options);
+    Status _prune_by_segment_zone_map(const SegmentReadOptions& read_options);
 
     bool _use_segment_zone_map_filter(const SegmentReadOptions& read_options);
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "base/format.h"
@@ -59,6 +60,7 @@
 #include "storage/index/vector/vector_index_reader_factory.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/update_manager.h"
+#include "storage/non_closing_chunk_iterator.h"
 #include "storage/rowset/bitmap_index_evaluator.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/column_decoder.h"
@@ -132,14 +134,18 @@ public:
     ~SegmentIterator() override = default;
 
     void close() override;
+    Status reset_for_reuse(const SegmentReadOptions& options);
 
-    // Public entry point used by segment_seek_range_to_rowid_range(). The caller
+    // Public entry point used by the segment_seek_range_to_rowid_range() /
+    // segment_seek_ranges_to_rowid_ranges() free functions. The caller
     // must ensure the segment's short-key index has already been loaded; this
     // does not touch any other iterator state, so it is safe to invoke before
     // do_init() / do_get_next().
     StatusOr<std::optional<Range<>>> resolve_range_to_rowid_range(const SeekRange& range) {
         return _seek_range_to_rowid_range(range);
     }
+
+    StatusOr<SparseRange<>> prepared_pruned_row_ranges() { return _get_prepared_pruned_row_ranges(); }
 
 protected:
     Status do_get_next(Chunk* chunk) override;
@@ -192,6 +198,9 @@ private:
 
         // Release all chunk resources to free memory
         void close();
+        // Clear per-scan context while keeping the embedded scan strategies bound
+        // to this ScanContext instance.
+        void reset();
         // Seek all column iterators to the specified ordinal position
         Status seek_columns(ordinal_t pos, bool predicate_col_late_materialize_read);
         // Read column data from the specified range into the chunk
@@ -349,6 +358,8 @@ private:
 
     Status _init();
     Status _init_internal();
+    Status _init_reused_scan();
+    Status _init_scan_range_and_context();
     Status _try_to_update_ranges_by_runtime_filter();
     Status _do_get_next(Chunk* result, vector<rowid_t>* rowid);
 
@@ -368,8 +379,10 @@ private:
     Status _get_row_ranges_by_bloom_filter();
     Status _get_row_ranges_by_rowid_range();
     Status _get_row_ranges_by_row_ids(std::vector<int64_t>* result_ids, SparseRange<>* r);
+    StatusOr<SparseRange<>> _get_prepared_pruned_row_ranges();
 
     Status _apply_tablet_range();
+    Status _apply_precomputed_scan_range();
     StatusOr<std::optional<Range<>>> _seek_range_to_rowid_range(const SeekRange& range);
 
     uint32_t segment_id() const { return _segment->id(); }
@@ -573,6 +586,7 @@ private:
     int _reserve_chunk_size = 0;
 
     bool _inited = false;
+    bool _one_time_setup_done = false;
 
     std::unordered_map<ColumnId, ColumnAccessPath*> _column_access_paths;
     std::unordered_map<ColumnId, ColumnAccessPath*> _predicate_column_access_paths;
@@ -593,6 +607,41 @@ void SegmentIterator::ScanContext::close() {
     _dict_chunk.reset();
     _final_chunk.reset();
     _adapt_global_dict_chunk.reset();
+}
+
+void SegmentIterator::ScanContext::reset() {
+    close();
+    stats = nullptr;
+    runtime_filters_by_column = nullptr;
+    _read_schema = Schema();
+    _dict_decode_schema = Schema();
+    _is_dict_column.clear();
+    _column_iterators.clear();
+    _subfield_columns.clear();
+    _subfield_iterators.clear();
+    _column_iterators_for_predicate_late_materialize.clear();
+    _column_id_for_predicate_late_materialize.clear();
+    _column_ids_to_column_iterators.clear();
+    _column_ids_to_index.clear();
+    _row_id_column_id = 0;
+    _next = nullptr;
+    _skip_dict_decode_indexes.clear();
+    _read_index_map.clear();
+    _has_dict_column = false;
+    _late_materialize = false;
+    _has_force_dict_encode = false;
+    _prune_cols.clear();
+    _prune_column_after_index_filter = false;
+    _enable_predicate_col_late_materialize = false;
+    _only_output_one_predicate_col_with_filter_push_down = false;
+    _support_push_down_predicate = false;
+    _predicate_order.clear();
+    _column_predicate_map.clear();
+    _is_filtered = false;
+    _predicate_selectivity_map.clear();
+    _evaluated_chunk_nums = 0;
+    _first_column_total_rows_read = 0;
+    _first_column_total_rows_passed = 0;
 }
 
 Status SegmentIterator::ScanContext::seek_columns(ordinal_t pos, bool predicate_col_late_materialize_read) {
@@ -893,6 +942,33 @@ Status SegmentIterator::_init() {
     return st;
 }
 
+Status SegmentIterator::reset_for_reuse(const SegmentReadOptions& options) {
+    _opts.pred_tree = options.pred_tree;
+    _opts.pred_tree_for_zone_map = options.pred_tree_for_zone_map;
+    _opts.runtime_filter_preds = options.runtime_filter_preds;
+    _opts.delete_predicates = options.delete_predicates;
+    _opts.rowid_range_option = options.rowid_range_option;
+    _opts.read_state_cache = options.read_state_cache;
+    _opts.is_first_split_of_segment = options.is_first_split_of_segment;
+    _opts.ranges = options.ranges;
+    _opts.tablet_range = options.tablet_range;
+    _opts.runtime_range_pruner = options.runtime_range_pruner;
+    _opts.short_key_ranges = options.short_key_ranges;
+    _opts.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
+    _opts.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
+    _opts.global_dictmaps = options.global_dictmaps;
+    _opts.unused_output_column_ids = options.unused_output_column_ids;
+    _opts.is_cancelled = options.is_cancelled;
+    _opts.chunk_size = options.chunk_size;
+    _chunk_size = options.chunk_size;
+    _predicate_columns = _opts.pred_tree.num_columns();
+    _enable_predicate_col_late_materialize = _opts.enable_predicate_col_late_materialize;
+    _reserve_chunk_size =
+            static_cast<int32_t>(std::min(static_cast<uint32_t>(options.chunk_size), _segment->num_rows()));
+    _inited = false;
+    return Status::OK();
+}
+
 Status SegmentIterator::_init_internal() {
     SCOPED_RAW_TIMER(&_opts.stats->segment_init_ns);
     if (_opts.is_cancelled != nullptr && _opts.is_cancelled->load(std::memory_order_acquire)) {
@@ -921,6 +997,10 @@ Status SegmentIterator::_init_internal() {
 
     StorageMetrics::instance()->segment_read_total.increment(1);
 
+    if (_one_time_setup_done) {
+        return _init_reused_scan();
+    }
+
     /// the calling order matters, do not change unless you know why.
 
     _segment->turn_on_batch_update_cache_size();
@@ -932,22 +1012,33 @@ Status SegmentIterator::_init_internal() {
     RETURN_IF_ERROR(_init_ann_reader());
     RETURN_IF_ERROR(_check_low_cardinality_optimization());
     RETURN_IF_ERROR(_init_column_iterators<true>(_schema));
-    // filter by index stage
-    // Use indexes and predicates to filter some data page
+    RETURN_IF_ERROR(_init_scan_range_and_context());
+
+    _one_time_setup_done = true;
+    return Status::OK();
+}
+
+Status SegmentIterator::_init_scan_range_and_context() {
+    // Use indexes and predicates to filter some data page.
     RETURN_IF_ERROR(_get_row_ranges_by_rowid_range());
-    RETURN_IF_ERROR(_get_row_ranges_by_keys());
-    RETURN_IF_ERROR(_apply_tablet_range());
-    bool apply_del_vec_after_all_index_filter = config::apply_del_vec_after_all_index_filter;
-    if (!apply_del_vec_after_all_index_filter) {
-        RETURN_IF_ERROR(_apply_del_vector());
-    }
-    // Support prefilter for now
-    RETURN_IF_ERROR(_apply_bitmap_index());
-    RETURN_IF_ERROR(_get_row_ranges_by_zone_map());
-    RETURN_IF_ERROR(_get_row_ranges_by_bloom_filter());
-    RETURN_IF_ERROR(_apply_inverted_index());
-    if (apply_del_vec_after_all_index_filter) {
-        RETURN_IF_ERROR(_apply_del_vector());
+    if (_opts.read_state_cache.scan_range != nullptr) {
+        // The seed already folded every page filter into the prepared range; just apply it.
+        RETURN_IF_ERROR(_apply_precomputed_scan_range());
+    } else {
+        RETURN_IF_ERROR(_get_row_ranges_by_keys());
+        RETURN_IF_ERROR(_apply_tablet_range());
+        bool apply_del_vec_after_all_index_filter = config::apply_del_vec_after_all_index_filter;
+        if (!apply_del_vec_after_all_index_filter) {
+            RETURN_IF_ERROR(_apply_del_vector());
+        }
+        // Support prefilter for now.
+        RETURN_IF_ERROR(_apply_bitmap_index());
+        RETURN_IF_ERROR(_get_row_ranges_by_zone_map());
+        RETURN_IF_ERROR(_get_row_ranges_by_bloom_filter());
+        RETURN_IF_ERROR(_apply_inverted_index());
+        if (apply_del_vec_after_all_index_filter) {
+            RETURN_IF_ERROR(_apply_del_vector());
+        }
     }
 
     // rewrite stage
@@ -955,26 +1046,106 @@ Status SegmentIterator::_init_internal() {
     // residual bitmap there evaluates the rewritten (dict-code) predicates and inherits the
     // ALWAYS_TRUE / ALWAYS_FALSE collapses; must stay after the index filters above (the inverted
     // index consumes predicates from the tree) and before _init_column_predicates (which splits
-    // the tree into the read-loop copies the vector stage's pruning must precede).
+    // the tree into the read-loop copies); the vector stage's pruning must precede that split.
     RETURN_IF_ERROR(_rewrite_predicates());
+    // Data sampling must NOT re-run on a reused (precomputed) scan range: it is non-idempotent --
+    // re-sampling an already-sampled range shrinks it again -- so it is only run when the range is
+    // computed from scratch. Vector-index narrowing, in contrast, is always run: it is idempotent on a
+    // reused range (the ANN search is filtered by the current scan_range via DelIdFilter and the result
+    // is intersected, not overwritten), and it MUST run so each split child repopulates its per-iterator
+    // id2distance_map -- otherwise the distance lookup during read fails ("not found row id in distance
+    // map"). For non-vector scans it is a cheap no-op early-return.
     RETURN_IF_ERROR(_get_row_ranges_by_vector_index());
-    RETURN_IF_ERROR(_apply_data_sampling());
+    if (_opts.read_state_cache.scan_range == nullptr) {
+        RETURN_IF_ERROR(_apply_data_sampling());
+    }
     _init_column_predicates();
     RETURN_IF_ERROR(_init_context());
 
-    // reverse scan_range
-    // when desc_hint_split_range is not greater than 0, we don't split and reverse the scan_range
+    // When desc_hint_split_range is not greater than 0, we don't split and reverse the scan_range.
     if (!_opts.asc_hint && config::desc_hint_split_range > 0) {
         _scan_range.split_and_reverse(config::desc_hint_split_range, config::vector_chunk_size);
     }
-
     _range_iter = _scan_range.new_iterator();
 
     for (auto column_index : _io_coalesce_column_index) {
         RETURN_IF_ERROR(_column_iterators[column_index]->convert_sparse_range_to_io_range(_scan_range));
     }
-
     return Status::OK();
+}
+
+Status SegmentIterator::_init_reused_scan() {
+    _scan_range.clear();
+    _range_iter = SparseRangeIterator<>();
+    _non_expr_pred_tree = PredicateTree{};
+    _expr_pred_tree = PredicateTree{};
+    _runtime_filter_preds = RuntimeFilterPredicates{};
+    _column_to_runtime_filters_map.clear();
+    _context_list[0].reset();
+    _context_list[1].reset();
+    _context = nullptr;
+    _context_switch_count = 0;
+    _cur_rowid = 0;
+    if (_vector_index_ctx) {
+        _vector_index_ctx->id2distance_map.clear();
+    }
+    if (_inverted_index_ctx) {
+        _inverted_index_ctx->cleanup();
+    }
+    _bitmap_index_evaluator.close();
+    // Release per-scan objects appended via _obj_pool.add() during _init_scan_range_and_context (rewritten
+    // predicate iterators, dict-decode column iterators, ...). They are otherwise only freed by close(),
+    // which reuse skips (the returned NonClosingChunkIterator makes close() a no-op). Clear the pool here,
+    // after the predicate trees / scan contexts that reference these objects have been reset above, so it
+    // does not accumulate unboundedly across reuse cycles (e.g. the lake prepared-split fan-out).
+    _obj_pool.clear();
+
+    _segment->turn_on_batch_update_cache_size();
+    DeferOp op([&] { _segment->turn_off_batch_update_cache_size(); });
+
+    return _init_scan_range_and_context();
+}
+
+StatusOr<SparseRange<>> SegmentIterator::_get_prepared_pruned_row_ranges() {
+    if (_opts.is_cancelled != nullptr && _opts.is_cancelled->load(std::memory_order_acquire)) {
+        return Status::Cancelled("Cancelled");
+    }
+    if (!_get_del_vec_st.ok()) {
+        return _get_del_vec_st;
+    }
+    if (!_get_dcg_st.ok()) {
+        return _get_dcg_st;
+    }
+    if (_opts.is_primary_keys && _opts.version > 0 && _del_vec && _segment->num_rows() == _del_vec->cardinality()) {
+        return SparseRange<>();
+    }
+
+    _segment->turn_on_batch_update_cache_size();
+    DeferOp op([&] { _segment->turn_off_batch_update_cache_size(); });
+
+    _init_column_access_paths();
+    RETURN_IF_ERROR(_init_ann_reader());
+    RETURN_IF_ERROR(_check_low_cardinality_optimization());
+    RETURN_IF_ERROR(_init_column_iterators<true>(_schema));
+
+    RETURN_IF_ERROR(_get_row_ranges_by_rowid_range());
+    RETURN_IF_ERROR(_get_row_ranges_by_keys());
+    RETURN_IF_ERROR(_apply_tablet_range());
+
+    const bool apply_del_vec_after_all_index_filter = config::apply_del_vec_after_all_index_filter;
+    if (!apply_del_vec_after_all_index_filter) {
+        RETURN_IF_ERROR(_apply_del_vector());
+    }
+    RETURN_IF_ERROR(_apply_bitmap_index());
+    RETURN_IF_ERROR(_get_row_ranges_by_zone_map());
+    RETURN_IF_ERROR(_get_row_ranges_by_bloom_filter());
+    RETURN_IF_ERROR(_apply_inverted_index());
+    if (apply_del_vec_after_all_index_filter) {
+        RETURN_IF_ERROR(_apply_del_vector());
+    }
+    RETURN_IF_ERROR(_get_row_ranges_by_vector_index());
+    RETURN_IF_ERROR(_apply_data_sampling());
+    return _scan_range;
 }
 
 inline Status SegmentIterator::_init_reader_from_file(const std::string& index_path,
@@ -1949,15 +2120,31 @@ Status SegmentIterator::_apply_tablet_range() {
         return Status::OK();
     }
 
-    // _lookup_ordinal() relies on short key index.
-    RETURN_IF_ERROR(_segment->load_index(_opts.lake_io_opts));
-    ASSIGN_OR_RETURN(auto rowid_range_opt, _seek_range_to_rowid_range(_opts.tablet_range.value()));
+    std::optional<Range<>> rowid_range_opt;
+    if (_opts.read_state_cache.tablet_rowid_range != nullptr) {
+        rowid_range_opt = *_opts.read_state_cache.tablet_rowid_range;
+    } else {
+        // _lookup_ordinal() relies on short key index.
+        RETURN_IF_ERROR(_segment->load_index(_opts.lake_io_opts));
+        ASSIGN_OR_RETURN(rowid_range_opt, _seek_range_to_rowid_range(_opts.tablet_range.value()));
+    }
     if (rowid_range_opt.has_value()) {
         _scan_range &= SparseRange<>(rowid_range_opt.value());
     } else {
         // no valid rowid range, clear the scan range
         _scan_range.clear();
     }
+    return Status::OK();
+}
+
+Status SegmentIterator::_apply_precomputed_scan_range() {
+    if (_opts.read_state_cache.scan_range == nullptr) {
+        return Status::OK();
+    }
+
+    const size_t prev_size = _scan_range.span_size();
+    _scan_range &= *_opts.read_state_cache.scan_range;
+    _opts.stats->rows_stats_filtered += prev_size - _scan_range.span_size();
     return Status::OK();
 }
 
@@ -1968,6 +2155,16 @@ StatusOr<SparseRange<>> SegmentIterator::_get_row_ranges_by_key_ranges() {
 
     if (_opts.ranges.empty()) {
         res.add(Range<>(0, num_rows()));
+        return res;
+    }
+
+    if (_opts.read_state_cache.seek_range_rowid_ranges != nullptr &&
+        _opts.read_state_cache.seek_range_rowid_ranges->size() == _opts.ranges.size()) {
+        for (const auto& rowid_range_opt : *_opts.read_state_cache.seek_range_rowid_ranges) {
+            if (rowid_range_opt.has_value()) {
+                res.add(rowid_range_opt.value());
+            }
+        }
         return res;
     }
 
@@ -4338,6 +4535,8 @@ void SegmentIterator::close() {
     if (_inverted_index_ctx) {
         _inverted_index_ctx->cleanup();
     }
+    _one_time_setup_done = false;
+    _inited = false;
 }
 
 // put the field that has predicated on it ahead of those without one, for handle late
@@ -4359,16 +4558,207 @@ inline Schema reorder_schema(const Schema& input, const PredicateTree& pred_tree
     return output;
 }
 
+static ChunkIteratorPtr maybe_project_iterator(const Schema& output_schema, const ChunkIteratorPtr& iter) {
+    if (iter->schema().num_fields() == output_schema.num_fields()) {
+        bool same_schema = true;
+        for (int i = 0; i < output_schema.num_fields(); ++i) {
+            if (iter->schema().field(i)->id() != output_schema.field(i)->id()) {
+                same_schema = false;
+                break;
+            }
+        }
+        if (same_schema) {
+            return iter;
+        }
+    }
+    return new_projection_iterator(output_schema, iter);
+}
+
 ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, const Schema& schema,
                                       const SegmentReadOptions& options) {
     if (options.pred_tree.empty() || options.pred_tree.num_columns() >= schema.num_fields()) {
         return std::make_shared<SegmentIterator>(segment, schema, options);
-    } else {
-        // _check_low_cardinality_optimization() implementation counts on this schema reorder
-        Schema ordered_schema = reorder_schema(schema, options.pred_tree);
-        auto seg_iter = std::make_shared<SegmentIterator>(segment, ordered_schema, options);
-        return new_projection_iterator(schema, seg_iter);
     }
+
+    // _check_low_cardinality_optimization() implementation counts on this schema reorder.
+    Schema ordered_schema = reorder_schema(schema, options.pred_tree);
+    return new_projection_iterator(schema, std::make_shared<SegmentIterator>(segment, ordered_schema, options));
+}
+
+StatusOr<ChunkIteratorPtr> new_reusable_segment_iterator(const std::shared_ptr<Segment>& segment,
+                                                         const Schema& iterator_schema, const Schema& output_schema,
+                                                         const SegmentReadOptions& options,
+                                                         ChunkIteratorPtr* reusable_slot) {
+    if (reusable_slot == nullptr) {
+        return Status::InvalidArgument("reusable segment iterator slot is null");
+    }
+    if (*reusable_slot == nullptr) {
+        if (options.pred_tree.empty() || options.pred_tree.num_columns() >= iterator_schema.num_fields()) {
+            *reusable_slot = std::make_shared<SegmentIterator>(segment, iterator_schema, options);
+        } else {
+            // Keep the reusable slot bound to the same internal schema choice as new_segment_iterator().
+            Schema ordered_schema = reorder_schema(iterator_schema, options.pred_tree);
+            *reusable_slot = std::make_shared<SegmentIterator>(segment, ordered_schema, options);
+        }
+    } else {
+        auto* seg_iter = dynamic_cast<SegmentIterator*>(reusable_slot->get());
+        if (seg_iter == nullptr) {
+            return Status::NotSupported("iterator is not a reusable segment iterator");
+        }
+        // The stored iterator's schema field-order was fixed at creation from the first scan's predicate
+        // layout: reorder_schema() moves predicate columns to the front and _build_context() treats the
+        // leading _predicate_columns fields as the predicate columns. If the new scan's predicate layout
+        // would pick a different field order, reusing the stale schema mis-maps the predicate columns
+        // (wrong results, or a null predicate-column iterator). Rebuild the slot in that case; otherwise
+        // reset and reuse the existing iterator.
+        Schema expected_schema =
+                (options.pred_tree.empty() || options.pred_tree.num_columns() >= iterator_schema.num_fields())
+                        ? iterator_schema
+                        : reorder_schema(iterator_schema, options.pred_tree);
+        const Schema& current_schema = seg_iter->schema();
+        bool same_layout = expected_schema.num_fields() == current_schema.num_fields();
+        for (int i = 0; same_layout && i < expected_schema.num_fields(); ++i) {
+            same_layout = expected_schema.field(i)->id() == current_schema.field(i)->id();
+        }
+        if (same_layout) {
+            RETURN_IF_ERROR(seg_iter->reset_for_reuse(options));
+        } else {
+            *reusable_slot = std::make_shared<SegmentIterator>(segment, std::move(expected_schema), options);
+        }
+    }
+    return maybe_project_iterator(output_schema, new_non_closing_chunk_iterator(*reusable_slot));
+}
+
+StatusOr<SparseRange<>> get_prepared_pruned_row_ranges(const std::shared_ptr<Segment>& segment, const Schema& schema,
+                                                       const SegmentReadOptions& options) {
+    Schema iterator_schema = schema;
+    if (!options.pred_tree.empty() && options.pred_tree.num_columns() < schema.num_fields()) {
+        iterator_schema = reorder_schema(schema, options.pred_tree);
+    }
+    SegmentIterator iter(segment, std::move(iterator_schema), options);
+    return iter.prepared_pruned_row_ranges();
+}
+
+static rowid_t lower_bound_block_aligned_rowid(Segment* segment, const SeekTuple& key, bool lower) {
+    std::string index_key =
+            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+    auto start_iter = segment->lower_bound(index_key);
+    uint32_t start_block_id = 0;
+    if (start_iter.valid()) {
+        // Previous block may contain this key, so start from its first row.
+        start_block_id = start_iter.ordinal();
+        if (start_block_id > 0) {
+            --start_block_id;
+        }
+    } else {
+        // If all short keys are smaller, the key may exist in the last block.
+        start_block_id = segment->last_block();
+    }
+    return start_block_id * segment->num_rows_per_block();
+}
+
+static rowid_t upper_bound_block_aligned_rowid(Segment* segment, const SeekTuple& key, bool lower, rowid_t end) {
+    std::string index_key =
+            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
+    auto end_iter = segment->upper_bound(index_key);
+    if (end_iter.valid()) {
+        end = end_iter.ordinal() * segment->num_rows_per_block();
+    }
+    return end;
+}
+
+StatusOr<SparseRange<>> block_aligned_rowid_range_from_seek_ranges(Segment* segment,
+                                                                   const std::vector<SeekRange>& ranges) {
+    if (segment == nullptr) {
+        return Status::InvalidArgument("segment is null");
+    }
+
+    SparseRange<> scan_range;
+    if (ranges.empty()) {
+        scan_range.add(Range<>(0, segment->num_rows()));
+        return scan_range;
+    }
+
+    for (const auto& range : ranges) {
+        rowid_t lower_rowid = 0;
+        rowid_t upper_rowid = segment->num_rows();
+        if (!range.upper().empty()) {
+            upper_rowid = upper_bound_block_aligned_rowid(segment, range.upper(), !range.inclusive_upper(),
+                                                          segment->num_rows());
+        }
+        if (!range.lower().empty() && upper_rowid > 0) {
+            lower_rowid = lower_bound_block_aligned_rowid(segment, range.lower(), range.inclusive_lower());
+        }
+        if (lower_rowid <= upper_rowid) {
+            scan_range.add(Range<>(lower_rowid, upper_rowid));
+        }
+    }
+    return scan_range;
+}
+
+static bool init_seek_range_iterator_schema(const SeekRange& range, Schema* iterator_schema) {
+    if (!range.upper().empty()) {
+        *iterator_schema = range.upper().schema();
+        return true;
+    }
+    if (!range.lower().empty()) {
+        *iterator_schema = range.lower().schema();
+        return true;
+    }
+    return false;
+}
+
+template <typename ResolveFn>
+static auto with_segment_seek_range_iterator(const std::shared_ptr<Segment>& segment, const Schema& iterator_schema,
+                                             const LakeIOOptions& lake_io_opts, ResolveFn&& resolve_fn)
+        -> decltype(std::declval<ResolveFn>()(std::declval<SegmentIterator&>())) {
+    RETURN_IF_ERROR(segment->load_index(lake_io_opts));
+
+    OlapReaderStatistics local_stats;
+    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(segment->file_info().path));
+    SegmentReadOptions read_options;
+    read_options.lake_io_opts = lake_io_opts;
+    read_options.stats = &local_stats;
+    read_options.fs = std::move(file_system);
+    SegmentIterator iterator(segment, iterator_schema, read_options);
+    return resolve_fn(iterator);
+}
+
+StatusOr<std::vector<std::optional<Range<rowid_t>>>> segment_seek_ranges_to_rowid_ranges(
+        const std::shared_ptr<Segment>& segment, const std::vector<SeekRange>& ranges,
+        const LakeIOOptions& lake_io_opts) {
+    std::vector<std::optional<Range<rowid_t>>> rowid_ranges;
+    rowid_ranges.reserve(ranges.size());
+    if (ranges.empty()) {
+        return rowid_ranges;
+    }
+    if (segment == nullptr) {
+        return Status::InvalidArgument("segment is null");
+    }
+
+    Schema iterator_schema;
+    bool need_index_lookup = false;
+    for (const auto& range : ranges) {
+        if (init_seek_range_iterator_schema(range, &iterator_schema)) {
+            need_index_lookup = true;
+            break;
+        }
+    }
+    if (!need_index_lookup) {
+        for (size_t i = 0; i < ranges.size(); ++i) {
+            rowid_ranges.emplace_back(Range<rowid_t>{0, segment->num_rows()});
+        }
+        return rowid_ranges;
+    }
+    return with_segment_seek_range_iterator(
+            segment, iterator_schema, lake_io_opts,
+            [&](SegmentIterator& iterator) -> StatusOr<std::vector<std::optional<Range<rowid_t>>>> {
+                for (const auto& range : ranges) {
+                    ASSIGN_OR_RETURN(auto rowid_range, iterator.resolve_range_to_rowid_range(range));
+                    rowid_ranges.emplace_back(rowid_range);
+                }
+                return rowid_ranges;
+            });
 }
 
 StatusOr<std::optional<Range<rowid_t>>> segment_seek_range_to_rowid_range(const std::shared_ptr<Segment>& segment,
@@ -4377,33 +4767,15 @@ StatusOr<std::optional<Range<rowid_t>>> segment_seek_range_to_rowid_range(const 
     if (segment == nullptr) {
         return Status::InvalidArgument("segment is null");
     }
-    RETURN_IF_ERROR(segment->load_index(lake_io_opts));
 
-    // Schema is only used by the iterator's constructor; _seek_range_to_rowid_range
-    // picks the right schema from range.lower()/range.upper() on each side.
     Schema iterator_schema;
-    if (!range.upper().empty()) {
-        iterator_schema = range.upper().schema();
-    } else if (!range.lower().empty()) {
-        iterator_schema = range.lower().schema();
-    } else {
-        // (-inf, +inf): the full segment.
+    if (!init_seek_range_iterator_schema(range, &iterator_schema)) {
         return std::optional<Range<rowid_t>>{Range<rowid_t>{0, segment->num_rows()}};
     }
-
-    // SegmentReadOptions::stats is documented as required by ColumnIterator init
-    // (sanity_check() CHECK_NOTNULLs it). SegmentReadOptions::fs is required by
-    // _init_column_iterator_by_cid, which opens a RandomAccessFile on the
-    // segment's file. Supply both from locals — nothing downstream inspects the
-    // accumulated stats here.
-    OlapReaderStatistics local_stats;
-    ASSIGN_OR_RETURN(auto file_system, FileSystemFactory::CreateSharedFromString(segment->file_info().path));
-    SegmentReadOptions read_options;
-    read_options.lake_io_opts = lake_io_opts;
-    read_options.stats = &local_stats;
-    read_options.fs = std::move(file_system);
-    SegmentIterator iterator(segment, iterator_schema, read_options);
-    return iterator.resolve_range_to_rowid_range(range);
+    return with_segment_seek_range_iterator(segment, iterator_schema, lake_io_opts,
+                                            [&](SegmentIterator& iterator) -> StatusOr<std::optional<Range<rowid_t>>> {
+                                                return iterator.resolve_range_to_rowid_range(range);
+                                            });
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.h
+++ b/be/src/storage/rowset/segment_iterator.h
@@ -37,12 +37,28 @@ struct LakeIOOptions;
 
 ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, const Schema& schema,
                                       const SegmentReadOptions& options);
+// Returns a per-scan iterator backed by |reusable_slot|. Closing the returned
+// iterator does not close |reusable_slot|; the slot owner must close it.
+StatusOr<ChunkIteratorPtr> new_reusable_segment_iterator(const std::shared_ptr<Segment>& segment,
+                                                         const Schema& iterator_schema, const Schema& output_schema,
+                                                         const SegmentReadOptions& options,
+                                                         ChunkIteratorPtr* reusable_slot);
+StatusOr<SparseRange<>> get_prepared_pruned_row_ranges(const std::shared_ptr<Segment>& segment, const Schema& schema,
+                                                       const SegmentReadOptions& options);
 
-// Resolve a key-space SeekRange to the corresponding rowid range within |segment|.
-// Wraps the lookup machinery of SegmentIterator so callers outside the
-// iterator scan path can convert a TabletRangePB-derived SeekRange into a
-// contiguous [lower, upper) rowid window.
-// Returns std::nullopt when the range is empty on this segment.
+// Build a block-aligned rowid range from key-space SeekRanges. The segment's
+// short-key index must be loaded before calling this when |ranges| is non-empty.
+StatusOr<SparseRange<>> block_aligned_rowid_range_from_seek_ranges(Segment* segment,
+                                                                   const std::vector<SeekRange>& ranges);
+
+// Resolve key-space SeekRanges to corresponding rowid ranges within |segment|.
+// This wraps SegmentIterator's lookup machinery so callers outside the scan
+// path can precompute rowid windows and reuse them later.
+// Each result is std::nullopt when the corresponding range is empty on this segment.
+StatusOr<std::vector<std::optional<Range<rowid_t>>>> segment_seek_ranges_to_rowid_ranges(
+        const std::shared_ptr<Segment>& segment, const std::vector<SeekRange>& ranges,
+        const LakeIOOptions& lake_io_opts);
+// Convenience wrapper for a single SeekRange.
 StatusOr<std::optional<Range<rowid_t>>> segment_seek_range_to_rowid_range(const std::shared_ptr<Segment>& segment,
                                                                           const SeekRange& range,
                                                                           const LakeIOOptions& lake_io_opts);

--- a/be/src/storage/rowset/segment_options.cpp
+++ b/be/src/storage/rowset/segment_options.cpp
@@ -67,6 +67,7 @@ Status SegmentReadOptions::convert_to(SegmentReadOptions* dst, const std::vector
     dst->profile = profile;
     dst->global_dictmaps = global_dictmaps;
     dst->rowid_range_option = rowid_range_option;
+    dst->read_state_cache = read_state_cache;
     dst->short_key_ranges = short_key_ranges;
     dst->is_first_split_of_segment = is_first_split_of_segment;
     if (tablet_range.has_value()) {

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -28,6 +28,7 @@
 #include "storage/seek_range.h"
 #include "storage_primitive/disjunctive_predicates.h"
 #include "storage_primitive/predicate_tree/predicate_tree.hpp"
+#include "storage_primitive/range.h"
 #include "storage_primitive/runtime_filter_predicate.h"
 
 namespace starrocks {
@@ -48,6 +49,16 @@ struct VectorSearchOption;
 
 using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
 using VectorSearchOptionPtr = std::shared_ptr<VectorSearchOption>;
+
+struct SegmentReadStateCache {
+    // Optional prepared scan state owned by the caller. SegmentIterator only borrows
+    // these ranges while it is initialized, so the owner must outlive the iterator.
+    // The prepared scan_range already has every page filter (zonemap, bloom filter) folded in at
+    // the seed, so a reusing child just applies it and never re-runs a page filter on its sub-range.
+    SparseRangePtr scan_range = nullptr;
+    const std::vector<std::optional<Range<rowid_t>>>* seek_range_rowid_ranges = nullptr;
+    const std::optional<Range<rowid_t>>* tablet_rowid_range = nullptr;
+};
 
 class SegmentReadOptions {
 public:
@@ -105,6 +116,7 @@ public:
     /// A segment may be divided into multiple split to scan concurrently.
     bool is_first_split_of_segment = true;
     SparseRangePtr rowid_range_option = nullptr;
+    SegmentReadStateCache read_state_cache;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
     RuntimeScanRangePruner runtime_range_pruner;

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -32,17 +32,22 @@
 #include "common/config_rowset_fwd.h"
 #include "common/config_scan_io_fwd.h"
 #include "common/object_pool.h"
+#include "fs/fs.h"
+#include "fs/fs_factory.h"
 #include "fs/fs_memory.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/olap_common.h"
+#include "storage/options.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/runtime_filter_predicate.h"
+#include "storage/seek_range.h"
+#include "storage/seek_tuple.h"
 #include "storage/tablet_schema_helper.h"
 #include "types/logical_type.h"
 
@@ -1417,6 +1422,262 @@ TEST_F(SegmentIteratorTest, TestDictLookupBatchDuplicateValues) {
     }
     // 2000/50 = 40 each. 10 matching values -> 400
     ASSERT_EQ(total, 400);
+}
+
+// Verifies the reusable-segment-iterator path: a single underlying SegmentIterator, kept in a
+// caller-owned slot, is driven for two independent scans. The second scan must go through
+// reset_for_reuse() (not rebuild a fresh iterator) and still return the full result set.
+TEST_F(SegmentIteratorTest, ReuseSegmentIteratorAcrossScans) {
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/reusable_iterator";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema =
+            builder.create(1, false, TYPE_INT, true).create(2, false, TYPE_INT).build();
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = 100;
+    auto key_provider = [](int32_t i) { return i; };
+    auto val_provider = [](int32_t i) { return i * 2; };
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, key_provider));
+    ASSERT_OK(segment_data_builder.append(1, val_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    OlapReaderStatistics stats;
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_INT);
+    auto vec_schema = schema_builder.build();
+
+    auto make_opts = [&]() {
+        SegmentReadOptions o;
+        o.fs = _fs;
+        o.stats = &stats;
+        o.chunk_size = chunk_size;
+        return o;
+    };
+    auto drain = [&](const ChunkIteratorPtr& it) -> size_t {
+        auto chunk = ChunkFactory::new_chunk(it->output_schema(), chunk_size);
+        size_t total = 0;
+        while (true) {
+            chunk->reset();
+            auto st = it->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            total += chunk->num_rows();
+        }
+        return total;
+    };
+
+    // Empty slot -> the first call builds the underlying SegmentIterator and stores it in the slot.
+    ChunkIteratorPtr reusable_slot;
+    ASSIGN_OR_ABORT(auto iter1, segment->new_reusable_iterator(vec_schema, vec_schema, make_opts(), &reusable_slot));
+    ASSERT_NE(nullptr, reusable_slot.get());
+    void* underlying = reusable_slot.get();
+    ASSERT_EQ(num_rows, drain(iter1));
+    // NonClosingChunkIterator: closing the returned iterator must NOT tear down the reused iterator.
+    iter1->close();
+
+    // Second scan reuses the same slot: new_reusable_iterator takes the reset_for_reuse() branch,
+    // so the SAME underlying SegmentIterator instance re-drives the scan and returns all rows again.
+    ASSIGN_OR_ABORT(auto iter2, segment->new_reusable_iterator(vec_schema, vec_schema, make_opts(), &reusable_slot));
+    ASSERT_EQ(underlying, reusable_slot.get()) << "expected the slot's iterator to be reused, not rebuilt";
+    ASSERT_EQ(num_rows, drain(iter2));
+    iter2->close();
+
+    // Third scan reuses the slot with a precomputed scan range (as the prepared-split seed supplies one).
+    // This exercises SegmentReadStateCache + _apply_precomputed_scan_range: the reused iterator applies the
+    // narrowed range instead of re-pruning, so it returns exactly the precomputed subset.
+    const size_t precomputed_rows = 50;
+    auto precomputed = std::make_shared<SparseRange<>>();
+    precomputed->add(Range<rowid_t>(0, precomputed_rows));
+    auto opts3 = make_opts();
+    opts3.read_state_cache.scan_range = precomputed; // borrowed during the scan; must outlive iter3
+    ASSIGN_OR_ABORT(auto iter3, segment->new_reusable_iterator(vec_schema, vec_schema, opts3, &reusable_slot));
+    ASSERT_EQ(underlying, reusable_slot.get());
+    ASSERT_EQ(precomputed_rows, drain(iter3));
+    iter3->close();
+}
+
+// Reusing a slot whose predicate column layout differs from the first scan must rebuild the underlying
+// iterator, not reset it: the stored schema was reordered (predicate columns first) for the first scan, and
+// reusing that stale ordering would mis-map predicate columns. Here scan 1 filters c1 and scan 2 filters c2,
+// so the reorder differs; the slot must be rebuilt and each scan must return its own correct row count.
+TEST_F(SegmentIteratorTest, ReuseRebuildsWhenPredicateLayoutChanges) {
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/reusable_pred_layout";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema =
+            builder.create(1, false, TYPE_INT, true).create(2, false, TYPE_INT).create(3, false, TYPE_INT).build();
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = 100;
+    auto k_provider = [](int32_t i) { return i; };       // c0 key: 0..99
+    auto c1_provider = [](int32_t i) { return i % 10; }; // c1 == 5 -> 10 rows
+    auto c2_provider = [](int32_t i) { return i % 20; }; // c2 == 7 -> 5 rows
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, k_provider));
+    ASSERT_OK(segment_data_builder.append(1, c1_provider));
+    ASSERT_OK(segment_data_builder.append(2, c2_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    OlapReaderStatistics stats;
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_INT).add(2, "c2", TYPE_INT);
+    auto vec_schema = schema_builder.build();
+
+    // Predicate on a single (non-key) column, so reorder_schema() moves it to the front and the schema
+    // ordering depends on which column is filtered.
+    auto make_pred_opts = [&](ColumnId cid, const std::string& value, std::unique_ptr<ColumnPredicate>& holder) {
+        holder.reset(new_column_eq_predicate(get_type_info(TYPE_INT), cid, value));
+        PredicateAndNode root;
+        root.add_child(PredicateColumnNode{holder.get()});
+        SegmentReadOptions o;
+        o.fs = _fs;
+        o.stats = &stats;
+        o.chunk_size = chunk_size;
+        o.enable_predicate_col_late_materialize = true;
+        o.pred_tree = PredicateTree::create(std::move(root));
+        return o;
+    };
+    auto drain = [&](const ChunkIteratorPtr& it) -> size_t {
+        CHECK_OK(it->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+        CHECK_OK(it->init_output_schema(std::unordered_set<uint32_t>()));
+        auto chunk = ChunkFactory::new_chunk(it->output_schema(), chunk_size);
+        size_t total = 0;
+        while (true) {
+            chunk->reset();
+            auto st = it->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            total += chunk->num_rows();
+        }
+        return total;
+    };
+
+    ChunkIteratorPtr reusable_slot;
+
+    // First scan filters c1 -> reorder_schema puts c1 first.
+    std::unique_ptr<ColumnPredicate> pred_c1;
+    auto opts_c1 = make_pred_opts(1, "5", pred_c1);
+    ASSIGN_OR_ABORT(auto iter_c1, segment->new_reusable_iterator(vec_schema, vec_schema, opts_c1, &reusable_slot));
+    void* first_slot = reusable_slot.get();
+    ASSERT_NE(nullptr, first_slot);
+    ASSERT_EQ(10u, drain(iter_c1));
+    iter_c1->close();
+
+    // Second scan filters c2: the predicate layout no longer matches the stored schema, so the slot must be
+    // rebuilt (different underlying iterator) and still return c2's correct row count.
+    std::unique_ptr<ColumnPredicate> pred_c2;
+    auto opts_c2 = make_pred_opts(2, "7", pred_c2);
+    ASSIGN_OR_ABORT(auto iter_c2, segment->new_reusable_iterator(vec_schema, vec_schema, opts_c2, &reusable_slot));
+    ASSERT_NE(first_slot, reusable_slot.get()) << "predicate layout changed -> slot must be rebuilt";
+    ASSERT_EQ(5u, drain(iter_c2));
+    iter_c2->close();
+}
+
+// Directly exercises the exported seed/rowid helpers used by the lake prepared-split seed path:
+// get_prepared_pruned_row_ranges (seed pruning), block_aligned_rowid_range_from_seek_ranges and
+// segment_seek_ranges_to_rowid_ranges (key-range -> rowid-range resolution), for both the empty-range
+// fast paths and a non-empty key range that drives the block-aligned bound lookups.
+TEST_F(SegmentIteratorTest, PreparedRowRangeAndSeekHelpers) {
+    using namespace starrocks::test;
+
+    // block_aligned_rowid_range_from_seek_ranges / segment_seek_ranges_to_rowid_ranges re-derive the
+    // FileSystem from the segment's stored path via FileSystemFactory::CreateSharedFromString, so the
+    // segment must live on a real (posix) path -- the in-memory MemoryFileSystem the other cases use is
+    // invisible to the derived posix fs. Write it under a private temp dir and clean it up.
+    const std::string dir = "/tmp/sr_prepared_row_range_helpers";
+    const std::string file_name = dir + "/seg.dat";
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(file_name));
+    (void)fs->delete_dir_recursive(dir);
+    ASSERT_OK(fs->create_dir_recursive(dir));
+    DeferOp cleanup([&] { (void)fs->delete_dir_recursive(dir); });
+
+    ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema =
+            builder.create(1, false, TYPE_INT, true).create(2, false, TYPE_INT).build();
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = 100;
+    auto key_provider = [](int32_t i) { return i; };
+    auto val_provider = [](int32_t i) { return i * 2; };
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, key_provider));
+    ASSERT_OK(segment_data_builder.append(1, val_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(fs, FileInfo{file_name}, 0, tablet_schema));
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    OlapReaderStatistics stats;
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_INT);
+    auto vec_schema = schema_builder.build();
+
+    // get_prepared_pruned_row_ranges: no predicate -> the seed pruning keeps every row.
+    {
+        SegmentReadOptions o;
+        o.fs = fs;
+        o.stats = &stats;
+        o.chunk_size = chunk_size;
+        o.tablet_schema = tablet_schema;
+        ASSIGN_OR_ABORT(auto pruned, get_prepared_pruned_row_ranges(segment, vec_schema, o));
+        ASSERT_EQ(num_rows, pruned.span_size());
+    }
+
+    // Empty-range fast paths: no key bounds -> both helpers cover the whole segment without an index lookup.
+    ASSIGN_OR_ABORT(auto full_block_range, block_aligned_rowid_range_from_seek_ranges(segment.get(), {}));
+    ASSERT_EQ(num_rows, full_block_range.span_size());
+    ASSIGN_OR_ABORT(auto empty_rowid_ranges, segment_seek_ranges_to_rowid_ranges(segment, {}, LakeIOOptions{}));
+    ASSERT_TRUE(empty_rowid_ranges.empty());
+
+    // A non-empty key range [10, 50) on the key column drives the short-key bound lookups.
+    // block_aligned_rowid_range_from_seek_ranges requires the index to be loaded first (per its contract);
+    // segment_seek_ranges_to_rowid_ranges loads it internally.
+    LakeIOOptions io_opts{.fill_data_cache = false};
+    ASSERT_OK(segment->load_index());
+    // The SeekTuple key column must carry the segment's short-key length (INT index_length = 4). Without it
+    // short_key_encode emits only a marker byte and every bound collapses to the same block (empty window).
+    auto key_field = std::make_shared<Field>(0, "c0", TYPE_INT, -1, -1, false);
+    key_field->set_uid(0);
+    key_field->set_is_key(true);
+    key_field->set_short_key_length(4);
+    Schema key_schema({key_field});
+    std::vector<SeekRange> seek_ranges;
+    seek_ranges.emplace_back(SeekTuple(key_schema, {Datum(10)}), SeekTuple(key_schema, {Datum(50)}));
+
+    // The block-aligned window is a non-empty subset of the segment (keys 10..49 live in blocks of 10 rows).
+    ASSIGN_OR_ABORT(auto block_range, block_aligned_rowid_range_from_seek_ranges(segment.get(), seek_ranges));
+    ASSERT_GT(block_range.span_size(), 0u);
+    ASSERT_LE(block_range.span_size(), num_rows);
+
+    // One resolved rowid range per input SeekRange.
+    ASSIGN_OR_ABORT(auto rowid_ranges, segment_seek_ranges_to_rowid_ranges(segment, seek_ranges, io_opts));
+    ASSERT_EQ(1u, rowid_ranges.size());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Today StarRocks builds a brand-new `SegmentIterator` for every scan of a segment, repeating the one-time setup (schema resolution, predicate/index preparation) each time. When the same segment is scanned many times in quick succession — most notably by the upcoming lake prepared-physical-split scan, where one segment is fanned out into many child scans — that rebuild is pure overhead. There is currently no way to reset an existing `SegmentIterator` and re-drive it against a new scan range while keeping its one-time setup intact.

## What I'm doing:

Add the segment-layer machinery to reuse a `SegmentIterator` across scans, plus the precomputed-scan-range plumbing a reused iterator consumes:

- **Reset/reuse**: `SegmentIterator::reset_for_reuse()` + `_init_reused_scan()`, with the one-time setup split out behind `_one_time_setup_done` (and `ScanContext::reset()` / `_init_scan_range_and_context()`). Per-scan state is reset while the expensive one-time setup is preserved.
- **Create/reuse via a caller-owned slot**: `Segment::new_reusable_iterator()` / `new_reusable_segment_iterator()`. An empty slot builds the underlying iterator; a populated slot resets and reuses it.
- **`NonClosingChunkIterator`**: a wrapper whose `close()` is a no-op, so a finishing driver does not tear down the shared reused iterator held in the slot.
- **`SegmentReadOptions::read_state_cache` (`SegmentReadStateCache`)** + `_apply_precomputed_scan_range()` + `_get_prepared_pruned_row_ranges()`: a reused iterator can be handed a precomputed (already page-filtered) scan range and apply it directly instead of re-running the pruning pipeline.
- **`BitmapIndexEvaluator::init()`** idempotency reset so it can be re-initialized on reuse.

This is infrastructure only. Nothing populates the read-state cache or calls `reset_for_reuse()` yet — the lake prepared physical split scan follow-ups do — so there is **no behavior change** on the existing scan path.

## Tests:

`SegmentIteratorTest.ReuseSegmentIteratorAcrossScans` drives a single underlying `SegmentIterator`, kept in a caller-owned slot, across three scans:
1. first scan builds the iterator (empty slot) and reads all rows;
2. second scan reuses the **same instance** (asserted by pointer identity — `reset_for_reuse`, not a rebuild) and still returns the full result set;
3. third scan reuses the slot with a precomputed `SegmentReadStateCache::scan_range`, exercising `_apply_precomputed_scan_range()` — the reused iterator applies the narrowed range and returns exactly that subset.

It also verifies that closing the returned `NonClosingChunkIterator` does not tear down the reused iterator.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(New infrastructure with no caller yet; the existing scan path is unchanged.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5