### PR TITLE
[BugFix] Invalidate Iceberg table metadata cache after sink commit (backport #67230)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1609,8 +1609,9 @@ public class IcebergMetadata implements ConnectorMetadata {
             LOG.error("Failed to commit iceberg transaction on {}.{}", dbName, tableName, e);
             throw new StarRocksConnectorException(e.getMessage());
         } finally {
-            // Do we really need that? because partition cache is associated with snapshotId
-            icebergCatalog.invalidatePartitionCache(dbName, tableName);
+            // Invalidate this FE's cached table after commit so a read-after-write sees the new snapshot.
+            tables.remove(TableIdentifier.of(dbName, tableName));
+            icebergCatalog.invalidateCache(dbName, tableName);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

On branch-4.0, an Iceberg `INSERT` commits the new snapshot but `finishSink` only invalidates the partition cache and asynchronously refreshes *other* FEs — it never invalidates the committing FE's own cached `Table`. So a read that immediately follows the commit on the same FE resolves its scan against the **stale pre-commit snapshot**.

This is most damaging for a self-referential `INSERT INTO t SELECT * FROM t`: its `SELECT` reads the stale (smaller) snapshot, so it appends fewer rows and **permanently loses data**. Reproduced on a hive Iceberg catalog — the doubling `insert into t select * from t` intermittently committed fewer than 2x rows (e.g. 1,280,000 → 960,000), which cascades into a short `count(*)` and a wrong `c_map != ...` result.

`main` already fixed this: `finishSink` invalidates the local table cache after commit (added in #67230, later refactored into `invalidateCacheAfterCommit`/`commitWithCleanup` by #67567). branch-4.0 never received it — its `finishSink` `finally` still carries the old `// Do we really need that?` comment and only calls `invalidatePartitionCache`.

## What I'm doing:

Invalidate this FE's cached table in the `finishSink` `finally` block after the commit, so a read-after-write sees the new snapshot:

```java
} finally {
    tables.remove(TableIdentifier.of(dbName, tableName));
    icebergCatalog.invalidateCache(dbName, tableName);
}
```

This ports `main`'s post-commit invalidation to branch-4.0 using the existing `invalidateCache` (branch-4.0 has no narrow `invalidateTableCache`; `invalidateCache` is a superset that also clears the manifest/partition caches, which is safe). Verified on a live hive-Iceberg cluster: the doubling ingest that previously lost rows on the first run is now correct across 30/30 runs once the cache is invalidated after commit.

Fixes #issue: N/A — backport of the `finishSink` cache invalidation (#67230 / #67567) missing on branch-4.0; found via Iceberg read-after-write testing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

