### PR TITLE
[Tool] Add manual workflow_dispatch to bugfix-version-index

### DIFF
--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -48,6 +48,16 @@ on:
   schedule:
     - cron: '0 19 * * *'    # daily 19:00 UTC (03:00 Asia/Shanghai) → reconcile (pending-only)
     - cron: '0 20 * * 0'    # weekly Sun 20:00 UTC (Mon 04:00 Asia/Shanghai) → reconcile-all (concrete too)
+  workflow_dispatch:        # manual trigger — run a self-heal sweep on demand, don't only wait for cron
+    inputs:
+      mode:
+        description: 'Self-heal sweep to run (same jobs the cron fires)'
+        type: choice
+        required: true
+        default: reconcile
+        options:
+          - reconcile        # = daily: index-fix pending sweep + affected-versions cause self-heal
+          - reconcile-all    # = weekly: re-check concrete records too (heavier)
 
 # Concurrency is per-ORIGIN for the single-origin EVENTS (origin-merge / backport-merge share
 # `BVI-…-origin-N`, so different origins run in parallel but the same origin serializes — a
@@ -182,7 +192,9 @@ jobs:
 
   # ④ daily self-heal → pending-only sweep across all maintained lines.
   reconcile:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 19 * * *'
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 19 * * *') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'reconcile')
     concurrency:
       group: BVI-${{ github.repository }}-reconcile
       cancel-in-progress: false
@@ -220,7 +232,9 @@ jobs:
   # (reverse error like #74855: stored 4.1.3 but really 4.1.2). Heavier — every maintained-line
   # origin is rebuilt from GitHub — so weekly, off-peak, not on the daily cron.
   reconcile-all:
-    if: github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0'
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 20 * * 0') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'reconcile-all')
     concurrency:
       group: BVI-${{ github.repository }}-reconcile-all
       cancel-in-progress: false


### PR DESCRIPTION
## Why I'm doing:

The `bugfix-version-index` reconcile / reconcile-all sweeps only run on the daily/weekly cron. There is no way to trigger a self-heal on demand (e.g. right after fixing the index or landing a plugin change).

> **Scope note:** this PR is **only** the manual trigger. It does **not** fix the separate issue that this workflow currently fails on the `[ubuntu, ai]` runner because it runs `claude` as **root** (`--dangerously-skip-permissions cannot be used with root`). The obvious `IS_SANDBOX=1` shortcut was **rejected in review** — it merely skips the guard without creating any isolation, and since `pull_request_target` feeds attacker-controllable PR content to a root `claude` holding `CLAUDE_CODE_OAUTH_TOKEN` / `GITHUB_TOKEN` / ContextBase-write plus `--dangerously-skip-permissions`, a prompt injection would be root RCE / credential exfiltration. The real fix (a bubblewrap OS sandbox with `failIfUnavailable` + a network allowlist, or a dedicated non-root user) is a runner-side change handled separately. This dispatch trigger is safe and useful once that lands.

## What I'm doing:

Add a `workflow_dispatch` trigger with a `mode` input (choice: `reconcile` | `reconcile-all`) and extend the `reconcile` / `reconcile-all` job `if` conditions to also fire on the matching manual dispatch. No other job is affected.

celerdata inherits this workflow via the sync pipeline.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5