### PR TITLE
[BugFix] Key MV pinned-range map by Table#getUUID() so it is cross-database-unique

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -173,7 +173,9 @@ public class IcebergTable extends Table {
     @Override
     public String getUUID() {
         if (CatalogMgr.isExternalCatalog(catalogName)) {
-            String uuid = ((BaseTable) getNativeTable()).operations().current().uuid();
+            org.apache.iceberg.Table nativeTable = getNativeTable();
+            String uuid = nativeTable instanceof BaseTable
+                    ? ((BaseTable) nativeTable).operations().current().uuid() : null;
             return String.join(".", catalogName, catalogDBName, catalogTableName,
                     uuid == null ? "" : uuid);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -340,10 +340,10 @@ public abstract class MVRefreshProcessor {
                 continue;
             }
             final TvrVersionRange pinned = TvrTableSnapshot.of(tvr.end());
-            // Must key by Table#getTableIdentifier() to match every consumer (MVPCTRefreshPlanBuilder,
-            // PartitionDiffer#pinnedRangeFor). For native OLAP BaseTableInfo#getTableIdentifier() yields
-            // the table id but Table yields the name, so the old key silently missed every lookup.
-            pinnedMap.put(info.getBaseTable().getTableIdentifier(), pinned);
+            // Key by getUUID() — cross-db-unique and identical at every consumer
+            // (MVPCTRefreshPlanBuilder, PartitionDiffer#pinnedRangeFor). A bare table
+            // name would collide across databases.
+            pinnedMap.put(info.getBaseTable().getUUID(), pinned);
 
             if (info instanceof PCTTableSnapshotInfo) {
                 ((PCTTableSnapshotInfo) info).setPinnedRange(pinned);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPlanBuilder.java
@@ -142,12 +142,12 @@ public class MVPCTRefreshPlanBuilder {
         for (Map.Entry<String, TableRelation> entry : tableRelations.entries()) {
             TableRelation relation = entry.getValue();
             Table table = relation.getTable();
-            // Skip null here to avoid NPE on getTableIdentifier(); the relation-grouping loop below
+            // Skip null here to avoid NPE on getUUID(); the relation-grouping loop below
             // throws a controlled AnalysisException for any base table that resolved to null.
             if (table == null) {
                 continue;
             }
-            TvrVersionRange pinned = pinnedMap.get(table.getTableIdentifier());
+            TvrVersionRange pinned = pinnedMap.get(table.getUUID());
             if (pinned != null) {
                 relation.setTvrVersionRange(pinned);
                 logger.info("Inject pinned TVR {} into table relation {} for scan",

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -35,7 +35,7 @@ public abstract class PartitionDiffer {
     // consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
     protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
-    // Pinned ranges keyed by Table.getTableIdentifier(). Empty means no pinning.
+    // Pinned ranges keyed by Table.getUUID(). Empty means no pinning.
     protected Map<String, TvrVersionRange> pinnedRangeByTableIdentifier = Collections.emptyMap();
 
     public PartitionDiffer(MaterializedView mv, MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
@@ -49,7 +49,7 @@ public abstract class PartitionDiffer {
     }
 
     protected TvrVersionRange pinnedRangeFor(Table table) {
-        return pinnedRangeByTableIdentifier.get(table.getTableIdentifier());
+        return pinnedRangeByTableIdentifier.get(table.getUUID());
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #76320. That change aligned the MV pinned-range map's producer and
consumers on `Table#getTableIdentifier()`, but for native tables that returns
the bare table name, which is not unique across databases. An MV referencing two
same-named tables in different databases (`db_a.t` + `db_b.t`) makes
`setupPinnedRangesIfNeeded` overwrite one map entry, so one table's pinned
snapshot is silently lost and consumers read the wrong (or no) pinned range.

## What I'm doing:

Key the pinned-range map by `Table#getUUID()` on both the producer
(`setupPinnedRangesIfNeeded`) and the consumers (`MVPCTRefreshPlanBuilder`,
`PartitionDiffer#pinnedRangeFor`). `getUUID()` is cross-database-unique for every
table kind — the table id for native/cloud-native tables, `catalog.db.table.uuid`
for external tables — and is identical at producer and every consumer. This keeps
producer/consumer in agreement (the point of #76320) while making the key unique
across databases.

`IcebergTable#getUUID()` also gains an `instanceof BaseTable` guard so a
non-BaseTable native table degrades to an empty uuid instead of a
`ClassCastException`, matching the existing `getTableIdentifier()`.

Fixes #issue: N/A — self-contained follow-up to #76320.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Pinning now takes effect (and does not collide) for an MV over same-named base
tables in different databases; previously such an MV lost one table's pinned
snapshot.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
