### PR TITLE
[Doc] Clarify what enable_compaction_flat_json actually controls

### DIFF
--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -104,7 +104,7 @@ This topic introduces the following types of BE configurations:
 - Type: Boolean
 - Unit:
 - Is mutable: Yes
-- Description: Whether to enable compaction for Flat JSON data.
+- Description: Whether compaction reads flattened JSON sub-columns directly when every input segment stores the JSON column flattened, skipping the reassemble-whole-JSON and re-parse round trip. This only affects how compaction reads its input. Compaction itself always runs, and whether the merged output is flattened is governed by the Flat JSON configuration, regardless of this item.
 - Introduced in: v3.3.3
 
 ### enable_json_flat

--- a/docs/zh/administration/management/BE_parameters/query_loading.md
+++ b/docs/zh/administration/management/BE_parameters/query_loading.md
@@ -101,7 +101,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 类型：Bool
 - 单位：
 - 是否动态：是
-- 描述：控制是否为 Flat Json 数据进行 Compaction。
+- 描述：当所有输入 Segment 中的 JSON 列均已扁平化存储时，Compaction 是否直接读取扁平化的子列，从而跳过“重组完整 JSON 再重新解析”的往返开销。该配置仅影响 Compaction 读取输入的方式：Compaction 本身始终会执行，合并结果是否扁平化由 Flat JSON 配置决定，与该配置无关。
 - 引入版本：v3.3.3
 
 ### enable_json_flat


### PR DESCRIPTION
Relates to #76356 (context: the parameter has been inert since its introduction, which is
how this description drift went unnoticed; a separate BugFix PR revives the behavior).

## Why I'm doing:

The BE parameter reference describes `enable_compaction_flat_json` as "Whether to enable compaction for Flat JSON data", which reads as if the flag gates whether flat JSON data gets compacted (or flattened) at all. It does not — compaction always runs, and whether the merged output is flattened is governed by the Flat JSON configuration regardless of this item. The flag — introduced in #49411 as a compaction performance optimization — only chooses how compaction *reads* its input: directly over the flattened sub-columns, or by reassembling and re-parsing whole JSON values (verified empirically: with the flag off, the merged segment is still written flattened, at the same size).

## What I'm doing:

Rewrite the description (en/zh) to state what the flag actually controls and what it does not affect.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
