### PR TITLE
[Refactor] Move colocation bucket dispatch onto AbstractOlapTableScanNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
@@ -14,12 +14,20 @@
 
 package com.starrocks.planner;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTableSchemaKey;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -67,6 +75,96 @@ public abstract class AbstractOlapTableScanNode extends ScanNode {
      */
     public Optional<SchemaInfo> getSchema() {
         return index.cachedSchema;
+    }
+
+    /**
+     * Returns the map from colocation bucket sequence to the scan-range locations of that bucket's
+     * tablets, which the colocation-aware backend selector uses to co-place matching buckets. Only a
+     * scan that participates in colocation bucket dispatch overrides this; the others do not support it.
+     */
+    public ArrayListMultimap<Integer, TScanRangeLocations> getBucketSeqToLocations() {
+        throw new UnsupportedOperationException(
+                getClass().getSimpleName() + " does not participate in colocation bucket dispatch");
+    }
+
+    /**
+     * Returns the scan's bucket count for {@code olapTable}. For a HASH table this is the table's
+     * bucket count, except that a single selected partition reports its own count, because the
+     * partitions of a non-colocate table can have different bucket counts. For a RANGE table it is
+     * the colocate group's bucket count when the table is colocated, otherwise the distribution's own
+     * count (always 1, one tablet per partition).
+     */
+    protected static int computeBucketNums(
+            OlapTable olapTable, long indexMetaId, Collection<Long> selectedLogicalPartitionIds,
+            List<PhysicalPartition> selectedPhysicalPartitions, Map<Long, Integer> tabletId2BucketSeq) {
+        DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
+        if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
+            RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(olapTable);
+            if (dispatch != null) {
+                // This bucket-count computation is reached from
+                // ExecutionFragment.getOrCreateColocatedAssignment only when BackendSelectorFactory has
+                // chosen a colocate-dispatch path. Verify alignment HERE, after the dispatch decision: a
+                // misaligned ColocateRangeMgr would silently produce wrong join results under colocate
+                // dispatch. Non-colocate scans go through NormalBackendSelector and never reach this point.
+                //
+                // requireAligned fails closed on two conditions: the group is currently unaligned, OR the
+                // bucketSeq this scan actually built (tabletId2BucketSeq) does not match the aligned mapping.
+                // The second check closes the fill-vs-dispatch TOCTOU: the bucketSeq fill falls back to a
+                // position-based assignment when the group is momentarily unaligned (so a non-colocate scan
+                // still works); if the group then re-aligns before this guard runs, comparing the built
+                // assignment against the aligned mapping catches the stale position pairing that would
+                // otherwise reach the colocate join and silently return wrong results.
+                //
+                // Invariant: the bucketSeq fill always runs before backend selection reaches this guard, so
+                // tabletId2BucketSeq holds the whole scan's built assignment here — an empty map would itself
+                // be a not-built/stale state and fails closed.
+                dispatch.requireAligned(selectedPhysicalPartitions, indexMetaId, tabletId2BucketSeq);
+                return dispatch.bucketCount();
+            }
+            // Range distribution without a colocate group: RangeDistributionInfo always
+            // reports 1 (one tablet per partition by design).
+            return distInfo.getBucketNum();
+        }
+        // HASH path.
+        int bucketNum = distInfo.getBucketNum();
+        if (selectedLogicalPartitionIds.size() <= 1) {
+            for (Long pid : selectedLogicalPartitionIds) {
+                bucketNum = olapTable.getPartition(pid).getDistributionInfo().getBucketNum();
+            }
+        }
+        return bucketNum;
+    }
+
+    /**
+     * Fills {@code target} with the tablet-id → bucket-sequence assignment for {@code selectedIndex},
+     * applying the position-fallback policy shared by every scan-time producer of the bucket-sequence map:
+     *
+     * <ul>
+     *   <li>range colocate and aligned — {@code dispatch != null} and
+     *       {@link RangeColocateScanDispatch#computeBucketSeq} returns a mapping — uses that mapping;</li>
+     *   <li>everything else (HASH, range non-colocate, or a transiently unaligned range colocate group
+     *       where {@code computeBucketSeq} returns {@code null}) falls back to position-based bucketSeq.</li>
+     * </ul>
+     *
+     * <p>Entries are added to {@code target} without clearing it, so a caller can accumulate the
+     * whole-scan assignment across sub-partitions. The dispatch-time alignment guard in
+     * {@link #computeBucketNums} fails closed on the colocate-dispatch path when the built assignment is a
+     * stale position fallback, so no unaligned observation needs to be recorded here.
+     */
+    public static void fillTabletId2BucketSeq(@Nullable RangeColocateScanDispatch dispatch,
+                                              MaterializedIndex selectedIndex,
+                                              List<Long> allTabletIds,
+                                              Map<Long, Integer> target) {
+        if (dispatch != null) {
+            Map<Long, Integer> rangeColocateMap = dispatch.computeBucketSeq(selectedIndex);
+            if (rangeColocateMap != null) {
+                target.putAll(rangeColocateMap);
+                return;
+            }
+        }
+        for (int i = 0; i < allTabletIds.size(); i++) {
+            target.put(allTabletIds.get(i), i);
+        }
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -144,7 +144,7 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     private final HashSet<Long> scanBackendIds = new HashSet<>();
     private final List<String> unUsedOutputStringColumns = new ArrayList<>();
     // a bucket seq may map to many tablets, and each tablet has a TScanRangeLocations.
-    public ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2locations = ArrayListMultimap.create();
+    private final ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2locations = ArrayListMultimap.create();
     public List<Expr> prunedPartitionPredicates = Lists.newArrayList();
     /*
      * When the field value is ON, the storage engine can return the data directly without pre-aggregation.
@@ -327,47 +327,14 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
     }
 
     @Override
-    public int getBucketNums() {
-        DistributionInfo distInfo = olapTable.getDefaultDistributionInfo();
-        if (distInfo.getType() == DistributionInfo.DistributionInfoType.RANGE) {
-            return getRangeDistributionBucketNums(distInfo);
-        }
-        // HASH path.
-        int bucketNum = distInfo.getBucketNum();
-        if (getSelectedPartitionIds().size() <= 1) {
-            for (Long pid : getSelectedPartitionIds()) {
-                bucketNum = olapTable.getPartition(pid).getDistributionInfo().getBucketNum();
-            }
-        }
-        return bucketNum;
+    public ArrayListMultimap<Integer, TScanRangeLocations> getBucketSeqToLocations() {
+        return bucketSeq2locations;
     }
 
-    private int getRangeDistributionBucketNums(DistributionInfo distInfo) {
-        RangeColocateScanDispatch dispatch = RangeColocateScanDispatch.forTable(olapTable);
-        if (dispatch != null) {
-            // getBucketNums() is invoked from ExecutionFragment.getOrCreateColocatedAssignment
-            // only when BackendSelectorFactory has chosen a colocate-dispatch path. Verify
-            // alignment HERE, after the dispatch decision: a misaligned ColocateRangeMgr
-            // would silently produce wrong join results under colocate dispatch.
-            // Non-colocate scans go through NormalBackendSelector and never reach this point.
-            //
-            // requireAligned fails closed on two conditions: the group is currently unaligned, OR the
-            // bucketSeq this scan actually built (tabletId2BucketSeq) does not match the aligned mapping.
-            // The second check closes the fill-vs-dispatch TOCTOU: the bucketSeq fill falls back to a
-            // position-based assignment when the group is momentarily unaligned (so a non-colocate scan
-            // still works); if the group then re-aligns before this guard runs, comparing the built
-            // assignment against the aligned mapping catches the stale position pairing that would
-            // otherwise reach the colocate join and silently return wrong results.
-            //
-            // Invariant: the bucketSeq fill (getScanRangeLocations, optimizer or legacy path) always runs
-            // before backend selection reaches this guard, so tabletId2BucketSeq holds the whole scan's
-            // built assignment here — an empty map would itself be a not-built/stale state and fails closed.
-            dispatch.requireAligned(getSelectedPhysicalPartitions(), index.indexMetaId, tabletId2BucketSeq);
-            return dispatch.bucketCount();
-        }
-        // Range distribution without a colocate group: RangeDistributionInfo always
-        // reports 1 (one tablet per partition by design).
-        return distInfo.getBucketNum();
+    @Override
+    public int getBucketNums() {
+        return computeBucketNums(olapTable, index.indexMetaId, getSelectedPartitionIds(),
+                getSelectedPhysicalPartitions(), tabletId2BucketSeq);
     }
 
     /**
@@ -886,40 +853,6 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                 selectedTabletsNum += tablets.size();
                 addScanRangeLocations(partition, physicalPartition, selectedIndex, tablets, List.of(), localBeId);
             }
-        }
-    }
-
-    /**
-     * Fills {@code target} with the tablet-id → bucket-sequence assignment for {@code selectedIndex},
-     * applying the position-fallback policy shared by both scan-time producers of
-     * {@link #tabletId2BucketSeq} — this class's {@link #computeTabletInfo} and
-     * {@link com.starrocks.sql.plan.PlanFragmentBuilder}:
-     *
-     * <ul>
-     *   <li>range colocate and aligned — {@code dispatch != null} and
-     *       {@link RangeColocateScanDispatch#computeBucketSeq} returns a mapping — uses that mapping;</li>
-     *   <li>everything else (HASH, range non-colocate, or a transiently unaligned range colocate group
-     *       where {@code computeBucketSeq} returns {@code null}) falls back to position-based bucketSeq.</li>
-     * </ul>
-     *
-     * <p>Entries are added to {@code target} without clearing it, so a caller can accumulate the
-     * whole-scan assignment across sub-partitions. The dispatch-time alignment guard in
-     * {@link #getBucketNums()} fails closed on the colocate-dispatch path when the built assignment is a
-     * stale position fallback, so no unaligned observation needs to be recorded here.
-     */
-    public static void fillTabletId2BucketSeq(@Nullable RangeColocateScanDispatch dispatch,
-                                              MaterializedIndex selectedIndex,
-                                              List<Long> allTabletIds,
-                                              Map<Long, Integer> target) {
-        if (dispatch != null) {
-            Map<Long, Integer> rangeColocateMap = dispatch.computeBucketSeq(selectedIndex);
-            if (rangeColocateMap != null) {
-                target.putAll(rangeColocateMap);
-                return;
-            }
-        }
-        for (int i = 0; i < allTabletIds.size(); i++) {
-            target.put(allTabletIds.get(i), i);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ColocatedBackendSelector.java
@@ -20,7 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
-import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.AbstractOlapTableScanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.scheduler.WorkerProvider;
@@ -48,14 +48,14 @@ import java.util.function.Function;
 public class ColocatedBackendSelector implements BackendSelector {
     private static final Logger LOG = LogManager.getLogger(ColocatedBackendSelector.class);
 
-    private final OlapScanNode scanNode;
+    private final AbstractOlapTableScanNode scanNode;
     private final FragmentScanRangeAssignment assignment;
     private final ColocatedBackendSelector.Assignment colocatedAssignment;
     private final boolean isRightOrFullBucketShuffleFragment;
     private final WorkerProvider workerProvider;
     private final BucketSequenceIterator bucketSequenceIterator;
 
-    public ColocatedBackendSelector(OlapScanNode scanNode, FragmentScanRangeAssignment assignment,
+    public ColocatedBackendSelector(AbstractOlapTableScanNode scanNode, FragmentScanRangeAssignment assignment,
                                     ColocatedBackendSelector.Assignment colocatedAssignment,
                                     boolean isRightOrFullBucketShuffleFragment, WorkerProvider workerProvider,
                                     int maxBucketsPerBeToUseBalancerAssignment) {
@@ -76,7 +76,7 @@ public class ColocatedBackendSelector implements BackendSelector {
 
         Iterable<Integer> bucketSeqs = bucketSequenceIterator.createIterable();
         for (Integer bucketSeq : bucketSeqs) {
-            List<TScanRangeLocations> locations = scanNode.bucketSeq2locations.get(bucketSeq);
+            List<TScanRangeLocations> locations = scanNode.getBucketSeqToLocations().get(bucketSeq);
             if (!bucketSeqToWorkerId.containsKey(bucketSeq)) {
                 // Use the first tablet to represent the locations, calculate the backend assigned to this bucket sequence.
                 // In colocation table, all tablets of a bucket sequence have the same locations.
@@ -227,7 +227,7 @@ public class ColocatedBackendSelector implements BackendSelector {
      * {@link NormalBucketSequenceIterator}, so only use {@link BalancerBucketSequenceIterator} when  {@code numBucketsPerBe} is
      * smaller than the parameter {@code maxBucketsPerBeToUseBalancerAssignment}.
      */
-    private static BucketSequenceIterator createBucketIterator(OlapScanNode scanNode,
+    private static BucketSequenceIterator createBucketIterator(AbstractOlapTableScanNode scanNode,
                                                                int maxBucketsPerBeToUseBalancerAssignment) {
         if (maxBucketsPerBeToUseBalancerAssignment <= 0) {
             return new NormalBucketSequenceIterator(scanNode);
@@ -236,8 +236,8 @@ public class ColocatedBackendSelector implements BackendSelector {
         boolean hasMultiReplications = false;
         int numTotalBuckets = 0;
         Set<Long> backends = Sets.newHashSet();
-        for (Integer bucket : scanNode.bucketSeq2locations.keySet()) {
-            List<TScanRangeLocations> bucketLocations = scanNode.bucketSeq2locations.get(bucket);
+        for (Integer bucket : scanNode.getBucketSeqToLocations().keySet()) {
+            List<TScanRangeLocations> bucketLocations = scanNode.getBucketSeqToLocations().get(bucket);
             if (bucketLocations.isEmpty()) {
                 continue;
             }
@@ -283,8 +283,8 @@ public class ColocatedBackendSelector implements BackendSelector {
     private static class NormalBucketSequenceIterator implements BucketSequenceIterator {
         private final Iterator<Integer> iterator;
 
-        public NormalBucketSequenceIterator(OlapScanNode scanNode) {
-            this.iterator = scanNode.bucketSeq2locations.keySet().iterator();
+        public NormalBucketSequenceIterator(AbstractOlapTableScanNode scanNode) {
+            this.iterator = scanNode.getBucketSeqToLocations().keySet().iterator();
         }
 
         @Override
@@ -347,8 +347,8 @@ public class ColocatedBackendSelector implements BackendSelector {
         private final Map<Integer, Integer> bucketToBackendUsedTimes;
         private final NavigableSet<Integer> buckets;
 
-        public BalancerBucketSequenceIterator(OlapScanNode scanNode) {
-            ArrayListMultimap<Integer, TScanRangeLocations> bucketToLocations = scanNode.bucketSeq2locations;
+        public BalancerBucketSequenceIterator(AbstractOlapTableScanNode scanNode) {
+            ArrayListMultimap<Integer, TScanRangeLocations> bucketToLocations = scanNode.getBucketSeqToLocations();
 
             this.backendToBuckets = Maps.newHashMap();
             this.bucketToBackendUsedTimes = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -873,7 +873,7 @@ public class DefaultSharedDataWorkerProviderTest {
                 4, ImmutableList.of(5L),
                 5, ImmutableList.of(6L)
         );
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 3);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 3));
         List<TScanRangeLocations> scanLocations = generateScanRangeLocations(id2AllNodes, 10, bucketNum);
         WorkerProvider provider = newWorkerProvider();
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeColocateScanRangeDispatchTest.java
@@ -186,7 +186,7 @@ public class RangeColocateScanRangeDispatchTest {
         Assertions.assertEquals(2, olapScans.size(), "expected two OlapScanNodes for the join");
 
         for (OlapScanNode scan : olapScans) {
-            ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2Locations = scan.bucketSeq2locations;
+            ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2Locations = scan.getBucketSeqToLocations();
             Assertions.assertFalse(bucketSeq2Locations.isEmpty(),
                     "scan node " + scan.getTableName() + " has no bucketSeq2locations entries");
             Assertions.assertEquals(1, bucketSeq2Locations.keySet().size(),

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
@@ -67,7 +67,7 @@ public class ColocatedBackendSelectorTest {
                 bucketSeqToBackends.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
         OlapScanNode scanNode = genOlapScanNode(0, numBuckets);
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 3);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 3));
         WorkerProvider workerProvider = genWorkerProvider(backendIds);
 
         {
@@ -98,7 +98,7 @@ public class ColocatedBackendSelectorTest {
                 bucketSeqToBackends.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
         OlapScanNode scanNode = genOlapScanNode(0, numBuckets);
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 3);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 3));
         WorkerProvider workerProvider = genWorkerProvider(backendIds);
 
         {
@@ -148,7 +148,7 @@ public class ColocatedBackendSelectorTest {
                 bucketSeqToBackends.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
         OlapScanNode scanNode = genOlapScanNode(0, numBuckets);
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 3);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 3));
         WorkerProvider workerProvider = genWorkerProvider(backendIds);
 
         {
@@ -214,9 +214,9 @@ public class ColocatedBackendSelectorTest {
                 .flatMap(Collection::stream).collect(Collectors.toSet());
 
         OlapScanNode scanNode0 = genOlapScanNode(0, numBuckets);
-        scanNode0.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends0, 3);
+        scanNode0.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends0, 3));
         OlapScanNode scanNode1 = genOlapScanNode(1, numBuckets);
-        scanNode1.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends1, 4);
+        scanNode1.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends1, 4));
         List<OlapScanNode> scanNodes = ImmutableList.of(scanNode0, scanNode1);
 
         WorkerProvider workerProvider = genWorkerProvider(backendIds);
@@ -383,7 +383,7 @@ public class ColocatedBackendSelectorTest {
                 };
 
         OlapScanNode scanNode = genOlapScanNode(0, numBuckets);
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 1);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 1));
 
         FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
         ColocatedBackendSelector.Assignment colocatedAssignment =
@@ -429,7 +429,7 @@ public class ColocatedBackendSelectorTest {
             }
         };
         OlapScanNode scanNode = genOlapScanNode(0, numBuckets);
-        scanNode.bucketSeq2locations = genBucketSeq2Locations(bucketSeqToBackends, 1);
+        scanNode.getBucketSeqToLocations().putAll(genBucketSeq2Locations(bucketSeqToBackends, 1));
 
         FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
         ColocatedBackendSelector.Assignment colocatedAssignment =


### PR DESCRIPTION
## Why I'm doing:

The colocation bucket-dispatch contract — the bucket-sequence-to-locations map, the
bucket-count computation, and the tablet-id-to-bucket-sequence fill — lived inside
`OlapScanNode`, and `ColocatedBackendSelector` reached into the concrete `OlapScanNode`
(and directly into a public `bucketSeq2locations` field) instead of depending on an
abstraction. Hoisting the contract lets any OLAP scan that takes part in colocation
reuse the same machinery, and lets the selector depend on the base type rather than a
concrete node and its public field.

## What I'm doing:

Move the colocation bucket-dispatch contract onto `AbstractOlapTableScanNode`:

- Add `getBucketSeqToLocations()` as an optional operation that throws
  `UnsupportedOperationException` by default; a scan that takes part in colocation
  overrides it to return its own map. Scans that do not (e.g. `MetaScanNode`) simply
  inherit the default and never call it.
- Add the stateless static helpers `computeBucketNums(...)` and
  `fillTabletId2BucketSeq(...)`.
- `OlapScanNode`'s `bucketSeq2locations` map is now `private final`, reached only through
  the getter; `getBucketNums()` delegates to `computeBucketNums(...)`.
- `ColocatedBackendSelector` takes `AbstractOlapTableScanNode` and reads the map through
  the getter, instead of the concrete `OlapScanNode` and its public field.

No behavior change: `computeBucketNums` reproduces the former
`getBucketNums`/`getRangeDistributionBucketNums` logic verbatim (the instance reads are
now explicit parameters); `fillTabletId2BucketSeq` moves unchanged and still resolves for
existing `OlapScanNode.fillTabletId2BucketSeq` callers via inherited static access;
`getBucketSeqToLocations()` returns the same map the selector previously read directly.
Existing colocate tests were updated to reach the map through the getter and otherwise
pass unchanged (ColocateJoinTest, RangeColocateScanDispatchTest,
RangeColocateScanRangeDispatchTest, ColocatedBackendSelectorTest,
DefaultSharedDataWorkerProviderTest).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
