### PR TITLE
[Enhancement] Pre-split base and rollup for INSERT-from-table into a range table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/AbstractSqlSampleSubqueryExecutor.java
@@ -45,7 +45,9 @@ import java.util.stream.Collectors;
  *
  * <p>Subclasses implement {@link #resolveSampleSpec} to supply the FROM clause
  * SQL, an optional WHERE predicate, the total input byte count, the compute
- * resource, and the projected column identifier lists. Everything else —
+ * resource, and the base sort-key / partition projection identifier lists; a
+ * subclass may also override {@link #secondaryProjectionIdents} to control how
+ * the secondary indexes' sort keys are projected. Everything else —
  * sampling-rate math, SQL synthesis, BE invocation, JSON row decode — is shared
  * here.
  */
@@ -168,7 +170,7 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
         List<SecondaryIndexSpec> secondaryIndexSortKeys = request.getSecondaryIndexSortKeys();
         String sampleSql = buildSampleSql(
                 spec.fromClauseSql(), spec.whereClauseSqlOrNull(),
-                spec.sortKeyProjectionIdents(), secondaryProjectionIdents(secondaryIndexSortKeys),
+                spec.sortKeyProjectionIdents(), secondaryProjectionIdents(request),
                 spec.partitionProjectionIdents(),
                 samplingRate, rowLimit, request.getSeed());
         List<TResultBatch> resultBatches = runSampleQuery(
@@ -180,20 +182,17 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
     }
 
     /**
-     * Flattens each {@link SecondaryIndexSpec}'s sort-key column names into
-     * backtick-quoted SQL identifiers, in spec order then per-spec column
-     * order. Empty when {@code secondaryIndexSortKeys} is empty, so the
-     * projection is byte-identical to the pre-multi-index SQL.
+     * Projection idents to SELECT for the request's secondary indexes (rollups), flattened in
+     * spec order then per-spec column order. Empty when the request carries no secondary indexes,
+     * so the projection is byte-identical to the pre-multi-index SQL. The default projects each
+     * column by its own name -- correct when the source is name-aligned to the target. A subclass
+     * that remaps source columns back to target columns overrides this to project by the
+     * source-table column name instead.
      */
-    private static List<String> secondaryProjectionIdents(List<SecondaryIndexSpec> secondaryIndexSortKeys) {
-        if (secondaryIndexSortKeys.isEmpty()) {
-            return List.of();
-        }
+    protected List<String> secondaryProjectionIdents(SampleRequest request) throws StarRocksException {
         List<String> idents = new ArrayList<>();
-        for (SecondaryIndexSpec secondaryIndexSpec : secondaryIndexSortKeys) {
-            for (Column column : secondaryIndexSpec.sortKey()) {
-                idents.add(SqlUtils.getIdentSql(column.getName()));
-            }
+        for (SecondaryIndexSpec spec : request.getSecondaryIndexSortKeys()) {
+            idents.addAll(columnIdentsOf(spec.sortKey()));
         }
         return idents;
     }
@@ -478,5 +477,14 @@ abstract class AbstractSqlSampleSubqueryExecutor implements SampleSubqueryExecut
      */
     protected static List<String> identsOf(List<String> columnNames) {
         return columnNames.stream().map(SqlUtils::getIdentSql).collect(Collectors.toList());
+    }
+
+    /**
+     * Backtick-quotes each column's own name into a SQL identifier. Column-typed sibling of
+     * {@link #identsOf}, shared by the default {@link #secondaryProjectionIdents} and by
+     * name-aligned subclasses that project by target column name.
+     */
+    protected static List<String> columnIdentsOf(List<Column> columns) {
+        return columns.stream().map(column -> SqlUtils.getIdentSql(column.getName())).collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHook.java
@@ -15,7 +15,6 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.load.BrokerFileGroup;
@@ -27,7 +26,6 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
@@ -158,28 +156,8 @@ public final class BrokerLoadPreSplitHook {
                 targetTable.getPartitionInfo().getPartitionColumns(targetTable.getIdToColumn()),
                 sumFileBytes(fileStatuses),
                 computeResource,
-                buildSecondaryIndexSpecs(targetTable));
+                SecondaryIndexSpec.forVisibleRollups(targetTable));
         PreSplitFlow.dispatch(database, targetTable, prepared, LoadKind.BROKER_LOAD, shouldAbort, context);
-    }
-
-    /**
-     * Builds one {@link SecondaryIndexSpec} per visible rollup index of {@code targetTable}
-     * (every visible index except the base), each carrying its own sort key, so the
-     * multi-partition data-tier sampler can project and sample every visible index
-     * alongside the base sort key.
-     *
-     * <p>Package-private (not private) so the unit test can drive it directly.
-     */
-    static List<SecondaryIndexSpec> buildSecondaryIndexSpecs(OlapTable targetTable) {
-        List<SecondaryIndexSpec> specs = new ArrayList<>();
-        for (MaterializedIndexMeta meta : targetTable.getVisibleIndexMetas()) {
-            if (meta.getIndexMetaId() == targetTable.getBaseIndexMetaId()) {
-                continue;
-            }
-            specs.add(new SecondaryIndexSpec(meta.getIndexMetaId(),
-                    MetaUtils.getRangeDistributionColumns(targetTable, meta.getIndexMetaId())));
-        }
-        return specs;
     }
 
     private static long sumFileBytes(List<List<TBrokerFileStatus>> fileStatuses) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesPreSplitSource.java
@@ -16,7 +16,6 @@ package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
@@ -34,7 +33,6 @@ import com.starrocks.thrift.TBrokerFileStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -82,30 +80,9 @@ final class FilesPreSplitSource implements InsertPreSplitSource {
         List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(target);
         List<Column> partitionColumns =
                 target.getPartitionInfo().getPartitionColumns(target.getIdToColumn());
-        List<SecondaryIndexSpec> secondaryIndexSpecs = buildSecondaryIndexSpecs(target);
         return new PreSplitFlow.Prepared(scanContext, sortKeyColumns, partitionColumns,
-                sumFileBytes(sourceTable), context.getCurrentComputeResource(), secondaryIndexSpecs);
-    }
-
-    /**
-     * Builds one {@link SecondaryIndexSpec} per visible rollup index of {@code target}
-     * (every visible index except the base), each carrying its own sort key, so the
-     * multi-partition data-tier sampler can project and sample every visible index
-     * alongside the base sort key.
-     *
-     * <p>Package-private (not private) so the unit test can drive it directly without
-     * mocking the full FILES resolution chain that precedes it.
-     */
-    static List<SecondaryIndexSpec> buildSecondaryIndexSpecs(OlapTable target) {
-        List<SecondaryIndexSpec> specs = new ArrayList<>();
-        for (MaterializedIndexMeta meta : target.getVisibleIndexMetas()) {
-            if (meta.getIndexMetaId() == target.getBaseIndexMetaId()) {
-                continue;
-            }
-            specs.add(new SecondaryIndexSpec(meta.getIndexMetaId(),
-                    MetaUtils.getRangeDistributionColumns(target, meta.getIndexMetaId())));
-        }
-        return specs;
+                sumFileBytes(sourceTable), context.getCurrentComputeResource(),
+                SecondaryIndexSpec.forVisibleRollups(target));
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/FilesSampleSubqueryExecutor.java
@@ -17,7 +17,6 @@ package com.starrocks.alter.reshard.presplit;
 import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.Column;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.SqlUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 
 import java.util.List;
@@ -82,12 +81,6 @@ abstract class FilesSampleSubqueryExecutor extends AbstractSqlSampleSubqueryExec
                 source.totalFileBytes(), source.computeResource(),
                 columnIdentsOf(sortKeyColumns), columnIdentsOf(partitionSourceColumns),
                 sortKeyColumns, partitionSourceColumns);
-    }
-
-    private static List<String> columnIdentsOf(List<Column> columns) {
-        return columns.stream()
-                .map(column -> SqlUtils.getIdentSql(column.getName()))
-                .collect(Collectors.toList());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutor.java
@@ -15,7 +15,12 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.catalog.Column;
 import com.starrocks.common.StarRocksException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Data-tier {@link SampleSubqueryExecutor} for the INSERT-from-OLAP-table path.
@@ -45,20 +50,58 @@ final class InsertFromTableSampleSubqueryExecutor extends AbstractSqlSampleSubqu
 
     @Override
     protected SampleSpec resolveSampleSpec(SampleRequest request) throws StarRocksException {
-        ScanContext scanContext = request.getScanContext();
-        if (!(scanContext instanceof InsertFromTableScanContext context)) {
-            throw new StarRocksException(ERROR_PREFIX + "received a "
-                    + scanContext.getClass().getSimpleName()
-                    + " — wire only the INSERT-from-table load kind here");
-        }
+        InsertFromTableScanContext context = contextOf(request);
         return new SampleSpec(
                 context.sourceFromSql(),
                 context.wherePredicateSql(),
                 Math.max(0L, context.sourceTable().getDataSize()),
                 context.computeResource(),
-                identsOf(context.sortKeySourceColumnNames()),
-                identsOf(context.partitionSourceColumnNames()),
+                identsOf(mapToSource(request.getSortKey(), context.targetToSourceColumnNames())),
+                identsOf(mapToSource(request.getPartitionSourceColumns(), context.targetToSourceColumnNames())),
                 request.getSortKey(),
                 request.getPartitionSourceColumns());
+    }
+
+    /**
+     * Projects each rollup's sort key by remapping every column to its source-table name via the
+     * scan context's target-&gt;source map. The base sort key is projected the same way in
+     * {@link #resolveSampleSpec}; both go through {@link #mapToSource}, so a rollup whose sort key
+     * reorders or subsets the base is projected correctly regardless of source column naming.
+     */
+    @Override
+    protected List<String> secondaryProjectionIdents(SampleRequest request) throws StarRocksException {
+        InsertFromTableScanContext context = contextOf(request);
+        List<String> idents = new ArrayList<>();
+        for (SecondaryIndexSpec spec : request.getSecondaryIndexSortKeys()) {
+            idents.addAll(identsOf(mapToSource(spec.sortKey(), context.targetToSourceColumnNames())));
+        }
+        return idents;
+    }
+
+    private static InsertFromTableScanContext contextOf(SampleRequest request) throws StarRocksException {
+        ScanContext scanContext = request.getScanContext();
+        if (!(scanContext instanceof InsertFromTableScanContext context)) {
+            throw new StarRocksException(ERROR_PREFIX + "received a "
+                    + scanContext.getClass().getSimpleName()
+                    + " -- wire only the INSERT-from-table load kind here");
+        }
+        return context;
+    }
+
+    /**
+     * Remaps target columns (a sort key -- base or rollup -- or the partition columns) to their
+     * source-table column names via {@link InsertSelectSourceColumns#lookup}. Throws (-&gt; the
+     * sample fails -&gt; the load proceeds without pre-split) if any column is unmapped, so a
+     * boundary is never computed against the wrong source column. {@code prepare} gates this at
+     * admission time; the throw remains as the fail-safe for a metadata race between prepare and
+     * sampling.
+     */
+    private static List<String> mapToSource(
+            List<Column> targetColumns, Map<String, String> targetToSourceColumnNames) throws StarRocksException {
+        List<String> sourceNames = InsertSelectSourceColumns.lookup(targetColumns, targetToSourceColumnNames);
+        if (sourceNames == null) {
+            throw new StarRocksException(ERROR_PREFIX + "a projected column has no source-table column mapping");
+        }
+        return sourceNames;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertFromTableScanContext.java
@@ -17,31 +17,29 @@ package com.starrocks.alter.reshard.presplit;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
  * {@link ScanContext} concrete for the INSERT-from-OLAP-table integration.
  * Carries the source {@link OlapTable} reference so the sampler can obtain its
- * data-size estimate and the pre-quoted FROM clause SQL, plus the source-column
- * name lists that map the target sort key and partition columns back to their
- * source equivalents. The optional WHERE predicate SQL is threaded through
- * verbatim from the INSERT-SELECT statement so the sample covers only the rows
- * the load will actually write.
+ * data-size estimate and the pre-quoted FROM clause SQL, plus the full target-&gt;source
+ * column-name map the sampler uses to project any index's sort key (base or rollup) and
+ * the partition columns by their source-table column names. The optional WHERE predicate
+ * SQL is threaded through verbatim from the INSERT-SELECT statement so the sample covers
+ * only the rows the load will actually write.
  */
 public record InsertFromTableScanContext(
         OlapTable sourceTable,
         String sourceFromSql,                       // "`db`.`tbl` `alias`" or "`db`.`tbl`"
-        List<String> sortKeySourceColumnNames,
-        List<String> partitionSourceColumnNames,
+        Map<String, String> targetToSourceColumnNames,   // lower-cased target name -> source column name
         String wherePredicateSql,                   // nullable
         ComputeResource computeResource) implements ScanContext {
 
     public InsertFromTableScanContext {
         Objects.requireNonNull(sourceTable, "sourceTable");
         Objects.requireNonNull(sourceFromSql, "sourceFromSql");
-        Objects.requireNonNull(sortKeySourceColumnNames, "sortKeySourceColumnNames");
-        Objects.requireNonNull(partitionSourceColumnNames, "partitionSourceColumnNames");
+        Objects.requireNonNull(targetToSourceColumnNames, "targetToSourceColumnNames");
         Objects.requireNonNull(computeResource, "computeResource");
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumns.java
@@ -30,32 +30,22 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Maps each target sort-key / partition column to the source column name to sample,
- * given a parsed {@code INSERT INTO <range-dist target> SELECT ... FROM <single OLAP source>}.
+ * Resolves the full target-&gt;source column-name map (lower-cased target name -&gt; source column
+ * name, total over the target's non-generated base columns) for a parsed
+ * {@code INSERT INTO <range-dist target> SELECT ... FROM <single OLAP source>}. The sampler uses
+ * the map to project any index's sort key (base or rollup) and the partition columns by their
+ * source-table column names.
  *
  * <p>Returns {@code null} whenever the projection cannot be cleanly and safely mapped
  * (caller then silently skips pre-split).
  */
 final class InsertSelectSourceColumns {
-    private final List<String> sortKeySourceColumnNames;
-    private final List<String> partitionSourceColumnNames;
 
-    private InsertSelectSourceColumns(List<String> sortKeySourceColumnNames,
-                                      List<String> partitionSourceColumnNames) {
-        this.sortKeySourceColumnNames = sortKeySourceColumnNames;
-        this.partitionSourceColumnNames = partitionSourceColumnNames;
-    }
-
-    List<String> sortKeySourceColumnNames() {
-        return sortKeySourceColumnNames;
-    }
-
-    List<String> partitionSourceColumnNames() {
-        return partitionSourceColumnNames;
+    private InsertSelectSourceColumns() {
     }
 
     /**
-     * Resolves the source-column names for each sort-key and partition column of the target table.
+     * Resolves the target-&gt;source column-name map for the INSERT-SELECT projection.
      *
      * @param insertStmt          the parsed INSERT statement
      * @param selectRelation      the SELECT body of the INSERT
@@ -65,9 +55,10 @@ final class InsertSelectSourceColumns {
      * @param sourceAlias         the FROM-clause alias for the source relation, or {@code null}
      * @param sortKeyColumns      sort-key columns of the target (from MetaUtils)
      * @param partitionColumns    partition columns of the target
-     * @return resolved mapping, or {@code null} when the projection is ambiguous or unsafe
+     * @return the target-&gt;source column-name map, or {@code null} when the projection is
+     *         ambiguous or unsafe
      */
-    static InsertSelectSourceColumns resolve(
+    static Map<String, String> resolve(
             InsertStmt insertStmt, SelectRelation selectRelation,
             OlapTable targetTable, OlapTable sourceTable,
             TableName normalizedSourceName, String sourceAlias,
@@ -148,15 +139,13 @@ final class InsertSelectSourceColumns {
             }
         }
 
-        List<String> sortKeyNames = lookup(sortKeyColumns, targetToSource);
-        if (sortKeyNames == null) {
+        // A sort-key or partition column with no source mapping cannot be sampled -> skip pre-split.
+        // The executor derives both projections from the map at sample time (see mapToSource), so
+        // only the presence gate matters here.
+        if (lookup(sortKeyColumns, targetToSource) == null || lookup(partitionColumns, targetToSource) == null) {
             return null;
         }
-        List<String> partitionNames = lookup(partitionColumns, targetToSource);
-        if (partitionNames == null) {
-            return null;
-        }
-        return new InsertSelectSourceColumns(sortKeyNames, partitionNames);
+        return Map.copyOf(targetToSource);
     }
 
     private static Set<String> targetNames(List<Column> targetCols) {
@@ -167,7 +156,14 @@ final class InsertSelectSourceColumns {
         return names;
     }
 
-    private static List<String> lookup(List<Column> columns, Map<String, String> targetToSource) {
+    /**
+     * Maps each target column to its source-table column name via {@code targetToSource}
+     * (keyed by lower-cased target name), or returns {@code null} when ANY column is absent from
+     * the map. The shared primitive for every "are these columns mappable to source names?" gate
+     * and for the executor's sample-time remap; package-private so those same-package callers
+     * share one implementation of the map-key convention.
+     */
+    static List<String> lookup(List<Column> columns, Map<String, String> targetToSource) {
         List<String> names = new ArrayList<>(columns.size());
         for (Column column : columns) {
             String sourceName = targetToSource.get(column.getName().toLowerCase());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -42,9 +42,7 @@ import java.util.function.BooleanSupplier;
  *   <li>{@link #dispatch} — partitioned-vs-unpartitioned routing, including the
  *       automatic-partition gate that conservatively skips manually
  *       list/range-partitioned targets (those cannot pre-create partitions from
- *       sampled values), and the INSERT-from-table rollup descope (a rollup's sort
- *       key cannot be remapped to source columns, so a multi-index target skips
- *       before sampling for that load kind only).</li>
+ *       sampled values).</li>
  *   <li>{@link #runSinglePartitionFlow} — resolve the unique partition + base
  *       tablet, build a {@link DefaultPreSplitPipeline}, submit via
  *       {@link TabletPreSplitCoordinator#submitAsynchronously}, then sync-await
@@ -76,29 +74,15 @@ final class PreSplitFlow {
      * requested tablet count; computeResource sizes the active CN count; scanContext carries
      * the source-specific scan inputs; secondaryIndexSpecs names every OTHER visible index
      * (rollup) whose sort key the multi-partition data-tier sampler should project alongside
-     * the base sort key -- empty for single-index targets and for INSERT-from-table (descoped).
+     * the base sort key -- empty for single-index targets.
      */
     record Prepared(ScanContext scanContext, List<Column> sortKeyColumns,
                     List<Column> partitionColumns, long estimatedBytes,
                     ComputeResource computeResource, List<SecondaryIndexSpec> secondaryIndexSpecs) {
-
-        /**
-         * Backward-compatible constructor for callers with no rollup to project;
-         * defaults secondaryIndexSpecs to empty.
-         */
-        Prepared(ScanContext scanContext, List<Column> sortKeyColumns,
-                List<Column> partitionColumns, long estimatedBytes, ComputeResource computeResource) {
-            this(scanContext, sortKeyColumns, partitionColumns, estimatedBytes, computeResource, List.of());
-        }
     }
 
     static void dispatch(Database database, OlapTable target, Prepared prepared,
                          LoadKind loadKind, BooleanSupplier shouldAbort, ConnectContext context) {
-        if (loadKind == LoadKind.INSERT_FROM_TABLE && target.getVisibleIndexMetas().size() > 1) {
-            // INSERT-from-table cannot remap a divergent rollup sort key to source columns (descoped).
-            PreSplitMetrics.recordEligibilitySkip(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
-            return;
-        }
         if (target.getPartitionInfo().isPartitioned()) {
             // Manually list/range-partitioned targets do not support pre-creating partitions
             // from sampled values; skip conservatively, let the load proceed.
@@ -115,13 +99,6 @@ final class PreSplitFlow {
                                        LoadKind loadKind, BooleanSupplier shouldAbort) {
         PreSplitTargets.EligibleTarget target = PreSplitTargets.findEligibleTarget(database, table);
         if (target == null) {
-            return;
-        }
-        if (loadKind == LoadKind.INSERT_FROM_TABLE && target.indexTargets().size() > 1) {
-            // Authoritative re-check on the resolved index set: a rollup that became visible after the
-            // dispatch-time descope gate must not be sampled with the base-only INSERT-from-table source
-            // mapping. Skip pre-split (load proceeds) -- INSERT-from-table with a rollup is out of scope.
-            PreSplitMetrics.recordEligibilitySkip(SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP);
             return;
         }
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpec.java
@@ -15,7 +15,11 @@
 package com.starrocks.alter.reshard.presplit;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.common.MetaUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -26,4 +30,21 @@ import java.util.List;
  * routed back to the correct index downstream.
  */
 public record SecondaryIndexSpec(long indexMetaId, List<Column> sortKey) {
+
+    /**
+     * Builds one spec per visible rollup index of {@code target} (every visible index except the
+     * base), each carrying its own sort key. Shared by the FILES / Broker / INSERT-from-table
+     * pre-split sources so the "every visible index except base" enumeration lives in one place.
+     */
+    static List<SecondaryIndexSpec> forVisibleRollups(OlapTable target) {
+        List<SecondaryIndexSpec> specs = new ArrayList<>();
+        for (MaterializedIndexMeta meta : target.getVisibleIndexMetas()) {
+            if (meta.getIndexMetaId() == target.getBaseIndexMetaId()) {
+                continue;
+            }
+            specs.add(new SecondaryIndexSpec(meta.getIndexMetaId(),
+                    MetaUtils.getRangeDistributionColumns(target, meta.getIndexMetaId())));
+        }
+        return specs;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TablePreSplitSource.java
@@ -100,23 +100,30 @@ final class TablePreSplitSource implements InsertPreSplitSource {
         List<Column> sortKeyColumns = MetaUtils.getRangeDistributionColumns(target);
         List<Column> partitionColumns =
                 target.getPartitionInfo().getPartitionColumns(target.getIdToColumn());
-        InsertSelectSourceColumns mapping = InsertSelectSourceColumns.resolve(
+        Map<String, String> targetToSource = InsertSelectSourceColumns.resolve(
                 insertStmt, selectRelation, target, resolvedSource.sourceTable(),
                 resolvedSource.normalizedName(), resolvedSource.sourceAlias(),
                 sortKeyColumns, partitionColumns);
-        if (mapping == null) {
+        if (targetToSource == null) {
             return null;
         }
         InsertFromTableScanContext scanContext = new InsertFromTableScanContext(
                 resolvedSource.sourceTable(), resolvedSource.sourceFromSql(),
-                mapping.sortKeySourceColumnNames(), mapping.partitionSourceColumnNames(),
+                targetToSource,
                 wherePredicateSql, context.getCurrentComputeResource());
         long estimatedBytes = Math.max(0L, resolvedSource.sourceTable().getDataSize());
-        // INSERT-from-table cannot remap a rollup's sort key to source columns, so the
-        // dispatch gate already skips multi-index targets for this load kind; secondaryIndexSpecs
-        // stays empty here via the backward-compatible Prepared constructor.
+        List<SecondaryIndexSpec> secondaryIndexSpecs = SecondaryIndexSpec.forVisibleRollups(target);
+        for (SecondaryIndexSpec spec : secondaryIndexSpecs) {
+            // A rollup sort-key column with no source mapping (e.g. a range DUP rollup whose ORDER BY
+            // promotes a generated column) cannot be projected by source name -> skip pre-split for the
+            // whole load, using the same lookup gate as the base sort key above. The executor's
+            // mapToSource throw stays as the fail-safe for a metadata race between here and sampling.
+            if (InsertSelectSourceColumns.lookup(spec.sortKey(), targetToSource) == null) {
+                return null;
+            }
+        }
         return new PreSplitFlow.Prepared(scanContext, sortKeyColumns, partitionColumns,
-                estimatedBytes, context.getCurrentComputeResource());
+                estimatedBytes, context.getCurrentComputeResource(), secondaryIndexSpecs);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/BrokerLoadPreSplitHookPartitionedTest.java
@@ -447,46 +447,6 @@ public class BrokerLoadPreSplitHookPartitionedTest {
         }
     }
 
-    // ---------- Secondary index spec construction ----------
-
-    @Test
-    public void buildSecondaryIndexSpecsIncludesEveryRollupExceptBase() {
-        // A target with a base index (id 1) and one rollup (id 2) must produce exactly
-        // one SecondaryIndexSpec for the rollup, carrying its own (divergent) sort key.
-        OlapTable table = mock(OlapTable.class);
-        when(table.getBaseIndexMetaId()).thenReturn(1L);
-        com.starrocks.catalog.MaterializedIndexMeta baseMeta =
-                mock(com.starrocks.catalog.MaterializedIndexMeta.class);
-        when(baseMeta.getIndexMetaId()).thenReturn(1L);
-        com.starrocks.catalog.MaterializedIndexMeta rollupMeta =
-                mock(com.starrocks.catalog.MaterializedIndexMeta.class);
-        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
-
-        List<Column> rollupSortKey = List.of(bigintColumn("r"));
-        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L)).thenReturn(rollupSortKey);
-
-            List<SecondaryIndexSpec> specs = BrokerLoadPreSplitHook.buildSecondaryIndexSpecs(table);
-
-            Assertions.assertEquals(1, specs.size(), "exactly one rollup spec expected");
-            Assertions.assertEquals(2L, specs.get(0).indexMetaId());
-            Assertions.assertEquals(rollupSortKey, specs.get(0).sortKey());
-        }
-    }
-
-    @Test
-    public void buildSecondaryIndexSpecsEmptyForSingleIndexTarget() {
-        // A single-index (base only) target must produce no secondary specs.
-        // mockPartitionedRangeTable's single visible index carries BASE_INDEX_META_ID;
-        // stub getBaseIndexMetaId() to match so the loop recognizes it as the base.
-        OlapTable table = mockPartitionedRangeTable();
-        when(table.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
-
-        Assertions.assertTrue(BrokerLoadPreSplitHook.buildSecondaryIndexSpecs(table).isEmpty(),
-                "a single-index target must produce no secondary index specs");
-    }
-
     // The await-helper polling semantics (finished, aborted, disappeared, timeout)
     // are covered by InsertPreSplitHookFilesPartitionedTest's
     // awaitCombinedJobAllowingFallback* tests now that the helper lives on

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertFromTableSampleSubqueryExecutorTest.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.jsonResultBatch;
@@ -191,6 +193,102 @@ class InsertFromTableSampleSubqueryExecutorTest {
     }
 
     // ---------------------------------------------------------------------------
+    // Source-name remap tests (base + rollup)
+    // ---------------------------------------------------------------------------
+
+    @Test
+    void baseSortKeyProjectedBySourceNameFromMap() throws Exception {
+        // target column "k" maps to source column "src_k"; projection must use the source name.
+        OlapTable sourceTable = mockOlapTable(0L);
+        StringBuilder capturedSql = new StringBuilder();
+        InsertFromTableSampleSubqueryExecutor executor = new InsertFromTableSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(tableRequest(sourceTable, "`db`.`src`", List.of("src_k"), List.of(), /*where=*/ null,
+                List.of(bigintColumn("k")), List.of()));
+
+        Assertions.assertTrue(capturedSql.toString().startsWith("SELECT `src_k` FROM"),
+                "base sort key must be projected by its mapped source name: " + capturedSql);
+    }
+
+    @Test
+    void rollupSortKeyProjectedBySourceNameByName() throws Exception {
+        // by-name identity map: base (k1,k2) + rollup (k2) all project by their own source names.
+        OlapTable sourceTable = mockOlapTable(0L);
+        StringBuilder capturedSql = new StringBuilder();
+        InsertFromTableSampleSubqueryExecutor executor = new InsertFromTableSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(rollupRequest(sourceTable, Map.of("k1", "k1", "k2", "k2"),
+                List.of(bigintColumn("k1"), bigintColumn("k2")),
+                List.of(new SecondaryIndexSpec(101L, List.of(bigintColumn("k2"))))));
+
+        Assertions.assertTrue(capturedSql.toString().startsWith("SELECT `k1`, `k2`, `k2` FROM"),
+                "base (k1,k2) then rollup (k2), all by source name: " + capturedSql);
+    }
+
+    @Test
+    void rollupSortKeyProjectedBySourceNameByPositionRenamed() throws Exception {
+        // by-position renamed map: target k1->s1, k2->s2; rollup ORDER BY(k2) projects `s2`.
+        OlapTable sourceTable = mockOlapTable(0L);
+        StringBuilder capturedSql = new StringBuilder();
+        InsertFromTableSampleSubqueryExecutor executor = new InsertFromTableSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(rollupRequest(sourceTable, Map.of("k1", "s1", "k2", "s2"),
+                List.of(bigintColumn("k1"), bigintColumn("k2")),
+                List.of(new SecondaryIndexSpec(101L, List.of(bigintColumn("k2"))))));
+
+        Assertions.assertTrue(capturedSql.toString().startsWith("SELECT `s1`, `s2`, `s2` FROM"),
+                "rollup sort key must remap to source names: " + capturedSql);
+    }
+
+    @Test
+    void rollupReorderingSubsetOfBaseStillMapped() throws Exception {
+        // rollup sort key reorders/subsets the base: base (k1,k2,k3) + rollup (k3,k1).
+        OlapTable sourceTable = mockOlapTable(0L);
+        StringBuilder capturedSql = new StringBuilder();
+        InsertFromTableSampleSubqueryExecutor executor = new InsertFromTableSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> {
+                    capturedSql.append(sql);
+                    return List.of();
+                });
+
+        executor.execute(rollupRequest(sourceTable, Map.of("k1", "s1", "k2", "s2", "k3", "s3"),
+                List.of(bigintColumn("k1"), bigintColumn("k2"), bigintColumn("k3")),
+                List.of(new SecondaryIndexSpec(101L, List.of(bigintColumn("k3"), bigintColumn("k1"))))));
+
+        Assertions.assertTrue(capturedSql.toString().startsWith("SELECT `s1`, `s2`, `s3`, `s3`, `s1` FROM"),
+                "rollup (k3,k1) must project `s3`,`s1` after the base slice: " + capturedSql);
+    }
+
+    @Test
+    void unmappedRollupColumnThrowsFailSafe() {
+        // A rollup sort-key column absent from the map must fail the sample (-> load proceeds).
+        OlapTable sourceTable = mockOlapTable(0L);
+        InsertFromTableSampleSubqueryExecutor executor = new InsertFromTableSampleSubqueryExecutor(
+                (sql, computeResource, ignoredTimeout) -> List.of());
+
+        SampleRequest request = rollupRequest(sourceTable, Map.of("k1", "s1"),
+                List.of(bigintColumn("k1")),
+                List.of(new SecondaryIndexSpec(101L, List.of(bigintColumn("missing")))));
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> executor.execute(request));
+        Assertions.assertTrue(thrown.getMessage().contains("no source-table column mapping"),
+                "fail-safe throw must report an unmapped sort-key column: " + thrown.getMessage());
+    }
+
+    // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
 
@@ -209,11 +307,37 @@ class InsertFromTableSampleSubqueryExecutorTest {
             List<Column> sortKeyColumns,
             List<Column> partitionSourceColumns) {
         ComputeResource computeResource = Mockito.mock(ComputeResource.class);
+        // Build the target->source map from the paired lists (both sort-key and partition columns):
+        // sortKeyColumns[i].name -> sortKeySourceColumnNames[i], partitionSourceColumns[i].name -> ...[i].
+        Map<String, String> targetToSource = new HashMap<>();
+        for (int i = 0; i < sortKeyColumns.size(); i++) {
+            targetToSource.put(sortKeyColumns.get(i).getName().toLowerCase(), sortKeySourceColumnNames.get(i));
+        }
+        for (int i = 0; i < partitionSourceColumns.size(); i++) {
+            targetToSource.put(partitionSourceColumns.get(i).getName().toLowerCase(), partitionSourceColumnNames.get(i));
+        }
         InsertFromTableScanContext scanContext = new InsertFromTableScanContext(
-                sourceTable, sourceFromSql, sortKeySourceColumnNames, partitionSourceColumnNames,
-                wherePredicateSql, computeResource);
+                sourceTable, sourceFromSql, targetToSource, wherePredicateSql, computeResource);
         return new SampleRequest(
                 scanContext, sortKeyColumns, partitionSourceColumns,
+                /*sampleByteLimit=*/ Long.MAX_VALUE, /*seed=*/ 0L);
+    }
+
+    /**
+     * Builds a request whose context map covers every (lower-cased target -> source) pair
+     * in {@code targetToSource}, with the given base sort key and rollup specs. Base sort-key
+     * columns and each rollup spec carry TARGET columns; the executor remaps to source names.
+     */
+    private static SampleRequest rollupRequest(
+            OlapTable sourceTable,
+            Map<String, String> targetToSource,
+            List<Column> baseSortKeyColumns,
+            List<SecondaryIndexSpec> rollups) {
+        ComputeResource computeResource = Mockito.mock(ComputeResource.class);
+        InsertFromTableScanContext scanContext = new InsertFromTableScanContext(
+                sourceTable, "`db`.`src`", targetToSource, /*where=*/ null, computeResource);
+        return new SampleRequest(
+                scanContext, baseSortKeyColumns, rollups, List.of(),
                 /*sampleByteLimit=*/ Long.MAX_VALUE, /*seed=*/ 0L);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookFilesPartitionedTest.java
@@ -21,7 +21,6 @@ import com.starrocks.alter.reshard.TabletReshardJobMgr;
 import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.TableFunctionTable;
@@ -32,7 +31,6 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -247,45 +245,6 @@ public class InsertPreSplitHookFilesPartitionedTest {
         }
     }
 
-    // ---------- Secondary index spec construction ----------
-
-    @Test
-    public void buildSecondaryIndexSpecsIncludesEveryRollupExceptBase() {
-        // A target with a base index (id 1) and one rollup (id 2) must produce exactly
-        // one SecondaryIndexSpec for the rollup, carrying its own (divergent) sort key.
-        OlapTable table = mock(OlapTable.class);
-        when(table.getBaseIndexMetaId()).thenReturn(1L);
-        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
-        when(baseMeta.getIndexMetaId()).thenReturn(1L);
-        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
-        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
-
-        List<Column> rollupSortKey = List.of(bigintColumn("r"));
-        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
-            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L)).thenReturn(rollupSortKey);
-
-            List<SecondaryIndexSpec> specs = FilesPreSplitSource.buildSecondaryIndexSpecs(table);
-
-            Assertions.assertEquals(1, specs.size(), "exactly one rollup spec expected");
-            Assertions.assertEquals(2L, specs.get(0).indexMetaId());
-            Assertions.assertEquals(rollupSortKey, specs.get(0).sortKey());
-        }
-    }
-
-    @Test
-    public void buildSecondaryIndexSpecsEmptyForSingleIndexTarget() {
-        // A single-index (base only) target must produce no secondary specs.
-        OlapTable table = mock(OlapTable.class);
-        when(table.getBaseIndexMetaId()).thenReturn(1L);
-        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
-        when(baseMeta.getIndexMetaId()).thenReturn(1L);
-        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
-
-        Assertions.assertTrue(FilesPreSplitSource.buildSecondaryIndexSpecs(table).isEmpty(),
-                "a single-index target must produce no secondary index specs");
-    }
-
     /**
      * Build a {@link PreSplitFlow.Prepared} bundle carrying an
      * {@link InsertFromFilesScanContext} so the dispatched flow is genuinely FILES-flavored.
@@ -297,7 +256,7 @@ public class InsertPreSplitHookFilesPartitionedTest {
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         List<Column> partitionColumns = List.of(bigintColumn("p_col"));
         return new PreSplitFlow.Prepared(scanContext, sortKey, partitionColumns,
-                /*estimatedBytes*/ 0L, mock(ComputeResource.class));
+                /*estimatedBytes*/ 0L, mock(ComputeResource.class), List.of());
     }
 
     // ---------- Outer try/catch swallows internal throws ----------

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertPreSplitHookTableTest.java
@@ -523,9 +523,8 @@ public class InsertPreSplitHookTableTest {
             InsertFromTableScanContext scanContext = fixture.prepareScanContext();
 
             Assertions.assertNotNull(scanContext, "prepare must build a scan context for the eligible source");
-            Assertions.assertEquals(List.of("k"), scanContext.sortKeySourceColumnNames(),
-                    "scan context must carry the resolved source sort-key column");
-            Assertions.assertEquals(List.of(), scanContext.partitionSourceColumnNames());
+            Assertions.assertEquals(Map.of("k", "k", "v", "v"), scanContext.targetToSourceColumnNames(),
+                    "scan context must carry the full resolved target->source column map");
             Assertions.assertNull(scanContext.wherePredicateSql(),
                     "no WHERE clause must yield a null predicate SQL");
             Assertions.assertSame(fixture.sourceTable, scanContext.sourceTable(),
@@ -574,7 +573,42 @@ public class InsertPreSplitHookTableTest {
             Assertions.assertNotNull(scanContext, "source == target must still build a scan context");
             Assertions.assertSame(fixture.target(), scanContext.sourceTable(),
                     "scan context must carry the target table as its source when source == target");
-            Assertions.assertEquals(List.of("k"), scanContext.sortKeySourceColumnNames());
+            Assertions.assertEquals(Map.of("k", "k", "v", "v"), scanContext.targetToSourceColumnNames());
+        }
+    }
+
+    @Test
+    public void prepareBuildsSecondaryIndexSpecsForRollup() throws Exception {
+        // A range target carrying a rollup: prepare must emit one SecondaryIndexSpec per
+        // visible rollup, carrying that rollup's TARGET sort-key columns (the remap to
+        // source names happens later, in the executor, via the scan-context map).
+        try (SourceFixture fixture = sourceFixture()) {
+            fixture.withVisibleRollup(/*rollupMetaId=*/ 202L, List.of("k"));
+
+            PreSplitFlow.Prepared prepared = fixture.prepare();
+
+            Assertions.assertNotNull(prepared, "prepare must build a Prepared for the rollup target");
+            Assertions.assertEquals(1, prepared.secondaryIndexSpecs().size(),
+                    "one visible rollup -> one secondary index spec");
+            SecondaryIndexSpec spec = prepared.secondaryIndexSpecs().get(0);
+            Assertions.assertEquals(202L, spec.indexMetaId());
+            Assertions.assertEquals(List.of("k"),
+                    spec.sortKey().stream().map(Column::getName).collect(java.util.stream.Collectors.toList()),
+                    "spec carries the rollup's TARGET sort-key columns");
+        }
+    }
+
+    @Test
+    public void prepareSkipsWhenRollupSortKeyUnmappable() throws Exception {
+        // A rollup whose sort-key column has no source mapping (e.g. a range DUP rollup whose
+        // ORDER BY promotes a generated column -- absent from the non-generated base-schema map)
+        // must skip pre-split cleanly (prepare returns null), not build a spec that later fails
+        // the sample. Here "g" is not among the fixture's non-generated base columns {k, v}.
+        try (SourceFixture fixture = sourceFixture()) {
+            fixture.withVisibleRollup(/*rollupMetaId=*/ 203L, List.of("g"));
+
+            Assertions.assertNull(fixture.prepare(),
+                    "a rollup sort-key column with no source mapping must skip pre-split");
         }
     }
 
@@ -741,11 +775,38 @@ public class InsertPreSplitHookTableTest {
          * mock suffices.
          */
         private InsertFromTableScanContext prepareScanContext() throws AccessDeniedException {
+            PreSplitFlow.Prepared prepared = prepare();
+            return prepared == null ? null : (InsertFromTableScanContext) prepared.scanContext();
+        }
+
+        /**
+         * Drives {@link TablePreSplitSource#prepare} directly and returns the full
+         * {@link PreSplitFlow.Prepared} (or {@code null} when prepare skipped), so a test
+         * can inspect the built {@code secondaryIndexSpecs}.
+         */
+        private PreSplitFlow.Prepared prepare() throws AccessDeniedException {
             SelectRelation selectRelation =
                     (SelectRelation) insertStmt.getQueryStatement().getQueryRelation();
-            PreSplitFlow.Prepared prepared = new TablePreSplitSource().prepare(
+            return new TablePreSplitSource().prepare(
                     insertStmt, selectRelation, targetTable, mock(Database.class), context);
-            return prepared == null ? null : (InsertFromTableScanContext) prepared.scanContext();
+        }
+
+        /**
+         * Adds one visible rollup ({@code rollupMetaId}) with the given sort-key columns to
+         * the target's visible-index set, alongside the base index, so prepare builds a
+         * secondary index spec for it.
+         */
+        private void withVisibleRollup(long rollupMetaId, List<String> rollupSortKeyColumnNames) {
+            com.starrocks.catalog.MaterializedIndexMeta baseMeta =
+                    mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+            when(baseMeta.getIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+            com.starrocks.catalog.MaterializedIndexMeta rollupMeta =
+                    mock(com.starrocks.catalog.MaterializedIndexMeta.class);
+            when(rollupMeta.getIndexMetaId()).thenReturn(rollupMetaId);
+            when(targetTable.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+            when(targetTable.getBaseIndexMetaId()).thenReturn(BASE_INDEX_META_ID);
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(eq(targetTable), eq(rollupMetaId)))
+                    .thenReturn(columnsOf(rollupSortKeyColumnNames));
         }
 
         /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/InsertSelectSourceColumnsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -107,15 +108,32 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(cols, cols, false);
         OlapTable source = olapTable(cols, cols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());
 
         Assertions.assertNotNull(result);
-        Assertions.assertEquals(Collections.singletonList("k"), result.sortKeySourceColumnNames());
-        Assertions.assertEquals(Collections.emptyList(), result.partitionSourceColumnNames());
+        Assertions.assertEquals("k", result.get("k"));
+    }
+
+    @Test
+    public void resolveExposesFullTargetToSourceMap() {
+        // source [k, v]; target [k, v]; SELECT * by position -> full map covers EVERY
+        // non-generated base column (not just the sort key), lower-cased target -> source.
+        List<Column> cols = Arrays.asList(col("k"), col("v"));
+        OlapTable target = olapTable(cols, cols, false);
+        OlapTable source = olapTable(cols, cols, false);
+
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
+                insertStmt(false), starRelation(),
+                target, source, SRC_NAME, null,
+                Collections.singletonList(col("k")),
+                Collections.emptyList());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(Map.of("k", "k", "v", "v"), result);
     }
 
     @Test
@@ -126,7 +144,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -143,7 +161,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -160,14 +178,14 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());
 
         Assertions.assertNotNull(result);
-        Assertions.assertEquals(Collections.singletonList("k"), result.sortKeySourceColumnNames());
+        Assertions.assertEquals("k", result.get("k"));
     }
 
     @Test
@@ -178,7 +196,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -195,7 +213,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -211,7 +229,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(cols, cols, false);
         OlapTable source = olapTable(cols, cols, true); // has generated column
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -230,7 +248,7 @@ public class InsertSelectSourceColumnsTest {
 
         SelectRelation rel = bareRelation(bareItem("b"), bareItem("a"));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("b")),
@@ -238,7 +256,7 @@ public class InsertSelectSourceColumnsTest {
 
         Assertions.assertNotNull(result);
         // target[1]=b <- output[1]="a"; sortKey b -> source "a"
-        Assertions.assertEquals(Collections.singletonList("a"), result.sortKeySourceColumnNames());
+        Assertions.assertEquals("a", result.get("b"));
     }
 
     @Test
@@ -253,14 +271,14 @@ public class InsertSelectSourceColumnsTest {
                 bareItem("v", null, "k"),   // SELECT v AS k
                 bareItem("k", null, "v"));  // SELECT k AS v
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());
 
         Assertions.assertNotNull(result);
-        Assertions.assertEquals(Collections.singletonList("v"), result.sortKeySourceColumnNames());
+        Assertions.assertEquals("v", result.get("k"));
     }
 
     @Test
@@ -273,7 +291,7 @@ public class InsertSelectSourceColumnsTest {
         TableName otherTbl = new TableName(null, null, "other");
         SelectRelation rel = bareRelation(bareItem("k", otherTbl, null), bareItem("v", null, null));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -292,7 +310,7 @@ public class InsertSelectSourceColumnsTest {
         TableName wrongDb = new TableName(null, "db2", "src");
         SelectRelation rel = bareRelation(bareItem("k", wrongDb, null), bareItem("v", null, null));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -311,14 +329,14 @@ public class InsertSelectSourceColumnsTest {
         TableName srcTbl = new TableName(null, null, "src");
         SelectRelation rel = bareRelation(bareItem("k", srcTbl, null), bareItem("v", null, null));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.emptyList());
 
         Assertions.assertNotNull(result);
-        Assertions.assertEquals(Collections.singletonList("k"), result.sortKeySourceColumnNames());
+        Assertions.assertEquals("k", result.get("k"));
     }
 
     @Test
@@ -331,7 +349,7 @@ public class InsertSelectSourceColumnsTest {
 
         SelectRelation rel = bareRelation(bareItem("ghost"), bareItem("v"));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -350,7 +368,7 @@ public class InsertSelectSourceColumnsTest {
 
         SelectRelation rel = bareRelation(bareItem("k")); // only 1 item, target has 2
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -369,7 +387,7 @@ public class InsertSelectSourceColumnsTest {
 
         SelectRelation rel = bareRelation(bareItem("k", null, null), bareItem("x", null, "k"));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -389,7 +407,7 @@ public class InsertSelectSourceColumnsTest {
         // SELECT k, v, extra — output has "extra" not in target
         SelectRelation rel = bareRelation(bareItem("k"), bareItem("v"), bareItem("extra"));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -409,7 +427,7 @@ public class InsertSelectSourceColumnsTest {
         // SELECT k, v by-name aligned but sortKey is col("z") which is absent
         SelectRelation rel = bareRelation(bareItem("k"), bareItem("v"));
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(true), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("z")),  // z not in target
@@ -425,15 +443,15 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(cols, cols, false);
         OlapTable source = olapTable(cols, cols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
                 Collections.singletonList(col("dt")));
 
         Assertions.assertNotNull(result);
-        Assertions.assertEquals(Collections.singletonList("k"), result.sortKeySourceColumnNames());
-        Assertions.assertEquals(Collections.singletonList("dt"), result.partitionSourceColumnNames());
+        Assertions.assertEquals("k", result.get("k"));
+        Assertions.assertEquals("dt", result.get("dt"));
     }
 
     @Test
@@ -444,7 +462,7 @@ public class InsertSelectSourceColumnsTest {
         OlapTable target = olapTable(targetCols, targetCols, false);
         OlapTable source = olapTable(sourceCols, sourceCols, false);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), starRelation(),
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),
@@ -470,7 +488,7 @@ public class InsertSelectSourceColumnsTest {
         SelectRelation rel = mock(SelectRelation.class);
         when(rel.getSelectList()).thenReturn(list);
 
-        InsertSelectSourceColumns result = InsertSelectSourceColumns.resolve(
+        Map<String, String> result = InsertSelectSourceColumns.resolve(
                 insertStmt(false), rel,
                 target, source, SRC_NAME, null,
                 Collections.singletonList(col("k")),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -18,12 +18,10 @@ import com.starrocks.alter.reshard.TabletReshardJob;
 import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.junit.jupiter.api.AfterEach;
@@ -182,43 +180,34 @@ public class PreSplitFlowTest {
     }
 
     @Test
-    public void dispatchInsertFromTableWithRollupSkipsBeforeSampling() {
-        // INSERT-from-table cannot remap a divergent rollup sort key to source columns, so a
-        // target with more than one visible index (base + rollup) must skip before sampling /
-        // grouping / pre-create -- regardless of partition shape. The gate is the FIRST line of
-        // dispatch, so none of the multi-partition scaffolding below (sampler, grouper) ever runs.
+    public void dispatchInsertFromTableWithRollupRoutesToMultiPartitionFlow() {
+        // INSERT-from-table with a rollup is no longer descoped: an automatic-partition target
+        // routes to the multi-partition flow, which constructs the data-tier sampler and groups.
         Database database = mock(Database.class);
         when(database.getId()).thenReturn(7L);
         OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
-        when(table.getVisibleIndexMetas()).thenReturn(
-                List.of(mock(MaterializedIndexMeta.class), mock(MaterializedIndexMeta.class)));
         PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
+        SampleSet samples = new SampleSet(List.of(), List.of(), Estimates.ZERO);
 
-        boolean savedHasInit = MetricRepo.hasInit;
-        MetricRepo.hasInit = true;
-        try (MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<PartitionSampleGrouper> grouper = Mockito.mockStatic(PartitionSampleGrouper.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
                         Mockito.mockStatic(TabletPreSplitCoordinator.class);
-                MockedConstruction<ReservoirSampler> sampler = Mockito.mockConstruction(ReservoirSampler.class)) {
-            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
-            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+                MockedConstruction<ReservoirSampler> sampler = Mockito.mockConstruction(ReservoirSampler.class,
+                        (mock, ctx) -> when(mock.sample(any(SampleRequest.class))).thenReturn(samples))) {
+            grouper.when(() -> PartitionSampleGrouper.group(
+                            any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
+                            anyLong(), anyLong(), any()))
+                    .thenReturn(List.of());
 
             PreSplitFlow.dispatch(database, table, prepared, LoadKind.INSERT_FROM_TABLE,
                     () -> false, mock(ConnectContext.class));
 
-            Assertions.assertTrue(sampler.constructed().isEmpty(), "the data-tier sampler must never be constructed");
+            Assertions.assertEquals(1, sampler.constructed().size(),
+                    "INSERT-from-table with a rollup must reach the data-tier sampler");
             grouper.verify(() -> PartitionSampleGrouper.group(
-                    any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class), anyLong(), anyLong(), any()),
-                    never());
-            coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
-                    any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
-            coordinator.verify(() -> TabletPreSplitCoordinator.submitForPartitionsCombined(
-                    any(), any(), anyList(), anyInt(), any(), any(), any()), never());
-            Assertions.assertEquals(baseline + 1L,
-                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
-                    "INSERT-from-table with a rollup must bump the has_materialized_view_or_rollup bucket");
-        } finally {
-            MetricRepo.hasInit = savedHasInit;
+                    any(SampleSet.class), any(OlapTable.class), any(ConnectContext.class),
+                    anyLong(), anyLong(), any()), times(1));
         }
     }
 
@@ -280,38 +269,30 @@ public class PreSplitFlowTest {
     }
 
     @Test
-    public void singleFlowSkipsInsertFromTableWhenResolvedIndexTargetsHaveRollup() {
-        // Race regression: the dispatch-time descope gate reads target.getVisibleIndexMetas()
-        // before findEligibleTarget resolves the authoritative indexTargets. If a rollup becomes
-        // visible in between, the RESOLVED indexTargets can have 2 entries (base + rollup) even
-        // though the table had a single visible index at dispatch time. runSinglePartitionFlow
-        // must re-check the resolved set and skip -- not sample the rollup with the base-only
-        // INSERT-from-table source mapping.
+    public void singleFlowInsertFromTableWithRollupProceeds() {
+        // INSERT-from-table with a resolved base+rollup index set is no longer skipped:
+        // the single-partition flow builds the pipeline and submits.
         Database database = mock(Database.class);
         OlapTable table = mockTable(/*partitioned*/ false, /*automatic*/ false);
         PreSplitFlow.Prepared prepared = preparedFor(mock(ScanContext.class));
 
-        boolean savedHasInit = MetricRepo.hasInit;
-        MetricRepo.hasInit = true;
-        try (MockedStatic<PreSplitTargets> targets = Mockito.mockStatic(PreSplitTargets.class);
+        try (MockedStatic<TabletReshardUtils> reshardUtils = PresplitTestSupport.stubComputeNodeCount(1);
+                MockedStatic<PreSplitTargets> targets = Mockito.mockStatic(PreSplitTargets.class);
+                MockedStatic<DefaultPreSplitPipeline> pipelineStatic =
+                        Mockito.mockStatic(DefaultPreSplitPipeline.class);
                 MockedStatic<TabletPreSplitCoordinator> coordinator =
                         Mockito.mockStatic(TabletPreSplitCoordinator.class)) {
             stubEligibleTargetWithRollup(targets, database, table);
-            String label = SkipReason.HAS_MATERIALIZED_VIEW_OR_ROLLUP.name().toLowerCase();
-            long baseline = MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue();
+            stubPipelineFactory(pipelineStatic);
+            coordinator.when(() -> TabletPreSplitCoordinator.submitAsynchronously(
+                            any(), any(), anyLong(), any(), any(), any(), anyInt()))
+                    .thenReturn(new PreSplitOutcome.Skipped(SkipReason.SAMPLE_FAILED));
 
             PreSplitFlow.runSinglePartitionFlow(database, table, prepared,
                     LoadKind.INSERT_FROM_TABLE, () -> false);
 
             coordinator.verify(() -> TabletPreSplitCoordinator.submitAsynchronously(
-                    any(), any(), anyLong(), any(), any(), any(), anyInt()), never());
-            coordinator.verify(() -> TabletPreSplitCoordinator.awaitFinishedAllowingFallback(
-                    any(), any(), any(), any(), any()), never());
-            Assertions.assertEquals(baseline + 1L,
-                    MetricRepo.COUNTER_TABLET_PRE_SPLIT_ELIGIBILITY_SKIPPED.getMetric(label).getValue().longValue(),
-                    "resolved rollup on INSERT-from-table must bump the has_materialized_view_or_rollup bucket");
-        } finally {
-            MetricRepo.hasInit = savedHasInit;
+                    any(), any(), anyLong(), any(), any(), any(), anyInt()), times(1));
         }
     }
 
@@ -441,7 +422,7 @@ public class PreSplitFlowTest {
     private static PreSplitFlow.Prepared preparedFor(ScanContext scanContext) {
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         return new PreSplitFlow.Prepared(scanContext, sortKey, List.of(),
-                /*estimatedBytes*/ 0L, mock(ComputeResource.class));
+                /*estimatedBytes*/ 0L, mock(ComputeResource.class), List.of());
     }
 
     /** Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target for {@code table}. */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/SecondaryIndexSpecTest.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard.presplit;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.sql.common.MetaUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SecondaryIndexSpecTest {
+
+    @Test
+    void forVisibleRollupsIncludesEveryRollupExceptBase() {
+        // A target with a base index (id 1) and one rollup (id 2) must produce exactly
+        // one SecondaryIndexSpec for the rollup, carrying its own (divergent) sort key.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta rollupMeta = mock(MaterializedIndexMeta.class);
+        when(rollupMeta.getIndexMetaId()).thenReturn(2L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta, rollupMeta));
+
+        List<Column> rollupSortKey = List.of(bigintColumn("r"));
+        try (MockedStatic<MetaUtils> metaUtils = Mockito.mockStatic(MetaUtils.class)) {
+            metaUtils.when(() -> MetaUtils.getRangeDistributionColumns(table, 2L)).thenReturn(rollupSortKey);
+
+            List<SecondaryIndexSpec> specs = SecondaryIndexSpec.forVisibleRollups(table);
+
+            Assertions.assertEquals(1, specs.size(), "exactly one rollup spec expected");
+            Assertions.assertEquals(2L, specs.get(0).indexMetaId());
+            Assertions.assertEquals(rollupSortKey, specs.get(0).sortKey());
+        }
+    }
+
+    @Test
+    void forVisibleRollupsEmptyForSingleIndexTarget() {
+        // A single-index (base only) target must produce no secondary specs.
+        OlapTable table = mock(OlapTable.class);
+        when(table.getBaseIndexMetaId()).thenReturn(1L);
+        MaterializedIndexMeta baseMeta = mock(MaterializedIndexMeta.class);
+        when(baseMeta.getIndexMetaId()).thenReturn(1L);
+        when(table.getVisibleIndexMetas()).thenReturn(List.of(baseMeta));
+
+        Assertions.assertTrue(SecondaryIndexSpec.forVisibleRollups(table).isEmpty(),
+                "a single-index target must produce no secondary index specs");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Sample-Based Tablet Pre-Split previously skipped `INSERT ... SELECT ... FROM <single OLAP table>` whenever the range-distribution target carried a rollup, so on such a load neither the base index nor the rollup got pre-split (they stayed at one tablet and relied on post-load auto-merge/compaction). PR #76233 shipped multi-index pre-split for FILES/Broker loads but documented INSERT-from-table + rollup as a descope, because the sampler could only project the base sort key and only by target column name, whereas INSERT-from-table must project by the *source* column name via the target->source column remap.

## What I'm doing:

Make INSERT-from-table split every visible index (base plus each rollup):

- `InsertFromTableScanContext` now carries the full target->source column-name map instead of a base-only source-column list. The data-tier executor maps whatever sort key it is handed through that map: `request.getSortKey()` for the base (in the multi-partition single-request flow, and per-index in the single-partition flow), and each rollup spec's sort key for the secondary projection.
- The shared secondary-index projection becomes an overridable executor seam (`AbstractSqlSampleSubqueryExecutor.secondaryIndexProjectionIdents`). The default projects by target column name, so FILES/Broker generate byte-identical SQL; INSERT-from-table overrides it to remap to source names.
- `TablePreSplitSource` now builds one secondary index spec per visible rollup.
- The two guards that skipped multi-index INSERT-from-table are removed.

Safety: single-index (no-rollup) INSERT-from-table is byte-identical (the base sort key maps to the same source names). FILES/Broker and the ALTER-side pre-split path are untouched. Any unmapped sort-key column fails the sample so the load simply proceeds without pre-split (a base-only or no split is data-safe, since the BE routes each row by its true value). Data tier only -- an OLAP source has no Parquet/ORC footer, so the meta tier is already bypassed for this load kind.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5