### PR TITLE
[Enhancement] Cache the lake tablet-reader seek range across per-split reopens

### DIFF
--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -611,8 +611,16 @@ Status TabletReader::init_rowset_read_options(const TabletReaderParams& params, 
     KeysType keys_type = _tablet_schema->keys_type();
     RETURN_IF_ERROR(init_predicates(params));
     RETURN_IF_ERROR(init_delete_predicates(params, &_delete_predicates));
-    RETURN_IF_ERROR(parse_seek_range(*_tablet_schema, params.range, params.end_range, params.start_key, params.end_key,
-                                     &options->ranges, &_mempool));
+    // The seek range is invariant across this reader's per-split reopens, so parse it once and reuse the
+    // cached result. This skips the per-reopen seek-tuple rebuild (convert_field + datum decode +
+    // allocations) that dominated the lake split-scan open path.
+    if (!_cached_seek_ranges) {
+        std::vector<SeekRange> ranges;
+        RETURN_IF_ERROR(parse_seek_range(*_tablet_schema, params.range, params.end_range, params.start_key,
+                                         params.end_key, &ranges, &_mempool));
+        _cached_seek_ranges = std::move(ranges);
+    }
+    options->ranges = *_cached_seek_ranges;
     options->pred_tree = params.pred_tree;
     options->runtime_filter_preds = params.runtime_filter_preds;
     RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_tree(&_obj_pool, options->pred_tree,

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <optional>
+#include <vector>
+
 #include "exec_primitive/pipeline/scan/scan_morsel.h"
 #include "runtime/mem_pool.h"
 #include "storage/delete_predicates.h"
@@ -154,6 +157,11 @@ private:
 
     MemPool _mempool;
     ObjectPool _obj_pool;
+
+    // Cached parse_seek_range() result, reused across this reader's per-split reopens: the seek range
+    // derives only from the tablet schema and scan-constant key ranges, so it is invariant across reopens
+    // (runtime filters narrow rows separately). Its datums live in _mempool, so declare it after _mempool.
+    std::optional<std::vector<SeekRange>> _cached_seek_ranges;
 
     bool _is_asc_hint = true;
 

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -42,7 +42,9 @@
 #include "storage/lake/versioned_tablet.h"
 #include "storage/query/split_scan_morsel.h"
 #include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/rowset_options.h"
 #include "storage/rowset/segment_options.h"
+#include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
 #include "storage_primitive/rowid_types.h"
 #include "test_util.h"
@@ -1627,6 +1629,47 @@ TEST_F(LakeTabletReaderSpit, test_prepared_physical_split_end_to_end_equivalence
     // so the per-segment scan-row counter sums to the full row count.
     EXPECT_EQ(4, refined_segments);
     EXPECT_EQ(static_cast<int64_t>(expected.size()), refined_scan_rows);
+}
+
+// parse_seek_range() is parsed once and cached in _cached_seek_ranges, then reused on every subsequent
+// init_rowset_read_options (a reader's per-split reopens re-run it). Prove the second call reuses the
+// cache instead of re-parsing: open() populates the cache, then we overwrite it with a size-1 sentinel;
+// a reused cache yields the size-1 sentinel, while a re-parse of these (empty-key) params would yield an
+// empty range list and overwrite the sentinel.
+TEST_F(LakeTabletReaderSpit, test_seek_range_cached_across_reopen) {
+    std::vector<int> keys{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<int> vals{2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    build_split_test_tablet(tablet, _schema, _tablet_metadata, keys, vals);
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    ASSERT_OK(reader->prepare());
+    auto params = generate_tablet_reader_params(&scan_range);
+
+    // open() runs init_rowset_read_options once, which parses the seek range and engages the cache.
+    ASSERT_FALSE(reader->_cached_seek_ranges.has_value());
+    ASSERT_OK(reader->open(params));
+    ASSERT_TRUE(reader->_cached_seek_ranges.has_value());
+
+    // Overwrite the cache with a size-1 sentinel; the reader is fully set up now, so a second
+    // init_rowset_read_options is safe. A reused cache yields size 1; a re-parse of the empty-key params
+    // would yield size 0 and overwrite the sentinel.
+    reader->_cached_seek_ranges = std::vector<SeekRange>(1);
+    RowsetReadOptions opts;
+    ASSERT_OK(reader->init_rowset_read_options(params, &opts));
+    EXPECT_EQ(1u, opts.ranges.size()) << "init_rowset_read_options re-parsed instead of reusing the cache";
+    ASSERT_TRUE(reader->_cached_seek_ranges.has_value());
+    EXPECT_EQ(1u, reader->_cached_seek_ranges->size());
+
+    reader->close();
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

The lake prepared-physical-split scan reopens the same `TabletReader` once per REFINED split. `init_rowset_read_options()` calls `parse_seek_range()` on every reopen, which rebuilds the seek tuples (`convert_field` + datum decode + allocations) each time. For a heavily-split scan this repeated rebuild adds up in the open path.

## What I'm doing:

The seek range derives only from the tablet schema and the scan-constant key ranges (`params.range` / `start_key` / `end_key` from the planned scan range), so it is invariant across a reader's per-split reopens — runtime filters narrow the row range separately rather than feeding back into the key range. Cache the parsed `std::vector<SeekRange>` on first use (`_cached_seek_ranges`) and reuse it on subsequent reopens, dropping the per-reopen rebuild from the lake split-scan open path. The cached datums live in the reader's `_mempool`, so the cache stays valid for the reader's lifetime.

Part of #76355.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5