### PR TITLE
[BugFix] Restore ConnectContext on query-deploy workers

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionSchedule.java
@@ -47,22 +47,33 @@ public class AllAtOnceExecutionSchedule implements ExecutionSchedule {
      */
     class TracerContext implements AutoCloseable {
         private final ConnectContext savedConnectContext;
+        private final boolean connectContextSwapped;
 
         TracerContext(Tracers forkedTracers, ConnectContext connectContext) {
             Tracers.set(forkedTracers);
             if (connectContext != null) {
                 savedConnectContext = ConnectContext.get();
                 ConnectContext.set(connectContext);
+                connectContextSwapped = true;
             } else {
                 savedConnectContext = null;
+                connectContextSwapped = false;
             }
         }
 
         @Override
         public void close() {
             Tracers.close();
-            if (savedConnectContext != null) {
-                ConnectContext.set(savedConnectContext);
+            // Restore whenever a context was swapped in: on a pooled query-deploy worker the
+            // previous context is null, and skipping the restore would leave the query's
+            // ConnectContext (and every plan object it references) pinned in the worker's
+            // ThreadLocal indefinitely.
+            if (connectContextSwapped) {
+                if (savedConnectContext != null) {
+                    ConnectContext.set(savedConnectContext);
+                } else {
+                    ConnectContext.remove();
+                }
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionScheduleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/dag/AllAtOnceExecutionScheduleTest.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.qe.ConnectContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AllAtOnceExecutionScheduleTest {
+
+    @Test
+    public void testTracerContextUnpinsConnectContextOnPooledWorker() throws Exception {
+        AllAtOnceExecutionSchedule schedule = new AllAtOnceExecutionSchedule();
+        ConnectContext queryContext = new ConnectContext();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            // Simulates a query-deploy worker: no ConnectContext before the task runs.
+            Future<Boolean> cleanedUp = executor.submit(() -> {
+                assertNull(ConnectContext.get());
+                try (AllAtOnceExecutionSchedule.TracerContext ignored =
+                        schedule.new TracerContext(Tracers.get(), queryContext)) {
+                    assertSame(queryContext, ConnectContext.get());
+                }
+                // Before the fix the query context stayed pinned in this worker's ThreadLocal.
+                return ConnectContext.get() == null;
+            });
+            assertTrue(cleanedUp.get(), "worker ThreadLocal must not retain the query's ConnectContext");
+
+            // A later task on the same (previously clean) worker must also leave no residue.
+            Future<Boolean> secondRun = executor.submit(() -> {
+                try (AllAtOnceExecutionSchedule.TracerContext ignored =
+                        schedule.new TracerContext(Tracers.get(), queryContext)) {
+                    assertSame(queryContext, ConnectContext.get());
+                }
+                return ConnectContext.get() == null;
+            });
+            assertTrue(secondRun.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testTracerContextRestoresPreviousConnectContext() {
+        AllAtOnceExecutionSchedule schedule = new AllAtOnceExecutionSchedule();
+        ConnectContext outerContext = new ConnectContext();
+        ConnectContext innerContext = new ConnectContext();
+        ConnectContext.set(outerContext);
+        try {
+            try (AllAtOnceExecutionSchedule.TracerContext ignored =
+                    schedule.new TracerContext(Tracers.get(), innerContext)) {
+                assertSame(innerContext, ConnectContext.get());
+            }
+            assertSame(outerContext, ConnectContext.get());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`AllAtOnceExecutionSchedule.TracerContext.close()` only restores the saved `ConnectContext` when it is non-null. On a pooled `query-deploy` worker the previous context is always null, so the restore is skipped and the query's `ConnectContext` — together with the whole `ExecPlan` object graph it references (scan nodes, scan ranges, session state) — stays pinned in the worker's ThreadLocal indefinitely.

The leak is self-sustaining: the next query on the same worker saves the leaked context, swaps in its own, and on close restores the leaked first context back. Each worker therefore permanently pins the `ConnectContext` of the first query it ever deployed. With `query_deploy_threadpool_size = max(50, cores * 10)` workers and `enable_connector_deploy_scan_ranges_background` on by default, connector-heavy workloads accumulate GC-immune FE heap retention (multi-GB on large FEs).

Verified with JFR: `jdk.OldObjectSample` reference chains (dump with `path-to-gc-roots=true`) end at `Thread Name: query-deploy-N / Handle Area` for queries that finished long ago, and `jmap -histo:live` after a forced GC still shows the finished query's plan objects.

Fixes #76363

## What I'm doing:

Track whether a context was actually swapped in (`connectContextSwapped`) and restore unconditionally on close: put the saved context back when there was one, otherwise `ConnectContext.remove()` so the worker returns to its pristine state.

The `savedConnectContext != null` branch is kept for correctness in case a worker legitimately had a context before the swap; behavior on the main-thread path (no swap performed) is unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
