### PR TITLE
[BugFix] Avoid rewriting inside array_map lambda when pulling scan predicates up

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PullUpScanPredicateRule.java
@@ -67,6 +67,17 @@ public class PullUpScanPredicateRule extends TransformationRule {
             return columnRefMap.get(root);
         }
 
+        // Do not rewrite anything inside a lambda function body. A lambda body is evaluated in the
+        // lambda's local context, where only the lambda arguments and captured columns exist. Replacing
+        // a sub-expression there with a reference to an outer (scan projection) column produces a column
+        // ref that cannot be resolved in the lambda's local chunk at runtime. For a constant that lives
+        // inside a const IN-predicate (e.g. `x IN (CAST(1 AS BIGINT), 2)`), this rewrites a literal into a
+        // ColumnRef, which crashes VectorizedInConstPredicate::open() on the BE. This mirrors
+        // SubfieldCollector#visitLambdaFunctionOperator, which likewise never descends into lambdas.
+        if (root instanceof LambdaFunctionOperator) {
+            return root;
+        }
+
         List<ScalarOperator> children = root.getChildren();
         for (int i = 0; i < children.size(); i++) {
             root.setChild(i, replaceScalarOperator(children.get(i), columnRefMap));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReproLambdaInReuseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReproLambdaInReuseTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+public class ReproLambdaInReuseTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE test_table_repro (\n" +
+                "  id INT,\n" +
+                "  arr_datetime ARRAY<DATETIME>\n" +
+                ") DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 1 " +
+                "PROPERTIES ( \"replication_num\"=\"1\" );");
+    }
+
+    // PullUpScanPredicateRule (gated by enable_predicate_expr_reuse) rewrites sub-expressions of the
+    // pulled-up predicate to reuse scan projection output columns. It must NOT descend into a lambda
+    // body: rewriting the constant `CAST(1 AS BIGINT)` inside the array_map lambda's IN-list into a
+    // ColumnRef of the outer `SELECT CAST(1 AS BIGINT)` column produced a column ref that BE cannot
+    // resolve in the lambda's local chunk, and turned a const IN-predicate into one with a non-constant
+    // element, crashing VectorizedInConstPredicate::open() (SIGSEGV).
+    @Test
+    public void testLambdaInPredicateNotRewrittenToOuterColumnRef() throws Exception {
+        String sql = "WITH input AS (\n" +
+                "    SELECT\n" +
+                "        ARRAY_MAP(arg->(CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime) AS arr\n" +
+                "    FROM test_table_repro\n" +
+                ")\n" +
+                "SELECT\n" +
+                "    CAST(1 AS BIGINT)\n" +
+                "FROM input\n" +
+                "WHERE ARRAY_SUM(arr)";
+
+        boolean origin = connectContext.getSessionVariable().isEnablePredicateExprReuse();
+        try {
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(true);
+            String plan = getFragmentPlan(sql);
+            // The IN-list must stay a pure constant list inside the lambda, not reference an outer column.
+            assertContains(plan, "IN (1, 2)");
+            // Reject a column reference (any slot id) appearing as an IN-list element, instead of
+            // hard-coding one slot id which can shift across planner changes. A constant list like
+            // "IN (1, 2)" has no "<id>:" token; a rewritten element renders as e.g. "IN (5: cast, 2)".
+            Assertions.assertFalse(Pattern.compile("IN \\([^)]*\\d+\\s*:").matcher(plan).find(),
+                    "IN-list must not contain a column reference:\n" + plan);
+        } finally {
+            connectContext.getSessionVariable().setEnablePredicateExprReuse(origin);
+        }
+    }
+}

--- a/test/sql/test_array_fn/R/test_array_map_in_predicate_reuse
+++ b/test/sql/test_array_fn/R/test_array_map_in_predicate_reuse
@@ -1,0 +1,38 @@
+-- name: test_array_map_in_predicate_reuse
+CREATE TABLE array_map_in_reuse_t (
+  id INT,
+  arr_datetime ARRAY<DATETIME>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into array_map_in_reuse_t values
+  (1, ['2024-01-15 00:00:00', '2024-02-20 00:00:00']),
+  (2, ['2024-03-10 00:00:00']),
+  (3, ['2024-01-01 00:00:00']);
+-- result:
+-- !result
+set enable_predicate_expr_reuse = true;
+-- result:
+-- !result
+WITH input AS (
+    SELECT id, ARRAY_MAP(arg -> (CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime) AS arr
+    FROM array_map_in_reuse_t
+)
+SELECT id, CAST(1 AS BIGINT) FROM input WHERE ARRAY_SUM(arr) ORDER BY id;
+-- result:
+1	1
+3	1
+-- !result
+SELECT id, CAST(1 AS BIGINT)
+FROM array_map_in_reuse_t
+WHERE ARRAY_SUM(ARRAY_MAP(arg -> (CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime))
+ORDER BY id;
+-- result:
+1	1
+3	1
+-- !result

--- a/test/sql/test_array_fn/T/test_array_map_in_predicate_reuse
+++ b/test/sql/test_array_fn/T/test_array_map_in_predicate_reuse
@@ -1,0 +1,28 @@
+-- name: test_array_map_in_predicate_reuse
+CREATE TABLE array_map_in_reuse_t (
+  id INT,
+  arr_datetime ARRAY<DATETIME>
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into array_map_in_reuse_t values
+  (1, ['2024-01-15 00:00:00', '2024-02-20 00:00:00']),
+  (2, ['2024-03-10 00:00:00']),
+  (3, ['2024-01-01 00:00:00']);
+
+set enable_predicate_expr_reuse = true;
+
+WITH input AS (
+    SELECT id, ARRAY_MAP(arg -> (CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime) AS arr
+    FROM array_map_in_reuse_t
+)
+SELECT id, CAST(1 AS BIGINT) FROM input WHERE ARRAY_SUM(arr) ORDER BY id;
+
+SELECT id, CAST(1 AS BIGINT)
+FROM array_map_in_reuse_t
+WHERE ARRAY_SUM(ARRAY_MAP(arg -> (CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime))
+ORDER BY id;


### PR DESCRIPTION
 ## Why I'm doing:

```
*** SIGSEGV (@0x58) received by PID 9963 (TID 0x149c001b06c0) LWP(10257) from PID 88; stack trace: ***
    @         0x32cb9b07 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x149c734a1ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x32cb9306 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x149c73445330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @         0x1d2e314d phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<int, unsigned long>, starrocks::StdHash<int>, phmap
::EqualTo<int>, std::allocator<std::pair<int const, unsigned long> > >::end()
    @         0x1d2e3012 phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<int, unsigned long>, starrocks::StdHash<int>, phmap
::EqualTo<int>, std::allocator<std::pair<int const, unsigned long> > >::end() const
    @         0x1d2e2ebf bool phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<int, unsigned long>, starrocks::StdHash<int>,
phmap::EqualTo<int>, std::allocator<std::pair<int const, unsigned long> > >::contains<int>(int const&) const
    @         0x1d2e25f6 starrocks::Chunk::is_slot_exist(int) const
    @         0x1e1f0fba starrocks::Chunk::get_column_by_slot_id(int)
    @         0x2c8b8d8d starrocks::ColumnRef::get_column(starrocks::Expr*, starrocks::Chunk*)
    @         0x2c8b8d3a starrocks::ColumnRef::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2cac74ec starrocks::VectorizedInConstPredicate<(starrocks::LogicalType)7>::open(starrocks::RuntimeState*, starrocks::
ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4c3cf1 starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4c3cf1 starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2abba37d starrocks::ArrayMapExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4c3cf1 starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2ca28efc starrocks::VectorizedFunctionCallExpr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4c3cf1 starrocks::Expr::open(starrocks::RuntimeState*, starrocks::ExprContext*, starrocks::FunctionContext::FunctionStateScope)
    @         0x2a4bca6c starrocks::ExprContext::open(starrocks::RuntimeState*)
    @         0x2ca24de4 starrocks::ExprExecutor::open(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::RuntimeState*)
    @         0x1e6eaba3 starrocks::pipeline::SelectOperatorFactory::prepare(starrocks::RuntimeState*)
    @         0x23395101 starrocks::pipeline::Pipeline::prepare(starrocks::RuntimeState*)
    @         0x2338e36f starrocks::pipeline::NormalExecutionGroup::prepare_pipelines(starrocks::RuntimeState*)
```

  A query using array_map with a lambda whose body contains a constant IN list crashes the BE (SIGSEGV) when enable_predicate_expr_reuse is on (the default). Minimal repro:

```
  WITH input AS (
      SELECT ARRAY_MAP(arg -> (CAST(MONTH(arg) AS BIGINT) IN (1, 2)), arr_datetime) AS arr
      FROM test_table
  )
  SELECT CAST(1 AS BIGINT) FROM input WHERE ARRAY_SUM(arr);
```

```
  Problematic plan (note 12: cast injected inside the array_map lambda's IN list):
  
  2:SELECT
  |  predicates: CAST(array_sum(array_map(<slot 10> -> CAST(month(<slot 10>) AS BIGINT) IN (12: cast, 2), 2: arr_datetime)) AS BOOLEAN)
  | 
  1:Project
  |  <slot 2> : 2: arr_datetime
  |  <slot 12> : 1                <-- outer SELECT CAST(1 AS BIGINT) becomes projection column slot 12
  |  
  0:OlapScanNode
     TABLE: test_table
```

  12: cast is the outer SELECT CAST(1 AS BIGINT) output column. It is a valid column at the top of the SELECT node, but here it sits inside the lambda body, where only lambda arguments (<slot 10>) and captured columns exist — slot 12
  is not in the lambda's local chunk.

  Root cause: PullUpScanPredicateRule.replaceScalarOperator recursively rewrites every sub-expression of a pulled-up predicate to reuse scan projection columns, with no lambda boundary. When the outer query also selects a constant
  (CAST(1 AS BIGINT)), that constant becomes a scan projection column (slot), and the structurally-identical constant sitting inside the array_map lambda's IN list gets rewritten into a ColumnRef of that column — producing ... IN
  (<slot>, 2).

  A lambda body is evaluated in a local chunk (only lambda arguments and captured columns exist), and the constant IN-predicate is built as VectorizedInConstPredicate on the BE, whose open() evaluates its elements against a null
  chunk. Dereferencing that ColumnRef against the null chunk crashes the BE (Chunk::get_column_by_slot_id on nullptr).

## What I'm doing:

  Do not rewrite anything inside a LambdaFunctionOperator body in PullUpScanPredicateRule.replaceScalarOperator. Reuse of scan projection columns is only valid at the top level of the predicate, where the column exists in the
  operator's input chunk; inside a lambda only lambda arguments and captured columns are in scope. This mirrors SubfieldCollector#visitLambdaFunctionOperator, which already never descends into lambdas. Lambda-internal
  common-subexpression reuse continues to be handled correctly by ScalarOperatorsReuseRule, which is lambda-aware.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
