### PR TITLE
[BugFix][CVE] Exclude unused avro-ipc that bundles vulnerable jquery 1.4.2 (backport #76270)

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -225,6 +225,9 @@ subprojects {
             implementation("org.bouncycastle:bcpkix-jdk18on:${project.ext["bouncycastle.version"]}")
             implementation("org.bouncycastle:bcprov-jdk18on:${project.ext["bouncycastle.version"]}")
             implementation("org.bouncycastle:bcutil-jdk18on:${project.ext["bouncycastle.version"]}")
+            // xz used to reach fe/lib only via the excluded avro-ipc; keep it for the
+            // jars that still reference it (commons-compress, clickhouse-jdbc, ...)
+            implementation("org.tukaani:xz:1.9")
             implementation("org.eclipse.jetty:jetty-client:${project.ext["jetty.version"]}")
             implementation("org.eclipse.jetty:jetty-io:${project.ext["jetty.version"]}")
             implementation("org.eclipse.jetty:jetty-security:${project.ext["jetty.version"]}")
@@ -270,6 +273,9 @@ subprojects {
         // JSP engine, unused by FE; tomcat 9.0.93 carries CVE-2025-55754/CVE-2025-52434
         exclude(group = "org.apache.tomcat")
         exclude(group = "org.apache.tomcat.embed")
+        // ships jquery 1.4.2 (CVE-2011-4969 etc.); only avro-mapred's unused tether feature references it
+        exclude(group = "org.apache.avro", module = "avro-ipc")
+        exclude(group = "org.apache.avro", module = "avro-ipc-jetty")
     }
 
     // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -289,6 +289,9 @@ dependencies {
     }
     implementation("org.slf4j:slf4j-api")
     implementation("org.threeten:threeten-extra:1.7.2")
+    // xz used to reach fe/lib only via the excluded avro-ipc; keep it for the
+    // jars that still reference it (commons-compress, clickhouse-jdbc, ...)
+    implementation("org.tukaani:xz")
     implementation("org.xerial.snappy:snappy-java")
     implementation("software.amazon.awssdk:glue")
     implementation("software.amazon.awssdk:dynamodb")

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -97,6 +97,13 @@ under the License.
     </profiles>
 
     <dependencies>
+        <!-- xz used to reach fe/lib only via the excluded avro-ipc; keep it for the
+             jars that still reference it (commons-compress, clickhouse-jdbc, ...) -->
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.starrocks</groupId>
             <artifactId>spark-dpp</artifactId>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -564,6 +564,14 @@ under the License.
                 <version>3.4.0</version>
             </dependency>
 
+            <!-- xz used to reach fe/lib only via the excluded avro-ipc; keep it for the
+                 7 jars that still reference it (commons-compress, clickhouse-jdbc, ...) -->
+            <dependency>
+                <groupId>org.tukaani</groupId>
+                <artifactId>xz</artifactId>
+                <version>1.9</version>
+            </dependency>
+
             <!-- pin okio-jvm to the same version as okio; okhttp 4.10.0 drags in
                  okio-jvm 3.0.0 which is affected by CVE-2023-3635 -->
             <dependency>
@@ -720,6 +728,12 @@ under the License.
                     <exclusion>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-server</artifactId>
+                    </exclusion>
+                    <!-- avro-ipc ships jquery 1.4.2 (CVE-2011-4969 etc.); only referenced by
+                         avro-mapred's tether feature which is never used -->
+                    <exclusion>
+                        <groupId>org.apache.avro</groupId>
+                        <artifactId>avro-ipc</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.eclipse.jetty</groupId>
@@ -1644,6 +1658,10 @@ under the License.
                                         <exclude>org.apache.tomcat.embed:*</exclude>
                                         <!-- tencentcloud-sdk below 3.1.1471 drags in EOL okhttp 2.7.5 -->
                                         <exclude>com.tencentcloudapi:*:[,3.1.1471)</exclude>
+                                        <!-- ships jquery 1.4.2 (CVE-2011-4969 etc.); only avro-mapred's
+                                             unused tether feature references it -->
+                                        <exclude>org.apache.avro:avro-ipc</exclude>
+                                        <exclude>org.apache.avro:avro-ipc-jetty</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/java-extensions/hive-reader/pom.xml
+++ b/java-extensions/hive-reader/pom.xml
@@ -74,6 +74,24 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro-mapred</artifactId>
             <version>${avro.version}</version>
+            <!-- avro-ipc ships jquery 1.4.2 (CVE-2011-4969 etc.); only referenced by
+                 avro-mapred's tether feature which is never used -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-ipc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-ipc-jetty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>1.9</version>
         </dependency>
 
         <dependency>

--- a/java-extensions/hive-reader/src/test/java/com/starrocks/hive/reader/TestHiveScanner.java
+++ b/java-extensions/hive-reader/src/test/java/com/starrocks/hive/reader/TestHiveScanner.java
@@ -16,6 +16,12 @@ package com.starrocks.hive.reader;
 
 import com.starrocks.jni.connector.OffHeapTable;
 import com.starrocks.utils.Platform;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,6 +173,32 @@ public class TestHiveScanner {
     public void c1DoScanTestOnPrimitiveType() throws IOException {
         Map<String, String> params = createScanTestParams();
         runScanOnParams(params);
+    }
+
+    @Test
+    public void scanXzCompressedAvroFile() throws IOException {
+        Map<String, String> params = createScanTestParams();
+        File sourceFile = new File(params.get("data_file_path"));
+        File xzFile = File.createTempFile("starrocks-hive-reader-", ".avro");
+        try {
+            writeXzCompressedAvroFile(sourceFile, xzFile);
+            params.put("data_file_path", xzFile.getPath());
+            params.put("block_length", String.valueOf(xzFile.length()));
+            runScanOnParams(params);
+        } finally {
+            Assertions.assertTrue(xzFile.delete(), "Failed to delete temporary Avro file");
+        }
+    }
+
+    private void writeXzCompressedAvroFile(File sourceFile, File targetFile) throws IOException {
+        try (DataFileReader<GenericRecord> reader = new DataFileReader<>(sourceFile, new GenericDatumReader<>());
+                DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+            writer.setCodec(CodecFactory.xzCodec(6));
+            writer.create(reader.getSchema(), targetFile);
+            while (reader.hasNext()) {
+                writer.append(reader.next());
+            }
+        }
     }
 
     @Test

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -625,6 +625,10 @@
                                         <exclude>com.fasterxml.jackson.jaxrs:*:[,2.15.0)</exclude>
                                         <!-- commons-lang3 below 3.18.0 is affected by CVE-2025-48924 -->
                                         <exclude>org.apache.commons:commons-lang3:[,3.18.0)</exclude>
+                                        <!-- ships jquery 1.4.2 (CVE-2011-4969 etc.); only avro-mapred's
+                                             unused tether feature references it -->
+                                        <exclude>org.apache.avro:avro-ipc</exclude>
+                                        <exclude>org.apache.avro:avro-ipc-jetty</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>


### PR DESCRIPTION
Manual backport of #76270 (the auto-backport hit conflicts).

## Why I'm doing:

`avro-ipc-1.11.4.jar` ships `jquery-1.4.2.min.js` (CVE-2011-4969, CVE-2014-6071 and six more jQuery XSS CVEs, two of them rated critical by downstream scanners) as static assets of Avro's stats server, which StarRocks never runs. Scanning the whole build output, the only class that references `org.apache.avro.ipc` is avro-mapred's `tether/TetheredProcess` (Avro's tethered-MapReduce debugging feature, also unused), so the jar is dead weight on both sides it ships to:

- FE classpath: `spark-core_2.12 -> avro-mapred -> avro-ipc`
- BE hive-reader lib: direct `avro-mapred` dependency drags in `avro-ipc` + `avro-ipc-jetty`

Upgrading Avro does not help: the latest avro-ipc 1.12.1 still bundles the same jquery 1.4.2.

## What I'm doing:

Pom/gradle-only, no Java code changes:

1. **Exclude `avro-ipc`** from spark-core (fe) and **`avro-ipc`/`avro-ipc-jetty`** from avro-mapred (hive-reader). Avro core and avro-mapred stay untouched — `org.apache.avro.mapred.FsInput` etc. remain on the classpath for Hive Avro reads.
2. **Keep `org.tukaani:xz` as an explicit dependency**: it used to reach `fe/lib` only through avro-ipc, while commons-compress, clickhouse-jdbc and 5 other shipped jars still reference it. Without this, the exclusion would silently drop the XZ codec.
3. **Ban `avro-ipc`/`avro-ipc-jetty` in the maven-enforcer gates** (fe + java-extensions root poms) so a future dependency bump cannot re-introduce them.
4. **Mirror everything in the Gradle build** (`fe/build.gradle.kts`, `fe/fe-core/build.gradle.kts`).

Verification (full FE rebuild + BE hive-reader repackage):

- `fe/lib` is byte-identical minus `avro-ipc-1.11.4.jar` (the explicit xz keeps `xz-1.9.jar` in place); no `jquery-1.4*` asset remains anywhere in `fe/lib`.
- FE starts clean, metadata queries work, zero `ClassNotFound`/`NoClassDefFound` in fe.log.
- `hive-reader-lib` drops `avro-ipc`/`avro-ipc-jetty`; hive-reader's `TestHiveScanner` (real `.avro` file reads through `AvroSerDe`/`AvroContainerInputFormat`) passes with the exclusion in place.
- Both maven reactors pass `validate` with the new enforcer bans active.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
