### PR TITLE
[Tool] inspection-pipeline: re-enable scheduled runs

### DIFF
--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -1,13 +1,15 @@
 name: INSPECTION PIPELINE
 
 on:
-  # Scheduled inspection runs disabled 2026-07-08: the runs are not currently
-  # meaningful. Kept here (commented) for easy re-enable. Manual dispatch stays.
-  # schedule:
-  #   - cron: "0 0 * * 1-5"
-  #   - cron: "30 4 * * 1-5"
-  #   - cron: "0 11 * * 1,3,5"
-  #   - cron: "0 11 * * 2,4"
+  # Re-enabled 2026-07-15: unstable-case-review deploys the periodic inspection
+  # build (per-branch, keyed by commit sha) and OSS auto-deletes those packages
+  # after 3 days, so the schedule must run to keep a fresh package available for
+  # each reviewed branch (main, branch-4.0.x, branch-4.1.x).
+  schedule:
+    - cron: "0 0 * * 1-5"
+    - cron: "30 4 * * 1-5"
+    - cron: "0 11 * * 1,3,5"
+    - cron: "0 11 * * 2,4"
   workflow_dispatch:
     inputs:
       BRANCH:


### PR DESCRIPTION
## Why I'm doing:
Scheduled inspection runs were commented out by #75995 on 2026-07-08. The `unstable-case-review` workflow deploys the periodic **inspection** build to re-run flaky cases, and OSS auto-deletes those packages after **3 days** — so with the schedule off, `<owner>-ci-release/<branch>/Release/inspection/pr/ubuntu/` goes empty and the review has no build to deploy.

## What I'm doing:
Re-enable the four schedule crons (restoring the original behavior). Manual `workflow_dispatch` is unchanged. This keeps a fresh inspection package available for each reviewed branch.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
