### PR TITLE
[Enhancement] Lake prepared physical split scan: seed pruning and prepared read state

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <future>
+#include <set>
 #include <unordered_set>
 
 #include "base/debug/trace.h"
@@ -27,6 +28,8 @@
 #include "fs/fs_factory.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_env.h"
+#include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
 #include "storage/delete_predicates.h"
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/filenames.h"
@@ -52,6 +55,18 @@
 #include "types/type_descriptor.h"
 
 namespace starrocks::lake {
+
+static SegmentReadStateCache make_segment_read_state_cache(const PreparedSegmentReadState& state) {
+    SegmentReadStateCache cache;
+    if (state.has_pruned_scan_range()) {
+        cache.scan_range = state.pruned_scan_range;
+    }
+    if (state.has_rowid_bounds_cache()) {
+        cache.seek_range_rowid_ranges = &state.seek_ranges_rowid_bounds;
+        cache.tablet_rowid_range = &state.tablet_range_rowid_bounds;
+    }
+    return cache;
+}
 
 Rowset::Rowset(TabletManager* tablet_mgr, int64_t tablet_id, const RowsetMetadataPB* metadata, int index,
                TabletSchemaPtr tablet_schema)
@@ -271,44 +286,75 @@ Status Rowset::add_partial_compaction_segments_info(TxnLogPB_OpCompaction* op_co
 }
 
 StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const RowsetReadOptions& options) {
-    SegmentReadOptions seg_options;
-    if (options.lake_io_opts.fs) {
-        seg_options.fs = options.lake_io_opts.fs;
+    return do_read(schema, options, ReadContext{});
+}
+
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const RowsetReadOptions& options,
+                                                     const std::vector<SegmentPtr>& prepared_segments) {
+    return do_read(schema, options, ReadContext{.prepared_segments = &prepared_segments});
+}
+
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read_prepared_segment(
+        const Schema& schema, const RowsetReadOptions& options, const std::vector<SegmentPtr>& prepared_segments,
+        size_t segment_idx, const PreparedSegmentReadStatePtr& prepared_segment_state,
+        std::vector<ChunkIteratorPtr>* reusable_segment_iterators) {
+    return do_read(schema, options,
+                   ReadContext{.prepared_segments = &prepared_segments,
+                               .target_segment_idx = segment_idx,
+                               .prepared_segment_state = prepared_segment_state.get(),
+                               .reusable_segment_iterators = reusable_segment_iterators});
+}
+
+Status Rowset::init_segment_read_options(const RowsetReadOptions& options, const LakeIOOptions& lake_io_opts,
+                                         const DisjunctivePredicates& delete_predicates, OlapReaderStatistics* stats,
+                                         SegmentReadOptions* segment_options) const {
+    if (segment_options == nullptr) {
+        return Status::InvalidArgument("segment read options is null");
+    }
+    if (lake_io_opts.fs) {
+        segment_options->fs = lake_io_opts.fs;
     } else {
         auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
-        ASSIGN_OR_RETURN(seg_options.fs, FileSystemFactory::CreateSharedFromString(root_loc));
+        ASSIGN_OR_RETURN(segment_options->fs, FileSystemFactory::CreateSharedFromString(root_loc));
     }
-    seg_options.stats = options.stats;
-    seg_options.ranges = options.ranges;
-    seg_options.pred_tree = options.pred_tree;
-    seg_options.pred_tree_for_zone_map = options.pred_tree_for_zone_map;
-    seg_options.runtime_filter_preds = options.runtime_filter_preds;
-    seg_options.enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
-    seg_options.has_predicate_above_iterator = options.has_predicate_above_iterator;
-    seg_options.use_page_cache = options.use_page_cache;
-    seg_options.profile = options.profile;
-    seg_options.reader_type = options.reader_type;
-    seg_options.chunk_size = options.chunk_size;
-    seg_options.global_dictmaps = options.global_dictmaps;
-    seg_options.unused_output_column_ids = options.unused_output_column_ids;
-    seg_options.runtime_range_pruner = options.runtime_range_pruner;
-    seg_options.tablet_schema = options.tablet_schema;
-    seg_options.lake_io_opts = options.lake_io_opts;
-    seg_options.asc_hint = options.asc_hint;
-    seg_options.column_access_paths = options.column_access_paths;
-    seg_options.use_vector_index = options.use_vector_index;
-    seg_options.vector_search_option = options.vector_search_option;
-    seg_options.belonged_to_cloud_native = true;
-    seg_options.has_preaggregation = options.has_preaggregation;
-    seg_options.enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
-    seg_options.tablet_id = tablet_id();
-    seg_options.rowset_id = metadata().id();
-    seg_options.dynamic_rss_id_base = options.dynamic_rss_id_base;
+    segment_options->lake_io_opts.fs = segment_options->fs;
+    segment_options->stats = stats;
+    segment_options->ranges = options.ranges;
+    segment_options->pred_tree = options.pred_tree;
+    segment_options->pred_tree_for_zone_map = options.pred_tree_for_zone_map;
+    segment_options->runtime_filter_preds = options.runtime_filter_preds;
+    segment_options->delete_predicates = delete_predicates;
+    segment_options->enable_join_runtime_filter_pushdown = options.enable_join_runtime_filter_pushdown;
+    segment_options->has_predicate_above_iterator = options.has_predicate_above_iterator;
+    if (options.runtime_state != nullptr) {
+        segment_options->is_cancelled = &options.runtime_state->cancelled_ref();
+    }
+    segment_options->use_page_cache = options.use_page_cache;
+    segment_options->profile = options.profile;
+    segment_options->reader_type = options.reader_type;
+    segment_options->chunk_size = options.chunk_size;
+    segment_options->global_dictmaps = options.global_dictmaps;
+    segment_options->unused_output_column_ids = options.unused_output_column_ids;
+    segment_options->runtime_range_pruner = options.runtime_range_pruner;
+    segment_options->tablet_schema = options.tablet_schema;
+    segment_options->lake_io_opts = lake_io_opts;
+    segment_options->asc_hint = options.asc_hint;
+    segment_options->column_access_paths = options.column_access_paths;
+    segment_options->use_vector_index = options.use_vector_index;
+    segment_options->vector_search_option = options.vector_search_option;
+    segment_options->belonged_to_cloud_native = true;
+    segment_options->has_preaggregation = options.has_preaggregation;
+    segment_options->sample_options = options.sample_options;
+    segment_options->enable_predicate_col_late_materialize = options.enable_predicate_col_late_materialize;
+    segment_options->tablet_id = tablet_id();
+    segment_options->rowset_id = metadata().id();
+    segment_options->rowsetid = rowset_id();
+    segment_options->dynamic_rss_id_base = options.dynamic_rss_id_base;
     if (options.is_primary_keys) {
-        seg_options.is_primary_keys = true;
-        seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(
-                _tablet_mgr, nullptr, seg_options.lake_io_opts.fill_data_cache, seg_options.lake_io_opts);
-        seg_options.dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
+        segment_options->is_primary_keys = true;
+        segment_options->delvec_loader = std::make_shared<LakeDelvecLoader>(
+                _tablet_mgr, nullptr, segment_options->lake_io_opts.fill_data_cache, segment_options->lake_io_opts);
+        segment_options->dcg_loader = std::make_shared<LakeDeltaColumnGroupLoader>(_tablet_metadata);
     }
     // The Index Delta Group (ADD INDEX fast-path) sidecar applies to ALL lake
     // key types, not just PRIMARY_KEYS: CREATE INDEX / SET bloom_filter_columns
@@ -317,39 +363,59 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     // the is_primary_keys block; otherwise non-PK tables get a null idg_loader
     // (and version 0), the .idx is invisible at query time, and the index is
     // silently never applied. delvec/dcg above stay PK-only.
-    seg_options.idg_loader = std::make_shared<LakeIndexDeltaGroupLoader>(_tablet_metadata);
-    seg_options.version = options.version;
-    if (options.delete_predicates != nullptr) {
-        seg_options.delete_predicates = options.delete_predicates->get_predicates(_index);
-    }
-
+    segment_options->idg_loader = std::make_shared<LakeIndexDeltaGroupLoader>(_tablet_metadata);
+    segment_options->version = options.version;
     if (options.short_key_ranges_option != nullptr) { // logical split.
-        seg_options.short_key_ranges = options.short_key_ranges_option->short_key_ranges;
+        segment_options->short_key_ranges = options.short_key_ranges_option->short_key_ranges;
     }
-    seg_options.reader_type = options.reader_type;
-    seg_options.enable_gin_filter = options.enable_gin_filter;
-    seg_options.prune_column_after_index_filter = options.prune_column_after_index_filter;
-    seg_options.has_preaggregation = options.has_preaggregation;
+    segment_options->enable_gin_filter = options.enable_gin_filter;
+    segment_options->prune_column_after_index_filter = options.prune_column_after_index_filter;
+    segment_options->is_first_split_of_segment = true;
+    return Status::OK();
+}
 
-    std::unique_ptr<Schema> segment_schema_guard;
-    auto* segment_schema = const_cast<Schema*>(&schema);
-    // Append the columns with delete condition to segment schema.
+Status Rowset::set_segment_tablet_range(size_t segment_idx, const std::optional<SeekRange>& shared_segment_range,
+                                        SegmentReadOptions* segment_options) const {
+    if (segment_options == nullptr) {
+        return Status::InvalidArgument("segment read options is null");
+    }
+    segment_options->tablet_range = std::nullopt;
+    if (segment_idx < static_cast<size_t>(_metadata->segment_metas_size()) &&
+        _metadata->segment_metas(segment_idx).shared() && shared_segment_range.has_value()) {
+        segment_options->tablet_range = *shared_segment_range;
+    }
+    return Status::OK();
+}
+
+Schema Rowset::build_segment_schema(const Schema& schema, const RowsetReadOptions& options,
+                                    const DisjunctivePredicates& delete_predicates) const {
+    Schema segment_schema = schema;
     std::set<ColumnId> need_added_column;
-    seg_options.delete_predicates.get_column_ids(&need_added_column);
-
+    delete_predicates.get_column_ids(&need_added_column);
     for (ColumnId cid : need_added_column) {
         const TabletColumn& col = options.tablet_schema->column(cid);
-        if (segment_schema->get_field_by_name(std::string(col.name())) != nullptr) {
+        if (segment_schema.get_field_by_name(std::string(col.name())) != nullptr) {
             continue;
         }
-        // copy on write
-        if (segment_schema == &schema) {
-            segment_schema = new Schema(schema);
-            segment_schema_guard.reset(segment_schema);
-        }
-        auto f = StorageSchemaHelper::convert_field(cid, col);
-        segment_schema->append(std::make_shared<Field>(std::move(f)));
+        segment_schema.append(std::make_shared<Field>(StorageSchemaHelper::convert_field(cid, col)));
     }
+    return segment_schema;
+}
+
+StatusOr<std::vector<ChunkIteratorPtr>> Rowset::do_read(const Schema& schema, const RowsetReadOptions& options,
+                                                        const ReadContext& context) {
+    if (context.target_segment_idx.has_value() && *context.target_segment_idx >= static_cast<size_t>(num_segments())) {
+        return Status::InvalidArgument("target segment index exceeds rowset segment count");
+    }
+
+    const auto delete_predicates = options.delete_predicates != nullptr
+                                           ? options.delete_predicates->get_predicates(_index)
+                                           : DisjunctivePredicates{};
+    SegmentReadOptions seg_options;
+    RETURN_IF_ERROR(
+            init_segment_read_options(options, options.lake_io_opts, delete_predicates, options.stats, &seg_options));
+    auto segment_schema = build_segment_schema(schema, options, delete_predicates);
+    const bool use_projection = segment_schema.num_fields() != schema.num_fields();
 
     // Expose the fully-populated SegmentReadOptions so unit tests can verify the read-options
     // propagation chain (TabletReaderParams -> RowsetReadOptions -> SegmentReadOptions). No-op
@@ -357,7 +423,6 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     TEST_SYNC_POINT_CALLBACK("Rowset::read::seg_options", &seg_options);
 
     std::vector<ChunkIteratorPtr> segment_iterators;
-
     ASSIGN_OR_RETURN(auto shared_segment_range, get_seek_range());
 
     // Check if segment metadata filter can be used.
@@ -368,6 +433,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     std::unordered_set<int> skip_segment_idxs;
     if (use_metadata_filter) {
         for (int i = 0; i < metadata().segment_metas_size() && i < num_segments(); i++) {
+            if (context.target_segment_idx.has_value() && static_cast<size_t>(i) != *context.target_segment_idx) {
+                continue;
+            }
             const auto& segment_meta = metadata().segment_metas(i);
             if (!SegmentMetadataFilter::may_contain(segment_meta, options.pred_tree_for_zone_map,
                                                     *options.tablet_schema)) {
@@ -385,15 +453,36 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
 
     std::vector<LoadedSegment> segments;
     const std::unordered_set<int>* skip_ptr = skip_segment_idxs.empty() ? nullptr : &skip_segment_idxs;
-    RETURN_IF_ERROR(load_segments(&segments, seg_options, nullptr, skip_ptr));
+    if (context.prepared_segments != nullptr) {
+        if (context.prepared_segments->size() != static_cast<size_t>(num_segments())) {
+            return Status::InvalidArgument("prepared segment count does not match rowset segment count");
+        }
+    } else {
+        RETURN_IF_ERROR(load_segments(&segments, seg_options, nullptr, skip_ptr));
+    }
 
     // Update segments_read_count after filtering
     if (options.stats) {
-        options.stats->segments_read_count += num_segments() - skip_segment_idxs.size();
+        if (context.target_segment_idx.has_value()) {
+            options.stats->segments_read_count +=
+                    skip_segment_idxs.contains(static_cast<int>(*context.target_segment_idx)) ? 0 : 1;
+        } else {
+            options.stats->segments_read_count += num_segments() - skip_segment_idxs.size();
+        }
     }
 
-    for (int i = 0; i < segments.size(); i++) {
-        auto& seg_ptr = segments[i].segment;
+    const size_t segment_begin = context.target_segment_idx.value_or(0);
+    const size_t segment_count =
+            context.prepared_segments != nullptr ? context.prepared_segments->size() : segments.size();
+    const size_t segment_end = context.target_segment_idx.has_value() ? *context.target_segment_idx + 1 : segment_count;
+    for (size_t i = segment_begin; i < segment_end; i++) {
+        // Prepared segments are indexed by metadata position and are not pre-filtered by load_segments(),
+        // so apply the metadata filter here; the non-prepared path already carries nullptr placeholders
+        // for filtered segments (handled by the nullptr check below).
+        if (context.prepared_segments != nullptr && skip_segment_idxs.contains(static_cast<int>(i))) {
+            continue;
+        }
+        auto& seg_ptr = context.prepared_segments != nullptr ? (*context.prepared_segments)[i] : segments[i].segment;
         // Skip segments that were filtered by metadata filter (nullptr placeholders)
         if (seg_ptr == nullptr) {
             continue;
@@ -402,18 +491,17 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             continue;
         }
 
-        seg_options.tablet_range = std::nullopt;
-        // Consult shared() by the segment's true metadata position, recorded at load time. The loaded
-        // position i is NOT the metadata index in segment-range / partial-compaction modes.
-        const int32_t meta_pos = segments[i].segment_meta_pos;
-        if (meta_pos < _metadata->segment_metas_size() && _metadata->segment_metas(meta_pos).shared() &&
-            shared_segment_range.has_value()) {
-            seg_options.tablet_range = *shared_segment_range;
-        }
+        // Consult shared() by the segment's true metadata position. The loaded position i is NOT the
+        // metadata index in segment-range / partial-compaction modes, so use segment_meta_pos for the
+        // non-prepared path; the prepared-segment vector is already indexed by metadata position.
+        const int32_t meta_pos =
+                context.prepared_segments != nullptr ? static_cast<int32_t>(i) : segments[i].segment_meta_pos;
+        RETURN_IF_ERROR(set_segment_tablet_range(meta_pos, shared_segment_range, &seg_options));
         // Owner tablet id for .vi naming: a segment shared across tablets after a split must
         // resolve the same .vi from every reader (see resolve_segment_vector_index_uid). Set only for
-        // vector-indexed segments; read() is the sole entry point that sets belonged_to_cloud_native,
-        // so only its iterators reach the ANN-reader path that consumes this.
+        // vector-indexed segments; the read()/read_prepared_segment() family (all funneling through
+        // do_read -> init_segment_read_options) sets belonged_to_cloud_native -- unlike
+        // get_each_segment_iterator* -- so only their iterators reach the ANN-reader path that consumes this.
         if (meta_pos < _metadata->segment_metas_size() &&
             _metadata->segment_metas(meta_pos).vector_index_ids_size() > 0) {
             seg_options.segment_vector_index_uid = resolve_segment_vector_index_uid(_metadata->segment_metas(meta_pos));
@@ -427,23 +515,49 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
             }
             seg_options.rowid_range_option = std::move(rowid_range);
             seg_options.is_first_split_of_segment = is_first_split_of_segment;
+            if (context.prepared_segment_state != nullptr) {
+                seg_options.read_state_cache = make_segment_read_state_cache(*context.prepared_segment_state);
+            }
         } else if (options.short_key_ranges_option != nullptr) { // logical split.
             seg_options.is_first_split_of_segment = options.short_key_ranges_option->is_first_split_of_tablet;
         } else {
             seg_options.is_first_split_of_segment = true;
         }
 
-        auto res = seg_ptr->new_iterator(*segment_schema, seg_options);
-        if (res.status().is_end_of_file()) {
-            continue;
-        }
-        if (!res.ok()) {
-            return res.status();
-        }
-        if (segment_schema != &schema) {
-            segment_iterators.emplace_back(new_projection_iterator(schema, std::move(res).value()));
-        } else {
+        if (context.reusable_segment_iterators != nullptr) {
+            if (context.reusable_segment_iterators->size() <= i) {
+                context.reusable_segment_iterators->resize(i + 1);
+            }
+            const bool reuse_segment_iter = (*context.reusable_segment_iterators)[i] != nullptr;
+            auto res = seg_ptr->new_reusable_iterator(segment_schema, schema, seg_options,
+                                                      &(*context.reusable_segment_iterators)[i]);
+            if (res.status().is_end_of_file()) {
+                continue;
+            }
+            if (!res.ok()) {
+                return res.status();
+            }
+            if (options.stats != nullptr) {
+                if (reuse_segment_iter) {
+                    options.stats->lake_reusable_segment_iter_reused++;
+                } else {
+                    options.stats->lake_reusable_segment_iter_created++;
+                }
+            }
             segment_iterators.emplace_back(std::move(res).value());
+        } else {
+            auto res = seg_ptr->new_iterator(segment_schema, seg_options);
+            if (res.status().is_end_of_file()) {
+                continue;
+            }
+            if (!res.ok()) {
+                return res.status();
+            }
+            if (use_projection) {
+                segment_iterators.emplace_back(new_projection_iterator(schema, std::move(res).value()));
+            } else {
+                segment_iterators.emplace_back(std::move(res).value());
+            }
         }
     }
     if (segment_iterators.size() > 1 && !is_overlapped()) {

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -14,9 +14,16 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <unordered_set>
+#include <vector>
 
+#include "common/status.h"
 #include "common/statusor.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet.h"
@@ -27,11 +34,105 @@
 #include "storage/seek_range.h"
 #include "storage_primitive/range.h"
 
+namespace starrocks {
+class DisjunctivePredicates;
+class RowsetReadOptions;
+class SegmentReadOptions;
+} // namespace starrocks
+
 namespace starrocks::lake {
 
 class MetaFileBuilder;
 class TabletManager;
 class TabletWriter;
+
+struct PreparedSegmentReadState {
+    // The seed folds every page filter (zonemap, bloom filter) into pruned_scan_range, so reusing
+    // children apply it directly without re-running any page filter.
+    SparseRangePtr pruned_scan_range;
+    std::atomic<bool> pruned_scan_range_cache_disabled{false};
+    std::atomic<bool> pruned_scan_range_ready{false};
+
+    bool has_pruned_scan_range() const {
+        return !pruned_scan_range_cache_disabled.load(std::memory_order_acquire) &&
+               pruned_scan_range_ready.load(std::memory_order_acquire) && pruned_scan_range != nullptr;
+    }
+
+    void publish_pruned_scan_range(SparseRangePtr range) {
+        pruned_scan_range = std::move(range);
+        pruned_scan_range_ready.store(true, std::memory_order_release);
+    }
+
+    void clear_pruned_scan_range() {
+        pruned_scan_range_ready.store(false, std::memory_order_release);
+        pruned_scan_range.reset();
+    }
+
+    void disable_pruned_scan_range_cache() {
+        pruned_scan_range_cache_disabled.store(true, std::memory_order_release);
+        clear_pruned_scan_range();
+    }
+
+    // Rowid equivalents of RowsetReadOptions::ranges and the rowset's tablet range
+    // (SegmentReadOptions::tablet_range derived from get_seek_range()).
+    // Children reuse them to avoid repeating short-key index lookups.
+    std::vector<std::optional<Range<rowid_t>>> seek_ranges_rowid_bounds;
+    std::optional<Range<rowid_t>> tablet_range_rowid_bounds;
+    std::atomic<bool> rowid_bounds_cache_disabled{false};
+    std::atomic<bool> rowid_bounds_cache_ready{false};
+
+    bool has_rowid_bounds_cache() const {
+        return !rowid_bounds_cache_disabled.load(std::memory_order_acquire) &&
+               rowid_bounds_cache_ready.load(std::memory_order_acquire);
+    }
+
+    void publish_rowid_bounds_cache(std::vector<std::optional<Range<rowid_t>>>&& seek_range_bounds,
+                                    std::optional<Range<rowid_t>> tablet_range_bound) {
+        seek_ranges_rowid_bounds = std::move(seek_range_bounds);
+        tablet_range_rowid_bounds = std::move(tablet_range_bound);
+        rowid_bounds_cache_ready.store(true, std::memory_order_release);
+    }
+
+    void clear_rowid_bounds_cache() {
+        rowid_bounds_cache_ready.store(false, std::memory_order_release);
+        seek_ranges_rowid_bounds.clear();
+        tablet_range_rowid_bounds.reset();
+    }
+
+    void disable_rowid_bounds_cache() {
+        rowid_bounds_cache_disabled.store(true, std::memory_order_release);
+        clear_rowid_bounds_cache();
+    }
+
+    void disable_runtime_filter_dependent_cache() {
+        disable_pruned_scan_range_cache();
+        disable_rowid_bounds_cache();
+    }
+
+    // State shared by coarse rowid range tasks and refined rowid range tasks.
+    // Coarse range issuing fields are protected by |coarse_range_lock|.
+    std::mutex coarse_range_lock;
+    SparseRange<> coarse_scan_range;
+    SparseRangeIterator<> coarse_scan_range_iter;
+    SparseRange<> allocated_coarse_ranges;
+    bool coarse_split_allocation_closed = false;
+};
+
+struct PreparedTabletReadState {
+    std::vector<RowsetPtr> rowsets;
+    std::vector<std::vector<SegmentPtr>> rowset_segments;
+    std::vector<std::vector<PreparedSegmentReadStatePtr>> rowset_prepared_states;
+
+    void disable_runtime_filter_dependent_cache() {
+        for (const auto& prepared_states : rowset_prepared_states) {
+            for (const auto& segment_state : prepared_states) {
+                if (segment_state != nullptr) {
+                    segment_state->disable_runtime_filter_dependent_cache();
+                }
+            }
+        }
+    }
+};
 
 class Rowset : public BaseRowset {
 public:
@@ -69,6 +170,20 @@ public:
     DISALLOW_COPY_AND_MOVE(Rowset);
 
     StatusOr<std::vector<ChunkIteratorPtr>> read(const Schema& schema, const RowsetReadOptions& options);
+    StatusOr<std::vector<ChunkIteratorPtr>> read(const Schema& schema, const RowsetReadOptions& options,
+                                                 const std::vector<SegmentPtr>& prepared_segments);
+    StatusOr<std::vector<ChunkIteratorPtr>> read_prepared_segment(
+            const Schema& schema, const RowsetReadOptions& options, const std::vector<SegmentPtr>& prepared_segments,
+            size_t segment_idx, const PreparedSegmentReadStatePtr& prepared_segment_state,
+            std::vector<ChunkIteratorPtr>* reusable_segment_iterators = nullptr);
+    StatusOr<std::optional<SeekRange>> get_seek_range() const;
+    Status init_segment_read_options(const RowsetReadOptions& options, const LakeIOOptions& lake_io_opts,
+                                     const DisjunctivePredicates& delete_predicates, OlapReaderStatistics* stats,
+                                     SegmentReadOptions* segment_options) const;
+    Status set_segment_tablet_range(size_t segment_idx, const std::optional<SeekRange>& shared_segment_range,
+                                    SegmentReadOptions* segment_options) const;
+    Schema build_segment_schema(const Schema& schema, const RowsetReadOptions& options,
+                                const DisjunctivePredicates& delete_predicates) const;
 
     StatusOr<size_t> get_read_iterator_num();
 
@@ -186,7 +301,15 @@ public:
     int64_t end_version() const override { return 0; }
 
 private:
-    StatusOr<std::optional<SeekRange>> get_seek_range() const;
+    struct ReadContext {
+        const std::vector<SegmentPtr>* prepared_segments = nullptr;
+        std::optional<size_t> target_segment_idx = std::nullopt;
+        const PreparedSegmentReadState* prepared_segment_state = nullptr;
+        std::vector<ChunkIteratorPtr>* reusable_segment_iterators = nullptr;
+    };
+
+    StatusOr<std::vector<ChunkIteratorPtr>> do_read(const Schema& schema, const RowsetReadOptions& options,
+                                                    const ReadContext& context);
 
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -14,7 +14,9 @@
 
 #include "storage/lake/tablet_reader.h"
 
+#include <algorithm>
 #include <future>
+#include <limits>
 #include <utility>
 
 #include "base/testutil/sync_point.h"
@@ -28,6 +30,7 @@
 #include "common/status.h"
 #include "common/thread/threadpool.h"
 #include "exec_primitive/pipeline/scan/scan_morsel.h"
+#include "fs/fs_factory.h"
 #include "gutil/stl_util.h"
 #include "runtime/runtime_env.h"
 #include "runtime/runtime_state.h"
@@ -42,6 +45,8 @@
 #include "storage/query/split_scan_morsel.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/rowset_options.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
 #include "storage/rowset/short_key_range_option.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema_map.h"
@@ -61,6 +66,207 @@ using Datum = starrocks::Datum;
 using Field = starrocks::Field;
 using PredicateParser = starrocks::PredicateParser;
 using ZonemapPredicatesRewriter = starrocks::ZonemapPredicatesRewriter;
+
+static Schema build_prepare_pruning_schema(const RowsetPtr& rowset, const Schema& read_schema,
+                                           const RowsetReadOptions& rowset_read_options,
+                                           const DisjunctivePredicates& delete_predicates) {
+    Schema prepare_schema = rowset->build_segment_schema(read_schema, rowset_read_options, delete_predicates);
+    if (rowset_read_options.tablet_schema == nullptr) {
+        return prepare_schema;
+    }
+
+    for (ColumnId cid : rowset_read_options.pred_tree_for_zone_map.column_ids()) {
+        const TabletColumn& col = rowset_read_options.tablet_schema->column(cid);
+        if (prepare_schema.get_field_by_name(std::string(col.name())) != nullptr) {
+            continue;
+        }
+        prepare_schema.append(std::make_shared<Field>(StorageSchemaHelper::convert_field(cid, col)));
+    }
+    return prepare_schema;
+}
+
+static Status prepare_segment_pruned_scan_range(const SegmentPtr& segment, const Schema& schema,
+                                                const SegmentReadOptions& segment_read_options,
+                                                const PreparedSegmentReadStatePtr& prepared_segment_read_state) {
+    if (segment == nullptr || prepared_segment_read_state == nullptr) {
+        return Status::InvalidArgument("invalid prepared segment read state");
+    }
+
+    auto range_or = get_prepared_pruned_row_ranges(segment, schema, segment_read_options);
+    if (!range_or.ok()) {
+        return range_or.status();
+    }
+    prepared_segment_read_state->publish_pruned_scan_range(
+            std::make_shared<SparseRange<>>(std::move(range_or).value()));
+    return Status::OK();
+}
+
+static Status prepare_segment_pruned_scan_range_for_split(
+        const RowsetPtr& rowset, size_t segment_idx, const SegmentPtr& segment,
+        const PreparedSegmentReadStatePtr& segment_state, const Schema& read_schema,
+        const RowsetReadOptions& rowset_read_options, const LakeIOOptions& lake_io_opts,
+        const std::optional<SeekRange>& shared_segment_range, OlapReaderStatistics* prepare_stats) {
+    const auto delete_predicates = rowset_read_options.delete_predicates != nullptr
+                                           ? rowset_read_options.delete_predicates->get_predicates(rowset->index())
+                                           : DisjunctivePredicates{};
+    SegmentReadOptions segment_read_options;
+    RETURN_IF_ERROR(rowset->init_segment_read_options(rowset_read_options, lake_io_opts, delete_predicates,
+                                                      prepare_stats, &segment_read_options));
+    RETURN_IF_ERROR(rowset->set_segment_tablet_range(segment_idx, shared_segment_range, &segment_read_options));
+    std::vector<SeekRange> ranges_to_resolve = segment_read_options.ranges;
+    std::optional<size_t> tablet_range_offset;
+    if (segment_read_options.tablet_range.has_value() && !segment_read_options.tablet_range->all_range()) {
+        tablet_range_offset = ranges_to_resolve.size();
+        ranges_to_resolve.emplace_back(segment_read_options.tablet_range.value());
+    }
+    ASSIGN_OR_RETURN(auto resolved_ranges, segment_seek_ranges_to_rowid_ranges(segment, ranges_to_resolve,
+                                                                               segment_read_options.lake_io_opts));
+    std::vector<std::optional<Range<rowid_t>>> seek_ranges_rowid_bounds(
+            resolved_ranges.begin(), resolved_ranges.begin() + segment_read_options.ranges.size());
+    std::optional<Range<rowid_t>> tablet_range_rowid_bounds;
+    if (tablet_range_offset.has_value()) {
+        tablet_range_rowid_bounds = resolved_ranges[*tablet_range_offset];
+    }
+    segment_state->publish_rowid_bounds_cache(std::move(seek_ranges_rowid_bounds), tablet_range_rowid_bounds);
+    segment_read_options.read_state_cache.seek_range_rowid_ranges = &segment_state->seek_ranges_rowid_bounds;
+    segment_read_options.read_state_cache.tablet_rowid_range = &segment_state->tablet_range_rowid_bounds;
+    auto prepare_schema = build_prepare_pruning_schema(rowset, read_schema, rowset_read_options, delete_predicates);
+    return prepare_segment_pruned_scan_range(segment, prepare_schema, segment_read_options, segment_state);
+}
+
+static void append_refined_segment_split_tasks(const RowsetPtr& rowset, const SegmentPtr& segment,
+                                               const PreparedTabletReadStatePtr& prepared_tablet_read_state,
+                                               const PreparedSegmentReadStatePtr& segment_state, size_t rowset_idx,
+                                               size_t segment_idx, const SparseRange<>& refined_scan_range,
+                                               rowid_t rows_per_split, bool is_first_split_of_segment,
+                                               std::vector<pipeline::ScanSplitContextPtr>* split_tasks) {
+    if (refined_scan_range.span_size() == 0) {
+        return;
+    }
+
+    auto range_iter = refined_scan_range.new_iterator();
+    while (range_iter.has_more()) {
+        SparseRange<> split_range;
+        range_iter.next_range(rows_per_split, &split_range);
+        if (split_range.span_size() == 0) {
+            break;
+        }
+
+        auto rowid_range = std::make_shared<RowidRangeOption>();
+        rowid_range->add(rowset.get(), segment.get(), std::make_shared<SparseRange<>>(std::move(split_range)),
+                         is_first_split_of_segment);
+        is_first_split_of_segment = false;
+
+        auto ctx = std::make_unique<pipeline::LakeSplitContext>();
+        ctx->rowid_range = std::move(rowid_range);
+        ctx->rowid_range_source = pipeline::LakeSplitContext::RowidRangeSource::REFINED;
+        ctx->prepared_tablet_read_state = prepared_tablet_read_state;
+        ctx->prepared_segment_read_state = segment_state;
+        ctx->rowset_index = rowset_idx;
+        ctx->segment_index = segment_idx;
+        split_tasks->emplace_back(std::move(ctx));
+    }
+}
+
+static StatusOr<SparseRange<>> build_initial_coarse_scan_range(const SegmentPtr& segment,
+                                                               const SegmentReadOptions& segment_read_options) {
+    const bool need_short_key_index =
+            !segment_read_options.ranges.empty() ||
+            (segment_read_options.tablet_range.has_value() && !segment_read_options.tablet_range->all_range());
+    if (need_short_key_index) {
+        RETURN_IF_ERROR(segment->load_index(segment_read_options.lake_io_opts));
+    }
+    ASSIGN_OR_RETURN(auto scan_range,
+                     block_aligned_rowid_range_from_seek_ranges(segment.get(), segment_read_options.ranges));
+    if (segment_read_options.tablet_range.has_value() && !segment_read_options.tablet_range->all_range()) {
+        ASSIGN_OR_RETURN(auto tablet_scan_range, block_aligned_rowid_range_from_seek_ranges(
+                                                         segment.get(), {segment_read_options.tablet_range.value()}));
+        scan_range &= tablet_scan_range;
+    }
+    return scan_range;
+}
+
+// Exposed (declared in tablet_reader.h) for unit testing; see subtract_sparse_ranges there.
+SparseRange<> subtract_sparse_ranges(const SparseRange<>& lhs, const SparseRange<>& rhs) {
+    SparseRange<> result;
+    size_t rhs_idx = 0;
+    for (size_t lhs_idx = 0; lhs_idx < lhs.size(); ++lhs_idx) {
+        auto cur = lhs[lhs_idx];
+        while (rhs_idx < rhs.size() && rhs[rhs_idx].end() <= cur.begin()) {
+            ++rhs_idx;
+        }
+        size_t probe = rhs_idx;
+        while (probe < rhs.size() && rhs[probe].begin() < cur.end()) {
+            const auto& cut = rhs[probe];
+            if (cut.begin() > cur.begin()) {
+                result.add(Range<>(cur.begin(), std::min(cur.end(), cut.begin())));
+            }
+            if (cut.end() >= cur.end()) {
+                cur = Range<>(cur.end(), cur.end());
+                break;
+            }
+            cur = Range<>(std::max(cur.begin(), cut.end()), cur.end());
+            ++probe;
+        }
+        if (!cur.empty()) {
+            result.add(cur);
+        }
+    }
+    return result;
+}
+
+static void init_coarse_split_allocation_state(const PreparedSegmentReadStatePtr& segment_state,
+                                               const SparseRange<>& coarse_scan_range) {
+    std::lock_guard<std::mutex> guard(segment_state->coarse_range_lock);
+    segment_state->coarse_scan_range = coarse_scan_range;
+    segment_state->coarse_scan_range_iter = segment_state->coarse_scan_range.new_iterator();
+    segment_state->allocated_coarse_ranges.clear();
+    segment_state->coarse_split_allocation_closed = false;
+    segment_state->clear_pruned_scan_range();
+    segment_state->clear_rowid_bounds_cache();
+}
+
+static bool allocate_initial_coarse_split(const PreparedSegmentReadStatePtr& segment_state, Rowset* rowset,
+                                          Segment* segment, rowid_t rows_per_split, RowidRangeOptionPtr* rowid_range) {
+    *rowid_range = nullptr;
+    std::lock_guard<std::mutex> guard(segment_state->coarse_range_lock);
+    if (segment_state->coarse_split_allocation_closed || !segment_state->coarse_scan_range_iter.has_more()) {
+        return false;
+    }
+
+    auto result = std::make_shared<RowidRangeOption>();
+    size_t num_taken_rows = 0;
+    while (segment_state->coarse_scan_range_iter.has_more() && num_taken_rows < rows_per_split) {
+        const size_t remaining_rows = segment_state->coarse_scan_range_iter.remaining_rows();
+        size_t rows_to_take = std::min<size_t>(rows_per_split - num_taken_rows, remaining_rows);
+        if (remaining_rows > rows_to_take && remaining_rows - rows_to_take < rows_per_split) {
+            rows_to_take = remaining_rows;
+        }
+
+        SparseRange<> taken_range;
+        segment_state->coarse_scan_range_iter.next_range(rows_to_take, &taken_range);
+        if (taken_range.span_size() == 0) {
+            break;
+        }
+        const bool is_first_split_of_segment = segment_state->allocated_coarse_ranges.span_size() == 0;
+        segment_state->allocated_coarse_ranges |= taken_range;
+        num_taken_rows += taken_range.span_size();
+        result->add(rowset, segment, std::make_shared<SparseRange<>>(std::move(taken_range)),
+                    is_first_split_of_segment);
+    }
+
+    if (result->rowid_range_per_segment_per_rowset.empty()) {
+        return false;
+    }
+    *rowid_range = std::move(result);
+    return true;
+}
+
+static rowid_t rows_per_split(const TabletReaderParams& params) {
+    return params.splitted_scan_rows > 0 ? static_cast<rowid_t>(std::min<int64_t>(params.splitted_scan_rows,
+                                                                                  std::numeric_limits<rowid_t>::max()))
+                                         : std::numeric_limits<rowid_t>::max();
+}
 
 TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema)
         : ChunkIterator(std::move(schema)), _tablet_mgr(tablet_mgr), _tablet_metadata(std::move(metadata)) {}
@@ -136,6 +342,10 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         return Status::NotSupported("reader type not supported now");
     }
     RETURN_IF_ERROR(init_compaction_column_paths(read_params));
+    if (_collect_iter != nullptr) {
+        _collect_iter->close();
+        _collect_iter.reset();
+    }
 
     if (_need_split) {
         std::vector<BaseTabletSharedPtr> tablets;
@@ -165,6 +375,17 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
             // otherwise, iterator will return empty.
             _need_split = false;
             return init_collector(read_params);
+        }
+
+        if (_could_split_physically && read_params.enable_prepared_physical_split_scan) {
+            auto prepared_tablet_read_state = std::make_shared<PreparedTabletReadState>();
+            RETURN_IF_ERROR(build_prepared_tablet_read_state(read_params, prepared_tablet_read_state.get()));
+            RETURN_IF_ERROR(build_initial_coarse_split_tasks(read_params, prepared_tablet_read_state));
+            if (_split_tasks.empty()) {
+                _need_split = false;
+                return init_collector(read_params);
+            }
+            return Status::OK();
         }
 
         pipeline::Morsels morsels;
@@ -220,7 +441,12 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         }
 
     } else {
-        return init_collector(read_params);
+        TabletReaderParams effective_params = read_params;
+        if (effective_params.refine_initial_coarse_split_and_append_refined_tasks) {
+            RETURN_IF_ERROR(refine_initial_coarse_split_and_append_refined_tasks(effective_params,
+                                                                                 &effective_params.rowid_range_option));
+        }
+        return init_collector(effective_params);
     }
 
     return Status::OK();
@@ -298,6 +524,15 @@ void TabletReader::close() {
         _collect_iter->close();
         _collect_iter.reset();
     }
+    for (auto& rowset_iters : _reusable_rowset_iterators) {
+        for (auto& iter : rowset_iters) {
+            if (iter != nullptr) {
+                iter->close();
+                iter.reset();
+            }
+        }
+    }
+    _reusable_rowset_iterators.clear();
     STLDeleteElements(&_predicate_free_list);
     _rowsets.clear();
     _obj_pool.clear();
@@ -334,69 +569,357 @@ Status TabletReader::do_get_next(Chunk* chunk, std::vector<RowSourceMask>* sourc
     return Status::OK();
 }
 
-// TODO: support
-//  1. rowid range and short key range
-Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters) {
-    RowsetReadOptions rs_opts;
+Status TabletReader::build_prepared_tablet_read_state(const TabletReaderParams& params,
+                                                      PreparedTabletReadState* state) {
+    if (state == nullptr) {
+        return Status::InvalidArgument("prepared tablet read state is null");
+    }
+    if (!state->rowsets.empty()) {
+        return Status::OK();
+    }
+    if (!_rowsets_inited) {
+        _rowsets = Rowset::get_rowsets(_tablet_mgr, _tablet_metadata);
+        _rowsets_inited = true;
+    }
+
+    std::vector<RowsetPtr> rowsets = _rowsets;
+    std::vector<std::vector<SegmentPtr>> rowset_segments;
+    std::vector<std::vector<PreparedSegmentReadStatePtr>> rowset_prepared_states;
+    rowset_segments.reserve(rowsets.size());
+    rowset_prepared_states.reserve(rowsets.size());
+    for (const auto& rowset : rowsets) {
+        ASSIGN_OR_RETURN(auto segments, rowset->segments(params.lake_io_opts));
+        std::vector<PreparedSegmentReadStatePtr> prepared_states;
+        prepared_states.reserve(segments.size());
+        for (size_t i = 0; i < segments.size(); ++i) {
+            prepared_states.emplace_back(std::make_shared<PreparedSegmentReadState>());
+        }
+        rowset_segments.emplace_back(std::move(segments));
+        rowset_prepared_states.emplace_back(std::move(prepared_states));
+    }
+
+    state->rowsets = std::move(rowsets);
+    state->rowset_segments = std::move(rowset_segments);
+    state->rowset_prepared_states = std::move(rowset_prepared_states);
+    return Status::OK();
+}
+
+Status TabletReader::init_rowset_read_options(const TabletReaderParams& params, RowsetReadOptions* options) {
+    if (options == nullptr) {
+        return Status::InvalidArgument("rowset read options is null");
+    }
     KeysType keys_type = _tablet_schema->keys_type();
     RETURN_IF_ERROR(init_predicates(params));
     RETURN_IF_ERROR(init_delete_predicates(params, &_delete_predicates));
     RETURN_IF_ERROR(parse_seek_range(*_tablet_schema, params.range, params.end_range, params.start_key, params.end_key,
-                                     &rs_opts.ranges, &_mempool));
-    rs_opts.pred_tree = params.pred_tree;
-    rs_opts.runtime_filter_preds = params.runtime_filter_preds;
-    PredicateTree pred_tree_for_zone_map;
-    RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, rs_opts.pred_tree,
-                                                                      rs_opts.pred_tree_for_zone_map));
-    rs_opts.sorted = ((keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation) ||
-                     is_compaction(params.reader_type) || params.sorted_by_keys_per_tablet;
-    rs_opts.reader_type = params.reader_type;
-    rs_opts.chunk_size = params.chunk_size;
-    rs_opts.delete_predicates = &_delete_predicates;
-    rs_opts.stats = &_stats;
-    rs_opts.runtime_state = params.runtime_state;
-    rs_opts.profile = params.profile;
-    rs_opts.use_page_cache = params.use_page_cache;
-    rs_opts.tablet_schema = _tablet_schema;
-    rs_opts.global_dictmaps = params.global_dictmaps;
-    rs_opts.unused_output_column_ids = params.unused_output_column_ids;
-    rs_opts.runtime_range_pruner = params.runtime_range_pruner;
-    rs_opts.lake_io_opts = params.lake_io_opts;
-    rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
-    rs_opts.has_predicate_above_iterator = params.has_predicate_above_iterator;
-    rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
-    rs_opts.enable_gin_filter = params.enable_gin_filter;
-    rs_opts.enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
+                                     &options->ranges, &_mempool));
+    options->pred_tree = params.pred_tree;
+    options->runtime_filter_preds = params.runtime_filter_preds;
+    RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, options->pred_tree,
+                                                                      options->pred_tree_for_zone_map));
+    options->sorted = ((keys_type != DUP_KEYS && keys_type != PRIMARY_KEYS) && !params.skip_aggregation) ||
+                      is_compaction(params.reader_type) || params.sorted_by_keys_per_tablet;
+    options->reader_type = params.reader_type;
+    options->chunk_size = params.chunk_size;
+    options->delete_predicates = &_delete_predicates;
+    options->stats = &_stats;
+    options->runtime_state = params.runtime_state;
+    options->profile = params.profile;
+    options->use_page_cache = params.use_page_cache;
+    options->tablet_schema = _tablet_schema;
+    options->global_dictmaps = params.global_dictmaps;
+    options->unused_output_column_ids = params.unused_output_column_ids;
+    options->runtime_range_pruner = params.runtime_range_pruner;
+    options->lake_io_opts = params.lake_io_opts;
+    options->enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
+    options->has_predicate_above_iterator = params.has_predicate_above_iterator;
+    options->prune_column_after_index_filter = params.prune_column_after_index_filter;
+    options->enable_gin_filter = params.enable_gin_filter;
+    options->enable_predicate_col_late_materialize = params.enable_predicate_col_late_materialize;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
-        rs_opts.is_primary_keys = true;
+        options->is_primary_keys = true;
     }
     // Read version is required by the Index Delta Group (ADD INDEX fast-path)
     // visibility filter for ALL key types, not only PRIMARY_KEYS. Leaving it 0
     // for DUPLICATE / UNIQUE / AGGREGATE reads hides every .idx entry
     // (entry.version > 0 == query_version), so the index is silently skipped.
-    rs_opts.version = _tablet_metadata->version();
-    rs_opts.reader_type = params.reader_type;
+    options->version = _tablet_metadata->version();
 
     if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS) {
-        rs_opts.asc_hint = _is_asc_hint;
+        options->asc_hint = _is_asc_hint;
     }
 
-    rs_opts.rowid_range_option = params.rowid_range_option;
-    rs_opts.short_key_ranges_option = params.short_key_ranges_option;
-
-    rs_opts.column_access_paths = params.column_access_paths;
-    rs_opts.use_vector_index = params.use_vector_index;
-    rs_opts.vector_search_option = params.vector_search_option;
-    rs_opts.has_preaggregation = true;
+    options->rowid_range_option = params.rowid_range_option;
+    options->short_key_ranges_option = params.short_key_ranges_option;
+    options->column_access_paths = params.column_access_paths;
+    options->use_vector_index = params.use_vector_index;
+    options->vector_search_option = params.vector_search_option;
+    options->sample_options = params.sample_options;
+    options->has_preaggregation = true;
     if ((is_compaction(params.reader_type) || params.sorted_by_keys_per_tablet)) {
-        rs_opts.has_preaggregation = true;
+        options->has_preaggregation = true;
     } else if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS ||
                (keys_type == UNIQUE_KEYS && params.skip_aggregation)) {
-        rs_opts.has_preaggregation = false;
+        options->has_preaggregation = false;
+    }
+    return Status::OK();
+}
+
+Status TabletReader::init_rowset_read_options_for_split(const TabletReaderParams& params, RowsetReadOptions* options,
+                                                        LakeIOOptions* lake_io_opts) {
+    if (lake_io_opts == nullptr) {
+        return Status::InvalidArgument("lake io options is null");
+    }
+    RETURN_IF_ERROR(init_rowset_read_options(params, options));
+
+    *lake_io_opts = params.lake_io_opts;
+    if (lake_io_opts->fs == nullptr) {
+        auto root_loc = _tablet_mgr->tablet_root_location(_tablet_metadata->id());
+        ASSIGN_OR_RETURN(lake_io_opts->fs, FileSystemFactory::CreateSharedFromString(root_loc));
+    }
+    if (lake_io_opts->location_provider == nullptr) {
+        lake_io_opts->location_provider = _tablet_mgr->location_provider();
+    }
+    options->lake_io_opts = *lake_io_opts;
+    return Status::OK();
+}
+
+Status TabletReader::build_initial_coarse_split_tasks(const TabletReaderParams& params,
+                                                      const PreparedTabletReadStatePtr& prepared_tablet_read_state) {
+    if (prepared_tablet_read_state == nullptr) {
+        return Status::InvalidArgument("prepared tablet read state is null");
+    }
+    if (prepared_tablet_read_state->rowsets.size() != prepared_tablet_read_state->rowset_segments.size() ||
+        prepared_tablet_read_state->rowsets.size() != prepared_tablet_read_state->rowset_prepared_states.size()) {
+        return Status::InvalidArgument("prepared tablet read state has inconsistent rowset state");
     }
 
+    RowsetReadOptions rowset_read_options;
+    LakeIOOptions lake_io_opts;
+    RETURN_IF_ERROR(init_rowset_read_options_for_split(params, &rowset_read_options, &lake_io_opts));
+
+    OlapReaderStatistics prepare_stats;
+    _split_tasks.clear();
+    const auto split_rows = rows_per_split(params);
+    for (size_t rowset_idx = 0; rowset_idx < prepared_tablet_read_state->rowsets.size(); ++rowset_idx) {
+        const auto& rowset = prepared_tablet_read_state->rowsets[rowset_idx];
+        if (rowset == nullptr) {
+            continue;
+        }
+        const auto& segments = prepared_tablet_read_state->rowset_segments[rowset_idx];
+        const auto& segment_states = prepared_tablet_read_state->rowset_prepared_states[rowset_idx];
+        if (segments.size() != segment_states.size()) {
+            return Status::InvalidArgument("prepared tablet read state has inconsistent segment state");
+        }
+        _stats.lake_prepared_rowsets++;
+        ASSIGN_OR_RETURN(auto shared_segment_range, rowset->get_seek_range());
+
+        for (size_t segment_idx = 0; segment_idx < segments.size(); ++segment_idx) {
+            const auto& segment = segments[segment_idx];
+            if (segment == nullptr || segment->num_rows() == 0) {
+                continue;
+            }
+            const auto& segment_state = segment_states[segment_idx];
+            const auto delete_predicates =
+                    rowset_read_options.delete_predicates != nullptr
+                            ? rowset_read_options.delete_predicates->get_predicates(rowset->index())
+                            : DisjunctivePredicates{};
+            SegmentReadOptions segment_read_options;
+            RETURN_IF_ERROR(rowset->init_segment_read_options(rowset_read_options, lake_io_opts, delete_predicates,
+                                                              &prepare_stats, &segment_read_options));
+            RETURN_IF_ERROR(rowset->set_segment_tablet_range(segment_idx, shared_segment_range, &segment_read_options));
+            ASSIGN_OR_RETURN(auto coarse_scan_range, build_initial_coarse_scan_range(segment, segment_read_options));
+            if (coarse_scan_range.span_size() == 0) {
+                continue;
+            }
+            init_coarse_split_allocation_state(segment_state, coarse_scan_range);
+
+            RowidRangeOptionPtr seed_rowid_range;
+            if (!allocate_initial_coarse_split(segment_state, rowset.get(), segment.get(), split_rows,
+                                               &seed_rowid_range)) {
+                continue;
+            }
+
+            auto ctx = std::make_unique<pipeline::LakeSplitContext>();
+            ctx->rowid_range = std::move(seed_rowid_range);
+            ctx->rowid_range_source = pipeline::LakeSplitContext::RowidRangeSource::INITIAL_COARSE;
+            ctx->prepared_tablet_read_state = prepared_tablet_read_state;
+            ctx->prepared_segment_read_state = segment_state;
+            ctx->rowset_index = rowset_idx;
+            ctx->segment_index = segment_idx;
+            _split_tasks.emplace_back(std::move(ctx));
+        }
+    }
+    return Status::OK();
+}
+
+Status TabletReader::refine_initial_coarse_split_and_append_refined_tasks(const TabletReaderParams& params,
+                                                                          RowidRangeOptionPtr* local_rowid_range) {
+    if (local_rowid_range == nullptr) {
+        return Status::InvalidArgument("local rowid range is null");
+    }
+    auto seed_rowid_range_option = params.rowid_range_option;
+    *local_rowid_range = nullptr;
+    if (params.prepared_tablet_read_state == nullptr || params.prepared_segment_read_state == nullptr ||
+        params.prepared_rowset_index >= params.prepared_tablet_read_state->rowsets.size() ||
+        params.prepared_rowset_index >= params.prepared_tablet_read_state->rowset_segments.size() ||
+        params.prepared_rowset_index >= params.prepared_tablet_read_state->rowset_prepared_states.size()) {
+        return Status::InvalidArgument("invalid initial coarse split context");
+    }
+
+    const auto& prepared_tablet_read_state = params.prepared_tablet_read_state;
+    const auto& segment_state = params.prepared_segment_read_state;
+    const auto rowset_idx = params.prepared_rowset_index;
+    const auto segment_idx = params.prepared_segment_index;
+    if (segment_idx >= prepared_tablet_read_state->rowset_segments[rowset_idx].size() ||
+        segment_idx >= prepared_tablet_read_state->rowset_prepared_states[rowset_idx].size() ||
+        prepared_tablet_read_state->rowset_prepared_states[rowset_idx][segment_idx] != segment_state) {
+        return Status::InvalidArgument("initial coarse split context does not match prepared state");
+    }
+
+    const auto& rowset = prepared_tablet_read_state->rowsets[rowset_idx];
+    const auto& segment = prepared_tablet_read_state->rowset_segments[rowset_idx][segment_idx];
+    if (rowset == nullptr || segment == nullptr || segment->num_rows() == 0) {
+        *local_rowid_range = std::make_shared<RowidRangeOption>();
+        return Status::OK();
+    }
+
+    TabletReaderParams prepare_params = params;
+    // The seed morsel carries only one coarse split. Segment prepare must compute the
+    // final pruned range for the whole segment so refined children can cover the rest.
+    prepare_params.rowid_range_option = nullptr;
+
+    RowsetReadOptions rowset_read_options;
+    LakeIOOptions lake_io_opts;
+    RETURN_IF_ERROR(init_rowset_read_options_for_split(prepare_params, &rowset_read_options, &lake_io_opts));
+
+    OlapReaderStatistics prepare_stats;
+    ASSIGN_OR_RETURN(auto shared_segment_range, rowset->get_seek_range());
+    Status st;
+    {
+        // Time the seed-only prepared-scan-range preparation (zonemap/bloom page-filter folding + seek-range
+        // resolution). This otherwise hides inside IOTaskExecTime with no dedicated counter; for highly
+        // selective scans over a big tablet it can dominate the whole scan.
+        SCOPED_RAW_TIMER(&_stats.lake_prepared_seed_ns);
+        st = prepare_segment_pruned_scan_range_for_split(rowset, segment_idx, segment, segment_state, schema(),
+                                                         rowset_read_options, lake_io_opts, shared_segment_range,
+                                                         &prepare_stats);
+    }
+    {
+        std::lock_guard<std::mutex> guard(segment_state->coarse_range_lock);
+        segment_state->coarse_split_allocation_closed = true;
+    }
+    RETURN_IF_ERROR(st);
+
+    // Fold the seed prepare's otherwise-discarded sub-metrics into the reader stats so the SeedPrepareTime
+    // breakdown (IO / segment-init / zonemap / bloom) is visible in the profile. Accumulated across segments.
+    _stats.lake_prepared_seed_io_ns += prepare_stats.io_ns;
+    _stats.lake_prepared_seed_io_count += prepare_stats.io_count;
+    _stats.lake_prepared_seed_segment_init_ns += prepare_stats.segment_init_ns;
+    _stats.lake_prepared_seed_zonemap_ns += prepare_stats.zone_map_filter_ns;
+    _stats.lake_prepared_seed_zonemap_filtered_rows += prepare_stats.rows_stats_filtered;
+    _stats.lake_prepared_seed_bf_ns += prepare_stats.bf_filter_ns;
+    _stats.lake_prepared_seed_bf_filtered_rows += prepare_stats.rows_bf_filtered;
+
+    SparseRange<> pruned_scan_range;
+    if (segment_state->pruned_scan_range != nullptr) {
+        pruned_scan_range = *segment_state->pruned_scan_range;
+        _stats.lake_prepared_scan_rows += segment_state->pruned_scan_range->span_size();
+        _stats.lake_prepared_scan_ranges += segment_state->pruned_scan_range->size();
+    } else {
+        pruned_scan_range.add(Range<>(0, segment->num_rows()));
+    }
+    if (pruned_scan_range.span_size() == 0) {
+        *local_rowid_range = std::make_shared<RowidRangeOption>();
+        return Status::OK();
+    }
+
+    if (seed_rowid_range_option != nullptr) {
+        auto seed_split = seed_rowid_range_option->get_segment_rowid_range(rowset.get(), segment.get());
+        if (seed_split.row_id_range != nullptr) {
+            SparseRange<> seed_scan_range = *seed_split.row_id_range;
+            seed_scan_range &= pruned_scan_range;
+            if (seed_scan_range.span_size() > 0) {
+                auto rowid_range = std::make_shared<RowidRangeOption>();
+                rowid_range->add(rowset.get(), segment.get(),
+                                 std::make_shared<SparseRange<>>(std::move(seed_scan_range)),
+                                 seed_split.is_first_split_of_segment);
+                *local_rowid_range = std::move(rowid_range);
+            }
+        }
+    }
+
+    SparseRange<> allocated_coarse_ranges;
+    {
+        std::lock_guard<std::mutex> guard(segment_state->coarse_range_lock);
+        allocated_coarse_ranges = segment_state->allocated_coarse_ranges;
+    }
+    SparseRange<> remaining_scan_range = subtract_sparse_ranges(pruned_scan_range, allocated_coarse_ranges);
+    // Emit is_first_split_of_segment=true from the refined tasks only when no coarse split was allocated
+    // for this segment. If a coarse split was allocated, the coarse/seed child already carries the flag
+    // (allocate_initial_coarse_split / the seed child above), so letting the first refined split also carry
+    // it would double-count segment-level stats. This keeps exactly one split per segment flagged.
+    const bool refined_carries_first_split = allocated_coarse_ranges.span_size() == 0;
+    append_refined_segment_split_tasks(rowset, segment, prepared_tablet_read_state, segment_state, rowset_idx,
+                                       segment_idx, remaining_scan_range, rows_per_split(params),
+                                       refined_carries_first_split, &_split_tasks);
+    _stats.lake_prepared_segments++;
+
+    if (*local_rowid_range == nullptr) {
+        // Keep this seed child as an empty read if its coarse range was fully pruned.
+        *local_rowid_range = std::make_shared<RowidRangeOption>();
+    }
+    return Status::OK();
+}
+
+Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters) {
+    RowsetReadOptions rs_opts;
+    RETURN_IF_ERROR(init_rowset_read_options(params, &rs_opts));
+
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
+
+    const auto& prepared_tablet_read_state = params.prepared_tablet_read_state;
+    const bool use_prepared_segments = prepared_tablet_read_state != nullptr;
+    if (use_prepared_segments &&
+        (prepared_tablet_read_state->rowsets.size() != _rowsets.size() ||
+         prepared_tablet_read_state->rowset_segments.size() != prepared_tablet_read_state->rowsets.size() ||
+         prepared_tablet_read_state->rowset_prepared_states.size() != prepared_tablet_read_state->rowsets.size())) {
+        return Status::InvalidArgument("prepared tablet read state does not match reader rowsets");
+    }
+    const bool use_prepared_segment_target = use_prepared_segments && params.prepared_segment_read_state != nullptr;
+    if (use_prepared_segment_target) {
+        if (params.prepared_rowset_index >= _rowsets.size()) {
+            return Status::InvalidArgument("prepared target rowset index exceeds reader rowsets");
+        }
+        const auto rowset_idx = params.prepared_rowset_index;
+        const auto segment_idx = params.prepared_segment_index;
+        auto& rowset = _rowsets[rowset_idx];
+        const auto& prepared_rowset = prepared_tablet_read_state->rowsets[rowset_idx];
+        if (prepared_rowset == nullptr || prepared_rowset->rowset_id() != rowset->rowset_id()) {
+            return Status::InvalidArgument("prepared tablet read state rowset order does not match reader rowsets");
+        }
+        const auto& prepared_segments = prepared_tablet_read_state->rowset_segments[rowset_idx];
+        const auto& prepared_segment_states = prepared_tablet_read_state->rowset_prepared_states[rowset_idx];
+        if (segment_idx >= prepared_segments.size() || segment_idx >= prepared_segment_states.size()) {
+            return Status::InvalidArgument("prepared target segment index exceeds prepared segment state");
+        }
+        if (prepared_segment_states[segment_idx] != params.prepared_segment_read_state) {
+            return Status::InvalidArgument("prepared target segment state does not match split context");
+        }
+        if (_reusable_rowset_iterators.size() < _rowsets.size()) {
+            _reusable_rowset_iterators.resize(_rowsets.size());
+        }
+        ASSIGN_OR_RETURN(auto seg_iters,
+                         enhance_error_prompt(rowset->read_prepared_segment(
+                                 schema(), rs_opts, prepared_segments, segment_idx, params.prepared_segment_read_state,
+                                 &_reusable_rowset_iterators[rowset_idx])));
+        iters->insert(iters->end(), seg_iters.begin(), seg_iters.end());
+        return Status::OK();
+    }
+    if (use_prepared_segments) {
+        return Status::InvalidArgument("prepared tablet read state requires a prepared segment target");
+    }
 
     std::vector<std::future<StatusOr<std::vector<ChunkIteratorPtr>>>> futures;
     // The parallel tasks capture local variables and |this| by reference.
@@ -409,22 +932,24 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
             }
         }
     });
-    for (auto& rowset : _rowsets) {
+    for (size_t rowset_idx = 0; rowset_idx < _rowsets.size(); ++rowset_idx) {
+        auto& rowset = _rowsets[rowset_idx];
         if (params.rowid_range_option != nullptr && !params.rowid_range_option->contains_rowset(rowset.get())) {
             continue;
         }
 
         if (config::enable_load_segment_parallel) {
-            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>([&, rowset]() {
+            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
+                    [&, rowset_idx, rowset]() {
 #ifdef BE_TEST
-                Status injected_st;
-                TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);
-                if (!injected_st.ok()) {
-                    return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
-                }
+                        Status injected_st;
+                        TEST_SYNC_POINT_CALLBACK("TabletReader::get_segment_iterators::parallel_read", &injected_st);
+                        if (!injected_st.ok()) {
+                            return StatusOr<std::vector<ChunkIteratorPtr>>(injected_st);
+                        }
 #endif
-                return enhance_error_prompt(rowset->read(schema(), rs_opts));
-            });
+                        return enhance_error_prompt(rowset->read(schema(), rs_opts));
+                    });
 
             auto packaged_func = [task]() { (*task)(); };
             if (auto st = RuntimeEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -20,6 +20,7 @@
 #include "storage/lake/versioned_tablet.h"
 #include "storage/tablet_reader_params.h"
 #include "storage_primitive/chunk_iterator.h"
+#include "storage_primitive/range.h"
 #include "types_fwd.h"
 
 namespace starrocks {
@@ -35,11 +36,18 @@ class SeekTuple;
 class Segment;
 class TabletSchema;
 class TabletMetadataPB;
+class RowsetReadOptions;
 
 namespace lake {
 
+struct PreparedTabletReadState;
 class Rowset;
 class TabletManager;
+
+// Set difference lhs - rhs over two sorted, internally non-overlapping sparse ranges. Used by the
+// prepared-split refine path to compute the REFINED coverage (pruned - already-allocated-coarse).
+// Declared here so it can be unit-tested directly (the definition lives in tablet_reader.cpp).
+SparseRange<> subtract_sparse_ranges(const SparseRange<>& lhs, const SparseRange<>& rhs);
 
 class TabletReader final : public ChunkIterator {
     using Chunk = starrocks::Chunk;
@@ -109,7 +117,15 @@ private:
     using PredicateList = std::vector<const ColumnPredicate*>;
     using PredicateMap = std::unordered_map<ColumnId, PredicateList>;
 
+    Status build_prepared_tablet_read_state(const TabletReaderParams& params, PreparedTabletReadState* state);
+    Status build_initial_coarse_split_tasks(const TabletReaderParams& params,
+                                            const PreparedTabletReadStatePtr& prepared_tablet_read_state);
+    Status refine_initial_coarse_split_and_append_refined_tasks(const TabletReaderParams& params,
+                                                                RowidRangeOptionPtr* local_rowid_range);
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
+    Status init_rowset_read_options(const TabletReaderParams& params, RowsetReadOptions* options);
+    Status init_rowset_read_options_for_split(const TabletReaderParams& params, RowsetReadOptions* options,
+                                              LakeIOOptions* lake_io_opts);
 
     Status init_predicates(const TabletReaderParams& read_params);
     Status init_delete_predicates(const TabletReaderParams& read_params, DeletePredicates* dels);
@@ -128,6 +144,7 @@ private:
     bool _rowsets_inited = false;
     std::vector<RowsetPtr> _rowsets;
     std::vector<SegmentSharedPtr> _segments;
+    std::vector<std::vector<ChunkIteratorPtr>> _reusable_rowset_iterators;
     std::shared_ptr<ChunkIterator> _collect_iter;
 
     DeletePredicates _delete_predicates;

--- a/be/src/storage/lake/types_fwd.h
+++ b/be/src/storage/lake/types_fwd.h
@@ -42,11 +42,15 @@ class Tablet;
 class CompactionTask;
 class LocationProvider;
 class PersistentIndexSstable;
+struct PreparedSegmentReadState;
+struct PreparedTabletReadState;
 
 using RowsetPtr = std::shared_ptr<starrocks::lake::Rowset>;
 using SegmentPtr = std::shared_ptr<starrocks::Segment>;
 using TabletSchemaPtr = std::shared_ptr<const starrocks::TabletSchema>;
 using CompactionTaskPtr = std::shared_ptr<CompactionTask>;
+using PreparedSegmentReadStatePtr = std::shared_ptr<PreparedSegmentReadState>;
+using PreparedTabletReadStatePtr = std::shared_ptr<PreparedTabletReadState>;
 using segment_rowid_t = uint32_t;
 using DeletesMap = std::unordered_map<uint32_t, std::vector<segment_rowid_t>>;
 using DelVectorPtr = std::shared_ptr<DelVector>;

--- a/be/src/storage/query/split_scan_morsel.h
+++ b/be/src/storage/query/split_scan_morsel.h
@@ -14,12 +14,15 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
 #include "exec_primitive/pipeline/scan/scan_morsel.h"
+#include "storage/lake/types_fwd.h"
 
 namespace starrocks {
 
@@ -33,11 +36,36 @@ namespace pipeline {
 class SplitMorselQueue;
 
 struct LakeSplitContext : public ScanSplitContext {
+    // Describes how rowid_range was produced. REGULAR is used by normal physical
+    // splits. The other values are used by Lake range-refinement scheduling.
+    enum class RowidRangeSource : uint8_t {
+        REGULAR,
+        // First coarse range used to start scanning before refined ranges exist.
+        INITIAL_COARSE,
+        // Additional coarse range issued before segment-level refinement finishes.
+        PRE_REFINEMENT_COARSE,
+        // Range backed by final refined/pruned segment ranges.
+        REFINED,
+    };
+
     // physical split
     RowidRangeOptionPtr rowid_range;
+    RowidRangeSource rowid_range_source = RowidRangeSource::REGULAR;
     // logical split
     ShortKeyRangesOptionPtr short_key_range;
     std::shared_ptr<SplitMorselQueue> split_morsel_queue = nullptr;
+
+    // Optional metadata for Lake prepared physical split children.
+    // prepared_segment_read_state and indices are set only when the rowid range maps to one segment.
+    lake::PreparedTabletReadStatePtr prepared_tablet_read_state = nullptr;
+    lake::PreparedSegmentReadStatePtr prepared_segment_read_state = nullptr;
+    size_t rowset_index = 0;
+    size_t segment_index = 0;
+
+    bool is_prepared_physical_split() const {
+        return rowid_range != nullptr && short_key_range == nullptr && prepared_tablet_read_state != nullptr &&
+               prepared_segment_read_state != nullptr;
+    }
 };
 
 class PhysicalSplitScanMorsel final : public ScanMorsel {

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <limits>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -32,6 +35,11 @@ namespace starrocks {
 
 class RuntimeProfile;
 class RuntimeState;
+
+namespace lake {
+struct PreparedSegmentReadState;
+struct PreparedTabletReadState;
+} // namespace lake
 
 class ColumnPredicate;
 struct RowidRangeOption;
@@ -88,6 +96,14 @@ struct TabletReaderParams {
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
     ShortKeyRangesOptionPtr short_key_ranges_option = nullptr;
+    std::shared_ptr<lake::PreparedTabletReadState> prepared_tablet_read_state = nullptr;
+    std::shared_ptr<lake::PreparedSegmentReadState> prepared_segment_read_state = nullptr;
+    size_t prepared_rowset_index = std::numeric_limits<size_t>::max();
+    size_t prepared_segment_index = std::numeric_limits<size_t>::max();
+    bool refine_initial_coarse_split_and_append_refined_tasks = false;
+    // Per-scan decision that this lake scan should take the prepared physical split scan path. Set by the
+    // lake scan connector in a follow-up; defaults off, so this path is inert until the connector wires it.
+    bool enable_prepared_physical_split_scan = false;
 
     bool sorted_by_keys_per_tablet = false;
     RuntimeScanRangePruner runtime_range_pruner;

--- a/be/src/storage_primitive/storage_stats.h
+++ b/be/src/storage_primitive/storage_stats.h
@@ -147,6 +147,25 @@ struct OlapReaderStatistics {
     int64_t prefetch_hit_count = 0;
     int64_t prefetch_wait_finish_ns = 0;
     int64_t prefetch_pending_ns = 0;
+
+    int64_t lake_prepared_rowsets = 0;
+    int64_t lake_prepared_segments = 0;
+    int64_t lake_prepared_scan_rows = 0;
+    int64_t lake_prepared_scan_ranges = 0;
+    int64_t lake_reusable_segment_iter_created = 0;
+    int64_t lake_reusable_segment_iter_reused = 0;
+    // Time (ns) spent in the seed morsel's prepared-scan-range preparation (zonemap/bloom page-filter folding
+    // + seek-range resolution). Only the seed pays this; refined children reuse the published range.
+    int64_t lake_prepared_seed_ns = 0;
+    // Breakdown of the seed prepare above, accumulated from the otherwise-discarded prepare-only
+    // OlapReaderStatistics: where the seed's one-time per-segment prune spends its time / IO.
+    int64_t lake_prepared_seed_io_ns = 0;
+    int64_t lake_prepared_seed_io_count = 0;
+    int64_t lake_prepared_seed_segment_init_ns = 0;
+    int64_t lake_prepared_seed_zonemap_ns = 0;
+    int64_t lake_prepared_seed_zonemap_filtered_rows = 0;
+    int64_t lake_prepared_seed_bf_ns = 0;
+    int64_t lake_prepared_seed_bf_filtered_rows = 0;
     // ------ for lake tablet ------
 
     // ------ for json type, to count flat column ------

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <iomanip>
+#include <set>
 #include <utility>
 
 #include "base/testutil/assert.h"
@@ -34,10 +35,12 @@
 #include "common/logging.h"
 #include "exec/pipeline/scan/morsel.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/versioned_tablet.h"
+#include "storage/query/split_scan_morsel.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/segment_options.h"
 #include "storage/tablet_schema.h"
@@ -1308,6 +1311,322 @@ TEST_F(LakeDuplicateTabletReaderTest, test_propagate_has_predicate_above_iterato
 
     ASSERT_TRUE(seen);
     EXPECT_TRUE(propagated);
+}
+
+// Drives the lake prepared-physical-split SEED path: with enable_prepared_physical_split_scan set,
+// TabletReader::open runs build_prepared_tablet_read_state -> build_initial_coarse_split_tasks, and
+// get_split_tasks returns INITIAL_COARSE seed tasks carrying the shared prepared read state -- rather
+// than the force-split PhysicalSplitMorselQueue path taken when the flag is off.
+TEST_F(LakeTabletReaderSpit, test_prepared_physical_split_seed) {
+    std::vector<int> keys{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> vals{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44};
+    auto make_chunk = [&]() {
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+        c1->append_numbers(vals.data(), vals.size() * sizeof(int));
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
+    };
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        // Several segments so the tablet has well above splitted_scan_rows * lake_tablet_rows_splitted_ratio
+        // rows and the split heuristic allows splitting.
+        for (int i = 0; i < 4; i++) {
+            auto chunk = make_chunk();
+            ASSERT_OK(writer->write(chunk));
+            ASSERT_OK(writer->finish());
+        }
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        rowset->set_num_rows(4 * keys.size());
+        for (const auto& file : writer->segments()) {
+            auto* segment_meta = rowset->add_segment_metas();
+            segment_meta->set_filename(file.path);
+            segment_meta->set_size(file.size.value());
+        }
+        writer->close();
+    }
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema, /*need_split=*/true,
+                                                 /*could_split_physically=*/true);
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+    auto params = generate_tablet_reader_params(&scan_range);
+    params.enable_prepared_physical_split_scan = true; // take the prepared-split seed path
+
+    ASSERT_OK(reader->prepare());
+    ASSERT_OK(reader->open(params));
+
+    // Profile counters: the seed builds prepared state for the single rowset. The per-segment prune
+    // counters (lake_prepared_segments / scan_rows) are bumped later when a child refines, not on the
+    // seed -- see the end-to-end test -- so they stay 0 here.
+    EXPECT_EQ(1, reader->stats().lake_prepared_rowsets);
+    EXPECT_EQ(0, reader->stats().lake_prepared_segments);
+
+    std::vector<pipeline::ScanSplitContextPtr> split_tasks;
+    reader->get_split_tasks(&split_tasks);
+    ASSERT_GT(split_tasks.size(), 0);
+
+    for (auto& task : split_tasks) {
+        auto* ctx = dynamic_cast<pipeline::LakeSplitContext*>(task.get());
+        ASSERT_NE(nullptr, ctx) << "prepared-split seed must produce LakeSplitContext tasks";
+        EXPECT_EQ(pipeline::LakeSplitContext::RowidRangeSource::INITIAL_COARSE, ctx->rowid_range_source);
+        EXPECT_NE(nullptr, ctx->prepared_tablet_read_state)
+                << "seed task must carry the shared prepared tablet read state";
+    }
+    reader->close();
+}
+
+// subtract_sparse_ranges is the core range math behind the REFINED coverage set
+// (pruned - already-allocated-coarse). Exercise each branch: empty / exact-cover / superset-cover /
+// left-cut / right-cut / hole / disjoint / rhs-spanning-two-lhs / multiple-cuts.
+TEST(SubtractSparseRangesTest, CoversAllBranches) {
+    auto mk = [](std::initializer_list<std::pair<rowid_t, rowid_t>> parts) {
+        SparseRange<> r;
+        for (const auto& p : parts) {
+            r.add(Range<>(p.first, p.second));
+        }
+        return r;
+    };
+    auto to_vec = [](const SparseRange<>& r) {
+        std::vector<std::pair<rowid_t, rowid_t>> v;
+        for (size_t i = 0; i < r.size(); ++i) {
+            v.emplace_back(r[i].begin(), r[i].end());
+        }
+        return v;
+    };
+    using V = std::vector<std::pair<rowid_t, rowid_t>>;
+
+    EXPECT_EQ((V{{0, 10}}), to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({}))));               // rhs empty
+    EXPECT_TRUE(to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{0, 10}}))).empty());            // exact cover
+    EXPECT_TRUE(to_vec(subtract_sparse_ranges(mk({{2, 8}}), mk({{0, 10}}))).empty());             // superset cover
+    EXPECT_EQ((V{{5, 10}}), to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{0, 5}}))));         // left cut
+    EXPECT_EQ((V{{0, 5}}), to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{5, 10}}))));         // right cut
+    EXPECT_EQ((V{{0, 3}, {7, 10}}), to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{3, 7}})))); // hole in the middle
+    EXPECT_EQ((V{{0, 10}}), to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{20, 30}}))));       // disjoint
+    EXPECT_EQ((V{{0, 2}, {18, 20}}),
+              to_vec(subtract_sparse_ranges(mk({{0, 5}, {15, 20}}), mk({{2, 18}})))); // rhs spans 2 lhs ranges
+    EXPECT_EQ((V{{0, 2}, {4, 6}, {8, 10}}),
+              to_vec(subtract_sparse_ranges(mk({{0, 10}}), mk({{2, 4}, {6, 8}})))); // multiple cuts in one lhs
+}
+
+// PreparedSegmentReadState is the cross-child shared cache. Verify the publish / clear / disable
+// truth table for both caches, and that the disabled flag is sticky: once a runtime-filter arrival
+// disables the cache, a later re-publish must NOT silently re-enable it.
+TEST(PreparedReadStateCacheTest, CacheStateMachine) {
+    PreparedSegmentReadState s;
+    EXPECT_FALSE(s.has_pruned_scan_range());
+    EXPECT_FALSE(s.has_rowid_bounds_cache());
+
+    // publish -> visible; clear -> hidden; re-publish after clear -> visible again.
+    s.publish_pruned_scan_range(std::make_shared<SparseRange<>>(0, 10));
+    EXPECT_TRUE(s.has_pruned_scan_range());
+    s.clear_pruned_scan_range();
+    EXPECT_FALSE(s.has_pruned_scan_range());
+    s.publish_pruned_scan_range(std::make_shared<SparseRange<>>(0, 5));
+    EXPECT_TRUE(s.has_pruned_scan_range());
+
+    std::vector<std::optional<Range<rowid_t>>> bounds{Range<rowid_t>(0, 5)};
+    s.publish_rowid_bounds_cache(std::move(bounds), Range<rowid_t>(0, 5));
+    EXPECT_TRUE(s.has_rowid_bounds_cache());
+
+    // disable_runtime_filter_dependent_cache disables BOTH caches and stays disabled after re-publish.
+    s.disable_runtime_filter_dependent_cache();
+    EXPECT_FALSE(s.has_pruned_scan_range());
+    EXPECT_FALSE(s.has_rowid_bounds_cache());
+    s.publish_pruned_scan_range(std::make_shared<SparseRange<>>(0, 3));
+    EXPECT_FALSE(s.has_pruned_scan_range()) << "disabled cache must stay disabled after re-publish";
+}
+
+// Build a 1-rowset, 4-segment DUP_KEYS tablet (22 rows/segment) on |tablet|; returns rows/segment.
+static int build_split_test_tablet(VersionedTablet& tablet, const std::shared_ptr<Schema>& schema,
+                                   const std::shared_ptr<TabletMetadata>& metadata, const std::vector<int>& keys,
+                                   const std::vector<int>& vals) {
+    auto make_chunk = [&]() {
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+        c1->append_numbers(vals.data(), vals.size() * sizeof(int));
+        return Chunk({std::move(c0), std::move(c1)}, schema);
+    };
+    int64_t txn_id = next_id();
+    auto writer_or = tablet.new_writer(kHorizontal, txn_id);
+    CHECK(writer_or.ok());
+    auto writer = std::move(writer_or.value());
+    CHECK_OK(writer->open());
+    for (int i = 0; i < 4; i++) {
+        auto chunk = make_chunk();
+        CHECK_OK(writer->write(chunk));
+        CHECK_OK(writer->finish());
+    }
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_overlapped(true);
+    rowset->set_id(1);
+    rowset->set_num_rows(4 * keys.size());
+    for (const auto& file : writer->segments()) {
+        auto* segment_meta = rowset->add_segment_metas();
+        segment_meta->set_filename(file.path);
+        segment_meta->set_size(file.size.value());
+    }
+    writer->close();
+    return static_cast<int>(keys.size());
+}
+
+// Gate OFF (default): the seed reader must NOT take the prepared-split path -- it falls back to the
+// regular PhysicalSplitMorselQueue, so every split task is a REGULAR one with no prepared state.
+TEST_F(LakeTabletReaderSpit, test_prepared_physical_split_gate_off) {
+    std::vector<int> keys{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> vals{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44};
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    build_split_test_tablet(tablet, _schema, _tablet_metadata, keys, vals);
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema,
+                                                 /*need_split=*/true, /*could_split_physically=*/true);
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+    auto params = generate_tablet_reader_params(&scan_range);
+    // enable_prepared_physical_split_scan left at its default (false).
+
+    ASSERT_OK(reader->prepare());
+    ASSERT_OK(reader->open(params));
+
+    std::vector<pipeline::ScanSplitContextPtr> split_tasks;
+    reader->get_split_tasks(&split_tasks);
+    ASSERT_GT(split_tasks.size(), 0);
+    for (auto& task : split_tasks) {
+        auto* ctx = dynamic_cast<pipeline::LakeSplitContext*>(task.get());
+        ASSERT_NE(nullptr, ctx);
+        EXPECT_EQ(pipeline::LakeSplitContext::RowidRangeSource::REGULAR, ctx->rowid_range_source);
+        EXPECT_EQ(nullptr, ctx->prepared_tablet_read_state) << "gate off must not build prepared state";
+        EXPECT_FALSE(ctx->is_prepared_physical_split());
+    }
+    // Gate off must leave every prepared-split profile counter untouched.
+    EXPECT_EQ(0, reader->stats().lake_prepared_rowsets);
+    EXPECT_EQ(0, reader->stats().lake_prepared_segments);
+    reader->close();
+}
+
+// End-to-end correctness contract: the INITIAL_COARSE seed children (which read their coarse range
+// and refine) plus the REFINED children they append must together reproduce EXACTLY the full-scan
+// result -- no missing rows, no duplicates. This drives refine_initial_coarse_split_and_append_refined_tasks,
+// subtract_sparse_ranges, get_segment_iterators / read_prepared_segment and the shared prepared state,
+// mimicking how LakeDataSource (a follow-up PR) drives them.
+TEST_F(LakeTabletReaderSpit, test_prepared_physical_split_end_to_end_equivalence) {
+    std::vector<int> keys{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> vals{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44};
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    const int rows_per_segment = build_split_test_tablet(tablet, _schema, _tablet_metadata, keys, vals);
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    using Row = std::pair<int, int>;
+    auto collect = [&](TabletReader* r, std::multiset<Row>* out) {
+        auto chunk = ChunkFactory::new_chunk(*_schema, 1024);
+        while (true) {
+            chunk->reset();
+            auto st = r->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            ASSERT_OK(st);
+            for (size_t i = 0; i < chunk->num_rows(); ++i) {
+                out->emplace(chunk->get(i)[0].get_int32(), chunk->get(i)[1].get_int32());
+            }
+        }
+    };
+
+    // Baseline: a plain, non-split full scan.
+    std::multiset<Row> expected;
+    {
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+        ASSERT_OK(reader->prepare());
+        TabletReaderParams params;
+        ASSERT_OK(reader->open(params));
+        collect(reader.get(), &expected);
+        reader->close();
+    }
+    ASSERT_EQ(static_cast<size_t>(4 * rows_per_segment), expected.size());
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    // Seed: produces INITIAL_COARSE tasks carrying the shared prepared state.
+    std::vector<pipeline::ScanSplitContextPtr> queue;
+    {
+        auto seed = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema,
+                                                   /*need_split=*/true, /*could_split_physically=*/true);
+        auto params = generate_tablet_reader_params(&scan_range);
+        params.enable_prepared_physical_split_scan = true;
+        ASSERT_OK(seed->prepare());
+        ASSERT_OK(seed->open(params));
+        seed->get_split_tasks(&queue);
+        seed->close();
+    }
+    ASSERT_GT(queue.size(), 0u);
+
+    // Drive the children the way the connector does: an INITIAL_COARSE child reads its coarse range and
+    // refines (appending REFINED tasks); a REFINED child just reads its range.
+    std::multiset<Row> actual;
+    int64_t refined_segments = 0;
+    int64_t refined_scan_rows = 0;
+    int guard = 0;
+    for (size_t head = 0; head < queue.size(); ++head) {
+        ASSERT_LT(guard++, 10000) << "runaway split loop";
+        auto* ctx = dynamic_cast<pipeline::LakeSplitContext*>(queue[head].get());
+        ASSERT_NE(nullptr, ctx);
+        ASSERT_TRUE(ctx->is_prepared_physical_split());
+        const bool is_initial = ctx->rowid_range_source == pipeline::LakeSplitContext::RowidRangeSource::INITIAL_COARSE;
+
+        auto child = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema,
+                                                    /*need_split=*/false, /*could_split_physically=*/true);
+        auto params = generate_tablet_reader_params(&scan_range);
+        params.rowid_range_option = ctx->rowid_range;
+        params.prepared_tablet_read_state = ctx->prepared_tablet_read_state;
+        params.prepared_segment_read_state = ctx->prepared_segment_read_state;
+        params.prepared_rowset_index = ctx->rowset_index;
+        params.prepared_segment_index = ctx->segment_index;
+        params.refine_initial_coarse_split_and_append_refined_tasks = is_initial;
+
+        ASSERT_OK(child->prepare());
+        ASSERT_OK(child->open(params));
+        collect(child.get(), &actual);
+        // Only the INITIAL_COARSE children refine; each bumps the per-segment prune counters once for the
+        // single segment it owns. Accumulate across children to confirm the counters track refine.
+        refined_segments += child->stats().lake_prepared_segments;
+        refined_scan_rows += child->stats().lake_prepared_scan_rows;
+
+        std::vector<pipeline::ScanSplitContextPtr> refined;
+        child->get_split_tasks(&refined);
+        for (auto& t : refined) {
+            queue.emplace_back(std::move(t));
+        }
+        child->close();
+    }
+
+    EXPECT_EQ(expected, actual) << "prepared-split children must reproduce the full scan exactly";
+
+    // Each of the 4 segments is refined exactly once; with no predicates the pruned range keeps every row,
+    // so the per-segment scan-row counter sums to the full row count.
+    EXPECT_EQ(4, refined_segments);
+    EXPECT_EQ(static_cast<int64_t>(expected.size()), refined_scan_rows);
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
Part of #76355

## Why I'm doing:

The lake prepared physical split scan wants to prune each segment **once**, at the seed scan, and share the result (the page-filtered row ranges plus the resolved rowid bounds) with every split child, so the children can skip re-running the page-filter pipeline. This PR adds the lake storage core for that: the cross-child shared read state and the seed build / refine paths that populate it. It builds on the reusable `SegmentIterator` from #76340.

## What I'm doing:

- **`PreparedTabletReadState` / `PreparedSegmentReadState`**: cross-child shared scan state — an atomic-guarded pruned scan range and rowid-bounds cache, plus a coarse split cursor protected by `coarse_range_lock`.
- **Seed path** (`TabletReader`): `build_prepared_tablet_read_state` → `build_initial_coarse_split_tasks` → `prepare_segment_pruned_scan_range_for_split`, which folds every page filter (short-key / zonemap / bloom / bitmap / inverted / vector) into the prepared scan range at the seed, and `refine_initial_coarse_split_and_append_refined_tasks` which emits the refined tasks (using `subtract_sparse_ranges` to compute the remaining coverage).
- **CHILD path**: a split child reuses the prepared segment iterator / read state (`make_segment_read_state_cache` → `SegmentReadStateCache`) so it skips re-pruning.
- **`Rowset::read` refactor**: a shared `do_read` kernel plus a `read_prepared_segment` entry, with `init_segment_read_options` / `set_segment_tablet_range` / `build_segment_schema` extracted for reuse.
- **`LakeSplitContext`** (`split_scan_morsel.h`): carries the prepared state and the rowid-range source between the seed and the split-morsel scheduler.
- Prepared-split profile counters on `OlapReaderStatistics`.

Gated by `TabletReaderParams::enable_prepared_physical_split_scan` (default **off**, set by a follow-up connector) — a no-op when off. The split-morsel queue that consumes these tasks is a follow-up.

## Tests:

- **`LakeTabletReaderSpit.test_prepared_physical_split_end_to_end_equivalence`** — the core correctness contract: the INITIAL_COARSE seed children (which read their coarse range and refine) plus the REFINED children they append reproduce the full-scan result **exactly** — no missing rows, no duplicates. Drives `refine_initial_coarse_split_and_append_refined_tasks`, `subtract_sparse_ranges`, the CHILD `read_prepared_segment` consumption, and the shared prepared state end to end.
- **`LakeTabletReaderSpit.test_prepared_physical_split_gate_off`** — gate off (default) falls back to the regular `PhysicalSplitMorselQueue`; every task is a REGULAR split with no prepared state.
- **`LakeTabletReaderSpit.test_prepared_physical_split_seed`** — the seed produces INITIAL_COARSE tasks carrying the shared, non-null prepared tablet read state.
- **`SubtractSparseRangesTest.CoversAllBranches`** — `subtract_sparse_ranges` (the REFINED coverage math) across empty / exact-cover / left-cut / right-cut / hole / disjoint / rhs-spanning-two-ranges / multiple-cuts.
- **`PreparedReadStateCacheTest.CacheStateMachine`** — the publish / clear / disable truth table for both caches, including the sticky-disabled behavior.

All existing lake `tablet_reader` tests (plain dup read, aggregate, delete-predicate reads, split read) pass through the refactored `do_read`, so the existing read path is unchanged.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(The new prepared-split path is gated off by default and has no caller yet — the connector is a follow-up. The only always-on change is the `Rowset::read` → `do_read` refactor, which is behavior-preserving and covered by the existing lake `tablet_reader` tests.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5