### PR TITLE
[Refactor] Remove redundant RANGE guard from range-colocate scan dispatch construction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -860,11 +860,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
          */
         Preconditions.checkState(scanBackendIds.size() == 0);
         Preconditions.checkState(scanTabletIds.size() == 0);
-        DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
-        RangeColocateScanDispatch dispatch = null;
-        if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
-            dispatch = RangeColocateScanDispatch.forTable(olapTable);
-        }
+        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(olapTable);
         for (Long partitionId : selectedPartitionIds) {
             final Partition partition = olapTable.getPartition(partitionId);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
-import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.IcebergTable;
@@ -997,11 +996,7 @@ public class PlanFragmentBuilder {
                             .getBackendIdByHost(FrontendOptions.getLocalHostAddress());
                 }
 
-                DistributionInfo distInfo = referenceTable.getDefaultDistributionInfo();
-                RangeColocateScanDispatch dispatch = null;
-                if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
-                    dispatch = RangeColocateScanDispatch.forTable(referenceTable);
-                }
+                RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(referenceTable);
 
                 // Filter out logical partitions that have no non-empty physical sub-partition. The result
                 // keeps deduplicated LOGICAL (parent) partition ids -- matching the convention used by every


### PR DESCRIPTION
## Why I'm doing:

The two dispatch-construction preambles on the range-colocate scan path guard the `RangeColocateScanDispatch.forTable(...)` call with a redundant `type == RANGE` check, e.g.:

```java
DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
RangeColocateScanDispatch dispatch = null;
if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
    dispatch = RangeColocateScanDispatch.forTable(olapTable);
}
```

`RangeColocateScanDispatch.forTable(OlapTable)` already returns `null` for non-RANGE tables as its **first** statement — before any `ColocateTableIndex`/`GlobalStateMgr` lookup and with no side effects:

```java
if (olapTable.getDefaultDistributionInfo().getType() != DistributionInfo.DistributionInfoType.RANGE) {
    return null;
}
```

So the outer guard only re-checked the first third of the predicate `forTable` already enforces internally. The sibling call site `OlapScanNode.getRangeDistributionBucketNums(...)` already calls it guard-free, so the two guarded sites were simply inconsistent with the clean one.

## What I'm doing:

Collapse each guarded preamble to a single guard-free call, matching `getRangeDistributionBucketNums`:

- `OlapScanNode.computeTabletInfo()` → `RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(olapTable);`
- `PlanFragmentBuilder.visitPhysicalOlapScan(...)` → `RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(referenceTable);`

The `DistributionInfo distInfo` local (used only by the removed guard) is dropped at both sites, and the now-unused `import com.starrocks.catalog.DistributionInfo;` is removed from `PlanFragmentBuilder` (the import is retained in `OlapScanNode`, where `DistributionInfo` is still referenced elsewhere). All three `forTable` call sites are now consistent.

**No behavior change.** `dispatch` is identical for every distribution type:

- non-RANGE: old code set `dispatch = null` (guard false); new code calls `forTable(...)`, which returns `null` via its leading non-RANGE early-return.
- RANGE: both call `forTable(...)`.

The nullable consumers (`OlapScanNode.fillTabletId2BucketSeq(@Nullable dispatch, ...)` and the downstream `if (dispatch != null)` blocks) already handle `null`; the set of cases producing a `null` dispatch is unchanged. Cost is neutral-to-cheaper: `getDefaultDistributionInfo()` is a trivial field getter, and the change removes the guard's duplicate getter call on the RANGE path.

### Testing

Behavior-identical guard removal — no new test needed; covered by the existing range-colocate and scan suites, all green locally (JDK 17 + Maven): `RangeColocateScanDispatchTest` (13), `RangeColocateScanRangeDispatchTest` (7), `RangeColocateMixedJoinPlanTest` (17), `RangeColocateNullSafeJoinPlanTest` (7), `RangeColocateColumnsTest` (7), `RangeColocateTableTest` (5), `OlapScanNodeTest` (4) — 60 tests, 0 failures. `:fe-core:checkstyleMain` / `checkstyleTest` clean.

### Backport

Main-only. `[Refactor]` is not auto-backported. The identical guard also exists on the branch-4.1 range-colocate line; 4.1 parity is optional/cosmetic — happy to cherry-pick if feature-line consistency is preferred.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
