### PR TITLE
[Tool] ai-analysis: render analysis into run Summary

### DIFF
--- a/.github/workflows/unstable-case-ai-analysis.yml
+++ b/.github/workflows/unstable-case-ai-analysis.yml
@@ -74,6 +74,15 @@ jobs:
             --limit "${{ inputs.limit || '10' }}" \
             --out "${WORK}/out"
 
+          # Surface the analysis directly on the run Summary page — this is the
+          # primary, always-visible output (no need to open OSS or download the
+          # artifact). analyze_unstable_cases.py writes analysis.md with each
+          # case in a <details> block (header stays visible collapsed), so it
+          # stays scannable and under GitHub's 1 MB step-summary cap.
+          if [ -f "${WORK}/out/analysis.md" ]; then
+            cat "${WORK}/out/analysis.md" >> "$GITHUB_STEP_SUMMARY" || true
+          fi
+
           # Publish to OSS (timestamped). Do NOT mask a failed upload with a
           # fake success URL — the report is this workflow's output. The report
           # dir is also attached as a run artifact (next step, always), so it is
@@ -82,12 +91,15 @@ jobs:
           TS=$(date -u +%Y%m%d-%H%M%S)
           OUT_OSS="oss://${bucket}/unstable-case-ai-analysis/${ch_branch}/${TS}/"
           if ${_oss} cp "${WORK}/out/analysis.html" "${OUT_OSS}analysis.html" -f \
-             && ${_oss} cp "${WORK}/out/analysis.json" "${OUT_OSS}analysis.json" -f; then
+             && ${_oss} cp "${WORK}/out/analysis.json" "${OUT_OSS}analysis.json" -f \
+             && ${_oss} cp "${WORK}/out/analysis.md"   "${OUT_OSS}analysis.md"   -f; then
             echo "AI analysis report: ${OUT_OSS}analysis.html"
-            echo "AI analysis report (OSS): ${OUT_OSS}analysis.html" >> "$GITHUB_STEP_SUMMARY" || true
+            echo "" >> "$GITHUB_STEP_SUMMARY" || true
+            echo "_Full report (html): ${OUT_OSS}analysis.html_" >> "$GITHUB_STEP_SUMMARY" || true
           else
             echo "::warning::OSS upload failed — report is attached as the 'ai-analysis-report' run artifact instead."
-            echo "OSS upload failed — download the 'ai-analysis-report' run artifact." >> "$GITHUB_STEP_SUMMARY" || true
+            echo "" >> "$GITHUB_STEP_SUMMARY" || true
+            echo "_OSS upload failed — download the 'ai-analysis-report' run artifact for the html report._" >> "$GITHUB_STEP_SUMMARY" || true
           fi
 
       - name: Upload report artifact (fallback, always)


### PR DESCRIPTION
## Why I'm doing:
The ai-analysis workflow only wrote an `oss://.../analysis.html` link into the run Summary — not clickable, and you must open OSS or download the artifact to read any of the analysis.

## What I'm doing:
`cat` the new `analysis.md` (produced by ci-tool `analyze_unstable_cases.py`, StarRocks/ci-tool#4714) into `$GITHUB_STEP_SUMMARY`, so the per-case AI assessment is readable directly on the run's Summary page. Each case is in a `<details>` block (header visible when collapsed) — scannable and under GitHub's 1 MB step-summary cap. `analysis.md` is also uploaded to OSS; the OSS html link stays as a supplementary trailing line.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
