### PR TITLE
[Tool] unstable-case-review: owner-based bucket for the inspection package

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -4,8 +4,8 @@ name: UNSTABLE CASE REVIEW
 # Cases that now pass are auto-removed from unstable_case.json.
 # Still-failing cases get AI analysis in an HTML report uploaded to OSS.
 # Runs on the native ubuntu server ([self-hosted, ubuntu, ai]).
-# Manual-only for now (schedule removed): once validated on CelerData and
-# runners are also registered on StarRocks, a schedule can be re-added.
+# Manual-only for now (schedule removed): once validated and self-hosted
+# [ubuntu, ai] runners are registered, a schedule can be re-added.
 
 on:
   workflow_dispatch:
@@ -28,7 +28,7 @@ on:
         default: '3'
         type: string
       grant_probation:
-        description: 'Open a PR moving now-passing blacklisted cases into PROBATION (default false; needs SYNC_PAT, i.e. CelerData)'
+        description: 'Open a PR moving now-passing blacklisted cases into PROBATION (default false; needs SYNC_PAT to open the PR)'
         required: false
         default: 'false'
         type: string
@@ -189,25 +189,23 @@ jobs:
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null && source lib/init.sh
           ./bin/elastic-cluster.sh --template ci-admit --linuxdistro ubuntu
           _oss="/var/local/env/ossutil64 --config-file /root/.ossutilconfig"
-          # Deploy the LATEST per-PR build under Release/pr/ (NOT Release/inspection/).
-          # The per-PR CI publishes the real product build here for BOTH repos —
-          # starrocks-ci-release/.../StarRocks-*.tar.gz and
-          # celerdata-ci-release/.../CelerData-*.tar.gz. The old code hardcoded
-          # starrocks-ci-release + the inspection path; on CelerData that deployed
-          # a StarRocks COMMUNITY binary (inspection-pipeline never populates
-          # CelerData's inspection dir), so enterprise-only cases could never
-          # recover. Derive the bucket from the owner, pick the newest BE tar by
-          # upload time, and derive its FE sibling from the same path — product
-          # name and PR-dir are taken straight from the object key, so this is
-          # owner/product-agnostic.
+          # Deploy the latest inspection build. The inspection-pipeline does a
+          # periodic FULL build of the branch (BE+FE together, keyed by the
+          # 40-char commit sha) under <owner>-ci-release/<branch>/Release/inspection/pr/ubuntu/,
+          # so it is ALWAYS a complete pair. The bucket and the tar-name prefix are
+          # derived from github.repository_owner, so the same workflow works in
+          # whatever org/fork runs it (no hardcoded owner).
+          # NOTE: OSS auto-deletes these after 3 days, so the inspection-pipeline
+          # schedule must be enabled for ${BRANCH} or there is nothing to deploy.
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           [[ "$owner" == "starrocks" ]] && bucket="starrocks-ci-release" || bucket="${owner}-ci-release"
-          _base="oss://${bucket}/${BRANCH}/Release/pr/ubuntu"
-          # ossutil ls lines start with the upload date, so `sort -r` = newest first.
-          BE_OUTPUT_TAR=$(${_oss} ls "${_base}/" | grep -E '/be/.*-BE\.tar\.gz' | sort -r | head -1 | awk '{print $NF}')
-          [[ -z "${BE_OUTPUT_TAR}" ]] && echo "::error::No package found under ${_base}/" && exit 1
-          FE_OUTPUT_TAR=$(echo "${BE_OUTPUT_TAR}" | sed -e 's#/be/#/fe/#' -e 's#-BE\.tar\.gz#-FE.tar.gz#')
-          echo "Inspection commit: ${LATEST_SHA}"
+          product="${{ github.repository_owner }}"   # tar-name prefix = the org name
+          _base="oss://${bucket}/${BRANCH}/Release/inspection/pr/ubuntu"
+          LATEST_SHA=$(${_oss} ls "${_base}/" | grep '\-BE\.tar\.gz' | sort -r | head -1 | awk '{print $NF}' | grep -oE '[a-f0-9]{40}')
+          [[ -z "${LATEST_SHA}" ]] && echo "::error::No inspection package under ${_base}/ -- is the inspection-pipeline schedule enabled for ${BRANCH}? (packages auto-delete after 3 days)" && exit 1
+          SHORT_SHA=${LATEST_SHA:0:7}
+          BE_OUTPUT_TAR="${_base}/${LATEST_SHA}/be/${product}-${SHORT_SHA}-BE.tar.gz"
+          FE_OUTPUT_TAR="${_base}/${LATEST_SHA}/fe/${product}-${SHORT_SHA}-FE.tar.gz"
           echo "BE: ${BE_OUTPUT_TAR}"
           echo "FE: ${FE_OUTPUT_TAR}"
           export BE_OUTPUT_TAR FE_OUTPUT_TAR LINUX_DISTRO=ubuntu
@@ -328,7 +326,7 @@ jobs:
         # unstable_case_recovered_pool.json; the promote-demote workflow drips them
         # into probation. This step opens a PR carrying the pool update.
         # Opt-in via the grant_probation input (kept for backward compat — same
-        # cron/dispatch flag). Needs SYNC_PAT (CelerData) and ubuntu/ai runners.
+        # cron/dispatch flag). Needs SYNC_PAT and [ubuntu, ai] runners.
         if: ${{ inputs.grant_probation == 'true' }}
         id: open_pr
         env:


### PR DESCRIPTION
## Why I'm doing:
The `unstable-case-review` deploy step hardcoded the package path to `oss://starrocks-ci-release/${BRANCH}/Release/inspection/pr/ubuntu` with a fixed tar-name prefix. A fork whose builds land in a different bucket (`<owner>-ci-release`) could not deploy its own build.

## What I'm doing:
Derive the bucket and the tar-name prefix from `github.repository_owner`, so the same workflow works in whatever org/fork runs it. The inspection path and the "latest 40-char-sha, complete BE+FE pair" selection are unchanged — the inspection-pipeline produces a periodic full build of the branch (BE+FE together, keyed by the commit sha), so it is always a complete pair. Also drop internal-org references from this workflow's comments/descriptions.

Operational note: OSS auto-deletes inspection packages after 3 days, so the inspection-pipeline schedule must be enabled for the branch under review.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
