### PR TITLE
[BugFix] Reject oversized array/map constructor results instead of silent corruption

### DIFF
--- a/be/src/exprs/array_expr.cpp
+++ b/be/src/exprs/array_expr.cpp
@@ -70,6 +70,13 @@ public:
         }
 
         auto ptr = ArrayColumn::create(std::move(array_elements), std::move(array_offsets));
+        // Flattening all children into one element column may exceed the 4GB capacity of
+        // BinaryColumn's uint32 offsets within a single chunk, which would silently wrap
+        // and corrupt the data. Fail the query instead.
+        if (auto st = ptr->capacity_limit_reached(); !st.ok()) {
+            return Status::CapacityLimitExceed("array constructor result exceeds column capacity limit, " +
+                                               std::string(st.message()));
+        }
         if (all_const) {
             return ConstColumn::create(std::move(ptr), output_rows);
         }

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -87,6 +87,13 @@ StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk
     }
 
     auto res = MapColumn::create(std::move(key_col), std::move(value_col), std::move(offsets));
+    // Flattening all pairs into the key/value columns may exceed the 4GB capacity of
+    // BinaryColumn's uint32 offsets within a single chunk, which would silently wrap
+    // and corrupt the data. Fail the query instead.
+    if (auto st = res->capacity_limit_reached(); !st.ok()) {
+        return Status::CapacityLimitExceed("map constructor result exceeds column capacity limit, " +
+                                           std::string(st.message()));
+    }
 
     if (all_const) {
         res->assign(num_rows, 0);

--- a/be/test/exprs/array_expr_test.cpp
+++ b/be/test/exprs/array_expr_test.cpp
@@ -19,12 +19,14 @@
 
 #include <utility>
 
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "gutil/casts.h"
 #include "testutil/column_test_helper.h"
 #include "testutil/exprs_test_helper.h"
+#include "testutil/parallel_test.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -188,6 +190,37 @@ TEST_F(ArrayExprTest, test_evaluate) {
         EXPECT_EQ(4, result->get(2).get_array()[1].get_int32());
         EXPECT_EQ(8, result->get(2).get_array()[2].get_int32());
     }
+}
+
+// NOLINTNEXTLINE
+GROUP_SLOW_PARALLEL_TEST(ArrayExprOverflowTest, test_flatten_bytes_exceed_uint32_capacity) {
+    // Two children share one 2100-row x 1MB varchar column, so the flattened element
+    // column is ~4.4GB and overflows BinaryColumn's uint32 offsets. Expect an explicit
+    // CapacityLimitExceed error instead of silently wrapped (corrupted) data.
+    // Transient peak memory is ~13GB due to bytes vector growth.
+    TypeDescriptor type_varchar(LogicalType::TYPE_VARCHAR);
+    type_varchar.len = 1048576;
+    TypeDescriptor type_arr_str;
+    type_arr_str.type = LogicalType::TYPE_ARRAY;
+    type_arr_str.children.push_back(type_varchar);
+
+    const size_t num_rows = 2100;
+    const std::string payload(1024 * 1024, 'x');
+    auto fat_column_builder = BinaryColumn::create();
+    fat_column_builder->reserve(num_rows);
+    for (size_t i = 0; i < num_rows; i++) {
+        fat_column_builder->append(Slice(payload));
+    }
+    BinaryColumn::Ptr fat_column = std::move(fat_column_builder);
+
+    ObjectPool pool;
+    std::unique_ptr<Expr> expr(ExprsTestHelper::create_array_expr(type_arr_str));
+    expr->add_child(pool.add(new MockExpr(type_varchar, fat_column)));
+    expr->add_child(pool.add(new MockExpr(type_varchar, fat_column)));
+
+    auto result = expr->evaluate_checked(nullptr, nullptr);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_capacity_limit_exceeded());
 }
 
 } // namespace starrocks

--- a/be/test/exprs/map_expr_test.cpp
+++ b/be/test/exprs/map_expr_test.cpp
@@ -17,11 +17,13 @@
 
 #include <utility>
 
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "exprs/array_expr.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "testutil/column_test_helper.h"
 #include "testutil/exprs_test_helper.h"
+#include "testutil/parallel_test.h"
 #include "types/logical_type.h"
 #include "util/slice.h"
 
@@ -155,6 +157,46 @@ TEST_F(MapExprTest, test_const_evaluate) {
         EXPECT_TRUE(result->is_map());
         ASSERT_EQ("{1:'a',4:'x'}", result->debug_string());
     }
+}
+
+// NOLINTNEXTLINE
+GROUP_SLOW_PARALLEL_TEST(MapExprOverflowTest, test_flatten_bytes_exceed_uint32_capacity) {
+    // Two key-value pairs (4 children) whose value columns share one 2100-row x 1MB
+    // varchar column, so the flattened value column is ~4.4GB and overflows
+    // BinaryColumn's uint32 offsets. Expect an explicit CapacityLimitExceed error.
+    // Transient peak memory is ~13GB due to bytes vector growth.
+    TypeDescriptor type_varchar(LogicalType::TYPE_VARCHAR);
+    type_varchar.len = 1048576;
+    TypeDescriptor type_map;
+    type_map.type = LogicalType::TYPE_MAP;
+    type_map.children.push_back(type_varchar);
+    type_map.children.push_back(type_varchar);
+
+    const size_t num_rows = 2100;
+    const std::string payload(1024 * 1024, 'x');
+    auto fat_column_builder = BinaryColumn::create();
+    auto key1_column_builder = BinaryColumn::create();
+    auto key2_column_builder = BinaryColumn::create();
+    fat_column_builder->reserve(num_rows);
+    for (size_t i = 0; i < num_rows; i++) {
+        fat_column_builder->append(Slice(payload));
+        key1_column_builder->append(Slice("k1"));
+        key2_column_builder->append(Slice("k2"));
+    }
+    BinaryColumn::Ptr fat_column = std::move(fat_column_builder);
+    BinaryColumn::Ptr key1_column = std::move(key1_column_builder);
+    BinaryColumn::Ptr key2_column = std::move(key2_column_builder);
+
+    ObjectPool pool;
+    std::unique_ptr<Expr> expr(ExprsTestHelper::create_map_expr(type_map));
+    expr->add_child(pool.add(new MockExpr(type_varchar, key1_column)));
+    expr->add_child(pool.add(new MockExpr(type_varchar, fat_column)));
+    expr->add_child(pool.add(new MockExpr(type_varchar, key2_column)));
+    expr->add_child(pool.add(new MockExpr(type_varchar, fat_column)));
+
+    auto result = expr->evaluate_checked(nullptr, nullptr);
+    ASSERT_FALSE(result.ok());
+    ASSERT_TRUE(result.status().is_capacity_limit_exceeded());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`ArrayExpr` and `MapExpr` flatten all children into a single element (key/value) column. When the flattened bytes of one chunk exceed `UINT32_MAX` (~4.3GB), `BinaryColumn`'s uint32 offsets silently wrap around while the bytes buffer keeps growing: every element keeps its correct length but points at bytes ~4GB earlier in the buffer. The query returns silently corrupted `ARRAY<VARCHAR>` / `MAP` values, which can then be persisted by CTAS / INSERT / MV refresh.

Unlike function calls (`function_call_expr.cpp`) and `array_map` / `array_agg`, these two constructor exprs performed no capacity check at all.

**Why this PR targets branch-4.1 instead of main**: on main this is already fixed at the root by #74549 / #74838 (`AdaptiveOffsets` promote `BinaryColumn` offsets to uint64, and `capacity_limit_reached()` was relaxed to 2^64), so oversized results are legal there and this guard is unnecessary (the added UT would even fail on main by design). That rework is an invasive Enhancement and not backportable, while release branches still use `Buffer<uint32_t>` offsets and silently corrupt data, so they need this explicit guard.

## What I'm doing:

Add a `capacity_limit_reached()` check on the constructed column in `ArrayExpr::evaluate_checked` and `MapExpr::evaluate_checked`, so such queries now fail with an explicit `CapacityLimitExceed` error instead of returning wrong data.

Workaround for affected queries: reduce `chunk_size` or split the constructor expression.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)


