### PR TITLE
[BugFix] Exclude NULL rows for negated MATCH in OR inverted-index fallback

### DIFF
--- a/be/src/storage/column_predicate_inverted_index_fallback.cpp
+++ b/be/src/storage/column_predicate_inverted_index_fallback.cpp
@@ -38,19 +38,15 @@ Status InvertedIndexFallbackPredicate::evaluate(const Column* column, uint8_t* s
     DCHECK(from == 0);
     DCHECK_LE(to, _rowid_buffer->size());
 
-    const bool is_negated = is_negated_expr();
-    const uint8_t hit_value = is_negated ? 0 : 1;
-    const uint8_t miss_value = is_negated ? 1 : 0;
+    // `_bitmap` already holds the rows for which the wrapped predicate is TRUE
+    // (built via seek_inverted_index, which folds in the negation and NULL
+    // handling), so selection is a plain membership test — no flip here.
     roaring::BulkContext ctx;
     const auto& rowids = *_rowid_buffer;
     for (uint16_t i = from; i < to; i++) {
-        selection[i] = _bitmap.containsBulk(ctx, rowids[i]) ? hit_value : miss_value;
+        selection[i] = _bitmap.containsBulk(ctx, rowids[i]) ? 1 : 0;
     }
     return Status::OK();
-}
-
-bool InvertedIndexFallbackPredicate::is_negated_expr() const {
-    return _wrapped_predicate->is_negated_expr();
 }
 
 Status InvertedIndexFallbackPredicate::evaluate_and(const Column* column, uint8_t* sel, uint16_t from,

--- a/be/src/storage/column_predicate_inverted_index_fallback.h
+++ b/be/src/storage/column_predicate_inverted_index_fallback.h
@@ -65,9 +65,6 @@ public:
     // Access to the wrapped predicate
     const ColumnExprPredicate* wrapped_predicate() const { return _wrapped_predicate; }
 
-    // Forward to wrapped predicate
-    bool is_negated_expr() const;
-
     // Access to the segment-specific bitmap for optimization decisions
     const roaring::Roaring& get_bitmap() const { return _bitmap; }
 

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -317,8 +317,11 @@ StatusOr<ColumnPredicateRewriter::RewriteStatus> ColumnPredicateRewriter::_rewri
 
     if (PredicateType::kGinFallback == pred->type()) {
         const auto* fallback_pred = down_cast<const InvertedIndexFallbackPredicate*>(pred);
+        // The bitmap is the set of rows for which the predicate is TRUE (negation
+        // and NULLs already folded in), so an empty bitmap means the predicate
+        // holds for no row regardless of whether it was negated.
         if (fallback_pred->get_bitmap().isEmpty()) {
-            return fallback_pred->is_negated_expr() ? RewriteStatus::ALWAYS_TRUE : RewriteStatus::ALWAYS_FALSE;
+            return RewriteStatus::ALWAYS_FALSE;
         }
         return RewriteStatus::UNCHANGED;
     }

--- a/be/src/storage/rowset/or_match_fallback_visitor.h
+++ b/be/src/storage/rowset/or_match_fallback_visitor.h
@@ -33,6 +33,14 @@ namespace starrocks {
 // ColumnExprPredicate it finds with an InvertedIndexFallbackPredicate that
 // carries the segment-local rowid bitmap pre-loaded from the inverted index.
 //
+// The bitmap is built through the same ColumnExprPredicate::seek_inverted_index
+// path the normal AND filtering uses, so it already is the set of rows for
+// which the predicate evaluates TRUE. In particular the negated case
+// (NOT (col MATCH x)) has both the matching rows and the NULL rows removed,
+// matching SQL three-valued logic (NOT (NULL MATCH x) = NULL, not TRUE). The
+// fallback predicate can therefore select rows by plain bitmap membership
+// without re-applying the negation.
+//
 // Lives in a header (rather than as a function-local class) for two reasons:
 //   1. C++ forbids member function templates inside function-local classes,
 //      and the compound-node overload here is a template on CompoundNodeType.
@@ -48,6 +56,7 @@ struct OrMatchFallbackVisitor {
     ObjectPool& pool;
     const std::vector<rowid_t>* rowid_buffer;
     bool* has_fallback_predicates;
+    uint32_t num_rows; // segment row count; the universe seek_inverted_index filters down from
 
     Status operator()(PredicateColumnNode& node) const {
         const auto* pred = node.col_pred();
@@ -62,11 +71,14 @@ struct OrMatchFallbackVisitor {
         if (iter == nullptr) {
             return Status::OK();
         }
-        ASSIGN_OR_RETURN(auto bitmap_opt, expr_pred->read_inverted_index(expr_pred->slot_desc()->col_name(), iter));
-        if (!bitmap_opt.has_value()) {
-            bitmap_opt.emplace(); // empty bitmap => no matches in this segment
-        }
-        auto* wrapper = pool.add(new InvertedIndexFallbackPredicate(expr_pred, std::move(*bitmap_opt), rowid_buffer));
+        // Seed with the whole segment and let seek_inverted_index narrow it to the
+        // rows where the predicate is TRUE (intersecting matches for a plain MATCH,
+        // subtracting both matches and NULLs for a negated MATCH).
+        roaring::Roaring bitmap;
+        bitmap.addRange(0, num_rows);
+        std::string col_name(expr_pred->slot_desc()->col_name());
+        RETURN_IF_ERROR(expr_pred->seek_inverted_index(col_name, iter, &bitmap));
+        auto* wrapper = pool.add(new InvertedIndexFallbackPredicate(expr_pred, std::move(bitmap), rowid_buffer));
         node.set_col_pred(wrapper);
         *has_fallback_predicates = true;
         return Status::OK();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -4031,7 +4031,8 @@ Status SegmentIterator::_wrap_or_match_predicates_for_fallback() {
     }
 
     OrMatchFallbackVisitor visitor{_inverted_index_ctx->inverted_index_iterators, _obj_pool,
-                                   &_inverted_index_ctx->rowid_buffer, &_inverted_index_ctx->has_fallback_predicates};
+                                   &_inverted_index_ctx->rowid_buffer, &_inverted_index_ctx->has_fallback_predicates,
+                                   num_rows()};
     auto root = _opts.pred_tree.release_root();
     for (auto& or_child : root.compound_children()) {
         RETURN_IF_ERROR(or_child.visit(visitor));

--- a/be/src/storage_primitive/column_expr_predicate.cpp
+++ b/be/src/storage_primitive/column_expr_predicate.cpp
@@ -184,14 +184,6 @@ bool ColumnExprPredicate::is_match_expr() const {
     return root->node_type() == TExprNodeType::MATCH_EXPR;
 }
 
-bool ColumnExprPredicate::is_negated_expr() const {
-    if (_expr_ctxs.empty()) {
-        return false;
-    }
-    Expr* root = _expr_ctxs[0]->root();
-    return root->node_type() == TExprNodeType::COMPOUND_PRED && root->op() == TExprOpcode::COMPOUND_NOT;
-}
-
 bool ColumnExprPredicate::zone_map_filter(const ZoneMapDetail& detail) const {
     // if expr does not satisfy monotonicity, we can not apply zone map.
     if (!_monotonic) return true;

--- a/be/src/storage_primitive/column_expr_predicate.cpp
+++ b/be/src/storage_primitive/column_expr_predicate.cpp
@@ -390,10 +390,11 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
 
     ASSIGN_OR_RETURN(auto roaring_opt, read_inverted_index(column_name, iterator));
 
-    // nullopt means empty match string - clear bitmap
+    // nullopt means an empty match string, which matches no rows. Fall through
+    // with an empty posting set so the shared logic below produces the right
+    // result
     if (!roaring_opt.has_value()) {
-        *row_bitmap -= *row_bitmap;
-        return Status::OK();
+        roaring_opt.emplace();
     }
 
     if (with_not) {

--- a/be/src/storage_primitive/column_expr_predicate.h
+++ b/be/src/storage_primitive/column_expr_predicate.h
@@ -47,7 +47,6 @@ public:
     Status evaluate_or(const Column* column, uint8_t* sel, uint16_t from, uint16_t to) const override;
 
     bool is_match_expr() const;
-    bool is_negated_expr() const;
     bool zone_map_filter(const ZoneMapDetail& detail) const override;
     bool support_original_bloom_filter() const override { return false; }
     bool support_ngram_bloom_filter() const override { return _expr_ctxs[0]->support_ngram_bloom_filter(); }
@@ -67,8 +66,6 @@ public:
     // otherwise, it will contain one or more predicates which form the conjunction normal form
     Status try_to_rewrite_for_zone_map_filter(starrocks::ObjectPool* pool,
                                               std::vector<const ColumnExprPredicate*>* output) const;
-    StatusOr<std::optional<roaring::Roaring>> read_inverted_index(const std::string_view column_name,
-                                                                  InvertedIndexIterator* iterator) const;
     Status seek_inverted_index(const std::string& column_name, InvertedIndexIterator* iterator,
                                roaring::Roaring* row_bitmap) const override;
 
@@ -77,6 +74,12 @@ public:
 private:
     ColumnExprPredicate(TypeInfoPtr type_info, ColumnId column_id, RuntimeState* state,
                         const SlotDescriptor* slot_desc);
+
+    // Reads the raw positive-match posting list for the (NOT) LIKE/MATCH literal.
+    // Only used by seek_inverted_index, which layers negation and NULL handling
+    // on top; not part of the public predicate surface.
+    StatusOr<std::optional<roaring::Roaring>> read_inverted_index(const std::string_view column_name,
+                                                                  InvertedIndexIterator* iterator) const;
 
     void _add_expr_ctxs(const std::vector<ExprContext*>& expr_ctxs);
 

--- a/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
+++ b/be/test/storage/column_predicate_inverted_index_fallback_test.cpp
@@ -35,11 +35,11 @@ namespace starrocks {
 
 // Verifies that InvertedIndexFallbackPredicate, which is the wrapper introduced
 // by the OR-MATCH fallback path, evaluates correctly against its segment-local
-// rowid bitmap. The wrapped ColumnExprPredicate carries no real expression
-// context here (passing nullptr expr_ctx is a documented no-op), so calls into
-// the wrapped predicate that depend on the AST (is_negated_expr, is_match_expr)
-// return the safe defaults. That is precisely the surface we want to exercise:
-// the bitmap-vs-rowid loop and the [from, to) bounds contract.
+// rowid bitmap. The bitmap is always the set of rows for which the wrapped
+// predicate is TRUE (the visitor builds it through seek_inverted_index, which
+// folds in negation and NULL handling), so evaluate() is a plain membership
+// test with no negation flip. That is precisely the surface we want to
+// exercise: the bitmap-vs-rowid loop and the [from, to) bounds contract.
 class InvertedIndexFallbackPredicateTest : public ::testing::Test {
 protected:
     static ColumnExprPredicate* make_wrapped(ColumnId cid = 0) {
@@ -218,24 +218,24 @@ TEST_F(InvertedIndexFallbackPredicateTest, seek_inverted_index_is_rejected) {
     EXPECT_TRUE(st.is_internal_error());
 }
 
-// is_negated_expr() forwards to the wrapped predicate; with an empty expr ctx
-// chain the wrapped predicate reports false, so hits stay 1 and misses stay 0.
-// This is the same expectation as evaluate_mixed, just exercised through the
-// is_negated_expr() forwarding code path explicitly.
-TEST_F(InvertedIndexFallbackPredicateTest, non_negated_uses_hit_one) {
+// evaluate() no longer flips on negation: the bitmap already is the predicate's
+// TRUE-set. For a negated MATCH the visitor stores (all_rows - matches - nulls)
+// there, and evaluate must select exactly those rows by membership. Simulate
+// that TRUE-set directly and assert rows in the bitmap are selected, rows absent
+// (a match or a NULL row, both excluded upstream) are not.
+TEST_F(InvertedIndexFallbackPredicateTest, evaluate_treats_bitmap_as_true_set) {
     std::unique_ptr<ColumnExprPredicate> wrapped(make_wrapped());
-    EXPECT_FALSE(wrapped->is_negated_expr());
+    // rowids 10 and 40 are the negated-predicate TRUE-set; 20 (a match) and
+    // 30 (a NULL row) were dropped upstream and must stay unselected.
+    roaring::Roaring true_set;
+    true_set.add(10);
+    true_set.add(40);
+    std::vector<rowid_t> rowids{10, 20, 30, 40};
 
-    roaring::Roaring bitmap;
-    bitmap.add(50);
-    std::vector<rowid_t> rowids{50, 60};
-
-    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(bitmap), &rowids);
-    EXPECT_FALSE(pred.is_negated_expr());
-
-    std::vector<uint8_t> sel(2, 0);
-    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 2));
-    EXPECT_EQ("1,0", render(sel, 2));
+    InvertedIndexFallbackPredicate pred(wrapped.get(), std::move(true_set), &rowids);
+    std::vector<uint8_t> sel(4, 0);
+    ASSERT_OK(pred.evaluate(/*column=*/nullptr, sel.data(), 0, 4));
+    EXPECT_EQ("1,0,0,1", render(sel, 4));
 }
 
 // ---------------------------------------------------------------------------
@@ -246,13 +246,14 @@ TEST_F(InvertedIndexFallbackPredicateTest, non_negated_uses_hit_one) {
 // (non-Expr predicate, non-MATCH Expr predicate) and the compound-node
 // template overload that recurses through OR-subtrees.
 //
-// The "MATCH wrap" path (load bitmap, allocate InvertedIndexFallbackPredicate,
-// set_col_pred) is reachable only with a real MATCH expression whose AST
-// satisfies ColumnExprPredicate::read_inverted_index's structural checks
-// (MATCH_EXPR root with slot_ref + string_literal children). Standing up that
-// expression machinery at the BE unit-test level is significantly heavier than
-// the surface it would cover. End-to-end coverage of that path, plus the
-// SegmentIterator::do_get_next() branches that flip on
+// The "MATCH wrap" path (seek_inverted_index into the segment bitmap, allocate
+// InvertedIndexFallbackPredicate, set_col_pred) is reachable only with a real
+// MATCH expression whose AST satisfies seek_inverted_index's structural checks
+// (MATCH_EXPR root with slot_ref + string_literal children) plus a live
+// InvertedIndexIterator. Standing up that machinery at the BE unit-test level is
+// significantly heavier than the surface it would cover. End-to-end coverage of
+// that path -- including that a negated MATCH inside an OR excludes NULL rows --
+// plus the SegmentIterator::do_get_next() branches that flip on
 // _inverted_index_ctx->has_fallback_predicates, comes from the SQL-tester
 // integration suite under test/sql/test_inverted_index.
 
@@ -264,7 +265,7 @@ protected:
     std::vector<rowid_t> rowid_buffer;
 
     OrMatchFallbackVisitor make_visitor() {
-        return OrMatchFallbackVisitor{iterators, pool, &rowid_buffer, &has_fallback};
+        return OrMatchFallbackVisitor{iterators, pool, &rowid_buffer, &has_fallback, /*num_rows=*/1024};
     }
 };
 

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -778,6 +778,20 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 4	This is Gin Index
 5	None
 -- !result
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "";
+-- result:
+1	ABC
+2	abc
+3	ABD
+4	This is Gin Index
+-- !result
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "" OR id1 = 100;
+-- result:
+1	ABC
+2	abc
+3	ABD
+4	This is Gin Index
+-- !result
 DROP TABLE t_gin_index_multiple_predicate_none;
 -- result:
 -- !result

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -759,6 +759,25 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 3	ABD
 4	This is Gin Index
 -- !result
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "ABC" OR id1 = 100;
+-- result:
+1	ABC
+3	ABD
+4	This is Gin Index
+-- !result
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE id1 = 100 OR text_column NOT match_any "ABC";
+-- result:
+1	ABC
+3	ABD
+4	This is Gin Index
+-- !result
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "ABC" OR id1 = 5;
+-- result:
+1	ABC
+3	ABD
+4	This is Gin Index
+5	None
+-- !result
 DROP TABLE t_gin_index_multiple_predicate_none;
 -- result:
 -- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -320,6 +320,11 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_an
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE id1 = 100 OR text_column NOT match_any "ABC";
 -- A sibling OR arm may still legitimately select the NULL row.
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "ABC" OR id1 = 5;
+-- Empty match literal: match_any '' matches nothing, so NOT is TRUE for every
+-- non-null row. Both the AND path and the OR-MATCH fallback must keep those
+-- rows (only the NULL row stays out), not drop them.
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "";
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "" OR id1 = 100;
 
 DROP TABLE t_gin_index_multiple_predicate_none;
 

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -313,6 +313,13 @@ SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column match_any "a
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "abc ABC";
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_all "abc ABC";
 SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "This Index";
+-- Regression: a negated MATCH inside an OR must exclude NULL rows. Under
+-- three-valued logic NOT (NULL match_any 'ABC') is NULL (not TRUE), so the NULL
+-- row (id1=5) must not leak in through the OR-MATCH inverted-index fallback.
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "ABC" OR id1 = 100;
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE id1 = 100 OR text_column NOT match_any "ABC";
+-- A sibling OR arm may still legitimately select the NULL row.
+SELECT * FROM t_gin_index_multiple_predicate_none WHERE text_column NOT match_any "ABC" OR id1 = 5;
 
 DROP TABLE t_gin_index_multiple_predicate_none;
 


### PR DESCRIPTION
## Why I'm doing:

The OR-MATCH inverted-index fallback returned NULL rows for negated MATCH
predicates nested inside an OR (e.g. `col1 MATCH 'a' OR col2 NOT MATCH 'b'`).
Under SQL three-valued logic `NOT (NULL MATCH x)` is NULL, not TRUE, so those
NULL rows must not be returned. The canonical AND filtering path
(`ColumnExprPredicate::seek_inverted_index`) already handled this correctly by
subtracting the NULL posting list; the fallback path did not.

## What I'm doing:

The fallback built its bitmap from the raw positive-match posting list and
flipped membership at `evaluate()` time for negated predicates. Because NULL
rows are never present in a posting list, the flip selected them, producing
extra rows.

This PR builds the fallback bitmap through
`ColumnExprPredicate::seek_inverted_index` instead — the same path the normal
AND filtering uses — so the bitmap already is the set of rows for which the
predicate is TRUE (matches intersected for a plain MATCH; matches **and** NULLs
subtracted for a negated MATCH). `evaluate()` then selects rows by plain
membership with no flip, and the rewriter treats an empty bitmap as
`ALWAYS_FALSE` unconditionally. The now-unused `is_negated_expr()` is removed
and `read_inverted_index()` is made private (it is only an implementation
detail of `seek_inverted_index`).

Tests: a C++ unit test for the no-flip `evaluate()` contract, plus SQL
regression cases under `test/sql/test_inverted_index` proving a negated MATCH
inside an OR excludes NULL rows while a sibling OR arm can still legitimately
select them.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
