### PR TITLE
[Tool] ai-analysis workflow: add limit input (default 10)

### DIFF
--- a/.github/workflows/unstable-case-ai-analysis.yml
+++ b/.github/workflows/unstable-case-ai-analysis.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: 'all'
         type: string
+      limit:
+        description: 'Max cases to AI-analyze this run (caps claude calls/cost; 0 = no limit)'
+        required: false
+        default: '10'
+        type: string
 
 permissions:
   contents: read
@@ -66,6 +71,7 @@ jobs:
             --branch "${BRANCH}" \
             --types "${CASE_TYPES}" \
             --history-dir "${HIST}" \
+            --limit "${{ inputs.limit || '10' }}" \
             --out "${WORK}/out"
 
           # Publish to OSS (timestamped). Do NOT mask a failed upload with a


### PR DESCRIPTION
## Why I'm doing:
Companion to **StarRocks/ci-tool** `analyze_unstable_cases.py --limit`. `ai-analysis` currently AI-analyzes every blacklisted case with failure history (hundreds of `claude` calls). This adds a knob to bound it for quick/partial runs.

**Merge AFTER the ci-tool PR** — the old script has no `--limit` and would argparse-error.

## What I'm doing:
- `unstable-case-ai-analysis.yml`: new optional `limit` input (default `10`), passed as `--limit "${{ inputs.limit || '10' }}"` to `analyze_unstable_cases.py`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

(CI tooling only: a manual ai-analysis run now caps analyzed cases at `limit` (default 10) instead of the whole blacklist. No product code.)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
