### PR TITLE
[Enhancement] Support metadata-only add of a trailing sort-key column on shared-data range-distribution tables

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -163,9 +163,9 @@ StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
     // range's bound arity; the current sort key is a prefix-preserving superset of the archived one,
     // so the leading column types agree.
     if (_tablet_metadata != nullptr) {
-        const int range_arity = range_pb->has_lower_bound()  ? range_pb->lower_bound().values_size()
-                                : range_pb->has_upper_bound() ? range_pb->upper_bound().values_size()
-                                                             : 0;
+        const int range_arity = range_pb->has_lower_bound()
+                                        ? range_pb->lower_bound().values_size()
+                                        : range_pb->has_upper_bound() ? range_pb->upper_bound().values_size() : 0;
         if (range_arity > 0 && static_cast<int>(range_schema->sort_key_idxes().size()) != range_arity) {
             auto current_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
             if (static_cast<int>(current_schema->sort_key_idxes().size()) == range_arity) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -139,9 +139,6 @@ Rowset::~Rowset() {
 
 StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
     const TabletRangePB* range_pb = nullptr;
-    // _tablet_schema is this rowset's own schema, which for an old rowset may be an archived
-    // historical schema with fewer sort-key columns than the current tablet schema.
-    TabletSchemaPtr range_schema = _tablet_schema;
     if (_metadata->has_range()) {
         range_pb = &_metadata->range();
     } else if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
@@ -152,29 +149,23 @@ StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
         return std::optional<SeekRange>{};
     }
 
-    // A tablet range is expressed in whatever tablet sort key was current when the range was written,
-    // which can differ from this rowset's own (possibly archived) schema after a metadata-only trailing
-    // sort-key add (N -> N+1): the tablet-level fallback range is always in the current sort key, and a
-    // reshard that runs AFTER the add stamps a per-rowset range in the current sort key onto an old
-    // rowset that still carries its archived (N) schema. When the range's bound arity does not match
-    // this rowset's schema, decode with the current tablet schema instead -- its arity matches, and the
-    // current sort key is a prefix-preserving superset of the archived one, so the leading column types
-    // agree. A same-arity range decodes identically under either schema.
-    if (_tablet_metadata != nullptr) {
-        const int range_arity = range_pb->has_lower_bound()
-                                        ? range_pb->lower_bound().values_size()
-                                        : range_pb->has_upper_bound() ? range_pb->upper_bound().values_size() : 0;
-        if (range_arity > 0 && static_cast<int>(range_schema->sort_key_idxes().size()) != range_arity) {
-            auto current_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
-            if (static_cast<int>(current_schema->sort_key_idxes().size()) == range_arity) {
-                range_schema = current_schema;
-            }
-        }
-    }
+    // The SeekRange is used to seek into THIS rowset's segments, which are laid out per _tablet_schema
+    // (for an old rowset, an archived historical schema with fewer sort-key columns than the current
+    // tablet). The SeekRange's field ids are positional in the schema it is decoded with, so we MUST
+    // decode with _tablet_schema for the positions to align with the segments. A range can be written at
+    // a larger (later) sort-key arity than _tablet_schema -- a tablet-level fallback range is in the
+    // current sort key, and a reshard that runs after a metadata-only trailing key add can stamp a
+    // per-rowset range at a later arity onto an old rowset. create_seek_range_from projects such a wider
+    // bound onto _tablet_schema's sort key, comparing the added columns' defaults (what old rows in this
+    // rowset read) -- taken from the current tablet schema -- against the dropped trailing bound values.
+    TabletSchemaCSPtr current_schema =
+            _tablet_metadata != nullptr ? GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first
+                                        : nullptr;
 
     // Do not use mem_pool here. SeekRange will reference the data owned by protobuf metadata,
     // and metadata lifetime is guaranteed to outlive rowset iterators.
-    ASSIGN_OR_RETURN(auto range, TabletRangeHelper::create_seek_range_from(*range_pb, range_schema, nullptr));
+    ASSIGN_OR_RETURN(auto range,
+                     TabletRangeHelper::create_seek_range_from(*range_pb, _tablet_schema, nullptr, current_schema));
     return std::optional<SeekRange>(std::move(range));
 }
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -139,10 +139,18 @@ Rowset::~Rowset() {
 
 StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
     const TabletRangePB* range_pb = nullptr;
+    // _tablet_schema is this rowset's own schema, which for an old rowset may be an archived
+    // historical schema with fewer sort-key columns than the current tablet schema. The explicit
+    // per-rowset range was encoded with the rowset's schema, but the tablet-level fallback range is
+    // encoded with the current tablet sort key, so it must be decoded with the current schema. This
+    // keeps an old rowset readable after a metadata-only trailing sort-key add (N -> N+1), where the
+    // fallback range gains a value while the archived schema still has N sort keys.
+    TabletSchemaPtr range_schema = _tablet_schema;
     if (_metadata->has_range()) {
         range_pb = &_metadata->range();
     } else if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
         range_pb = &_tablet_metadata->range();
+        range_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
     }
 
     if (range_pb == nullptr) {
@@ -151,7 +159,7 @@ StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
 
     // Do not use mem_pool here. SeekRange will reference the data owned by protobuf metadata,
     // and metadata lifetime is guaranteed to outlive rowset iterators.
-    ASSIGN_OR_RETURN(auto range, TabletRangeHelper::create_seek_range_from(*range_pb, _tablet_schema, nullptr));
+    ASSIGN_OR_RETURN(auto range, TabletRangeHelper::create_seek_range_from(*range_pb, range_schema, nullptr));
     return std::optional<SeekRange>(std::move(range));
 }
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -140,11 +140,7 @@ Rowset::~Rowset() {
 StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
     const TabletRangePB* range_pb = nullptr;
     // _tablet_schema is this rowset's own schema, which for an old rowset may be an archived
-    // historical schema with fewer sort-key columns than the current tablet schema. The explicit
-    // per-rowset range was encoded with the rowset's schema, but the tablet-level fallback range is
-    // encoded with the current tablet sort key, so it must be decoded with the current schema. This
-    // keeps an old rowset readable after a metadata-only trailing sort-key add (N -> N+1), where the
-    // fallback range gains a value while the archived schema still has N sort keys.
+    // historical schema with fewer sort-key columns than the current tablet schema.
     TabletSchemaPtr range_schema = _tablet_schema;
     if (_metadata->has_range()) {
         range_pb = &_metadata->range();
@@ -155,6 +151,27 @@ StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
 
     if (range_pb == nullptr) {
         return std::optional<SeekRange>{};
+    }
+
+    // A tablet range is expressed in whatever tablet sort key was current when the range was
+    // written, which can differ from this rowset's own (possibly archived) schema after a
+    // metadata-only trailing sort-key add (N -> N+1). Two cases both leave a bound arity that does
+    // not match _tablet_schema: the tablet-level fallback range is always in the current (N+1) sort
+    // key (handled above by switching to the current schema), and a reshard that runs AFTER the add
+    // stamps a per-rowset range in the current (N+1) sort key onto an old rowset that still carries
+    // its archived (N) schema. Decode with whichever available schema's sort-key arity matches the
+    // range's bound arity; the current sort key is a prefix-preserving superset of the archived one,
+    // so the leading column types agree.
+    if (_tablet_metadata != nullptr) {
+        const int range_arity = range_pb->has_lower_bound()  ? range_pb->lower_bound().values_size()
+                                : range_pb->has_upper_bound() ? range_pb->upper_bound().values_size()
+                                                             : 0;
+        if (range_arity > 0 && static_cast<int>(range_schema->sort_key_idxes().size()) != range_arity) {
+            auto current_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
+            if (static_cast<int>(current_schema->sort_key_idxes().size()) == range_arity) {
+                range_schema = current_schema;
+            }
+        }
     }
 
     // Do not use mem_pool here. SeekRange will reference the data owned by protobuf metadata,

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -146,22 +146,20 @@ StatusOr<std::optional<SeekRange>> Rowset::get_seek_range() const {
         range_pb = &_metadata->range();
     } else if (_tablet_metadata != nullptr && _tablet_metadata->has_range()) {
         range_pb = &_tablet_metadata->range();
-        range_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
     }
 
     if (range_pb == nullptr) {
         return std::optional<SeekRange>{};
     }
 
-    // A tablet range is expressed in whatever tablet sort key was current when the range was
-    // written, which can differ from this rowset's own (possibly archived) schema after a
-    // metadata-only trailing sort-key add (N -> N+1). Two cases both leave a bound arity that does
-    // not match _tablet_schema: the tablet-level fallback range is always in the current (N+1) sort
-    // key (handled above by switching to the current schema), and a reshard that runs AFTER the add
-    // stamps a per-rowset range in the current (N+1) sort key onto an old rowset that still carries
-    // its archived (N) schema. Decode with whichever available schema's sort-key arity matches the
-    // range's bound arity; the current sort key is a prefix-preserving superset of the archived one,
-    // so the leading column types agree.
+    // A tablet range is expressed in whatever tablet sort key was current when the range was written,
+    // which can differ from this rowset's own (possibly archived) schema after a metadata-only trailing
+    // sort-key add (N -> N+1): the tablet-level fallback range is always in the current sort key, and a
+    // reshard that runs AFTER the add stamps a per-rowset range in the current sort key onto an old
+    // rowset that still carries its archived (N) schema. When the range's bound arity does not match
+    // this rowset's schema, decode with the current tablet schema instead -- its arity matches, and the
+    // current sort key is a prefix-preserving superset of the archived one, so the leading column types
+    // agree. A same-arity range decodes identically under either schema.
     if (_tablet_metadata != nullptr) {
         const int range_arity = range_pb->has_lower_bound()
                                         ? range_pb->lower_bound().values_size()

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -32,6 +32,7 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_writer.h"
@@ -42,6 +43,7 @@
 #include "storage/storage_metrics.h"
 #include "storage/tablet_index.h"
 #include "storage/tablet_reader_params.h"
+#include "storage/tablet_schema.h"
 #include "storage_primitive/flat_json_config.h"
 
 namespace starrocks::lake {
@@ -535,7 +537,21 @@ Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaIn
 Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
     auto timer = MonotonicStopWatch{};
     timer.start();
-    LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(tablet_meta_info);
+    if (tablet_meta_info.__isset.range) {
+        // A populated range carries raw user boundary values; do not log them. Log the other fields
+        // as before, and describe the range only by tablet id and per-bound arity.
+        TTabletMetaInfo redacted = tablet_meta_info;
+        redacted.__isset.range = false;
+        const int lower_arity =
+                tablet_meta_info.range.__isset.lower_bound ? tablet_meta_info.range.lower_bound.values.size() : -1;
+        const int upper_arity =
+                tablet_meta_info.range.__isset.upper_bound ? tablet_meta_info.range.upper_bound.values.size() : -1;
+        LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(redacted)
+                  << " tablet_id: " << tablet_meta_info.tablet_id << " range lower arity: " << lower_arity
+                  << " range upper arity: " << upper_arity;
+    } else {
+        LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(tablet_meta_info);
+    }
 
     auto tablet_id = tablet_meta_info.tablet_id;
     ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(tablet_id));
@@ -561,6 +577,19 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         if (tablet_meta_info.create_schema_file) {
             RETURN_IF_ERROR(_tablet_manager->create_schema_file(tablet_id, *new_schema));
         }
+    }
+
+    if (tablet_meta_info.__isset.range) {
+        // A range must always travel with the schema it is to be interpreted against.
+        if (!tablet_meta_info.__isset.tablet_schema) {
+            return Status::Corruption("tablet meta update carries a range without a tablet schema");
+        }
+        ASSIGN_OR_RETURN(auto pb_range, TabletRangeHelper::convert_t_range_to_pb_range(tablet_meta_info.range));
+        // Build has no authoritative base metadata version, so only structural checks are possible
+        // here; the exact trailing-ADD transition is validated at apply.
+        auto new_schema = TabletSchema::create(metadata_update_info->tablet_schema());
+        RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(pb_range, *new_schema));
+        metadata_update_info->mutable_range()->CopyFrom(pb_range);
     }
 
     // TODO(zhangqiang)

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -538,19 +538,21 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
     auto timer = MonotonicStopWatch{};
     timer.start();
     if (tablet_meta_info.__isset.tablet_range) {
-        // A populated range carries raw user boundary values; do not log them. Log the other fields
-        // as before, and describe the range only by tablet id and per-bound arity.
-        TTabletMetaInfo redacted = tablet_meta_info;
-        redacted.__isset.tablet_range = false;
+        // A populated range carries raw user boundary values; do not log them, and do not copy the whole
+        // message just to redact them (that would duplicate a possibly-oversized range before the caps in
+        // convert_t_range_to_pb_range run). Log the tablet id, the accompanying schema, and the per-bound
+        // arity only.
         const int lower_arity = tablet_meta_info.tablet_range.__isset.lower_bound
-                                        ? tablet_meta_info.tablet_range.lower_bound.values.size()
+                                        ? static_cast<int>(tablet_meta_info.tablet_range.lower_bound.values.size())
                                         : -1;
         const int upper_arity = tablet_meta_info.tablet_range.__isset.upper_bound
-                                        ? tablet_meta_info.tablet_range.upper_bound.values.size()
+                                        ? static_cast<int>(tablet_meta_info.tablet_range.upper_bound.values.size())
                                         : -1;
-        LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(redacted)
-                  << " tablet_id: " << tablet_meta_info.tablet_id << " range lower arity: " << lower_arity
-                  << " range upper arity: " << upper_arity;
+        LOG(INFO) << "Updating tablet metadata (with range): tablet_id: " << tablet_meta_info.tablet_id
+                  << ", tablet_schema: "
+                  << (tablet_meta_info.__isset.tablet_schema ? ThriftDebugString(tablet_meta_info.tablet_schema)
+                                                             : "<none>")
+                  << ", range lower arity: " << lower_arity << ", range upper arity: " << upper_arity;
     } else {
         LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(tablet_meta_info);
     }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -542,10 +542,12 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         // as before, and describe the range only by tablet id and per-bound arity.
         TTabletMetaInfo redacted = tablet_meta_info;
         redacted.__isset.tablet_range = false;
-        const int lower_arity =
-                tablet_meta_info.tablet_range.__isset.lower_bound ? tablet_meta_info.tablet_range.lower_bound.values.size() : -1;
-        const int upper_arity =
-                tablet_meta_info.tablet_range.__isset.upper_bound ? tablet_meta_info.tablet_range.upper_bound.values.size() : -1;
+        const int lower_arity = tablet_meta_info.tablet_range.__isset.lower_bound
+                                        ? tablet_meta_info.tablet_range.lower_bound.values.size()
+                                        : -1;
+        const int upper_arity = tablet_meta_info.tablet_range.__isset.upper_bound
+                                        ? tablet_meta_info.tablet_range.upper_bound.values.size()
+                                        : -1;
         LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(redacted)
                   << " tablet_id: " << tablet_meta_info.tablet_id << " range lower arity: " << lower_arity
                   << " range upper arity: " << upper_arity;

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -537,15 +537,15 @@ Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaIn
 Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
     auto timer = MonotonicStopWatch{};
     timer.start();
-    if (tablet_meta_info.__isset.range) {
+    if (tablet_meta_info.__isset.tablet_range) {
         // A populated range carries raw user boundary values; do not log them. Log the other fields
         // as before, and describe the range only by tablet id and per-bound arity.
         TTabletMetaInfo redacted = tablet_meta_info;
-        redacted.__isset.range = false;
+        redacted.__isset.tablet_range = false;
         const int lower_arity =
-                tablet_meta_info.range.__isset.lower_bound ? tablet_meta_info.range.lower_bound.values.size() : -1;
+                tablet_meta_info.tablet_range.__isset.lower_bound ? tablet_meta_info.tablet_range.lower_bound.values.size() : -1;
         const int upper_arity =
-                tablet_meta_info.range.__isset.upper_bound ? tablet_meta_info.range.upper_bound.values.size() : -1;
+                tablet_meta_info.tablet_range.__isset.upper_bound ? tablet_meta_info.tablet_range.upper_bound.values.size() : -1;
         LOG(INFO) << "Updating tablet metadata: " << ThriftDebugString(redacted)
                   << " tablet_id: " << tablet_meta_info.tablet_id << " range lower arity: " << lower_arity
                   << " range upper arity: " << upper_arity;
@@ -579,17 +579,17 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         }
     }
 
-    if (tablet_meta_info.__isset.range) {
+    if (tablet_meta_info.__isset.tablet_range) {
         // A range must always travel with the schema it is to be interpreted against.
         if (!tablet_meta_info.__isset.tablet_schema) {
             return Status::Corruption("tablet meta update carries a range without a tablet schema");
         }
-        ASSIGN_OR_RETURN(auto pb_range, TabletRangeHelper::convert_t_range_to_pb_range(tablet_meta_info.range));
+        ASSIGN_OR_RETURN(auto pb_range, TabletRangeHelper::convert_t_range_to_pb_range(tablet_meta_info.tablet_range));
         // Build has no authoritative base metadata version, so only structural checks are possible
         // here; the exact trailing-ADD transition is validated at apply.
         auto new_schema = TabletSchema::create(metadata_update_info->tablet_schema());
         RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(pb_range, *new_schema));
-        metadata_update_info->mutable_range()->CopyFrom(pb_range);
+        metadata_update_info->mutable_tablet_range()->CopyFrom(pb_range);
     }
 
     // TODO(zhangqiang)

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -856,6 +856,7 @@ using tablet_reshard_helper::DcgRowWindow;
 Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int64_t new_tablet_id,
                                               const RowsetMetadataPB& target_rowset, int target_segment_position,
                                               const TabletSchemaCSPtr& full_tablet_schema,
+                                              const TabletSchemaCSPtr& current_schema,
                                               const std::vector<DcgSourceRowsetReference>& source_references,
                                               const roaring::Roaring* gap_bits,
                                               std::shared_ptr<Segment>* out_base_segment,
@@ -889,9 +890,15 @@ Status compute_row_windows_for_source_rowsets(TabletManager* tablet_manager, int
     for (const auto& source_reference : source_references) {
         Range<rowid_t> window{0, num_rows_in_target};
         if (source_reference.effective_range != nullptr) {
+            // Decode with full_tablet_schema -- the schema the base segment is opened with above -- so the
+            // SeekRange's positional field ids align with that segment. A reshard that ran after a
+            // metadata-only trailing key add can stamp a per-rowset range at a larger sort-key arity than
+            // this rowset's schema; create_seek_range_from then projects the wider bound onto this segment's
+            // sort key, comparing the added columns' defaults (from current_schema) against the dropped
+            // trailing bound values so a boundary-prefix row routes exactly as under the full-arity range.
             ASSIGN_OR_RETURN(auto seek_range, TabletRangeHelper::create_seek_range_from(
                                                       *source_reference.effective_range, full_tablet_schema,
-                                                      /*mem_pool=*/nullptr));
+                                                      /*mem_pool=*/nullptr, current_schema));
             LakeIOOptions lake_io_options{.fill_data_cache = false};
             ASSIGN_OR_RETURN(auto rowid_range_opt,
                              segment_seek_range_to_rowid_range(base_segment, seek_range, lake_io_options));
@@ -1045,11 +1052,15 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
                 rebuild_columns.size(), rebuild_schema->num_columns()));
     }
 
-    // Step C — compute row windows.
+    // Step C — compute row windows. `current_schema` (the current tablet schema, which contains any
+    // later-added trailing key columns) lets a source range written at a wider sort-key arity than
+    // full_tablet_schema be projected onto the base segment's sort key using those columns' defaults.
+    TabletSchemaCSPtr current_schema =
+            new_metadata.has_schema() ? TabletSchema::create(new_metadata.schema()) : full_tablet_schema;
     std::vector<DcgRowWindow> windows;
     std::shared_ptr<Segment> base_segment;
     RETURN_IF_ERROR(compute_row_windows_for_source_rowsets(tablet_manager, new_tablet_id, target_rowset,
-                                                           target_segment_position, full_tablet_schema,
+                                                           target_segment_position, full_tablet_schema, current_schema,
                                                            source_references, gap_bits, &base_segment, &windows));
     const rowid_t num_rows_in_target = static_cast<rowid_t>(base_segment->num_rows());
 

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -396,16 +396,17 @@ Status TabletRangeHelper::validate_range_structural(const TabletRangePB& range, 
 
 Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_meta, const TabletSchema& new_schema,
                                                     const TabletRangePB& new_range) {
-    // 1. The schema change must be exactly a trailing sort-key ADD: the existing effective sort key
-    //    is preserved by unique id/type/order and exactly one new trailing sort key is appended.
+    // 1. The schema change must be a trailing sort-key ADD: the existing effective sort key is
+    //    preserved by unique id/type/order and one or more new trailing sort keys are appended.
     auto old_schema = TabletSchema::create(old_meta.schema());
     const auto& old_sk = old_schema->sort_key_idxes();
     const auto& new_sk = new_schema.sort_key_idxes();
-    if (new_sk.size() != old_sk.size() + 1) {
+    if (new_sk.size() <= old_sk.size()) {
         return Status::Corruption(
-                fmt::format("trailing sort-key ADD requires exactly one new sort key: old sort key size {}, new {}",
+                fmt::format("trailing sort-key ADD requires at least one new sort key: old sort key size {}, new {}",
                             old_sk.size(), new_sk.size()));
     }
+    const int num_added = static_cast<int>(new_sk.size() - old_sk.size());
     for (size_t i = 0; i < old_sk.size(); ++i) {
         const auto& oc = old_schema->column(old_sk[i]);
         const auto& nc = new_schema.column(new_sk[i]);
@@ -416,8 +417,8 @@ Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_
     }
 
     // 2. Each present bound of new_range == the corresponding bound of old_meta.range() with exactly
-    //    one trailing typed NULL_VALUE appended; bound presence and inclusivity are unchanged; and a
-    //    fully unbounded range (Range.all) stays fully unbounded.
+    //    `num_added` trailing typed NULL_VALUEs appended; bound presence and inclusivity are unchanged;
+    //    and a fully unbounded range (Range.all) stays fully unbounded.
     const auto& old_range = old_meta.range();
     if (old_range.has_lower_bound() != new_range.has_lower_bound() ||
         old_range.has_upper_bound() != new_range.has_upper_bound()) {
@@ -430,31 +431,35 @@ Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_
         return Status::Corruption("range upper bound inclusivity changed across the trailing ADD");
     }
 
-    const auto& new_trailing_col = new_schema.column(new_sk[new_sk.size() - 1]);
     auto check_bound = [&](bool has, const TuplePB& old_tuple, const TuplePB& new_tuple, const char* which) -> Status {
         if (!has) {
             return Status::OK();
         }
-        if (new_tuple.values_size() != old_tuple.values_size() + 1) {
-            return Status::Corruption(fmt::format("range {} bound must gain exactly one trailing value", which));
+        if (new_tuple.values_size() != old_tuple.values_size() + num_added) {
+            return Status::Corruption(
+                    fmt::format("range {} bound must gain exactly {} trailing value(s)", which, num_added));
         }
         for (int i = 0; i < old_tuple.values_size(); ++i) {
             if (!google::protobuf::util::MessageDifferencer::Equals(new_tuple.values(i), old_tuple.values(i))) {
                 return Status::Corruption(fmt::format("range {} bound prefix changed across the trailing ADD", which));
             }
         }
-        const auto& trailing = new_tuple.values(new_tuple.values_size() - 1);
-        if (trailing.variant_type() != VariantTypePB::NULL_VALUE) {
-            return Status::Corruption(fmt::format("range {} bound trailing value must be the NULL sentinel", which));
-        }
-        if (!trailing.has_type()) {
-            return Status::Corruption(fmt::format("range {} bound trailing value is missing a type", which));
-        }
-        const auto type_desc = TypeDescriptor::from_protobuf(trailing.type());
-        if (type_desc.type != new_trailing_col.type()) {
-            return Status::Corruption(fmt::format("range {} bound trailing NULL type {} != new sort-key column type {}",
-                                                  which, static_cast<int>(type_desc.type),
-                                                  static_cast<int>(new_trailing_col.type())));
+        for (int j = 0; j < num_added; ++j) {
+            const auto& new_trailing_col = new_schema.column(new_sk[old_sk.size() + j]);
+            const auto& trailing = new_tuple.values(old_tuple.values_size() + j);
+            if (trailing.variant_type() != VariantTypePB::NULL_VALUE) {
+                return Status::Corruption(
+                        fmt::format("range {} bound trailing value {} must be the NULL sentinel", which, j));
+            }
+            if (!trailing.has_type()) {
+                return Status::Corruption(fmt::format("range {} bound trailing value {} is missing a type", which, j));
+            }
+            const auto type_desc = TypeDescriptor::from_protobuf(trailing.type());
+            if (type_desc.type != new_trailing_col.type()) {
+                return Status::Corruption(
+                        fmt::format("range {} bound trailing NULL {} type {} != new sort-key column type {}", which, j,
+                                    static_cast<int>(type_desc.type), static_cast<int>(new_trailing_col.type())));
+            }
         }
         return Status::OK();
     };

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -321,8 +321,8 @@ bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const Tup
 namespace {
 // Defensive caps applied to an untrusted range before any per-value decoding, to bound allocation.
 constexpr int kMaxRangeSortKeyArity = 128;
-constexpr int64_t kMaxRangeValueBytes = 16LL * 1024 * 1024;  // per value
-constexpr int64_t kMaxRangeTotalBytes = 64LL * 1024 * 1024;  // whole range (both bounds)
+constexpr int64_t kMaxRangeValueBytes = 16LL * 1024 * 1024; // per value
+constexpr int64_t kMaxRangeTotalBytes = 64LL * 1024 * 1024; // whole range (both bounds)
 } // namespace
 
 Status TabletRangeHelper::validate_range_structural(const TabletRangePB& range, const TabletSchema& new_schema) {
@@ -359,8 +359,7 @@ Status TabletRangeHelper::validate_range_structural(const TabletRangePB& range, 
             }
             total_bytes += static_cast<int64_t>(v.value().size());
             if (total_bytes > kMaxRangeTotalBytes) {
-                return Status::Corruption(
-                        fmt::format("range total value bytes exceed cap {}", kMaxRangeTotalBytes));
+                return Status::Corruption(fmt::format("range total value bytes exceed cap {}", kMaxRangeTotalBytes));
             }
             if (!v.has_type()) {
                 return Status::Corruption(fmt::format("range {} value {} is missing a type", which, i));
@@ -459,8 +458,10 @@ Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_
         }
         return Status::OK();
     };
-    RETURN_IF_ERROR(check_bound(old_range.has_lower_bound(), old_range.lower_bound(), new_range.lower_bound(), "lower"));
-    RETURN_IF_ERROR(check_bound(old_range.has_upper_bound(), old_range.upper_bound(), new_range.upper_bound(), "upper"));
+    RETURN_IF_ERROR(
+            check_bound(old_range.has_lower_bound(), old_range.lower_bound(), new_range.lower_bound(), "lower"));
+    RETURN_IF_ERROR(
+            check_bound(old_range.has_upper_bound(), old_range.upper_bound(), new_range.upper_bound(), "upper"));
     return Status::OK();
 }
 

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -135,6 +135,41 @@ static StatusOr<DatumVariant> read_time_default(const TabletColumn& column) {
     return DatumVariant(type_info, datum);
 }
 
+// Whether two range-bound values are the SAME sort-key value, comparing semantically (variant kind,
+// logical type, and decoded value) rather than by raw proto bytes. The FE re-encodes a reprojected
+// range's leading Variants -- and a reshard persists boundary Variants through a different path -- so
+// byte-identical protos are not guaranteed even when the value is unchanged (e.g. an optional type or
+// variant_type field present on one side and defaulted on the other). Used to check that a trailing ADD
+// preserves the existing range prefix without spuriously rejecting an equivalent re-encoding.
+static StatusOr<bool> leading_value_preserved(const VariantPB& old_value, const VariantPB& new_value) {
+    if (old_value.variant_type() != new_value.variant_type()) {
+        return false;
+    }
+    if (old_value.has_type() != new_value.has_type()) {
+        return false;
+    }
+    if (old_value.has_type()) {
+        const auto old_type = TypeDescriptor::from_protobuf(old_value.type());
+        const auto new_type = TypeDescriptor::from_protobuf(new_value.type());
+        if (old_type.type != new_type.type) {
+            return false;
+        }
+    }
+    // Only NORMAL_VALUE carries a payload to compare; NULL/MIN/MAX are fully described by variant_type.
+    if (old_value.variant_type() != VariantTypePB::NORMAL_VALUE) {
+        return true;
+    }
+    Datum old_datum;
+    Datum new_datum;
+    RETURN_IF_ERROR(DatumVariant::from_proto(old_value, &old_datum));
+    RETURN_IF_ERROR(DatumVariant::from_proto(new_value, &new_datum));
+    const auto type_info = get_type_info(TypeDescriptor::from_protobuf(old_value.type()));
+    if (type_info == nullptr) {
+        return false;
+    }
+    return type_info->cmp(old_datum, new_datum) == 0;
+}
+
 StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangePB& tablet_range_pb,
                                                               const TabletSchemaCSPtr& tablet_schema, MemPool* mem_pool,
                                                               const TabletSchemaCSPtr& current_schema) {
@@ -546,7 +581,8 @@ Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_
                     fmt::format("range {} bound must gain exactly {} trailing value(s)", which, num_added));
         }
         for (int i = 0; i < old_tuple.values_size(); ++i) {
-            if (!google::protobuf::util::MessageDifferencer::Equals(new_tuple.values(i), old_tuple.values(i))) {
+            ASSIGN_OR_RETURN(bool preserved, leading_value_preserved(old_tuple.values(i), new_tuple.values(i)));
+            if (!preserved) {
                 return Status::Corruption(fmt::format("range {} bound prefix changed across the trailing ADD", which));
             }
         }

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -28,6 +28,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/datum_variant.h"
 #include "storage/types.h"
+#include "storage/variant_tuple.h"
 #include "storage_primitive/primary_key_encoder.h"
 #include "storage_primitive/schema_helper.h"
 #include "types/storage_type_traits.h"
@@ -303,6 +304,152 @@ bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const Tup
     return tuple_pb_equal(lhs, rhs);
 }
 } // namespace
+
+namespace {
+// Defensive caps applied to an untrusted range before any per-value decoding, to bound allocation.
+constexpr int kMaxRangeSortKeyArity = 128;
+constexpr int64_t kMaxRangeValueBytes = 16LL * 1024 * 1024;  // per value
+constexpr int64_t kMaxRangeTotalBytes = 64LL * 1024 * 1024;  // whole range (both bounds)
+} // namespace
+
+Status TabletRangeHelper::validate_range_structural(const TabletRangePB& range, const TabletSchema& new_schema) {
+    // Half-open flags + bound presence: lower inclusive / upper exclusive when set.
+    RETURN_IF_ERROR(validate_tablet_range(range));
+
+    // A fully unbounded range (Range.all) is always well-formed.
+    if (!range.has_lower_bound() && !range.has_upper_bound()) {
+        return Status::OK();
+    }
+
+    const auto& sort_key_idxes = new_schema.sort_key_idxes();
+    const int arity = static_cast<int>(sort_key_idxes.size());
+    if (arity <= 0) {
+        return Status::Corruption("range validation requires a non-empty sort key");
+    }
+
+    int64_t total_bytes = 0;
+    auto check_bound = [&](const TuplePB& tuple, const char* which) -> Status {
+        // Size caps are checked before decoding any value.
+        if (tuple.values_size() > kMaxRangeSortKeyArity) {
+            return Status::Corruption(fmt::format("range {} bound arity {} exceeds cap {}", which, tuple.values_size(),
+                                                  kMaxRangeSortKeyArity));
+        }
+        if (tuple.values_size() != arity) {
+            return Status::Corruption(fmt::format("range {} bound arity {} != effective sort-key arity {}", which,
+                                                  tuple.values_size(), arity));
+        }
+        for (int i = 0; i < arity; ++i) {
+            const auto& v = tuple.values(i);
+            if (v.value().size() > static_cast<size_t>(kMaxRangeValueBytes)) {
+                return Status::Corruption(fmt::format("range {} value {} size {} exceeds cap {}", which, i,
+                                                      v.value().size(), kMaxRangeValueBytes));
+            }
+            total_bytes += static_cast<int64_t>(v.value().size());
+            if (total_bytes > kMaxRangeTotalBytes) {
+                return Status::Corruption(
+                        fmt::format("range total value bytes exceed cap {}", kMaxRangeTotalBytes));
+            }
+            if (!v.has_type()) {
+                return Status::Corruption(fmt::format("range {} value {} is missing a type", which, i));
+            }
+            const auto type_desc = TypeDescriptor::from_protobuf(v.type());
+            const auto& col = new_schema.column(sort_key_idxes[i]);
+            if (type_desc.type != col.type()) {
+                return Status::Corruption(fmt::format("range {} value {} type {} != sort-key column type {}", which, i,
+                                                      static_cast<int>(type_desc.type), static_cast<int>(col.type())));
+            }
+        }
+        return Status::OK();
+    };
+
+    if (range.has_lower_bound()) {
+        RETURN_IF_ERROR(check_bound(range.lower_bound(), "lower"));
+    }
+    if (range.has_upper_bound()) {
+        RETURN_IF_ERROR(check_bound(range.upper_bound(), "upper"));
+    }
+
+    // Typed lower < upper when both bounds are present.
+    if (range.has_lower_bound() && range.has_upper_bound()) {
+        VariantTuple lower;
+        VariantTuple upper;
+        RETURN_IF_ERROR(lower.from_proto(range.lower_bound()));
+        RETURN_IF_ERROR(upper.from_proto(range.upper_bound()));
+        if (lower.compare(upper) >= 0) {
+            return Status::Corruption("range lower bound must be strictly less than upper bound");
+        }
+    }
+    return Status::OK();
+}
+
+Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_meta, const TabletSchema& new_schema,
+                                                    const TabletRangePB& new_range) {
+    // 1. The schema change must be exactly a trailing sort-key ADD: the existing effective sort key
+    //    is preserved by unique id/type/order and exactly one new trailing sort key is appended.
+    auto old_schema = TabletSchema::create(old_meta.schema());
+    const auto& old_sk = old_schema->sort_key_idxes();
+    const auto& new_sk = new_schema.sort_key_idxes();
+    if (new_sk.size() != old_sk.size() + 1) {
+        return Status::Corruption(
+                fmt::format("trailing sort-key ADD requires exactly one new sort key: old sort key size {}, new {}",
+                            old_sk.size(), new_sk.size()));
+    }
+    for (size_t i = 0; i < old_sk.size(); ++i) {
+        const auto& oc = old_schema->column(old_sk[i]);
+        const auto& nc = new_schema.column(new_sk[i]);
+        if (oc.unique_id() != nc.unique_id() || oc.type() != nc.type()) {
+            return Status::Corruption(
+                    fmt::format("existing sort key {} changed across the trailing ADD (unique id/type)", i));
+        }
+    }
+
+    // 2. Each present bound of new_range == the corresponding bound of old_meta.range() with exactly
+    //    one trailing typed NULL_VALUE appended; bound presence and inclusivity are unchanged; and a
+    //    fully unbounded range (Range.all) stays fully unbounded.
+    const auto& old_range = old_meta.range();
+    if (old_range.has_lower_bound() != new_range.has_lower_bound() ||
+        old_range.has_upper_bound() != new_range.has_upper_bound()) {
+        return Status::Corruption("range bound presence changed across the trailing ADD");
+    }
+    if (old_range.has_lower_bound() && old_range.lower_bound_included() != new_range.lower_bound_included()) {
+        return Status::Corruption("range lower bound inclusivity changed across the trailing ADD");
+    }
+    if (old_range.has_upper_bound() && old_range.upper_bound_included() != new_range.upper_bound_included()) {
+        return Status::Corruption("range upper bound inclusivity changed across the trailing ADD");
+    }
+
+    const auto& new_trailing_col = new_schema.column(new_sk[new_sk.size() - 1]);
+    auto check_bound = [&](bool has, const TuplePB& old_tuple, const TuplePB& new_tuple, const char* which) -> Status {
+        if (!has) {
+            return Status::OK();
+        }
+        if (new_tuple.values_size() != old_tuple.values_size() + 1) {
+            return Status::Corruption(fmt::format("range {} bound must gain exactly one trailing value", which));
+        }
+        for (int i = 0; i < old_tuple.values_size(); ++i) {
+            if (!google::protobuf::util::MessageDifferencer::Equals(new_tuple.values(i), old_tuple.values(i))) {
+                return Status::Corruption(fmt::format("range {} bound prefix changed across the trailing ADD", which));
+            }
+        }
+        const auto& trailing = new_tuple.values(new_tuple.values_size() - 1);
+        if (trailing.variant_type() != VariantTypePB::NULL_VALUE) {
+            return Status::Corruption(fmt::format("range {} bound trailing value must be the NULL sentinel", which));
+        }
+        if (!trailing.has_type()) {
+            return Status::Corruption(fmt::format("range {} bound trailing value is missing a type", which));
+        }
+        const auto type_desc = TypeDescriptor::from_protobuf(trailing.type());
+        if (type_desc.type != new_trailing_col.type()) {
+            return Status::Corruption(fmt::format("range {} bound trailing NULL type {} != new sort-key column type {}",
+                                                  which, static_cast<int>(type_desc.type),
+                                                  static_cast<int>(new_trailing_col.type())));
+        }
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(check_bound(old_range.has_lower_bound(), old_range.lower_bound(), new_range.lower_bound(), "lower"));
+    RETURN_IF_ERROR(check_bound(old_range.has_upper_bound(), old_range.upper_bound(), new_range.upper_bound(), "upper"));
+    return Status::OK();
+}
 
 Status TabletRangeHelper::validate_new_tablet_ranges(
         const TabletRangePB& old_tablet_range,

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -269,7 +269,20 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
             if (t_val.variant_type == TVariantType::MINIMUM || t_val.variant_type == TVariantType::MAXIMUM) {
                 return Status::InvalidArgument("MINIMUM/MAXIMUM variant is not supported in tablet range");
             }
-            pb_val->set_variant_type(static_cast<VariantTypePB>(t_val.variant_type));
+            // Thrift permits any i32 for an enum field, so map only the values we support instead of
+            // blindly casting into VariantTypePB (an out-of-range cast is an invalid proto enum that
+            // aborts on assertion-enabled builds).
+            switch (t_val.variant_type) {
+            case TVariantType::NORMAL_VALUE:
+                pb_val->set_variant_type(VariantTypePB::NORMAL_VALUE);
+                break;
+            case TVariantType::NULL_VALUE:
+                pb_val->set_variant_type(VariantTypePB::NULL_VALUE);
+                break;
+            default:
+                return Status::InvalidArgument(
+                        fmt::format("unsupported TVariant variant_type: {}", static_cast<int>(t_val.variant_type)));
+            }
         }
         return Status::OK();
     };

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -36,6 +36,12 @@
 
 namespace starrocks::lake {
 
+// Defensive caps applied to an untrusted range to bound allocation: at ingest (before the thrift->proto
+// copy in convert_t_range_to_pb_range) and again at apply/replay (validate_range_structural).
+constexpr int kMaxRangeSortKeyArity = 128;
+constexpr int64_t kMaxRangeValueBytes = 16LL * 1024 * 1024; // per value
+constexpr int64_t kMaxRangeTotalBytes = 64LL * 1024 * 1024; // whole range (both bounds)
+
 // Produce a Datum holding the minimum value for the given logical type.
 // Uses TypeInfo::set_to_min() which calls std::numeric_limits<CppType>::lowest().
 // Covers all PK-supported types (APPLY_FOR_ALL_PK_SUPPORT_TYPE in logical_type_infra.h).
@@ -108,9 +114,30 @@ Status TabletRangeHelper::validate_tablet_range(const TabletRangePB& tablet_rang
     return Status::OK();
 }
 
+// The value old rows of a segment read for a sort-key column added later by a metadata-only fast schema
+// evolution, mirroring DefaultValueColumnIterator::init: a declared default of the literal "NULL", or no
+// declared default on a nullable column, reads as NULL; otherwise the declared default parsed to its type.
+static StatusOr<DatumVariant> read_time_default(const TabletColumn& column) {
+    const TypeInfoPtr& type_info = get_type_info(column);
+    Datum datum;
+    if (column.has_default_value()) {
+        if (column.default_value() == "NULL") {
+            datum.set_null();
+        } else {
+            RETURN_IF_ERROR(datum_from_string(type_info.get(), &datum, column.default_value(), nullptr));
+        }
+    } else if (column.is_nullable()) {
+        datum.set_null();
+    } else {
+        return Status::Corruption(
+                fmt::format("added sort-key column {} has no default and is not nullable", column.name()));
+    }
+    return DatumVariant(type_info, datum);
+}
+
 StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangePB& tablet_range_pb,
-                                                              const TabletSchemaCSPtr& tablet_schema,
-                                                              MemPool* mem_pool) {
+                                                              const TabletSchemaCSPtr& tablet_schema, MemPool* mem_pool,
+                                                              const TabletSchemaCSPtr& current_schema) {
     SeekRange tablet_range;
     RETURN_IF_ERROR(validate_tablet_range(tablet_range_pb));
     if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
@@ -119,18 +146,15 @@ StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangeP
     }
     const auto& sort_key_idxes = tablet_schema->sort_key_idxes();
     DCHECK(!sort_key_idxes.empty());
-    auto parse_bound_to_seek_tuple = [&](const TuplePB& tuple) -> StatusOr<SeekTuple> {
-        const int n = tuple.values_size();
-        if (n != sort_key_idxes.size()) {
-            return Status::Corruption(
-                    fmt::format("Unexpected number of values in TabletRangePB bound value, expected: {}, actual: {}",
-                                sort_key_idxes.size(), n));
-        }
+    const size_t seg_arity = sort_key_idxes.size();
 
+    // Decode the leading `seg_arity` values of a bound with `tablet_schema` so the SeekTuple's positional
+    // field ids align with the target segment.
+    auto decode_leading = [&](const TuplePB& tuple) -> StatusOr<SeekTuple> {
         Schema schema;
         std::vector<Datum> values;
-        values.reserve(n);
-        for (int i = 0; i < n; i++) {
+        values.reserve(seg_arity);
+        for (size_t i = 0; i < seg_arity; i++) {
             const int idx = sort_key_idxes[i];
             schema.append_sort_key_idx(idx);
             auto f = std::make_shared<Field>(StorageSchemaHelper::convert_field(idx, tablet_schema->column(idx)));
@@ -143,18 +167,77 @@ StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangeP
         return SeekTuple(std::move(schema), std::move(values));
     };
 
+    // Sign of (added-column defaults D) minus (a bound's dropped trailing values at [seg_arity, m)), a
+    // lexicographic NULL-aware comparison. D comes from `current_schema`'s sort-key columns [seg_arity, m):
+    // for an old segment every row reads those columns as their default, so D vs the trailing decides how a
+    // boundary-prefix row routes.
+    auto compare_default_to_trailing = [&](const TuplePB& tuple) -> StatusOr<int> {
+        const int m = tuple.values_size();
+        if (current_schema == nullptr) {
+            return Status::Corruption("current schema is required to project a wider range bound");
+        }
+        const auto& cur_sort_key_idxes = current_schema->sort_key_idxes();
+        if (static_cast<int>(cur_sort_key_idxes.size()) < m) {
+            return Status::Corruption(fmt::format("current schema sort-key arity {} < range bound arity {}",
+                                                  cur_sort_key_idxes.size(), m));
+        }
+        VariantTuple default_trailing;
+        VariantTuple bound_trailing;
+        default_trailing.reserve(m - seg_arity);
+        bound_trailing.reserve(m - seg_arity);
+        for (int i = static_cast<int>(seg_arity); i < m; i++) {
+            ASSIGN_OR_RETURN(auto d, read_time_default(current_schema->column(cur_sort_key_idxes[i])));
+            default_trailing.append(std::move(d));
+            DatumVariant bound_value;
+            RETURN_IF_ERROR(bound_value.from_proto(tuple.values(i)));
+            bound_trailing.append(std::move(bound_value));
+        }
+        return default_trailing.compare(bound_trailing);
+    };
+
+    // Decode a bound into a SeekTuple and its (possibly projected) inclusivity.
+    auto build_bound = [&](const TuplePB& tuple, bool pb_included, bool is_lower, SeekTuple* out_tuple,
+                           bool* out_included) -> Status {
+        const int m = tuple.values_size();
+        if (m < static_cast<int>(seg_arity)) {
+            return Status::Corruption(fmt::format(
+                    "Unexpected number of values in TabletRangePB bound value, expected at least: {}, actual: {}",
+                    seg_arity, m));
+        }
+        ASSIGN_OR_RETURN(*out_tuple, decode_leading(tuple));
+        if (m == static_cast<int>(seg_arity)) {
+            *out_included = pb_included;
+            return Status::OK();
+        }
+        // The bound is wider than this segment's sort key: project it onto the leading `seg_arity` columns
+        // and derive inclusivity from D (what old rows read for the dropped columns) vs the trailing values.
+        // A boundary-prefix row (prefix, D) is on the >= side of a lower bound iff D >= trailing, and on the
+        // < side of an upper bound iff D < trailing.
+        ASSIGN_OR_RETURN(const int cmp, compare_default_to_trailing(tuple));
+        if (is_lower) {
+            *out_included = pb_included ? (cmp >= 0) : (cmp > 0);
+        } else {
+            *out_included = pb_included ? (cmp <= 0) : (cmp < 0);
+        }
+        return Status::OK();
+    };
+
     SeekTuple lower;
     SeekTuple upper;
+    bool inclusive_lower = tablet_range_pb.lower_bound_included();
+    bool inclusive_upper = tablet_range_pb.upper_bound_included();
     if (tablet_range_pb.has_lower_bound()) {
-        ASSIGN_OR_RETURN(lower, parse_bound_to_seek_tuple(tablet_range_pb.lower_bound()));
+        RETURN_IF_ERROR(build_bound(tablet_range_pb.lower_bound(), tablet_range_pb.lower_bound_included(),
+                                    /*is_lower=*/true, &lower, &inclusive_lower));
     }
     if (tablet_range_pb.has_upper_bound()) {
-        ASSIGN_OR_RETURN(upper, parse_bound_to_seek_tuple(tablet_range_pb.upper_bound()));
+        RETURN_IF_ERROR(build_bound(tablet_range_pb.upper_bound(), tablet_range_pb.upper_bound_included(),
+                                    /*is_lower=*/false, &upper, &inclusive_upper));
     }
 
     tablet_range = SeekRange(std::move(lower), std::move(upper));
-    tablet_range.set_inclusive_lower(tablet_range_pb.lower_bound_included());
-    tablet_range.set_inclusive_upper(tablet_range_pb.upper_bound_included());
+    tablet_range.set_inclusive_lower(inclusive_lower);
+    tablet_range.set_inclusive_upper(inclusive_upper);
     return tablet_range;
 }
 
@@ -245,7 +328,13 @@ StatusOr<SstSeekRange> TabletRangeHelper::create_sst_seek_range_from(const Table
 
 StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTabletRange& t_range) {
     TabletRangePB pb_range;
-    auto convert_bound = [](const auto& t_tuple, auto* pb_tuple) -> Status {
+    int64_t total_bytes = 0;
+    auto convert_bound = [&total_bytes](const auto& t_tuple, auto* pb_tuple) -> Status {
+        // Preflight arity before copying any values, to bound allocation on a malformed/oversized request.
+        if (t_tuple.values.size() > static_cast<size_t>(kMaxRangeSortKeyArity)) {
+            return Status::Corruption(
+                    fmt::format("range bound arity {} exceeds cap {}", t_tuple.values.size(), kMaxRangeSortKeyArity));
+        }
         for (const auto& t_val : t_tuple.values) {
             auto* pb_val = pb_tuple->add_values();
             if (t_val.__isset.type) {
@@ -258,6 +347,15 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
             }
 
             if (t_val.__isset.value) {
+                if (t_val.value.size() > static_cast<size_t>(kMaxRangeValueBytes)) {
+                    return Status::Corruption(
+                            fmt::format("range value bytes {} exceed cap {}", t_val.value.size(), kMaxRangeValueBytes));
+                }
+                total_bytes += static_cast<int64_t>(t_val.value.size());
+                if (total_bytes > kMaxRangeTotalBytes) {
+                    return Status::Corruption(
+                            fmt::format("range total value bytes exceed cap {}", kMaxRangeTotalBytes));
+                }
                 pb_val->set_value(t_val.value);
             } else if (!t_val.__isset.variant_type || t_val.variant_type == TVariantType::NORMAL_VALUE) {
                 return Status::InvalidArgument("TVariant value is required for NORMAL_VALUE variant");
@@ -316,13 +414,6 @@ bool tuple_bound_equal(bool lhs_has, const TuplePB& lhs, bool rhs_has, const Tup
     if (!lhs_has) return true;
     return tuple_pb_equal(lhs, rhs);
 }
-} // namespace
-
-namespace {
-// Defensive caps applied to an untrusted range before any per-value decoding, to bound allocation.
-constexpr int kMaxRangeSortKeyArity = 128;
-constexpr int64_t kMaxRangeValueBytes = 16LL * 1024 * 1024; // per value
-constexpr int64_t kMaxRangeTotalBytes = 64LL * 1024 * 1024; // whole range (both bounds)
 } // namespace
 
 Status TabletRangeHelper::validate_range_structural(const TabletRangePB& range, const TabletSchema& new_schema) {
@@ -413,6 +504,21 @@ Status TabletRangeHelper::validate_range_transition(const TabletMetadataPB& old_
         if (oc.unique_id() != nc.unique_id() || oc.type() != nc.type()) {
             return Status::Corruption(
                     fmt::format("existing sort key {} changed across the trailing ADD (unique id/type)", i));
+        }
+    }
+    // Each appended sort key must be a BRAND-NEW column (unique id absent from the entire old schema).
+    // Promoting an existing (e.g. value) column to a trailing sort key is not a metadata-only trailing
+    // ADD -- old rowsets are not physically sorted by it -- so reject it here even though FE already
+    // does, to defend against a malformed or stale task at apply/replay time.
+    std::unordered_set<ColumnUID> old_unique_ids;
+    for (const auto& col : old_schema->columns()) {
+        old_unique_ids.insert(col.unique_id());
+    }
+    for (int j = 0; j < num_added; ++j) {
+        const auto& nc = new_schema.column(new_sk[old_sk.size() + j]);
+        if (old_unique_ids.count(nc.unique_id()) > 0) {
+            return Status::Corruption(
+                    fmt::format("appended sort key {} (unique id {}) is not a brand-new column", j, nc.unique_id()));
         }
     }
 

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -425,10 +425,14 @@ StatusOr<TabletRangePB> TabletRangeHelper::convert_t_range_to_pb_range(const TTa
     if (t_range.__isset.upper_bound) {
         RETURN_IF_ERROR(convert_bound(t_range.upper_bound, pb_range.mutable_upper_bound()));
     }
-    if (t_range.__isset.lower_bound_included) {
+    // Persist an inclusivity flag only alongside a present bound. TabletRange.toThrift() sets the
+    // __isset.*_bound_included flags unconditionally, so an unbounded (Range.all) or one-sided range
+    // would otherwise carry a stray *_bound_included with no matching bound, leaving the persisted
+    // metadata inconsistent (has_*_bound_included() == true while has_*_bound() == false).
+    if (t_range.__isset.lower_bound_included && pb_range.has_lower_bound()) {
         pb_range.set_lower_bound_included(t_range.lower_bound_included);
     }
-    if (t_range.__isset.upper_bound_included) {
+    if (t_range.__isset.upper_bound_included && pb_range.has_upper_bound()) {
         pb_range.set_upper_bound_included(t_range.upper_bound_included);
     }
     return pb_range;

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -19,6 +19,7 @@
 #include "column/chunk.h"
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h"
+#include "gen_cpp/lake_types.pb.h"
 #include "gen_cpp/types.pb.h"
 #include "storage/lake/sst_seek_range.h"
 #include "storage/seek_range.h"
@@ -73,6 +74,27 @@ public:
     static Status validate_new_tablet_ranges(
             const TabletRangePB& old_tablet_range,
             const google::protobuf::RepeatedPtrField<TabletRangePB>& new_tablet_ranges);
+
+    // Schema-aware structural validation of a single tablet range against the schema it will be
+    // interpreted with. Used at BOTH build (before the txn log is written) and apply. Checks, in
+    // order: half-open flags (lower inclusive / upper exclusive when set); defensive size caps
+    // (per-bound arity, per-value bytes, total range bytes) applied before any value decoding; the
+    // per-bound arity equals the schema's effective sort-key count; each value's logical type equals
+    // its sort-key column's type; and, when both bounds are present, the lower bound is strictly less
+    // than the upper bound under type-aware comparison. A fully unbounded range (Range.all) is
+    // accepted. Callers must ensure a schema is present whenever a range is present.
+    static Status validate_range_structural(const TabletRangePB& range, const TabletSchema& new_schema);
+
+    // Apply-only validation that the schema/range change is exactly a trailing sort-key ADD relative
+    // to the currently-installed metadata. Requires: the new effective sort key equals the old
+    // effective sort key plus exactly one new trailing column (existing sort-key unique-ids, types and
+    // order unchanged); each present bound of `new_range` equals the corresponding bound of
+    // `old_meta.range()` with exactly one trailing typed NULL_VALUE appended; bound presence and
+    // inclusivity are unchanged; and a fully unbounded (Range.all) range stays fully unbounded.
+    // Rejections return Status::Corruption. `new_schema` is the resolved new schema; the old schema
+    // and old range are read from `old_meta`.
+    static Status validate_range_transition(const TabletMetadataPB& old_meta, const TabletSchema& new_schema,
+                                            const TabletRangePB& new_range);
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -103,9 +103,9 @@ public:
 
     // Apply-only validation that the schema/range change is exactly a trailing sort-key ADD relative
     // to the currently-installed metadata. Requires: the new effective sort key equals the old
-    // effective sort key plus exactly one new trailing column (existing sort-key unique-ids, types and
+    // effective sort key plus one or more new trailing columns (existing sort-key unique-ids, types and
     // order unchanged); each present bound of `new_range` equals the corresponding bound of
-    // `old_meta.range()` with exactly one trailing typed NULL_VALUE appended; bound presence and
+    // `old_meta.range()` with one trailing typed NULL_VALUE per added column appended; bound presence and
     // inclusivity are unchanged; and a fully unbounded (Range.all) range stays fully unbounded.
     // Rejections return Status::Corruption. `new_schema` is the resolved new schema; the old schema
     // and old range are read from `old_meta`.

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -45,8 +45,24 @@ public:
      * @return StatusOr<SeekRange> A SeekRange referencing data owned either by
      *         `tablet_range_pb` or `mem_pool`, depending on `mem_pool`.
      */
+    // Decode a persisted tablet range into a SeekRange under `tablet_schema`'s sort key. `tablet_schema`
+    // must be the schema the TARGET SEGMENT is read with (for an old rowset, its archived schema): the
+    // SeekRange's field ids are positional in `tablet_schema`, so callers pass the segment's own schema so
+    // the seek positions align with it.
+    //
+    // A range's bound arity normally equals `tablet_schema`'s sort-key arity (exact decode). It can be
+    // LARGER when the range was written under a wider (later) sort key than this segment -- e.g. a reshard
+    // stamps a per-rowset range in the current sort key after a metadata-only trailing key add, onto an old
+    // rowset that still carries its archived schema. In that case the segment's rows all read the added
+    // columns' constant default `D`, so the bound is projected onto `tablet_schema`'s sort key: keep the
+    // leading (segment-arity) values, and derive the bound's inclusivity by comparing `D` against the
+    // dropped trailing bound values (via `current_schema`, which must contain the added columns). This makes
+    // a boundary-prefix row route exactly as it would under the full-arity range. `current_schema` is
+    // required whenever a bound arity exceeds `tablet_schema`'s sort-key arity; it is unused for exact
+    // decodes.
     static StatusOr<SeekRange> create_seek_range_from(const TabletRangePB& tablet_range_pb,
-                                                      const TabletSchemaCSPtr& tablet_schema, MemPool* mem_pool);
+                                                      const TabletSchemaCSPtr& tablet_schema, MemPool* mem_pool,
+                                                      const TabletSchemaCSPtr& current_schema = nullptr);
 
     static StatusOr<SstSeekRange> create_sst_seek_range_from(const TabletRangePB& tablet_range_pb,
                                                              const TabletSchemaCSPtr& tablet_schema);

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -78,13 +78,13 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
         // metadata as it stands (old schema + old range), archive the pre-alter schema without
         // clearing existing history, then install the new schema and range. This path is independent
         // of `lake_enable_alter_struct` and must not touch the clearing branch below.
-        if (alter_meta.has_range()) {
+        if (alter_meta.has_tablet_range()) {
             if (!alter_meta.has_tablet_schema()) {
                 return Status::Corruption("alter metadata carries a range without a tablet schema");
             }
             auto new_schema = TabletSchema::create(alter_meta.tablet_schema());
-            RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(alter_meta.range(), *new_schema));
-            RETURN_IF_ERROR(TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.range()));
+            RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(alter_meta.tablet_range(), *new_schema));
+            RETURN_IF_ERROR(TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.tablet_range()));
 
             // Non-clearing archival of the pre-alter schema: map every currently-unmapped rowset to
             // the current schema id, and record the current schema in history only if it is absent.
@@ -102,7 +102,7 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             }
 
             metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
-            metadata->mutable_range()->CopyFrom(alter_meta.range());
+            metadata->mutable_range()->CopyFrom(alter_meta.tablet_range());
         }
         // update tablet meta
         // 1. rowset_to_schema is empty, maybe upgrade from old version or first time to do fast ddl. So we will

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -84,7 +84,8 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             }
             auto new_schema = TabletSchema::create(alter_meta.tablet_schema());
             RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(alter_meta.tablet_range(), *new_schema));
-            RETURN_IF_ERROR(TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.tablet_range()));
+            RETURN_IF_ERROR(
+                    TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.tablet_range()));
 
             // Non-clearing archival of the pre-alter schema: map every currently-unmapped rowset to
             // the current schema id, and record the current schema in history only if it is absent.

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -93,7 +93,8 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
         }
         // A range-carrying update is a metadata-only trailing sort-key ADD: the schema arity grows by
-        // one and every tablet bound gains a trailing NULL sentinel. Validate the change against the
+        // one or more and every tablet bound gains one trailing NULL sentinel per added column.
+        // Validate the change against the
         // metadata as it stands (old schema + old range), archive the pre-alter schema without
         // clearing existing history, then install the new schema and range. This path is independent
         // of `lake_enable_alter_struct` and must not touch the clearing branch below.

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -46,6 +46,25 @@ namespace starrocks::lake {
 
 namespace {
 
+// Non-clearing archival of the tablet's current schema before a new schema is installed: map every
+// currently-unmapped rowset to the current schema id, and record the current schema in
+// historical_schemas only if it is absent. Must be called BEFORE the caller overwrites
+// metadata->schema() with the new schema.
+void archive_current_schema_into_history(TabletMetadataPB* metadata) {
+    const auto& old_schema = metadata->schema();
+    bool record_old_schema_in_history = false;
+    for (const auto& rowset : metadata->rowsets()) {
+        if (metadata->rowset_to_schema().count(rowset.id()) <= 0) {
+            record_old_schema_in_history = true;
+            metadata->mutable_rowset_to_schema()->insert({rowset.id(), old_schema.id()});
+        }
+    }
+    if (record_old_schema_in_history && metadata->historical_schemas().count(old_schema.id()) <= 0) {
+        auto& item = (*metadata->mutable_historical_schemas())[old_schema.id()];
+        item.CopyFrom(old_schema);
+    }
+}
+
 Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMetadata& op_alter_metas,
                             TabletManager* tablet_mgr) {
     for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
@@ -87,20 +106,8 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             RETURN_IF_ERROR(
                     TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.tablet_range()));
 
-            // Non-clearing archival of the pre-alter schema: map every currently-unmapped rowset to
-            // the current schema id, and record the current schema in history only if it is absent.
-            auto& old_schema = metadata->schema();
-            bool record_old_schema_in_history = false;
-            for (const auto& rowset : metadata->rowsets()) {
-                if (metadata->rowset_to_schema().count(rowset.id()) <= 0) {
-                    record_old_schema_in_history = true;
-                    metadata->mutable_rowset_to_schema()->insert({rowset.id(), old_schema.id()});
-                }
-            }
-            if (record_old_schema_in_history && metadata->historical_schemas().count(old_schema.id()) <= 0) {
-                auto& item = (*metadata->mutable_historical_schemas())[old_schema.id()];
-                item.CopyFrom(old_schema);
-            }
+            // Archive the pre-alter schema (non-clearing) before installing the new one.
+            archive_current_schema_into_history(metadata);
 
             metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
             metadata->mutable_range()->CopyFrom(alter_meta.tablet_range());
@@ -188,17 +195,7 @@ Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
               << new_schema->schema_version() << ", old schema id/version: " << old_schema.id() << "/"
               << old_schema.schema_version();
 
-    bool record_old_schema_in_history = false;
-    for (auto& rowset : tablet_meta->rowsets()) {
-        if (tablet_meta->rowset_to_schema().count(rowset.id()) <= 0) {
-            record_old_schema_in_history = true;
-            tablet_meta->mutable_rowset_to_schema()->insert({rowset.id(), old_schema.id()});
-        }
-    }
-    if (record_old_schema_in_history && tablet_meta->historical_schemas().count(old_schema.id()) <= 0) {
-        auto& item = (*tablet_meta->mutable_historical_schemas())[old_schema.id()];
-        item.CopyFrom(old_schema);
-    }
+    archive_current_schema_into_history(tablet_meta.get());
     tablet_meta->mutable_schema()->Clear();
     new_schema->to_schema_pb(tablet_meta->mutable_schema());
     return Status::OK();

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -36,9 +36,11 @@
 #include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/update_manager.h"
+#include "storage/tablet_schema.h"
 
 namespace starrocks::lake {
 
@@ -71,12 +73,43 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
             // Try to remove the index from the index cache
             (void)update_mgr->index_cache().try_remove_by_key(metadata->id());
         }
+        // A range-carrying update is a metadata-only trailing sort-key ADD: the schema arity grows by
+        // one and every tablet bound gains a trailing NULL sentinel. Validate the change against the
+        // metadata as it stands (old schema + old range), archive the pre-alter schema without
+        // clearing existing history, then install the new schema and range. This path is independent
+        // of `lake_enable_alter_struct` and must not touch the clearing branch below.
+        if (alter_meta.has_range()) {
+            if (!alter_meta.has_tablet_schema()) {
+                return Status::Corruption("alter metadata carries a range without a tablet schema");
+            }
+            auto new_schema = TabletSchema::create(alter_meta.tablet_schema());
+            RETURN_IF_ERROR(TabletRangeHelper::validate_range_structural(alter_meta.range(), *new_schema));
+            RETURN_IF_ERROR(TabletRangeHelper::validate_range_transition(*metadata, *new_schema, alter_meta.range()));
+
+            // Non-clearing archival of the pre-alter schema: map every currently-unmapped rowset to
+            // the current schema id, and record the current schema in history only if it is absent.
+            auto& old_schema = metadata->schema();
+            bool record_old_schema_in_history = false;
+            for (const auto& rowset : metadata->rowsets()) {
+                if (metadata->rowset_to_schema().count(rowset.id()) <= 0) {
+                    record_old_schema_in_history = true;
+                    metadata->mutable_rowset_to_schema()->insert({rowset.id(), old_schema.id()});
+                }
+            }
+            if (record_old_schema_in_history && metadata->historical_schemas().count(old_schema.id()) <= 0) {
+                auto& item = (*metadata->mutable_historical_schemas())[old_schema.id()];
+                item.CopyFrom(old_schema);
+            }
+
+            metadata->mutable_schema()->CopyFrom(alter_meta.tablet_schema());
+            metadata->mutable_range()->CopyFrom(alter_meta.range());
+        }
         // update tablet meta
         // 1. rowset_to_schema is empty, maybe upgrade from old version or first time to do fast ddl. So we will
         //    add the tablet schema before alter into historical schema.
         // 2. rowset_to_schema is not empty, no need to update historical schema because we historical schema already
         //    keep the tablet schema before alter.
-        if (alter_meta.has_tablet_schema()) {
+        else if (alter_meta.has_tablet_schema()) {
             VLOG(2) << "old schema: " << metadata->schema().DebugString()
                     << " new schema: " << alter_meta.tablet_schema().DebugString();
             // add/drop field for struct column is under testing, To avoid impacting the existing logic, add the

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -17,6 +17,8 @@
 #include "agent/agent_task.h"
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/id_generator.h"
+#include "base/utility/defer_op.h"
+#include "common/config_lake_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
@@ -26,6 +28,7 @@
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log_applier.h"
 #include "test_util.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks::lake {
 
@@ -669,6 +672,227 @@ TEST_F(AlterTabletMetaTest, test_compaction_strategy) {
     auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(CompactionStrategyPB::REAL_TIME, new_tablet_meta.value()->compaction_strategy());
+}
+
+namespace {
+
+// Builds a DUP schema PB whose first `num_sort_keys` INT columns are the contiguous sort key
+// (stable unique ids 100..) followed by a single INT value column.
+TabletSchemaPB build_range_schema_pb(int num_sort_keys, int64_t schema_id) {
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_id(schema_id);
+    pb.set_schema_version(schema_id);
+    pb.set_num_short_key_columns(1);
+    for (int i = 0; i < num_sort_keys; ++i) {
+        auto* c = pb.add_column();
+        c->set_unique_id(100 + i);
+        c->set_name("k" + std::to_string(i));
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(i == num_sort_keys - 1);
+        c->set_aggregation("NONE");
+        pb.add_sort_key_idxes(i);
+    }
+    auto* v = pb.add_column();
+    v->set_unique_id(200);
+    v->set_name("v");
+    v->set_type("INT");
+    v->set_is_key(false);
+    v->set_is_nullable(true);
+    v->set_aggregation("NONE");
+    return pb;
+}
+
+void add_int_value(TuplePB* t, int32_t v) {
+    auto* pb = t->add_values();
+    TypeDescriptor td(TYPE_INT);
+    pb->mutable_type()->CopyFrom(td.to_protobuf());
+    pb->set_value(std::to_string(v));
+    pb->set_variant_type(VariantTypePB::NORMAL_VALUE);
+}
+
+void add_null_value(TuplePB* t) {
+    auto* pb = t->add_values();
+    TypeDescriptor td(TYPE_INT);
+    pb->mutable_type()->CopyFrom(td.to_protobuf());
+    pb->set_variant_type(VariantTypePB::NULL_VALUE);
+}
+
+} // namespace
+
+// apply_alter_meta_log with a range-carrying update installs the new tablet range and archives the
+// pre-alter schema via the NON-CLEARING pattern, independent of `lake_enable_alter_struct`.
+TEST_F(AlterTabletMetaTest, test_apply_range_alter_meta_non_clearing_archival) {
+    auto saved = config::lake_enable_alter_struct;
+    config::lake_enable_alter_struct = false;
+    DeferOp restore([&]() { config::lake_enable_alter_struct = saved; });
+
+    constexpr int64_t kOlderSchemaId = 400;
+    constexpr int64_t kOldSchemaId = 500;
+    constexpr int64_t kNewSchemaId = 501;
+    constexpr uint32_t kRowset0 = 10;
+    constexpr uint32_t kRowset1 = 11;
+    constexpr uint32_t kRowset2 = 12;
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(100);
+    metadata->mutable_schema()->CopyFrom(build_range_schema_pb(1, kOldSchemaId));
+
+    // Old range [(1), (2)).
+    {
+        auto* r = metadata->mutable_range();
+        add_int_value(r->mutable_lower_bound(), 1);
+        add_int_value(r->mutable_upper_bound(), 2);
+        r->set_lower_bound_included(true);
+        r->set_upper_bound_included(false);
+    }
+
+    // Three rowsets; only rowset0 is pre-mapped (to an even older schema).
+    metadata->add_rowsets()->set_id(kRowset0);
+    metadata->add_rowsets()->set_id(kRowset1);
+    metadata->add_rowsets()->set_id(kRowset2);
+    (*metadata->mutable_rowset_to_schema())[kRowset0] = kOlderSchemaId;
+    (*metadata->mutable_historical_schemas())[kOlderSchemaId] = build_range_schema_pb(1, kOlderSchemaId);
+
+    // Alter log: trailing sort-key ADD -> 2 sort keys, range [(1, NULL), (2, NULL)).
+    TxnLogPB log;
+    log.set_tablet_id(metadata->id());
+    auto* upd = log.mutable_op_alter_metadata()->add_metadata_update_infos();
+    upd->mutable_tablet_schema()->CopyFrom(build_range_schema_pb(2, kNewSchemaId));
+    {
+        auto* r = upd->mutable_range();
+        add_int_value(r->mutable_lower_bound(), 1);
+        add_null_value(r->mutable_lower_bound());
+        add_int_value(r->mutable_upper_bound(), 2);
+        add_null_value(r->mutable_upper_bound());
+        r->set_lower_bound_included(true);
+        r->set_upper_bound_included(false);
+    }
+
+    auto version = metadata->version() + 1;
+    std::unique_ptr<TxnLogApplier> applier =
+            new_txn_log_applier(Tablet(_tablet_mgr.get(), metadata->id()), metadata, version, false, false);
+    ASSERT_OK(applier->apply(log));
+
+    // New range installed with the trailing NULL sentinel.
+    ASSERT_TRUE(metadata->has_range());
+    ASSERT_EQ(2, metadata->range().lower_bound().values_size());
+    ASSERT_EQ(2, metadata->range().upper_bound().values_size());
+    ASSERT_EQ(VariantTypePB::NULL_VALUE, metadata->range().lower_bound().values(1).variant_type());
+    ASSERT_EQ(VariantTypePB::NULL_VALUE, metadata->range().upper_bound().values(1).variant_type());
+
+    // New schema installed.
+    ASSERT_EQ(kNewSchemaId, metadata->schema().id());
+
+    // Non-clearing archival: preexisting mapping/history preserved; only unmapped rowsets added.
+    ASSERT_EQ(3, metadata->rowset_to_schema().size());
+    ASSERT_EQ(kOlderSchemaId, metadata->rowset_to_schema().at(kRowset0)); // preserved
+    ASSERT_EQ(kOldSchemaId, metadata->rowset_to_schema().at(kRowset1));   // newly mapped to old schema
+    ASSERT_EQ(kOldSchemaId, metadata->rowset_to_schema().at(kRowset2));
+    ASSERT_EQ(2, metadata->historical_schemas().size());
+    ASSERT_TRUE(metadata->historical_schemas().count(kOlderSchemaId) > 0); // preserved, not cleared
+    ASSERT_TRUE(metadata->historical_schemas().count(kOldSchemaId) > 0);   // pre-alter schema archived
+}
+
+// do_process_update_tablet_meta copies the thrift range into the proto update info (via structural
+// validation) without logging raw boundary values.
+TEST_F(AlterTabletMetaTest, test_do_process_update_tablet_meta_copies_range) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+
+    // A DUP range tablet with a single INT sort key.
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(1);
+    metadata->mutable_schema()->CopyFrom(build_range_schema_pb(1, 600));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+    auto tablet_id = metadata->id();
+
+    int64_t txn_id = next_id();
+    TUpdateTabletMetaInfoReq req;
+    req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo info;
+    info.__set_tablet_id(tablet_id);
+
+    // New schema: 2 INT sort keys (trailing ADD).
+    TTabletSchema t_schema;
+    t_schema.__set_id(601);
+    t_schema.__set_schema_version(2);
+    t_schema.__set_short_key_column_count(1);
+    t_schema.__set_keys_type(TKeysType::DUP_KEYS);
+    for (int i = 0; i < 2; ++i) {
+        TColumn c;
+        c.__set_column_name("k" + std::to_string(i));
+        c.column_type.__set_type(TPrimitiveType::INT);
+        c.__set_col_unique_id(100 + i);
+        c.__set_is_key(true);
+        c.__set_is_allow_null(i == 1);
+        t_schema.columns.push_back(c);
+    }
+    {
+        TColumn v;
+        v.__set_column_name("v");
+        v.column_type.__set_type(TPrimitiveType::INT);
+        v.__set_col_unique_id(200);
+        v.__set_is_key(false);
+        v.__set_is_allow_null(true);
+        t_schema.columns.push_back(v);
+    }
+    t_schema.sort_key_idxes.push_back(0);
+    t_schema.sort_key_idxes.push_back(1);
+    t_schema.__isset.sort_key_idxes = true;
+    info.__set_tablet_schema(t_schema);
+
+    // Range [(1, NULL), (2, NULL)).
+    TTabletRange t_range;
+    TTypeDesc int_type;
+    int_type.types.resize(1);
+    int_type.__isset.types = true;
+    int_type.types[0].type = TTypeNodeType::SCALAR;
+    int_type.types[0].scalar_type.__set_type(TPrimitiveType::INT);
+    int_type.types[0].__isset.scalar_type = true;
+    auto make_variant = [&](std::optional<int32_t> v) {
+        TVariant var;
+        var.__set_type(int_type);
+        if (v.has_value()) {
+            var.__set_value(std::to_string(*v));
+            var.__set_variant_type(TVariantType::NORMAL_VALUE);
+        } else {
+            var.__set_variant_type(TVariantType::NULL_VALUE);
+        }
+        return var;
+    };
+    TTuple lower;
+    lower.values.push_back(make_variant(1));
+    lower.values.push_back(make_variant(std::nullopt));
+    TTuple upper;
+    upper.values.push_back(make_variant(2));
+    upper.values.push_back(make_variant(std::nullopt));
+    t_range.__set_lower_bound(lower);
+    t_range.__set_upper_bound(upper);
+    t_range.__set_lower_bound_included(true);
+    t_range.__set_upper_bound_included(false);
+    info.__set_range(t_range);
+
+    req.tabletMetaInfos.push_back(info);
+    ASSERT_OK(handler.process_update_tablet_meta(req));
+
+    // The generated txn log carries the range copied into the proto update info.
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_TRUE(txn_log->has_op_alter_metadata());
+    ASSERT_EQ(1, txn_log->op_alter_metadata().metadata_update_infos_size());
+    const auto& upd = txn_log->op_alter_metadata().metadata_update_infos(0);
+    ASSERT_TRUE(upd.has_range());
+    ASSERT_EQ(2, upd.range().lower_bound().values_size());
+    ASSERT_EQ(2, upd.range().upper_bound().values_size());
+    ASSERT_EQ("1", upd.range().lower_bound().values(0).value());
+    ASSERT_EQ(VariantTypePB::NULL_VALUE, upd.range().lower_bound().values(1).variant_type());
+    ASSERT_TRUE(upd.range().lower_bound_included());
+    ASSERT_FALSE(upd.range().upper_bound_included());
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_flat_json_config) {

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -763,7 +763,7 @@ TEST_F(AlterTabletMetaTest, test_apply_range_alter_meta_non_clearing_archival) {
     auto* upd = log.mutable_op_alter_metadata()->add_metadata_update_infos();
     upd->mutable_tablet_schema()->CopyFrom(build_range_schema_pb(2, kNewSchemaId));
     {
-        auto* r = upd->mutable_range();
+        auto* r = upd->mutable_tablet_range();
         add_int_value(r->mutable_lower_bound(), 1);
         add_null_value(r->mutable_lower_bound());
         add_int_value(r->mutable_upper_bound(), 2);
@@ -876,7 +876,7 @@ TEST_F(AlterTabletMetaTest, test_do_process_update_tablet_meta_copies_range) {
     t_range.__set_upper_bound(upper);
     t_range.__set_lower_bound_included(true);
     t_range.__set_upper_bound_included(false);
-    info.__set_range(t_range);
+    info.__set_tablet_range(t_range);
 
     req.tabletMetaInfos.push_back(info);
     ASSERT_OK(handler.process_update_tablet_meta(req));
@@ -886,13 +886,13 @@ TEST_F(AlterTabletMetaTest, test_do_process_update_tablet_meta_copies_range) {
     ASSERT_TRUE(txn_log->has_op_alter_metadata());
     ASSERT_EQ(1, txn_log->op_alter_metadata().metadata_update_infos_size());
     const auto& upd = txn_log->op_alter_metadata().metadata_update_infos(0);
-    ASSERT_TRUE(upd.has_range());
-    ASSERT_EQ(2, upd.range().lower_bound().values_size());
-    ASSERT_EQ(2, upd.range().upper_bound().values_size());
-    ASSERT_EQ("1", upd.range().lower_bound().values(0).value());
-    ASSERT_EQ(VariantTypePB::NULL_VALUE, upd.range().lower_bound().values(1).variant_type());
-    ASSERT_TRUE(upd.range().lower_bound_included());
-    ASSERT_FALSE(upd.range().upper_bound_included());
+    ASSERT_TRUE(upd.has_tablet_range());
+    ASSERT_EQ(2, upd.tablet_range().lower_bound().values_size());
+    ASSERT_EQ(2, upd.tablet_range().upper_bound().values_size());
+    ASSERT_EQ("1", upd.tablet_range().lower_bound().values(0).value());
+    ASSERT_EQ(VariantTypePB::NULL_VALUE, upd.tablet_range().lower_bound().values(1).variant_type());
+    ASSERT_TRUE(upd.tablet_range().lower_bound_included());
+    ASSERT_FALSE(upd.tablet_range().upper_bound_included());
 }
 
 TEST_F(AlterTabletMetaTest, test_alter_flat_json_config) {

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -743,10 +743,11 @@ TEST_F(LakeRowsetTest, test_rowset_range_overrides_tablet_range) {
 
 // Regression: after a metadata-only trailing sort-key add (N -> N+1), a reshard that runs later
 // stamps a per-rowset range in the CURRENT (N+1) sort key onto an old rowset that still carries its
-// archived (N) schema. get_seek_range must decode that range with the current schema (whose sort-key
-// arity matches the range), not the archived rowset schema, otherwise the read fails with an arity
-// mismatch ("expected N, actual N+1").
-TEST_F(LakeRowsetTest, test_rowset_range_uses_current_schema_on_arity_mismatch) {
+// archived (N) schema. get_seek_range must decode that range with THIS rowset's own (archived) schema
+// -- so the SeekRange's positional field ids align with the rowset's segments -- and project the wider
+// bound onto the leading N sort-key columns using the added columns' defaults (from the current schema);
+// otherwise the read fails with an arity mismatch ("expected N, actual N+1").
+TEST_F(LakeRowsetTest, test_rowset_range_larger_arity_decodes_with_rowset_schema_prefix) {
     auto add_int_col = [](TabletSchemaPB* s, int uid, const std::string& name, bool is_key, bool nullable) {
         auto* c = s->add_column();
         c->set_unique_id(uid);
@@ -808,8 +809,96 @@ TEST_F(LakeRowsetTest, test_rowset_range_uses_current_schema_on_arity_mismatch) 
 
     auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
     // Without the fix this returns an arity-mismatch error (archived arity-1 schema vs arity-2 range).
+    // With it, get_seek_range decodes the leading value with the archived schema (positions aligned) and
+    // projects the arity-2 bound onto that one column using k2's default. k2 is nullable-no-default, so
+    // D(k2)=NULL < the non-NULL trailing values (10/20): an old row (p, NULL) is excluded from the lower
+    // bound and included under the upper.
     ASSIGN_OR_ABORT(auto seek_range, rowset->get_seek_range());
     ASSERT_TRUE(seek_range.has_value());
+    EXPECT_EQ(1u, seek_range->lower().columns());
+    EXPECT_FALSE(seek_range->inclusive_lower());
+    EXPECT_TRUE(seek_range->inclusive_upper());
+}
+
+// Regression: chained metadata-only adds interleaved with reshard can leave a per-rowset range at an
+// arity (2) between the rowset's archived schema (1) and the current tablet schema (3). get_seek_range
+// must decode it with THIS rowset's own (archived) schema prefix -- so positions align with the rowset's
+// segments -- NOT the current schema (whose column positions differ once a key is inserted before value
+// columns). It uses the leading (rowset sort-key arity) values and drops the rest.
+TEST_F(LakeRowsetTest, test_rowset_range_decodes_with_rowset_schema_not_current) {
+    auto add_int_col = [](TabletSchemaPB* s, int uid, const std::string& name, bool is_key, bool nullable) {
+        auto* c = s->add_column();
+        c->set_unique_id(uid);
+        c->set_name(name);
+        c->set_type("INT");
+        c->set_is_nullable(nullable);
+        c->set_is_key(is_key);
+        if (!is_key) {
+            c->set_aggregation("NONE");
+        }
+    };
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(1);
+
+    // Current schema: 3 sort keys (k1, k2, k3) + value v -- two trailing adds beyond the original k1.
+    auto* schema = metadata->mutable_schema();
+    schema->set_id(300);
+    schema->set_keys_type(DUP_KEYS);
+    schema->set_num_short_key_columns(1);
+    schema->set_num_rows_per_row_block(65535);
+    add_int_col(schema, 1, "k1", true, false);
+    add_int_col(schema, 2, "k2", true, false);
+    add_int_col(schema, 3, "k3", true, true);
+    add_int_col(schema, 4, "v", false, true);
+    schema->mutable_column(1)->set_default_value("0"); // k2 added with a const default
+    schema->add_sort_key_idxes(0);
+    schema->add_sort_key_idxes(1);
+    schema->add_sort_key_idxes(2);
+
+    // Archived original schema: 1 sort key (k1) + value v.
+    constexpr int64_t kArchivedId = 100;
+    auto& archived = (*metadata->mutable_historical_schemas())[kArchivedId];
+    archived.set_id(kArchivedId);
+    archived.set_keys_type(DUP_KEYS);
+    archived.set_num_short_key_columns(1);
+    archived.set_num_rows_per_row_block(65535);
+    add_int_col(&archived, 1, "k1", true, false);
+    add_int_col(&archived, 4, "v", false, true);
+    archived.add_sort_key_idxes(0);
+
+    // A rowset mapped to the archived (arity-1) schema, carrying an INTERMEDIATE-arity (2-value) range
+    // as a reshard between the two adds would stamp.
+    auto* rs = metadata->add_rowsets();
+    rs->set_id(10);
+    rs->set_overlapped(false);
+    rs->set_num_rows(0);
+    rs->set_data_size(0);
+    (*metadata->mutable_rowset_to_schema())[10] = kArchivedId;
+    {
+        auto* range = rs->mutable_range();
+        auto* lo = range->mutable_lower_bound();
+        *lo->add_values() = make_int_variant_pb(1);
+        *lo->add_values() = make_int_variant_pb(10);
+        range->set_lower_bound_included(true);
+        auto* hi = range->mutable_upper_bound();
+        *hi->add_values() = make_int_variant_pb(100);
+        *hi->add_values() = make_int_variant_pb(20);
+        range->set_upper_bound_included(false);
+    }
+
+    auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+    // Decodes the leading value with the rowset's archived schema (arity 1) -- positions aligned with the
+    // segment -- and projects the arity-2 bound onto that column using k2's const default D=0 (from the
+    // current schema). D=0 < the trailing values (10/20), so lower drops to exclusive and upper to
+    // inclusive. The current (arity-3) schema is used only for the projection defaults, never for positions.
+    ASSIGN_OR_ABORT(auto seek_range, rowset->get_seek_range());
+    ASSERT_TRUE(seek_range.has_value());
+    EXPECT_EQ(1u, seek_range->lower().columns());
+    EXPECT_FALSE(seek_range->inclusive_lower());
+    EXPECT_TRUE(seek_range->inclusive_upper());
 }
 
 TEST_F(LakeRowsetTest, test_tablet_range_pb_invalid_bounds) {
@@ -1973,6 +2062,42 @@ static TabletSchemaPB make_two_int_dup_schema(int64_t schema_id, int32_t schema_
     return schema_pb;
 }
 
+// Build the current schema after a metadata-only trailing key ADD: [c0 key, c_new key(const default),
+// c1 value] with sort key (c0, c_new). c_new is a brand-new column not physically present in the old
+// segment, so its rows read as `cnew_default`; c1 keeps its unique_id and shifts one position right.
+static TabletSchemaPB make_trailing_key_add_schema(int64_t schema_id, int32_t schema_version, int64_t c0_uid,
+                                                   int64_t cnew_uid, int64_t c1_uid, const std::string& cnew_default) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_id(schema_id);
+    schema_pb.set_schema_version(schema_version);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto* c0 = schema_pb.add_column();
+    c0->set_unique_id(c0_uid);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_nullable(false);
+    c0->set_is_key(true);
+    auto* cnew = schema_pb.add_column();
+    cnew->set_unique_id(cnew_uid);
+    cnew->set_name("c_new");
+    cnew->set_type("INT");
+    cnew->set_is_nullable(false);
+    cnew->set_is_key(true);
+    cnew->set_default_value(cnew_default);
+    auto* c1 = schema_pb.add_column();
+    c1->set_unique_id(c1_uid);
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_nullable(false);
+    c1->set_is_key(false);
+    c1->set_aggregation("NONE");
+    schema_pb.add_sort_key_idxes(0);
+    schema_pb.add_sort_key_idxes(1);
+    return schema_pb;
+}
+
 // Set a two-column INT tablet range [ (lo0,lo1), (hi0,hi1) ) (closed-open).
 static void set_tablet_range_two_int(TabletMetadata* tablet_meta, int32_t lo0, int32_t lo1, int32_t hi0, int32_t hi1) {
     auto* range = tablet_meta->mutable_range();
@@ -2020,16 +2145,21 @@ static void write_single_segment_rowset(TabletManager* tablet_mgr, TabletMetadat
 
 } // namespace
 
-// Trailing sort-key ADD (N -> N+1): an old rowset archived under the previous N-sort-key schema
-// must stay readable after a metadata-only change that appends a trailing sort-key column, which
-// grows the tablet fallback range to N+1 values. Rowset::get_seek_range() must decode the tablet
-// fallback range with the CURRENT tablet schema (2 sort keys), not the rowset's archived schema
-// (1 sort key); otherwise create_seek_range_from returns Status::Corruption on the arity mismatch
-// and the read fails. The rowset's segments are marked shared() so that Rowset::read installs the
-// tablet seek range (it is only applied to shared segments), exercising the decode path.
-TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema) {
+// Trailing sort-key ADD (N -> N+1): an old rowset archived under the previous N-sort-key schema must
+// stay readable after a metadata-only change that appends a BRAND-NEW trailing sort-key column. The
+// added column is not physically present in the old segment, so its rows read as the column default; a
+// later reshard stamps a per-rowset/tablet range in the (N+1)-value sort key onto the old rowset.
+// Rowset::get_seek_range() must decode that wider range with the rowset's own (archived) schema for
+// positional alignment, and PROJECT the trailing bound value against the added column's default to fix
+// each bound's inclusivity -- not merely truncate it. The boundary here (trailing 5 on the lower bound,
+// -5 on the upper) is chosen so correct projection and naive truncation disagree on the count: with
+// default D=0, the lower's 0<5 excludes the c0==20 rows and the upper's 0>-5 excludes the c0==40 rows,
+// leaving only c0==30 (1 row); truncation to [20,40) would keep {20,30} (2 rows). Segments are marked
+// shared() so Rowset::read installs the tablet seek range (applied only to shared segments).
+TEST_F(LakeRowsetTest, test_seek_range_trailing_key_add_projects_and_compacts) {
     const int64_t c0_uid = next_id();
     const int64_t c1_uid = next_id();
+    const int64_t cnew_uid = next_id();
     const int64_t archived_schema_id = next_id();
     const int64_t current_schema_id = next_id();
 
@@ -2047,14 +2177,14 @@ TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema)
     auto write_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(archived_schema));
     write_single_segment_rowset(_tablet_mgr.get(), metadata.get(), write_schema);
 
-    // Apply the metadata-only trailing sort-key add: archive the old schema, install the current
-    // 2-sort-key schema, map the old rowset to the archived schema, grow the tablet range to two
-    // values, and mark the rowset's segments shared so the tablet range is applied on read.
+    // Apply the metadata-only trailing key add: archive the old schema, install the current schema
+    // [c0 key, c_new key(default 0), c1 value] with sort key (c0, c_new), map the old rowset to the
+    // archived schema, stamp a 2-value tablet range as a later reshard would, and mark segments shared.
     metadata->mutable_historical_schemas()->insert({archived_schema_id, metadata->schema()});
-    *metadata->mutable_schema() =
-            make_two_int_dup_schema(current_schema_id, /*schema_version=*/2, /*num_key_columns=*/2, c0_uid, c1_uid);
+    *metadata->mutable_schema() = make_trailing_key_add_schema(current_schema_id, /*schema_version=*/2, c0_uid,
+                                                               cnew_uid, c1_uid, /*cnew_default=*/"0");
     metadata->mutable_rowset_to_schema()->insert({1, archived_schema_id});
-    set_tablet_range_two_int(metadata.get(), 20, 100, 40, 100); // [ (20,100), (40,100) )
+    set_tablet_range_two_int(metadata.get(), 20, 5, 40, -5); // [ (20,5), (40,-5) )
     set_rowset_shared_segments(metadata->mutable_rowsets(0), true);
     metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
@@ -2062,9 +2192,9 @@ TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema)
     auto current_schema = TabletSchema::create(metadata->schema());
     auto input_schema = ChunkHelper::convert_schema(current_schema, std::vector<ColumnId>{0});
 
-    // BEFORE the fix, get_seek_range decodes the 2-value fallback range with the archived
-    // 1-sort-key schema and read() fails with Status::Corruption. AFTER the fix it decodes with
-    // the current schema and returns the two in-range rows: (20,100) and (30,100).
+    // BEFORE the fix, get_seek_range decodes the 2-value fallback range with the archived 1-sort-key
+    // schema and read() fails with Status::Corruption. AFTER the fix it projects to c0 in (20, 40)
+    // (both boundaries exclusive), leaving only c0==30.
     {
         OlapReaderStatistics stats;
         RowsetReadOptions rs_opts;
@@ -2072,16 +2202,15 @@ TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema)
         rs_opts.tablet_schema = std::make_shared<const TabletSchema>(metadata->schema());
         auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
         auto read_res = rowset->read(input_schema, rs_opts);
-        ASSERT_TRUE(read_res.ok()) << "get_seek_range must decode the tablet fallback range with the current "
-                                      "schema after a trailing sort-key add, not corrupt on arity mismatch: "
+        ASSERT_TRUE(read_res.ok()) << "get_seek_range must project the wider tablet range onto the rowset's "
+                                      "archived sort key, not corrupt on arity mismatch: "
                                    << read_res.status();
-        EXPECT_EQ(2, count_rows_from_iters(read_res.value()));
+        EXPECT_EQ(1, count_rows_from_iters(read_res.value()));
     }
 
-    // Force a compaction of the archived rowset. The compaction itself reads the shared segment
-    // through get_seek_range (so it also exercises the fix) and, because the segment is shared,
-    // applies the tablet range while merging, yielding a private output rowset with the two
-    // in-range rows. Reading that output must still return the same two rows.
+    // Force a compaction of the archived rowset. The compaction reads the shared segment through
+    // get_seek_range (so it also exercises the projection) and, because the segment is shared, applies
+    // the tablet range while merging, yielding a private output rowset with the single in-range row.
     int64_t compact_txn = next_id();
     auto input_rowset =
             std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
@@ -2100,7 +2229,7 @@ TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema)
     auto compacted =
             std::make_shared<lake::Rowset>(_tablet_mgr.get(), new_metadata, 0, 0 /* compaction_segment_limit */);
     ASSIGN_OR_ABORT(auto iters2, compacted->read(input_schema, rs_opts2));
-    EXPECT_EQ(2, count_rows_from_iters(iters2));
+    EXPECT_EQ(1, count_rows_from_iters(iters2));
 }
 
 // Regression: when the sort-key arity is unchanged, decoding the tablet fallback range with the

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -741,6 +741,77 @@ TEST_F(LakeRowsetTest, test_rowset_range_overrides_tablet_range) {
     ASSERT_EQ(count_rows_from_iters(iters), 3 * 2);
 }
 
+// Regression: after a metadata-only trailing sort-key add (N -> N+1), a reshard that runs later
+// stamps a per-rowset range in the CURRENT (N+1) sort key onto an old rowset that still carries its
+// archived (N) schema. get_seek_range must decode that range with the current schema (whose sort-key
+// arity matches the range), not the archived rowset schema, otherwise the read fails with an arity
+// mismatch ("expected N, actual N+1").
+TEST_F(LakeRowsetTest, test_rowset_range_uses_current_schema_on_arity_mismatch) {
+    auto add_int_col = [](TabletSchemaPB* s, int uid, const std::string& name, bool is_key, bool nullable) {
+        auto* c = s->add_column();
+        c->set_unique_id(uid);
+        c->set_name(name);
+        c->set_type("INT");
+        c->set_is_nullable(nullable);
+        c->set_is_key(is_key);
+        if (!is_key) {
+            c->set_aggregation("NONE");
+        }
+    };
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(1);
+
+    // Current schema: 2 sort keys (k1, k2) + value v; k2 is the trailing added key.
+    auto* schema = metadata->mutable_schema();
+    schema->set_id(200);
+    schema->set_keys_type(DUP_KEYS);
+    schema->set_num_short_key_columns(1);
+    schema->set_num_rows_per_row_block(65535);
+    add_int_col(schema, 1, "k1", true, false);
+    add_int_col(schema, 2, "k2", true, true);
+    add_int_col(schema, 3, "v", false, true);
+    schema->add_sort_key_idxes(0);
+    schema->add_sort_key_idxes(1);
+
+    // Archived pre-add schema: 1 sort key (k1) + value v.
+    constexpr int64_t kArchivedId = 100;
+    auto& archived = (*metadata->mutable_historical_schemas())[kArchivedId];
+    archived.set_id(kArchivedId);
+    archived.set_keys_type(DUP_KEYS);
+    archived.set_num_short_key_columns(1);
+    archived.set_num_rows_per_row_block(65535);
+    add_int_col(&archived, 1, "k1", true, false);
+    add_int_col(&archived, 3, "v", false, true);
+    archived.add_sort_key_idxes(0);
+
+    // One rowset mapped to the archived (arity-1) schema, carrying a current-arity (2-value) range.
+    auto* rs = metadata->add_rowsets();
+    rs->set_id(10);
+    rs->set_overlapped(false);
+    rs->set_num_rows(0);
+    rs->set_data_size(0);
+    (*metadata->mutable_rowset_to_schema())[10] = kArchivedId;
+    {
+        auto* range = rs->mutable_range();
+        auto* lo = range->mutable_lower_bound();
+        *lo->add_values() = make_int_variant_pb(1);
+        *lo->add_values() = make_int_variant_pb(10);
+        range->set_lower_bound_included(true);
+        auto* hi = range->mutable_upper_bound();
+        *hi->add_values() = make_int_variant_pb(100);
+        *hi->add_values() = make_int_variant_pb(20);
+        range->set_upper_bound_included(false);
+    }
+
+    auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+    // Without the fix this returns an arity-mismatch error (archived arity-1 schema vs arity-2 range).
+    ASSIGN_OR_ABORT(auto seek_range, rowset->get_seek_range());
+    ASSERT_TRUE(seek_range.has_value());
+}
+
 TEST_F(LakeRowsetTest, test_tablet_range_pb_invalid_bounds) {
     create_rowsets_for_testing();
     auto* rs_meta = _tablet_metadata->mutable_rowsets(0);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1871,4 +1871,211 @@ TEST_F(LakeRowsetTest, test_propagate_has_predicate_above_iterator) {
     EXPECT_TRUE(propagated);
 }
 
+namespace {
+
+// Build a DUP_KEYS schema over two INT columns c0,c1. `num_key_columns` sets the sort-key
+// arity (when the PB's sort_key_idxes is empty, TabletSchema falls the sort key back to the
+// key columns): 1 -> sort key (c0); 2 -> sort key (c0,c1). The column unique_ids are passed
+// in so the archived and current schemas keep the same column identity across the
+// metadata-only change.
+static TabletSchemaPB make_two_int_dup_schema(int64_t schema_id, int32_t schema_version, int num_key_columns,
+                                              int64_t c0_uid, int64_t c1_uid) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_id(schema_id);
+    schema_pb.set_schema_version(schema_version);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(65535);
+    const int64_t uids[2] = {c0_uid, c1_uid};
+    for (int i = 0; i < 2; i++) {
+        auto* c = schema_pb.add_column();
+        c->set_unique_id(uids[i]);
+        c->set_name("c" + std::to_string(i));
+        c->set_type("INT");
+        c->set_is_nullable(false);
+        const bool is_key = i < num_key_columns;
+        c->set_is_key(is_key);
+        if (!is_key) {
+            c->set_aggregation("NONE");
+        }
+    }
+    return schema_pb;
+}
+
+// Set a two-column INT tablet range [ (lo0,lo1), (hi0,hi1) ) (closed-open).
+static void set_tablet_range_two_int(TabletMetadata* tablet_meta, int32_t lo0, int32_t lo1, int32_t hi0, int32_t hi1) {
+    auto* range = tablet_meta->mutable_range();
+    range->Clear();
+    auto* lb = range->mutable_lower_bound();
+    *lb->add_values() = make_int_variant_pb(lo0);
+    *lb->add_values() = make_int_variant_pb(lo1);
+    range->set_lower_bound_included(true);
+    auto* ub = range->mutable_upper_bound();
+    *ub->add_values() = make_int_variant_pb(hi0);
+    *ub->add_values() = make_int_variant_pb(hi1);
+    range->set_upper_bound_included(false);
+}
+
+// Write one rowset (a single segment) with rows {(10,100),(20,100),(30,100),(40,100),(50,100)}
+// under `write_metadata`'s current schema. c0 is distinct and c1 is constant, so the row order
+// is identical whether the segment is sorted by (c0) or (c0,c1); the two-column boundary is
+// unambiguous. Appends the rowset (id=1, num_rows=5) to `metadata` but does not persist it.
+static void write_single_segment_rowset(TabletManager* tablet_mgr, TabletMetadata* metadata,
+                                        const std::shared_ptr<Schema>& write_schema) {
+    ASSIGN_OR_ABORT(auto tablet, tablet_mgr->get_tablet(metadata->id()));
+    int64_t write_txn = next_id();
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, write_txn));
+    ASSERT_OK(writer->open());
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    for (int k : {10, 20, 30, 40, 50}) {
+        c0->append(k);
+        c1->append(100);
+    }
+    Chunk chunk({c0, c1}, write_schema);
+    ASSERT_OK(writer->write(chunk));
+    ASSERT_OK(writer->finish());
+    ASSERT_EQ(1, writer->segments().size());
+
+    auto* rowset_meta = metadata->add_rowsets();
+    rowset_meta->set_overlapped(false);
+    rowset_meta->set_id(1);
+    rowset_meta->set_num_rows(5);
+    for (const auto& file : writer->segments()) {
+        rowset_meta->add_segment_metas()->set_filename(file.path);
+    }
+    writer->close();
+}
+
+} // namespace
+
+// Trailing sort-key ADD (N -> N+1): an old rowset archived under the previous N-sort-key schema
+// must stay readable after a metadata-only change that appends a trailing sort-key column, which
+// grows the tablet fallback range to N+1 values. Rowset::get_seek_range() must decode the tablet
+// fallback range with the CURRENT tablet schema (2 sort keys), not the rowset's archived schema
+// (1 sort key); otherwise create_seek_range_from returns Status::Corruption on the arity mismatch
+// and the read fails. The rowset's segments are marked shared() so that Rowset::read installs the
+// tablet seek range (it is only applied to shared segments), exercising the decode path.
+TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema) {
+    const int64_t c0_uid = next_id();
+    const int64_t c1_uid = next_id();
+    const int64_t archived_schema_id = next_id();
+    const int64_t current_schema_id = next_id();
+
+    // The physical rowset is written under the archived 1-sort-key schema (c0 key, c1 value).
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_cumulative_point(0);
+    metadata->set_next_rowset_id(2);
+    *metadata->mutable_schema() =
+            make_two_int_dup_schema(archived_schema_id, /*schema_version=*/1, /*num_key_columns=*/1, c0_uid, c1_uid);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto archived_schema = TabletSchema::create(metadata->schema());
+    auto write_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(archived_schema));
+    write_single_segment_rowset(_tablet_mgr.get(), metadata.get(), write_schema);
+
+    // Apply the metadata-only trailing sort-key add: archive the old schema, install the current
+    // 2-sort-key schema, map the old rowset to the archived schema, grow the tablet range to two
+    // values, and mark the rowset's segments shared so the tablet range is applied on read.
+    metadata->mutable_historical_schemas()->insert({archived_schema_id, metadata->schema()});
+    *metadata->mutable_schema() =
+            make_two_int_dup_schema(current_schema_id, /*schema_version=*/2, /*num_key_columns=*/2, c0_uid, c1_uid);
+    metadata->mutable_rowset_to_schema()->insert({1, archived_schema_id});
+    set_tablet_range_two_int(metadata.get(), 20, 100, 40, 100); // [ (20,100), (40,100) )
+    set_rowset_shared_segments(metadata->mutable_rowsets(0), true);
+    metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto current_schema = TabletSchema::create(metadata->schema());
+    auto input_schema = ChunkHelper::convert_schema(current_schema, std::vector<ColumnId>{0});
+
+    // BEFORE the fix, get_seek_range decodes the 2-value fallback range with the archived
+    // 1-sort-key schema and read() fails with Status::Corruption. AFTER the fix it decodes with
+    // the current schema and returns the two in-range rows: (20,100) and (30,100).
+    {
+        OlapReaderStatistics stats;
+        RowsetReadOptions rs_opts;
+        rs_opts.stats = &stats;
+        rs_opts.tablet_schema = std::make_shared<const TabletSchema>(metadata->schema());
+        auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+        auto read_res = rowset->read(input_schema, rs_opts);
+        ASSERT_TRUE(read_res.ok()) << "get_seek_range must decode the tablet fallback range with the current "
+                                      "schema after a trailing sort-key add, not corrupt on arity mismatch: "
+                                   << read_res.status();
+        EXPECT_EQ(2, count_rows_from_iters(read_res.value()));
+    }
+
+    // Force a compaction of the archived rowset. The compaction itself reads the shared segment
+    // through get_seek_range (so it also exercises the fix) and, because the segment is shared,
+    // applies the tablet range while merging, yielding a private output rowset with the two
+    // in-range rows. Reading that output must still return the same two rows.
+    int64_t compact_txn = next_id();
+    auto input_rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+    auto ctx = std::make_unique<CompactionTaskContext>(compact_txn, metadata->id(), metadata->version(),
+                                                       /*force_base_compaction=*/false,
+                                                       /*skip_write_txnlog=*/false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get(), {input_rowset}));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    ASSIGN_OR_ABORT(auto new_metadata, publish_single_version(metadata->id(), metadata->version() + 1, compact_txn));
+
+    ASSERT_EQ(1, new_metadata->rowsets_size());
+    OlapReaderStatistics stats2;
+    RowsetReadOptions rs_opts2;
+    rs_opts2.stats = &stats2;
+    rs_opts2.tablet_schema = std::make_shared<const TabletSchema>(new_metadata->schema());
+    auto compacted =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), new_metadata, 0, 0 /* compaction_segment_limit */);
+    ASSIGN_OR_ABORT(auto iters2, compacted->read(input_schema, rs_opts2));
+    EXPECT_EQ(2, count_rows_from_iters(iters2));
+}
+
+// Regression: when the sort-key arity is unchanged, decoding the tablet fallback range with the
+// current schema is identical to decoding it with the rowset's (same-arity) archived schema. An
+// old rowset mapped to a same-arity historical schema still prunes correctly, with no behavior
+// change relative to before the fix.
+TEST_F(LakeRowsetTest, test_seek_range_same_arity_historical_schema_unchanged) {
+    const int64_t c0_uid = next_id();
+    const int64_t c1_uid = next_id();
+    const int64_t archived_schema_id = next_id();
+    const int64_t current_schema_id = next_id();
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_cumulative_point(0);
+    metadata->set_next_rowset_id(2);
+    *metadata->mutable_schema() =
+            make_two_int_dup_schema(archived_schema_id, /*schema_version=*/1, /*num_key_columns=*/1, c0_uid, c1_uid);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto archived_schema = TabletSchema::create(metadata->schema());
+    auto write_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(archived_schema));
+    write_single_segment_rowset(_tablet_mgr.get(), metadata.get(), write_schema);
+
+    // Keep the same 1-sort-key arity as the "current" schema (only the schema id/version change),
+    // and map the rowset to the archived (same-arity) schema. Use a single-value tablet range.
+    metadata->mutable_historical_schemas()->insert({archived_schema_id, metadata->schema()});
+    *metadata->mutable_schema() =
+            make_two_int_dup_schema(current_schema_id, /*schema_version=*/2, /*num_key_columns=*/1, c0_uid, c1_uid);
+    metadata->mutable_rowset_to_schema()->insert({1, archived_schema_id});
+    set_tablet_range_int(metadata.get(), 20, true, 40, false); // [20, 40)
+    set_rowset_shared_segments(metadata->mutable_rowsets(0), true);
+    metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto current_schema = TabletSchema::create(metadata->schema());
+    auto input_schema = ChunkHelper::convert_schema(current_schema, std::vector<ColumnId>{0});
+    OlapReaderStatistics stats;
+    RowsetReadOptions rs_opts;
+    rs_opts.stats = &stats;
+    rs_opts.tablet_schema = std::make_shared<const TabletSchema>(metadata->schema());
+    auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+    ASSIGN_OR_ABORT(auto iters, rowset->read(input_schema, rs_opts));
+    // Range [20, 40) keeps 20 and 30 => 2 rows, identical whether decoded with the archived or the
+    // current schema.
+    EXPECT_EQ(2, count_rows_from_iters(iters));
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -2012,7 +2012,8 @@ TEST_F(LakeRowsetTest, test_seek_range_trailing_sortkey_add_uses_current_schema)
     // applies the tablet range while merging, yielding a private output rowset with the two
     // in-range rows. Reading that output must still return the same two rows.
     int64_t compact_txn = next_id();
-    auto input_rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
+    auto input_rowset =
+            std::make_shared<lake::Rowset>(_tablet_mgr.get(), metadata, 0, 0 /* compaction_segment_limit */);
     auto ctx = std::make_unique<CompactionTaskContext>(compact_txn, metadata->id(), metadata->version(),
                                                        /*force_base_compaction=*/false,
                                                        /*skip_write_txnlog=*/false, nullptr);

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -1024,8 +1024,13 @@ TEST_F(TableSchemaServiceTest, build_initial_metadata) {
 
         ASSIGN_OR_ABORT(auto metadata, _tablet_manager->build_initial_metadata(tablet_id, resp));
         ASSERT_TRUE(metadata->has_range());
-        ASSERT_TRUE(metadata->range().lower_bound_included());
-        ASSERT_FALSE(metadata->range().upper_bound_included());
+        // The TTabletRange carried inclusivity flags but no bounds (a fully unbounded Range.all).
+        // convert_t_range_to_pb_range persists an inclusivity flag only alongside a present bound, so the
+        // persisted range keeps neither a bound nor a stray inclusivity flag.
+        ASSERT_FALSE(metadata->range().has_lower_bound());
+        ASSERT_FALSE(metadata->range().has_upper_bound());
+        ASSERT_FALSE(metadata->range().has_lower_bound_included());
+        ASSERT_FALSE(metadata->range().has_upper_bound_included());
     }
 
     // Case 4: tablet_ranges set but does not contain this tablet

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -1153,6 +1153,38 @@ TEST(TabletRangeHelperTest, validate_range_transition_accepts_trailing_null_add)
     ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
 }
 
+TEST(TabletRangeHelperTest, validate_range_transition_accepts_multiple_trailing_null_adds) {
+    // old: 1 sort key, range [(1),(2)); new: 3 sort keys, range [(1,NULL,NULL),(2,NULL,NULL)).
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(3, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_wrong_trailing_count_for_multi_add) {
+    // old: 1 sort key; new: 3 sort keys, but the range appends only ONE trailing NULL (needs two).
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(3, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+}
+
 TEST(TabletRangeHelperTest, validate_range_transition_accepts_range_all_stays_all) {
     auto old_meta = make_old_meta(1, std::nullopt, std::nullopt); // Range.all()
     auto new_schema = make_range_schema(2, /*schema_id=*/8);

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -420,6 +420,41 @@ TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_only_lower_bound) {
     ASSERT_FALSE(pb_range.has_upper_bound_included());
 }
 
+// TabletRange.toThrift() sets BOTH *_bound_included flags unconditionally, so a one-sided or Range.all
+// range arrives with a stray inclusivity flag whose matching bound is absent. convert_t_range_to_pb_range
+// must persist an inclusivity flag only alongside a present bound, otherwise the persisted metadata is
+// inconsistent (has_*_bound_included() == true while has_*_bound() == false).
+TEST(TabletRangeHelperTest, test_convert_t_range_drops_included_flag_without_bound) {
+    TTabletRange t_range;
+
+    TTuple lower_bound;
+    TVariant value;
+    TTypeDesc type_desc;
+    type_desc.types.resize(1);
+    type_desc.__isset.types = true;
+    type_desc.types[0].type = TTypeNodeType::SCALAR;
+    type_desc.types[0].scalar_type.__set_type(TPrimitiveType::INT);
+    type_desc.types[0].__isset.scalar_type = true;
+    value.__set_type(type_desc);
+    value.__set_value("10");
+    value.__set_variant_type(TVariantType::NORMAL_VALUE);
+    lower_bound.values.push_back(value);
+
+    t_range.__set_lower_bound(lower_bound);
+    // Simulate toThrift(): both flags __set even though upper_bound is absent.
+    t_range.__set_lower_bound_included(true);
+    t_range.__set_upper_bound_included(false);
+
+    auto res = TabletRangeHelper::convert_t_range_to_pb_range(t_range);
+    ASSERT_OK(res.status());
+    TabletRangePB pb_range = res.value();
+
+    ASSERT_TRUE(pb_range.has_lower_bound());
+    ASSERT_TRUE(pb_range.has_lower_bound_included()); // kept: matching bound present
+    ASSERT_FALSE(pb_range.has_upper_bound());
+    ASSERT_FALSE(pb_range.has_upper_bound_included()); // dropped: no matching bound
+}
+
 TEST(TabletRangeHelperTest, test_convert_t_range_to_pb_range_only_upper_bound) {
     TTabletRange t_range;
 

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -1185,6 +1185,47 @@ TEST(TabletRangeHelperTest, validate_range_transition_rejects_wrong_trailing_cou
     ASSERT_TRUE(s.is_corruption()) << s;
 }
 
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_promoting_existing_column) {
+    // old: 1 sort key k0(uid 100) + value v(uid 200), range [(1),(2)). make_range_schema(1) gives
+    // exactly this shape (v has uid 200).
+    auto old_meta = make_old_meta(1, 1, 2);
+    // new: sort key [k0(uid 100), v(uid 200)] -- v is an EXISTING column promoted to a sort key, not a
+    // brand-new column. Must be rejected even though the prefix is unchanged and the arity grows by one.
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_id(9);
+    pb.set_num_short_key_columns(1);
+    auto* c0 = pb.add_column();
+    c0->set_unique_id(100);
+    c0->set_name("k0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_aggregation("NONE");
+    auto* c1 = pb.add_column();
+    c1->set_unique_id(200);
+    c1->set_name("v");
+    c1->set_type("INT");
+    c1->set_is_key(true);
+    c1->set_is_nullable(true);
+    c1->set_aggregation("NONE");
+    pb.add_sort_key_idxes(0);
+    pb.add_sort_key_idxes(1);
+    auto new_schema = TabletSchema::create(pb);
+
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("brand-new"));
+}
+
 TEST(TabletRangeHelperTest, validate_range_transition_accepts_range_all_stays_all) {
     auto old_meta = make_old_meta(1, std::nullopt, std::nullopt); // Range.all()
     auto new_schema = make_range_schema(2, /*schema_id=*/8);
@@ -1302,6 +1343,140 @@ TEST(TabletRangeHelperTest, validate_range_transition_rejects_trailing_not_null)
     ASSERT_FALSE(s.ok());
     ASSERT_TRUE(s.is_corruption()) << s;
     ASSERT_THAT(s.to_string(), testing::HasSubstr("NULL"));
+}
+
+namespace {
+
+// A DUP-key schema with `num_keys` INT sort-key columns (k0..k{num_keys-1}). The trailing key column takes
+// the given nullability/default so read-time-default resolution can be exercised.
+static TabletSchemaCSPtr make_dup_key_schema(int schema_id, int num_keys, bool last_nullable, bool last_has_default,
+                                             const std::string& last_default) {
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_id(schema_id);
+    pb.set_num_short_key_columns(1);
+    pb.set_num_rows_per_row_block(65535);
+    for (int i = 0; i < num_keys; i++) {
+        auto* c = pb.add_column();
+        c->set_unique_id(i + 1);
+        c->set_name(std::string("k") + std::to_string(i));
+        c->set_type("INT");
+        c->set_is_key(true);
+        const bool is_last = (i == num_keys - 1);
+        c->set_is_nullable(is_last ? last_nullable : false);
+        if (is_last && last_has_default) {
+            c->set_default_value(last_default);
+        }
+        pb.add_sort_key_idxes(i);
+    }
+    return TabletSchema::create(pb);
+}
+
+static void append_int(TuplePB* t, int32_t v) {
+    DatumVariant(get_type_info(LogicalType::TYPE_INT), Datum(v)).to_proto(t->add_values());
+}
+
+static void append_null_int(TuplePB* t) {
+    Datum d;
+    d.set_null();
+    DatumVariant(get_type_info(LogicalType::TYPE_INT), d).to_proto(t->add_values());
+}
+
+} // namespace
+
+// A range written under a wider sort key than the target segment (a reshard stamps a current-arity
+// per-rowset range after a metadata-only trailing key add, onto an old rowset that still carries its
+// archived schema) is projected onto the segment's sort key by comparing the added column's read-time
+// default D against the dropped trailing bound values. This makes a boundary-prefix old row route exactly
+// as under the full-arity range -- the correctness core of the reshard-after-add read/merge path.
+TEST(TabletRangeHelperTest, test_create_seek_range_projects_wider_bound_with_default) {
+    // Segment sort key: [k0] (archived, arity 1). Current sort key: [k0, k1], k1 INT DEFAULT '0'.
+    auto seg = make_dup_key_schema(100, 1, /*last_nullable=*/false, /*last_has_default=*/false, "");
+    auto cur = make_dup_key_schema(200, 2, /*last_nullable=*/false, /*last_has_default=*/true, "0"); // D(k1)=0
+
+    // [ (lo0, lo1), (hi0, hi1) ), lower inclusive / upper exclusive.
+    auto project = [&](int lo0, int lo1, int hi0, int hi1) {
+        TabletRangePB r;
+        r.set_lower_bound_included(true);
+        r.set_upper_bound_included(false);
+        append_int(r.mutable_lower_bound(), lo0);
+        append_int(r.mutable_lower_bound(), lo1);
+        append_int(r.mutable_upper_bound(), hi0);
+        append_int(r.mutable_upper_bound(), hi1);
+        return TabletRangeHelper::create_seek_range_from(r, seg, nullptr, cur);
+    };
+
+    // Trailing > default (D=0 < 5): an old row (p, 0) sorts BELOW (p, 5), so it is excluded from
+    // [ (10,5), .. ) (lower drops to exclusive at 10) and included in [ .., (20,5) ) (upper becomes
+    // inclusive at 20). Both bounds also project down to a single (leading) column.
+    {
+        ASSIGN_OR_ABORT(auto sr, project(10, 5, 20, 5));
+        EXPECT_EQ(1u, sr.lower().columns());
+        EXPECT_EQ(1u, sr.upper().columns());
+        EXPECT_FALSE(sr.inclusive_lower());
+        EXPECT_TRUE(sr.inclusive_upper());
+    }
+    // Trailing < default (D=0 > -5): symmetric -- lower stays inclusive, upper drops to exclusive.
+    {
+        ASSIGN_OR_ABORT(auto sr, project(10, -5, 20, -5));
+        EXPECT_TRUE(sr.inclusive_lower());
+        EXPECT_FALSE(sr.inclusive_upper());
+    }
+    // Trailing == default (boundary sampled from an old row): standard prefix truncation.
+    {
+        ASSIGN_OR_ABORT(auto sr, project(10, 0, 20, 0));
+        EXPECT_TRUE(sr.inclusive_lower());
+        EXPECT_FALSE(sr.inclusive_upper());
+    }
+    // Trailing == NULL sentinel (the add-time reprojected range): NULL is the minimum, so D=0 > NULL --
+    // same shape as the exact prefix range (lower inclusive, upper exclusive).
+    {
+        TabletRangePB r;
+        r.set_lower_bound_included(true);
+        r.set_upper_bound_included(false);
+        append_int(r.mutable_lower_bound(), 10);
+        append_null_int(r.mutable_lower_bound());
+        append_int(r.mutable_upper_bound(), 20);
+        append_null_int(r.mutable_upper_bound());
+        ASSIGN_OR_ABORT(auto sr, TabletRangeHelper::create_seek_range_from(r, seg, nullptr, cur));
+        EXPECT_TRUE(sr.inclusive_lower());
+        EXPECT_FALSE(sr.inclusive_upper());
+    }
+}
+
+// When the added trailing key is nullable with no default, old rows read it as NULL (the minimum), so a
+// non-NULL boundary trailing value sorts ABOVE every old row at that prefix.
+TEST(TabletRangeHelperTest, test_create_seek_range_projection_null_default) {
+    auto seg = make_dup_key_schema(101, 1, false, false, "");
+    auto cur = make_dup_key_schema(201, 2, /*last_nullable=*/true, /*last_has_default=*/false, ""); // D(k1)=NULL
+
+    TabletRangePB r;
+    r.set_lower_bound_included(true);
+    r.set_upper_bound_included(false);
+    append_int(r.mutable_lower_bound(), 10);
+    append_int(r.mutable_lower_bound(), 5);
+    append_int(r.mutable_upper_bound(), 20);
+    append_int(r.mutable_upper_bound(), 5);
+    ASSIGN_OR_ABORT(auto sr, TabletRangeHelper::create_seek_range_from(r, seg, nullptr, cur));
+    // D=NULL < 5: an old row (p, NULL) is excluded from the lower bound and included under the upper.
+    EXPECT_FALSE(sr.inclusive_lower());
+    EXPECT_TRUE(sr.inclusive_upper());
+}
+
+// Projecting a wider bound requires the current schema; without it the helper must fail loudly rather than
+// silently drop the trailing values (which would misroute boundary-prefix rows).
+TEST(TabletRangeHelperTest, test_create_seek_range_wider_bound_requires_current_schema) {
+    auto seg = make_dup_key_schema(102, 1, false, false, "");
+    TabletRangePB r;
+    r.set_lower_bound_included(true);
+    r.set_upper_bound_included(false);
+    append_int(r.mutable_lower_bound(), 10);
+    append_int(r.mutable_lower_bound(), 5);
+    append_int(r.mutable_upper_bound(), 20);
+    append_int(r.mutable_upper_bound(), 5);
+    auto st = TabletRangeHelper::create_seek_range_from(r, seg, nullptr, /*current_schema=*/nullptr);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.status().is_corruption()) << st.status();
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -966,4 +966,310 @@ TEST(TabletRangeHelperTest, validate_new_tablet_ranges_happy_path_unbounded_pare
     ASSERT_TRUE(s.ok()) << s;
 }
 
+// =============================================================================
+// validate_range_structural / validate_range_transition: schema-aware validators
+// for the metadata-only trailing sort-key ADD.
+// =============================================================================
+
+namespace {
+
+// Builds a DUP schema whose first `num_sort_keys` INT columns are the (contiguous) sort key,
+// followed by a single INT value column. Unique ids are stable (100, 101, ...) so a transition
+// schema can share the prefix uids. The trailing sort-key column is nullable to allow a NULL
+// boundary sentinel.
+static TabletSchemaSPtr make_range_schema(int num_sort_keys, int64_t schema_id = 1) {
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_id(schema_id);
+    pb.set_num_short_key_columns(1);
+    for (int i = 0; i < num_sort_keys; ++i) {
+        auto* c = pb.add_column();
+        c->set_unique_id(100 + i);
+        c->set_name("k" + std::to_string(i));
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(i == num_sort_keys - 1);
+        c->set_aggregation("NONE");
+        pb.add_sort_key_idxes(i);
+    }
+    auto* v = pb.add_column();
+    v->set_unique_id(200);
+    v->set_name("v");
+    v->set_type("INT");
+    v->set_is_key(false);
+    v->set_is_nullable(true);
+    v->set_aggregation("NONE");
+    return TabletSchema::create(pb);
+}
+
+static void add_int_val(TuplePB* t, int32_t v) {
+    auto* pb = t->add_values();
+    TypeDescriptor td(TYPE_INT);
+    pb->mutable_type()->CopyFrom(td.to_protobuf());
+    pb->set_value(std::to_string(v));
+    pb->set_variant_type(VariantTypePB::NORMAL_VALUE);
+}
+
+static void add_typed_val(TuplePB* t, LogicalType lt, const std::string& v) {
+    auto* pb = t->add_values();
+    TypeDescriptor td(lt);
+    pb->mutable_type()->CopyFrom(td.to_protobuf());
+    pb->set_value(v);
+    pb->set_variant_type(VariantTypePB::NORMAL_VALUE);
+}
+
+static void add_null_val(TuplePB* t, LogicalType lt = TYPE_INT) {
+    auto* pb = t->add_values();
+    TypeDescriptor td(lt);
+    pb->mutable_type()->CopyFrom(td.to_protobuf());
+    pb->set_variant_type(VariantTypePB::NULL_VALUE);
+}
+
+} // namespace
+
+TEST(TabletRangeHelperTest, validate_range_structural_accepts_well_formed) {
+    auto schema = make_range_schema(2);
+    // [(1, NULL), (2, NULL))
+    TabletRangePB range;
+    add_int_val(range.mutable_lower_bound(), 1);
+    add_null_val(range.mutable_lower_bound());
+    add_int_val(range.mutable_upper_bound(), 2);
+    add_null_val(range.mutable_upper_bound());
+    range.set_lower_bound_included(true);
+    range.set_upper_bound_included(false);
+    ASSERT_OK(TabletRangeHelper::validate_range_structural(range, *schema));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_accepts_range_all) {
+    auto schema = make_range_schema(2);
+    TabletRangePB range; // both bounds unbounded
+    ASSERT_OK(TabletRangeHelper::validate_range_structural(range, *schema));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_rejects_wrong_arity) {
+    auto schema = make_range_schema(2);
+    TabletRangePB range;
+    add_int_val(range.mutable_lower_bound(), 1); // only 1 value, schema wants 2
+    range.set_lower_bound_included(true);
+    auto s = TabletRangeHelper::validate_range_structural(range, *schema);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("arity"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_rejects_wrong_variant_type) {
+    auto schema = make_range_schema(2);
+    TabletRangePB range;
+    add_int_val(range.mutable_lower_bound(), 1);
+    add_typed_val(range.mutable_lower_bound(), TYPE_BIGINT, "5"); // should be INT
+    add_int_val(range.mutable_upper_bound(), 2);
+    add_null_val(range.mutable_upper_bound());
+    range.set_lower_bound_included(true);
+    range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_structural(range, *schema);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("type"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_rejects_reversed_bounds) {
+    auto schema = make_range_schema(2);
+    // lower=(5,NULL) > upper=(2,NULL)
+    TabletRangePB range;
+    add_int_val(range.mutable_lower_bound(), 5);
+    add_null_val(range.mutable_lower_bound());
+    add_int_val(range.mutable_upper_bound(), 2);
+    add_null_val(range.mutable_upper_bound());
+    range.set_lower_bound_included(true);
+    range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_structural(range, *schema);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("less than"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_rejects_missing_half_open_flag) {
+    auto schema = make_range_schema(2);
+    TabletRangePB range;
+    add_int_val(range.mutable_lower_bound(), 1);
+    add_null_val(range.mutable_lower_bound());
+    // lower_bound present but lower_bound_included flag omitted.
+    auto s = TabletRangeHelper::validate_range_structural(range, *schema);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("lower_bound_included is required"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_structural_rejects_oversized_arity) {
+    auto schema = make_range_schema(2);
+    TabletRangePB range;
+    for (int i = 0; i < 200; ++i) { // far beyond the arity cap
+        add_int_val(range.mutable_lower_bound(), i);
+    }
+    range.set_lower_bound_included(true);
+    auto s = TabletRangeHelper::validate_range_structural(range, *schema);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("cap"));
+}
+
+// ---- validate_range_transition (apply only) ----
+
+namespace {
+
+// old_meta = schema with `old_sort_keys` sort keys + range [(lo..),(hi..)) using leading INT value
+// `lo`/`hi` and trailing NULLs to fill the remaining sort-key positions.
+static TabletMetadataPB make_old_meta(int old_sort_keys, std::optional<int32_t> lo, std::optional<int32_t> hi) {
+    TabletMetadataPB meta;
+    auto schema = make_range_schema(old_sort_keys, /*schema_id=*/7);
+    schema->to_schema_pb(meta.mutable_schema());
+    auto* range = meta.mutable_range();
+    if (lo.has_value()) {
+        add_int_val(range->mutable_lower_bound(), *lo);
+        for (int i = 1; i < old_sort_keys; ++i) add_null_val(range->mutable_lower_bound());
+        range->set_lower_bound_included(true);
+    }
+    if (hi.has_value()) {
+        add_int_val(range->mutable_upper_bound(), *hi);
+        for (int i = 1; i < old_sort_keys; ++i) add_null_val(range->mutable_upper_bound());
+        range->set_upper_bound_included(false);
+    }
+    return meta;
+}
+
+} // namespace
+
+TEST(TabletRangeHelperTest, validate_range_transition_accepts_trailing_null_add) {
+    // old: 1 sort key, range [(1),(2)); new: 2 sort keys, range [(1,NULL),(2,NULL)).
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_accepts_range_all_stays_all) {
+    auto old_meta = make_old_meta(1, std::nullopt, std::nullopt); // Range.all()
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range; // still all
+    ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_altered_prefix) {
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 9); // prefix changed (was 1)
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("prefix"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_changed_inclusivity) {
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(false); // old was inclusive
+    new_range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("inclusiv"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_range_all_to_non_all) {
+    auto old_meta = make_old_meta(1, std::nullopt, std::nullopt); // Range.all()
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range; // becomes bounded
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    new_range.set_lower_bound_included(true);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("presence"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_non_trailing_add) {
+    // new schema changes the existing sort key's unique id -> not a trailing ADD.
+    auto old_meta = make_old_meta(1, 1, 2);
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    pb.set_id(8);
+    pb.set_num_short_key_columns(1);
+    {
+        auto* c = pb.add_column();
+        c->set_unique_id(999); // changed from 100
+        c->set_name("k0");
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(false);
+        c->set_aggregation("NONE");
+        pb.add_sort_key_idxes(0);
+    }
+    {
+        auto* c = pb.add_column();
+        c->set_unique_id(101);
+        c->set_name("k1");
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(true);
+        c->set_aggregation("NONE");
+        pb.add_sort_key_idxes(1);
+    }
+    {
+        auto* v = pb.add_column();
+        v->set_unique_id(200);
+        v->set_name("v");
+        v->set_type("INT");
+        v->set_is_key(false);
+        v->set_is_nullable(true);
+        v->set_aggregation("NONE");
+    }
+    auto new_schema = TabletSchema::create(pb);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("sort key"));
+}
+
+TEST(TabletRangeHelperTest, validate_range_transition_rejects_trailing_not_null) {
+    // new trailing value is a normal value instead of the NULL sentinel.
+    auto old_meta = make_old_meta(1, 1, 2);
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1);
+    add_int_val(new_range.mutable_lower_bound(), 7); // should be NULL
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+    ASSERT_THAT(s.to_string(), testing::HasSubstr("NULL"));
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -1169,6 +1169,44 @@ TEST(TabletRangeHelperTest, validate_range_transition_accepts_multiple_trailing_
     ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
 }
 
+TEST(TabletRangeHelperTest, validate_range_transition_accepts_reencoded_prefix) {
+    // Reshard-before-add: the FE reprojects an already-bounded (post-reshard) per-tablet range and the
+    // task path re-encodes the leading boundary Variants, so the new range's prefix can be byte-different
+    // from the BE's persisted old range even though the value and type are identical. The transition
+    // check must compare the prefix SEMANTICALLY, not by raw proto bytes, or the metadata-only publish
+    // wedges. Here the old range's leading values leave variant_type DEFAULTED while the new range sets
+    // it explicitly (add_int_val) -- same value, different bytes.
+    TabletMetadataPB old_meta;
+    auto old_schema = make_range_schema(1, /*schema_id=*/7);
+    old_schema->to_schema_pb(old_meta.mutable_schema());
+    auto* old_range = old_meta.mutable_range();
+    auto* lo = old_range->mutable_lower_bound()->add_values();
+    lo->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    lo->set_value("1"); // variant_type intentionally left unset (defaults to NORMAL_VALUE)
+    auto* hi = old_range->mutable_upper_bound()->add_values();
+    hi->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    hi->set_value("2");
+    old_range->set_lower_bound_included(true);
+    old_range->set_upper_bound_included(false);
+
+    auto new_schema = make_range_schema(2, /*schema_id=*/8);
+    TabletRangePB new_range;
+    add_int_val(new_range.mutable_lower_bound(), 1); // variant_type SET -> different bytes, same value
+    add_null_val(new_range.mutable_lower_bound());
+    add_int_val(new_range.mutable_upper_bound(), 2);
+    add_null_val(new_range.mutable_upper_bound());
+    new_range.set_lower_bound_included(true);
+    new_range.set_upper_bound_included(false);
+    ASSERT_OK(TabletRangeHelper::validate_range_transition(old_meta, *new_schema, new_range));
+
+    // Control: a genuinely different prefix value is still rejected.
+    TabletRangePB changed = new_range;
+    changed.mutable_lower_bound()->mutable_values(0)->set_value("999");
+    auto s = TabletRangeHelper::validate_range_transition(old_meta, *new_schema, changed);
+    ASSERT_FALSE(s.ok());
+    ASSERT_TRUE(s.is_corruption()) << s;
+}
+
 TEST(TabletRangeHelperTest, validate_range_transition_rejects_wrong_trailing_count_for_multi_add) {
     // old: 1 sort key; new: 3 sort keys, but the range appends only ONE trailing NULL (needs two).
     auto old_meta = make_old_meta(1, 1, 2);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -179,6 +179,17 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         // Default implementation is empty. Subclasses can override this to prepare data.
     }
 
+    /**
+     * Hook for fallible validation that must run under the table WRITE lock BEFORE the FINISHED
+     * state is journaled by {@code persistStateChange}. A failure here throws before any WAL record
+     * is written, so the job stays at {@link JobState#FINISHED_REWRITING} with the catalog untouched.
+     * The default implementation is a no-op; subclasses whose finish callback performs a mutation
+     * that must not fail can move the fallible checks here.
+     */
+    protected void validateBeforeFinishUnprotected(Database db, OlapTable table) throws AlterCancelException {
+        // Default implementation is empty. Subclasses can override this to validate before persist.
+    }
+
     protected abstract void restoreState(LakeTableAlterMetaJobBase job);
 
     protected abstract boolean enableFileBundling();
@@ -261,6 +272,9 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
             this.finishedTimeMs = System.currentTimeMillis();
+            // Run all fallible validation before persisting the FINISHED record, so a failure leaves
+            // the job at FINISHED_REWRITING without a durable FINISHED whose callback did not complete.
+            validateBeforeFinishUnprotected(db, table);
             // Prepare data before persist, so that copyForPersist() can include this data
             prepareForPersist(db, table);
             persistStateChange(this, JobState.FINISHED, () -> {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -25,6 +25,8 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
@@ -40,8 +42,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -79,6 +84,15 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     @SerializedName(value = "historySchema")
     private OlapTableHistorySchema historySchema;
 
+    /**
+     * Per-tablet TARGET (N+1) range for an arity-changing trailing sort-key ADD on a
+     * range-distribution table. Built once (before the first job WAL) and used for BE task
+     * construction, the leader catalog flip, and replay. When null, this is an ordinary fast
+     * schema-evolution job and every range-specific behavior is skipped.
+     */
+    @SerializedName(value = "targetRanges")
+    private Map<Long, TabletRange> targetRanges;
+
     private Set<String> partitionsWithSchemaFile = new HashSet<>();
 
     // for deserialization
@@ -99,6 +113,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         }
         this.disableFastSchemaEvolutionV2 = other.disableFastSchemaEvolutionV2;
         this.historySchema = other.historySchema;
+        this.targetRanges = other.targetRanges == null ? null : new HashMap<>(other.targetRanges);
         partitionsWithSchemaFile.addAll(other.partitionsWithSchemaFile);
     }
 
@@ -107,10 +122,23 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         this.schemaInfos = job.schemaInfos == null ? null : new ArrayList<>(job.schemaInfos);
         this.disableFastSchemaEvolutionV2 = job.disableFastSchemaEvolutionV2;
         this.historySchema = job.historySchema;
+        this.targetRanges = job.targetRanges == null ? null : new HashMap<>(job.targetRanges);
     }
 
     public void setIndexTabletSchema(long indexMetaId, String indexName, SchemaInfo schemaInfo) {
         schemaInfos.add(new IndexSchemaInfo(indexMetaId, indexName, schemaInfo));
+    }
+
+    /**
+     * Installs the per-tablet target range map. Package-private so the schema-change routing (and
+     * tests) can set it when constructing the job for a metadata-only trailing sort-key ADD.
+     */
+    void setTargetRanges(Map<Long, TabletRange> targetRanges) {
+        this.targetRanges = targetRanges;
+    }
+
+    Map<Long, TabletRange> getTargetRanges() {
+        return targetRanges;
     }
 
     @Override
@@ -125,7 +153,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
                 // `Set.add()` returns true means this set did not already contain the specified element
                 boolean createSchemaFile = partitionsWithSchemaFile.add(tag);
                 task = TabletMetadataUpdateAgentTaskFactory.createTabletSchemaUpdateTask(nodeId,
-                        new ArrayList<>(tablets), info.getSchemaInfo().toTabletSchema(), createSchemaFile);
+                        new ArrayList<>(tablets), info.getSchemaInfo().toTabletSchema(), createSchemaFile, targetRanges);
                 break;
             }
         }
@@ -183,8 +211,23 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             List<Column> oldColumns = indexMeta.getSchema();
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
-            Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion());
-            Preconditions.checkState(Objects.equals(indexMeta.getShortKeyColumnCount(), schemaInfo.getShortKeyColumnCount()));
+            if (targetRanges != null) {
+                // Range path: the short-key count may change, so the equal-assertion is relaxed and
+                // the version relation is handled explicitly for exact-state replay idempotency.
+                if (schemaInfo.getVersion() == indexMeta.getSchemaVersion()) {
+                    // Exact-state replay: the flip already happened. Verify the live ranges already
+                    // equal the targets and return WITHOUT re-appending (no double-append).
+                    verifyLiveRangesMatchTargets(table, indexMetaId);
+                    return;
+                }
+                Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion(),
+                        "range flip target schema version " + schemaInfo.getVersion()
+                                + " is older than current " + indexMeta.getSchemaVersion());
+            } else {
+                Preconditions.checkState(schemaInfo.getVersion() > indexMeta.getSchemaVersion());
+                Preconditions.checkState(
+                        Objects.equals(indexMeta.getShortKeyColumnCount(), schemaInfo.getShortKeyColumnCount()));
+            }
 
             if (hasMv) {
                 droppedOrModifiedColumns.addAll(AlterHelper.collectDroppedOrModifiedColumns(oldColumns, schemaInfo.getColumns()));
@@ -195,16 +238,101 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             indexMeta.setSchemaId(schemaInfo.getId());
             indexMeta.setSortKeyIdxes(schemaInfo.getSortKeyIndexes());
             indexMeta.setSortKeyUniqueIds(schemaInfo.getSortKeyUniqueIds());
+            if (targetRanges != null) {
+                indexMeta.setShortKeyColumnCount(schemaInfo.getShortKeyColumnCount());
+            }
 
             // update the indexIdToMeta
             table.getIndexMetaIdToMeta().put(indexMetaId, indexMeta);
             table.setIndexes(schemaInfo.getIndexes());
             table.renameColumnNamePrefix(indexMetaId);
+
+            if (targetRanges != null) {
+                flipTabletRangesInPlace(table, indexMetaId);
+            }
+        }
+        if (targetRanges != null) {
+            table.lastSchemaUpdateTime.set(System.currentTimeMillis());
         }
         table.rebuildFullSchema();
 
         // If modified columns are already done, inactive related mv
         AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, droppedOrModifiedColumns);
+    }
+
+    /**
+     * In-place reference swap of each live tablet's range to its persisted target, over every tablet
+     * of every visible physical partition. In-place (not copy-and-swap) so background lake-stat and
+     * autovacuum work that holds the same Tablet object is not orphaned.
+     */
+    private void flipTabletRangesInPlace(OlapTable table, long indexMetaId) {
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            MaterializedIndex index = physicalPartition.getLatestIndex(indexMetaId);
+            if (index == null) {
+                continue;
+            }
+            for (Tablet tablet : index.getTablets()) {
+                TabletRange target = targetRanges.get(tablet.getId());
+                Preconditions.checkState(target != null, "no target range for tablet " + tablet.getId());
+                tablet.setRange(target);
+            }
+        }
+    }
+
+    /**
+     * Exact-state replay guard: every live tablet's range must already equal its persisted target
+     * (value comparison via {@link TabletRange#equals}), proving the flip was applied exactly once.
+     */
+    private void verifyLiveRangesMatchTargets(OlapTable table, long indexMetaId) {
+        for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+            MaterializedIndex index = physicalPartition.getLatestIndex(indexMetaId);
+            if (index == null) {
+                continue;
+            }
+            for (Tablet tablet : index.getTablets()) {
+                TabletRange target = targetRanges.get(tablet.getId());
+                Preconditions.checkState(target != null && Objects.equals(target, tablet.getRange()),
+                        "exact-state replay range mismatch for tablet " + tablet.getId());
+            }
+        }
+    }
+
+    @Override
+    protected void validateBeforeFinishUnprotected(Database db, OlapTable table) throws AlterCancelException {
+        if (targetRanges == null) {
+            return;
+        }
+        Set<Long> liveTabletIds = new HashSet<>();
+        for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
+            long indexMetaId = indexSchemaInfo.getIndexMetaId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(indexMetaId);
+            if (indexMeta == null) {
+                throw new AlterCancelException("index meta not found for range flip, indexMetaId: " + indexMetaId);
+            }
+            // The target must not be older than the current schema (corruption / stale replay).
+            if (indexSchemaInfo.getSchemaInfo().getVersion() < indexMeta.getSchemaVersion()) {
+                throw new AlterCancelException("range flip target schema version "
+                        + indexSchemaInfo.getSchemaInfo().getVersion() + " is older than current "
+                        + indexMeta.getSchemaVersion());
+            }
+            for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                MaterializedIndex index = physicalPartition.getLatestIndex(indexMetaId);
+                if (index == null) {
+                    continue;
+                }
+                for (Tablet tablet : index.getTablets()) {
+                    if (!targetRanges.containsKey(tablet.getId())) {
+                        throw new AlterCancelException("missing target range for tablet " + tablet.getId());
+                    }
+                    liveTabletIds.add(tablet.getId());
+                }
+            }
+        }
+        // Reject stale coverage: the target map must cover exactly the live tablet set, no extras.
+        if (!targetRanges.keySet().equals(liveTabletIds)) {
+            throw new AlterCancelException("target range coverage mismatch: targets=" + targetRanges.keySet()
+                    + " liveTablets=" + liveTabletIds);
+        }
     }
 
     private void setFastSchemaEvolutionV2(OlapTable table, boolean enabled) {
@@ -227,6 +355,8 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         }
         this.disableFastSchemaEvolutionV2 = schemaChangeJob.disableFastSchemaEvolutionV2;
         this.historySchema = ((LakeTableAsyncFastSchemaChangeJob) job).historySchema;
+        // Replay reprojects from the identical persisted targets, so the flip is reproduced exactly.
+        this.targetRanges = schemaChangeJob.targetRanges;
     }
 
     @Override
@@ -317,5 +447,8 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     @Override
     public void gsonPostProcess() throws IOException {
         partitionsWithSchemaFile = new HashSet<>();
+        if (targetRanges != null) {
+            targetRanges = Collections.unmodifiableMap(targetRanges);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -257,7 +257,10 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             }
         }
         if (targetRanges != null) {
-            table.lastSchemaUpdateTime.set(System.currentTimeMillis());
+            // Must use the same clock as OptimisticVersion.generate() (System.nanoTime), which the
+            // lock-free planner compares against; mixing it with epoch millis would break stale-plan
+            // invalidation after the in-place range flip. Mirrors SplitTabletJob's reshard flip.
+            table.lastSchemaUpdateTime.set(System.nanoTime());
         }
         table.rebuildFullSchema();
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -214,6 +214,11 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             if (targetRanges != null) {
                 // Range path: the short-key count may change, so the equal-assertion is relaxed and
                 // the version relation is handled explicitly for exact-state replay idempotency.
+                // The exact-state-replay `return` below exits the whole loop, which is only correct
+                // because the metadata-only range route guarantees exactly one index; a future
+                // multi-index extension must revisit this instead of silently skipping other indexes.
+                Preconditions.checkState(schemaInfos.size() == 1,
+                        "range flip target only supports a single index, got " + schemaInfos.size());
                 if (schemaInfo.getVersion() == indexMeta.getSchemaVersion()) {
                     // Exact-state replay: the flip already happened. Verify the live ranges already
                     // equal the targets and return WITHOUT re-appending (no double-append).
@@ -299,6 +304,11 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
 
     @Override
     protected void validateBeforeFinishUnprotected(Database db, OlapTable table) throws AlterCancelException {
+        // Runs after publishVersion() (see LakeTableAlterMetaJobBase#runFinishedRewritingJob) but before
+        // the catalog flip; that ordering is safe only because (a) visibility is gated on this
+        // validation succeeding and (b) this job inherits allowConcurrentPartitionCreation() == false,
+        // so the live tablet set cannot change during the SCHEMA_CHANGE window. If this job ever opts
+        // into concurrent partition creation, the coverage validation below must move before publish.
         if (targetRanges == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -134,7 +134,20 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
      * tests) can set it when constructing the job for a metadata-only trailing sort-key ADD.
      */
     void setTargetRanges(Map<Long, TabletRange> targetRanges) {
-        this.targetRanges = targetRanges;
+        if (targetRanges == null) {
+            this.targetRanges = null;
+            return;
+        }
+        // Defensively copy and freeze so the must-not-fail catalog callback cannot observe a
+        // caller-mutated map or a null key/value (which would throw mid-flip after the FINISHED
+        // record is journaled).
+        Map<Long, TabletRange> copy = new HashMap<>();
+        for (Map.Entry<Long, TabletRange> entry : targetRanges.entrySet()) {
+            Preconditions.checkArgument(entry.getKey() != null && entry.getValue() != null,
+                    "target range map must not contain null keys or values");
+            copy.put(entry.getKey(), entry.getValue());
+        }
+        this.targetRanges = Collections.unmodifiableMap(copy);
     }
 
     Map<Long, TabletRange> getTargetRanges() {
@@ -315,6 +328,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         if (targetRanges == null) {
             return;
         }
+        // Everything the must-not-fail catalog callback (updateCatalogUnprotected range path)
+        // depends on is validated HERE, before the FINISHED record is journaled, so the callback
+        // cannot throw mid-flip and leave a durable FINISHED record with a partial catalog update.
+        if (schemaInfos.size() != 1) {
+            throw new AlterCancelException("range flip target only supports a single index, got " + schemaInfos.size());
+        }
         Set<Long> liveTabletIds = new HashSet<>();
         for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
             long indexMetaId = indexSchemaInfo.getIndexMetaId();
@@ -328,13 +347,18 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
                         + indexSchemaInfo.getSchemaInfo().getVersion() + " is older than current "
                         + indexMeta.getSchemaVersion());
             }
+            // Mirror the callback's keysType precondition so it cannot throw post-journal.
+            if (!Objects.equals(indexMeta.getKeysType(), indexSchemaInfo.getSchemaInfo().getKeysType())) {
+                throw new AlterCancelException("range flip keysType mismatch for indexMetaId " + indexMetaId);
+            }
             for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
                 MaterializedIndex index = physicalPartition.getLatestIndex(indexMetaId);
                 if (index == null) {
                     continue;
                 }
                 for (Tablet tablet : index.getTablets()) {
-                    if (!targetRanges.containsKey(tablet.getId())) {
+                    // Non-null value check (not just containsKey) — the callback dereferences the target.
+                    if (targetRanges.get(tablet.getId()) == null) {
                         throw new AlterCancelException("missing target range for tablet " + tablet.getId());
                     }
                     liveTabletIds.add(tablet.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
@@ -2580,6 +2581,12 @@ public class SchemaChangeHandler extends AlterHandler {
         Map<String, String> propertyMap = new HashMap<>();
         Set<String> modifyFieldColumns = new HashSet<>();
         Map<Long, Set<String>> alterIndexMetaIdToIncrVarcharLenColNames = new HashMap<>();
+        // Set when an ADD COLUMN of a key column on a shared-data range table is routed
+        // (needsRangeRewriteSchemaChange). Instead of early-returning the K-tablet rewrite job here,
+        // clause processing continues through finalAnalyze so the resolved schema + short-key count are
+        // available; the dispatch tail then classifies it as either a metadata-only trailing sort-key
+        // add (async schema-evolution job) or the rewrite fallback.
+        boolean rangeKeyAddPending = false;
         // NOTE: be very careful with the order of processing alter clauses and early return!!!
         // It is in a for-loop!
         for (AlterClause alterClause : alterClauses) {
@@ -2610,14 +2617,14 @@ public class SchemaChangeHandler extends AlterHandler {
                 fastSchemaEvolution &=
                         processAddColumn((AddColumnClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
                 if (needsRangeRewriteSchemaChange(olapTable, alterClause)) {
-                    return buildRoutedAddKeyColumnJob(db, olapTable, indexMetaIdToSchema, alterClauses);
+                    rangeKeyAddPending = true;
                 }
             } else if (alterClause instanceof AddColumnsClause) {
                 // add columns
                 fastSchemaEvolution &=
                         processAddColumns((AddColumnsClause) alterClause, olapTable, indexMetaIdToSchema, colUniqueIdSupplier);
                 if (needsRangeRewriteSchemaChange(olapTable, alterClause)) {
-                    return buildRoutedAddKeyColumnJob(db, olapTable, indexMetaIdToSchema, alterClauses);
+                    rangeKeyAddPending = true;
                 }
             } else if (alterClause instanceof DropColumnClause) {
                 DropColumnClause dropColumnClause = (DropColumnClause) alterClause;
@@ -2866,6 +2873,17 @@ public class SchemaChangeHandler extends AlterHandler {
         if (schemaChangeData.getNewIndexMetaIdToSchema().isEmpty() && !schemaChangeData.isHasIndexChanged()) {
             // Nothing changed.
             return null;
+        }
+
+        if (rangeKeyAddPending) {
+            // A routed ADD of a key column on a shared-data range table: if the resolved change is a
+            // metadata-only trailing sort-key add, run the async schema-evolution job that reprojects
+            // tablet ranges in place; otherwise fall back to the K-tablet data-rewrite job.
+            AlterJobV2 metadataOnlyJob = tryCreateMetadataOnlyTrailingKeyAddJob(olapTable, schemaChangeData);
+            if (metadataOnlyJob != null) {
+                return metadataOnlyJob;
+            }
+            return buildRoutedAddKeyColumnJob(db, olapTable, indexMetaIdToSchema, alterClauses);
         }
 
         if (!fastSchemaEvolution) {
@@ -4478,6 +4496,77 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         job.setComputeResource(schemaChangeData.getComputeResource());
         return job;
+    }
+
+    /**
+     * If {@code schemaChangeData} describes a metadata-only trailing sort-key key-column ADD on a
+     * shared-data range-distribution table (see {@link #isMetadataOnlyTrailingKeyAdd}), build the async
+     * schema-evolution job carrying the per-tablet target range map -- each existing tablet boundary
+     * reprojected with a trailing NULL sentinel for the new column. Returns null when the change is not
+     * metadata-only or the async job could not be built, so the caller falls back to the K-tablet
+     * data-rewrite job.
+     */
+    private AlterJobV2 tryCreateMetadataOnlyTrailingKeyAddJob(OlapTable olapTable, SchemaChangeData schemaChangeData) {
+        if (!isMetadataOnlyTrailingKeyAdd(schemaChangeData)) {
+            return null;
+        }
+        Column newTrailingColumn = findNewTrailingKeyColumn(olapTable, schemaChangeData);
+        if (newTrailingColumn == null) {
+            return null;
+        }
+        AlterJobV2 job = createFastSchemaEvolutionJobInSharedDataMode(schemaChangeData);
+        if (!(job instanceof LakeTableAsyncFastSchemaChangeJob)) {
+            return null;
+        }
+        LakeTableAsyncFastSchemaChangeJob asyncJob = (LakeTableAsyncFastSchemaChangeJob) job;
+        asyncJob.setTargetRanges(computeTargetRanges(olapTable, newTrailingColumn));
+        return asyncJob;
+    }
+
+    /**
+     * The single brand-new key column of a metadata-only trailing key-column ADD: the resolved base
+     * schema column whose unique id is absent from the live pre-add base schema. {@link
+     * #isMetadataOnlyTrailingKeyAdd} has already verified there is exactly one such key column.
+     */
+    private static Column findNewTrailingKeyColumn(OlapTable olapTable, SchemaChangeData schemaChangeData) {
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        List<Column> newSchema = schemaChangeData.getNewIndexMetaIdToSchema().get(baseIndexMetaId);
+        if (newSchema == null) {
+            return null;
+        }
+        Set<Integer> oldUniqueIds = new HashSet<>();
+        for (Column column : olapTable.getSchemaByIndexMetaId(baseIndexMetaId)) {
+            oldUniqueIds.add(column.getUniqueId());
+        }
+        for (Column column : newSchema) {
+            if (column.isKey() && !oldUniqueIds.contains(column.getUniqueId())) {
+                return column;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reproject every base-index tablet's current boundary with a trailing NULL sentinel for {@code
+     * newTrailingColumn}, keyed by tablet id, over every tablet of every visible physical partition.
+     * Mirrors the job's in-place flip / coverage-validation iteration so the target map covers exactly
+     * the live tablet set.
+     */
+    private static Map<Long, TabletRange> computeTargetRanges(OlapTable olapTable, Column newTrailingColumn) {
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        for (PhysicalPartition physicalPartition : olapTable.getPhysicalPartitions()) {
+            MaterializedIndex index = physicalPartition.getLatestIndex(baseIndexMetaId);
+            if (index == null) {
+                continue;
+            }
+            for (Tablet tablet : index.getTablets()) {
+                targetRanges.put(tablet.getId(), new TabletRange(
+                        TrailingSortKeyRangeReprojection.appendTrailing(
+                                tablet.getRange().getRange(), newTrailingColumn)));
+            }
+        }
+        return targetRanges;
     }
 
     private AlterJobV2 createJob(@NotNull SchemaChangeData schemaChangeData) throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2878,10 +2878,15 @@ public class SchemaChangeHandler extends AlterHandler {
         if (rangeKeyAddPending) {
             // A routed ADD of a key column on a shared-data range table: if the resolved change is a
             // metadata-only trailing sort-key add, run the async schema-evolution job that reprojects
-            // tablet ranges in place; otherwise fall back to the K-tablet data-rewrite job.
-            AlterJobV2 metadataOnlyJob = tryCreateMetadataOnlyTrailingKeyAddJob(olapTable, schemaChangeData);
-            if (metadataOnlyJob != null) {
-                return metadataOnlyJob;
+            // tablet ranges in place; otherwise fall back to the K-tablet data-rewrite job. The
+            // metadata-only route only applies to a single-clause ADD -- a multi-clause batch (e.g. ADD
+            // + MODIFY) must fall through to buildRoutedAddKeyColumnJob, which rejects it precisely,
+            // rather than shipping the other clause's change under the new schema with no data rewrite.
+            if (alterClauses.size() == 1) {
+                AlterJobV2 metadataOnlyJob = tryCreateMetadataOnlyTrailingKeyAddJob(olapTable, schemaChangeData);
+                if (metadataOnlyJob != null) {
+                    return metadataOnlyJob;
+                }
             }
             return buildRoutedAddKeyColumnJob(db, olapTable, indexMetaIdToSchema, alterClauses);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -5030,6 +5030,14 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        // The metadata-only route adds exactly one column: the trailing sort key. A single ADD COLUMNS
+        // clause that co-adds other new columns (e.g. a value column needing materialization such as an
+        // AUTO_INCREMENT, generated, or non-constant-default column) must fall through to the data-rewrite
+        // path, which materializes them; classifying it as metadata-only would install the new schema
+        // without materializing those columns' values for existing rows.
+        if (newSchema.size() != oldSchema.size() + 1) {
+            return false;
+        }
         Set<Integer> oldUniqueIds = new HashSet<>();
         for (Column column : oldSchema) {
             oldUniqueIds.add(column.getUniqueId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -4566,9 +4566,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 continue;
             }
             for (Tablet tablet : index.getTablets()) {
+                TabletRange tabletRange = tablet.getRange();
+                Preconditions.checkState(tabletRange != null && tabletRange.getRange() != null,
+                        "Tablet range is null, tabletId=" + tablet.getId());
                 targetRanges.put(tablet.getId(), new TabletRange(
                         TrailingSortKeyRangeReprojection.appendTrailing(
-                                tablet.getRange().getRange(), newTrailingColumn)));
+                                tabletRange.getRange(), newTrailingColumn)));
             }
         }
         return targetRanges;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -4835,6 +4835,140 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     /**
+     * Resolve the effective sort-key columns of {@code schema}, following the same precedence BE
+     * applies when loading a {@code TabletSchemaPB} (see {@code tablet_schema.cpp}'s sort-key
+     * resolution): a non-empty {@code sortKeyUniqueIds} locates sort-key columns by unique id;
+     * otherwise a non-empty {@code sortKeyIdxes} locates them by schema position; otherwise the sort
+     * key is the leading run of key columns ({@link Column#isKey()}). Both {@code null} and empty
+     * lists fall through to the next precedence level. This differs from {@link
+     * MetaUtils#getRangeDistributionColumns(OlapTable, long)}, which treats a non-null (but possibly
+     * empty) {@code sortKeyIdxes} as an explicit sort key and never falls back to key columns.
+     */
+    @VisibleForTesting
+    static List<Column> resolveEffectiveSortKeyColumns(List<Column> schema, @Nullable List<Integer> sortKeyUniqueIds,
+                                                        @Nullable List<Integer> sortKeyIdxes) {
+        if (sortKeyUniqueIds != null && !sortKeyUniqueIds.isEmpty()) {
+            Map<Integer, Column> uniqueIdToColumn = new HashMap<>();
+            for (Column column : schema) {
+                uniqueIdToColumn.put(column.getUniqueId(), column);
+            }
+            List<Column> sortKeyColumns = new ArrayList<>(sortKeyUniqueIds.size());
+            for (Integer uniqueId : sortKeyUniqueIds) {
+                Column column = uniqueIdToColumn.get(uniqueId);
+                Preconditions.checkArgument(column != null, "no column with unique id %s in schema", uniqueId);
+                sortKeyColumns.add(column);
+            }
+            return sortKeyColumns;
+        }
+        if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
+            List<Column> sortKeyColumns = new ArrayList<>(sortKeyIdxes.size());
+            for (Integer idx : sortKeyIdxes) {
+                sortKeyColumns.add(schema.get(idx));
+            }
+            return sortKeyColumns;
+        }
+        long keyColumnCount = schema.stream().filter(Column::isKey).count();
+        return new ArrayList<>(schema.subList(0, (int) keyColumnCount));
+    }
+
+    /**
+     * Whether {@code resolved} -- the {@link SchemaChangeData} produced by {@link #finalAnalyze} --
+     * describes a metadata-only trailing key-column add on a shared-data range-distribution table: the
+     * new column's value is a constant/NULL sentinel appended after every existing range sort-key
+     * column, so existing tablet range boundaries stay valid without a data rewrite. Self-contained:
+     * computed entirely from the resolved schema, independent of {@link #needsRangeRewriteSchemaChange}
+     * (which routes a broader set of key changes to the K-tablet rewrite job).
+     *
+     * <p>Eligible iff ALL of:
+     * <ul>
+     *   <li>the table is a shared-data (cloud-native) range-distribution table;</li>
+     *   <li>the table has exactly one index meta (no rollup / synchronous MV);</li>
+     *   <li>the table is not a colocate table, has no AUTO_INCREMENT column, and has no temp
+     *       partitions;</li>
+     *   <li>the table's keysType is DUP_KEYS, AGG_KEYS, or UNIQUE_KEYS (not PRIMARY_KEYS);</li>
+     *   <li>the base index's resolved schema adds exactly one brand-new key column (a unique id not
+     *       present in the current live schema -- excludes promoting an existing value column to key),
+     *       whose default is constant or NULL (not auto-increment, not generated, not a variable
+     *       expression default such as {@code uuid()});</li>
+     *   <li>the base index's resolved schema's key columns form a contiguous leading prefix;</li>
+     *   <li>the resolved (candidate) effective sort key -- resolved with {@link
+     *       #resolveEffectiveSortKeyColumns} -- equals the current effective sort key plus exactly
+     *       that one new column trailing at the end.</li>
+     * </ul>
+     */
+    @VisibleForTesting
+    static boolean isMetadataOnlyTrailingKeyAdd(SchemaChangeData resolved) {
+        OlapTable table = resolved.getTable();
+        if (!table.isCloudNativeTable() || !table.isRangeDistribution()) {
+            return false;
+        }
+        if (table.getIndexMetaIdToMeta().size() != 1) {
+            return false;
+        }
+        if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(table.getId())
+                || table.hasAutoIncrementColumn() || table.existTempPartitions()) {
+            return false;
+        }
+        KeysType keysType = table.getKeysType();
+        if (keysType != KeysType.DUP_KEYS && keysType != KeysType.AGG_KEYS && keysType != KeysType.UNIQUE_KEYS) {
+            return false;
+        }
+
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> newSchema = resolved.getNewIndexMetaIdToSchema().get(baseIndexMetaId);
+        if (newSchema == null) {
+            return false;
+        }
+        // Key columns must form a contiguous leading prefix; a metadata-only classification must not
+        // bypass this invariant.
+        boolean sawValue = false;
+        for (Column column : newSchema) {
+            if (column.isKey()) {
+                if (sawValue) {
+                    return false;
+                }
+            } else {
+                sawValue = true;
+            }
+        }
+
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        Set<Integer> oldUniqueIds = new HashSet<>();
+        for (Column column : oldSchema) {
+            oldUniqueIds.add(column.getUniqueId());
+        }
+        List<Column> newKeyColumns = new ArrayList<>();
+        for (Column column : newSchema) {
+            if (column.isKey() && !oldUniqueIds.contains(column.getUniqueId())) {
+                newKeyColumns.add(column);
+            }
+        }
+        if (newKeyColumns.size() != 1) {
+            return false;
+        }
+        Column newKeyColumn = newKeyColumns.get(0);
+        if (newKeyColumn.isAutoIncrement() || newKeyColumn.isGeneratedColumn()
+                || newKeyColumn.getDefaultValueType() == Column.DefaultValueType.VARY) {
+            return false;
+        }
+
+        MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Column> oldSortKey = resolveEffectiveSortKeyColumns(oldSchema,
+                oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
+        List<Column> newSortKey = resolveEffectiveSortKeyColumns(newSchema,
+                resolved.getSortKeyUniqueIds(), resolved.getSortKeyIdxes());
+        if (newSortKey.size() != oldSortKey.size() + 1) {
+            return false;
+        }
+        for (int i = 0; i < oldSortKey.size(); i++) {
+            if (oldSortKey.get(i).getUniqueId() != newSortKey.get(i).getUniqueId()) {
+                return false;
+            }
+        }
+        return newSortKey.get(newSortKey.size() - 1).getUniqueId() == newKeyColumn.getUniqueId();
+    }
+
+    /**
      * Reject the operation if the named column belongs to the range-
      * distribution sort-key column set of the given index.
      *

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -5057,6 +5057,12 @@ public class SchemaChangeHandler extends AlterHandler {
         if (newSortKey.size() != oldSortKey.size() + 1) {
             return false;
         }
+        // Keep the metadata-only route within the arity the BE range channel supports (kMaxRangeSortKeyArity
+        // = 128 in be/src/storage/lake/tablet_range_helper.cpp); a larger sort key must fall through to the
+        // K-tablet rewrite instead of being rejected at BE apply.
+        if (newSortKey.size() > 128) {
+            return false;
+        }
         for (int i = 0; i < oldSortKey.size(); i++) {
             if (oldSortKey.get(i).getUniqueId() != newSortKey.get(i).getUniqueId()) {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -4515,8 +4515,8 @@ public class SchemaChangeHandler extends AlterHandler {
         if (!isMetadataOnlyTrailingKeyAdd(schemaChangeData)) {
             return null;
         }
-        Column newTrailingColumn = findNewTrailingKeyColumn(olapTable, schemaChangeData);
-        if (newTrailingColumn == null) {
+        List<Column> newTrailingColumns = findNewTrailingKeyColumns(olapTable, schemaChangeData);
+        if (newTrailingColumns.isEmpty()) {
             return null;
         }
         AlterJobV2 job = createFastSchemaEvolutionJobInSharedDataMode(schemaChangeData);
@@ -4524,40 +4524,42 @@ public class SchemaChangeHandler extends AlterHandler {
             return null;
         }
         LakeTableAsyncFastSchemaChangeJob asyncJob = (LakeTableAsyncFastSchemaChangeJob) job;
-        asyncJob.setTargetRanges(computeTargetRanges(olapTable, newTrailingColumn));
+        asyncJob.setTargetRanges(computeTargetRanges(olapTable, newTrailingColumns));
         return asyncJob;
     }
 
     /**
-     * The single brand-new key column of a metadata-only trailing key-column ADD: the resolved base
-     * schema column whose unique id is absent from the live pre-add base schema. {@link
-     * #isMetadataOnlyTrailingKeyAdd} has already verified there is exactly one such key column.
+     * The brand-new trailing key columns of a metadata-only trailing key-column ADD, in schema order:
+     * the resolved base schema columns whose unique id is absent from the live pre-add base schema.
+     * {@link #isMetadataOnlyTrailingKeyAdd} has already verified every such new column is a trailing
+     * key column with a constant/NULL default.
      */
-    private static Column findNewTrailingKeyColumn(OlapTable olapTable, SchemaChangeData schemaChangeData) {
+    private static List<Column> findNewTrailingKeyColumns(OlapTable olapTable, SchemaChangeData schemaChangeData) {
         long baseIndexMetaId = olapTable.getBaseIndexMetaId();
         List<Column> newSchema = schemaChangeData.getNewIndexMetaIdToSchema().get(baseIndexMetaId);
         if (newSchema == null) {
-            return null;
+            return List.of();
         }
         Set<Integer> oldUniqueIds = new HashSet<>();
         for (Column column : olapTable.getSchemaByIndexMetaId(baseIndexMetaId)) {
             oldUniqueIds.add(column.getUniqueId());
         }
+        List<Column> newKeyColumns = new ArrayList<>();
         for (Column column : newSchema) {
             if (column.isKey() && !oldUniqueIds.contains(column.getUniqueId())) {
-                return column;
+                newKeyColumns.add(column);
             }
         }
-        return null;
+        return newKeyColumns;
     }
 
     /**
-     * Reproject every base-index tablet's current boundary with a trailing NULL sentinel for {@code
-     * newTrailingColumn}, keyed by tablet id, over every tablet of every visible physical partition.
-     * Mirrors the job's in-place flip / coverage-validation iteration so the target map covers exactly
-     * the live tablet set.
+     * Reproject every base-index tablet's current boundary with one trailing NULL sentinel per column
+     * in {@code newTrailingColumns} (in order), keyed by tablet id, over every tablet of every visible
+     * physical partition. Mirrors the job's in-place flip / coverage-validation iteration so the target
+     * map covers exactly the live tablet set.
      */
-    private static Map<Long, TabletRange> computeTargetRanges(OlapTable olapTable, Column newTrailingColumn) {
+    private static Map<Long, TabletRange> computeTargetRanges(OlapTable olapTable, List<Column> newTrailingColumns) {
         long baseIndexMetaId = olapTable.getBaseIndexMetaId();
         Map<Long, TabletRange> targetRanges = new HashMap<>();
         for (PhysicalPartition physicalPartition : olapTable.getPhysicalPartitions()) {
@@ -4571,7 +4573,7 @@ public class SchemaChangeHandler extends AlterHandler {
                         "Tablet range is null, tabletId=" + tablet.getId());
                 targetRanges.put(tablet.getId(), new TabletRange(
                         TrailingSortKeyRangeReprojection.appendTrailing(
-                                tabletRange.getRange(), newTrailingColumn)));
+                                tabletRange.getRange(), newTrailingColumns)));
             }
         }
         return targetRanges;
@@ -5030,31 +5032,32 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
-        // The metadata-only route adds exactly one column: the trailing sort key. A single ADD COLUMNS
-        // clause that co-adds other new columns (e.g. a value column needing materialization such as an
-        // AUTO_INCREMENT, generated, or non-constant-default column) must fall through to the data-rewrite
-        // path, which materializes them; classifying it as metadata-only would install the new schema
-        // without materializing those columns' values for existing rows.
-        if (newSchema.size() != oldSchema.size() + 1) {
-            return false;
-        }
         Set<Integer> oldUniqueIds = new HashSet<>();
         for (Column column : oldSchema) {
             oldUniqueIds.add(column.getUniqueId());
         }
-        List<Column> newKeyColumns = new ArrayList<>();
+        // Collect the brand-new columns (unique id not in the live schema), in schema order.
+        List<Column> newColumns = new ArrayList<>();
         for (Column column : newSchema) {
-            if (column.isKey() && !oldUniqueIds.contains(column.getUniqueId())) {
-                newKeyColumns.add(column);
+            if (!oldUniqueIds.contains(column.getUniqueId())) {
+                newColumns.add(column);
             }
         }
-        if (newKeyColumns.size() != 1) {
+        // The metadata-only route adds one or more columns, and EVERY added column must be a trailing
+        // sort key with a constant/NULL default. A batch that co-adds a value column (needs
+        // materialization) or a key column with an auto-increment / generated / variable default must
+        // fall through to the data-rewrite path, which materializes them; classifying it as
+        // metadata-only would install the new schema without materializing those values for existing
+        // rows. Requiring newSchema.size() == oldSchema.size() + newColumns.size() also rejects any
+        // concurrent column drop.
+        if (newColumns.isEmpty() || newSchema.size() != oldSchema.size() + newColumns.size()) {
             return false;
         }
-        Column newKeyColumn = newKeyColumns.get(0);
-        if (newKeyColumn.isAutoIncrement() || newKeyColumn.isGeneratedColumn()
-                || newKeyColumn.getDefaultValueType() == Column.DefaultValueType.VARY) {
-            return false;
+        for (Column column : newColumns) {
+            if (!column.isKey() || column.isAutoIncrement() || column.isGeneratedColumn()
+                    || column.getDefaultValueType() == Column.DefaultValueType.VARY) {
+                return false;
+            }
         }
 
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
@@ -5062,7 +5065,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
         List<Column> newSortKey = resolveEffectiveSortKeyColumns(newSchema,
                 resolved.getSortKeyUniqueIds(), resolved.getSortKeyIdxes());
-        if (newSortKey.size() != oldSortKey.size() + 1) {
+        // The new sort key must be the old sort key with exactly the new columns appended as a trailing
+        // block, in add order.
+        if (newSortKey.size() != oldSortKey.size() + newColumns.size()) {
             return false;
         }
         // Keep the metadata-only route within the arity the BE range channel supports (kMaxRangeSortKeyArity
@@ -5076,7 +5081,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 return false;
             }
         }
-        return newSortKey.get(newSortKey.size() - 1).getUniqueId() == newKeyColumn.getUniqueId();
+        for (int j = 0; j < newColumns.size(); j++) {
+            if (newSortKey.get(oldSortKey.size() + j).getUniqueId() != newColumns.get(j).getUniqueId()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -4934,43 +4934,6 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     /**
-     * Resolve the effective sort-key columns of {@code schema}, following the same precedence BE
-     * applies when loading a {@code TabletSchemaPB} (see {@code tablet_schema.cpp}'s sort-key
-     * resolution): a non-empty {@code sortKeyUniqueIds} locates sort-key columns by unique id;
-     * otherwise a non-empty {@code sortKeyIdxes} locates them by schema position; otherwise the sort
-     * key is the leading run of key columns ({@link Column#isKey()}). Both {@code null} and empty
-     * lists fall through to the next precedence level. This differs from {@link
-     * MetaUtils#getRangeDistributionColumns(OlapTable, long)}, which treats a non-null (but possibly
-     * empty) {@code sortKeyIdxes} as an explicit sort key and never falls back to key columns.
-     */
-    @VisibleForTesting
-    static List<Column> resolveEffectiveSortKeyColumns(List<Column> schema, @Nullable List<Integer> sortKeyUniqueIds,
-                                                        @Nullable List<Integer> sortKeyIdxes) {
-        if (sortKeyUniqueIds != null && !sortKeyUniqueIds.isEmpty()) {
-            Map<Integer, Column> uniqueIdToColumn = new HashMap<>();
-            for (Column column : schema) {
-                uniqueIdToColumn.put(column.getUniqueId(), column);
-            }
-            List<Column> sortKeyColumns = new ArrayList<>(sortKeyUniqueIds.size());
-            for (Integer uniqueId : sortKeyUniqueIds) {
-                Column column = uniqueIdToColumn.get(uniqueId);
-                Preconditions.checkArgument(column != null, "no column with unique id %s in schema", uniqueId);
-                sortKeyColumns.add(column);
-            }
-            return sortKeyColumns;
-        }
-        if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
-            List<Column> sortKeyColumns = new ArrayList<>(sortKeyIdxes.size());
-            for (Integer idx : sortKeyIdxes) {
-                sortKeyColumns.add(schema.get(idx));
-            }
-            return sortKeyColumns;
-        }
-        long keyColumnCount = schema.stream().filter(Column::isKey).count();
-        return new ArrayList<>(schema.subList(0, (int) keyColumnCount));
-    }
-
-    /**
      * Whether {@code resolved} -- the {@link SchemaChangeData} produced by {@link #finalAnalyze} --
      * describes a metadata-only trailing key-column add on a shared-data range-distribution table: the
      * new column's value is a constant/NULL sentinel appended after every existing range sort-key
@@ -4985,14 +4948,14 @@ public class SchemaChangeHandler extends AlterHandler {
      *   <li>the table is not a colocate table, has no AUTO_INCREMENT column, and has no temp
      *       partitions;</li>
      *   <li>the table's keysType is DUP_KEYS, AGG_KEYS, or UNIQUE_KEYS (not PRIMARY_KEYS);</li>
-     *   <li>the base index's resolved schema adds exactly one brand-new key column (a unique id not
+     *   <li>the base index's resolved schema adds one or more brand-new key columns (unique ids not
      *       present in the current live schema -- excludes promoting an existing value column to key),
-     *       whose default is constant or NULL (not auto-increment, not generated, not a variable
+     *       each whose default is constant or NULL (not auto-increment, not generated, not a variable
      *       expression default such as {@code uuid()});</li>
      *   <li>the base index's resolved schema's key columns form a contiguous leading prefix;</li>
      *   <li>the resolved (candidate) effective sort key -- resolved with {@link
-     *       #resolveEffectiveSortKeyColumns} -- equals the current effective sort key plus exactly
-     *       that one new column trailing at the end.</li>
+     *       MetaUtils#resolveEffectiveSortKeyColumns} -- equals the current effective sort key plus
+     *       those new columns trailing at the end, in add order.</li>
      * </ul>
      */
     @VisibleForTesting
@@ -5061,9 +5024,9 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
-        List<Column> oldSortKey = resolveEffectiveSortKeyColumns(oldSchema,
+        List<Column> oldSortKey = MetaUtils.resolveEffectiveSortKeyColumns(oldSchema,
                 oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
-        List<Column> newSortKey = resolveEffectiveSortKeyColumns(newSchema,
+        List<Column> newSortKey = MetaUtils.resolveEffectiveSortKeyColumns(newSchema,
                 resolved.getSortKeyUniqueIds(), resolved.getSortKeyIdxes());
         // The new sort key must be the old sort key with exactly the new columns appended as a trailing
         // block, in add order.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/TrailingSortKeyRangeReprojection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/TrailingSortKeyRangeReprojection.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reprojects a range-distribution tablet's boundary tuple when a trailing sort-key
+ * column is appended to the table's sort key.
+ */
+public class TrailingSortKeyRangeReprojection {
+
+    /**
+     * Appends one {@link Variant#nullVariant(com.starrocks.type.Type)} sentinel for
+     * {@code newTrailingSortKeyColumn} to each bounded side of {@code old}, preserving the
+     * existing prefix, inclusivity, and any unbounded side.
+     *
+     * @param old the tablet's current boundary range, keyed on the sort key before the new column
+     * @param newTrailingSortKeyColumn the trailing sort-key column being appended
+     * @return the reprojected range, keyed on the sort key including the new column
+     */
+    public static Range<Tuple> appendTrailing(Range<Tuple> old, Column newTrailingSortKeyColumn) {
+        if (old.isAll()) {
+            return Range.all();
+        }
+        Tuple lowerBound = old.isMinimum() ? null
+                : appendNull(old.getLowerBound(), newTrailingSortKeyColumn);
+        Tuple upperBound = old.isMaximum() ? null
+                : appendNull(old.getUpperBound(), newTrailingSortKeyColumn);
+        return Range.of(lowerBound, upperBound,
+                old.isLowerBoundIncluded(),
+                old.isUpperBoundIncluded());
+    }
+
+    private static Tuple appendNull(Tuple tuple, Column newTrailingSortKeyColumn) {
+        List<Variant> values = new ArrayList<>(tuple.getValues());
+        values.add(Variant.nullVariant(newTrailingSortKeyColumn.getType()));
+        return new Tuple(values);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/TrailingSortKeyRangeReprojection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/TrailingSortKeyRangeReprojection.java
@@ -29,30 +29,32 @@ import java.util.List;
 public class TrailingSortKeyRangeReprojection {
 
     /**
-     * Appends one {@link Variant#nullVariant(com.starrocks.type.Type)} sentinel for
-     * {@code newTrailingSortKeyColumn} to each bounded side of {@code old}, preserving the
+     * Appends one {@link Variant#nullVariant(com.starrocks.type.Type)} sentinel per column in
+     * {@code newTrailingSortKeyColumns} (in order) to each bounded side of {@code old}, preserving the
      * existing prefix, inclusivity, and any unbounded side.
      *
-     * @param old the tablet's current boundary range, keyed on the sort key before the new column
-     * @param newTrailingSortKeyColumn the trailing sort-key column being appended
-     * @return the reprojected range, keyed on the sort key including the new column
+     * @param old the tablet's current boundary range, keyed on the sort key before the new columns
+     * @param newTrailingSortKeyColumns the trailing sort-key columns being appended, in sort-key order
+     * @return the reprojected range, keyed on the sort key including the new columns
      */
-    public static Range<Tuple> appendTrailing(Range<Tuple> old, Column newTrailingSortKeyColumn) {
+    public static Range<Tuple> appendTrailing(Range<Tuple> old, List<Column> newTrailingSortKeyColumns) {
         if (old.isAll()) {
             return Range.all();
         }
         Tuple lowerBound = old.isMinimum() ? null
-                : appendNull(old.getLowerBound(), newTrailingSortKeyColumn);
+                : appendNulls(old.getLowerBound(), newTrailingSortKeyColumns);
         Tuple upperBound = old.isMaximum() ? null
-                : appendNull(old.getUpperBound(), newTrailingSortKeyColumn);
+                : appendNulls(old.getUpperBound(), newTrailingSortKeyColumns);
         return Range.of(lowerBound, upperBound,
                 old.isLowerBoundIncluded(),
                 old.isUpperBoundIncluded());
     }
 
-    private static Tuple appendNull(Tuple tuple, Column newTrailingSortKeyColumn) {
+    private static Tuple appendNulls(Tuple tuple, List<Column> newTrailingSortKeyColumns) {
         List<Variant> values = new ArrayList<>(tuple.getValues());
-        values.add(Variant.nullVariant(newTrailingSortKeyColumn.getType()));
+        for (Column column : newTrailingSortKeyColumns) {
+            values.add(Variant.nullVariant(column.getType()));
+        }
         return new Tuple(values);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -191,6 +191,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return shortKeyColumnCount;
     }
 
+    public void setShortKeyColumnCount(short shortKeyColumnCount) {
+        this.shortKeyColumnCount = shortKeyColumnCount;
+    }
+
     public int getSchemaVersion() {
         return schemaVersion;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
@@ -19,6 +19,8 @@ import com.starrocks.common.Range;
 import com.starrocks.proto.TabletRangePB;
 import com.starrocks.thrift.TTabletRange;
 
+import java.util.Objects;
+
 public class TabletRange {
 
     @SerializedName(value = "range")
@@ -81,6 +83,23 @@ public class TabletRange {
         boolean lowerIncluded = tabletRangePB.lowerBoundIncluded != null ? tabletRangePB.lowerBoundIncluded : false;
         boolean upperIncluded = tabletRangePB.upperBoundIncluded != null ? tabletRangePB.upperBoundIncluded : false;
         return new TabletRange(Range.of(lowerBound, upperBound, lowerIncluded, upperIncluded));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TabletRange other = (TabletRange) o;
+        return Objects.equals(range, other.range);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(range);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
@@ -54,10 +54,11 @@ public class RangeDistributionPruner implements DistributionPruner {
         this.rangeDistributionColumns = rangeDistributionColumns;
         this.distributionColumnFilters = distributionColumnFilters;
 
-        // Capture each tablet's id and range exactly once (never call Tablet#getRange() twice) and
-        // validate arity only after every tablet has been captured, so a concurrent flip can't swap the
-        // range reference between validation and TreeMap construction, and a mismatch found partway
-        // through never truncates the tablet id list already captured.
+        // Single pass: capture each tablet's id and range (never call Tablet#getRange() twice) and check
+        // its arity in the same iteration, adding the id BEFORE the arity check and never breaking on a
+        // mismatch (only flag `degrade`). So a concurrent flip can't swap the range reference between
+        // capture and use, and a mismatch found partway through never truncates the id list already
+        // captured. The TreeMap is built only after the loop completes.
         List<Long> ids = new ArrayList<>(tabletsInOrder.size());
         List<Range<Tuple>> ranges = new ArrayList<>(tabletsInOrder.size());
         boolean degrade = false;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
@@ -35,8 +35,14 @@ import java.util.Set;
 import java.util.TreeMap;
 
 public class RangeDistributionPruner implements DistributionPruner {
-    // tablets in range order
+    // tablets in range order; unused (empty) when degradeToFullScan is true
     private final TreeMap<Range<Tuple>, Long> tabletInOrder;
+    // all tablet ids captured from the input, in input order; used as the full-scan fallback result
+    private final List<Long> allTabletIds;
+    // true when a captured tablet range's arity doesn't match rangeDistributionColumns; a concurrent
+    // metadata-only flip can transiently mix old-arity and new-arity tablet ranges, so we fall back to
+    // scanning every tablet instead of asserting or silently dropping tablets
+    private final boolean degradeToFullScan;
     // range distribution columns
     private final List<Column> rangeDistributionColumns;
     // distribution column filters
@@ -45,30 +51,53 @@ public class RangeDistributionPruner implements DistributionPruner {
     public RangeDistributionPruner(List<Tablet> tabletsInOrder,
                                    List<Column> rangeDistributionColumns,
                                    Map<String, PartitionColumnFilter> distributionColumnFilters) {
-        this.tabletInOrder = new TreeMap<>();
+        this.rangeDistributionColumns = rangeDistributionColumns;
+        this.distributionColumnFilters = distributionColumnFilters;
+
+        // Capture each tablet's id and range exactly once (never call Tablet#getRange() twice) and
+        // validate arity only after every tablet has been captured, so a concurrent flip can't swap the
+        // range reference between validation and TreeMap construction, and a mismatch found partway
+        // through never truncates the tablet id list already captured.
+        List<Long> ids = new ArrayList<>(tabletsInOrder.size());
+        List<Range<Tuple>> ranges = new ArrayList<>(tabletsInOrder.size());
+        boolean degrade = false;
         for (Tablet tablet : tabletsInOrder) {
             TabletRange tabletRange = tablet.getRange();
             Preconditions.checkState(tabletRange != null && tabletRange.getRange() != null, "Tablet range is null");
             Range<Tuple> range = tabletRange.getRange();
-            this.tabletInOrder.put(range, tablet.getId());
-            
-            int rangeColumnCount = 0;
-            if (!range.isMinimum()) {
-                rangeColumnCount = range.getLowerBound().getValues().size();
-            } else if (!range.isMaximum()) {
-                rangeColumnCount = range.getUpperBound().getValues().size();
-            }
+            ids.add(tablet.getId());
+            ranges.add(range);
 
             if (!range.isAll()) {
-                Preconditions.checkState(rangeColumnCount == rangeDistributionColumns.size(), "Range column count mismatch");
+                int rangeColumnCount = 0;
+                if (!range.isMinimum()) {
+                    rangeColumnCount = range.getLowerBound().getValues().size();
+                } else if (!range.isMaximum()) {
+                    rangeColumnCount = range.getUpperBound().getValues().size();
+                }
+                if (rangeColumnCount != rangeDistributionColumns.size()) {
+                    degrade = true;
+                }
             }
         }
-        this.rangeDistributionColumns = rangeDistributionColumns;
-        this.distributionColumnFilters = distributionColumnFilters;
+
+        this.allTabletIds = ids;
+        this.degradeToFullScan = degrade;
+        TreeMap<Range<Tuple>, Long> tree = new TreeMap<>();
+        if (!degrade) {
+            for (int i = 0; i < ids.size(); i++) {
+                tree.put(ranges.get(i), ids.get(i));
+            }
+        }
+        this.tabletInOrder = tree;
     }
 
     @Override
     public Collection<Long> prune() {
+        if (degradeToFullScan) {
+            return new ArrayList<>(allTabletIds);
+        }
+
         if (distributionColumnFilters == null || distributionColumnFilters.isEmpty() ||
             (tabletInOrder.size() == 1 && tabletInOrder.firstEntry().getKey().isAll())) {
             return new ArrayList<>(tabletInOrder.values());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -53,10 +54,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public class MetaUtils {
 
@@ -467,5 +470,42 @@ public class MetaUtils {
         } else {
             return "`" + column.getName() + "`";
         }
+    }
+
+    /**
+     * Resolve the effective sort-key columns of {@code schema}, following the same precedence BE
+     * applies when loading a {@code TabletSchemaPB} (see {@code tablet_schema.cpp}'s sort-key
+     * resolution): a non-empty {@code sortKeyUniqueIds} locates sort-key columns by unique id;
+     * otherwise a non-empty {@code sortKeyIdxes} locates them by schema position; otherwise the sort
+     * key is the leading run of key columns ({@link Column#isKey()}). Both {@code null} and empty
+     * lists fall through to the next precedence level. This differs from {@link
+     * #getRangeDistributionColumns(OlapTable, long)}, which treats a non-null (but possibly
+     * empty) {@code sortKeyIdxes} as an explicit sort key and never falls back to key columns.
+     */
+    public static List<Column> resolveEffectiveSortKeyColumns(List<Column> schema,
+                                                              @Nullable List<Integer> sortKeyUniqueIds,
+                                                              @Nullable List<Integer> sortKeyIdxes) {
+        if (sortKeyUniqueIds != null && !sortKeyUniqueIds.isEmpty()) {
+            Map<Integer, Column> uniqueIdToColumn = new HashMap<>();
+            for (Column column : schema) {
+                uniqueIdToColumn.put(column.getUniqueId(), column);
+            }
+            List<Column> sortKeyColumns = new ArrayList<>(sortKeyUniqueIds.size());
+            for (Integer uniqueId : sortKeyUniqueIds) {
+                Column column = uniqueIdToColumn.get(uniqueId);
+                Preconditions.checkArgument(column != null, "no column with unique id %s in schema", uniqueId);
+                sortKeyColumns.add(column);
+            }
+            return sortKeyColumns;
+        }
+        if (sortKeyIdxes != null && !sortKeyIdxes.isEmpty()) {
+            List<Column> sortKeyColumns = new ArrayList<>(sortKeyIdxes.size());
+            for (Integer idx : sortKeyIdxes) {
+                sortKeyColumns.add(schema.get(idx));
+            }
+            return sortKeyColumns;
+        }
+        long keyColumnCount = schema.stream().filter(Column::isKey).count();
+        return new ArrayList<>(schema.subList(0, (int) keyColumnCount));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -434,7 +434,7 @@ public class TabletMetadataUpdateAgentTaskFactory {
                 if (tabletRanges != null) {
                     TabletRange range = tabletRanges.get(tabletId);
                     if (range != null) {
-                        metaInfo.setRange(range.toThrift());
+                        metaInfo.setTablet_range(range.toThrift());
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TabletMetadataUpdateAgentTaskFactory.java
@@ -19,6 +19,7 @@ import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.FlatJsonConfig;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TabletRange;
 import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TCompactionStrategy;
@@ -30,6 +31,7 @@ import com.starrocks.thrift.TTabletSchema;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -134,7 +136,15 @@ public class TabletMetadataUpdateAgentTaskFactory {
                                                                              List<Long> tabletIds,
                                                                              TTabletSchema tabletSchema,
                                                                              boolean createSchemaFile) {
-        return new UpdateTabletSchemaTask(backendId, tabletIds, tabletSchema, createSchemaFile);
+        return createTabletSchemaUpdateTask(backendId, tabletIds, tabletSchema, createSchemaFile, null);
+    }
+
+    public static TabletMetadataUpdateAgentTask createTabletSchemaUpdateTask(long backendId,
+                                                                             List<Long> tabletIds,
+                                                                             TTabletSchema tabletSchema,
+                                                                             boolean createSchemaFile,
+                                                                             Map<Long, TabletRange> tabletRanges) {
+        return new UpdateTabletSchemaTask(backendId, tabletIds, tabletSchema, createSchemaFile, tabletRanges);
     }
 
     private static class UpdatePartitionIdTask extends TabletMetadataUpdateAgentTask {
@@ -389,15 +399,19 @@ public class TabletMetadataUpdateAgentTaskFactory {
         private final List<Long> tablets;
         private final TTabletSchema tabletSchema;
         private final boolean createSchemaFile;
+        // Per-tablet target range, only set for an arity-changing range-distribution schema change.
+        // Null on the ordinary fast-schema-evolution path (no range is sent).
+        private final Map<Long, TabletRange> tabletRanges;
 
         private UpdateTabletSchemaTask(long backendId, List<Long> tablets, TTabletSchema tabletSchema,
-                                       boolean createSchemaFile) {
+                                       boolean createSchemaFile, Map<Long, TabletRange> tabletRanges) {
             super(backendId, tablets.hashCode());
             this.tablets = new ArrayList<>(tablets);
             // tabletSchema may be null when the table has multi materialized index
             // and the schema of some materialized indexes are not needed to be updated
             this.tabletSchema = tabletSchema;
             this.createSchemaFile = createSchemaFile;
+            this.tabletRanges = tabletRanges;
         }
 
         @Override
@@ -415,6 +429,13 @@ public class TabletMetadataUpdateAgentTaskFactory {
 
                 if (tabletSchema != null) {
                     metaInfo.setTablet_schema(tabletSchema);
+                }
+
+                if (tabletRanges != null) {
+                    TabletRange range = tabletRanges.get(tabletId);
+                    if (range != null) {
+                        metaInfo.setRange(range.toThrift());
+                    }
                 }
 
                 metaInfos.add(metaInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobKeyColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobKeyColumnTest.java
@@ -148,10 +148,11 @@ public class LakeRangeRewriteSchemaChangeJobKeyColumnTest {
 
     @Test
     public void testAddKeyColumnBuildsPrefixedShadowSchemaFreshUniqueIdNoAggKey() throws Exception {
-        // AGG range table: v1 SUM (no explicit key), so ADD COLUMN k2 INT KEY joins a key-derived range
-        // sort key and is routed to the range rewrite job with a prefixed shadow schema.
-        String sql = "create table t_range_agg (k1 int, v1 int sum)\n"
-                + "aggregate key(k1)\n"
+        // DUP range table with an explicit ORDER BY: ADD COLUMN k2 INT KEY does not extend the explicit
+        // sort key, so it is not metadata-only and stays on the range rewrite job with a prefixed shadow
+        // schema (AGG/UNIQUE and key-derived DUP adds now take the metadata-only path instead).
+        String sql = "create table t_range_agg (k1 int, v1 int)\n"
+                + "duplicate key(k1)\n"
                 + "order by(k1)\n"
                 + "properties('replication_num' = '1');";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
@@ -178,10 +179,10 @@ public class LakeRangeRewriteSchemaChangeJobKeyColumnTest {
 
     @Test
     public void testRegisterShadowExposesPrefixedAddedColumnHiddenFromUser() throws Exception {
-        // AGG range table (v1 SUM, no explicit key): ADD COLUMN k2 INT KEY routes to the range rewrite
-        // job with a prefixed shadow schema (see testAddKeyColumnBuildsPrefixedShadowSchemaFreshUniqueIdNoAggKey).
-        String sql = "create table t_range_agg_add (k1 int, v1 int sum)\n"
-                + "aggregate key(k1)\n"
+        // DUP range table with an explicit ORDER BY: ADD COLUMN k2 INT KEY stays on the range rewrite job
+        // with a prefixed shadow schema (see testAddKeyColumnBuildsPrefixedShadowSchemaFreshUniqueIdNoAggKey).
+        String sql = "create table t_range_agg_add (k1 int, v1 int)\n"
+                + "duplicate key(k1)\n"
                 + "order by(k1)\n"
                 + "properties('replication_num' = '1');";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -14,23 +14,41 @@
 
 package com.starrocks.alter;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.NullVariant;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Range;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.rpc.ThriftConnectionPool;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAgentTaskRequest;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TTabletMetaInfo;
 import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TUpdateTabletMetaInfoReq;
+import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.MockGenericPool;
 import com.starrocks.utframe.MockedBackend;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeTestBase {
@@ -112,5 +130,309 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
             thriftClients.forEach(MockedBackend.MockBeThriftClient::clearCapturedAgentTasks);
         }
     }
-}
 
+    // ---------------------------------------------------------------------------------------------
+    // Trailing sort-key range flip: persisted target map, in-place flip, pre-WAL validation,
+    // exact-state replay idempotency. Every new behavior is guarded on targetRanges != null.
+    // ---------------------------------------------------------------------------------------------
+
+    private static Tuple oneColTuple(String v) {
+        return new Tuple(Lists.newArrayList(Variant.of(IntegerType.INT, v)));
+    }
+
+    private static TabletRange oneColRange(int base) {
+        return new TabletRange(Range.of(oneColTuple(String.valueOf(base)),
+                oneColTuple(String.valueOf(base + 9)), true, true));
+    }
+
+    private List<Tablet> baseTablets(LakeTable table) {
+        List<Tablet> tablets = new ArrayList<>();
+        for (PhysicalPartition pp : table.getPhysicalPartitions()) {
+            MaterializedIndex index = pp.getLatestIndex(table.getBaseIndexMetaId());
+            if (index != null) {
+                tablets.addAll(index.getTablets());
+            }
+        }
+        return tablets;
+    }
+
+    /** New trailing key column with a constant default and a fresh unique id. */
+    private static Column newTrailingKeyColumn(LakeTable table) {
+        Column c = new Column("c_new", IntegerType.INT);
+        c.setIsKey(true);
+        c.setUniqueId(table.getMaxColUniqueId() + 1);
+        c.setDefaultValue("0");
+        return c;
+    }
+
+    /**
+     * Build the TARGET schema info for a metadata-only trailing key add on a DUP table with base
+     * schema (c0 key, c1 value): result is (c0 key, c_new key, c1 value) with the sort key spanning
+     * (c0, c_new), a bumped version, and a short-key count that increases by one.
+     */
+    private SchemaInfo buildTrailingKeyTargetSchema(LakeTable table, Column newKeyColumn) {
+        MaterializedIndexMeta baseMeta = table.getIndexMetaByMetaId(table.getBaseIndexMetaId());
+        List<Column> oldSchema = baseMeta.getSchema();
+        Column c0 = oldSchema.get(0);
+        Column c1 = oldSchema.get(1);
+        List<Column> targetColumns = Lists.newArrayList(c0, newKeyColumn, c1);
+        short targetShortKey = (short) (baseMeta.getShortKeyColumnCount() + 1);
+        return SchemaInfo.newBuilder()
+                .setId(GlobalStateMgr.getCurrentState().getNextId())
+                .setVersion(baseMeta.getSchemaVersion() + 1)
+                .setKeysType(baseMeta.getKeysType())
+                .setShortKeyColumnCount(targetShortKey)
+                .setStorageType(table.getStorageType())
+                .addColumns(targetColumns)
+                .setSortKeyIndexes(List.of(0, 1))
+                .setSortKeyUniqueIds(List.of(c0.getUniqueId(), newKeyColumn.getUniqueId()))
+                .setIndexes(table.getCopiedIndexes())
+                .build();
+    }
+
+    private LakeTable createDupTableWithBuckets(String name, int buckets) throws Exception {
+        return createTable(connectContext, String.format(
+                "CREATE TABLE %s (c0 INT, c1 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS %d " +
+                        "PROPERTIES('cloud_native_fast_schema_evolution_v2'='false')", name, buckets));
+    }
+
+    private LakeTableAsyncFastSchemaChangeJob newJob(Database db, LakeTable table, SchemaInfo target) {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        LakeTableAsyncFastSchemaChangeJob job = new LakeTableAsyncFastSchemaChangeJob(
+                jobId, db.getId(), table.getId(), table.getName(), 3600_000L);
+        job.setIndexTabletSchema(table.getBaseIndexMetaId(),
+                table.getIndexNameByMetaId(table.getBaseIndexMetaId()), target);
+        return job;
+    }
+
+    @Test
+    public void testTargetRangeFlipInPlace() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createDupTableWithBuckets("t_range_flip", 3);
+        long baseMetaId = table.getBaseIndexMetaId();
+
+        List<Tablet> tablets = baseTablets(table);
+        Assertions.assertEquals(3, tablets.size());
+
+        Column newKey = newTrailingKeyColumn(table);
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        int i = 0;
+        for (Tablet tablet : tablets) {
+            TabletRange old = oneColRange(i * 10);
+            tablet.setRange(old);
+            targetRanges.put(tablet.getId(),
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+            i++;
+        }
+
+        int oldVersion = table.getIndexMetaByMetaId(baseMetaId).getSchemaVersion();
+        SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
+
+        LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);
+        job.setTargetRanges(targetRanges);
+        job.updateCatalog(db, table, false);
+
+        // Index-meta arity and short-key installed.
+        MaterializedIndexMeta after = table.getIndexMetaByMetaId(baseMetaId);
+        Assertions.assertEquals(List.of(0, 1), after.getSortKeyIdxes());
+        Assertions.assertEquals(List.of(after.getSchema().get(0).getUniqueId(), newKey.getUniqueId()),
+                after.getSortKeyUniqueIds());
+        Assertions.assertEquals((short) 2, after.getShortKeyColumnCount());
+        Assertions.assertEquals(3, after.getSchema().size());
+        Assertions.assertTrue(after.getSchemaVersion() > oldVersion);
+
+        // In-place flip: same tablet object identity, range gained one trailing NULL sentinel.
+        List<Tablet> refetched = baseTablets(table);
+        Assertions.assertEquals(tablets.size(), refetched.size());
+        for (Tablet tablet : refetched) {
+            Assertions.assertSame(tabletById(tablets, tablet.getId()), tablet);
+            List<Variant> lower = tablet.getRange().getRange().getLowerBound().getValues();
+            List<Variant> upper = tablet.getRange().getRange().getUpperBound().getValues();
+            Assertions.assertEquals(2, lower.size());
+            Assertions.assertEquals(2, upper.size());
+            Assertions.assertInstanceOf(NullVariant.class, lower.get(1));
+            Assertions.assertInstanceOf(NullVariant.class, upper.get(1));
+            // Prefix preserved.
+            Assertions.assertEquals(targetRanges.get(tablet.getId()), tablet.getRange());
+        }
+    }
+
+    private static Tablet tabletById(List<Tablet> tablets, long id) {
+        return tablets.stream().filter(t -> t.getId() == id).findFirst().orElseThrow();
+    }
+
+    @Test
+    public void testExactVersionReplayDoesNotDoubleAppend() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createDupTableWithBuckets("t_range_replay", 2);
+        long baseMetaId = table.getBaseIndexMetaId();
+
+        List<Tablet> tablets = baseTablets(table);
+        Column newKey = newTrailingKeyColumn(table);
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        int i = 0;
+        for (Tablet tablet : tablets) {
+            TabletRange old = oneColRange(i * 10);
+            tablet.setRange(old);
+            targetRanges.put(tablet.getId(),
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+            i++;
+        }
+        SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
+
+        LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);
+        job.setTargetRanges(targetRanges);
+
+        // First apply flips to N+1. After this, the job's schema version equals the current one.
+        job.updateCatalog(db, table, false);
+        int versionAfterFirst = table.getIndexMetaByMetaId(baseMetaId).getSchemaVersion();
+
+        // Exact-state replay: verifies live == target and returns without re-appending.
+        job.updateCatalog(db, table, true);
+        Assertions.assertEquals(versionAfterFirst, table.getIndexMetaByMetaId(baseMetaId).getSchemaVersion());
+        for (Tablet tablet : baseTablets(table)) {
+            // Still exactly N+1 columns (no double append).
+            Assertions.assertEquals(2, tablet.getRange().getRange().getLowerBound().getValues().size());
+            Assertions.assertEquals(targetRanges.get(tablet.getId()), tablet.getRange());
+        }
+    }
+
+    @Test
+    public void testMissingCoverageRejectedBeforeWal() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createDupTableWithBuckets("t_range_missing", 3);
+        long baseMetaId = table.getBaseIndexMetaId();
+
+        List<Tablet> tablets = baseTablets(table);
+        Column newKey = newTrailingKeyColumn(table);
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        int i = 0;
+        for (Tablet tablet : tablets) {
+            TabletRange old = oneColRange(i * 10);
+            tablet.setRange(old);
+            // Deliberately drop coverage for the first tablet.
+            if (i != 0) {
+                targetRanges.put(tablet.getId(),
+                        new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+            }
+            i++;
+        }
+        int oldVersion = table.getIndexMetaByMetaId(baseMetaId).getSchemaVersion();
+        SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
+
+        LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);
+        job.setTargetRanges(targetRanges);
+        job.setJobState(AlterJobV2.JobState.FINISHED_REWRITING);
+
+        Assertions.assertThrows(AlterCancelException.class, () -> job.validateBeforeFinishUnprotected(db, table));
+
+        // Pre-WAL failure: job stays FINISHED_REWRITING, catalog + ranges untouched (still 1-col).
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, job.getJobState());
+        Assertions.assertEquals(oldVersion, table.getIndexMetaByMetaId(baseMetaId).getSchemaVersion());
+        for (Tablet tablet : baseTablets(table)) {
+            Assertions.assertEquals(1, tablet.getRange().getRange().getLowerBound().getValues().size());
+        }
+    }
+
+    @Test
+    public void testExtraCoverageRejectedBeforeWal() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createDupTableWithBuckets("t_range_extra", 2);
+
+        List<Tablet> tablets = baseTablets(table);
+        Column newKey = newTrailingKeyColumn(table);
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        int i = 0;
+        for (Tablet tablet : tablets) {
+            TabletRange old = oneColRange(i * 10);
+            tablet.setRange(old);
+            targetRanges.put(tablet.getId(),
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+            i++;
+        }
+        // An extra tablet id that is not part of the live set.
+        targetRanges.put(-9999L, new TabletRange(
+                TrailingSortKeyRangeReprojection.appendTrailing(oneColRange(0).getRange(), newKey)));
+
+        SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
+        LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);
+        job.setTargetRanges(targetRanges);
+
+        Assertions.assertThrows(AlterCancelException.class, () -> job.validateBeforeFinishUnprotected(db, table));
+    }
+
+    @Test
+    public void testGsonRoundTripPreservesTargetsByValue() {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        LakeTableAsyncFastSchemaChangeJob job = new LakeTableAsyncFastSchemaChangeJob(
+                jobId, 1L, 2L, "t_gson", 1000L);
+        Map<Long, TabletRange> targetRanges = new HashMap<>();
+        targetRanges.put(100L, new TabletRange(Range.of(oneColTuple("5"), oneColTuple("9"), true, true)));
+        targetRanges.put(200L, new TabletRange(Range.of(oneColTuple("10"), oneColTuple("19"), false, true)));
+        job.setTargetRanges(targetRanges);
+
+        String json = GsonUtils.GSON.toJson(job.copyForPersist());
+        LakeTableAsyncFastSchemaChangeJob restored =
+                (LakeTableAsyncFastSchemaChangeJob) GsonUtils.GSON.fromJson(json, AlterJobV2.class);
+
+        Assertions.assertEquals(targetRanges, restored.getTargetRanges());
+        // Re-wrapped immutable in gsonPostProcess.
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> restored.getTargetRanges().put(300L, new TabletRange()));
+    }
+
+    @Test
+    public void testTabletRangeEqualsIsValueBased() {
+        TabletRange a = new TabletRange(Range.of(oneColTuple("1"), oneColTuple("5"), true, true));
+        TabletRange b = new TabletRange(Range.of(oneColTuple("1"), oneColTuple("5"), true, true));
+        TabletRange c = new TabletRange(Range.of(oneColTuple("1"), oneColTuple("6"), true, true));
+
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertNotEquals(a, c);
+    }
+
+    // Regression: with targetRanges unset, an ordinary value-column FSE update behaves exactly as
+    // before -- no coverage rejection, no NPE, no range flip, and the original short-key assertion
+    // still applies.
+    @Test
+    public void testUnsetTargetRangesIsByteForByte() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createDupTableWithBuckets("t_range_unset", 2);
+        long baseMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta baseMeta = table.getIndexMetaByMetaId(baseMetaId);
+
+        // Value-column add: short-key count unchanged (the original :187 assertion must hold).
+        List<Column> oldSchema = baseMeta.getSchema();
+        Column c2 = new Column("c2", IntegerType.INT);
+        c2.setUniqueId(table.getMaxColUniqueId() + 1);
+        c2.setDefaultValue("0");
+        List<Column> targetColumns = Lists.newArrayList(oldSchema.get(0), oldSchema.get(1), c2);
+        SchemaInfo target = SchemaInfo.newBuilder()
+                .setId(GlobalStateMgr.getCurrentState().getNextId())
+                .setVersion(baseMeta.getSchemaVersion() + 1)
+                .setKeysType(baseMeta.getKeysType())
+                .setShortKeyColumnCount(baseMeta.getShortKeyColumnCount())
+                .setStorageType(table.getStorageType())
+                .addColumns(targetColumns)
+                .setSortKeyIndexes(baseMeta.getSortKeyIdxes())
+                .setSortKeyUniqueIds(baseMeta.getSortKeyUniqueIds())
+                .setIndexes(table.getCopiedIndexes())
+                .build();
+
+        List<Tablet> tablets = baseTablets(table);
+        LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);
+        // No targetRanges set: validation is a no-op even though nothing covers the tablets.
+        Assertions.assertDoesNotThrow(() -> job.validateBeforeFinishUnprotected(db, table));
+
+        job.updateCatalog(db, table, false);
+
+        Assertions.assertEquals(3, table.getIndexMetaByMetaId(baseMetaId).getSchema().size());
+        Assertions.assertEquals(baseMeta.getShortKeyColumnCount(),
+                table.getIndexMetaByMetaId(baseMetaId).getShortKeyColumnCount());
+        // Hash-distribution tablets keep a null range -- no flip on the unset path.
+        for (Tablet tablet : tablets) {
+            Assertions.assertNull(tablet.getRange());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -221,7 +221,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
             TabletRange old = oneColRange(i * 10);
             tablet.setRange(old);
             targetRanges.put(tablet.getId(),
-                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), List.of(newKey))));
             i++;
         }
 
@@ -275,7 +275,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
             TabletRange old = oneColRange(i * 10);
             tablet.setRange(old);
             targetRanges.put(tablet.getId(),
-                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), List.of(newKey))));
             i++;
         }
         SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
@@ -313,7 +313,7 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
             // Deliberately drop coverage for the first tablet.
             if (i != 0) {
                 targetRanges.put(tablet.getId(),
-                        new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+                        new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), List.of(newKey))));
             }
             i++;
         }
@@ -347,12 +347,12 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends LakeFastSchemaChangeT
             TabletRange old = oneColRange(i * 10);
             tablet.setRange(old);
             targetRanges.put(tablet.getId(),
-                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), newKey)));
+                    new TabletRange(TrailingSortKeyRangeReprojection.appendTrailing(old.getRange(), List.of(newKey))));
             i++;
         }
         // An extra tablet id that is not part of the live set.
         targetRanges.put(-9999L, new TabletRange(
-                TrailingSortKeyRangeReprojection.appendTrailing(oneColRange(0).getRange(), newKey)));
+                TrailingSortKeyRangeReprojection.appendTrailing(oneColRange(0).getRange(), List.of(newKey))));
 
         SchemaInfo target = buildTrailingKeyTargetSchema(table, newKey);
         LakeTableAsyncFastSchemaChangeJob job = newJob(db, table, target);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -16,6 +16,8 @@ package com.starrocks.alter;
 
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DefaultExpr;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
@@ -28,6 +30,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.KeysType;
 import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -38,6 +41,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -746,5 +750,335 @@ public class RangeDistributionGuardTest {
         // A real ADD ROLLUP now falls through to the existing range rejection.
         assertAlterRejectedWithRangeDistribution(
                 "alter table t_guard_rollup_existing add rollup r_new(k1, k2, v1) order by (k2, k1)");
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd / resolveEffectiveSortKeyColumns
+    //
+    // These are additive, self-contained pieces (not wired into the ALTER dispatch yet), so they are
+    // exercised as pure functions over a hand-built resolved SchemaChangeData rather than by driving a
+    // real ADD COLUMN KEY through analyzeAndCreateJob (which today still routes to the existing
+    // needsRangeRewriteSchemaChange path before finalAnalyze ever runs).
+    // ------------------------------------------------------------------------------------------
+
+    private static String dupRangeTableWithValueDdl(String name) {
+        return "create table " + name + " (k1 int, k2 int, v1 int)\n" +
+                "DUPLICATE KEY(k1, k2)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1');";
+    }
+
+    private static String aggRangeTableWithValueDdl(String name) {
+        return "create table " + name + " (k1 int, k2 int, v1 int sum)\n" +
+                "AGGREGATE KEY(k1, k2)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1');";
+    }
+
+    private static String uniqueRangeTableWithValueDdl(String name) {
+        return "create table " + name + " (k1 int, k2 int, v1 int)\n" +
+                "UNIQUE KEY(k1, k2)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1');";
+    }
+
+    private static String primaryKeyRangeTableWithValueDdl(String name) {
+        return "create table " + name + " (k1 int not null, k2 int not null, v1 int)\n" +
+                "PRIMARY KEY(k1, k2)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1');";
+    }
+
+    private static OlapTable getTable(String name) {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", name);
+    }
+
+    private static Column constKeyColumn(OlapTable table, String name) {
+        Column column = new Column(name, IntegerType.INT);
+        column.setIsKey(true);
+        column.setUniqueId(table.getMaxColUniqueId() + 1000);
+        column.setDefaultValue("0");
+        return column;
+    }
+
+    /**
+     * Build a resolved {@link SchemaChangeData} simulating {@code ADD COLUMN <newKeyColumn> KEY} on
+     * {@code table}: the base index schema with {@code newKeyColumn} inserted as a brand-new trailing
+     * key column (after the existing key columns, keeping the key set a contiguous prefix), and a
+     * candidate sort key that is the table's current effective sort key plus that new column,
+     * expressed via {@code sortKeyUniqueIds} -- the resolver's highest-precedence tier, so this is
+     * valid regardless of which tier the live table itself uses.
+     */
+    private static SchemaChangeData buildTrailingKeyAddCandidate(OlapTable table, Column newKeyColumn) {
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
+
+        List<Column> newSchema = new ArrayList<>();
+        for (Column column : oldSchema) {
+            if (column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        newSchema.add(newKeyColumn);
+        for (Column column : oldSchema) {
+            if (!column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+
+        List<Integer> candidateSortKeyUniqueIds = new ArrayList<>();
+        for (Column column : oldSortKey) {
+            candidateSortKeyUniqueIds.add(column.getUniqueId());
+        }
+        candidateSortKeyUniqueIds.add(newKeyColumn.getUniqueId());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        return SchemaChangeData.newBuilder()
+                .withDatabase(db)
+                .withTable(table)
+                .withNewIndexMetaIdToSchema(baseIndexMetaId, newSchema)
+                .withSortKeyUniqueIds(candidateSortKeyUniqueIds)
+                .build();
+    }
+
+    @Test
+    public void testDupTrailingKeyAddIsMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_dup"));
+        OlapTable table = getTable("t_meta_dup");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        assertTrue(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testAggTrailingKeyAddIsMetadataOnly() throws Exception {
+        starRocksAssert.withTable(aggRangeTableWithValueDdl("t_meta_agg"));
+        OlapTable table = getTable("t_meta_agg");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        assertTrue(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testUniqueTrailingKeyAddIsMetadataOnly() throws Exception {
+        starRocksAssert.withTable(uniqueRangeTableWithValueDdl("t_meta_unique"));
+        OlapTable table = getTable("t_meta_unique");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        assertTrue(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    /**
+     * Same AGG scenario as {@link #testAggTrailingKeyAddIsMetadataOnly}, but the candidate sort key is
+     * expressed via {@code sortKeyIdxes} (schema position) instead of {@code sortKeyUniqueIds},
+     * exercising the resolver's second precedence tier at the classifier level, over a resolved schema
+     * whose key columns (k1, k2, c_new) form a contiguous leading prefix matching those idxes.
+     */
+    @Test
+    public void testAggIdxBasedTrailingKeyAddIsMetadataOnly() throws Exception {
+        starRocksAssert.withTable(aggRangeTableWithValueDdl("t_meta_agg_idx"));
+        OlapTable table = getTable("t_meta_agg_idx");
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+
+        Column newKeyColumn = constKeyColumn(table, "c_new");
+        List<Column> newSchema = new ArrayList<>();
+        for (Column column : oldSchema) {
+            if (column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        newSchema.add(newKeyColumn);
+        for (Column column : oldSchema) {
+            if (!column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        // k1, k2, c_new form the leading contiguous key prefix -> idxes [0, 1, 2].
+        assertTrue(newSchema.get(0).isKey() && newSchema.get(1).isKey() && newSchema.get(2).isKey());
+        assertFalse(newSchema.get(3).isKey());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        SchemaChangeData resolved = SchemaChangeData.newBuilder()
+                .withDatabase(db)
+                .withTable(table)
+                .withNewIndexMetaIdToSchema(baseIndexMetaId, newSchema)
+                .withSortKeyIdxes(List.of(0, 1, 2))
+                .build();
+        assertTrue(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testPrimaryKeyTableNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(primaryKeyRangeTableWithValueDdl("t_meta_pk"));
+        OlapTable table = getTable("t_meta_pk");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    /**
+     * Promoting an EXISTING value column to key (a value-to-key flip) is not an ADD of a brand-new
+     * column: the classifier must reject it even though the resulting sort key also grows by one.
+     */
+    @Test
+    public void testPromotingExistingColumnNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_promote"));
+        OlapTable table = getTable("t_meta_promote");
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
+
+        List<Column> newSchema = new ArrayList<>();
+        Column promotedV1 = null;
+        for (Column column : oldSchema) {
+            if (!column.isKey()) {
+                Column copy = column.deepCopy();
+                copy.setIsKey(true);
+                promotedV1 = copy;
+                newSchema.add(copy);
+            } else {
+                newSchema.add(column);
+            }
+        }
+
+        List<Integer> candidateSortKeyUniqueIds = new ArrayList<>();
+        for (Column column : oldSortKey) {
+            candidateSortKeyUniqueIds.add(column.getUniqueId());
+        }
+        candidateSortKeyUniqueIds.add(promotedV1.getUniqueId());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        SchemaChangeData resolved = SchemaChangeData.newBuilder()
+                .withDatabase(db)
+                .withTable(table)
+                .withNewIndexMetaIdToSchema(baseIndexMetaId, newSchema)
+                .withSortKeyUniqueIds(candidateSortKeyUniqueIds)
+                .build();
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testColocateTableNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_colocate"));
+        OlapTable table = getTable("t_meta_colocate");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isColocateTable(long tableId) {
+                return true;
+            }
+        };
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testAutoIncrementTableNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable("create table t_meta_autoinc "
+                + "(k1 int not null, k2 int not null, id bigint not null auto_increment)\n"
+                + "DUPLICATE KEY(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        OlapTable table = getTable("t_meta_autoinc");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testMultiIndexTableNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_multi"));
+        OlapTable table = getTable("t_meta_multi");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+
+        long extraMetaId = GlobalStateMgr.getCurrentState().getNextId();
+        List<Column> rollupSchema = table.getSchemaByIndexMetaId(table.getBaseIndexMetaId()).subList(0, 2);
+        table.setIndexMeta(extraMetaId, "r_meta_multi", rollupSchema, 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS, null, List.of(0, 1));
+
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testTempPartitionsTableNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_temp"));
+        OlapTable table = getTable("t_meta_temp");
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, constKeyColumn(table, "c_new"));
+        new MockUp<OlapTable>() {
+            @Mock
+            public boolean existTempPartitions() {
+                return true;
+            }
+        };
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    @Test
+    public void testNonConstDefaultNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_nonconst"));
+        OlapTable table = getTable("t_meta_nonconst");
+        Column newKeyColumn = constKeyColumn(table, "c_new");
+        // Force a variable (non-constant) default, as if DEFAULT uuid() had been specified.
+        Deencapsulation.setField(newKeyColumn, "defaultExpr", new DefaultExpr("uuid()", false));
+        SchemaChangeData resolved = buildTrailingKeyAddCandidate(table, newKeyColumn);
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
+    // -- resolveEffectiveSortKeyColumns: BE-compatible precedence (tablet_schema.cpp) --
+
+    private static List<Column> threeColumnSchema() {
+        Column a = new Column("a", IntegerType.INT);
+        a.setIsKey(true);
+        a.setUniqueId(10);
+        Column b = new Column("b", IntegerType.INT);
+        b.setIsKey(true);
+        b.setUniqueId(11);
+        Column c = new Column("c", IntegerType.INT);
+        c.setUniqueId(12);
+        return new ArrayList<>(List.of(a, b, c));
+    }
+
+    @Test
+    public void testResolverPrefersSortKeyUniqueIds() {
+        List<Column> schema = threeColumnSchema();
+        // Reordered relative to schema position, and ignores sortKeyIdxes entirely.
+        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                schema, List.of(11, 10), List.of(2, 1, 0));
+        assertEquals(List.of("b", "a"),
+                resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
+    }
+
+    @Test
+    public void testResolverFallsBackToSortKeyIdxesWhenUniqueIdsNull() {
+        List<Column> schema = threeColumnSchema();
+        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(schema, null, List.of(2, 0));
+        assertEquals(List.of("c", "a"),
+                resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
+    }
+
+    @Test
+    public void testResolverFallsBackToSortKeyIdxesWhenUniqueIdsEmpty() {
+        List<Column> schema = threeColumnSchema();
+        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                schema, List.of(), List.of(2, 0));
+        assertEquals(List.of("c", "a"),
+                resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
+    }
+
+    @Test
+    public void testResolverFallsBackToKeyColumnsWhenBothNull() {
+        List<Column> schema = threeColumnSchema();
+        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(schema, null, null);
+        assertEquals(List.of("a", "b"),
+                resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
+    }
+
+    @Test
+    public void testResolverFallsBackToKeyColumnsWhenBothEmpty() {
+        List<Column> schema = threeColumnSchema();
+        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                schema, List.of(), List.of());
+        assertEquals(List.of("a", "b"),
+                resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -36,6 +36,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
@@ -819,7 +820,7 @@ public class RangeDistributionGuardTest {
         long baseIndexMetaId = table.getBaseIndexMetaId();
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
-        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> oldSortKey = MetaUtils.resolveEffectiveSortKeyColumns(
                 oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
 
         List<Column> newSchema = new ArrayList<>();
@@ -933,7 +934,7 @@ public class RangeDistributionGuardTest {
         long baseIndexMetaId = table.getBaseIndexMetaId();
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
-        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> oldSortKey = MetaUtils.resolveEffectiveSortKeyColumns(
                 oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
 
         List<Column> newSchema = new ArrayList<>();
@@ -1004,7 +1005,7 @@ public class RangeDistributionGuardTest {
         long baseIndexMetaId = table.getBaseIndexMetaId();
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
-        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> oldSortKey = MetaUtils.resolveEffectiveSortKeyColumns(
                 oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
 
         Column newKeyColumn = constKeyColumn(table, "c_new");
@@ -1055,7 +1056,7 @@ public class RangeDistributionGuardTest {
         long baseIndexMetaId = table.getBaseIndexMetaId();
         List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
         MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
-        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> oldSortKey = MetaUtils.resolveEffectiveSortKeyColumns(
                 oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
 
         Column c1 = constKeyColumn(table, "c_new1");
@@ -1152,7 +1153,7 @@ public class RangeDistributionGuardTest {
     public void testResolverPrefersSortKeyUniqueIds() {
         List<Column> schema = threeColumnSchema();
         // Reordered relative to schema position, and ignores sortKeyIdxes entirely.
-        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> resolved = MetaUtils.resolveEffectiveSortKeyColumns(
                 schema, List.of(11, 10), List.of(2, 1, 0));
         assertEquals(List.of("b", "a"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
@@ -1161,7 +1162,7 @@ public class RangeDistributionGuardTest {
     @Test
     public void testResolverFallsBackToSortKeyIdxesWhenUniqueIdsNull() {
         List<Column> schema = threeColumnSchema();
-        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(schema, null, List.of(2, 0));
+        List<Column> resolved = MetaUtils.resolveEffectiveSortKeyColumns(schema, null, List.of(2, 0));
         assertEquals(List.of("c", "a"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
     }
@@ -1169,7 +1170,7 @@ public class RangeDistributionGuardTest {
     @Test
     public void testResolverFallsBackToSortKeyIdxesWhenUniqueIdsEmpty() {
         List<Column> schema = threeColumnSchema();
-        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> resolved = MetaUtils.resolveEffectiveSortKeyColumns(
                 schema, List.of(), List.of(2, 0));
         assertEquals(List.of("c", "a"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
@@ -1178,7 +1179,7 @@ public class RangeDistributionGuardTest {
     @Test
     public void testResolverFallsBackToKeyColumnsWhenBothNull() {
         List<Column> schema = threeColumnSchema();
-        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(schema, null, null);
+        List<Column> resolved = MetaUtils.resolveEffectiveSortKeyColumns(schema, null, null);
         assertEquals(List.of("a", "b"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
     }
@@ -1186,7 +1187,7 @@ public class RangeDistributionGuardTest {
     @Test
     public void testResolverFallsBackToKeyColumnsWhenBothEmpty() {
         List<Column> schema = threeColumnSchema();
-        List<Column> resolved = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+        List<Column> resolved = MetaUtils.resolveEffectiveSortKeyColumns(
                 schema, List.of(), List.of());
         assertEquals(List.of("a", "b"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -20,10 +20,17 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DefaultExpr;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.NullVariant;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Range;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -374,13 +381,13 @@ public class RangeDistributionGuardTest {
      * On an AGG range-distribution table, adding a column with no aggregate
      * function is auto-promoted to a key column by the schema-change handler
      * (no explicit KEY keyword needed). The added column joins the (key-derived)
-     * range sort key, so it is now routed to {@link LakeRangeRewriteSchemaChangeJob}
-     * instead of rejected -- the routing predicate's auto-promote handling must
+     * range sort key -- a trailing sort-key add -- so it now runs the metadata-only
+     * async schema-evolution job (the routing predicate's auto-promote handling must
      * catch this path too; an earlier draft checked isKey() before promotion and
-     * would have missed it.
+     * would have missed it).
      */
     @Test
-    public void testAddNoAggregateColumnOnAggRangeTableRoutedToRangeRewrite() throws Exception {
+    public void testAddNoAggregateColumnOnAggRangeTableRunsMetadataOnly() throws Exception {
         starRocksAssert.withTable(
                 "create table t_guard_addagg (k1 int, v1 int sum)\n" +
                 "AGGREGATE KEY(k1)\n" +
@@ -395,8 +402,7 @@ public class RangeDistributionGuardTest {
         AlterJobV2 job = GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
                 .analyzeAndCreateJob(stmt.getAlterClauseList(),
                         GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test"), table);
-        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob,
-                "Expected a LakeRangeRewriteSchemaChangeJob, got: " + job);
+        assertMetadataOnlyJob(job);
     }
 
     /**
@@ -1080,5 +1086,300 @@ public class RangeDistributionGuardTest {
                 schema, List.of(), List.of());
         assertEquals(List.of("a", "b"),
                 resolved.stream().map(Column::getName).collect(java.util.stream.Collectors.toList()));
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // End-to-end ADD COLUMN dispatch: a qualifying trailing key-column add on a shared-data range
+    // table is routed to the async metadata-only schema-evolution job (in-place range reprojection),
+    // NOT the K-tablet data-rewrite job. Jobs are built (not run) via analyzeAndCreateJob.
+    // ------------------------------------------------------------------------------------------
+
+    // DUP range table with a key-derived sort key (no explicit ORDER BY): the new key column joins
+    // the derived sort key, so the add is metadata-only.
+    private static String dupRangeKeyDerivedDdl(String name) {
+        return "create table " + name + " (k1 int, k2 int, v1 int)\n" +
+                "DUPLICATE KEY(k1, k2)\n" +
+                "properties('replication_num' = '1');";
+    }
+
+    private static AlterJobV2 buildAlterJob(String tableName, String alterSql) throws Exception {
+        com.starrocks.sql.ast.AlterTableStmt stmt = (com.starrocks.sql.ast.AlterTableStmt)
+                UtFrameUtils.parseStmtWithNewParser(alterSql, connectContext);
+        OlapTable table = getTable(tableName);
+        return GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .analyzeAndCreateJob(stmt.getAlterClauseList(),
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test"), table);
+    }
+
+    private static LakeTableAsyncFastSchemaChangeJob assertMetadataOnlyJob(AlterJobV2 job) {
+        assertNotNull(job, "expected a job to be built");
+        assertFalse(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "must NOT be the K-tablet data-rewrite job, got: " + job);
+        assertTrue(job instanceof LakeTableAsyncFastSchemaChangeJob,
+                "expected the async metadata-only job, got: " + job);
+        LakeTableAsyncFastSchemaChangeJob aj = (LakeTableAsyncFastSchemaChangeJob) job;
+        assertNotNull(aj.getTargetRanges(), "targetRanges must be set");
+        assertFalse(aj.getTargetRanges().isEmpty(), "targetRanges must be non-empty");
+        return aj;
+    }
+
+    private static void assertContiguousKeyPrefix(List<Column> columns) {
+        boolean sawValue = false;
+        for (Column column : columns) {
+            if (column.isKey()) {
+                assertFalse(sawValue, "key column after a value column breaks the prefix: " + column.getName());
+            } else {
+                sawValue = true;
+            }
+        }
+    }
+
+    private static int countBaseTablets(OlapTable table) {
+        long baseId = table.getBaseIndexMetaId();
+        int count = 0;
+        for (PhysicalPartition pp : table.getPhysicalPartitions()) {
+            MaterializedIndex idx = pp.getLatestIndex(baseId);
+            if (idx != null) {
+                count += idx.getTablets().size();
+            }
+        }
+        return count;
+    }
+
+    @Test
+    public void testAddTrailingKeyColRunsMetadataOnlyDup() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_dup"));
+        OlapTable table = getTable("t_add_meta_dup");
+        long baseId = table.getBaseIndexMetaId();
+        short oldShortKey = table.getIndexMetaByMetaId(baseId).getShortKeyColumnCount();
+        long oldKeyCount = table.getSchemaByIndexMetaId(baseId).stream().filter(Column::isKey).count();
+        int tabletCount = countBaseTablets(table);
+
+        AlterJobV2 job = buildAlterJob("t_add_meta_dup",
+                "alter table t_add_meta_dup add column c int key default '0'");
+        LakeTableAsyncFastSchemaChangeJob aj = assertMetadataOnlyJob(job);
+        assertEquals(tabletCount, aj.getTargetRanges().size(), "one target range per base tablet");
+
+        SchemaInfo si = aj.getSchemaInfoList().get(0);
+        Column added = si.getColumns().stream().filter(c -> c.getName().equalsIgnoreCase("c"))
+                .findFirst().orElseThrow();
+        assertTrue(added.isKey(), "added column c must be a key");
+        // DUP key-derived sort key == key columns, so the sort-key arity grows with the key count.
+        long newKeyCount = si.getColumns().stream().filter(Column::isKey).count();
+        assertEquals(oldKeyCount + 1, newKeyCount, "sort/key arity grew by one");
+        assertTrue(si.getShortKeyColumnCount() > oldShortKey, "short key count grew");
+        assertContiguousKeyPrefix(si.getColumns());
+    }
+
+    @Test
+    public void testAddTrailingKeyColRunsMetadataOnlyAgg() throws Exception {
+        starRocksAssert.withTable(aggRangeTableWithValueDdl("t_add_meta_agg"));
+        assertOrderByRangeTrailingKeyAddMetadataOnly("t_add_meta_agg");
+    }
+
+    @Test
+    public void testAddTrailingKeyColRunsMetadataOnlyUnique() throws Exception {
+        starRocksAssert.withTable(uniqueRangeTableWithValueDdl("t_add_meta_uniq"));
+        assertOrderByRangeTrailingKeyAddMetadataOnly("t_add_meta_uniq");
+    }
+
+    // AGG/UNIQUE range tables carry an explicit sort key (sortKeyIdxes); the new key column is appended
+    // to it in lockstep, so both the sort-key arity and the short-key count grow.
+    private void assertOrderByRangeTrailingKeyAddMetadataOnly(String tableName) throws Exception {
+        OlapTable table = getTable(tableName);
+        long baseId = table.getBaseIndexMetaId();
+        int oldSortKeyArity = table.getIndexMetaByMetaId(baseId).getSortKeyIdxes().size();
+        short oldShortKey = table.getIndexMetaByMetaId(baseId).getShortKeyColumnCount();
+
+        AlterJobV2 job = buildAlterJob(tableName,
+                "alter table " + tableName + " add column c int key default '0'");
+        LakeTableAsyncFastSchemaChangeJob aj = assertMetadataOnlyJob(job);
+
+        SchemaInfo si = aj.getSchemaInfoList().get(0);
+        assertEquals(oldSortKeyArity + 1, si.getSortKeyIndexes().size(), "sort key arity grew by one");
+        int lastIdx = si.getSortKeyIndexes().get(si.getSortKeyIndexes().size() - 1);
+        assertEquals("c", si.getColumns().get(lastIdx).getName(), "new column is the trailing sort key");
+        assertTrue(si.getColumns().get(lastIdx).isKey());
+        assertTrue(si.getShortKeyColumnCount() > oldShortKey, "short key count grew");
+        assertContiguousKeyPrefix(si.getColumns());
+    }
+
+    /**
+     * The resolved schema of a metadata-only AGG/UNIQUE trailing key add keeps the key columns a
+     * contiguous leading prefix and points {@code sort_key_idxes} exactly at those prefix positions --
+     * the FE obligation the BE merge/aggregate path relies on (design's AGG/UNIQUE lockstep rule).
+     */
+    @Test
+    public void testAggUniqueAddContiguousKeyPrefixAndSortKeyIdxes() throws Exception {
+        starRocksAssert.withTable(aggRangeTableWithValueDdl("t_add_meta_ck_agg"));
+        starRocksAssert.withTable(uniqueRangeTableWithValueDdl("t_add_meta_ck_uniq"));
+        for (String tableName : new String[] {"t_add_meta_ck_agg", "t_add_meta_ck_uniq"}) {
+            AlterJobV2 job = buildAlterJob(tableName,
+                    "alter table " + tableName + " add column c int key default '0'");
+            LakeTableAsyncFastSchemaChangeJob aj = assertMetadataOnlyJob(job);
+            SchemaInfo si = aj.getSchemaInfoList().get(0);
+            assertContiguousKeyPrefix(si.getColumns());
+            List<Integer> sortKeyIdxes = si.getSortKeyIndexes();
+            long keyCount = si.getColumns().stream().filter(Column::isKey).count();
+            assertEquals(keyCount, sortKeyIdxes.size(), "sort key covers exactly the key columns");
+            for (int i = 0; i < sortKeyIdxes.size(); i++) {
+                assertEquals(i, sortKeyIdxes.get(i).intValue(), "sort key idx matches key prefix position");
+                assertTrue(si.getColumns().get(sortKeyIdxes.get(i)).isKey());
+            }
+        }
+    }
+
+    /**
+     * A tablet with a bounded (non-all) range is reprojected in place: each existing boundary tuple
+     * gains one trailing NULL sentinel for the new column, its prefix values preserved.
+     */
+    @Test
+    public void testAddTrailingKeyColReprojectsBoundedRangeWithNullSentinel() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_bounded"));
+        OlapTable table = getTable("t_add_meta_bounded");
+        long baseId = table.getBaseIndexMetaId();
+        long tabletId = -1;
+        for (PhysicalPartition pp : table.getPhysicalPartitions()) {
+            for (Tablet t : pp.getLatestIndex(baseId).getTablets()) {
+                t.setRange(new TabletRange(Range.of(
+                        new Tuple(List.of(Variant.of(IntegerType.INT, "10"), Variant.of(IntegerType.INT, "20"))),
+                        new Tuple(List.of(Variant.of(IntegerType.INT, "30"), Variant.of(IntegerType.INT, "40"))),
+                        true, false)));
+                tabletId = t.getId();
+            }
+        }
+
+        AlterJobV2 job = buildAlterJob("t_add_meta_bounded",
+                "alter table t_add_meta_bounded add column c int key default '0'");
+        LakeTableAsyncFastSchemaChangeJob aj = assertMetadataOnlyJob(job);
+
+        Range<Tuple> reprojected = aj.getTargetRanges().get(tabletId).getRange();
+        assertEquals(3, reprojected.getLowerBound().getValues().size(), "lower bound arity grew to 3");
+        assertEquals(3, reprojected.getUpperBound().getValues().size(), "upper bound arity grew to 3");
+        assertTrue(reprojected.getLowerBound().getValues().get(2) instanceof NullVariant,
+                "trailing lower sentinel is NULL");
+        assertTrue(reprojected.getUpperBound().getValues().get(2) instanceof NullVariant,
+                "trailing upper sentinel is NULL");
+        assertEquals("10", reprojected.getLowerBound().getValues().get(0).getStringValue(),
+                "existing prefix values preserved");
+        assertEquals("40", reprojected.getUpperBound().getValues().get(1).getStringValue(),
+                "existing prefix values preserved");
+    }
+
+    /**
+     * A PRIMARY KEY range table's ADD COLUMN KEY is rejected during statement analysis (a PK key column
+     * cannot carry the aggregate the analyzer assigns), so it never reaches the metadata-only
+     * classifier -- existing behavior, not the async job.
+     */
+    @Test
+    public void testPkRangeAddKeyColNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(primaryKeyRangeTableWithValueDdl("t_add_meta_pk"));
+        assertThrows(Throwable.class, () ->
+                buildAlterJob("t_add_meta_pk", "alter table t_add_meta_pk add column c int key default '0'"));
+    }
+
+    /**
+     * Promoting an existing value column to a key is a MODIFY (keyness flip), not an ADD, so it is
+     * never diverted to the metadata-only ADD job; it stays on the MODIFY path and is rejected on
+     * range tables.
+     */
+    @Test
+    public void testPromoteExistingColumnToKeyNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_add_meta_promote"));
+        DdlException e = assertThrowsDdlException(() ->
+                buildAlterJob("t_add_meta_promote", "alter table t_add_meta_promote modify column v1 int key"));
+        assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("range distribution"),
+                "Expected 'range distribution' in: " + e.getMessage());
+    }
+
+    /**
+     * Colocate range tables are excluded from range-rewrite routing, so an ADD COLUMN KEY is not
+     * diverted and the existing range-distribution rejection applies (unaffected by the diversion).
+     */
+    @Test
+    public void testColocateRangeAddKeyColUnaffected() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_colo"));
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isColocateTable(long tableId) {
+                return true;
+            }
+        };
+        DdlException e = assertThrowsDdlException(() ->
+                buildAlterJob("t_add_meta_colo", "alter table t_add_meta_colo add column c int key default '0'"));
+        assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("range distribution"),
+                "Expected 'range distribution' in: " + e.getMessage());
+    }
+
+    /**
+     * AUTO_INCREMENT range tables are excluded from range-rewrite routing, so an ADD COLUMN KEY stays
+     * on the existing range-distribution rejection (unaffected by the diversion).
+     */
+    @Test
+    public void testAutoIncrementRangeAddKeyColUnaffected() throws Exception {
+        starRocksAssert.withTable("create table t_add_meta_autoinc "
+                + "(k1 int not null, k2 int not null, id bigint not null auto_increment)\n"
+                + "duplicate key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1');");
+        DdlException e = assertThrowsDdlException(() ->
+                buildAlterJob("t_add_meta_autoinc",
+                        "alter table t_add_meta_autoinc add column c int key default '0'"));
+        assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("range distribution"),
+                "Expected 'range distribution' in: " + e.getMessage());
+    }
+
+    /**
+     * With temp partitions present, the schema-change loop rejects early (unchanged), so an ADD COLUMN
+     * KEY never reaches the metadata-only diversion.
+     */
+    @Test
+    public void testTempPartitionRangeAddKeyColUnaffected() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_temp"));
+        new MockUp<OlapTable>() {
+            @Mock
+            public boolean existTempPartitions() {
+                return true;
+            }
+        };
+        DdlException e = assertThrowsDdlException(() ->
+                buildAlterJob("t_add_meta_temp", "alter table t_add_meta_temp add column c int key default '0'"));
+        assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("temp partition"),
+                "Expected 'temp partition' in: " + e.getMessage());
+    }
+
+    /**
+     * Regression: adding a VALUE column (not a key) to a range DUP table is unaffected by the
+     * diversion -- it is applied as an ordinary fast-schema-evolution change, never the metadata-only
+     * trailing-key job.
+     */
+    @Test
+    public void testDupValueColumnAddUnaffected() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_val"));
+        AlterJobV2 job = buildAlterJob("t_add_meta_val",
+                "alter table t_add_meta_val add column c int default '0'");
+        assertFalse(job instanceof LakeTableAsyncFastSchemaChangeJob,
+                "value-column add must not be the metadata-only job, got: " + job);
+    }
+
+    /**
+     * Regression: an ordinary (non-range) table's ADD COLUMN KEY is unaffected -- it stays on the
+     * standard schema-change path, never the metadata-only trailing-key job.
+     */
+    @Test
+    public void testNonRangeAddKeyColUnaffected() throws Exception {
+        boolean saved = Config.enable_range_distribution;
+        Config.enable_range_distribution = false;
+        try {
+            starRocksAssert.withTable("create table t_add_meta_hash (k1 int, k2 int, v1 int)\n"
+                    + "DUPLICATE KEY(k1, k2) DISTRIBUTED BY HASH(k1) BUCKETS 2\n"
+                    + "properties('replication_num' = '1');");
+            AlterJobV2 job = buildAlterJob("t_add_meta_hash",
+                    "alter table t_add_meta_hash add column c int key default '0'");
+            assertFalse(job instanceof LakeTableAsyncFastSchemaChangeJob,
+                    "non-range add key must not be metadata-only, got: " + job);
+        } finally {
+            Config.enable_range_distribution = saved;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -1382,4 +1382,22 @@ public class RangeDistributionGuardTest {
             Config.enable_range_distribution = saved;
         }
     }
+
+    /**
+     * A batch combining the trailing key-column ADD with another SCHEMA_CHANGE clause (ADD and MODIFY
+     * both map to AlterOpType.SCHEMA_CHANGE, so conflict analysis allows the batch) must NOT be routed
+     * to the metadata-only async job: that job would carry the MODIFY'd column's new type in the
+     * schema with no data rewrite, while old segments still hold the pre-MODIFY encoding. The batch
+     * must be rejected precisely, mirroring {@code buildRoutedAddKeyColumnJob}'s single-clause check.
+     */
+    @Test
+    public void testAddTrailingKeyColCombinedWithModifyColumnRejected() throws Exception {
+        starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_combined"));
+        DdlException e = assertThrowsDdlException(() ->
+                buildAlterJob("t_add_meta_combined",
+                        "alter table t_add_meta_combined add column c int key default '0', "
+                                + "modify column v1 bigint"));
+        assertTrue(e.getMessage().contains("can not be combined with other alter operations"),
+                "Expected combined-op rejection in: " + e.getMessage());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -991,6 +991,59 @@ public class RangeDistributionGuardTest {
         assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
     }
 
+    /**
+     * A single ADD COLUMNS clause that co-adds the trailing key AND another brand-new (value) column
+     * must NOT be classified as metadata-only: the extra column may need materialization (e.g.
+     * AUTO_INCREMENT / generated / non-constant default) that the metadata-only path does not perform.
+     * The batch must fall through to the data-rewrite path, which materializes it.
+     */
+    @Test
+    public void testCoAddedValueColumnNotMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_coadd"));
+        OlapTable table = getTable("t_meta_coadd");
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
+
+        Column newKeyColumn = constKeyColumn(table, "c_new");
+        // A second brand-new column co-added in the same clause: a value column.
+        Column newValueColumn = new Column("v_new", IntegerType.INT);
+        newValueColumn.setIsKey(false);
+        newValueColumn.setUniqueId(table.getMaxColUniqueId() + 2000);
+        newValueColumn.setDefaultValue("0");
+
+        List<Column> newSchema = new ArrayList<>();
+        for (Column column : oldSchema) {
+            if (column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        newSchema.add(newKeyColumn);
+        for (Column column : oldSchema) {
+            if (!column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        newSchema.add(newValueColumn);
+
+        List<Integer> candidateSortKeyUniqueIds = new ArrayList<>();
+        for (Column column : oldSortKey) {
+            candidateSortKeyUniqueIds.add(column.getUniqueId());
+        }
+        candidateSortKeyUniqueIds.add(newKeyColumn.getUniqueId());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        SchemaChangeData resolved = SchemaChangeData.newBuilder()
+                .withDatabase(db)
+                .withTable(table)
+                .withNewIndexMetaIdToSchema(baseIndexMetaId, newSchema)
+                .withSortKeyUniqueIds(candidateSortKeyUniqueIds)
+                .build();
+        assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
     @Test
     public void testMultiIndexTableNotMetadataOnly() throws Exception {
         starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_multi"));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -1044,6 +1044,57 @@ public class RangeDistributionGuardTest {
         assertFalse(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
     }
 
+    /**
+     * Adding two brand-new trailing key columns (both constant-default) in one clause is metadata-only:
+     * the candidate sort key is the old sort key plus both new keys as a trailing block, in order.
+     */
+    @Test
+    public void testMultipleTrailingKeyAddsAreMetadataOnly() throws Exception {
+        starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_multi_key"));
+        OlapTable table = getTable("t_meta_multi_key");
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        List<Column> oldSchema = table.getSchemaByIndexMetaId(baseIndexMetaId);
+        MaterializedIndexMeta oldIndexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Column> oldSortKey = SchemaChangeHandler.resolveEffectiveSortKeyColumns(
+                oldSchema, oldIndexMeta.getSortKeyUniqueIds(), oldIndexMeta.getSortKeyIdxes());
+
+        Column c1 = constKeyColumn(table, "c_new1");
+        Column c2 = new Column("c_new2", IntegerType.INT);
+        c2.setIsKey(true);
+        c2.setUniqueId(table.getMaxColUniqueId() + 2000);
+        c2.setDefaultValue("0");
+
+        List<Column> newSchema = new ArrayList<>();
+        for (Column column : oldSchema) {
+            if (column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+        newSchema.add(c1);
+        newSchema.add(c2);
+        for (Column column : oldSchema) {
+            if (!column.isKey()) {
+                newSchema.add(column);
+            }
+        }
+
+        List<Integer> candidateSortKeyUniqueIds = new ArrayList<>();
+        for (Column column : oldSortKey) {
+            candidateSortKeyUniqueIds.add(column.getUniqueId());
+        }
+        candidateSortKeyUniqueIds.add(c1.getUniqueId());
+        candidateSortKeyUniqueIds.add(c2.getUniqueId());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        SchemaChangeData resolved = SchemaChangeData.newBuilder()
+                .withDatabase(db)
+                .withTable(table)
+                .withNewIndexMetaIdToSchema(baseIndexMetaId, newSchema)
+                .withSortKeyUniqueIds(candidateSortKeyUniqueIds)
+                .build();
+        assertTrue(SchemaChangeHandler.isMetadataOnlyTrailingKeyAdd(resolved));
+    }
+
     @Test
     public void testMultiIndexTableNotMetadataOnly() throws Exception {
         starRocksAssert.withTable(dupRangeTableWithValueDdl("t_meta_multi"));

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeKeyColumnRoutingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeKeyColumnRoutingTest.java
@@ -164,12 +164,11 @@ public class RangeKeyColumnRoutingTest {
     @Test
     public void testAddKeyColumnAfterValueColumnRejected() throws Exception {
         // The added column is still routed (it is KEY and the sort key is key-derived), but placing it
-        // AFTER the value column v1 would break the key prefix (schema becomes [k1, v1, k2]). Routing
-        // must re-validate the post-add schema itself and reject precisely, rather than silently
-        // building a job on an invalid schema.
+        // AFTER the value column v1 would break the key prefix (schema becomes [k1, v1, k2]). The routed
+        // add now flows through finalAnalyze, which rejects the invalid column order before any job is
+        // built.
         OlapTable dup = buildLakeRangeTable(KeysType.DUP_KEYS, List.of("k1"));
-        assertThrowsDdl("ADD COLUMN produced an invalid key schema (keys must be a contiguous prefix) "
-                        + "on range-distribution table " + dup.getName(),
+        assertThrowsDdl("Invalid column order. value should be after key",
                 () -> alter(dup, "ADD COLUMN k2 INT KEY DEFAULT '0' AFTER v1"));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/TrailingSortKeyRangeReprojectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/TrailingSortKeyRangeReprojectionTest.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.NullVariant;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Range;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class TrailingSortKeyRangeReprojectionTest {
+
+    private static final Column NEW_COLUMN = new Column("k2", VarcharType.VARCHAR);
+
+    private static Tuple makeTuple(int value) {
+        return new Tuple(Arrays.asList(Variant.of(IntegerType.INT, String.valueOf(value))));
+    }
+
+    @Test
+    public void testAppendToAllRangeReturnsAll() {
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(Range.all(), NEW_COLUMN);
+        Assertions.assertTrue(result.isAll());
+    }
+
+    // [100, 200) -> [(100, NULL), (200, NULL))
+    @Test
+    public void testAppendToBoundedRangePreservesPrefixAndInclusivity() {
+        Range<Tuple> old = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+
+        Assertions.assertTrue(result.isLowerBoundIncluded());
+        Assertions.assertFalse(result.isUpperBoundIncluded());
+
+        Tuple lower = result.getLowerBound();
+        Assertions.assertEquals(2, lower.getValues().size());
+        Assertions.assertEquals("100", lower.getValues().get(0).getStringValue());
+        Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
+
+        Tuple upper = result.getUpperBound();
+        Assertions.assertEquals(2, upper.getValues().size());
+        Assertions.assertEquals("200", upper.getValues().get(0).getStringValue());
+        Assertions.assertTrue(upper.getValues().get(1) instanceof NullVariant);
+
+        // original tuple must not be mutated
+        Assertions.assertEquals(1, old.getLowerBound().getValues().size());
+        Assertions.assertEquals(1, old.getUpperBound().getValues().size());
+    }
+
+    // (-inf, 200) -> (-inf, (200, NULL))
+    @Test
+    public void testAppendKeepsLowerUnboundedAndExtendsUpperOnly() {
+        Range<Tuple> old = Range.lt(makeTuple(200));
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+
+        Assertions.assertTrue(result.isMinimum());
+        Assertions.assertNull(result.getLowerBound());
+        Assertions.assertFalse(result.isUpperBoundIncluded());
+
+        Tuple upper = result.getUpperBound();
+        Assertions.assertEquals(2, upper.getValues().size());
+        Assertions.assertEquals("200", upper.getValues().get(0).getStringValue());
+        Assertions.assertTrue(upper.getValues().get(1) instanceof NullVariant);
+    }
+
+    // [100, +inf) -> [(100, NULL), +inf)
+    @Test
+    public void testAppendKeepsUpperUnboundedAndExtendsLowerOnly() {
+        Range<Tuple> old = Range.ge(makeTuple(100));
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+
+        Assertions.assertTrue(result.isMaximum());
+        Assertions.assertNull(result.getUpperBound());
+        Assertions.assertTrue(result.isLowerBoundIncluded());
+
+        Tuple lower = result.getLowerBound();
+        Assertions.assertEquals(2, lower.getValues().size());
+        Assertions.assertEquals("100", lower.getValues().get(0).getStringValue());
+        Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
+    }
+
+    @Test
+    public void testAppendedNullVariantHasNewColumnType() {
+        Range<Tuple> old = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+
+        Assertions.assertEquals(VarcharType.VARCHAR, result.getLowerBound().getValues().get(1).getType());
+        Assertions.assertEquals(VarcharType.VARCHAR, result.getUpperBound().getValues().get(1).getType());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/TrailingSortKeyRangeReprojectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/TrailingSortKeyRangeReprojectionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class TrailingSortKeyRangeReprojectionTest {
 
@@ -36,7 +37,7 @@ public class TrailingSortKeyRangeReprojectionTest {
 
     @Test
     public void testAppendToAllRangeReturnsAll() {
-        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(Range.all(), NEW_COLUMN);
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(Range.all(), List.of(NEW_COLUMN));
         Assertions.assertTrue(result.isAll());
     }
 
@@ -44,7 +45,7 @@ public class TrailingSortKeyRangeReprojectionTest {
     @Test
     public void testAppendToBoundedRangePreservesPrefixAndInclusivity() {
         Range<Tuple> old = Range.gelt(makeTuple(100), makeTuple(200));
-        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, List.of(NEW_COLUMN));
 
         Assertions.assertTrue(result.isLowerBoundIncluded());
         Assertions.assertFalse(result.isUpperBoundIncluded());
@@ -68,7 +69,7 @@ public class TrailingSortKeyRangeReprojectionTest {
     @Test
     public void testAppendKeepsLowerUnboundedAndExtendsUpperOnly() {
         Range<Tuple> old = Range.lt(makeTuple(200));
-        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, List.of(NEW_COLUMN));
 
         Assertions.assertTrue(result.isMinimum());
         Assertions.assertNull(result.getLowerBound());
@@ -84,7 +85,7 @@ public class TrailingSortKeyRangeReprojectionTest {
     @Test
     public void testAppendKeepsUpperUnboundedAndExtendsLowerOnly() {
         Range<Tuple> old = Range.ge(makeTuple(100));
-        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, List.of(NEW_COLUMN));
 
         Assertions.assertTrue(result.isMaximum());
         Assertions.assertNull(result.getUpperBound());
@@ -96,10 +97,32 @@ public class TrailingSortKeyRangeReprojectionTest {
         Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
     }
 
+    // [100, 200) with two trailing keys -> [(100, NULL, NULL), (200, NULL, NULL))
+    @Test
+    public void testAppendMultipleTrailingColumns() {
+        Column k3 = new Column("k3", IntegerType.INT);
+        Range<Tuple> old = Range.gelt(makeTuple(100), makeTuple(200));
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, List.of(NEW_COLUMN, k3));
+
+        Tuple lower = result.getLowerBound();
+        Assertions.assertEquals(3, lower.getValues().size());
+        Assertions.assertEquals("100", lower.getValues().get(0).getStringValue());
+        Assertions.assertTrue(lower.getValues().get(1) instanceof NullVariant);
+        Assertions.assertTrue(lower.getValues().get(2) instanceof NullVariant);
+        Assertions.assertEquals(VarcharType.VARCHAR, lower.getValues().get(1).getType());
+        Assertions.assertEquals(IntegerType.INT, lower.getValues().get(2).getType());
+
+        Tuple upper = result.getUpperBound();
+        Assertions.assertEquals(3, upper.getValues().size());
+        Assertions.assertEquals("200", upper.getValues().get(0).getStringValue());
+        Assertions.assertTrue(upper.getValues().get(1) instanceof NullVariant);
+        Assertions.assertTrue(upper.getValues().get(2) instanceof NullVariant);
+    }
+
     @Test
     public void testAppendedNullVariantHasNewColumnType() {
         Range<Tuple> old = Range.gelt(makeTuple(100), makeTuple(200));
-        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, NEW_COLUMN);
+        Range<Tuple> result = TrailingSortKeyRangeReprojection.appendTrailing(old, List.of(NEW_COLUMN));
 
         Assertions.assertEquals(VarcharType.VARCHAR, result.getLowerBound().getValues().get(1).getType());
         Assertions.assertEquals(VarcharType.VARCHAR, result.getUpperBound().getValues().get(1).getType());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
@@ -32,6 +32,7 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -548,6 +549,85 @@ public class RangeDistributionPrunerTest {
         // signed-byte compare inverts that range and orders every tablet above the query, so the
         // pruner returns empty (misses tablet 3) -- this assertion is the RED/GREEN guard.
         Assertions.assertEquals(Collections.singleton(3L), new HashSet<>(pruner.prune()));
+    }
+
+    @Test
+    public void testArityMismatchOnFirstTabletReturnsAllTabletsNotPrefix() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        // Tablet 1's range has 2 columns while rangeDistributionColumns only has 1: arity mismatch.
+        tablets.add(createTablet(1L, Lists.newArrayList("0", "0"), Lists.newArrayList("9", "9"),
+                Lists.newArrayList(k1, k1)));
+        tablets.add(createTablet(2L, "10", "19", k1));
+        tablets.add(createTablet(3L, "20", "29", k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("15"), true);
+        filter.setUpperBound(new StringLiteral("15"), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(1L, 2L, 3L)),
+                new HashSet<>(result));
+    }
+
+    @Test
+    public void testArityMismatchOnMiddleTabletReturnsAllTablets() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "0", "9", k1));
+        // Tablet 2 (middle) has a 2-column range while rangeDistributionColumns only has 1: arity mismatch.
+        tablets.add(createTablet(2L, Lists.newArrayList("10", "10"), Lists.newArrayList("19", "19"),
+                Lists.newArrayList(k1, k1)));
+        tablets.add(createTablet(3L, "20", "29", k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("25"), true);
+        filter.setUpperBound(new StringLiteral("25"), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(1L, 2L, 3L)),
+                new HashSet<>(result));
+    }
+
+    @Test
+    public void testCaptureRangeOnceIgnoresDifferentReferenceOnSecondCall() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        Tablet mockedTablet = Mockito.mock(Tablet.class);
+        Mockito.when(mockedTablet.getId()).thenReturn(1L);
+        TabletRange firstSnapshot = new TabletRange(Range.of(
+                new Tuple(Lists.newArrayList(Variant.of(k1.getType(), "0"))),
+                new Tuple(Lists.newArrayList(Variant.of(k1.getType(), "9"))),
+                true, true));
+        // Every call after the first returns null: if the pruner ever re-fetches the range instead of
+        // using its first captured snapshot, this would surface as a crash rather than a wrong result.
+        Mockito.when(mockedTablet.getRange()).thenReturn(firstSnapshot, (TabletRange) null);
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("5"), true);
+        filter.setUpperBound(new StringLiteral("5"), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(Lists.newArrayList(mockedTablet), Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(Collections.singleton(1L), new HashSet<>(result));
     }
 
     private Tablet createTablet(long id, String lower, String upper, Column column) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeRollupPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeRollupPrunerTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Regression tests for the per-index distribution pruning fix:
@@ -107,20 +106,27 @@ public class RangeRollupPrunerTest {
     }
 
     /**
-     * Documents the pre-fix crash mode: supplying the base's 2-column list against
-     * rollup tablets with 1-column ranges raises an arity {@code IllegalStateException}.
-     * The fix avoids this by using the rollup's own column list.
+     * A concurrent metadata-only sort-key flip can transiently mix tablet ranges of the old and
+     * new arity, so an arity mismatch between the tablet ranges and the supplied column list must
+     * degrade to a full scan (return every tablet) rather than throwing or silently dropping
+     * tablets. Passing the rollup's own column list (see the tests above) keeps arity aligned so
+     * this fallback is not hit in the normal rollup path.
      */
     @Test
-    public void testPrunerArityMismatchThrows() {
+    public void testPrunerArityMismatchDegradesToFullScan() {
         Column k1 = new Column("k1", IntegerType.INT, false);
         Column k2 = new Column("k2", IntegerType.INT, false);
 
-        assertThrows(IllegalStateException.class, () ->
-                new RangeDistributionPruner(
-                        Lists.newArrayList(createTablet(1L, "0", "9", k2)),
-                        Lists.newArrayList(k1, k2), // base's 2-column list — arity mismatch
-                        Maps.newHashMap()));
+        List<Tablet> tablets = Lists.newArrayList(
+                createTablet(1L, "0", "9", k2),
+                createTablet(2L, "10", "19", k2),
+                createTablet(3L, "20", "29", k2));
+
+        // base's 2-column list against 1-column tablet ranges — arity mismatch
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1, k2), Maps.newHashMap());
+
+        assertEquals(Set.of(1L, 2L, 3L), new HashSet<>(pruner.prune()));
     }
 
     // ---- OptDistributionPruner (optimizer-rewrite) path tests ----------

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -350,6 +350,7 @@ message MetadataUpdateInfoPB {
     optional bool bundle_tablet_metadata = 4;
     optional CompactionStrategyPB compaction_strategy = 5;
     optional FlatJsonConfigPB flat_json_config = 6;
+    optional TabletRangePB range = 7;
 }
 
 message BundleTabletMetadataPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -350,7 +350,7 @@ message MetadataUpdateInfoPB {
     optional bool bundle_tablet_metadata = 4;
     optional CompactionStrategyPB compaction_strategy = 5;
     optional FlatJsonConfigPB flat_json_config = 6;
-    optional TabletRangePB range = 7;
+    optional TabletRangePB tablet_range = 7;
 }
 
 message BundleTabletMetadataPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -558,7 +558,7 @@ struct TTabletMetaInfo {
     12: optional TFlatJsonConfig flat_json_config;
     13: optional bool bundle_tablet_metadata;
     14: optional TCompactionStrategy compaction_strategy;
-    15: optional Types.TTabletRange range;
+    15: optional Types.TTabletRange tablet_range;
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -558,6 +558,7 @@ struct TTabletMetaInfo {
     12: optional TFlatJsonConfig flat_json_config;
     13: optional bool bundle_tablet_metadata;
     14: optional TCompactionStrategy compaction_strategy;
+    15: optional Types.TTabletRange range;
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
## Why I'm doing:

On shared-data (cloud-native) range-distribution tables, adding a key column currently routes to a full K-tablet data rewrite (O(data)), even when the change only appends a brand-new **trailing** sort-key column with a constant/NULL default. In that case the on-disk composite-key encoding of existing rows stays byte-identical (old segments serve the new column as a uniform default, which is non-discriminating in the per-segment sorted seek and the AGG/UNIQUE merge/aggregate), so the rewrite is unnecessary. This makes a common schema change far more expensive than it needs to be.

## What I'm doing:

Add an O(1) **metadata-only** fast path for `ALTER TABLE ... ADD COLUMN <c> KEY DEFAULT <const>` that appends one or more brand-new trailing sort-key columns on shared-data range-distribution **DUPLICATE / AGGREGATE / UNIQUE** tables, instead of the K-tablet data rewrite:

- Reproject each tablet's boundary tuple by appending one canonical NULL sentinel (`Variant.nullVariant`) per newly added column, preserving unbounded sides — routing-neutral, so every row still maps to the same tablet.
- Push the reprojected per-tablet ranges to the BE over the existing tablet-meta update channel via a new optional `tablet_range` field (thrift `TTabletMetaInfo`, proto `MetadataUpdateInfoPB`, reusing `TTabletRange`/`TabletRangePB`).
- BE apply validates the transition (new = old + exactly N trailing typed NULLs, one per added column; existing sort keys unchanged) and structural well-formedness, archives the old rowset schema with the non-clearing pattern, and writes `TabletMetadataPB.range`. `Rowset::get_seek_range()` decodes a per-rowset or tablet-fallback range with whichever available schema's sort-key arity matches the range's bound arity, so old rowsets stay readable across the arity change — including after a later automatic tablet reshard/split that stamps a current-arity range onto rowsets still carrying the archived (smaller) schema.
- FE flips tablet ranges in place under the table write lock in two phases (all fallible validation before the `FINISHED` journal record; a must-not-fail install after), from a persisted immutable target-range map, with exact-state replay idempotency. The range pruner degrades to a full scan (never drops tablets) on a transient arity mismatch.

Every non-eligible case falls through to the existing data-rewrite / reject paths unchanged: DROP, sort-key type widens, PRIMARY KEY, AGG/UNIQUE key drop, promoting an existing column to a key, a batch combined with other alter clauses, colocate / AUTO_INCREMENT / multi-index / temp-partition tables, and sort-key arities beyond the supported cap.

The result schema is byte-for-byte identical to what the rewrite path produces; only the execution mechanism and cost change. Covered by FE unit tests (routing/classifier, boundary reprojection, in-place flip + idempotency, pruner defense) and BE unit tests (transition/structural validation, non-clearing archival, seek-range decode incl. read-before/after-compaction for DUP/AGG/UNIQUE and the reshard-after-add arity-matching case). Validated end-to-end on a shared-data cluster (1 FE + 3 CN): the metadata-only add on DUP / AGG / UNIQUE (single- and multi-bounded-tablet) with `cloud_native_fast_schema_evolution_v2` both on and off — data conserved, per-tablet boundaries reprojected with the trailing NULL sentinel, routing preserved across reprojected tablet boundaries, and reads remain correct after a subsequent automatic tablet reshard/split of a metadata-only-altered tablet.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Compatibility

This is a forward-only on-disk change for shared-data range-distribution tables. After a metadata-only
trailing sort-key ADD (optionally followed by a reshard), a tablet's persisted per-tablet range can have
a sort-key arity larger than an old rowset's archived schema. The new BE reads this correctly via a
prefix-projection in `create_seek_range_from`; a pre-projection BE (e.g. an older 4.1 build) would fail
the exact-arity decode. Downgrade safety is addressed by backporting the read-side projection to
branch-4.1 so a downgraded 4.1 BE tolerates a main-written range. Rolling upgrade is safe by the
standard BE/CN-before-FE order: only a new FE emits the wider range, and it only meets already-upgraded
BEs. The feature is main-only / unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

