### PR TITLE
[BugFix] Carry predicateCommonOperators through Operator.Builder.withOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -265,6 +265,11 @@ public abstract class Operator {
         public B withOperator(O operator) {
             builder.limit = operator.limit;
             builder.predicate = operator.predicate;
+            // predicateCommonOperators defines the common sub-expression columns that predicate may
+            // reference (produced by ScalarOperatorsReuseRule). It must be copied together with predicate;
+            // otherwise the rebuilt operator keeps a predicate referencing columns that are no longer
+            // defined and the plan fails InputDependenciesChecker.
+            builder.predicateCommonOperators = operator.predicateCommonOperators;
             builder.projection = operator.projection;
             builder.equivalentOp = operator.equivalentOp;
             builder.opRuleBits.or(operator.opRuleBits);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/OperatorBuilderPredicateCommonOperatorsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/OperatorBuilderPredicateCommonOperatorsTest.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator;
+
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// Operator.Builder.withOperator copies predicate; it must copy predicateCommonOperators together with it.
+// ScalarOperatorsReuseRule may extract a common sub-expression out of a predicate into predicateCommonOperators,
+// so the predicate references columns defined only there. If withOperator kept the predicate but dropped
+// predicateCommonOperators, the rebuilt operator would reference undefined columns and fail InputDependenciesChecker.
+public class OperatorBuilderPredicateCommonOperatorsTest {
+
+    @Test
+    void withOperatorCopiesPredicateCommonOperators() {
+        ColumnRefOperator reuseCol = new ColumnRefOperator(100, IntegerType.BIGINT, "cse", true);
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ, reuseCol, ConstantOperator.createBigint(1L));
+        Map<ColumnRefOperator, ScalarOperator> common = Map.of(reuseCol, ConstantOperator.createBigint(1L));
+
+        LogicalFilterOperator src = new LogicalFilterOperator(predicate);
+        src.setPredicateCommonOperators(common);
+
+        LogicalFilterOperator copy = new LogicalFilterOperator.Builder().withOperator(src).build();
+
+        assertEquals(common, copy.getPredicateCommonOperators());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

  ScalarOperatorsReuseRule (physical rewrite phase) may extract a repeated sub-expression out of an operator's predicate into predicateCommonOperators; the rewritten predicate then references columns that are defined only in
  predicateCommonOperators. The two fields are a coupled pair — whoever keeps the predicate must also keep predicateCommonOperators, or the operator references undefined columns and the plan fails InputDependenciesChecker.

  Operator.Builder.withOperator(...) — the copy-an-operator idiom used across the optimizer (~150+ call sites on logical/physical operator builders) — copied predicate but not predicateCommonOperators. So any builder-based rebuild of
  an operator that carries a reused-CSE predicate silently drops the columns the predicate depends on. This is the same class of latent bug as the join-constructor path fixed in the previous PR (Carry predicateCommonOperators
  through PhysicalJoinOperator constructors), but on the builder path.

  It has not surfaced widely only because the trigger is narrow: predicateCommonOperators is non-null only after ScalarOperatorsReuseRule runs (late physical phase), and the intersection of "a post-reuse builder copy" and "a
  predicate that actually reuses a common sub-expression" is rare. It is still latent (e.g. late/lazy-materialization builder copies of a scan carrying a reused-CSE predicate).

## What I'm doing:

  Copy predicateCommonOperators together with predicate in Operator.Builder.withOperator, so the coupled pair always travels together on every logical/physical operator builder in one place.

  - One-line change in the base Operator.Builder.withOperator, right next to the existing predicate copy.
  - No effect on the vast majority of call sites (they run in the logical phase where predicateCommonOperators is always null, so the copy is a no-op); it only changes behavior for post-reuse builder copies, where carrying it is the
  correct behavior.
  - Add OperatorBuilderPredicateCommonOperatorsTest verifying withOperator preserves predicateCommonOperators.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
