### PR TITLE
[BugFix] Make analysis-time Iceberg time-travel snapshot binding best-effort

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryPeriodResolver.java
@@ -33,11 +33,15 @@ import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Optional;
 
 public class QueryPeriodResolver {
+    private static final Logger LOG = LogManager.getLogger(QueryPeriodResolver.class);
+
     private QueryPeriodResolver() {
     }
 
@@ -94,13 +98,26 @@ public class QueryPeriodResolver {
 
         QueryPeriod queryPeriod = tableRelation.getQueryPeriod();
         QueryPeriod.PeriodType periodType = queryPeriod.getPeriodType();
-        Optional<ConnectorTableVersion> startVersion = resolve(queryPeriod.getStart(), periodType, session);
-        Optional<ConnectorTableVersion> endVersion = resolve(queryPeriod.getEnd(), periodType, session);
-        TvrVersionRange versionRange = metadataMgr.getTableVersionRange(
-                tableRelation.getName().getDb(), table, startVersion, endVersion);
+        TvrVersionRange versionRange;
+        try {
+            Optional<ConnectorTableVersion> startVersion = resolve(queryPeriod.getStart(), periodType, session);
+            Optional<ConnectorTableVersion> endVersion = resolve(queryPeriod.getEnd(), periodType, session);
+            versionRange = metadataMgr.getTableVersionRange(
+                    tableRelation.getName().getDb(), table, startVersion, endVersion);
+        } catch (Exception e) {
+            // Best-effort version resolution: on failure keep the current table and leave the range unpinned.
+            // Time-travel-prohibited DDL (CREATE VIEW/MV, ALTER VIEW) then rejects the clause right after
+            // analysis; a genuine query re-resolves at transform time and surfaces the real error there.
+            // Binding stays outside this catch so its own failures are not swallowed.
+            LOG.debug("Deferring Iceberg time-travel version resolution for table {}: {}",
+                    tableRelation.getName(), e.getMessage());
+            return table;
+        }
+        // Pin only after a successful bind, so a failed (or retried) bind never leaves the relation
+        // pinned-but-unbound, which the guard above would later mistake for "already resolved".
+        Table boundTable = bindIcebergSnapshotReadView((IcebergTable) table, versionRange);
         tableRelation.setTvrVersionRange(versionRange);
-
-        return bindIcebergSnapshotReadView((IcebergTable) table, versionRange);
+        return boundTable;
     }
 
     // Rebind the Iceberg table to the resolved snapshot's read metadata (schema + partition specs),


### PR DESCRIPTION
## Why I'm doing:

#74711 moved Iceberg time-travel version resolution into the analyzer so column resolution honors the targeted snapshot's schema. But this eager binding in `QueryAnalyzer.resolveTableRef` now runs before the time-travel prohibition check of CREATE VIEW / CREATE MATERIALIZED VIEW / ALTER VIEW. As a result, a time-travel clause on an Iceberg table inside those statements crashes analysis instead of being rejected with the dedicated message. `MaterializedViewAnalyzerTest` fails on 5 such cases with `java.lang.ClassCastException: class java.lang.Byte cannot be cast to class java.lang.Long`, thrown when a small `FOR VERSION AS OF <int>` literal (TINYINT) reaches version resolution; in production the same path raises a version-resolution error rather than the intended rejection.

## What I'm doing:

Make the analysis-time snapshot binding best-effort in `QueryPeriodResolver.resolveAndBindTable`: if the version range cannot be resolved or bound, leave it unpinned and keep the current table instead of failing during analysis. The time-travel-prohibited DDL then rejects the clause right after analysis with its proper message, and any genuine time-travel query re-resolves the range at transform time (`RelationTransformer`) and surfaces the accurate error there — i.e. the behavior before the eager binding was introduced. Valid time-travel reads still bind the snapshot eagerly as #74711 intended.

Covered by the existing `MaterializedViewAnalyzerTest` time-travel cases: the 5 previously-failing ones now pass, and the `...OnView` cases keep their existing rejection message.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5