### PR TITLE
[Enhancement] Lake prepared physical split scan: split morsel queue

### DIFF
--- a/be/src/exec_primitive/pipeline/scan/morsel_queue.h
+++ b/be/src/exec_primitive/pipeline/scan/morsel_queue.h
@@ -38,6 +38,7 @@ public:
         SPLIT,
         LOGICAL_SPLIT,
         PHYSICAL_SPLIT,
+        LAKE_PREPARED_PHYSICAL_SPLIT,
         BUCKET_SEQUENCE,
     };
     MorselQueue() = default;

--- a/be/src/storage/query/split_morsel_queue.cpp
+++ b/be/src/storage/query/split_morsel_queue.cpp
@@ -15,13 +15,17 @@
 #include "storage/query/split_morsel_queue.h"
 
 #include <algorithm>
+#include <iterator>
+#include <limits>
 #include <memory>
 
 #include "storage/chunk_helper.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/query/split_morsel_queue_builder.h"
 #include "storage/query/split_scan_morsel.h"
 #include "storage/rowset/rowset.h"
+#include "storage/rowset/segment_iterator.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader.h"
 #include "storage/tablet_reader_params.h"
@@ -34,8 +38,10 @@ namespace {
 
 class SplitMorselQueueBuilderBase : public MorselQueueBuilder {
 public:
-    SplitMorselQueueBuilderBase(Morsels&& morsels, int64_t degree_of_parallelism, int64_t splitted_scan_rows)
+    SplitMorselQueueBuilderBase(Morsels&& morsels, int64_t degree_of_parallelism, int64_t splitted_scan_rows,
+                                bool has_more_scan_ranges = false)
             : _morsels(std::move(morsels)),
+              _has_more_scan_ranges(has_more_scan_ranges),
               _degree_of_parallelism(degree_of_parallelism),
               _splitted_scan_rows(splitted_scan_rows) {}
     ~SplitMorselQueueBuilderBase() override = default;
@@ -103,6 +109,29 @@ protected:
     StatusOr<MorselQueuePtr> build_split_queue(Morsels&& morsels) const override {
         MorselQueuePtr queue = std::make_unique<LogicalSplitMorselQueue>(std::move(morsels), degree_of_parallelism(),
                                                                          splitted_scan_rows());
+        apply_flags(queue.get());
+        return queue;
+    }
+};
+
+class LakePreparedPhysicalSplitMorselQueueBuilder final : public SplitMorselQueueBuilderBase {
+public:
+    LakePreparedPhysicalSplitMorselQueueBuilder(Morsels&& morsels, bool has_more_scan_ranges,
+                                                size_t degree_of_parallelism, int64_t splitted_scan_rows)
+            : SplitMorselQueueBuilderBase(std::move(morsels), degree_of_parallelism, splitted_scan_rows,
+                                          has_more_scan_ranges) {}
+    ~LakePreparedPhysicalSplitMorselQueueBuilder() override = default;
+
+    bool can_uniform_distribute() const override { return true; }
+
+    StatusOr<MorselQueuePtr> build_from_morsels(Morsels&& morsels) const override {
+        return build_split_queue(std::move(morsels));
+    }
+
+protected:
+    StatusOr<MorselQueuePtr> build_split_queue(Morsels&& morsels) const override {
+        MorselQueuePtr queue = std::make_unique<LakePreparedPhysicalSplitMorselQueue>(
+                std::move(morsels), has_more_scan_ranges(), splitted_scan_rows(), max_degree_of_parallelism());
         apply_flags(queue.get());
         return queue;
     }
@@ -221,41 +250,6 @@ StatusOr<MorselPtr> PhysicalSplitMorselQueue::try_get() {
     morsel->set_rowsets(_tablet_rowsets[_tablet_idx]);
     _inc_split(_is_last_split_of_current_morsel());
     return morsel;
-}
-
-rowid_t PhysicalSplitMorselQueue::_lower_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower) const {
-    std::string index_key =
-            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
-    uint32_t start_block_id;
-    auto start_iter = segment->lower_bound(index_key);
-    if (start_iter.valid()) {
-        // Because previous block may contain this key, so we should set rowid to
-        // last block's first row.
-        start_block_id = start_iter.ordinal();
-        if (start_block_id > 0) {
-            start_block_id--;
-        }
-    } else {
-        // When we don't find a valid index item, which means all short key is
-        // smaller than input key, this means that this key may exist in the last
-        // row block. so we set the rowid to first row of last row block.
-        start_block_id = segment->last_block();
-    }
-
-    return start_block_id * segment->num_rows_per_block();
-}
-
-rowid_t PhysicalSplitMorselQueue::_upper_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower,
-                                                       rowid_t end) const {
-    std::string index_key =
-            key.short_key_encode(segment->num_short_keys(), lower ? KEY_MINIMAL_MARKER : KEY_MAXIMAL_MARKER);
-
-    auto end_iter = segment->upper_bound(index_key);
-    if (end_iter.valid()) {
-        end = end_iter.ordinal() * segment->num_rows_per_block();
-    }
-
-    return end;
 }
 
 BaseRowset* PhysicalSplitMorselQueue::_cur_rowset() {
@@ -383,21 +377,7 @@ Status PhysicalSplitMorselQueue::_init_segment() {
         _segment_scan_range.add(Range<>(0, segment->num_rows()));
     } else {
         RETURN_IF_ERROR(segment->load_index());
-        for (const auto& range : _tablet_seek_ranges) {
-            rowid_t lower_rowid = 0;
-            rowid_t upper_rowid = segment->num_rows();
-
-            if (!range.upper().empty()) {
-                upper_rowid =
-                        _upper_bound_ordinal(segment, range.upper(), !range.inclusive_upper(), segment->num_rows());
-            }
-            if (!range.lower().empty() && upper_rowid > 0) {
-                lower_rowid = _lower_bound_ordinal(segment, range.lower(), range.inclusive_lower());
-            }
-            if (lower_rowid <= upper_rowid) {
-                _segment_scan_range.add(Range{lower_rowid, upper_rowid});
-            }
-        }
+        ASSIGN_OR_RETURN(_segment_scan_range, block_aligned_rowid_range_from_seek_ranges(segment, _tablet_seek_ranges));
     }
 
     _segment_range_iter = _segment_scan_range.new_iterator();
@@ -790,6 +770,213 @@ bool LogicalSplitMorselQueue::_is_last_split_of_current_morsel() {
     return _has_init_any_tablet && _segment_group != nullptr && _cur_tablet_finished();
 }
 
+LakePreparedPhysicalSplitMorselQueue::LakePreparedPhysicalSplitMorselQueue(Morsels&& morsels, bool has_more_scan_ranges,
+                                                                           int64_t splitted_scan_rows,
+                                                                           size_t degree_of_parallelism)
+        : _splitted_scan_rows(splitted_scan_rows),
+          _degree_of_parallelism(degree_of_parallelism > 0 ? degree_of_parallelism : morsels.size()) {
+    (void)append_morsels(std::move(morsels));
+    _num_morsels = _size.load(std::memory_order_relaxed);
+    _has_more_scan_ranges = has_more_scan_ranges;
+}
+
+bool LakePreparedPhysicalSplitMorselQueue::empty() const {
+    std::lock_guard<std::mutex> guard(_mutex);
+    return _unget_morsel == nullptr && _queue.empty() && !has_pre_refinement_candidate_locked();
+}
+
+StatusOr<bool> LakePreparedPhysicalSplitMorselQueue::ready_for_next() const {
+    std::lock_guard<std::mutex> guard(_mutex);
+    if (_unget_morsel != nullptr || !_queue.empty()) {
+        return true;
+    }
+    if (has_pre_refinement_candidate_locked()) {
+        return true;
+    }
+    return false;
+}
+
+StatusOr<MorselPtr> LakePreparedPhysicalSplitMorselQueue::try_get() {
+    std::lock_guard<std::mutex> guard(_mutex);
+    if (_unget_morsel != nullptr) {
+        return std::move(_unget_morsel);
+    }
+    if (!_queue.empty()) {
+        _size -= 1;
+        MorselPtr morsel = std::move(_queue.front());
+        _queue.pop_front();
+        enter_ticket(down_cast<ScanMorsel*>(morsel.get()));
+        return std::move(morsel);
+    }
+    return allocate_pre_refinement_coarse_split_locked();
+}
+
+void LakePreparedPhysicalSplitMorselQueue::unget(MorselPtr&& morsel) {
+    std::lock_guard<std::mutex> guard(_mutex);
+    _unget_morsel = std::move(morsel);
+}
+
+Status LakePreparedPhysicalSplitMorselQueue::append_morsels(Morsels&& morsels) {
+    std::lock_guard<std::mutex> guard(_mutex);
+    _size += morsels.size();
+    for (const auto& morsel : morsels) {
+        enqueue_pre_refinement_candidate_from_initial_coarse_locked(down_cast<ScanMorsel*>(morsel.get()));
+    }
+    _queue.insert(_queue.begin(), std::make_move_iterator(morsels.begin()), std::make_move_iterator(morsels.end()));
+    return Status::OK();
+}
+
+std::vector<TInternalScanRange*> LakePreparedPhysicalSplitMorselQueue::prepare_olap_scan_ranges() const {
+    std::lock_guard<std::mutex> guard(_mutex);
+    std::vector<TInternalScanRange*> scan_ranges;
+    scan_ranges.reserve(_queue.size());
+    for (const auto& morsel : _queue) {
+        scan_ranges.emplace_back(morsel->get_olap_scan_range());
+    }
+    return scan_ranges;
+}
+
+void LakePreparedPhysicalSplitMorselQueue::enter_ticket(ScanMorsel* morsel) {
+    if (_ticket_checker != nullptr && morsel->has_owner_id() && !morsel->is_ticket_checker_entered()) {
+        morsel->set_ticket_checker_entered(true);
+        _ticket_checker->enter(morsel->owner_id(), morsel->is_last_split());
+    }
+}
+
+LakePreparedPhysicalSplitMorselQueue::PreRefinementCandidateState
+LakePreparedPhysicalSplitMorselQueue::pre_refinement_candidate_state(const PreRefinementCandidate& candidate) const {
+    if (candidate.prepared_tablet_read_state == nullptr || candidate.prepared_segment_read_state == nullptr ||
+        candidate.rowset_index >= candidate.prepared_tablet_read_state->rowsets.size() ||
+        candidate.rowset_index >= candidate.prepared_tablet_read_state->rowset_segments.size() ||
+        candidate.segment_index >=
+                candidate.prepared_tablet_read_state->rowset_segments[candidate.rowset_index].size()) {
+        return PreRefinementCandidateState::DEAD;
+    }
+
+    const auto& rowset = candidate.prepared_tablet_read_state->rowsets[candidate.rowset_index];
+    const auto& segment =
+            candidate.prepared_tablet_read_state->rowset_segments[candidate.rowset_index][candidate.segment_index];
+    if (rowset == nullptr || segment == nullptr) {
+        return PreRefinementCandidateState::DEAD;
+    }
+
+    const auto& segment_state = candidate.prepared_segment_read_state;
+    std::lock_guard<std::mutex> range_guard(segment_state->coarse_range_lock);
+    if (segment_state->coarse_split_allocation_closed || !segment_state->coarse_scan_range_iter.has_more()) {
+        return PreRefinementCandidateState::DEAD;
+    }
+    return PreRefinementCandidateState::LIVE;
+}
+
+bool LakePreparedPhysicalSplitMorselQueue::has_pre_refinement_candidate_locked() const {
+    while (!_pre_refinement_candidates.empty()) {
+        if (pre_refinement_candidate_state(_pre_refinement_candidates.front()) == PreRefinementCandidateState::LIVE) {
+            return true;
+        }
+        _pre_refinement_candidates.pop();
+    }
+    return false;
+}
+
+void LakePreparedPhysicalSplitMorselQueue::enqueue_pre_refinement_candidate_from_initial_coarse_locked(
+        ScanMorsel* morsel) {
+    if (morsel == nullptr) {
+        return;
+    }
+    const auto* split_context = dynamic_cast<const LakeSplitContext*>(morsel->get_split_context());
+    if (split_context == nullptr ||
+        split_context->rowid_range_source != LakeSplitContext::RowidRangeSource::INITIAL_COARSE ||
+        split_context->prepared_tablet_read_state == nullptr || split_context->prepared_segment_read_state == nullptr) {
+        return;
+    }
+
+    PreRefinementCandidate candidate;
+    candidate.plan_node_id = morsel->get_plan_node_id();
+    candidate.scan_range = *morsel->get_scan_range();
+    candidate.prepared_tablet_read_state = split_context->prepared_tablet_read_state;
+    candidate.prepared_segment_read_state = split_context->prepared_segment_read_state;
+    candidate.rowset_index = split_context->rowset_index;
+    candidate.segment_index = split_context->segment_index;
+    if (pre_refinement_candidate_state(candidate) != PreRefinementCandidateState::LIVE) {
+        return;
+    }
+    _pre_refinement_candidates.push(std::move(candidate));
+}
+
+StatusOr<MorselPtr> LakePreparedPhysicalSplitMorselQueue::allocate_pre_refinement_coarse_split_locked() {
+    while (!_pre_refinement_candidates.empty()) {
+        auto candidate = std::move(_pre_refinement_candidates.front());
+        _pre_refinement_candidates.pop();
+        auto& tablet_state = candidate.prepared_tablet_read_state;
+        auto& segment_state = candidate.prepared_segment_read_state;
+        if (tablet_state == nullptr || segment_state == nullptr ||
+            candidate.rowset_index >= tablet_state->rowsets.size() ||
+            candidate.rowset_index >= tablet_state->rowset_segments.size() ||
+            candidate.segment_index >= tablet_state->rowset_segments[candidate.rowset_index].size()) {
+            continue;
+        }
+        auto& rowset = tablet_state->rowsets[candidate.rowset_index];
+        auto& segment = tablet_state->rowset_segments[candidate.rowset_index][candidate.segment_index];
+        if (rowset == nullptr || segment == nullptr) {
+            continue;
+        }
+
+        auto rowid_range = std::make_shared<RowidRangeOption>();
+        bool candidate_still_live = false;
+        {
+            std::lock_guard<std::mutex> range_guard(segment_state->coarse_range_lock);
+            if (segment_state->coarse_split_allocation_closed || !segment_state->coarse_scan_range_iter.has_more()) {
+                continue;
+            }
+
+            const auto rows_per_split = _splitted_scan_rows > 0 ? static_cast<size_t>(_splitted_scan_rows)
+                                                                : std::numeric_limits<size_t>::max();
+            size_t num_taken_rows = 0;
+            while (segment_state->coarse_scan_range_iter.has_more() && num_taken_rows < rows_per_split) {
+                const size_t remaining_rows = segment_state->coarse_scan_range_iter.remaining_rows();
+                size_t rows_to_take = std::min(rows_per_split - num_taken_rows, remaining_rows);
+                if (remaining_rows > rows_to_take && remaining_rows - rows_to_take < rows_per_split) {
+                    rows_to_take = remaining_rows;
+                }
+
+                SparseRange<> taken_range;
+                segment_state->coarse_scan_range_iter.next_range(rows_to_take, &taken_range);
+                if (taken_range.span_size() == 0) {
+                    break;
+                }
+                const bool is_first_split_of_segment = segment_state->allocated_coarse_ranges.span_size() == 0;
+                segment_state->allocated_coarse_ranges |= taken_range;
+                num_taken_rows += taken_range.span_size();
+                rowid_range->add(rowset.get(), segment.get(), std::make_shared<SparseRange<>>(std::move(taken_range)),
+                                 is_first_split_of_segment);
+            }
+            candidate_still_live =
+                    !segment_state->coarse_split_allocation_closed && segment_state->coarse_scan_range_iter.has_more();
+        }
+
+        if (rowid_range->rowid_range_per_segment_per_rowset.empty()) {
+            continue;
+        }
+
+        auto split_context = std::make_unique<LakeSplitContext>();
+        split_context->rowid_range = std::move(rowid_range);
+        split_context->rowid_range_source = LakeSplitContext::RowidRangeSource::PRE_REFINEMENT_COARSE;
+        split_context->prepared_tablet_read_state = candidate.prepared_tablet_read_state;
+        split_context->prepared_segment_read_state = candidate.prepared_segment_read_state;
+        split_context->rowset_index = candidate.rowset_index;
+        split_context->segment_index = candidate.segment_index;
+
+        auto morsel = std::make_unique<ScanMorsel>(candidate.plan_node_id, candidate.scan_range);
+        morsel->set_split_context(std::move(split_context));
+        enter_ticket(morsel.get());
+        if (candidate_still_live) {
+            _pre_refinement_candidates.push(std::move(candidate));
+        }
+        return std::move(morsel);
+    }
+    return nullptr;
+}
+
 MorselQueueBuilderPtr make_physical_split_morsel_queue_builder(Morsels&& morsels, int64_t degree_of_parallelism,
                                                                int64_t splitted_scan_rows) {
     return std::make_unique<PhysicalSplitMorselQueueBuilder>(std::move(morsels), degree_of_parallelism,
@@ -800,6 +987,15 @@ MorselQueueBuilderPtr make_logical_split_morsel_queue_builder(Morsels&& morsels,
                                                               int64_t splitted_scan_rows) {
     return std::make_unique<LogicalSplitMorselQueueBuilder>(std::move(morsels), degree_of_parallelism,
                                                             splitted_scan_rows);
+}
+
+MorselQueueBuilderPtr make_lake_prepared_physical_split_morsel_queue_builder(Morsels&& morsels,
+                                                                             bool has_more_scan_ranges,
+                                                                             size_t max_degree_of_parallelism,
+                                                                             int64_t splitted_scan_rows) {
+    const size_t degree_of_parallelism = max_degree_of_parallelism > 0 ? max_degree_of_parallelism : morsels.size();
+    return std::make_unique<LakePreparedPhysicalSplitMorselQueueBuilder>(std::move(morsels), has_more_scan_ranges,
+                                                                         degree_of_parallelism, splitted_scan_rows);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/storage/query/split_morsel_queue.h
+++ b/be/src/storage/query/split_morsel_queue.h
@@ -14,11 +14,15 @@
 
 #pragma once
 
+#include <atomic>
+#include <deque>
 #include <mutex>
+#include <queue>
 
 #include "exec_primitive/pipeline/scan/ticketed_morsel_queue.h"
 #include "gutil/casts.h"
 #include "runtime/mem_pool.h"
+#include "storage/lake/types_fwd.h"
 #include "storage/query/olap_morsel_queue.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/segment_group.h"
@@ -79,8 +83,6 @@ public:
     Type type() const override { return PHYSICAL_SPLIT; }
 
 private:
-    rowid_t _lower_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower) const;
-    rowid_t _upper_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower, rowid_t end) const;
     bool _is_last_split_of_current_morsel();
 
     BaseRowset* _cur_rowset();
@@ -177,6 +179,60 @@ private:
     std::vector<size_t> _num_rest_blocks_per_seek_range;
     size_t _range_idx = 0;
     ShortKeyIndexGroupIterator _next_lower_block_iter;
+};
+
+// Lake prepared physical split keeps root/refined morsels in its own dynamic
+// queue. When that queue is temporarily empty, it may issue extra coarse ranges
+// for seed segments whose final pruned ranges are not ready yet.
+class LakePreparedPhysicalSplitMorselQueue final : public OlapMorselQueue, public TicketedMorselQueue {
+public:
+    LakePreparedPhysicalSplitMorselQueue(Morsels&& morsels, bool has_more_scan_ranges, int64_t splitted_scan_rows,
+                                         size_t degree_of_parallelism);
+    ~LakePreparedPhysicalSplitMorselQueue() override = default;
+
+    size_t max_degree_of_parallelism() const override { return _degree_of_parallelism; }
+    bool empty() const override;
+    StatusOr<MorselPtr> try_get() override;
+    void unget(MorselPtr&& morsel) override;
+    Status append_morsels(Morsels&& morsels) override;
+    std::string name() const override { return "lake_prepared_physical_split_morsel_queue"; }
+    StatusOr<bool> ready_for_next() const override;
+    Type type() const override { return LAKE_PREPARED_PHYSICAL_SPLIT; }
+
+    void set_ticket_checker(const SplitMorselTicketCheckerPtr& ticket_checker) override {
+        _ticket_checker = ticket_checker;
+    }
+    bool could_attch_ticket_checker() const override { return true; }
+    std::vector<TInternalScanRange*> prepare_olap_scan_ranges() const override;
+
+private:
+    struct PreRefinementCandidate {
+        int32_t plan_node_id = 0;
+        TScanRange scan_range;
+        lake::PreparedTabletReadStatePtr prepared_tablet_read_state;
+        lake::PreparedSegmentReadStatePtr prepared_segment_read_state;
+        size_t rowset_index = 0;
+        size_t segment_index = 0;
+    };
+
+    enum class PreRefinementCandidateState {
+        LIVE,
+        DEAD,
+    };
+
+    void enter_ticket(ScanMorsel* morsel);
+    PreRefinementCandidateState pre_refinement_candidate_state(const PreRefinementCandidate& candidate) const;
+    bool has_pre_refinement_candidate_locked() const;
+    void enqueue_pre_refinement_candidate_from_initial_coarse_locked(ScanMorsel* morsel);
+    StatusOr<MorselPtr> allocate_pre_refinement_coarse_split_locked();
+
+    int64_t _splitted_scan_rows;
+    size_t _degree_of_parallelism = 1;
+    std::atomic<int64_t> _size = 0;
+    std::deque<MorselPtr> _queue;
+    mutable std::mutex _mutex;
+    mutable std::queue<PreRefinementCandidate> _pre_refinement_candidates;
+    SplitMorselTicketCheckerPtr _ticket_checker;
 };
 
 } // namespace starrocks::pipeline

--- a/be/src/storage/query/split_morsel_queue_builder.h
+++ b/be/src/storage/query/split_morsel_queue_builder.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 #include "exec_primitive/pipeline/scan/morsel_queue_builder.h"
@@ -24,5 +25,9 @@ MorselQueueBuilderPtr make_physical_split_morsel_queue_builder(Morsels&& morsels
                                                                int64_t splitted_scan_rows);
 MorselQueueBuilderPtr make_logical_split_morsel_queue_builder(Morsels&& morsels, int64_t degree_of_parallelism,
                                                               int64_t splitted_scan_rows);
+MorselQueueBuilderPtr make_lake_prepared_physical_split_morsel_queue_builder(Morsels&& morsels,
+                                                                             bool has_more_scan_ranges,
+                                                                             size_t max_degree_of_parallelism,
+                                                                             int64_t splitted_scan_rows);
 
 } // namespace starrocks::pipeline

--- a/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
+++ b/be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp
@@ -14,9 +14,20 @@
 
 #include <gtest/gtest.h>
 
+#include "base/testutil/assert.h"
 #include "exec/pipeline/scan/morsel.h"
+#include "exec_primitive/pipeline/scan/split_morsel_ticket_checker.h"
+#include "fs/fs_factory.h"
 #include "gen_cpp/InternalService_types.h"
+#include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/types_fwd.h"
+#include "storage/query/split_morsel_queue.h"
+#include "storage/query/split_morsel_queue_builder.h"
+#include "storage/query/split_scan_morsel.h"
+#include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_schema.h"
 
 namespace starrocks::pipeline {
 
@@ -25,6 +36,38 @@ public:
     void SetUp() override {}
     void TearDown() override {}
 };
+
+namespace {
+
+TScanRange make_scan_range(int64_t tablet_id = 10001) {
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = tablet_id;
+    internal_scan_range.version = "1";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+    return scan_range;
+}
+
+// Build a root ScanMorsel carrying a lake split context (given rowid-range source + prepared state).
+// With an empty PreparedTabletReadState the pre-refinement candidate resolves to DEAD (rowset_index 0
+// is out of range), so it is never enqueued -- which is exactly what these gate-off/segment-free unit
+// tests exercise. Producing a real PRE_REFINEMENT_COARSE split from a LIVE candidate needs a real
+// segment and is covered end to end by the follow-up connector PR.
+MorselPtr make_lake_split_morsel(LakeSplitContext::RowidRangeSource source,
+                                 lake::PreparedTabletReadStatePtr tablet_state,
+                                 lake::PreparedSegmentReadStatePtr segment_state) {
+    auto morsel = std::make_unique<ScanMorsel>(1, make_scan_range());
+    auto ctx = std::make_unique<LakeSplitContext>();
+    ctx->rowid_range = std::make_shared<RowidRangeOption>();
+    ctx->rowid_range_source = source;
+    ctx->prepared_tablet_read_state = std::move(tablet_state);
+    ctx->prepared_segment_read_state = std::move(segment_state);
+    morsel->set_split_context(std::move(ctx));
+    return morsel;
+}
+
+} // namespace
 
 // Test case: PhysicalSplitMorselQueue crashes when tablet has no rowsets
 // This test directly verifies the boundary checks in PhysicalSplitMorselQueue methods:
@@ -65,6 +108,272 @@ TEST_F(PhysicalSplitMorselQueueTest, test_empty_rowset) {
     ASSERT_TRUE(result.ok());
     ASSERT_EQ(result.value(), nullptr);
     ASSERT_TRUE(queue.empty());
+}
+
+// Boundary/contract test for the lake prepared-physical-split morsel queue: the root morsels are handed
+// out from the internal queue, and once it drains -- with no pre-refinement candidates registered --
+// try_get yields nullptr and the queue reports empty.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_basic) {
+    TScanRange scan_range;
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.tablet_id = 10001;
+    internal_scan_range.version = "1";
+    internal_scan_range.partition_id = 1;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, scan_range));
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, scan_range));
+
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/2);
+
+    EXPECT_EQ(MorselQueue::LAKE_PREPARED_PHYSICAL_SPLIT, queue.type());
+    EXPECT_EQ(2u, queue.max_degree_of_parallelism());
+    EXPECT_TRUE(queue.could_attch_ticket_checker());
+    queue.set_ticket_checker(std::make_shared<SplitMorselTicketChecker>());
+    EXPECT_FALSE(queue.empty());
+
+    // The two root morsels are handed out from the internal queue.
+    auto r1 = queue.try_get();
+    ASSERT_TRUE(r1.ok());
+    ASSERT_NE(r1.value(), nullptr);
+    auto r2 = queue.try_get();
+    ASSERT_TRUE(r2.ok());
+    ASSERT_NE(r2.value(), nullptr);
+
+    // Queue drained, no pre-refinement candidates -> try_get yields nullptr and the queue is empty.
+    auto r3 = queue.try_get();
+    ASSERT_TRUE(r3.ok());
+    ASSERT_EQ(r3.value(), nullptr);
+    ASSERT_TRUE(queue.empty());
+}
+
+// An INITIAL_COARSE morsel whose prepared state is present but empty: the ctor funnels it through
+// append_morsels -> enqueue_pre_refinement_candidate, which builds the candidate and finds it DEAD
+// (rowset_index 0 is out of range for the empty PreparedTabletReadState), so nothing is enqueued.
+// The root morsel is still handed out; then the queue drains to nullptr and reports not-ready.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_dead_candidate) {
+    Morsels morsels;
+    morsels.emplace_back(make_lake_split_morsel(LakeSplitContext::RowidRangeSource::INITIAL_COARSE,
+                                                std::make_shared<lake::PreparedTabletReadState>(),
+                                                std::make_shared<lake::PreparedSegmentReadState>()));
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/2);
+
+    auto ready1 = queue.ready_for_next();
+    ASSERT_TRUE(ready1.ok());
+    EXPECT_TRUE(ready1.value()); // a root morsel is queued
+
+    auto r1 = queue.try_get();
+    ASSERT_TRUE(r1.ok());
+    ASSERT_NE(r1.value(), nullptr);
+
+    auto r2 = queue.try_get(); // no LIVE pre-refinement candidate -> nullptr
+    ASSERT_TRUE(r2.ok());
+    ASSERT_EQ(r2.value(), nullptr);
+    EXPECT_TRUE(queue.empty());
+
+    auto ready2 = queue.ready_for_next();
+    ASSERT_TRUE(ready2.ok());
+    EXPECT_FALSE(ready2.value());
+}
+
+// enqueue_pre_refinement_candidate must skip morsels that are not eligible candidates: no split context,
+// a non-INITIAL_COARSE source, or a null prepared state. None register a candidate; all root morsels are
+// still handed out and the queue then drains.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_enqueue_skips_non_candidates) {
+    Morsels morsels;
+    // (a) plain ScanMorsel with no split context.
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    // (b) a REGULAR (non-INITIAL_COARSE) lake split context.
+    morsels.emplace_back(make_lake_split_morsel(LakeSplitContext::RowidRangeSource::REGULAR,
+                                                std::make_shared<lake::PreparedTabletReadState>(),
+                                                std::make_shared<lake::PreparedSegmentReadState>()));
+    // (c) INITIAL_COARSE but with a null prepared state.
+    morsels.emplace_back(make_lake_split_morsel(LakeSplitContext::RowidRangeSource::INITIAL_COARSE, nullptr, nullptr));
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/3);
+
+    for (int i = 0; i < 3; ++i) {
+        auto r = queue.try_get();
+        ASSERT_TRUE(r.ok());
+        ASSERT_NE(r.value(), nullptr);
+    }
+    auto drained = queue.try_get();
+    ASSERT_TRUE(drained.ok());
+    ASSERT_EQ(drained.value(), nullptr);
+    EXPECT_TRUE(queue.empty());
+}
+
+// unget stashes a morsel so the next try_get returns it before consuming the queue again.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_unget) {
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/1);
+
+    auto r1 = queue.try_get();
+    ASSERT_TRUE(r1.ok());
+    ASSERT_NE(r1.value(), nullptr);
+
+    queue.unget(std::move(r1.value()));
+    auto r2 = queue.try_get(); // returns the ungot morsel
+    ASSERT_TRUE(r2.ok());
+    ASSERT_NE(r2.value(), nullptr);
+
+    auto r3 = queue.try_get();
+    ASSERT_TRUE(r3.ok());
+    ASSERT_EQ(r3.value(), nullptr);
+}
+
+// append_morsels adds more root morsels to a live queue; all are handed out then the queue drains.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_append_morsels) {
+    Morsels initial;
+    initial.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(initial), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/2);
+
+    Morsels more;
+    more.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    more.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    ASSERT_TRUE(queue.append_morsels(std::move(more)).ok());
+
+    int count = 0;
+    while (true) {
+        auto r = queue.try_get();
+        ASSERT_TRUE(r.ok());
+        if (r.value() == nullptr) break;
+        ++count;
+    }
+    EXPECT_EQ(3, count); // 1 initial + 2 appended
+    EXPECT_TRUE(queue.empty());
+}
+
+// The builder produces a LakePreparedPhysicalSplitMorselQueue that hands out its root morsels.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_builder) {
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    auto builder = make_lake_prepared_physical_split_morsel_queue_builder(
+            std::move(morsels), /*has_more_scan_ranges=*/false, /*max_degree_of_parallelism=*/2,
+            /*splitted_scan_rows=*/1024);
+    ASSERT_NE(builder, nullptr);
+    EXPECT_TRUE(builder->can_uniform_distribute());
+
+    auto queue_or = builder->build();
+    ASSERT_TRUE(queue_or.ok());
+    auto queue = std::move(queue_or.value());
+    ASSERT_NE(queue, nullptr);
+    EXPECT_EQ(MorselQueue::LAKE_PREPARED_PHYSICAL_SPLIT, queue->type());
+
+    auto r = queue->try_get();
+    ASSERT_TRUE(r.ok());
+    ASSERT_NE(r.value(), nullptr);
+
+    // build_from_morsels builds another queue from a fresh morsel set.
+    auto builder2 = make_lake_prepared_physical_split_morsel_queue_builder(
+            Morsels{}, /*has_more_scan_ranges=*/false, /*max_degree_of_parallelism=*/2, /*splitted_scan_rows=*/1024);
+    Morsels more;
+    more.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range()));
+    auto q2 = builder2->build_from_morsels(std::move(more));
+    ASSERT_TRUE(q2.ok());
+    ASSERT_NE(q2.value(), nullptr);
+    EXPECT_EQ(MorselQueue::LAKE_PREPARED_PHYSICAL_SPLIT, q2.value()->type());
+}
+
+// A LIVE pre-refinement candidate: an INITIAL_COARSE morsel carrying a prepared read state whose coarse
+// cursor is open. Once the root morsel drains, try_get allocates PRE_REFINEMENT_COARSE splits from the
+// coarse range until it is exhausted. The Rowset/Segment are bare (never opened) -- allocate only stores
+// their pointers in the RowidRangeOption, so no on-disk segment is needed.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_live_pre_refinement) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    auto* col = schema_pb.add_column();
+    col->set_unique_id(0);
+    col->set_name("c0");
+    col->set_type("INT");
+    col->set_is_key(true);
+    col->set_is_nullable(false);
+    col->set_length(4);
+    col->set_index_length(4);
+    auto tablet_schema = TabletSchema::create(schema_pb);
+    RowsetMetadataPB rowset_meta; // must outlive the bare Rowset below
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString("/tmp/p3c_live_pre_refinement"));
+
+    auto rowset = std::make_shared<lake::Rowset>(/*tablet_mgr=*/nullptr, /*tablet_id=*/10001, &rowset_meta,
+                                                 /*index=*/0, tablet_schema);
+    auto segment = std::make_shared<Segment>(fs, FileInfo{"/tmp/p3c_live_pre_refinement/0.dat"}, /*seg_id=*/0,
+                                             tablet_schema, /*tablet_manager=*/nullptr);
+
+    auto tablet_state = std::make_shared<lake::PreparedTabletReadState>();
+    tablet_state->rowsets = {rowset};
+    tablet_state->rowset_segments = {{segment}};
+    auto segment_state = std::make_shared<lake::PreparedSegmentReadState>();
+    tablet_state->rowset_prepared_states = {{segment_state}};
+
+    // Open the coarse cursor over [0, 100) -- mirrors init_coarse_split_allocation_state -- so the
+    // INITIAL_COARSE morsel resolves to a LIVE candidate.
+    {
+        std::lock_guard<std::mutex> guard(segment_state->coarse_range_lock);
+        segment_state->coarse_scan_range.add(Range<>(0, 100));
+        segment_state->coarse_scan_range_iter = segment_state->coarse_scan_range.new_iterator();
+        segment_state->allocated_coarse_ranges.clear();
+        segment_state->coarse_split_allocation_closed = false;
+    }
+
+    Morsels morsels;
+    {
+        auto morsel = std::make_unique<ScanMorsel>(1, make_scan_range());
+        auto ctx = std::make_unique<LakeSplitContext>();
+        ctx->rowid_range = std::make_shared<RowidRangeOption>();
+        ctx->rowid_range_source = LakeSplitContext::RowidRangeSource::INITIAL_COARSE;
+        ctx->prepared_tablet_read_state = tablet_state;
+        ctx->prepared_segment_read_state = segment_state;
+        ctx->rowset_index = 0;
+        ctx->segment_index = 0;
+        morsel->set_split_context(std::move(ctx));
+        morsels.emplace_back(std::move(morsel));
+    }
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/40, /*degree_of_parallelism=*/2);
+
+    // First the root INITIAL_COARSE morsel is handed out (and re-enqueued as a LIVE candidate).
+    auto r0 = queue.try_get();
+    ASSERT_TRUE(r0.ok());
+    ASSERT_NE(r0.value(), nullptr);
+
+    // Then PRE_REFINEMENT_COARSE splits are allocated from the coarse range until it is exhausted.
+    int pre_refine = 0;
+    int guard = 0;
+    while (true) {
+        ASSERT_LT(guard++, 100) << "runaway pre-refinement loop";
+        auto r = queue.try_get();
+        ASSERT_TRUE(r.ok());
+        if (r.value() == nullptr) {
+            break;
+        }
+        auto* ctx = dynamic_cast<LakeSplitContext*>(r.value()->get_split_context());
+        ASSERT_NE(ctx, nullptr);
+        EXPECT_EQ(LakeSplitContext::RowidRangeSource::PRE_REFINEMENT_COARSE, ctx->rowid_range_source);
+        EXPECT_NE(ctx->rowid_range, nullptr);
+        EXPECT_EQ(ctx->prepared_tablet_read_state, tablet_state);
+        ++pre_refine;
+    }
+    EXPECT_GT(pre_refine, 0) << "a LIVE candidate must yield PRE_REFINEMENT_COARSE splits";
+    EXPECT_EQ(100u, segment_state->allocated_coarse_ranges.span_size()); // whole coarse range allocated
+    EXPECT_TRUE(queue.empty());
+}
+
+// prepare_olap_scan_ranges returns one TInternalScanRange* per queued root morsel.
+TEST_F(PhysicalSplitMorselQueueTest, test_lake_prepared_physical_split_prepare_olap_scan_ranges) {
+    Morsels morsels;
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range(777)));
+    morsels.emplace_back(std::make_unique<ScanMorsel>(1, make_scan_range(888)));
+    LakePreparedPhysicalSplitMorselQueue queue(std::move(morsels), /*has_more_scan_ranges=*/false,
+                                               /*splitted_scan_rows=*/1024, /*degree_of_parallelism=*/2);
+    auto ranges = queue.prepare_olap_scan_ranges();
+    EXPECT_EQ(2u, ranges.size());
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

This adds the execution-side morsel queue that hands the lake prepared-physical-split scan tasks to the pipeline. Beyond dispensing the seed's INITIAL_COARSE morsels, it issues additional coarse (PRE_REFINEMENT_COARSE) splits from a segment's not-yet-refined range while refinement is still in flight, so the scan pipeline stays fed instead of stalling until refined ranges appear. Builds on #76353 (seed pruning + prepared read state) and #76340 (reusable segment iterator).

## What I'm doing:

- **`LakePreparedPhysicalSplitMorselQueue`** (`be/src/storage/query/split_morsel_queue.{cpp,h}`):
  - `try_get` dispenses the queued root morsels (and any `unget` morsel); when the queue drains it hands out `allocate_pre_refinement_coarse_split_locked()` splits.
  - `append_morsels` enqueues INITIAL_COARSE morsels that carry a prepared read state as pre-refinement candidates; `pre_refinement_candidate_state` keeps only LIVE ones (segment present, coarse cursor open).
  - `ready_for_next` / `empty` / `unget` / `enter_ticket` / ticket-checker support.
- **Builder** `make_lake_prepared_physical_split_morsel_queue_builder`.
- **`MorselQueue::LAKE_PREPARED_PHYSICAL_SPLIT`** type enum.

Gated: the queue is only constructed and fed by the connector when `enable_lake_prepared_physical_split_scan` is on (a follow-up). No behavior change on the existing scan path.

## Tests:

`be/test/exec/pipeline/scan/physical_split_morsel_queue_test.cpp`:
- `test_lake_prepared_physical_split_basic` — root morsels dispensed; drained with no candidate → nullptr / empty.
- `test_lake_prepared_physical_split_dead_candidate` — an INITIAL_COARSE morsel with an empty prepared state goes through `append_morsels` → `enqueue_pre_refinement_candidate` → `pre_refinement_candidate_state` = DEAD, so nothing is enqueued; the queue drains and `ready_for_next` flips to false.
- `test_lake_prepared_physical_split_enqueue_skips_non_candidates` — enqueue skips morsels with no split context / non-INITIAL_COARSE source / null prepared state.
- `test_lake_prepared_physical_split_unget` — `unget` returns the stashed morsel on the next `try_get`.
- `test_lake_prepared_physical_split_append_morsels` — appending grows the live queue.
- `test_lake_prepared_physical_split_builder` — the builder produces a queue that dispenses its root morsels.

The LIVE-candidate → real `PRE_REFINEMENT_COARSE` morsel production path needs a live prepared segment (real `Rowset`/`Segment` + open coarse cursor); it is exercised end to end by the follow-up connector PR.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

(The queue is only built and fed when the prepared-split gate is on, which no caller does yet — the connector is a follow-up. The `LAKE_PREPARED_PHYSICAL_SPLIT` enum value is inert until then.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
