### PR TITLE
[BugFix] Make compaction direct read of flat JSON sub-columns actually take effect

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1992,7 +1992,11 @@ CONF_mInt32(dictionary_cache_refresh_threadpool_size, "8");
 // json flat flag
 CONF_mBool(enable_json_flat, "true");
 
-// enable compaction is base on flat json, not whole json
+// Whether compaction reads flat JSON sub-columns directly (skipping the
+// reassemble-whole-JSON and re-parse round trip) when every input segment
+// stores the column flattened. This only affects how compaction reads its
+// input; the merged output is flattened (or not) according to the flat_json
+// config regardless of this flag.
 CONF_mBool(enable_compaction_flat_json, "true");
 
 // direct read flat json

--- a/be/src/common/config_json_flat_fwd.h
+++ b/be/src/common/config_json_flat_fwd.h
@@ -24,7 +24,11 @@ namespace starrocks::config {
 // json flat flag
 CONF_mBool(enable_json_flat, "true");
 
-// enable compaction is base on flat json, not whole json
+// Whether compaction reads flat JSON sub-columns directly (skipping the
+// reassemble-whole-JSON and re-parse round trip) when every input segment
+// stores the column flattened. This only affects how compaction reads its
+// input; the merged output is flattened (or not) according to the flat_json
+// config regardless of this flag.
 CONF_mBool(enable_compaction_flat_json, "true");
 
 // direct read flat json

--- a/be/src/storage/json_path_deriver.cpp
+++ b/be/src/storage/json_path_deriver.cpp
@@ -161,6 +161,18 @@ JsonFlatPath* JsonPathDeriver::_normalize_exists_path(const std::string_view& pa
     return _normalize_exists_path(next, iter->second.get(), hits);
 }
 
+bool JsonPathDeriver::_has_leaf_object_conflict(const JsonFlatPath* node) {
+    for (const auto& [key, child] : node->children) {
+        if (child->base_type_count > 0 && !child->children.empty()) {
+            return true;
+        }
+        if (_has_leaf_object_conflict(child.get())) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void JsonPathDeriver::derived(const std::vector<const ColumnReader*>& json_readers) {
     DCHECK(_paths.empty());
     DCHECK(_types.empty());
@@ -197,6 +209,17 @@ void JsonPathDeriver::derived(const std::vector<const ColumnReader*>& json_reade
                 leaf->base_type_count += reader->num_rows();
             }
         }
+    }
+
+    // Segments may disagree structurally: a path stored as a concrete leaf in one
+    // segment and as an object (children paths) in another. There is no per-path read
+    // plan that is known to cover both layouts - planning the node as JSON was observed
+    // to lose the leaf segments' scalar values on a live cluster. Bail out and let
+    // compaction take the full JSON merge path, which reassembles each segment from
+    // its own layout and re-derives the merged layout from the actual values.
+    if (_has_leaf_object_conflict(_path_root.get())) {
+        _path_root.reset();
+        return;
     }
 
     _min_json_sparsity_factory = 1; // only extract common schema

--- a/be/src/storage/json_path_deriver.cpp
+++ b/be/src/storage/json_path_deriver.cpp
@@ -189,6 +189,13 @@ void JsonPathDeriver::derived(const std::vector<const ColumnReader*>& json_reade
             auto leaf = _normalize_exists_path(sub->name(), _path_root.get(), 0);
             leaf->json_type &= flat_json::LOGICAL_TYPE_TO_JSON_BITS.at(sub->column_type());
             leaf->hits += reader->num_rows();
+            // a sub-column stored as a concrete base type means every row of this segment
+            // held that base type, so feed base_type_count the same way the data-mode path
+            // does; otherwise the base-type gate in _finalize() drops every leaf under the
+            // default enable_json_flat_complex_type=false
+            if (sub->column_type() != LogicalType::TYPE_JSON) {
+                leaf->base_type_count += reader->num_rows();
+            }
         }
     }
 
@@ -222,6 +229,13 @@ void JsonPathDeriver::_derived_on_flat_json(const std::vector<const Column*>& js
             auto leaf = _normalize_exists_path(paths[i], _path_root.get(), hits);
             leaf->json_type &= flat_json::LOGICAL_TYPE_TO_JSON_BITS.at(types[i]);
             leaf->hits += hits;
+            // a flat sub-column carrying a concrete base type means every hit row held
+            // that base type; feed base_type_count like _visit_json_paths does, or the
+            // base-type gate in _finalize() drops these leaves and the compactor falls
+            // back to merging flat input into raw JSON
+            if (types[i] != LogicalType::TYPE_JSON) {
+                leaf->base_type_count += hits;
+            }
         }
     }
 }

--- a/be/src/storage/json_path_deriver.h
+++ b/be/src/storage/json_path_deriver.h
@@ -67,6 +67,7 @@ public:
 private:
     void _derived(const Column* json_data, size_t mark_row);
 
+    bool _has_leaf_object_conflict(const JsonFlatPath* node);
     JsonFlatPath* _normalize_exists_path(const std::string_view& path, JsonFlatPath* root, uint64_t hits);
 
     void _finalize();

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -497,10 +497,11 @@ Status TabletReader::init_compaction_column_paths(const TabletReaderParams& read
             // must all be flat json type
             JsonPathDeriver deriver;
 
-            if (auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_metadata->id());
-                metadata && metadata->has_flat_json_config()) {
+            // _tablet_metadata is the version this compaction reads; the latest-cached
+            // metadata is best-effort and can be stale or missing on a cold cache
+            if (_tablet_metadata->has_flat_json_config()) {
                 auto flat_json_config = std::make_shared<FlatJsonConfig>();
-                flat_json_config->update(metadata->flat_json_config());
+                flat_json_config->update(_tablet_metadata->flat_json_config());
                 deriver.init_flat_json_config(flat_json_config.get());
             }
 

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -17,7 +17,9 @@
 #include "agent/agent_task.h"
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "common/config_json_flat_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "fs/fs_util.h"
@@ -25,6 +27,7 @@
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log_applier.h"
 #include "test_util.h"
@@ -926,6 +929,114 @@ TEST_F(AlterTabletMetaTest, test_alter_flat_json_config) {
     ASSERT_DOUBLE_EQ(0.75, flat_json_config_pb.flat_json_sparsity_factor());
     ASSERT_EQ(12, flat_json_config_pb.flat_json_max_column_max());
     ASSERT_EQ(3, flat_json_config_pb.version());
+}
+
+TEST_F(AlterTabletMetaTest, test_compaction_read_derive_uses_versioned_flat_json_config) {
+    // (id INT KEY, j JSON) tablet with two flat segments: key 'a' appears in both segments,
+    // key 'b' only in the first, so the source-level ratio of 'b' is 50%.
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(next_id());
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(1);
+    auto* schema_pb = metadata->mutable_schema();
+    schema_pb->set_keys_type(DUP_KEYS);
+    schema_pb->set_id(next_id());
+    schema_pb->set_num_short_key_columns(1);
+    schema_pb->set_num_rows_per_row_block(65535);
+    {
+        auto* c = schema_pb->add_column();
+        c->set_unique_id(next_id());
+        c->set_name("id");
+        c->set_type("INT");
+        c->set_is_key(true);
+        c->set_is_nullable(false);
+    }
+    {
+        auto* c = schema_pb->add_column();
+        c->set_unique_id(next_id());
+        c->set_name("j");
+        c->set_type("JSON");
+        c->set_is_key(false);
+        c->set_is_nullable(true);
+        c->set_aggregation("NONE");
+    }
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+    int64_t tablet_id = metadata->id();
+    auto tablet_schema = TabletSchema::create(metadata->schema());
+    auto schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+
+    auto write_rows = [&](int64_t new_version, bool with_b) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_id));
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        auto id_col = Int32Column::create();
+        auto json_col = JsonColumn::create();
+        auto null_col = NullColumn::create();
+        for (int i = 0; i < 100; i++) {
+            id_col->append(i);
+            auto jv = with_b ? JsonValue::parse(R"({"a": 1, "b": 2})") : JsonValue::parse(R"({"a": 1})");
+            ASSERT_TRUE(jv.ok());
+            json_col->append(&jv.value());
+            null_col->append(0);
+        }
+        auto j_col = NullableColumn::create(std::move(json_col), std::move(null_col));
+        Chunk chunk({std::move(id_col), std::move(j_col)}, schema);
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+        auto txn_log = std::make_shared<TxnLog>();
+        txn_log->set_tablet_id(tablet_id);
+        txn_log->set_txn_id(txn_id);
+        auto* op_write = txn_log->mutable_op_write();
+        for (const auto& f : writer->segments()) {
+            op_write->mutable_rowset()->add_segment_metas()->set_filename(f.path);
+        }
+        op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+        op_write->mutable_rowset()->set_data_size(writer->data_size());
+        op_write->mutable_rowset()->set_overlapped(false);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+        writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, new_version, txn_id).status());
+    };
+    write_rows(2, true);
+    write_rows(3, false);
+
+    // v4 = v3 + a table-level flat_json config with a high sparsity factor: only keys present in
+    // >= 80% of the sources should be derived — 'a' (2/2) qualifies, 'b' (1/2) does not.
+    ASSIGN_OR_ABORT(auto v3, _tablet_mgr->get_tablet_metadata(tablet_id, 3));
+    auto v4 = std::make_shared<TabletMetadata>(*v3);
+    v4->set_version(4);
+    auto* cfg = v4->mutable_flat_json_config();
+    cfg->set_flat_json_enable(true);
+    cfg->set_flat_json_null_factor(1);
+    cfg->set_flat_json_sparsity_factor(0.8);
+    cfg->set_flat_json_max_column_max(100);
+    // Persist v4 while keeping the latest-metadata cache stale (still v3, which carries no
+    // flat_json_config) — the state of a node whose cache no longer holds this tablet.
+    SyncPoint::GetInstance()->SetCallBack("TabletManager::skip_cache_latest_metadata",
+                                          [](void* arg) { *(bool*)arg = true; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(v4));
+    SyncPoint::GetInstance()->ClearCallBack("TabletManager::skip_cache_latest_metadata");
+    SyncPoint::GetInstance()->DisableProcessing();
+
+    // A compaction-style read over v4 must derive flat_json paths from v4 itself, not from the
+    // best-effort latest-metadata cache.
+    TabletReader reader(_tablet_mgr.get(), v4, *schema);
+    ASSERT_OK(reader.prepare());
+    TabletReaderParams params;
+    params.reader_type = ReaderType::READER_BASE_COMPACTION;
+    params.chunk_size = 1024;
+    std::vector<ColumnAccessPathPtr> access_paths;
+    params.column_access_paths = &access_paths;
+    ASSERT_OK(reader.open(params));
+    reader.close();
+
+    ASSERT_EQ(1, access_paths.size());
+    std::vector<ColumnAccessPath*> leafs;
+    access_paths[0]->get_all_leafs(&leafs);
+    ASSERT_EQ(1, leafs.size());
+    EXPECT_EQ("a", leafs[0]->path());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/rowset/flat_json_column_compact_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_compact_test.cpp
@@ -1400,8 +1400,13 @@ TEST_F(FlatJsonColumnCompactTest, testNullHyperJsonCompactToFlatJson4) {
     JsonPathDeriver deriver;
     test_compact_path(jsons, &deriver);
 
-    EXPECT_EQ(2, deriver.flat_paths().size());
-    EXPECT_EQ(R"([a(BIGINT), b1.b2(BIGINT)])",
+    // A path stored as a concrete leaf in one segment and as an object in another has
+    // no per-path read plan known to cover both layouts (planning it as JSON was
+    // observed to lose the leaf segments' scalars on a live cluster). Reader-mode
+    // derivation detects the conflict and returns no paths, so compaction falls back
+    // to the full JSON merge, which re-derives the merged layout from actual values.
+    EXPECT_EQ(0, deriver.flat_paths().size());
+    EXPECT_EQ(R"([])",
               JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
 }
 
@@ -1495,8 +1500,13 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToFlatJsonRemain3) {
     JsonPathDeriver deriver;
     test_compact_path(jsons, &deriver);
 
-    EXPECT_EQ(2, deriver.flat_paths().size());
-    EXPECT_EQ(R"([a(BIGINT), b(VARCHAR)])",
+    // A path stored as a concrete leaf in one segment and as an object in another has
+    // no per-path read plan known to cover both layouts (planning it as JSON was
+    // observed to lose the leaf segments' scalars on a live cluster). Reader-mode
+    // derivation detects the conflict and returns no paths, so compaction falls back
+    // to the full JSON merge, which re-derives the merged layout from actual values.
+    EXPECT_EQ(0, deriver.flat_paths().size());
+    EXPECT_EQ(R"([])",
               JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
 }
 
@@ -1590,8 +1600,13 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactToFlatJsonRemainReadPaths)
     // clang-format on
     JsonPathDeriver deriver;
     test_compact_path(jsons, &deriver);
-    EXPECT_EQ(2, deriver.flat_paths().size());
-    EXPECT_EQ(R"([a(BIGINT), b(VARCHAR)])",
+    // A path stored as a concrete leaf in one segment and as an object in another has
+    // no per-path read plan known to cover both layouts (planning it as JSON was
+    // observed to lose the leaf segments' scalars on a live cluster). Reader-mode
+    // derivation detects the conflict and returns no paths, so compaction falls back
+    // to the full JSON merge, which re-derives the merged layout from actual values.
+    EXPECT_EQ(0, deriver.flat_paths().size());
+    EXPECT_EQ(R"([])",
               JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
 }
 
@@ -1718,8 +1733,13 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactPaths2) {
     JsonPathDeriver deriver;
     test_compact_path(jsons, &deriver);
 
-    EXPECT_EQ(2, deriver.flat_paths().size());
-    EXPECT_EQ(R"([a(BIGINT), b(VARCHAR)])",
+    // A path stored as a concrete leaf in one segment and as an object in another has
+    // no per-path read plan known to cover both layouts (planning it as JSON was
+    // observed to lose the leaf segments' scalars on a live cluster). Reader-mode
+    // derivation detects the conflict and returns no paths, so compaction falls back
+    // to the full JSON merge, which re-derives the merged layout from actual values.
+    EXPECT_EQ(0, deriver.flat_paths().size());
+    EXPECT_EQ(R"([])",
               JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
 }
 
@@ -1760,8 +1780,13 @@ TEST_F(FlatJsonColumnCompactTest, testHyperJsonCompactPaths3) {
     JsonPathDeriver deriver;
     test_compact_path(jsons, &deriver);
 
-    EXPECT_EQ(2, deriver.flat_paths().size());
-    EXPECT_EQ(R"([a(BIGINT), b(VARCHAR)])",
+    // A path stored as a concrete leaf in one segment and as an object in another has
+    // no per-path read plan known to cover both layouts (planning it as JSON was
+    // observed to lose the leaf segments' scalars on a live cluster). Reader-mode
+    // derivation detects the conflict and returns no paths, so compaction falls back
+    // to the full JSON merge, which re-derives the merged layout from actual values.
+    EXPECT_EQ(0, deriver.flat_paths().size());
+    EXPECT_EQ(R"([])",
               JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
 }
 
@@ -2073,5 +2098,71 @@ TEST_F(FlatJsonColumnCompactTest, CompactJsonNullableToNonNullableOutputErrorWit
         ASSERT_FALSE(st.ok()) << "mode=" << static_cast<int>(mode);
         EXPECT_TRUE(st.is_internal_error()) << "mode=" << static_cast<int>(mode) << " " << st.to_string();
     }
+}
+
+// The fixture enables enable_json_flat_complex_type to exercise wider shapes, but
+// production defaults to false, where the base-type gate in _finalize() is the only
+// way a leaf survives. Reader-based derivation (compaction read planning) never fed
+// base_type_count, so under the default config it dropped every leaf and
+// init_compaction_column_paths always produced zero paths. This test pins the
+// default-config behavior.
+TEST_F(FlatJsonColumnCompactTest, testCompactPathsBaseTypeGateDefaultConfig) {
+    config::enable_json_flat_complex_type = false; // production default
+
+    // clang-format off
+    MutableColumns jsons = to_mutable_columns({
+        more_flat_json({
+            R"({"a": 11, "b": "abc1"})",
+            R"({"a": 12, "b": "abc2"})",
+        }, true),
+        more_flat_json({
+            R"({"a": 21, "b": "efg1"})",
+            R"({"a": 22, "b": "efg2"})",
+        }, true),
+    });
+    // clang-format on
+
+    JsonPathDeriver deriver;
+    test_compact_path(jsons, &deriver);
+
+    EXPECT_EQ(2, deriver.flat_paths().size());
+    EXPECT_FALSE(deriver.has_remain_json());
+    // note: debug_flat_json closes with '}' when there is no remain, ']' when there is
+    EXPECT_EQ(R"([a(BIGINT), b(VARCHAR)})",
+              JsonFlatPath::debug_flat_json(deriver.flat_paths(), deriver.flat_types(), deriver.has_remain_json()));
+}
+
+// Same default-config pinning for the write side: _derived_on_flat_json (data-mode
+// derive over already-flat inputs, which only direct-read compaction produces) fed
+// no base_type_count either, so the compactor fell back to _merge_columns and wrote
+// the flat inputs back as raw JSON, silently dropping the columnar layout.
+TEST_F(FlatJsonColumnCompactTest, testFlatJsonCompactToFlatJsonDefaultConfig) {
+    config::enable_json_flat_complex_type = false; // production default
+
+    // clang-format off
+    MutableColumns jsons = to_mutable_columns({
+            flat_json(R"({"a": 1, "b": 21})", false),
+            flat_json(R"({"a": 2, "b": 22})", false),
+            flat_json(R"({"a": 3, "b": 23, "c": 33})", false),
+            flat_json(R"({"a": 4, "b": 24, "c": 34})", false),
+            flat_json(R"({"a": 5, "b": 25, "c": 35})", false),
+    });
+    // clang-format on
+
+    MutableColumnPtr read_col = jsons[0]->clone_empty();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, jsons, read_col);
+    EXPECT_TRUE(_meta->json_meta().is_flat());
+    EXPECT_TRUE(_meta->json_meta().has_remain());
+    EXPECT_EQ(3, _meta->children_columns_size());
+
+    auto* read_json = get_json_column(read_col);
+    EXPECT_EQ(5, read_json->size());
+    EXPECT_EQ(R"({"a": 1, "b": 21})", read_col->debug_item(0));
+    EXPECT_EQ(R"({"a": 2, "b": 22})", read_col->debug_item(1));
+    EXPECT_EQ(R"({"a": 3, "b": 23, "c": 33})", read_col->debug_item(2));
+    EXPECT_EQ(R"({"a": 4, "b": 24, "c": 34})", read_col->debug_item(3));
+    EXPECT_EQ(R"({"a": 5, "b": 25, "c": 35})", read_col->debug_item(4));
 }
 } // namespace starrocks


### PR DESCRIPTION
Fixes #76356

## Why I'm doing:

`enable_compaction_flat_json` (default `true`, introduced in #49411 as "[Enhancement][FlatJson] optimize flat json compaction performance") is meant to let compaction read flattened JSON sub-columns directly, skipping the reassemble-whole-JSON → re-parse → re-flatten round trip. It has never taken effect: the reader-based derivation that plans the direct read can never pass the base-type gate, so every compaction silently falls back to the full JSON round trip. Details and reproduction in #76356.

Three defects hide behind that one symptom, and reviving the feature safely requires all of them (plus one hazard guard discovered during live verification):

1. **The planner's derivation starves the base-type gate.** `derived(vector<const ColumnReader*>)` (compaction read planner, works from segment footers) updates `hits` but never feeds `base_type_count`, so under the production default (`enable_json_flat_complex_type=false`) every leaf fails `base_type_count >= hits * (1 - json_flat_complex_type_factor)` and the plan is always empty.
2. **The write side of direct-read compaction has the same gap.** `_derived_on_flat_json()` — only reachable when direct read feeds already-flat columns to `FlatJsonColumnCompactor` — also never fed the counter, so once (1) is fixed the compactor would fall back to `_merge_columns()` and write the flat inputs back as raw JSON (observed live: 33MB of flat input compacted into a 52MB raw segment, silently losing the columnar layout of the merged segment).
3. **The planner reads its config from a best-effort cache.** `init_compaction_column_paths()` took the tuning config (null factor / column max) from `get_latest_cached_tablet_metadata()` — null on a cold cache (silent fallback to global defaults, ignoring the table property) and possibly ahead/behind the version being compacted. The reader already holds the exact metadata version it compacts.
4. **Structurally conflicting segments have no safe read plan.** A path stored as a scalar leaf in one segment and as an object in another (each correct for its own batch) cannot be covered by any single per-path plan — planning the node as JSON was observed on a live cluster to silently drop the scalar side (500k `"c"` values gone after compaction; the fallback path preserves them).

## What I'm doing:

- Feed `base_type_count` in both metadata-based derivations: a sub-column stored as a concrete base type means every row of that segment held a base-typed value, so count those rows (the write-time flattener only types a sub-column when nothing mixed or complex was seen). Also rewrite the misleading one-line comment on `enable_compaction_flat_json`.
- Detect cross-segment leaf/object conflicts during reader-based derivation and return no paths, so compaction takes the full JSON merge path for such tablets — which re-derives the merged layout from actual values and stores the conflicted key as a JSON-typed sub-column, correctly. Homogeneous tablets keep the full speedup, and once writes homogenize, direct read resumes on later compactions (verified live).
- Take the derivation config from `_tablet_metadata` (the version being compacted): version-consistent, no extra I/O, independent of cache warmth — mirroring the shared-nothing reader, which has always read its own tablet meta.
- Tests: pin the production-default behavior for both derivation entries (the existing fixture sets `enable_json_flat_complex_type=true`, which is exactly why the dead gate was never exercised); update the five conflict-shaped tests to the new bail-out outcome; add a mixed-layout case (JSON-typed leaf in one segment vs object children in another) pinning that the bail-out stays quiet and the plan simply excludes the subtree; add a lake integration test that pins a stale latest-metadata cache via sync point and asserts the versioned config is used.

## Verification (all empirical, live clusters built from this branch)

- **Performance** (same binary, config toggled at runtime, decision log confirming the mode per run): 2M rows × 6 fields — 1.96s vs 2.83s (**−31%**, 3 runs each, identical IO stats); 10M rows × 12 fields — 30.1s vs 38.6s (−22%). Merged outputs identical in both modes (size, flattened layout, row-level aggregates).
- **Decision log**: `Compaction flat json column: [c1(BIGINT), c2(BIGINT), c3(BIGINT), c4(VARCHAR), c5(BIGINT), c6(DOUBLE)]` where it used to be `[]` — on shared-data (horizontal and vertical tasks) and shared-nothing alike.
- **Conflict lifecycle**: conflicting segments → plan `[]`, lossless fallback; re-introduced conflicts re-trigger the bail; homogenized segments resume direct read losslessly with the conflicted key folded through the remain path.
- **Safety sweeps**: a non-flat segment in the mix disables the gate (lossless); PK-table compactions never enter the planner (unchanged, results correct); result invariance spot-checked across mixed columnized/RAW layouts.
- BE UT green for the touched suites on the rebased head; a follow-up [Doc] PR corrects the parameter description (en/zh).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Rationale: `enable_compaction_flat_json=true` (the existing default) becomes effective for the first time — JSON compactions on fully-flattened tablets switch from the reassemble-and-reparse fallback to direct sub-column reads. Query results and merged-segment contents are unchanged; the change is CPU cost and the (already intended) decision logging.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
