### PR TITLE
[BugFix] Exclude touched indexes by metaId in file-bundling carry-forward

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -644,7 +644,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
 
             useAggregatePublish = table.isFileBundling();
-            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
+            Set<Long> publishedNormalIndexMetaIds = Sets.newHashSet();
             for (int i = 0; i < transactionStates.size(); i++) {
                 TransactionState txnState = transactionStates.get(i);
                 computeResource = txnState.getComputeResource();
@@ -669,7 +669,13 @@ public class PublishVersionDaemon extends LeaderDaemon {
                     } else {
                         normalTablets = (normalTablets == null) ? Sets.newHashSet() : normalTablets;
                         normalTablets.addAll(index.getTablets());
-                        publishedNormalIndexIds.add(index.getId());
+                        // Key by metaId, not physical index id: a tablet reshard (split/merge)
+                        // replaces an index with a new physical id but the SAME metaId. Keying by
+                        // physical id would make carry-forward treat the reshard'd base index as
+                        // "untouched" and re-publish its child tablets as no-op normal tablets while
+                        // they are also cross-published from their parent -- the two tasks then
+                        // self-collide on the per-tablet publish lock and wedge the partition.
+                        publishedNormalIndexMetaIds.add(index.getMetaId());
                     }
                 }
             }
@@ -682,7 +688,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             if (useAggregatePublish) {
                 carryForwardTablets = collectFileBundlingCarryForwardTablets(
                         partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
-                        publishedNormalIndexIds);
+                        publishedNormalIndexMetaIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1109,7 +1115,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             }
             baseVersion = partition.getVisibleVersion();
             List<MaterializedIndex> indexes = txnState.getPartitionLoadedIndexes(table.getId(), partition);
-            Set<Long> publishedNormalIndexIds = Sets.newHashSet();
+            Set<Long> publishedNormalIndexMetaIds = Sets.newHashSet();
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
                     LOG.info("Ignored index {} for transaction {}", table.getIndexNameByMetaId(index.getMetaId()), txnId);
@@ -1121,7 +1127,9 @@ public class PublishVersionDaemon extends LeaderDaemon {
                 } else {
                     normalTablets = (normalTablets == null) ? Lists.newArrayList() : normalTablets;
                     normalTablets.addAll(index.getTablets());
-                    publishedNormalIndexIds.add(index.getId());
+                    // Key by metaId (not physical index id) so a reshard'd index is still recognized
+                    // as touched -- see collectFileBundlingCarryForwardTablets and the sibling site above.
+                    publishedNormalIndexMetaIds.add(index.getMetaId());
                 }
             }
             // File bundling stores the metadata of ALL tablets of a partition version in a single bundle
@@ -1136,7 +1144,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
             if (useAggregatePublish) {
                 carryForwardTablets = collectFileBundlingCarryForwardTablets(
                         partition.getLatestMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE),
-                        publishedNormalIndexIds);
+                        publishedNormalIndexMetaIds);
             }
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.READ);
@@ -1196,7 +1204,7 @@ public class PublishVersionDaemon extends LeaderDaemon {
     }
 
     // For file bundling only: from the partition's currently-visible indexes, return the tablets of every
-    // NORMAL index that this transaction did not touch (i.e. whose index id is not in publishedNormalIndexIds).
+    // NORMAL index that this transaction did not touch (i.e. whose index metaId is not in publishedNormalIndexMetaIds).
     // These must be carried forward (empty version bump) into the new version's bundle so it stays a complete
     // whole-partition snapshot; otherwise a transaction with a stale index view (notably lake compaction
     // whose loaded-index set is snapshotted at txn begin, before a rollup/MV index became visible) would
@@ -1204,11 +1212,11 @@ public class PublishVersionDaemon extends LeaderDaemon {
     // needs carrying forward (e.g. a normal load already covers every visible index). Caller must hold the
     // table read lock while obtaining visibleIndexes.
     static List<Tablet> collectFileBundlingCarryForwardTablets(List<MaterializedIndex> visibleIndexes,
-                                                               Set<Long> publishedNormalIndexIds) {
+                                                               Set<Long> publishedNormalIndexMetaIds) {
         List<Tablet> carryForwardTablets = null;
         for (MaterializedIndex index : visibleIndexes) {
             if (index.getState() == MaterializedIndex.IndexState.SHADOW
-                    || publishedNormalIndexIds.contains(index.getId())) {
+                    || publishedNormalIndexMetaIds.contains(index.getMetaId())) {
                 continue;
             }
             carryForwardTablets = (carryForwardTablets == null) ? Lists.newArrayList() : carryForwardTablets;


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, a file-bundling range-distribution table can permanently wedge publish (a livelock under continuous batched ingestion with concurrent tablet reshards).

The file-bundling carry-forward path excludes already-touched indexes by **physical index id**. A tablet reshard (split/merge) replaces an index with a new physical id but the **same metaId**, so a batched pre-reshard publish treats the reshard'd base index as untouched and carries its child tablets forward as no-op normal tablets while the same children are also cross-published from their parent. The two tasks then self-collide on the per-tablet publish lock, so the aggregate publish never fully succeeds and the partition's publish wedges.

## What I'm doing:

Fixes #issue

Key the touched-index set by **metaId** instead of physical index id — at both collection sites and in `collectFileBundlingCarryForwardTablets` — so a reshard'd index is still recognized as touched and not carried forward.

Validated on a shared-data cluster: with continuous batched load forcing ~930 tablet splits on a `file_bundling=true` range-PK table, VisibleVersion advanced past 3600 with zero publish stalls (the same workload wedges without this fix).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
