### PR TITLE
[BugFix] Fix shared-data range-distribution tablet-reshard publish stalls and PK-index corruption

### DIFF
--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -28,6 +28,7 @@
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/tablet_splitter.h"
 #include "storage/lake/transactions.h"
+#include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h" // delete_files_async
 #include "storage/storage_env.h"
 
@@ -321,7 +322,20 @@ CONTINUE_HANDLE_IDENTICAL_TABLET:
         return old_tablet_old_metadata_or.status();
     }
 
-    const auto& old_tablet_old_metadata = old_tablet_old_metadata_or.value();
+    // Flush the old tablet's PK-index memtable into sstables before copying metadata to the
+    // identical new tablet, mirroring the pre-split flush in split_tablet. Without it the identical
+    // child inherits an sstable_meta that does not cover recently-written rowsets whose
+    // overwrite/delete resolution lived only in the in-memory memtable; the child's cold PK-index
+    // rebuild then re-derives an index inconsistent with the inherited delvec, surfacing as a
+    // duplicate-key on rebuild or a delvec-inconsistency when a cross-published op_write is applied.
+    // flush_pk_memtable is a no-op for non-PK / non-cloud-native-persistent-index tablets.
+    auto flushed_old_metadata_or =
+            tablet_manager->update_mgr()->flush_pk_memtable(old_tablet_old_metadata_or.value(), new_version);
+    if (!flushed_old_metadata_or.ok()) {
+        g_tablet_reshard_identical_failed << 1;
+        return flushed_old_metadata_or.status();
+    }
+    const auto& old_tablet_old_metadata = flushed_old_metadata_or.value();
 
     auto old_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
     old_tablet_new_metadata->set_version(new_version);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -644,7 +644,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
 
             useAggregatePublish = table.isFileBundling();
-            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
+            Set<Long> publishedNormalIndexMetaIds = Sets.newHashSet();
             for (int i = 0; i < transactionStates.size(); i++) {
                 TransactionState txnState = transactionStates.get(i);
                 computeResource = txnState.getComputeResource();
@@ -669,7 +669,13 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     } else {
                         normalTablets = (normalTablets == null) ? Sets.newHashSet() : normalTablets;
                         normalTablets.addAll(index.getTablets());
-                        publishedNormalIndexIds.add(index.getId());
+                        // Key by metaId, not physical index id: a tablet reshard (split/merge)
+                        // replaces an index with a new physical id but the SAME metaId. Keying by
+                        // physical id would make carry-forward treat the reshard'd base index as
+                        // "untouched" and re-publish its child tablets as no-op normal tablets while
+                        // they are also cross-published from their parent -- the two tasks then
+                        // self-collide on the per-tablet publish lock and wedge the partition.
+                        publishedNormalIndexMetaIds.add(index.getMetaId());
                     }
                 }
             }
@@ -682,7 +688,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             if (useAggregatePublish) {
                 carryForwardTablets = collectFileBundlingCarryForwardTablets(
                         partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
-                        publishedNormalIndexIds);
+                        publishedNormalIndexMetaIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1109,7 +1115,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
             baseVersion = partition.getVisibleVersion();
             List<MaterializedIndex> indexes = txnState.getPartitionLoadedIndexes(table.getId(), partition);
-            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
+            Set<Long> publishedNormalIndexMetaIds = Sets.newHashSet();
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
                     LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getMetaId()), txnId);
@@ -1121,7 +1127,9 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 } else {
                     normalTablets = (normalTablets == null) ? Lists.newArrayList() : normalTablets;
                     normalTablets.addAll(index.getTablets());
-                    publishedNormalIndexIds.add(index.getId());
+                    // Key by metaId (not physical index id) so a reshard'd index is still recognized
+                    // as touched -- see collectFileBundlingCarryForwardTablets and the sibling site above.
+                    publishedNormalIndexMetaIds.add(index.getMetaId());
                 }
             }
             // File bundling stores the metadata of ALL tablets of a partition version in a single bundle
@@ -1136,7 +1144,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             if (useAggregatePublish) {
                 carryForwardTablets = collectFileBundlingCarryForwardTablets(
                         partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
-                        publishedNormalIndexIds);
+                        publishedNormalIndexMetaIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1196,7 +1204,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
     }
 
     // For file bundling only: from the partition's currently-visible indexes, return the tablets of every
-    // NORMAL index that this transaction did not touch (i.e. whose index id is not in publishedNormalIndexIds).
+    // NORMAL index that this transaction did not touch (i.e. whose index metaId is not in publishedNormalIndexMetaIds).
     // These must be carried forward (empty version bump) into the new version's bundle so it stays a complete
     // whole-partition snapshot; otherwise a transaction with a stale index view (notably lake compaction
     // whose loaded-index set is snapshotted at txn begin, before a rollup/MV index became visible) would
@@ -1204,11 +1212,11 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // needs carrying forward (e.g. a normal load already covers every visible index). Caller must hold the
     // table read lock while obtaining visibleIndexes.
     static List<Tablet> collectFileBundlingCarryForwardTablets(List<MaterializedIndex> visibleIndexes,
-                                                               Set<Long> publishedNormalIndexIds) {
+                                                               Set<Long> publishedNormalIndexMetaIds) {
         List<Tablet> carryForwardTablets = null;
         for (MaterializedIndex index : visibleIndexes) {
             if (index.getState() == MaterializedIndex.IndexState.SHADOW
-                    || publishedNormalIndexIds.contains(index.getId())) {
+                    || publishedNormalIndexMetaIds.contains(index.getMetaId())) {
                 continue;
             }
             carryForwardTablets = (carryForwardTablets == null) ? Lists.newArrayList() : carryForwardTablets;


### PR DESCRIPTION
## Why I'm doing:

Shared-data range-distribution tables that support dynamic tablet reshard (split/merge) can permanently stall publish and corrupt the primary-key index under continuous batched ingestion with concurrent splits. Two independent bugs in the reshard publish path are responsible; both were reproduced on a daily-release shared-data cluster.

## What I'm doing:

Fixes #issue

**1. Identical-tablet reshard skips the PK-index flush (`be/src/storage/lake/tablet_reshard.cpp`)**

`handle_identical_tablet` copies the parent tablet metadata to the new tablet without flushing the parent's in-memory PK-index memtable, unlike `split_tablet` and the merge path. The identical child then inherits an `sstable_meta` that does not cover recently-written rowsets whose overwrite/delete resolution lived only in the memtable. Its cold PK-index rebuild re-derives an index inconsistent with the inherited delete vectors, surfacing as `insert found duplicate key ...` on rebuild, or `delvec inconsistent` when a cross-published `op_write` is re-applied. Fix: flush the PK-index memtable before the metadata copy, mirroring the pre-split flush in `split_tablet` (no-op for non-PK / non-cloud-native-persistent-index tablets).

**2. File-bundling carry-forward excludes touched indexes by physical id (`fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java`)**

The file-bundling carry-forward path excludes already-touched indexes by physical index id. A tablet reshard replaces an index with a new physical id but the same metaId, so a batched pre-reshard publish carries the reshard'd index's child tablets forward as no-op normal tablets while they are also cross-published from their parent; the two tasks self-collide on the per-tablet publish lock and wedge the partition. Fix: key the touched-index set by metaId at both collection sites and in `collectFileBundlingCarryForwardTablets`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
