### PR TITLE
[Refactor] Unify SplitTabletJobFactory factory entry points

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJobFactory.java
@@ -73,24 +73,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
      */
     @Override
     public TabletReshardJob createTabletReshardJob() throws StarRocksException {
-        if (!table.isCloudNativeTableOrMaterializedView()) {
-            throw new StarRocksException("Unsupported table type " + table.getType()
-                    + " in table " + db.getFullName() + '.' + table.getName());
-        }
-
-        if (!table.isRangeDistribution()) {
-            throw new StarRocksException("Unsupported distribution type " + table.getDefaultDistributionInfo().getType()
-                    + " in table " + db.getFullName() + '.' + table.getName());
-        }
-
-        // Block re-split while any peer GroupId is unstable: range-colocate group membership is
-        // shared across DBs, so a still-unaligned split would compound the unaligned state.
-        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
-        if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameColocateGroupIdUnstable(myGroupId.grpId)) {
-            throw new StarRocksException("Cannot split tablets for range-colocate group "
-                    + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
-        }
+        validateTableLevel(db, table);
 
         Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = createReshardingPhysicalPartitions();
         if (reshardingPhysicalPartitions.isEmpty()) {
@@ -98,140 +81,37 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + db.getFullName() + '.' + table.getName());
         }
 
-        long jobId = GlobalStateMgr.getCurrentState().getNextId();
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+        return newSplitTabletJob(db, table, reshardingPhysicalPartitions);
     }
 
     /**
-     * external boundaries entry point. Build a TabletReshardJob
-     * that splits exactly one tablet using FE-supplied K-1 boundaries
-     * instead of letting BE compute boundaries from segment distribution.
+     * External-boundaries entry point. Builds ONE {@link SplitTabletJob} whose splittingTablets
+     * span every entry in {@code oldTabletIdToRanges}, using FE-supplied K-1 boundaries instead
+     * of letting BE compute boundaries from segment distribution. Handles one or many tablets;
+     * a single-entry map is the single-tablet case.
      *
-     * <p>The new-tablet count is implied by {@code newTabletRanges.size()} and
-     * must be >= 2. FE owns range validity at this layer; BE re-validates
-     * structural and schema-aware invariants and falls back to an identical
-     * tablet on any mismatch.
+     * <p>The new-tablet count for each tablet is implied by its range-list size and must be
+     * >= 2. FE owns range validity at this layer; BE re-validates structural and schema-aware
+     * invariants and falls back to an identical tablet on any mismatch.
      *
-     * @throws IllegalArgumentException when {@code newTabletRanges} is null or
-     *         its size is outside {@code [2, tablet_reshard_max_split_count]}.
-     * @throws StarRocksException when table-level preconditions fail (not
-     *         cloud-native, not range-distribution, not in NORMAL state, or a
-     *         colocate peer is unstable), or the catalog lookup fails for
-     *         {@code oldTabletId}.
+     * <p>The job is metadata-only at this point; StarOS shard allocation happens later in
+     * {@link SplitTabletJob#createShardsOnStarOS} after admission, which iterates
+     * {@code reshardingPhysicalPartitions} and so handles multiple partitions with no further
+     * substrate change.
+     *
+     * <p>No partial state is left behind on throw — the factory has no side effects (no shard
+     * allocation, no catalog mutation).
+     *
+     * @throws IllegalArgumentException when {@code oldTabletIdToRanges} is empty or an entry's
+     *         range count is outside {@code [2, tablet_reshard_max_split_count]}.
+     * @throws StarRocksException when table-level preconditions fail (not cloud-native, not
+     *         range-distribution, not in NORMAL state, or a colocate peer is unstable), or
+     *         catalog lookup fails for any input old tablet id.
      */
-    public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table, long oldTabletId,
-            List<TabletRange> newTabletRanges) throws StarRocksException {
-        validateTableLevel(db, table);
-        validateRangeListShape(newTabletRanges);
-
-        Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
-
-        try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
-            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw new StarRocksException("Unexpected table state " + table.getState()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            TabletMeta tabletMeta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
-                    .getTabletMeta(oldTabletId);
-            // getTabletMeta returns null (raw map miss) when the tablet is
-            // unknown — distinct from getTabletMetaList's NOT_EXIST sentinel.
-            if (tabletMeta == null || tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META
-                    || tabletMeta.getTableId() != table.getId()) {
-                throw new StarRocksException("Cannot find tablet " + oldTabletId
-                        + " in inverted index in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(tabletMeta.getPhysicalPartitionId());
-            if (physicalPartition == null) {
-                throw new StarRocksException("Cannot find physical partition "
-                        + tabletMeta.getPhysicalPartitionId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
-            if (index == null) {
-                throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-            if (index.getState() != IndexState.NORMAL) {
-                throw new StarRocksException("Not a normal state materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-            if (index.getTablet(oldTabletId) == null) {
-                throw new StarRocksException("Cannot find tablet " + oldTabletId
-                        + " in materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            SplittingTablet splittingTablet = createSplittingTablet(oldTabletId, newTabletRanges);
-
-            // Build the full resharding-tablet list: external boundaries for the chosen
-            // tablet, IdenticalTablet for siblings in the same index.
-            List<ReshardingTablet> reshardingTablets = new ArrayList<>();
-            for (Tablet sibling : index.getTablets()) {
-                if (sibling.getId() == oldTabletId) {
-                    reshardingTablets.add(splittingTablet);
-                } else {
-                    reshardingTablets.add(createIdenticalTablet(sibling.getId()));
-                }
-            }
-
-            Map<Long, ReshardingMaterializedIndex> reshardingIndexes = new HashMap<>();
-            reshardingIndexes.put(index.getId(),
-                    new ReshardingMaterializedIndex(index.getId(),
-                            createMaterializedIndex(index, reshardingTablets),
-                            reshardingTablets));
-
-            reshardingPhysicalPartitions.put(physicalPartition.getId(),
-                    new ReshardingPhysicalPartition(physicalPartition.getId(), reshardingIndexes));
-        }
-
-        // Surface bad caller-supplied ranges synchronously, before the job is journaled
-        // and mutates table state. SplitTabletJob.runPendingJob would otherwise hit a
-        // Preconditions failure in createShardsOnStarOS, abort the job, and force the
-        // operator to fish the error out of SHOW TABLET RESHARD JOBS instead of seeing
-        // it on the DDL statement itself.
-        verifyNewTabletRanges(table, reshardingPhysicalPartitions);
-
-        long jobId = GlobalStateMgr.getCurrentState().getNextId();
-        // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
-        // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
-        // The triggering load's warehouse is applied by the caller via TabletReshardJob#setWarehouseId.
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
-    }
-
-    /**
-     * Multi-tablet variant of {@link #forExternalBoundaries}. Builds ONE
-     * {@link SplitTabletJob} whose splittingTablets list spans every entry in
-     * {@code oldTabletIdToRanges}. The job is metadata-only at this point;
-     * StarOS shard allocation happens later in
-     * {@link SplitTabletJob#createShardsOnStarOS} after admission, which already
-     * iterates {@code reshardingPhysicalPartitions} and so handles multiple
-     * partitions with no further substrate change.
-     *
-     * <p>Per-entry validation mirrors {@link #forExternalBoundaries}: each
-     * range list size is checked against {@code tablet_reshard_max_split_count}
-     * and each range list is shape-validated.
-     *
-     * <p>No partial state is left behind on throw — the factory has no side
-     * effects (no shard allocation, no catalog mutation).
-     *
-     * @throws IllegalArgumentException when {@code oldTabletIdToRanges} is
-     *         empty or an entry's range count is outside
-     *         {@code [2, tablet_reshard_max_split_count]}.
-     * @throws StarRocksException when table-level preconditions fail (not
-     *         cloud-native, not range-distribution, not in NORMAL state, or a
-     *         colocate peer is unstable), or catalog lookup fails for any
-     *         input old tablet id.
-     */
-    public static TabletReshardJob forExternalBoundariesMultiTablet(Database db, OlapTable table,
+    public static TabletReshardJob forExternalBoundaries(Database db, OlapTable table,
             Map<Long, List<TabletRange>> oldTabletIdToRanges) throws StarRocksException {
         Preconditions.checkArgument(oldTabletIdToRanges != null && !oldTabletIdToRanges.isEmpty(),
-                "External-boundaries multi-tablet split requires a non-empty oldTabletIdToRanges map");
+                "External-boundaries split requires a non-empty oldTabletIdToRanges map");
 
         validateTableLevel(db, table);
 
@@ -244,10 +124,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
 
         try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
-            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw new StarRocksException("Unexpected table state " + table.getState()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
+            checkTableNormalState(db, table);
 
             // Group input entries by (physicalPartition, materializedIndex) so each
             // ReshardingMaterializedIndex carries all of its targets in one pass.
@@ -256,44 +133,13 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
 
             for (Map.Entry<Long, List<TabletRange>> entry : oldTabletIdToRanges.entrySet()) {
                 long oldTabletId = entry.getKey();
-
                 TabletMeta tabletMeta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex()
                         .getTabletMeta(oldTabletId);
-                if (tabletMeta == null || tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META
-                        || tabletMeta.getTableId() != table.getId()) {
-                    throw new StarRocksException("Cannot find tablet " + oldTabletId
-                            + " in inverted index in table " + db.getFullName() + '.' + table.getName());
-                }
-
-                PhysicalPartition physicalPartition = table.getPhysicalPartition(tabletMeta.getPhysicalPartitionId());
-                if (physicalPartition == null) {
-                    throw new StarRocksException("Cannot find physical partition "
-                            + tabletMeta.getPhysicalPartitionId()
-                            + " in table " + db.getFullName() + '.' + table.getName());
-                }
-
-                MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
-                if (index == null) {
-                    throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
-                            + " in physical partition " + physicalPartition.getId()
-                            + " in table " + db.getFullName() + '.' + table.getName());
-                }
-                if (index.getState() != IndexState.NORMAL) {
-                    throw new StarRocksException("Not a normal state materialized index "
-                            + tabletMeta.getIndexId()
-                            + " in physical partition " + physicalPartition.getId()
-                            + " in table " + db.getFullName() + '.' + table.getName());
-                }
-                if (index.getTablet(oldTabletId) == null) {
-                    throw new StarRocksException("Cannot find tablet " + oldTabletId
-                            + " in materialized index " + tabletMeta.getIndexId()
-                            + " in physical partition " + physicalPartition.getId()
-                            + " in table " + db.getFullName() + '.' + table.getName());
-                }
+                ResolvedTablet resolved = resolveTabletMeta(db, table, oldTabletId, tabletMeta);
 
                 groupedByPartitionAndIndex
-                        .computeIfAbsent(physicalPartition.getId(), k -> new LinkedHashMap<>())
-                        .computeIfAbsent(index.getId(), k -> new LinkedHashMap<>())
+                        .computeIfAbsent(resolved.physicalPartition().getId(), k -> new LinkedHashMap<>())
+                        .computeIfAbsent(resolved.index().getId(), k -> new LinkedHashMap<>())
                         .put(oldTabletId, entry.getValue());
             }
 
@@ -335,35 +181,33 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                         }
                     }
 
-                    reshardingIndexes.put(indexId,
-                            new ReshardingMaterializedIndex(indexId,
-                                    createMaterializedIndex(index, reshardingTablets),
-                                    reshardingTablets));
+                    reshardingIndexes.put(indexId, newReshardingIndex(index, reshardingTablets));
                 }
                 reshardingPhysicalPartitions.put(physicalPartitionId,
                         new ReshardingPhysicalPartition(physicalPartitionId, reshardingIndexes));
             }
         }
 
-        // Same synchronous range-vs-colocate check as the single-tablet path:
-        // bad caller-supplied ranges surface at the DDL boundary instead of
-        // inside SplitTabletJob.createShardsOnStarOS after the job is journaled.
+        // Surface bad caller-supplied ranges synchronously, before the job is journaled
+        // and mutates table state. SplitTabletJob.runPendingJob would otherwise hit a
+        // Preconditions failure in createShardsOnStarOS, abort the job, and force the
+        // operator to fish the error out of SHOW TABLET RESHARD JOBS instead of seeing
+        // it on the DDL statement itself.
         verifyNewTabletRanges(table, reshardingPhysicalPartitions);
 
-        long jobId = GlobalStateMgr.getCurrentState().getNextId();
         // Pre-split: spread the new shards across compute nodes rather than PACKing them onto the
         // (empty) source tablet's single worker, so the load that follows parallelizes across BEs.
         // The triggering load's warehouse is applied by the caller via TabletReshardJob#setWarehouseId.
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+        return newSplitTabletJob(db, table, reshardingPhysicalPartitions);
     }
 
     /**
-     * Shared table-level preconditions for the external-boundaries factory
-     * variants: cloud-native + range distribution, plus the range-colocate
-     * unstable-group guard. Run BEFORE the table lock is acquired so a bad
-     * caller fails fast.
+     * Table-type + distribution preconditions shared by every factory entry:
+     * cloud-native and range-distribution. Excludes the unstable-group guard so
+     * {@link #forColocateAlignment} — which is the resolver of unstable state —
+     * can reuse this without the guard.
      */
-    private static void validateTableLevel(Database db, OlapTable table) throws StarRocksException {
+    private static void validateTableDistribution(Database db, OlapTable table) throws StarRocksException {
         if (!table.isCloudNativeTableOrMaterializedView()) {
             throw new StarRocksException("Unsupported table type " + table.getType()
                     + " in table " + db.getFullName() + '.' + table.getName());
@@ -373,14 +217,79 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + table.getDefaultDistributionInfo().getType()
                     + " in table " + db.getFullName() + '.' + table.getName());
         }
-        // Mirror the data-driven path's range-colocate unstable-group guard:
-        // refuse to start an external-boundaries split while any peer GroupId is unstable.
+    }
+
+    /**
+     * Shared table-level preconditions for the user-facing and external-boundaries
+     * entries: {@link #validateTableDistribution} plus the range-colocate
+     * unstable-group guard. Run BEFORE the table lock is acquired so a bad
+     * caller fails fast.
+     */
+    private static void validateTableLevel(Database db, OlapTable table) throws StarRocksException {
+        validateTableDistribution(db, table);
+        // Refuse to start a split while any peer GroupId is unstable: range-colocate group
+        // membership is shared across DBs, so a still-unaligned split compounds the unaligned state.
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         ColocateTableIndex.GroupId myGroupId = colocateTableIndex.getRangeColocateGroupId(table.getId());
         if (myGroupId != null && colocateTableIndex.isAnyGroupWithSameColocateGroupIdUnstable(myGroupId.grpId)) {
             throw new StarRocksException("Cannot split tablets for range-colocate group "
                     + myGroupId.grpId + ": group is unstable; wait for alignment to complete before retrying");
         }
+    }
+
+    /**
+     * In-lock guard: the table must be in NORMAL state to build a reshard job.
+     */
+    private static void checkTableNormalState(Database db, OlapTable table) throws StarRocksException {
+        if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+            throw new StarRocksException("Unexpected table state " + table.getState()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+    }
+
+    private record ResolvedTablet(PhysicalPartition physicalPartition, MaterializedIndex index, Tablet tablet) {
+    }
+
+    /**
+     * Resolves an old tablet id to its (physical partition, materialized index, tablet) triple,
+     * validating each level with the errors the factory entries share. Accepts a tablet meta
+     * fetched by either the single {@code getTabletMeta} (null on a raw-map miss) or the batch
+     * {@code getTabletMetaList} (NOT_EXIST sentinel) — both are treated as "not found".
+     */
+    private static ResolvedTablet resolveTabletMeta(Database db, OlapTable table, long tabletId,
+            TabletMeta tabletMeta) throws StarRocksException {
+        if (tabletMeta == null || tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META
+                || tabletMeta.getTableId() != table.getId()) {
+            throw new StarRocksException("Cannot find tablet " + tabletId
+                    + " in inverted index in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        PhysicalPartition physicalPartition = table.getPhysicalPartition(tabletMeta.getPhysicalPartitionId());
+        if (physicalPartition == null) {
+            throw new StarRocksException("Cannot find physical partition "
+                    + tabletMeta.getPhysicalPartitionId()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+
+        MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
+        if (index == null) {
+            throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
+                    + " in physical partition " + physicalPartition.getId()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        if (index.getState() != IndexState.NORMAL) {
+            throw new StarRocksException("Not a normal state materialized index " + tabletMeta.getIndexId()
+                    + " in physical partition " + physicalPartition.getId()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        Tablet tablet = index.getTablet(tabletId);
+        if (tablet == null) {
+            throw new StarRocksException("Cannot find tablet " + tabletId
+                    + " in materialized index " + tabletMeta.getIndexId()
+                    + " in physical partition " + physicalPartition.getId()
+                    + " in table " + db.getFullName() + '.' + table.getName());
+        }
+        return new ResolvedTablet(physicalPartition, index, tablet);
     }
 
     /**
@@ -448,10 +357,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
 
         try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
-            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw new StarRocksException("Unexpected table state " + table.getState()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
+            checkTableNormalState(db, table);
 
             if (splitTabletClause.getTabletList() != null) {
                 Map<PhysicalPartition, Map<MaterializedIndex, Collection<Tablet>>> tablets = getTabletsByTabletIds(
@@ -485,10 +391,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                         }
 
                         List<ReshardingTablet> reshardingTablets = createReshardingTablets(oldIndex, splittingTablets);
-                        reshardingIndexes.put(oldIndex.getId(),
-                                new ReshardingMaterializedIndex(oldIndex.getId(),
-                                        createMaterializedIndex(oldIndex, reshardingTablets),
-                                        reshardingTablets));
+                        reshardingIndexes.put(oldIndex.getId(), newReshardingIndex(oldIndex, reshardingTablets));
                     }
 
                     if (reshardingIndexes.isEmpty()) {
@@ -541,10 +444,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                         }
 
                         List<ReshardingTablet> reshardingTablets = createReshardingTablets(oldIndex, splittingTablets);
-                        reshardingIndexes.put(oldIndex.getId(),
-                                new ReshardingMaterializedIndex(oldIndex.getId(),
-                                        createMaterializedIndex(oldIndex, reshardingTablets),
-                                        reshardingTablets));
+                        reshardingIndexes.put(oldIndex.getId(), newReshardingIndex(oldIndex, reshardingTablets));
                     }
 
                     if (reshardingIndexes.isEmpty()) {
@@ -568,44 +468,11 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                 .getTabletMetaList(tabletIds);
         for (int i = 0; i < tabletMetas.size(); ++i) {
             long tabletId = tabletIds.get(i);
-            TabletMeta tabletMeta = tabletMetas.get(i);
-            if (tabletMeta == TabletInvertedIndex.NOT_EXIST_TABLET_META ||
-                    tabletMeta.getTableId() != table.getId()) {
-                throw new StarRocksException("Cannot find tablet " + tabletId
-                        + " in inverted index in table " + db.getFullName() + '.' + table.getName());
-            }
+            ResolvedTablet resolved = resolveTabletMeta(db, table, tabletId, tabletMetas.get(i));
 
-            PhysicalPartition physicalPartition = table.getPhysicalPartition(
-                    tabletMeta.getPhysicalPartitionId());
-            if (physicalPartition == null) {
-                throw new StarRocksException(
-                        "Cannot find physical partition " + tabletMeta.getPhysicalPartitionId()
-                                + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            MaterializedIndex index = physicalPartition.getIndex(tabletMeta.getIndexId());
-            if (index == null) {
-                throw new StarRocksException("Cannot find materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-            if (index.getState() != IndexState.NORMAL) {
-                throw new StarRocksException("Not a normal state materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            Tablet tablet = index.getTablet(tabletId);
-            if (tablet == null) {
-                throw new StarRocksException("Cannot find tablet " + tabletId
-                        + " in materialized index " + tabletMeta.getIndexId()
-                        + " in physical partition " + physicalPartition.getId()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
-
-            tablets.computeIfAbsent(physicalPartition, k -> new HashMap<>())
-                    .computeIfAbsent(index, k -> new HashSet<>())
-                    .add(tablet);
+            tablets.computeIfAbsent(resolved.physicalPartition(), k -> new HashMap<>())
+                    .computeIfAbsent(resolved.index(), k -> new HashSet<>())
+                    .add(resolved.tablet());
         }
 
         return tablets;
@@ -641,6 +508,19 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
         }
 
         return newIndex;
+    }
+
+    private static ReshardingMaterializedIndex newReshardingIndex(MaterializedIndex oldIndex,
+            List<ReshardingTablet> reshardingTablets) {
+        return new ReshardingMaterializedIndex(oldIndex.getId(),
+                createMaterializedIndex(oldIndex, reshardingTablets),
+                reshardingTablets);
+    }
+
+    private static TabletReshardJob newSplitTabletJob(Database db, OlapTable table,
+            Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions) {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
     }
 
     private static SplittingTablet createSplittingTablet(long oldTabletId, int newTabletCount) {
@@ -695,22 +575,13 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
             Map<Long, Map<Long, Map<Long, List<TabletRange>>>> alignmentMap) throws StarRocksException {
         Preconditions.checkArgument(alignmentMap != null && !alignmentMap.isEmpty(),
                 "alignmentMap must be non-empty");
-        if (!table.isCloudNativeTableOrMaterializedView()) {
-            throw new StarRocksException("Unsupported table type " + table.getType()
-                    + " in table " + db.getFullName() + '.' + table.getName());
-        }
-        if (!table.isRangeDistribution()) {
-            throw new StarRocksException("Unsupported distribution type "
-                    + table.getDefaultDistributionInfo().getType()
-                    + " in table " + db.getFullName() + '.' + table.getName());
-        }
+        // Deliberately NOT validateTableLevel: the checker is the resolver of unstable state, so
+        // it must act even while the group is unstable (see method javadoc). Distribution only.
+        validateTableDistribution(db, table);
 
         Map<Long, ReshardingPhysicalPartition> reshardingPhysicalPartitions = new HashMap<>();
         try (AutoCloseableLock lock = new AutoCloseableLock(db.getId(), table.getId(), LockType.READ)) {
-            if (table.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw new StarRocksException("Unexpected table state " + table.getState()
-                        + " in table " + db.getFullName() + '.' + table.getName());
-            }
+            checkTableNormalState(db, table);
             for (Map.Entry<Long, Map<Long, Map<Long, List<TabletRange>>>> partitionEntry : alignmentMap.entrySet()) {
                 long physicalPartitionId = partitionEntry.getKey();
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
@@ -738,10 +609,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                             reshardingTablets.add(createIdenticalTablet(sibling.getId()));
                         }
                     }
-                    reshardingIndexes.put(oldIndex.getId(),
-                            new ReshardingMaterializedIndex(oldIndex.getId(),
-                                    createMaterializedIndex(oldIndex, reshardingTablets),
-                                    reshardingTablets));
+                    reshardingIndexes.put(oldIndex.getId(), newReshardingIndex(oldIndex, reshardingTablets));
                 }
                 if (reshardingIndexes.isEmpty()) {
                     continue;
@@ -756,8 +624,7 @@ public class SplitTabletJobFactory implements TabletReshardJobFactory {
                     + db.getFullName() + '.' + table.getName());
         }
 
-        long jobId = GlobalStateMgr.getCurrentState().getNextId();
-        return new SplitTabletJob(jobId, db.getId(), table.getId(), reshardingPhysicalPartitions);
+        return newSplitTabletJob(db, table, reshardingPhysicalPartitions);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipeline.java
@@ -50,9 +50,8 @@ import java.util.stream.Collectors;
 /**
  * Production {@link PreSplitPipeline} composing the FE-side sampler tiers,
  * {@link BoundaryPlanner}, and {@link TabletReshardJobMgr}. The job itself comes
- * from {@link SplitTabletJobFactory#forExternalBoundaries} when a single visible
- * index is split, or {@link SplitTabletJobFactory#forExternalBoundariesMultiTablet}
- * when multiple visible indexes are split together. Constructor-injected
+ * from {@link SplitTabletJobFactory#forExternalBoundaries}, which builds one job
+ * spanning every split tablet (one or many visible indexes). Constructor-injected
  * dependencies keep the class testable without static mocking.
  *
  * <p>Tier routing: meta tier ({@link ParquetMetadataSampler#tryPlan}) is invoked
@@ -101,8 +100,8 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
     private final long fileTotalBytes;
     private final Duration pollInterval;
     private final Clock clock;
-    // The triggering load's compute resource, carried into the SplitTabletJobFactory job (forExternalBoundaries
-    // or forExternalBoundariesMultiTablet) so pre-split shards are scheduled in the load's warehouse.
+    // The triggering load's compute resource, carried into the SplitTabletJobFactory job
+    // (forExternalBoundaries) so pre-split shards are scheduled in the load's warehouse.
     // May be null (falls back to default).
     private final ComputeResource loadComputeResource;
 
@@ -253,13 +252,7 @@ public final class DefaultPreSplitPipeline implements PreSplitPipeline {
         if (!currentVisibleIndexMetaIds(database, table).equals(expectedIndexMetaIds)) {
             return Optional.empty();
         }
-        TabletReshardJob job;
-        if (oldTabletIdToRanges.size() == 1) {
-            Map.Entry<Long, List<TabletRange>> only = oldTabletIdToRanges.entrySet().iterator().next();
-            job = SplitTabletJobFactory.forExternalBoundaries(database, table, only.getKey(), only.getValue());
-        } else {
-            job = SplitTabletJobFactory.forExternalBoundariesMultiTablet(database, table, oldTabletIdToRanges);
-        }
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(database, table, oldTabletIdToRanges);
         // Carry the triggering load's warehouse so the job's shard creation + publish run there.
         if (loadComputeResource != null) {
             job.setWarehouseId(loadComputeResource.getWarehouseId());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinator.java
@@ -77,7 +77,7 @@ import java.util.function.BooleanSupplier;
  *       takes a {@link PartitionSampleGrouper#group grouped} list of
  *       {@link PartitionSamples}, pre-creates missing partitions, and
  *       submits ONE combined reshard via
- *       {@link com.starrocks.alter.reshard.SplitTabletJobFactory#forExternalBoundariesMultiTablet}.</li>
+ *       {@link com.starrocks.alter.reshard.SplitTabletJobFactory#forExternalBoundaries}.</li>
  * </ul>
  */
 public final class TabletPreSplitCoordinator {
@@ -568,7 +568,7 @@ public final class TabletPreSplitCoordinator {
      * </ul>
      *
      * <p>After the loop, when at least one partition contributed,
-     * {@link SplitTabletJobFactory#forExternalBoundariesMultiTablet} builds
+     * {@link SplitTabletJobFactory#forExternalBoundaries} builds
      * the combined job and
      * {@link com.starrocks.alter.reshard.TabletReshardJobMgr#addTabletReshardJob}
      * admits it. Any synchronous failure of either step downgrades the whole
@@ -630,7 +630,7 @@ public final class TabletPreSplitCoordinator {
         // SUBMIT_FAILED — the per-partition Submitted-pending markers were never promoted
         // to a real reshard job so callers see "no pre-split happened".
         try {
-            TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            TabletReshardJob combinedJob = SplitTabletJobFactory.forExternalBoundaries(
                     database, table, oldTabletIdToRanges);
             // Carry the load's acquired compute resource (the one that sized the split) so the job's
             // shard creation + publish run in the load's warehouse. Use prepared.computeResource() (passed
@@ -646,7 +646,7 @@ public final class TabletPreSplitCoordinator {
                     table.getName(), submitFailure.getMessage());
             return skipPostEligibility(SkipReason.SUBMIT_FAILED);
         } catch (RuntimeException submitFailure) {
-            // forExternalBoundariesMultiTablet validates the range list shape and may throw
+            // forExternalBoundaries validates the range list shape and may throw
             // IllegalArgumentException for bad caller-supplied ranges. Map to SUBMIT_FAILED
             // so the load still proceeds against the pre-create-only layout.
             LOG.warn("Pre-split combined submit rejected for table {}: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeColocateScanDispatch.java
@@ -242,8 +242,8 @@ public final class RangeColocateScanDispatch {
 
     /**
      * Converts the canonical-boundary list returned by {@link #computeForcedAlignmentBoundaries}
-     * into the per-new-tablet {@link TabletRange} list that the external boundaries
-     * {@code SplitTabletJobFactory.forExternalBoundaries} family of entries consumes
+     * into the per-new-tablet {@link TabletRange} list that the external-boundaries
+     * {@code SplitTabletJobFactory.forExternalBoundaries} entry point consumes
      * (or, for colocate alignment, the checker's per-new-tablet PACK assignment path).
      *
      * <p>For an old tablet with range {@code [lower, upper)} and K-1 canonical boundaries

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -689,7 +689,7 @@ public class SplitTabletJobColocateTest {
 
         // No exception expected — the default ColocateRange covers every colocate prefix.
         TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(
-                db, table, oldTabletId, newTabletRanges);
+                db, table, Map.of(oldTabletId, newTabletRanges));
         Assertions.assertNotNull(job);
     }
 
@@ -727,7 +727,7 @@ public class SplitTabletJobColocateTest {
 
         StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
                 () -> SplitTabletJobFactory.forExternalBoundaries(
-                        db, table, oldTabletId, newTabletRanges));
+                        db, table, Map.of(oldTabletId, newTabletRanges)));
         Assertions.assertTrue(thrown.getMessage().contains("no covering ColocateRange"),
                 "expected 'no covering ColocateRange' in message, got: " + thrown.getMessage());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobFactoryMultiTabletTest.java
@@ -50,13 +50,12 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Unit tests for {@link SplitTabletJobFactory#forExternalBoundariesMultiTablet}.
+ * Unit tests for {@link SplitTabletJobFactory#forExternalBoundaries}.
  *
  * <p>Substrate-only coverage: confirms the factory produces a metadata-only
  * {@link SplitTabletJob} (PENDING state, no shard allocation) whose
  * {@code splittingTablets} list spans every entry of the input
- * {@code Map<Long, List<TabletRange>>} and mirrors the existing single-tablet
- * factory's per-entry validation.
+ * {@code Map<Long, List<TabletRange>>}, with per-entry shape validation.
  */
 public class SplitTabletJobFactoryMultiTabletTest {
     private static ConnectContext connectContext;
@@ -84,17 +83,15 @@ public class SplitTabletJobFactoryMultiTabletTest {
         // The default range-distribution test table is born with one tablet
         // covering Range.all(). The multi-tablet tests below need at least 3
         // tablets in a single index so they can produce a map with 3 entries.
-        // Reuse the existing single-tablet factory to grow the index to >= 3
-        // tablets by splitting Range.all() into 3 contiguous external-boundaries
-        // ranges; that gives us a stable 3-tablet base for every test method.
+        // Grow the index to >= 3 tablets by inserting synthetic siblings; that
+        // gives us a stable 3-tablet base for every test method.
         ensureMultipleTablets();
     }
 
     /**
      * Bootstrap the shared static table to have at least 3 tablets in its
-     * latest base index by invoking the existing single-tablet
-     * {@code forExternalBoundaries} factory followed by a job run that drives
-     * the index to its final tablet set. Idempotent: skips when the index
+     * latest base index by inserting synthetic {@code LakeTablet} siblings
+     * directly. Idempotent: skips when the index
      * already has >= 3 tablets (e.g. the table was created with >1 buckets).
      */
     private static void ensureMultipleTablets() throws Exception {
@@ -116,7 +113,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
             Tablet tablet = new com.starrocks.lake.LakeTablet(tabletId, range);
             // updateInvertedIndex=true: the factory looks up each old tablet via
             // TabletInvertedIndex.getTabletMeta — synthetic siblings have to be
-            // registered there too, otherwise forExternalBoundariesMultiTablet
+            // registered there too, otherwise forExternalBoundaries
             // throws "Cannot find tablet ... in inverted index".
             index.addTablet(tablet, new com.starrocks.catalog.TabletMeta(
                     db.getId(), table.getId(), physicalPartition.getId(), index.getId(),
@@ -150,7 +147,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
             input.put(oldTabletId, twoRanges());
         }
 
-        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input);
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(db, table, input);
 
         Assertions.assertNotNull(job);
         Assertions.assertTrue(job instanceof SplitTabletJob, "factory must return SplitTabletJob");
@@ -184,7 +181,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
                 List.of(tabletRangeUpperOnly(50), tabletRange(50, 60), tabletRange(60, 70),
                         tabletRangeLowerOnly(70)));
 
-        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input);
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(db, table, input);
 
         // For each input entry, the produced SplittingTablet's
         // newTabletRanges must match the supplied list element-for-element.
@@ -217,7 +214,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
 
         // One bad entry must fail the whole factory call — no partial job is built.
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
     }
 
     @Test
@@ -247,46 +244,16 @@ public class SplitTabletJobFactoryMultiTabletTest {
             }
         };
 
-        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input);
+        TabletReshardJob job = SplitTabletJobFactory.forExternalBoundaries(db, table, input);
 
         // Two orthogonal checks: (1) StarOSAgent.createShardsForSplit was NOT
         // invoked during the factory call, and (2) the returned job is PENDING
         // (which is what allows the scheduler — not the factory — to allocate
         // shards later via SplitTabletJob.createShardsOnStarOS).
         Assertions.assertFalse(createShardsCalled.get(),
-                "factory must not invoke StarOSAgent.createShardsForSplit (parity with forExternalBoundaries)");
+                "factory must not invoke StarOSAgent.createShardsForSplit");
         Assertions.assertEquals(TabletReshardJob.JobState.PENDING, job.getJobState(),
-                "multi-tablet factory must return a PENDING job (no shard allocation yet)");
-    }
-
-    @Test
-    public void parityWithSingleTabletFactory() throws Exception {
-        List<Long> oldTabletIds = getOldTabletIds(1);
-        long oldTabletId = oldTabletIds.get(0);
-        List<TabletRange> ranges = twoRanges();
-
-        // Single-entry map through the multi-tablet factory must produce
-        // a job structurally equivalent to the single-tablet factory.
-        Map<Long, List<TabletRange>> input = new LinkedHashMap<>();
-        input.put(oldTabletId, ranges);
-        TabletReshardJob multiJob =
-                SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input);
-        TabletReshardJob singleJob =
-                SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId, ranges);
-
-        Assertions.assertEquals(singleJob.getClass(), multiJob.getClass(),
-                "multi-tablet and single-tablet factories must produce the same job class");
-
-        SplittingTablet multiSt = findSplittingTablet((SplitTabletJob) multiJob, oldTabletId);
-        SplittingTablet singleSt = findSplittingTablet((SplitTabletJob) singleJob, oldTabletId);
-
-        Assertions.assertEquals(singleSt.getNewTabletRanges().size(), multiSt.getNewTabletRanges().size(),
-                "newTabletRanges size must match the single-tablet factory output");
-        for (int i = 0; i < singleSt.getNewTabletRanges().size(); i++) {
-            Assertions.assertEquals(singleSt.getNewTabletRanges().get(i).getRange(),
-                    multiSt.getNewTabletRanges().get(i).getRange(),
-                    "newTabletRanges[" + i + "] must match the single-tablet factory");
-        }
+                "factory must return a PENDING job (no shard allocation yet)");
     }
 
     @Test
@@ -296,7 +263,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
         // so the operator gets the error synchronously instead of a silently
         // empty job that would later fail on submission.
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, empty));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, empty));
     }
 
     /**
@@ -353,7 +320,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
         input.put(oldTabletIdB, twoRanges());
 
         TabletReshardJob job =
-                SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, partitionedTable, input);
+                SplitTabletJobFactory.forExternalBoundaries(db, partitionedTable, input);
         SplitTabletJob splitJob = (SplitTabletJob) job;
 
         // Each ReshardingPhysicalPartition must enumerate exactly its own
@@ -394,9 +361,67 @@ public class SplitTabletJobFactoryMultiTabletTest {
         input.put(unknownTabletId, twoRanges());
 
         StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
-                () -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
         Assertions.assertTrue(thrown.getMessage().contains("Cannot find tablet"),
                 "unknown tablet id must report 'Cannot find tablet': " + thrown.getMessage());
+    }
+
+    @Test
+    public void rejectsTabletMetaWithMissingPhysicalPartition() {
+        // Inverted-index meta names this table but a physical partition id it does not
+        // contain -> resolveTabletMeta must surface "Cannot find physical partition".
+        long realIndexId = table.getAllPhysicalPartitions().iterator().next().getLatestBaseIndex().getId();
+        long tabletId = GlobalStateMgr.getCurrentState().getNextId();
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId,
+                new com.starrocks.catalog.TabletMeta(db.getId(), table.getId(),
+                        /*physicalPartitionId=*/ Long.MAX_VALUE, realIndexId,
+                        com.starrocks.thrift.TStorageMedium.HDD, true));
+        Map<Long, List<TabletRange>> input = new LinkedHashMap<>();
+        input.put(tabletId, twoRanges());
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
+        Assertions.assertTrue(thrown.getMessage().contains("Cannot find physical partition"),
+                "must report 'Cannot find physical partition': " + thrown.getMessage());
+    }
+
+    @Test
+    public void rejectsTabletMetaWithMissingIndex() {
+        // Meta resolves to a real physical partition but names an index id the partition
+        // does not contain -> "Cannot find materialized index".
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        long tabletId = GlobalStateMgr.getCurrentState().getNextId();
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId,
+                new com.starrocks.catalog.TabletMeta(db.getId(), table.getId(),
+                        physicalPartition.getId(), /*indexId=*/ Long.MAX_VALUE,
+                        com.starrocks.thrift.TStorageMedium.HDD, true));
+        Map<Long, List<TabletRange>> input = new LinkedHashMap<>();
+        input.put(tabletId, twoRanges());
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
+        Assertions.assertTrue(thrown.getMessage().contains("Cannot find materialized index"),
+                "must report 'Cannot find materialized index': " + thrown.getMessage());
+    }
+
+    @Test
+    public void rejectsTabletMetaAbsentFromItsIndex() {
+        // Meta resolves to a real, NORMAL index, but the tablet id is not one of that
+        // index's tablets -> "Cannot find tablet ... in materialized index".
+        PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
+        MaterializedIndex baseIndex = physicalPartition.getLatestBaseIndex();
+        long tabletId = GlobalStateMgr.getCurrentState().getNextId();
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().addTablet(tabletId,
+                new com.starrocks.catalog.TabletMeta(db.getId(), table.getId(),
+                        physicalPartition.getId(), baseIndex.getId(),
+                        com.starrocks.thrift.TStorageMedium.HDD, true));
+        Map<Long, List<TabletRange>> input = new LinkedHashMap<>();
+        input.put(tabletId, twoRanges());
+
+        StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
+        Assertions.assertTrue(thrown.getMessage().contains("in materialized index"),
+                "must report tablet missing from its materialized index: " + thrown.getMessage());
     }
 
     @Test
@@ -414,7 +439,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
         table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
         try {
             StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
-                    () -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, table, input));
+                    () -> SplitTabletJobFactory.forExternalBoundaries(db, table, input));
             Assertions.assertTrue(thrown.getMessage().contains("Unexpected table state"),
                     "non-NORMAL table must report 'Unexpected table state': " + thrown.getMessage());
         } finally {
@@ -438,7 +463,7 @@ public class SplitTabletJobFactoryMultiTabletTest {
         input.put(GlobalStateMgr.getCurrentState().getNextId(), twoRanges());
 
         StarRocksException thrown = Assertions.assertThrows(StarRocksException.class,
-                () -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(db, hashTable, input));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, hashTable, input));
         Assertions.assertTrue(thrown.getMessage().contains("Unsupported distribution type"),
                 "hash-distributed table must report 'Unsupported distribution type': " + thrown.getMessage());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -411,7 +411,7 @@ public class SplitTabletJobTest {
                 tabletRangeLowerOnly(200));
 
         TabletReshardJob tabletReshardJob = SplitTabletJobFactory.forExternalBoundaries(
-                db, table, oldTabletId, newTabletRanges);
+                db, table, Map.of(oldTabletId, newTabletRanges));
         Assertions.assertNotNull(tabletReshardJob);
 
         // The SplittingTablet inside the job must carry the FE-supplied
@@ -469,15 +469,15 @@ public class SplitTabletJobTest {
         PhysicalPartition physicalPartition = table.getAllPhysicalPartitions().iterator().next();
         long oldTabletId = physicalPartition.getLatestBaseIndex().getTablets().get(0).getId();
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId,
-                        List.of(tabletRange(0, 100))));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table,
+                        Map.of(oldTabletId, List.of(tabletRange(0, 100)))));
     }
 
     @Test
     public void testForExternalBoundariesRejectsUnknownTablet() {
         Assertions.assertThrows(StarRocksException.class,
-                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, /*oldTabletId=*/Long.MAX_VALUE,
-                        List.of(tabletRange(0, 100), tabletRange(100, 200))));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table,
+                        Map.of(/*oldTabletId=*/Long.MAX_VALUE, List.of(tabletRange(0, 100), tabletRange(100, 200)))));
     }
 
     // external boundaries must respect the tablet_reshard_max_split_count cap that the
@@ -493,7 +493,7 @@ public class SplitTabletJobTest {
             tooMany.add(tabletRange(i * 100, (i + 1) * 100));
         }
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, oldTabletId, tooMany));
+                () -> SplitTabletJobFactory.forExternalBoundaries(db, table, Map.of(oldTabletId, tooMany)));
     }
 
     // Installs a MockUp on MockLakeService that intercepts both publishVersion and

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/DefaultPreSplitPipelineTest.java
@@ -53,10 +53,8 @@ import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.DUMMY_CON
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintTuple;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -152,7 +150,7 @@ public class DefaultPreSplitPipelineTest {
 
         TabletReshardJob fakeJob = mock(TabletReshardJob.class);
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), eq(OLD_TABLET_ID), any()))
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), any()))
                     .thenReturn(fakeJob);
 
             DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, Clock.systemUTC());
@@ -176,7 +174,7 @@ public class DefaultPreSplitPipelineTest {
 
         TabletReshardJob fakeJob = mock(TabletReshardJob.class);
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), eq(OLD_TABLET_ID), any()))
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenReturn(fakeJob);
 
             DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, Clock.systemUTC());
@@ -208,7 +206,7 @@ public class DefaultPreSplitPipelineTest {
 
         TabletReshardJob fakeJob = mock(TabletReshardJob.class);
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), eq(OLD_TABLET_ID), any()))
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenReturn(fakeJob);
 
             DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, fixedClock);
@@ -417,9 +415,9 @@ public class DefaultPreSplitPipelineTest {
     // ---------- preSubmit: unified per-index plan ----------
 
     @Test
-    public void preSubmit_singleIndex_usesSingleTabletFactory() throws Exception {
-        // A single-index target list (base only, matching the pre-existing shape) must still
-        // route through forExternalBoundaries, never forExternalBoundariesMultiTablet.
+    public void preSubmit_singleIndex_buildsSingleEntryMapJob() throws Exception {
+        // A single-index target list (base only) builds one job from a single-entry
+        // {oldTabletId -> ranges} map.
         BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
         MetaTierSampler metaTier = (request, requestedTabletCount) -> metaTierResult;
         Sampler dataTier = request -> {
@@ -428,7 +426,10 @@ public class DefaultPreSplitPipelineTest {
 
         TabletReshardJob fakeJob = mock(TabletReshardJob.class);
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), eq(OLD_TABLET_ID), any()))
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
+                            eq(database), eq(table), mapCaptor.capture()))
                     .thenReturn(fakeJob);
 
             DefaultPreSplitPipeline pipeline = newPipeline(metaTier, dataTier, Clock.systemUTC());
@@ -437,14 +438,15 @@ public class DefaultPreSplitPipelineTest {
 
             Assertions.assertTrue(prepared.isPresent());
             Assertions.assertSame(fakeJob, prepared.get().payload());
-            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(1, map.size());
+            Assertions.assertTrue(map.containsKey(OLD_TABLET_ID));
         }
     }
 
     @Test
-    public void preSubmit_baseAndRollup_splitsBothViaMultiTablet() throws Exception {
-        // Both the base and a rollup produce cuts -> the {oldTabletId -> ranges} map has two
-        // entries -> forExternalBoundariesMultiTablet, never the single-tablet factory.
+    public void preSubmit_baseAndRollup_splitsBoth() throws Exception {
+        // Both the base and a rollup produce cuts -> the {oldTabletId -> ranges} map has two entries.
         stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
         BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
         MetaTierSampler metaTier = (request, requestedTabletCount) -> metaTierResult;
@@ -456,7 +458,7 @@ public class DefaultPreSplitPipelineTest {
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
             @SuppressWarnings("unchecked")
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                             eq(database), eq(table), mapCaptor.capture()))
                     .thenReturn(fakeJob);
 
@@ -470,15 +472,13 @@ public class DefaultPreSplitPipelineTest {
             Assertions.assertEquals(2, map.size());
             Assertions.assertTrue(map.containsKey(OLD_TABLET_ID));
             Assertions.assertTrue(map.containsKey(ROLLUP_TABLET_ID));
-            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), anyLong(), any()), never());
         }
     }
 
     @Test
-    public void preSubmit_rollupNoCuts_usesSingleTabletFactoryForBase() throws Exception {
+    public void preSubmit_rollupNoCuts_baseOnly() throws Exception {
         // The rollup's own sort key yields NO_SPLIT while the base still produces cuts -- the
-        // map ends up with only the base entry, so the single-tablet factory is used (a
-        // base-only submit is allowed).
+        // map ends up with only the base entry (a base-only submit is allowed).
         stubVisibleIndexMetas(BASE_INDEX_META_ID, ROLLUP_INDEX_META_ID);
         BoundaryPlannerResult metaTierResult = new BoundaryPlannerResult(List.of(bigintTuple(50)));
         MetaTierSampler metaTier = (request, requestedTabletCount) ->
@@ -489,7 +489,10 @@ public class DefaultPreSplitPipelineTest {
 
         TabletReshardJob fakeJob = mock(TabletReshardJob.class);
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(eq(database), eq(table), eq(OLD_TABLET_ID), any()))
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
+                            eq(database), eq(table), mapCaptor.capture()))
                     .thenReturn(fakeJob);
 
             DefaultPreSplitPipeline pipeline = newPipeline(baseAndRollupTargets(), metaTier, dataTier, Clock.systemUTC());
@@ -498,7 +501,9 @@ public class DefaultPreSplitPipelineTest {
 
             Assertions.assertTrue(prepared.isPresent(), "base-only cuts must still submit (allowed base-only)");
             Assertions.assertSame(fakeJob, prepared.get().payload());
-            mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
+            Map<Long, List<TabletRange>> map = mapCaptor.getValue();
+            Assertions.assertEquals(1, map.size());
+            Assertions.assertTrue(map.containsKey(OLD_TABLET_ID));
         }
     }
 
@@ -523,7 +528,7 @@ public class DefaultPreSplitPipelineTest {
         try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
             @SuppressWarnings("unchecked")
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = ArgumentCaptor.forClass(Map.class);
-            mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                             eq(database), eq(table), mapCaptor.capture()))
                     .thenReturn(fakeJob);
 
@@ -610,7 +615,7 @@ public class DefaultPreSplitPipelineTest {
 
             TabletReshardJob fakeJob = mock(TabletReshardJob.class);
             try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
-                mocked.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+                mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                         .thenReturn(fakeJob);
 
                 DefaultPreSplitPipeline pipeline =
@@ -661,7 +666,7 @@ public class DefaultPreSplitPipelineTest {
             TabletReshardJob fakeJob = mock(TabletReshardJob.class);
             try (MockedStatic<SplitTabletJobFactory> mocked = Mockito.mockStatic(SplitTabletJobFactory.class)) {
                 mocked.when(() -> SplitTabletJobFactory.forExternalBoundaries(
-                                eq(database), eq(table), eq(ROLLUP_TABLET_ID), any()))
+                                eq(database), eq(table), any()))
                         .thenReturn(fakeJob);
 
                 DefaultPreSplitPipeline pipeline =
@@ -671,7 +676,6 @@ public class DefaultPreSplitPipelineTest {
 
                 Assertions.assertTrue(prepared.isPresent(),
                         "rollup-only cuts must still submit (allowed base-no-cut/rollup-cut)");
-                mocked.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()), never());
             }
 
             Assertions.assertEquals(baselineTierCount + 1,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/TabletPreSplitCoordinatorMultiPartitionTest.java
@@ -177,7 +177,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -188,7 +188,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
             Assertions.assertTrue(mapCaptor.getValue().containsKey(21_001L));
             Assertions.assertTrue(mapCaptor.getValue().containsKey(21_002L));
             Assertions.assertTrue(mapCaptor.getValue().containsKey(21_003L));
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     times(1));
             verify(GlobalStateMgr.getCurrentState().getTabletReshardJobMgr(), times(1))
                     .addTabletReshardJob(combinedJob);
@@ -222,7 +222,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -257,7 +257,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
 
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -287,7 +287,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenThrow(new StarRocksException("synthetic factory rejection"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -313,7 +313,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenReturn(combinedJob);
             TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
             doThrow(new StarRocksException("capacity exceeded")).when(mgr).addTabletReshardJob(combinedJob);
@@ -342,7 +342,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -381,7 +381,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -439,7 +439,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                             }).when(mockLocker).unLockTableWithIntensiveDbLock(
                                     any(Long.class), any(Long.class), any(LockType.class));
                         })) {
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -466,7 +466,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.TABLE_NOT_NORMAL);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -490,7 +490,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -517,7 +517,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
         try (MockedStatic<GlobalStateMgr> gsm = mockGlobalStateMgrWithMgrs(null);
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()))
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()))
                     .thenThrow(new IllegalArgumentException("synthetic bad ranges"));
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -546,7 +546,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -570,7 +570,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -603,7 +603,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
 
             // Single entry dropped as PARTITION_NOT_ELIGIBLE_POST_CREATE -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -628,7 +628,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -662,7 +662,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
 
             // Single non-empty partition dropped -> overall NO_USEFUL_CUTS.
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -684,7 +684,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -710,7 +710,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -741,7 +741,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -780,7 +780,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -815,7 +815,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -845,7 +845,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -878,7 +878,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -907,7 +907,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -952,7 +952,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -981,7 +981,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -1017,7 +1017,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -1056,7 +1056,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of(ROLLUP_INDEX_META_ID));
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }
@@ -1078,7 +1078,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                 MockedStatic<SplitTabletJobFactory> factory = Mockito.mockStatic(SplitTabletJobFactory.class);
                 MockedConstruction<Locker> ignored = noopLockerCtor()) {
             ArgumentCaptor<Map<Long, List<TabletRange>>> mapCaptor = mapCaptor();
-            factory.when(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(
+            factory.when(() -> SplitTabletJobFactory.forExternalBoundaries(
                     eq(database), eq(table), mapCaptor.capture())).thenReturn(combinedJob);
 
             PreSplitOutcome outcome = TabletPreSplitCoordinator.submitForPartitionsCombined(
@@ -1115,7 +1115,7 @@ public class TabletPreSplitCoordinatorMultiPartitionTest {
                     database, table, entries, 3, freshConnectContext(), null, Set.of());
 
             assertSkippedReason(outcome, SkipReason.NO_USEFUL_CUTS);
-            factory.verify(() -> SplitTabletJobFactory.forExternalBoundariesMultiTablet(any(), any(), any()),
+            factory.verify(() -> SplitTabletJobFactory.forExternalBoundaries(any(), any(), any()),
                     never());
         }
     }


### PR DESCRIPTION
## Why I'm doing:

`SplitTabletJobFactory` exposed four entry points that build a `SplitTabletJob`, repeating the same mechanical blocks: table-level validation, the NORMAL-state check, the per-tablet catalog-lookup cascade (with identical error strings), the resharding-index construction, and the job-creation tail. The single-tablet `forExternalBoundaries` was a strict special case of the map-taking variant, and `DefaultPreSplitPipeline` branched on tablet count purely as ceremony.

## What I'm doing:

A behavior-preserving refactor that reduces the four entry points to three:

- Remove the single-tablet `forExternalBoundaries(db, table, long, List<TabletRange>)`. The map-taking `forExternalBoundaries(db, table, Map<Long, List<TabletRange>>)` (renamed from `forExternalBoundariesMultiTablet`) now handles one or many tablets, so `DefaultPreSplitPipeline` no longer branches on `size() == 1`.
- Extract allocation-neutral private helpers reused across the data-driven, external-boundaries, and colocate-alignment paths: `validateTableDistribution`, `validateTableLevel` (= distribution + unstable-group guard), `checkTableNormalState`, `resolveTabletMeta` (+ a `ResolvedTablet` record), `newReshardingIndex`, and `newSplitTabletJob`.
- Keep `forColocateAlignment` separate: it deliberately bypasses the unstable-group guard (it is the resolver of unstable state) and remains best-effort. The data-driven `createTabletReshardJob` also stays separate (different selection/failure semantics).
- Per-sibling splitting loops are left inline verbatim, so tablet-id allocation order is unchanged.

The three surviving entry points map cleanly onto the three distinct input models: data-driven (`SPLIT TABLET`), FE-supplied external boundaries (load-time pre-split), and checker-driven colocate alignment.

Tested: reshard/presplit + `ColocateCheckerTest` suites pass (123 tests, 0 failures); `mvn checkstyle:check` on fe-core is clean.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
