### PR TITLE
[BugFix] Fix Delta Lake partition pruning when a string date partition column is compared with a temporal value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -31,6 +31,7 @@ import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
+import com.starrocks.connector.PartitionCastPredicatePruner;
 import com.starrocks.connector.PredicateSearchKey;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
@@ -63,6 +64,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -217,14 +219,20 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         Set<String> partitionColumns = metadata.getPartitionColNames();
 
         List<ScalarOperator> scalarOperators = Utils.extractConjuncts(operator);
+        // Cast-on-string-partition conjuncts (e.g. CAST(c AS DATETIME) = <ts>) are unwrapped by
+        // ScalarOperationToDeltaLakeExpr into a string-domain comparison, which never equals a 'yyyy-MM-dd'
+        // partition value and would prune every file (wrong empty result / under-estimated cardinality). Keep them
+        // out of the pushed predicate and evaluate them StarRocks-side against each file's partition values below.
+        PartitionCastPredicatePruner.PartitionResidual residual = PartitionCastPredicatePruner.split(
+                scalarOperators, identityStringPartitionColumns(deltaLakeTable, partitionColumns));
         ScalarOperationToDeltaLakeExpr.DeltaLakeContext deltaLakeContext =
                 new ScalarOperationToDeltaLakeExpr.DeltaLakeContext(schema, partitionColumns);
-        Predicate deltaLakePredicate = new ScalarOperationToDeltaLakeExpr().convert(scalarOperators, deltaLakeContext);
+        Predicate deltaLakePredicate = new ScalarOperationToDeltaLakeExpr().convert(residual.pushable, deltaLakeContext);
 
         ScanBuilderImpl scanBuilder = (ScanBuilderImpl) snapshot.getScanBuilder();
         ScanImpl scan = (ScanImpl) scanBuilder.withFilter(deltaLakePredicate).build();
         long estimateRowSize = table.getColumns().stream().mapToInt(column -> column.getType().getTypeSize()).sum();
-        return new CloseableIterator<>() {
+        CloseableIterator<Pair<FileScanTask, DeltaLakeAddFileStatsSerDe>> baseIterator = new CloseableIterator<>() {
             CloseableIterator<FilteredColumnarBatch> scanFilesAsBatches;
             CloseableIterator<Row> scanFileRows;
             boolean hasMore = true;
@@ -290,6 +298,75 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
                 }
             }
         };
+
+        if (residual.residual.isEmpty()) {
+            return baseIterator;
+        }
+        // Evaluate the cast-on-string-partition residual StarRocks-side: keep a file unless its partition value
+        // provably cannot satisfy the residual (partitionMayMatch drops only on a definitive false), consistent
+        // with the backend filter and never dropping a possibly-matching file.
+        return new CloseableIterator<>() {
+            Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> nextMatch = null;
+            boolean finished = false;
+
+            @Override
+            public boolean hasNext() {
+                advance();
+                return nextMatch != null;
+            }
+
+            @Override
+            public Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> next() {
+                advance();
+                if (nextMatch == null) {
+                    throw new java.util.NoSuchElementException();
+                }
+                Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> result = nextMatch;
+                nextMatch = null;
+                return result;
+            }
+
+            private void advance() {
+                if (nextMatch != null || finished) {
+                    return;
+                }
+                while (baseIterator.hasNext()) {
+                    Pair<FileScanTask, DeltaLakeAddFileStatsSerDe> candidate = baseIterator.next();
+                    if (PartitionCastPredicatePruner.partitionMayMatch(
+                            residual.residual, candidate.first.getPartitionValues())) {
+                        nextMatch = candidate;
+                        return;
+                    }
+                }
+                finished = true;
+            }
+
+            @Override
+            public void close() {
+                try {
+                    baseIterator.close();
+                } catch (IOException e) {
+                    LOG.error("Failed to close delta lake scan file iterator", e);
+                }
+            }
+        };
+    }
+
+    // Partition columns of string type. Delta partitioning is always identity, so every string partition column is
+    // an identity string partition column for PartitionCastPredicatePruner.split. Package-private for testing.
+    static Set<String> identityStringPartitionColumns(DeltaLakeTable table, Set<String> partitionColumns) {
+        Set<String> lowerPartitionColumns = new HashSet<>();
+        for (String name : partitionColumns) {
+            lowerPartitionColumns.add(name.toLowerCase(Locale.ROOT));
+        }
+        Set<String> result = new HashSet<>();
+        for (Column column : table.getColumns()) {
+            if (lowerPartitionColumns.contains(column.getName().toLowerCase(Locale.ROOT))
+                    && column.getType().isStringType()) {
+                result.add(column.getName().toLowerCase(Locale.ROOT));
+            }
+        }
+        return result;
     }
 
     private RemoteFileInfoSource buildRemoteInfoSource(Table table, GetRemoteFilesParams params) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeMetadataTest.java
@@ -16,6 +16,8 @@ package com.starrocks.connector.delta;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
@@ -260,5 +262,22 @@ public class DeltaLakeMetadataTest {
         String expectedPrefix = "Failed to get deltalake table delta0.db_io.tbl_io";
         Assertions.assertTrue(ex.getMessage().contains(expectedPrefix));
         Assertions.assertTrue(ex.getMessage().contains("io failure"));
+    }
+
+    @Test
+    public void testIdentityStringPartitionColumns() {
+        // Only string-typed partition columns are identity string partition columns: a non-string partition column
+        // and a string non-partition column are both excluded. (Delta partitioning is always identity.)
+        List<Column> schema = Lists.newArrayList(
+                new Column("c1", com.starrocks.type.IntegerType.INT, true),      // non-partition int
+                new Column("c2", com.starrocks.type.StringType.STRING, true),    // partition string -> kept
+                new Column("c3", com.starrocks.type.IntegerType.INT, true),      // partition int -> excluded
+                new Column("c4", com.starrocks.type.StringType.STRING, true));   // non-partition string -> excluded
+        DeltaLakeTable table = new DeltaLakeTable(1, "delta0", "db1", "table1", schema,
+                Lists.newArrayList("c2", "c3"), null, null,
+                new MetastoreTable("db1", "table1", "path/to/table", 123));
+
+        Assertions.assertEquals(Sets.newHashSet("c2"),
+                DeltaLakeMetadata.identityStringPartitionColumns(table, Sets.newHashSet("c2", "c3")));
     }
 }

--- a/test/sql/test_deltalake/R/test_deltalake_string_date_partition_prune
+++ b/test/sql/test_deltalake/R/test_deltalake_string_date_partition_prune
@@ -1,0 +1,42 @@
+-- name: test_deltalake_string_date_partition_prune
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+set new_planner_optimize_timeout = 30000;
+-- result:
+-- !result
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part order by c1;
+-- result:
+1	2020-01-02
+2	2020-06-08
+3	2020-06-14
+4	2020-06-15
+5	2020-06-22
+-- !result
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = cast('2020-06-15' as date) - interval 1 day order by c1;
+-- result:
+3	2020-06-14
+-- !result
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = date_sub(cast('2020-06-15' as date), interval 1 day) order by c1;
+-- result:
+3	2020-06-14
+-- !result
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 >= cast('2020-06-15' as date) - interval 1 day order by c1;
+-- result:
+3	2020-06-14
+4	2020-06-15
+5	2020-06-22
+-- !result
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = '2020-06-14' order by c1;
+-- result:
+3	2020-06-14
+-- !result
+drop catalog delta_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_string_date_partition_prune
+++ b/test/sql/test_deltalake/T/test_deltalake_string_date_partition_prune
@@ -1,0 +1,35 @@
+-- name: test_deltalake_string_date_partition_prune
+-- description: A STRING date partition column compared with a temporal value coerces to CAST(c2 AS DATETIME) = <ts>.
+-- ScalarOperationToDeltaLakeExpr unwraps the cast and compares in the string domain, which never equals a
+-- 'yyyy-MM-dd' partition value, so buildFileScanTaskIterator pruned every file and the query returned empty.
+-- StarRocks now keeps such cast-on-string-partition conjuncts out of the pushed filter and evaluates them
+-- against each file's partition values. Same root cause as the Iceberg series (#76068 / #76107).
+--
+-- StarRocks/Spark can only read Delta; the fixture is created in advance with Spark:
+--   CREATE TABLE delta_oss_db.delta_str_date_part (c1 INT, c2 STRING) USING delta PARTITIONED BY (c2);
+--   INSERT INTO delta_oss_db.delta_str_date_part VALUES
+--     (1,'2020-01-02'),(2,'2020-06-08'),(3,'2020-06-14'),(4,'2020-06-15'),(5,'2020-06-22');
+
+create external catalog delta_test_${uuid0} PROPERTIES (
+    "type"="deltalake",
+    "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+set new_planner_optimize_timeout = 30000;
+
+-- baseline
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part order by c1;
+
+-- cast/interval form: pre-fix returned empty; now selects partition 2020-06-14.
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = cast('2020-06-15' as date) - interval 1 day order by c1;
+-- date_sub builtin form of the same value.
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = date_sub(cast('2020-06-15' as date), interval 1 day) order by c1;
+-- range comparison keeps the correct partitions.
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 >= cast('2020-06-15' as date) - interval 1 day order by c1;
+-- control: bare 'yyyy-MM-dd' literal (no cast, always worked) must agree with the cast forms.
+select c1, c2 from delta_test_${uuid0}.delta_oss_db.delta_str_date_part where c2 = '2020-06-14' order by c1;
+
+drop catalog delta_test_${uuid0};


### PR DESCRIPTION
  ## Why I'm doing

  Same root cause as the Iceberg series, now for the Delta Lake connector. When a STRING date partition
  column is compared with a temporal value, e.g.

      WHERE c2 = cast('2020-06-15' as date) - interval 1 day

  binary-predicate coercion produces `CAST(c2 AS DATETIME) = '2020-06-14 00:00:00'`.
  `ScalarOperationToDeltaLakeExpr` unwraps the cast and renders the temporal constant back to a string,
  so the pushed filter becomes `c2 = '2020-06-14 00:00:00'` (string domain), which never equals a
  `'yyyy-MM-dd'` partition value. `buildFileScanTaskIterator` then prunes every file.

  Because that single plan-files path feeds BOTH `getRemoteFiles` (scan) and `getTableStatistics`
  (cardinality), the query returns empty and the cardinality is under-estimated. This is the Delta
  equivalent of #76068 (scan) and #76107 (cardinality) combined — Delta is read-only and has one
  plan-files path, so a single change covers both symptoms (there is no DELETE / equality-delete path
  like Iceberg's).

  ## What I'm doing

  Reuse `PartitionCastPredicatePruner` (introduced for the Iceberg fix) in `buildFileScanTaskIterator`:

  - split the conjuncts and push **only the non-cast (`pushable`) conjuncts** to the Delta scan filter,
    so the cast-on-string-partition conjunct is no longer compared in the string domain;
  - evaluate the residual **StarRocks-side** against each file's partition values
    (`FileScanTask.getPartitionValues()`): keep a file unless its partition value provably cannot
    satisfy the residual (`partitionMayMatch` drops only on a definitive false, so a possibly-matching
    file is never dropped).

  `identityStringPartitionColumns` is the partition columns of string type (Delta partitioning is
  always identity, so every string partition column is an identity string partition column).

  ## Reproduce

  StarRocks can only read Delta, so the table is created with Spark:

      -- Spark
      CREATE TABLE delta_db.t_dstr (c1 INT, c2 STRING) USING delta PARTITIONED BY (c2);
      INSERT INTO delta_db.t_dstr VALUES (1,'2020-01-02'),(2,'2020-06-08'),(3,'2020-06-14'),(4,'2020-06-15'),(5,'2020-06-22');
    
      -- StarRocks
      SELECT * FROM t_dstr WHERE c2 = cast('2020-06-15' as date) - interval 1 day;
      -- before: Empty set
      -- after : 3 | 2020-06-14
      SELECT * FROM t_dstr WHERE c2 = '2020-06-14';   -- bare-string control, always worked

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
