### PR TITLE
[Refactor] Extract HashDistributionDesc.isShuffleLike() to de-duplicate the shuffle-like source-type predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -420,8 +420,7 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                 return updateEquivalentDescriptor(node, outputProperty,
                         leftOnPredicateColumns, rightOnPredicateColumns);
 
-            } else if ((leftDistributionDesc.isShuffle() || leftDistributionDesc.isShuffleEnforce()) &&
-                    (rightDistributionDesc.isShuffle() || rightDistributionDesc.isShuffleEnforce())) {
+            } else if (leftDistributionDesc.isShuffleLike() && rightDistributionDesc.isShuffleLike()) {
                 // shuffle join
                 PhysicalPropertySet outputProperty = computeShuffleJoinOutputProperty(node.getJoinType(),
                         leftDistributionDesc.getDistributionCols(), rightDistributionDesc.getDistributionCols());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/HashDistributionDesc.java
@@ -155,6 +155,12 @@ public class HashDistributionDesc {
         return this.sourceType == SourceType.SHUFFLE_ENFORCE;
     }
 
+    // True for any shuffle-derived source type: SHUFFLE_AGG / SHUFFLE_JOIN (isShuffle) plus the
+    // enforced variant SHUFFLE_ENFORCE. Broader than isShuffle(), which excludes SHUFFLE_ENFORCE.
+    public boolean isShuffleLike() {
+        return isShuffle() || isShuffleEnforce();
+    }
+
     public boolean isBucketJoin() {
         return this.sourceType == SourceType.BUCKET;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
@@ -266,7 +266,7 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
                 }
 
                 HashDistributionDesc desc = ((HashDistributionSpec) d.getDistributionSpec()).getHashDistributionDesc();
-                if (!desc.isShuffle() && !desc.isShuffleEnforce()) {
+                if (!desc.isShuffleLike()) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -3389,12 +3389,10 @@ public class PlanFragmentBuilder {
                         if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
                             return false;
                         }
-                        HashDistributionDesc.SourceType hashSourceType =
+                        HashDistributionDesc desc =
                                 ((HashDistributionSpec) (physicalPropertySet.getDistributionProperty().getSpec()))
-                                        .getHashDistributionDesc().getSourceType();
-                        return hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_JOIN) ||
-                                hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_ENFORCE) ||
-                                hashSourceType.equals(HashDistributionDesc.SourceType.SHUFFLE_AGG);
+                                        .getHashDistributionDesc();
+                        return desc.isShuffleLike();
                     });
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/HashDistributionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/base/HashDistributionDescTest.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.base;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HashDistributionDescTest {
+
+    private static HashDistributionDesc descOf(HashDistributionDesc.SourceType sourceType) {
+        return new HashDistributionDesc(Lists.newArrayList(1), sourceType);
+    }
+
+    @Test
+    void testIsShuffleLike() {
+        // Exhaustive truth table over every SourceType: true for the shuffle variants
+        // (SHUFFLE_AGG / SHUFFLE_JOIN / SHUFFLE_ENFORCE), false otherwise (LOCAL / BUCKET).
+        assertTrue(descOf(HashDistributionDesc.SourceType.SHUFFLE_AGG).isShuffleLike());
+        assertTrue(descOf(HashDistributionDesc.SourceType.SHUFFLE_JOIN).isShuffleLike());
+        assertTrue(descOf(HashDistributionDesc.SourceType.SHUFFLE_ENFORCE).isShuffleLike());
+        assertFalse(descOf(HashDistributionDesc.SourceType.LOCAL).isShuffleLike());
+        assertFalse(descOf(HashDistributionDesc.SourceType.BUCKET).isShuffleLike());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

The "shuffle-like source type" predicate — `sourceType` is `SHUFFLE_AGG`, `SHUFFLE_JOIN`, or `SHUFFLE_ENFORCE` — was open-coded at three call sites:

- `OutputPropertyDeriver` (shuffle-join branch) and `PruneShuffleColumnRule`, written as `isShuffle() || isShuffleEnforce()` (and its De Morgan negation);
- `PlanFragmentBuilder.isShuffleJoin(...)`, written as a raw `SourceType.equals(...)` triple.

`HashDistributionDesc` already has the sibling predicate `isShuffle()` (= `SHUFFLE_AGG || SHUFFLE_JOIN`) but no helper for the broader shuffle-like set. Duplicating the union inline is error-prone: PR [#76203](https://github.com/StarRocks/starrocks/pull/76203) fixed an operator-precedence bug in exactly the `OutputPropertyDeriver` copy of this predicate. Centralizing it removes that footgun and the duplication.

## What I'm doing:

Add `HashDistributionDesc.isShuffleLike()` = `isShuffle() || isShuffleEnforce()` (i.e. `sourceType` ∈ {`SHUFFLE_AGG`, `SHUFFLE_JOIN`, `SHUFFLE_ENFORCE`}), placed alongside the existing `isShuffle()` / `isShuffleEnforce()` predicate family, and route all three call sites through it:

- `OutputPropertyDeriver:423` → `leftDistributionDesc.isShuffleLike() && rightDistributionDesc.isShuffleLike()`
- `PruneShuffleColumnRule:269` → `!desc.isShuffleLike()` (De Morgan of `!isShuffle() && !isShuffleEnforce()`)
- `PlanFragmentBuilder.isShuffleJoin` → `desc.isShuffleLike()` (dropping the `hashSourceType` local and the raw-enum triple)

**No behavior change.** `isShuffleLike()` is boolean-equivalent to each replaced expression for every `SourceType`:
- `isShuffle() || isShuffleEnforce()` is the exact three-value union;
- the `PruneShuffleColumnRule` rewrite is a plain De Morgan (`!A && !B` ≡ `!(A||B)`);
- the `PlanFragmentBuilder` rewrite is the same three-value set (enum `.equals` ↔ `==`, `sourceType` non-null; `getHashDistributionDesc()` was already dereferenced unconditionally there behind the preceding property-level `isShuffle()` check, so no new NPE).

Adds a truth-table unit test (`HashDistributionDescTest`) pinning `isShuffleLike()` across all `SourceType` values.

Left intentionally untouched (different predicate / out of scope): `OutputPropertyDeriver:491` uses a raw-enum form of the *2-way* `isShuffle()` (no `SHUFFLE_ENFORCE`); `ChildOutputPropertyGuarantor` deliberately uses `isShuffle()` and excludes `SHUFFLE_ENFORCE` per its own comment.

### Testing

Focused FE unit tests green (JDK 17 + Maven): `HashDistributionDescTest`, `OutputPropertyDeriverRangeTest` (the #76203 shuffle-join precedence regression tests), `PruneShuffleColumnRuleTest`, `PlanFragmentWithCostTest` — 91 tests, 0 failures/errors. `:fe-core:checkstyleMain` / `checkstyleTest` clean.

### Backport

Intended for branch-4.1 as well, for parity with the range-colocate refactor line this predicate belongs to. `[Refactor]` is not auto-backported, so the 4.1 change will be a manual cherry-pick after this merges.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
