### PR TITLE
[Tool] bugfix-version-index: add migrate-enrichment dispatch mode + sync reconcile-bound comment

### DIFF
--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -290,6 +290,18 @@ jobs:
           fetch-tags: true
       - name: fetch release branches
         run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: validate budget input [FAIL-LOUD]
+        # A free-form dispatch input flows into a `--dangerously-skip-permissions` `claude -p` prompt as
+        # $ARGUMENTS. It is not a shell-injection vector (double-quoted env expansion), but an arbitrary
+        # string would be PROMPT injection, and a plain typo would be silently masked to a green no-op by
+        # the best-effort `|| true` below. So validate FIRST, in its own step WITHOUT continue-on-error:
+        # empty (= low default) is fine; otherwise it MUST be digits only. A bad value fails the job (red),
+        # and the best-effort step below is then skipped.
+        run: |
+          if [ -n "${RUN_BUDGET}" ] && ! [[ "${RUN_BUDGET}" =~ ^[0-9]+$ ]]; then
+            echo "::error::budget must be empty or a non-negative integer (got '${RUN_BUDGET}'); the skill clamps it to 50"
+            exit 1
+          fi
       - name: affected-versions migrate-enrichment (rich-schema backfill) [best-effort]
         continue-on-error: true
         run: |

--- a/.github/workflows/bugfix-version-index.yml
+++ b/.github/workflows/bugfix-version-index.yml
@@ -14,6 +14,10 @@ run-name: Bugfix Version Index - ${{ github.event_name }} ${{ github.event.numbe
 #                                             + :affected-versions reconcile (cause cache self-heal)
 #   ⑤ weekly schedule                      → :index-fix reconcile-all (re-check concrete too — corrects
 #                                             a wrong concrete tag / reverse error; heavier)
+#   ⑥ manual dispatch (migrate-enrichment) → :affected-versions migrate-enrichment (one-off: backfill
+#                                             legacy cause records up to the rich schema — severity /
+#                                             cause author+title / ## Summary + ## User Impact body;
+#                                             dispatch-only, separate from the daily correctness sweep)
 #
 # NOTE: plugin commands MUST be namespaced (/github-bugfix-versions:<cmd>). A bare /index-fix in
 # headless `-p` does NOT resolve — it is silently treated as prompt text (no write).
@@ -51,13 +55,19 @@ on:
   workflow_dispatch:        # manual trigger — run a self-heal sweep on demand, don't only wait for cron
     inputs:
       mode:
-        description: 'Self-heal sweep to run (same jobs the cron fires)'
+        description: 'Sweep to run'
         type: choice
         required: true
         default: reconcile
         options:
-          - reconcile        # = daily: index-fix pending sweep + affected-versions cause self-heal
-          - reconcile-all    # = weekly: re-check concrete records too (heavier)
+          - reconcile             # = daily: index-fix pending sweep + affected-versions cause self-heal
+          - reconcile-all         # = weekly: re-check concrete records too (heavier)
+          - migrate-enrichment    # = one-off: backfill legacy cause records up to the rich schema
+      budget:
+        description: 'migrate-enrichment only: per-run analysis cap (integer, e.g. 20; blank = low default). Clamped to 50 in the skill.'
+        type: string
+        required: false
+        default: ''
 
 # Concurrency is per-ORIGIN for the single-origin EVENTS (origin-merge / backport-merge share
 # `BVI-…-origin-N`, so different origins run in parallel but the same origin serializes — a
@@ -220,8 +230,10 @@ jobs:
         run: |
           # Cause-side self-heal: fill/refresh task_summaries for in-scope bugfixes whose cause is
           # missing/partial/stale (e.g. an origin-merge cause step that failed best-effort, or a
-          # historical gap). Bounded per run (N=30d priority / M=50 cap / R=10 reserved backlog),
-          # with per-record backoff so a poison record can't starve the quota — see the skill.
+          # historical gap). Bounded per run (N=30d priority / MAX_FULL_ANALYSES=12 default hard cap /
+          # R=3 reserved backlog / MAX_CONCURRENCY=4), with per-record backoff so a poison record can't
+          # starve the quota — see the skill. Rich-schema backfill of legacy records is a SEPARATE mode
+          # (migrate-enrichment, job ⑥), not this daily correctness sweep.
           # Best-effort + `|| true`: cause is heuristic; a transient blip must not fail the FAIL-LOUD
           # versions reconcile above, and tomorrow's run re-selects anything left cause-incomplete.
           echo "daily reconcile (cause side)"
@@ -254,3 +266,34 @@ jobs:
           echo "weekly reconcile-all"
           claude --dangerously-skip-permissions \
             -p "/github-bugfix-versions:index-fix reconcile-all" 2>&1 | tee "${RUNNER_TEMP}/reconcile_all.txt"
+
+  # ⑥ manual one-off → backfill legacy cause records up to the rich schema (severity / cause author+title /
+  # ## Summary + ## User Impact body). SEPARATE from the daily correctness reconcile (④) so it never
+  # competes for that budget; dispatch-only (no cron). Bounded in the skill: MAX_FULL_ANALYSES default 3,
+  # raised via the `budget` input and clamped to 50. Best-effort (cause is heuristic).
+  migrate-enrichment:
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.mode == 'migrate-enrichment'
+    concurrency:
+      group: BVI-${{ github.repository }}-migrate-enrichment
+      cancel-in-progress: false
+    runs-on: [ubuntu, ai]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      RUN_BUDGET: ${{ github.event.inputs.budget }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: fetch release branches
+        run: git fetch origin '+refs/heads/branch-*:refs/remotes/origin/branch-*' || true
+      - name: affected-versions migrate-enrichment (rich-schema backfill) [best-effort]
+        continue-on-error: true
+        run: |
+          echo "migrate-enrichment (budget='${RUN_BUDGET}')"
+          claude --dangerously-skip-permissions \
+            -p "/github-bugfix-versions:affected-versions migrate-enrichment ${RUN_BUDGET}" 2>&1 \
+            | tee "${RUNNER_TEMP}/migrate_enrichment.txt" || true


### PR DESCRIPTION
## Why I'm doing:

The `github-bugfix-versions` plugin now persists a richer cause schema (severity, cause author/title/first-seen, and a `## Summary` + `## User Impact` body). ~200 legacy `code_kb.task_summaries` records predate that schema — their upgrade advice is correct, they just lack the rich fields. Re-analyzing them must NOT ride the daily correctness reconcile (it would blow that job's token budget), so it needs its own bounded, dispatch-only sweep.

## What I'm doing:

- Add a `migrate-enrichment` option to the `workflow_dispatch` `mode` dropdown, an optional `budget` input, and a dispatch-only `migrate-enrichment` job that runs `/github-bugfix-versions:affected-versions migrate-enrichment ${budget}` (best-effort). It backfills legacy cause records up to the rich schema without competing for the daily reconcile budget. `budget` overrides the skill's per-run `MAX_FULL_ANALYSES` (low default; clamped to 50 in the skill) so a one-off drain can be sped up; blank = low default.
- Sync the daily `affected-versions reconcile` step comment to the current bounded model (`MAX_FULL_ANALYSES=12` default hard cap / `R=3` reserved backlog / `MAX_CONCURRENCY=4`), replacing the stale `M=50 / R=10`.

Workflow-only change. Requires the runner's `github-bugfix-versions` plugin to be `>= 1.1.5` for the new mode to resolve (an older plugin treats the arg as a PR ref and no-ops).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

CI/tooling workflow only — no StarRocks product behavior changes. The new job is dispatch-only (no cron), so it never fires automatically.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)