### PR TITLE
[BugFix] Use leader-resolved relations for forwarded statement audit logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.starrocks.authentication.AuthenticationException;
 import com.starrocks.authentication.AuthenticationProvider;
@@ -363,8 +364,7 @@ public class ConnectProcessor {
         }
 
         ctx.getAuditEventBuilder().setFeIp(FrontendOptions.getLocalHostAddress());
-        ctx.getAuditEventBuilder().setQueriedRelations(
-                AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(parsedStmt));
+        ctx.getAuditEventBuilder().setQueriedRelations(queriedRelationsForAudit(executor, parsedStmt));
 
         ctx.getAuditEventBuilder().setStmt(formatStmt(origStmt, parsedStmt));
 
@@ -457,6 +457,35 @@ public class ConnectProcessor {
             return leaderResult.getSql_digest();
         }
         return null;
+    }
+
+    private List<String> getQueriedRelationsFromLeader(StmtExecutor stmtExecutor) {
+        if (stmtExecutor == null || !stmtExecutor.getIsForwardToLeaderOrInit(false)) {
+            return null;
+        }
+        LeaderOpExecutor leaderOpExecutor = stmtExecutor.getLeaderOpExecutor();
+        if (leaderOpExecutor == null) {
+            return null;
+        }
+        TMasterOpResult leaderResult = leaderOpExecutor.getResult();
+        if (leaderResult != null && leaderResult.isSetQueried_relations()) {
+            return leaderResult.getQueried_relations();
+        }
+        return null;
+    }
+
+    // A follower that forwards the statement never analyzes it locally, so its own parse tree
+    // still carries CTE aliases and unqualified names. Prefer the relations the Leader resolved
+    // after analyze (shipped back via TMasterOpResult); only fall back to local collection when
+    // the statement ran locally or the Leader did not provide them (e.g. an older version).
+    // Package-private (would otherwise be private) so ConnectProcessorTest can exercise it directly.
+    @VisibleForTesting
+    List<String> queriedRelationsForAudit(StmtExecutor stmtExecutor, StatementBase parsedStmt) {
+        List<String> relationsFromLeader = getQueriedRelationsFromLeader(stmtExecutor);
+        if (relationsFromLeader != null) {
+            return relationsFromLeader;
+        }
+        return AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(parsedStmt);
     }
 
     private void setStmtFailure(Throwable e, String auditSql) {
@@ -1332,6 +1361,20 @@ public class ConnectProcessor {
             if (audit != null) {
                 result.setAudit_statistics(AuditStatisticsUtil.toThrift(audit));
             }
+        }
+
+        // Ship the relations the Leader resolved after analyze so the follower logs accurate
+        // QueriedRelations instead of falling back to its own unanalyzed parse tree (which still holds
+        // CTE aliases / unqualified names). Read from ctx.getExecutor() -- the executor that ran --
+        // rather than the local `executor`, which is null when doProxyExecute threw; this also covers
+        // ArrowFlightSql, which overrides doProxyExecute but reaches it only through this method.
+        // When an executor ran, set the field even if the relation list is empty (collectAll is
+        // null-safe) so an empty result means "leader resolved no relations", distinct from an unset
+        // field -- an older leader, or no executor at all -- which makes the follower fall back.
+        StmtExecutor executedStmt = ctx.getExecutor();
+        if (executedStmt != null) {
+            result.setQueried_relations(AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(
+                    executedStmt.getParsedStmt()));
         }
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -61,11 +61,14 @@ import com.starrocks.plugin.AuditEvent.AuditEventBuilder;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectProcessor;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.DDLTestBase;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.LargeInPredicateException;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TUniqueId;
@@ -87,6 +90,7 @@ import org.mockito.Mockito;
 import org.xnio.StreamConnection;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -1078,6 +1082,175 @@ public class ConnectProcessorTest extends DDLTestBase {
                 qualifiedRelationName("testDb1", "relation_view_cp"),
                 qualifiedRelationName("testDb1", "testTable1")),
                 auditEvent.queriedRelations);
+    }
+
+    // A forwarding follower never analyzes the statement, so its local parse tree still carries
+    // CTE aliases and unqualified names. When the Leader resolved the relations and shipped them
+    // back, the follower must log the Leader's list rather than its own inaccurate collection.
+    @Test
+    public void testQueriedRelationsPrefersLeaderResultWhenForwarded() throws Exception {
+        ConnectProcessor processor = new ConnectProcessor(new ConnectContext());
+
+        List<String> leaderRelations = Arrays.asList("default_catalog.k.leader_only_table");
+        TMasterOpResult leaderResult = new TMasterOpResult();
+        leaderResult.setQueried_relations(leaderRelations);
+
+        LeaderOpExecutor leaderOpExecutor = Mockito.mock(LeaderOpExecutor.class);
+        Mockito.when(leaderOpExecutor.getResult()).thenReturn(leaderResult);
+
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getIsForwardToLeaderOrInit(false)).thenReturn(true);
+        Mockito.when(executor.getLeaderOpExecutor()).thenReturn(leaderOpExecutor);
+
+        // Local collection would yield default_catalog.testDb1.testTable1, but the Leader's list must win.
+        StatementBase localStmt = UtFrameUtils.parseStmtWithNewParser("select v1 from testTable1", ctx);
+
+        Assertions.assertEquals(leaderRelations, processor.queriedRelationsForAudit(executor, localStmt));
+    }
+
+    // An explicitly-provided empty list from the Leader ("resolved no relations", e.g. a CTE-only
+    // query) must be preferred, not mistaken for "field missing" and overridden by local collection.
+    // Regressing the null-check to an isEmpty-check would silently re-log the CTE alias, so guard it.
+    @Test
+    public void testQueriedRelationsPrefersEmptyLeaderResultWhenForwarded() throws Exception {
+        ConnectProcessor processor = new ConnectProcessor(new ConnectContext());
+
+        List<String> leaderRelations = new ArrayList<>();
+        TMasterOpResult leaderResult = new TMasterOpResult();
+        leaderResult.setQueried_relations(leaderRelations);
+        // The empty list is still marked present on the wire.
+        Assertions.assertTrue(leaderResult.isSetQueried_relations());
+
+        LeaderOpExecutor leaderOpExecutor = Mockito.mock(LeaderOpExecutor.class);
+        Mockito.when(leaderOpExecutor.getResult()).thenReturn(leaderResult);
+
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getIsForwardToLeaderOrInit(false)).thenReturn(true);
+        Mockito.when(executor.getLeaderOpExecutor()).thenReturn(leaderOpExecutor);
+
+        // Local collection is non-empty here, so an empty result can only mean the Leader's empty
+        // list was preferred over a local fallback.
+        StatementBase localStmt = UtFrameUtils.parseStmtWithNewParser("select v1 from testTable1", ctx);
+        Assertions.assertFalse(
+                AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(localStmt).isEmpty());
+
+        Assertions.assertEquals(leaderRelations, processor.queriedRelationsForAudit(executor, localStmt));
+    }
+
+    // Statements that run locally (not forwarded) have an analyzed parse tree, so the follower
+    // falls back to its own accurate collection.
+    @Test
+    public void testQueriedRelationsFallsBackToLocalWhenNotForwarded() throws Exception {
+        ConnectProcessor processor = new ConnectProcessor(new ConnectContext());
+
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.getIsForwardToLeaderOrInit(false)).thenReturn(false);
+
+        StatementBase localStmt = UtFrameUtils.parseStmtWithNewParser("select v1 from testTable1", ctx);
+
+        Assertions.assertEquals(Arrays.asList(qualifiedRelationName("testDb1", "testTable1")),
+                processor.queriedRelationsForAudit(executor, localStmt));
+    }
+
+    // A forwarded statement that resolves to no real relations (e.g. a CTE-only query) must still
+    // mark queried_relations as set. Otherwise the follower cannot tell "leader found none" from
+    // "leader too old to send the field" and falls back to its unanalyzed parse tree, which still
+    // holds the CTE alias -- re-introducing exactly the inaccuracy this fix removes.
+    @Test
+    public void testProxyExecuteSetsEmptyQueriedRelationsForCteOnlyStatement() throws Exception {
+        StatementBase analyzedCteOnly =
+                UtFrameUtils.parseStmtWithNewParser("with t as (select 1) select * from t", ctx);
+        Assertions.assertTrue(
+                AnalyzerUtils.collectAllTableAndViewRelationNamesForAudit(analyzedCteOnly).isEmpty());
+
+        TMasterOpRequest request = new TMasterOpRequest();
+        request.setCatalog("default");
+        request.setDb("testDb1");
+        request.setUser("root");
+        request.setSql("with t as (select 1) select * from t");
+        request.setIsInternalStmt(true);
+        request.setCurrent_user_ident(new TUserIdentity().setUsername("root").setHost("127.0.0.1"));
+        request.setQueryId(UUIDUtil.genTUniqueId());
+        request.setSession_id(UUID.randomUUID().toString());
+        request.setIsLastStmt(true);
+
+        ConnectContext context = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        context.setCurrentCatalog("default");
+        context.setDatabase("testDb1");
+        context.setQualifiedUser("root");
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setSessionId(UUID.randomUUID());
+        context.setThreadLocalInfo();
+
+        ConnectProcessor processor = new ConnectProcessor(context);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doNothing().when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                    Mockito.when(mock.getParsedStmt()).thenReturn(analyzedCteOnly);
+                })) {
+            TMasterOpResult result = processor.proxyExecute(request, null);
+            Assertions.assertTrue(result.isSetQueried_relations());
+            Assertions.assertTrue(result.getQueried_relations().isEmpty());
+        }
+    }
+
+    // queried_relations must be populated even when execute() throws after analysis. Otherwise the
+    // follower sees "field missing" on an error, falls back to its unanalyzed parse tree, and a
+    // failed forwarded statement gets an inaccurate audit log. The collection runs in a finally
+    // around execute(), so an already-analyzed statement still ships its resolved relations.
+    @Test
+    public void testProxyExecuteSetsQueriedRelationsWhenExecuteFails() throws Exception {
+        StatementBase analyzed = UtFrameUtils.parseStmtWithNewParser("select v1 from testTable1", ctx);
+
+        TMasterOpRequest request = new TMasterOpRequest();
+        request.setCatalog("default");
+        request.setDb("testDb1");
+        request.setUser("root");
+        request.setSql("select v1 from testTable1");
+        request.setIsInternalStmt(true);
+        request.setCurrent_user_ident(new TUserIdentity().setUsername("root").setHost("127.0.0.1"));
+        request.setQueryId(UUIDUtil.genTUniqueId());
+        request.setSession_id(UUID.randomUUID().toString());
+        request.setIsLastStmt(true);
+
+        ConnectContext context = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        context.setCurrentCatalog("default");
+        context.setDatabase("testDb1");
+        context.setQualifiedUser("root");
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(UserIdentity.ROOT);
+        context.setSessionId(UUID.randomUUID());
+        context.setThreadLocalInfo();
+
+        ConnectProcessor processor = new ConnectProcessor(context);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doThrow(new RuntimeException("execution failed")).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                    Mockito.when(mock.getParsedStmt()).thenReturn(analyzed);
+                })) {
+            TMasterOpResult result = processor.proxyExecute(request, null);
+            Assertions.assertTrue(result.isSetQueried_relations());
+            Assertions.assertEquals(Arrays.asList(qualifiedRelationName("testDb1", "testTable1")),
+                    result.getQueried_relations());
+        }
+    }
+
+    // queried_relations is populated in the shared proxyExecute(), so every forward path is covered,
+    // including Arrow Flight SQL: ArrowFlightSqlConnectProcessor overrides doProxyExecute() but must
+    // inherit proxyExecute(). If it ever overrides proxyExecute(), forwarded Arrow queries would
+    // bypass the population and regress to logging CTE aliases / unqualified names -- guard that here.
+    @Test
+    public void testArrowFlightSqlInheritsProxyExecute() throws Exception {
+        Method proxyExecute = ArrowFlightSqlConnectProcessor.class.getMethod(
+                "proxyExecute", TMasterOpRequest.class, Frontend.class);
+        Assertions.assertEquals(ConnectProcessor.class, proxyExecute.getDeclaringClass(),
+                "ArrowFlightSqlConnectProcessor must inherit proxyExecute() so forwarded queries "
+                        + "populate queried_relations");
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -986,6 +986,10 @@ struct TMasterOpResult {
     10:optional string sql_digest;
     // StarMgr max journal ID for shared-data mode follower sync
     11:optional i64 maxStarMgrJournalId;
+    // Table/view relations collected by Leader after analyze (fully-qualified, CTE excluded).
+    // Followers that forward the statement never analyze it locally, so they cannot resolve
+    // CTE aliases or qualify names; they reuse this list for the audit log instead.
+    12:optional list<string> queried_relations;
 }
 
 struct TIsMethodSupportedRequest {


### PR DESCRIPTION
## Why I'm doing:

On a follower FE, the audit log's QueriedRelations kept CTE aliases (e.g.
`t`) and unqualified table names, while the leader logged the correct
fully-qualified relations with the CTE excluded.

A statement that is forwarded to the leader is analyzed only on the leader:
analysis and planning are gated behind `!isForwardToLeader()` in
StmtExecutor. The follower therefore collects QueriedRelations from its
un-analyzed parse tree, where a CTE reference is still a plain TableRelation
and table names have not been qualified with catalog/db. CTE resolution
(TableRelation -> CTERelation) and name normalization happen during analyze,
which the follower skips.

## What I'm doing:

Have the leader collect the relations from the analyzed statement and return
them in TMasterOpResult.queried_relations. The follower now prefers this
list for the audit log and only falls back to local collection when the
statement ran locally or the leader did not provide the list (e.g. an older
leader during a rolling upgrade). 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
