### PR TITLE
[Tool] Run bugfix-version-index on the ubuntu/ai runner with a checkout; add daily reconcile

### DIFF
--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -1,5 +1,5 @@
 name: Bugfix Version Index
-run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.number || github.ref_name || 'reconcile' }}
+run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.number || github.ref_name || github.event.schedule || 'run' }}
 
 # Maintains the deterministic code_kb.versions index (fix side) + the heuristic
 # code_kb.task_summaries cause cache, via the github-bugfix-versions plugin run directly with
@@ -10,15 +10,16 @@ run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.numbe
 #   ① origin bugfix PR merges to main      → :index-fix (seed versions) + :affected-versions (cache cause)
 #   ② a backport PR merges to branch-X.Y*  → :index-fix (rebuild the origin's versions record)
 #   ③ a release tag X.Y.Z is pushed        → :index-fix <tag> (resolve pending-<line> → concrete tag)
-#   ④ daily schedule                       → :index-fix reconcile (self-heal: re-sweep any pending
-#                                             a tag-cut missed/failed — the versions safety net)
+#   ④ daily schedule                       → :index-fix reconcile (pending-only self-heal)
+#   ⑤ weekly schedule                      → :index-fix reconcile-all (re-check concrete too — corrects
+#                                             a wrong concrete tag / reverse error; heavier)
 #
 # NOTE: plugin commands MUST be namespaced (/github-bugfix-versions:<cmd>). A bare /index-fix in
 # headless `-p` does NOT resolve — it is silently treated as prompt text (no write).
 #
-# The index steps FAIL LOUD (no `|| true` / no continue-on-error): a silent failure is exactly what
-# let `pending` records pile up unresolved. The cause step (affected-versions) stays best-effort,
-# and the daily reconcile backs up any transient index failure.
+# The index steps FAIL LOUD: no `|| true`, and `defaults.run.shell: bash` forces `-o pipefail`
+# so a failing `claude ... | tee` propagates claude's non-zero exit (tee's success does not mask it).
+# The cause step (affected-versions) stays best-effort; the daily reconcile backs up transient failures.
 #
 # PREREQUISITES on the [ubuntu, ai] runner (one-time, infra):
 #   - `gh` (authenticated via GITHUB_TOKEN), `git`, `python3` on PATH — version_backfill.py uses gh
@@ -33,8 +34,7 @@ on:
     branches:
       - main
       # release lines. Use [0-9]+ (one-or-more), NOT bare [0-9] (single digit) — else multi-digit
-      # versions like branch-3.12, branch-3.5.20, branch-3.12.20 silently never match the filter
-      # and their backport merges never trigger this workflow. (Mirrors the push-tag pattern below.)
+      # versions like branch-3.12, branch-3.5.20, branch-3.12.20 silently never match the filter.
       - 'branch-[0-9]+.[0-9]+'
       - 'branch-[0-9]+.[0-9]+.[0-9]+'
     types:
@@ -43,23 +43,30 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   schedule:
-    # Daily self-heal. 19:00 UTC = 03:00 Asia/Shanghai (low-traffic for the CN-centric project).
-    - cron: '0 19 * * *'
+    - cron: '0 19 * * *'    # daily 19:00 UTC (03:00 Asia/Shanghai) → reconcile (pending-only)
+    - cron: '0 20 * * 0'    # weekly Sun 20:00 UTC (Mon 04:00 Asia/Shanghai) → reconcile-all (concrete too)
 
-# Concurrency is per-ORIGIN, set at the JOB level (not here) — see each job's `concurrency:`.
-# A workflow-level group keyed on the triggering event (PR #/tag) would be WRONG: the entity
-# written is the *origin* PR's cumulative record (version/<repo>/<origin>), and two backports of
-# the same origin merging on different release branches fire as different events → different
-# groups → concurrent runs. Grouping by origin serializes all writers of the same record;
-# rebuild-from-source + the monotonic guard make a superseded run harmless.
+# Concurrency is per-ORIGIN for the single-origin EVENTS (origin-merge / backport-merge share
+# `BVI-…-origin-N`, so different origins run in parallel but the same origin serializes — a
+# whole-entity upsert can't be lost). The BULK jobs (tag-cut / reconcile / reconcile-all) use their
+# OWN group, so they are NOT serialized against a same-origin backport-merge. That race (a bulk run
+# overwriting a backport just written by an event) is handled in the plugin, NOT here: the monotonic
+# guard keeps a concrete earliest_fix_tag from reverting to pending, and the anti-clobber guard drops
+# any origin whose stored record was updated after the sweep started (so a mid-sweep backport-merge
+# write is never clobbered). A shared group is deliberately NOT used — it would make different-origin
+# backport-writes cancel each other (only one pending kept), dropping writes.
 
 permissions:
   contents: read
   pull-requests: read
 
+defaults:
+  run:
+    shell: bash    # GitHub runs this as `bash --noprofile --norc -eo pipefail {0}` → pipefail makes
+                   # `claude ... | tee` fail the step when claude fails (tee's exit no longer masks it).
+
 jobs:
   # ① origin bugfix PR merged to main → seed versions (fix side) + cache cause (task_summaries).
-  # Gated to [BugFix]-titled PRs (StarRocks convention) to avoid an LLM cause analysis on every merge.
   origin-merge:
     if: >
       github.event_name == 'pull_request_target' &&
@@ -80,9 +87,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0        # full history — `git tag --contains` needs the commit objects
-          fetch-tags: true      # all release tags
-      - name: fetch release branches (for branch --contains / pending resolution)
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
         run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
       - name: index-fix (deterministic fix side → code_kb.versions) [FAIL-LOUD]
         run: |
@@ -90,19 +97,13 @@ jobs:
           claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt"
       - name: affected-versions (heuristic cause → code_kb.task_summaries) [best-effort]
-        if: always()               # run even if index-fix failed; cause caching is decoupled
-        continue-on-error: true    # never fail the job on the cause step (its own daily backfill covers gaps)
+        if: always()
+        continue-on-error: true
         run: |
-          # Cause is stable at origin-merge (blame over immutable pre-fix history); cache it now
-          # so the pre-release report is a fast bulk query. Firewall runs inside the skill.
           claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
 
-  # ② a backport PR merged to a release branch → rebuild EACH origin it backports. A title can
-  # bundle several origins ((backport #a)(backport #b)...). FAN OUT: one matrix instance per origin,
-  # each serialized on that origin via `concurrency`. Exclude branch-sync PRs (head `…-sync-pr-…`):
-  # a sync carries 'backport' in its title but is NOT a real (backport #N) landing. Do NOT exclude
-  # `mergify/` here — mergify IS the backport mechanism (head `mergify/bp/branch-X.Y/pr-N`).
+  # ② a backport PR merged to a release branch → rebuild EACH origin it backports.
   backport-resolve:
     if: >
       github.event_name == 'pull_request_target' &&
@@ -120,8 +121,6 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # ALL markers (mirrors the skill's backport_markers), not just the last — bundled/chained
-          # titles backport several origins. Build the JSON array with awk so it is shell-agnostic.
           json="$(printf '%s' "$TITLE" | grep -oiE 'backport #[0-9]+' | grep -oE '[0-9]+' | sort -un \
                  | awk 'BEGIN{printf "["} {printf "%s\"%s\"",(NR>1?",":""),$0} END{printf "]"}')"
           echo "origins=$json" >> "$GITHUB_OUTPUT"
@@ -134,7 +133,6 @@ jobs:
       fail-fast: false
       matrix:
         origin: ${{ fromJSON(needs.backport-resolve.outputs.origins) }}
-    # Serialize per origin (shares the group with the origin-merge job of the same origin).
     concurrency:
       group: BVI-${{ github.repository }}-origin-${{ matrix.origin }}
       cancel-in-progress: false
@@ -156,8 +154,6 @@ jobs:
             -p "/github-bugfix-versions:index-fix ${{ github.repository }}#${{ matrix.origin }}" 2>&1 | tee "${RUNNER_TEMP}/index_fix_${{ matrix.origin }}.txt"
 
   # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
-  # The monotonic guard (in the plugin) prevents a late backport-write from reverting this
-  # pending→concrete resolution, so a per-origin group here is not needed for correctness.
   tag-cut:
     if: github.event_name == 'push'
     concurrency:
@@ -181,11 +177,9 @@ jobs:
           claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt"
 
-  # ④ daily self-heal → re-sweep pending on all maintained lines. Catches any tag-cut event that
-  # failed or was skipped, so a shipped fix never stays stuck at `pending`. Steady-state cheap
-  # (only genuinely-unreleased fixes remain pending after the first run clears the backlog).
+  # ④ daily self-heal → pending-only sweep across all maintained lines.
   reconcile:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' && github.event.schedule == '0 19 * * *'
     concurrency:
       group: BVI-${{ github.repository }}-reconcile
       cancel-in-progress: false
@@ -205,3 +199,28 @@ jobs:
           echo "daily reconcile"
           claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:index-fix reconcile" 2>&1 | tee "${RUNNER_TEMP}/reconcile.txt"
+
+  # ⑤ weekly deep self-heal → re-check concrete records too, correcting a wrong concrete tag
+  # (reverse error like #74855: stored 4.1.3 but really 4.1.2). Heavier — every maintained-line
+  # origin is rebuilt from GitHub — so weekly, off-peak, not on the daily cron.
+  reconcile-all:
+    if: github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0'
+    concurrency:
+      group: BVI-${{ github.repository }}-reconcile-all
+      cancel-in-progress: false
+    runs-on: [ubuntu, ai]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: index-fix reconcile-all (re-check concrete + pending on all maintained lines) [FAIL-LOUD]
+        run: |
+          echo "weekly reconcile-all"
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:index-fix reconcile-all" 2>&1 | tee "${RUNNER_TEMP}/reconcile_all.txt"

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -1,33 +1,32 @@
 name: Bugfix Version Index
-run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.number || github.ref_name }}
+run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.number || github.ref_name || 'reconcile' }}
 
 # Maintains the deterministic code_kb.versions index (fix side) + the heuristic
-# code_kb.task_summaries cause cache, via the github-bugfix-versions skill running in
-# the claude-cli container (same runner/container pattern as ai-sr-skills.yml). Three events:
+# code_kb.task_summaries cause cache, via the github-bugfix-versions plugin run directly with
+# `claude -p` on the [ubuntu, ai] runner. The runner checks out this repo, so the plugin's
+# version_backfill.py has a real clone for `git tag --contains` (no REST-only path, no container
+# mount). Events:
 #
-#   ① origin bugfix PR merges to main      → /github-bugfix-versions:index-fix (seed versions) + :affected-versions (cache cause)
-#   ② a backport PR merges to branch-X.Y*  → /github-bugfix-versions:index-fix (rebuild the origin's versions record)
-#   ③ a release tag X.Y.Z is pushed        → /github-bugfix-versions:index-fix <tag> (resolve pending-<line> → concrete tag)
+#   ① origin bugfix PR merges to main      → :index-fix (seed versions) + :affected-versions (cache cause)
+#   ② a backport PR merges to branch-X.Y*  → :index-fix (rebuild the origin's versions record)
+#   ③ a release tag X.Y.Z is pushed        → :index-fix <tag> (resolve pending-<line> → concrete tag)
+#   ④ daily schedule                       → :index-fix reconcile (self-heal: re-sweep any pending
+#                                             a tag-cut missed/failed — the versions safety net)
 #
-# NOTE: plugin commands MUST be namespaced (/github-bugfix-versions:<cmd>). A bare /index-fix
-# in headless `-p` does NOT resolve — it is silently treated as prompt text (no error, no write),
-# which combined with continue-on-error would look green while doing nothing.
+# NOTE: plugin commands MUST be namespaced (/github-bugfix-versions:<cmd>). A bare /index-fix in
+# headless `-p` does NOT resolve — it is silently treated as prompt text (no write).
 #
-# The skill computes everything (gh PR/backport data, git tag --contains / blame, the rung
-# firewall) and writes via the context-base MCP. RC stores/serves only; CI never POSTs to RC.
-# See: plugins/github-bugfix-versions (cd-claude-marketplace) and the version-index design doc.
+# The index steps FAIL LOUD (no `|| true` / no continue-on-error): a silent failure is exactly what
+# let `pending` records pile up unresolved. The cause step (affected-versions) stays best-effort,
+# and the daily reconcile backs up any transient index failure.
 #
-# PREREQUISITES on the self-hosted runner's claude-cli container (one-time, infra):
-#   - the `github-bugfix-versions` plugin installed (provides :index-fix, :affected-versions,
-#     :release-report — invoked namespaced as /github-bugfix-versions:<cmd>, see NOTE above);
-#   - the `context-base` MCP configured with `code_kb` USAGE (read+write data) for the
-#     container's identity — USAGE alone is enough to context_upsert (no ALTER needed);
-#   - the `code_kb.versions` (collection_type=knowledge) and `code_kb.task_summaries`
-#     (collection_type=task_summary — NOT knowledge; the task_summary family, shared with the
-#     release-bug write-back) collections pre-created by an admin (the emitter cannot create
-#     shared-base collections; MCP create_collection only targets the caller's personal base).
-# gh is NOT installed in the container, but GITHUB_TOKEN is passed in — the skill uses the
-# GitHub REST/compare API for PR/backport/tag-contains when no local clone is present.
+# PREREQUISITES on the [ubuntu, ai] runner (one-time, infra):
+#   - `gh` (authenticated via GITHUB_TOKEN), `git`, `python3` on PATH — version_backfill.py uses gh
+#     for PR/backport data and `git tag --contains` against the checkout to resolve concrete tags;
+#   - `claude` with the `github-bugfix-versions` plugin installed and the `context-base` MCP
+#     configured with `code_kb` USAGE (read+write) for the runner's identity;
+#   - `code_kb.versions` (collection_type=knowledge) and `code_kb.task_summaries`
+#     (collection_type=task_summary) collections pre-created by an admin.
 
 on:
   pull_request_target:
@@ -43,15 +42,16 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  schedule:
+    # Daily self-heal. 19:00 UTC = 03:00 Asia/Shanghai (low-traffic for the CN-centric project).
+    - cron: '0 19 * * *'
 
 # Concurrency is per-ORIGIN, set at the JOB level (not here) — see each job's `concurrency:`.
 # A workflow-level group keyed on the triggering event (PR #/tag) would be WRONG: the entity
 # written is the *origin* PR's cumulative record (version/<repo>/<origin>), and two backports of
 # the same origin merging on different release branches fire as different events → different
-# groups → concurrent runs. The earlier run can read the backport set before the later backport
-# merged, then write AFTER the later run, clobbering the just-accreted backport_set/earliest_fix_tag
-# (lost update). With continue-on-error that loss is silent. Grouping by origin serializes all
-# writers of the same record; rebuild-from-source makes a superseded pending run harmless.
+# groups → concurrent runs. Grouping by origin serializes all writers of the same record;
+# rebuild-from-source + the monotonic guard make a superseded run harmless.
 
 permissions:
   contents: read
@@ -59,8 +59,7 @@ permissions:
 
 jobs:
   # ① origin bugfix PR merged to main → seed versions (fix side) + cache cause (task_summaries).
-  # Gated to [BugFix]-titled PRs (StarRocks convention) to avoid an LLM cause analysis on every
-  # merge; broaden the title/label gate if your bugfixes are titled differently.
+  # Gated to [BugFix]-titled PRs (StarRocks convention) to avoid an LLM cause analysis on every merge.
   origin-merge:
     if: >
       github.event_name == 'pull_request_target' &&
@@ -70,48 +69,40 @@ jobs:
       contains(github.event.pull_request.title, '[BugFix]') &&
       !startsWith(github.head_ref, 'mergify/') &&
       !contains(github.head_ref, '-sync-pr-')
-    # Serialize on the origin = this PR's own number (it writes version/<repo>/<number> +
-    # task/pr/<repo>/<number>). Shares the group with any backport-write of the same origin.
     concurrency:
       group: BVI-${{ github.repository }}-origin-${{ github.event.number }}
       cancel-in-progress: false
-    runs-on: [self-hosted, normal]
-    continue-on-error: true
+    runs-on: [ubuntu, ai]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       PR_URL: ${{ github.event.pull_request.html_url }}
     steps:
-      - name: index-fix (deterministic fix side → code_kb.versions)
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history — `git tag --contains` needs the commit objects
+          fetch-tags: true      # all release tags
+      - name: fetch release branches (for branch --contains / pending resolution)
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: index-fix (deterministic fix side → code_kb.versions) [FAIL-LOUD]
         run: |
           echo "origin-merge PR #${{ github.event.number }} → ${PR_URL}"
-          docker exec -i -u claudeuser \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
-            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
-            claude-cli claude --dangerously-skip-permissions \
-            -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
-
-      - name: affected-versions (heuristic cause → code_kb.task_summaries)
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:index-fix ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt"
+      - name: affected-versions (heuristic cause → code_kb.task_summaries) [best-effort]
+        if: always()               # run even if index-fix failed; cause caching is decoupled
+        continue-on-error: true    # never fail the job on the cause step (its own daily backfill covers gaps)
         run: |
           # Cause is stable at origin-merge (blame over immutable pre-fix history); cache it now
-          # so the pre-release report is a fast bulk query, not dozens of live analyses. The
-          # firewall (version_emit_check / firewall_check) runs inside the skill before any write.
-          docker exec -i -u claudeuser \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
-            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
-            claude-cli claude --dangerously-skip-permissions \
+          # so the pre-release report is a fast bulk query. Firewall runs inside the skill.
+          claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:affected-versions ${PR_URL}" 2>&1 | tee "${RUNNER_TEMP}/affected_versions.txt" || true
 
   # ② a backport PR merged to a release branch → rebuild EACH origin it backports. A title can
-  # bundle several origins ((backport #a)(backport #b)...), so one event may touch multiple
-  # version/<repo>/<origin> records. FAN OUT: resolve every marker, then one matrix instance per
-  # origin, each serialized on that origin via `concurrency`. That is the P1 fix — two backports of
-  # the SAME origin landing on different branches (separate events) no longer write concurrently and
-  # clobber each other's accreted backport_set/earliest_fix_tag.
-  # Exclude branch-sync PRs (head like `branch-4.1-sync-pr-74722` → branch-4.1): a sync of a
-  # backport carries 'backport' in its title but is NOT a real (backport #N) landing — it would
-  # misattribute the origin. Do NOT exclude `mergify/` here (unlike origin-merge): mergify IS the
-  # backport mechanism (head `mergify/bp/branch-X.Y/pr-N`) — excluding it would drop real backports.
+  # bundle several origins ((backport #a)(backport #b)...). FAN OUT: one matrix instance per origin,
+  # each serialized on that origin via `concurrency`. Exclude branch-sync PRs (head `…-sync-pr-…`):
+  # a sync carries 'backport' in its title but is NOT a real (backport #N) landing. Do NOT exclude
+  # `mergify/` here — mergify IS the backport mechanism (head `mergify/bp/branch-X.Y/pr-N`).
   backport-resolve:
     if: >
       github.event_name == 'pull_request_target' &&
@@ -120,7 +111,7 @@ jobs:
       startsWith(github.base_ref, 'branch-') &&
       contains(github.event.pull_request.title, 'backport') &&
       !contains(github.head_ref, '-sync-pr-')
-    runs-on: [self-hosted, normal]
+    runs-on: [ubuntu, ai]
     outputs:
       origins: ${{ steps.parse.outputs.origins }}
     steps:
@@ -130,10 +121,7 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
           # ALL markers (mirrors the skill's backport_markers), not just the last — bundled/chained
-          # titles backport several origins. Looser than \(backport #N\) (no parens required): an
-          # extra non-origin number only yields a harmless no-op /index-fix (exits 0 on a non-origin).
-          # Build the JSON array with awk (not a shell for-loop) so it is shell-agnostic — unquoted
-          # word-splitting differs between bash and sh/zsh; awk handles the line stream itself.
+          # titles backport several origins. Build the JSON array with awk so it is shell-agnostic.
           json="$(printf '%s' "$TITLE" | grep -oiE 'backport #[0-9]+' | grep -oE '[0-9]+' | sort -un \
                  | awk 'BEGIN{printf "["} {printf "%s\"%s\"",(NR>1?",":""),$0} END{printf "]"}')"
           echo "origins=$json" >> "$GITHUB_OUTPUT"
@@ -146,52 +134,74 @@ jobs:
       fail-fast: false
       matrix:
         origin: ${{ fromJSON(needs.backport-resolve.outputs.origins) }}
-    # Serialize per origin: same-origin runs queue (1 running + at most 1 pending; a superseded
-    # pending run is harmless — /index-fix rebuilds the full set from GitHub). Different origins run
-    # in parallel (distinct groups). Shares the group with the origin-merge job of the same origin.
+    # Serialize per origin (shares the group with the origin-merge job of the same origin).
     concurrency:
       group: BVI-${{ github.repository }}-origin-${{ matrix.origin }}
       cancel-in-progress: false
-    runs-on: [self-hosted, normal]
-    continue-on-error: true
+    runs-on: [ubuntu, ai]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
-      - name: index-fix (rebuild origin ${{ matrix.origin }} from its merged backports)
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: index-fix (rebuild origin ${{ matrix.origin }} from its merged backports) [FAIL-LOUD]
         run: |
           echo "rebuild origin ${{ github.repository }}#${{ matrix.origin }} (triggered by backport PR #${{ github.event.number }})"
-          docker exec -i -u claudeuser \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
-            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
-            claude-cli claude --dangerously-skip-permissions \
-            -p "/github-bugfix-versions:index-fix ${{ github.repository }}#${{ matrix.origin }}" 2>&1 | tee "${RUNNER_TEMP}/index_fix_${{ matrix.origin }}.txt" || true
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:index-fix ${{ github.repository }}#${{ matrix.origin }}" 2>&1 | tee "${RUNNER_TEMP}/index_fix_${{ matrix.origin }}.txt"
 
   # ③ release tag cut → resolve pending-<line> records on that line to the concrete tag.
-  # A tag-cut touches MANY origins (every record pending on the line), so it can't share the
-  # per-origin groups above and CAN start concurrently with a same-origin backport-write. The
-  # pending->concrete clobber that would cause (a late backport-write reverting this resolution) is
-  # prevented at the WRITE layer, not here: /index-fix's monotonic guard refuses to overwrite a
-  # stored concrete earliest_fix_tag with pending-* (github-bugfix-versions plugin). So a per-origin
-  # group for tag-cut is not needed for correctness; a full fan-out (per pending origin, reusing
-  # BVI-...-origin-<N>) remains an option if stricter serialization is ever wanted.
+  # The monotonic guard (in the plugin) prevents a late backport-write from reverting this
+  # pending→concrete resolution, so a per-origin group here is not needed for correctness.
   tag-cut:
     if: github.event_name == 'push'
     concurrency:
       group: BVI-${{ github.repository }}-tagcut-${{ github.ref_name }}
       cancel-in-progress: false
-    runs-on: [self-hosted, normal]
-    continue-on-error: true
+    runs-on: [ubuntu, ai]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       TAG: ${{ github.ref_name }}
     steps:
-      - name: "index-fix (tag-cut → concrete tag for this line)"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: index-fix (tag-cut → concrete tag for this line) [FAIL-LOUD]
         run: |
           echo "tag-cut ${TAG}"
-          docker exec -i -u claudeuser \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
-            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
-            claude-cli claude --dangerously-skip-permissions \
-            -p "/github-bugfix-versions:index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt" || true
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:index-fix ${TAG}" 2>&1 | tee "${RUNNER_TEMP}/index_fix.txt"
+
+  # ④ daily self-heal → re-sweep pending on all maintained lines. Catches any tag-cut event that
+  # failed or was skipped, so a shipped fix never stays stuck at `pending`. Steady-state cheap
+  # (only genuinely-unreleased fixes remain pending after the first run clears the backlog).
+  reconcile:
+    if: github.event_name == 'schedule'
+    concurrency:
+      group: BVI-${{ github.repository }}-reconcile
+      cancel-in-progress: false
+    runs-on: [ubuntu, ai]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: index-fix reconcile (re-sweep pending on all maintained lines) [FAIL-LOUD]
+        run: |
+          echo "daily reconcile"
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:index-fix reconcile" 2>&1 | tee "${RUNNER_TEMP}/reconcile.txt"


### PR DESCRIPTION
## Why I'm doing:

The `Bugfix Version Index` workflow maintained the `code_kb.versions` index by
`docker exec`-ing into a persistent `claude-cli` container that had **no `gh` and
no repo clone** (REST-only). Two consequences:

- the tag-cut step could not reliably resolve `pending-<line>` records to a
  concrete tag (no `git tag --contains`), so shipped fixes stayed `pending` and
  a release report under-counted them;
- every step was `continue-on-error: true` + `| | true`, so any failure was
  green-washed and silently dropped.

## What I'm doing:

Run the `github-bugfix-versions` plugin **directly with `claude -p` on the
`[ubuntu, ai]` runner**, which checks out this repo — so the plugin's
`version_backfill.py` has a real clone (`git tag --contains`) and `gh`. Changes:

- `runs-on: [self-hosted, normal]` → `[ubuntu, ai]`; drop the `docker exec …
  claude-cli` wrapper for a direct `claude --dangerously-skip-permissions -p`.
- add `actions/checkout` (`fetch-depth: 0`, `fetch-tags: true`) + fetch release
  branches to every job that runs the plugin.
- **index steps FAIL LOUD** — remove `continue-on-error`/`| | true` on the
  version-index steps so a failure is visible (the cause step stays best-effort).
- add a **daily `reconcile` job** (`schedule: 0 19 * * *`, 03:00 Asia/Shanghai)
  that re-sweeps any `pending` a tag-cut event missed/failed — a self-healing
  safety net so no manual backfill is needed per release.

Plugin-side fixes (canonical slug, earliest-tag, the tag-cut sweep, `reconcile`
mode) are in CelerData/claude-marketplace#21; this PR is only the workflow wiring.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(CI-only: maintains an internal knowledge-base index; no product/user-facing behavior changes.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
