### PR TITLE
[Enhancement] Decouple inferred VARCHAR length from the OLAP maximum

### DIFF
--- a/be/src/connector/file/scanner/file_scanner.cpp
+++ b/be/src/connector/file/scanner/file_scanner.cpp
@@ -45,6 +45,19 @@
 
 namespace starrocks {
 
+namespace {
+
+void limit_inferred_varlen(TypeDescriptor* type) {
+    if (type->type == TYPE_VARCHAR || type->type == TYPE_VARBINARY) {
+        type->len = std::min(type->len, TypeDescriptor::VARCHAR_INFERENCE_LENGTH);
+    }
+    for (auto& child : type->children) {
+        limit_inferred_varlen(&child);
+    }
+}
+
+} // namespace
+
 FileScanner::FileScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfile* profile,
                          const starrocks::TBrokerScanRangeParams& params, starrocks::ScannerCounter* counter,
                          bool schema_only)
@@ -561,6 +574,10 @@ Status FileScanner::sample_schema(RuntimeState* state, const TBrokerScanRange& s
     if (schemas.empty()) return Status::InvalidArgument("get an empty schema");
 
     merge_schema(schemas, schema);
+    // Normalize variable-length fields before returning the inferred schema to FE.
+    for (auto& slot : *schema) {
+        limit_inferred_varlen(&slot.type());
+    }
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -38,7 +38,6 @@
 #include "common/bloom_filter.h"
 #include "common/config_json_flat_fwd.h"
 #include "common/config_rowset_fwd.h"
-#include "common/config_scan_io_fwd.h"
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
 #include "gutil/casts.h"
@@ -185,7 +184,7 @@ Status FlatJsonColumnWriter::_init_flat_writers() {
         opts.meta->set_unique_id(i);
         opts.meta->set_type(_flat_types[i]);
         if (_flat_types[i] == TYPE_VARCHAR) {
-            opts.meta->set_length(config::olap_string_max_length);
+            opts.meta->set_length(TypeDescriptor::VARCHAR_INFERENCE_LENGTH);
         } else {
             DCHECK_NE(_flat_types[i], TYPE_CHAR);
             // set length for non-string type (e.g. int, double, date, etc.

--- a/be/src/types/type_descriptor.h
+++ b/be/src/types/type_descriptor.h
@@ -36,6 +36,8 @@ struct TypeDescriptor {
     /// Only meaningful for type TYPE_CHAR/TYPE_VARCHAR/TYPE_HLL
     int len{-1};
     static constexpr int MAX_VARCHAR_LENGTH = 1048576;
+    // Default length used for VARCHAR/VARBINARY fields in inferred schemas.
+    static constexpr int VARCHAR_INFERENCE_LENGTH = 1024 * 1024;
     static constexpr int MAX_CHAR_LENGTH = 255;
     static constexpr int MAX_CHAR_INLINE_LENGTH = 128;
     static constexpr int DEFAULT_BITMAP_LENGTH = 128;

--- a/be/test/connector/file/scanner/file_scanner_test.cpp
+++ b/be/test/connector/file/scanner/file_scanner_test.cpp
@@ -119,7 +119,7 @@ TEST_F(FileScannerTest, sample_schema) {
         // result: col1,BIGINT; col2,VARCHAR; col3,BIGINT; col4,DOUBLE
         const std::vector<std::pair<std::string, TypeDescriptor>> expected_schema = {
                 {"col1", TypeDescriptor::from_logical_type(TYPE_BIGINT)},
-                {"col2", TypeDescriptor::from_logical_type(TYPE_VARCHAR)},
+                {"col2", TypeDescriptor::create_varchar_type(TypeDescriptor::VARCHAR_INFERENCE_LENGTH)},
                 {"col3", TypeDescriptor::from_logical_type(TYPE_BIGINT)},
                 {"col4", TypeDescriptor::from_logical_type(TYPE_DOUBLE)}};
 

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -211,16 +211,14 @@ TEST_F(FlatJsonColumnRWTest, testInferredStringLengthDoesNotFollowOlapMax) {
 
     MutableColumnPtr write_col = JsonColumn::create();
     auto* json_col = down_cast<JsonColumn*>(write_col.get());
-    const std::vector<std::string> jsons = {
-            R"({"message": "a"})", R"({"message": "b"})", R"({"message": "c"})"};
+    const std::vector<std::string> jsons = {R"({"message": "a"})", R"({"message": "b"})", R"({"message": "c"})"};
     for (const std::string& json : jsons) {
         ASSIGN_OR_ABORT(auto value, JsonValue::parse(json));
         json_col->append(value);
     }
 
     ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
-    ASSIGN_OR_ABORT(auto message_path,
-                    ColumnAccessPath::create(TAccessPathType::FIELD, "root.message", 0));
+    ASSIGN_OR_ABORT(auto message_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root.message", 0));
     root_path->children().emplace_back(std::move(message_path));
 
     MutableColumnPtr read_col = JsonColumn::create();

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -30,6 +30,7 @@
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/config_json_flat_fwd.h"
+#include "common/config_scan_io_fwd.h"
 #include "common/statusor.h"
 #include "fs/fs.h"
 #include "fs/fs_memory.h"
@@ -51,6 +52,7 @@
 #include "storage_primitive/flat_json_config.h"
 #include "types/json_value.h"
 #include "types/logical_type.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
 
@@ -100,12 +102,14 @@ public:
 
 protected:
     void SetUp() override {
+        _saved_olap_string_max_length = config::olap_string_max_length;
         config::enable_json_flat_complex_type = true;
         _meta = std::make_shared<ColumnMetaPB>();
         config::json_flat_sparsity_factor = 0.9;
     }
 
     void TearDown() override {
+        config::olap_string_max_length = _saved_olap_string_max_length;
         config::enable_json_flat_complex_type = false;
         config::json_flat_null_factor = 0.3;
     }
@@ -199,7 +203,39 @@ protected:
 protected:
     std::shared_ptr<TabletSchema> _dummy_segment_schema;
     std::shared_ptr<ColumnMetaPB> _meta;
+    int _saved_olap_string_max_length = 0;
 };
+
+TEST_F(FlatJsonColumnRWTest, testInferredStringLengthDoesNotFollowOlapMax) {
+    config::olap_string_max_length = TypeDescriptor::VARCHAR_INFERENCE_LENGTH * 2;
+
+    MutableColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+    const std::vector<std::string> jsons = {
+            R"({"message": "a"})", R"({"message": "b"})", R"({"message": "c"})"};
+    for (const std::string& json : jsons) {
+        ASSIGN_OR_ABORT(auto value, JsonValue::parse(json));
+        json_col->append(value);
+    }
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto message_path,
+                    ColumnAccessPath::create(TAccessPathType::FIELD, "root.message", 0));
+    root_path->children().emplace_back(std::move(message_path));
+
+    MutableColumnPtr read_col = JsonColumn::create();
+    ColumnWriterOptions writer_opts;
+    writer_opts.need_flat = true;
+    test_json(writer_opts, "/test_flat_json_inference_length.data", write_col, read_col, root_path.get());
+
+    ASSERT_TRUE(writer_opts.meta->json_meta().is_flat());
+    ASSERT_EQ(1, writer_opts.meta->children_columns_size());
+    const ColumnMetaPB& message_meta = writer_opts.meta->children_columns(0);
+    EXPECT_EQ("message", message_meta.name());
+    EXPECT_EQ(TYPE_VARCHAR, message_meta.type());
+    EXPECT_EQ(TypeDescriptor::VARCHAR_INFERENCE_LENGTH, message_meta.length());
+    EXPECT_NE(config::olap_string_max_length, message_meta.length());
+}
 
 TEST_F(FlatJsonColumnRWTest, testNormalJson) {
     MutableColumnPtr write_col = JsonColumn::create();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -144,7 +144,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 if ("varchar".equalsIgnoreCase(typeName)) {
                     return TypeFactory.createVarcharType(columnSize);
                 } else if ("text".equalsIgnoreCase(typeName)) {
-                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
@@ -197,7 +197,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                return TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
             }
             return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
@@ -116,7 +116,7 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
                 if (columnSize > 0) {
                     return TypeFactory.createVarcharType(columnSize);
                 } else {
-                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
                 }
             // DATETIMEOFFSET
             case -155:
@@ -126,7 +126,7 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
             case Types.LONGNVARCHAR:
                 if (typeName.equalsIgnoreCase("text") || typeName.equalsIgnoreCase("ntext") ||
                         typeName.equalsIgnoreCase("xml")) {
-                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
                 } else if (typeName.equalsIgnoreCase("datetimeoffset")) {
                     return TypeFactory.createVarcharType(columnSize);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1486,9 +1486,9 @@ public class AnalyzerUtils {
         return transformTableColumnType(srcType, convertDouble, Config.transform_type_prefer_string_for_varchar);
     }
 
-    // For char and varchar types, use the inferred length if the length can be inferred,
-    // otherwise (include null type) use the longest varchar value. When preferStringForVarchar
-    // is true, every fixed-length varchar/char is widened to the OLAP max varchar length instead.
+    // For char and varchar types, preserve an explicit length up to the default inference length.
+    // Use the default for wildcard/null types. When preferStringForVarchar is true, every
+    // fixed-length varchar/char uses the default inference length instead.
     // For double and float types, since they may be selected as key columns,
     // the key column must be an exact value, so we unified into a default decimal type.
     public static Type transformTableColumnType(Type srcType, boolean convertDouble, boolean preferStringForVarchar) {
@@ -1497,17 +1497,11 @@ public class AnalyzerUtils {
             if (PrimitiveType.VARCHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
-                int len = TypeFactory.getOlapMaxVarcharLength();
+                int len = TypeFactory.getOlapVarcharInferenceLength();
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
-                    if (preferStringForVarchar) {
-                        // always use max varchar length for char/varchar types if preferStringForVarchar is set.
-                        len = TypeFactory.getOlapMaxVarcharLength();
-                    } else {
-                        if (scalarType.getLength() > 0) {
-                            // Catalog's varchar length may larger than olap's max varchar length
-                            len = Integer.min(scalarType.getLength(), TypeFactory.getOlapMaxVarcharLength());
-                        }
+                    if (!preferStringForVarchar && scalarType.getLength() > 0) {
+                        len = Integer.min(TypeFactory.getOlapVarcharInferenceLength(), scalarType.getLength());
                     }
                 }
                 newType = TypeFactory.createVarcharType(len);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -563,7 +563,7 @@ public class CreateFunctionAnalyzer {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
-        ScalarType intermediateType = TypeFactory.createVarcharType(com.starrocks.type.TypeFactory.getOlapMaxVarcharLength());
+        ScalarType intermediateType = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
 
         Map<String, String> properties = stmt.getProperties();
         boolean isAnalyticFn = "true".equalsIgnoreCase(properties.get(CreateFunctionStmt.IS_ANALYTIC_NAME));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -602,9 +602,9 @@ public class CreateTableAnalyzer {
                 if (type.isScalarType()) {
                     ScalarType scalarType = (ScalarType) type;
                     if (scalarType.isWildcardChar()) {
-                        type = TypeFactory.createCharType(TypeFactory.getOlapMaxVarcharLength());
+                        type = TypeFactory.createCharType(TypeFactory.getOlapVarcharInferenceLength());
                     } else if (scalarType.isWildcardVarchar()) {
-                        type = TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                        type = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
                     }
                 }
                 TypeDef typeDef = new TypeDef(type);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -1660,9 +1660,9 @@ public class MaterializedViewAnalyzer {
         if (type.isScalarType()) {
             ScalarType scalarType = (ScalarType) type;
             if (scalarType.isWildcardChar()) {
-                type = TypeFactory.createCharType(TypeFactory.getOlapMaxVarcharLength());
+                type = TypeFactory.createCharType(TypeFactory.getOlapVarcharInferenceLength());
             } else if (scalarType.isWildcardVarchar()) {
-                type = TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+                type = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
             }
         }
         String columnName = FeConstants.GENERATED_PARTITION_COLUMN_PREFIX + placeHolderSlotId;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -348,10 +348,10 @@ public class StatisticUtils {
         ScalarType tableUUIDType = TypeFactory.createVarcharType(65530);
         ScalarType partitionNameType = TypeFactory.createVarcharType(65530);
         ScalarType dbNameType = TypeFactory.createVarcharType(65530);
-        ScalarType maxType = TypeFactory.createVarcharType(Config.max_varchar_length);
-        ScalarType minType = TypeFactory.createVarcharType(Config.max_varchar_length);
-        ScalarType bucketsType = TypeFactory.createVarcharType(Config.max_varchar_length);
-        ScalarType mostCommonValueType = TypeFactory.createVarcharType(Config.max_varchar_length);
+        ScalarType maxType = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
+        ScalarType minType = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
+        ScalarType bucketsType = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
+        ScalarType mostCommonValueType = TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength());
         ScalarType catalogNameType = TypeFactory.createVarcharType(65530);
 
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
@@ -27,6 +27,7 @@ import com.starrocks.qe.SessionVariableConstants;
  * across Type and ScalarType classes, following the Factory pattern.
  */
 public class TypeFactory {
+    private static final int OLAP_VARCHAR_INFERENCE_LENGTH = 1024 * 1024;
 
     private TypeFactory() {
         // Private constructor to prevent instantiation
@@ -57,15 +58,24 @@ public class TypeFactory {
     }
 
     /**
-     * Get the maximum varchar length for OLAP tables.
+     * Get the maximum VARCHAR length supported by OLAP tables.
      *
-     * @return the maximum varchar length
+     * @return the maximum supported VARCHAR length
      */
     public static int getOlapMaxVarcharLength() {
         return Config.max_varchar_length;
     }
 
-    // 1GB for each line, it's enough
+    /**
+     * Get the default length used when materializing an inferred OLAP VARCHAR type.
+     *
+     * @return the default inferred VARCHAR length
+     */
+    public static int getOlapVarcharInferenceLength() {
+        return OLAP_VARCHAR_INFERENCE_LENGTH;
+    }
+
+    // Compatibility length used for unbounded strings in external catalogs.
     public static final int CATALOG_MAX_VARCHAR_LENGTH = 1024 * 1024 * 1024;
 
     /**
@@ -342,9 +352,5 @@ public class TypeFactory {
         ScalarType res = PRIMITIVE_TYPE_SCALAR_TYPE_MAP.get(type);
         Preconditions.checkNotNull(res, "unknown type " + type);
         return res;
-    }
-
-    static {
-        StringType.STRING = new StringType(Config.max_varchar_length);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -40,6 +40,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnBuilder;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.sql.analyzer.ColumnDefAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AggregateType;
@@ -352,6 +353,29 @@ public class ColumnDefTest {
                     DefaultValueDef.NOT_SET, "");
             ColumnDefAnalyzer.analyze(column, true);
         });
+    }
+
+    @Test
+    public void testExplicitVarcharStillUsesConfiguredOlapMax() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        int configuredMax = TypeFactory.getOlapVarcharInferenceLength() + 128;
+        try {
+            Config.max_varchar_length = configuredMax;
+
+            ColumnDef aboveInference = new ColumnDef("above_inference",
+                    new TypeDef(TypeFactory.createVarcharType(TypeFactory.getOlapVarcharInferenceLength() + 1)));
+            Assertions.assertDoesNotThrow(() -> ColumnDefAnalyzer.analyze(aboveInference, true));
+
+            ColumnDef atConfiguredMax = new ColumnDef("at_configured_max",
+                    new TypeDef(TypeFactory.createVarcharType(configuredMax)));
+            Assertions.assertDoesNotThrow(() -> ColumnDefAnalyzer.analyze(atConfiguredMax, true));
+
+            ColumnDef aboveConfiguredMax = new ColumnDef("above_configured_max",
+                    new TypeDef(TypeFactory.createVarcharType(configuredMax + 1)));
+            assertThrows(SemanticException.class, () -> ColumnDefAnalyzer.analyze(aboveConfiguredMax, true));
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -20,7 +20,10 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -221,6 +224,31 @@ public class PostgresSchemaResolverTest {
                 postgresSchemaResolver.convertColumnType(Types.OTHER, "timestamp with time zone", 0, 0).isDatetime());
         Assertions.assertTrue(postgresSchemaResolver.convertColumnType(Types.OTHER, "json", 0, 0).isJsonType());
         Assertions.assertTrue(postgresSchemaResolver.convertColumnType(Types.OTHER, "jsonb", 0, 0).isJsonType());
+    }
+
+    @Test
+    public void testUnboundedStringFallbackUsesInferenceLength() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        int inferenceLength = TypeFactory.getOlapVarcharInferenceLength();
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+            PostgresSchemaResolver resolver = new PostgresSchemaResolver();
+
+            ScalarType declaredVarchar = (ScalarType) resolver.convertColumnType(
+                    Types.VARCHAR, "varchar", inferenceLength + 1, 0);
+            Assertions.assertEquals(inferenceLength + 1, declaredVarchar.getLength());
+
+            ScalarType text = (ScalarType) resolver.convertColumnType(
+                    Types.VARCHAR, "text", Integer.MAX_VALUE, 0);
+            Assertions.assertEquals(inferenceLength, text.getLength());
+
+            ScalarType unboundedNumeric = (ScalarType) resolver.convertColumnType(
+                    Types.NUMERIC, "numeric", 0, 0);
+            Assertions.assertTrue(unboundedNumeric.isVarchar());
+            Assertions.assertEquals(inferenceLength, unboundedNumeric.getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/SqlServerSchemaResolverTest.java
@@ -20,7 +20,10 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -238,6 +241,38 @@ public class SqlServerSchemaResolverTest {
         Assertions.assertEquals(1, partitions.size());
         Assertions.assertEquals("tbl1", partitions.get(0).getPartitionName());
         Assertions.assertTrue(partitions.get(0).getModifiedTime() > 0);
+    }
+
+    @Test
+    public void testUnboundedStringFallbackUsesInferenceLength() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        int inferenceLength = TypeFactory.getOlapVarcharInferenceLength();
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+            SqlServerSchemaResolver resolver = new SqlServerSchemaResolver();
+
+            ScalarType declaredVarchar = (ScalarType) resolver.convertColumnType(
+                    Types.VARCHAR, "varchar", inferenceLength + 1, 0);
+            Assertions.assertEquals(inferenceLength + 1, declaredVarchar.getLength());
+
+            ScalarType zeroLengthVarchar = (ScalarType) resolver.convertColumnType(
+                    Types.VARCHAR, "varchar", 0, 0);
+            Assertions.assertEquals(inferenceLength, zeroLengthVarchar.getLength());
+
+            ScalarType negativeLengthNvarchar = (ScalarType) resolver.convertColumnType(
+                    Types.NVARCHAR, "nvarchar", -1, 0);
+            Assertions.assertEquals(inferenceLength, negativeLengthNvarchar.getLength());
+
+            int[] unboundedTypes = {Types.LONGVARCHAR, Types.LONGNVARCHAR, Types.LONGNVARCHAR};
+            String[] unboundedTypeNames = {"text", "ntext", "xml"};
+            for (int i = 0; i < unboundedTypes.length; i++) {
+                ScalarType type = (ScalarType) resolver.convertColumnType(
+                        unboundedTypes[i], unboundedTypeNames[i], Integer.MAX_VALUE, 0);
+                Assertions.assertEquals(inferenceLength, type.getLength(), unboundedTypeNames[i]);
+            }
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -31,7 +31,13 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.NullType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.StarRocksAssert;
@@ -112,10 +118,10 @@ public class AnalyzerUtilsTest {
     }
 
     @Test
-    public void testConvertCatalogMaxStringToOlapMaxString() {
+    public void testConvertCatalogStringToInferenceLength() {
         ScalarType catalogString = TypeFactory.createDefaultCatalogString();
         ScalarType convertedString = (ScalarType) AnalyzerUtils.transformTableColumnType(catalogString);
-        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), convertedString.getLength());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), convertedString.getLength());
     }
 
     @Test
@@ -126,19 +132,75 @@ public class AnalyzerUtilsTest {
     }
 
     @Test
-    public void testTransformVarcharPreferStringTrueWidensToMax() {
+    public void testTransformDeclaredStringLengthBoundariesIgnoreOlapMax() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        int inferenceLength = TypeFactory.getOlapVarcharInferenceLength();
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+
+            int[] declaredLengths = {1, inferenceLength - 1, inferenceLength,
+                    inferenceLength + 1, Integer.MAX_VALUE - 1};
+            for (int declaredLength : declaredLengths) {
+                ScalarType varchar = TypeFactory.createVarcharType(declaredLength);
+                ScalarType preserved = (ScalarType) AnalyzerUtils.transformTableColumnType(varchar, true, false);
+                Assertions.assertEquals(Math.min(declaredLength, inferenceLength), preserved.getLength(),
+                        "declared VARCHAR length " + declaredLength);
+
+                ScalarType preferred = (ScalarType) AnalyzerUtils.transformTableColumnType(varchar, true, true);
+                Assertions.assertEquals(inferenceLength, preferred.getLength(),
+                        "preferred VARCHAR length " + declaredLength);
+            }
+
+            ScalarType wideChar = TypeFactory.createCharType(inferenceLength + 1);
+            ScalarType convertedChar = (ScalarType) AnalyzerUtils.transformTableColumnType(wideChar, true, false);
+            Assertions.assertTrue(convertedChar.isVarchar());
+            Assertions.assertEquals(inferenceLength, convertedChar.getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
+    }
+
+    @Test
+    public void testTransformVarcharPreferStringTrueUsesInferenceLength() {
         ScalarType narrow = TypeFactory.createVarcharType(64);
         ScalarType result = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true, true);
-        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), result.getLength());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), result.getLength());
     }
 
     @Test
     public void testTransformUnboundedVarcharWidensRegardlessOfPreferString() {
         ScalarType unbounded = TypeFactory.createVarcharType(-1);
         ScalarType keepLen = (ScalarType) AnalyzerUtils.transformTableColumnType(unbounded, true, false);
-        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), keepLen.getLength());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), keepLen.getLength());
         ScalarType preferStr = (ScalarType) AnalyzerUtils.transformTableColumnType(unbounded, true, true);
-        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), preferStr.getLength());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), preferStr.getLength());
+
+        ScalarType wildcardChar = TypeFactory.createCharType(-1);
+        ScalarType convertedChar = (ScalarType) AnalyzerUtils.transformTableColumnType(wildcardChar, true, false);
+        Assertions.assertTrue(convertedChar.isVarchar());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), convertedChar.getLength());
+
+        ScalarType convertedNull = (ScalarType) AnalyzerUtils.transformTableColumnType(NullType.NULL, true, false);
+        Assertions.assertTrue(convertedNull.isVarchar());
+        Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), convertedNull.getLength());
+    }
+
+    @Test
+    public void testTransformNestedStringTypesRecursively() {
+        int inferenceLength = TypeFactory.getOlapVarcharInferenceLength();
+        Type nested = new StructType(List.of(
+                new StructField("array_field",
+                        new ArrayType(TypeFactory.createVarcharType(inferenceLength + 1))),
+                new StructField("map_field",
+                        new MapType(TypeFactory.createVarcharType(8), TypeFactory.createVarcharType(-1)))), true);
+
+        StructType transformed = (StructType) AnalyzerUtils.transformTableColumnType(nested, true, false);
+        ArrayType array = (ArrayType) transformed.getField("array_field").getType();
+        Assertions.assertEquals(inferenceLength, ((ScalarType) array.getItemType()).getLength());
+
+        MapType map = (MapType) transformed.getField("map_field").getType();
+        Assertions.assertEquals(8, ((ScalarType) map.getKeyType()).getLength());
+        Assertions.assertEquals(inferenceLength, ((ScalarType) map.getValueType()).getLength());
     }
 
     @Test
@@ -148,7 +210,7 @@ public class AnalyzerUtilsTest {
         try {
             Config.transform_type_prefer_string_for_varchar = true;
             ScalarType widened = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true);
-            Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), widened.getLength());
+            Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), widened.getLength());
 
             Config.transform_type_prefer_string_for_varchar = false;
             ScalarType preserved = (ScalarType) AnalyzerUtils.transformTableColumnType(narrow, true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -15,11 +15,14 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UDFInternalClassLoader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateFunctionStmt;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -690,8 +693,10 @@ public class CreateFunctionStmtAnalyzerTest {
 
     @Test
     public void testVarargsUDAF() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
         try {
             Config.enable_udf = true;
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
             new MockUp<CreateFunctionAnalyzer>() {
                 @Mock
                 public String computeMd5(CreateFunctionStmt stmt) {
@@ -722,8 +727,13 @@ public class CreateFunctionStmtAnalyzerTest {
             new CreateFunctionAnalyzer().analyze(stmt, connectContext);
             Assertions.assertEquals("0xff", stmt.getFunction().getChecksum());
             Assertions.assertTrue(stmt.getFunction().hasVarArgs());
+
+            AggregateFunction function = (AggregateFunction) stmt.getFunction();
+            ScalarType intermediateType = (ScalarType) function.getIntermediateType();
+            Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(), intermediateType.getLength());
         } finally {
             Config.enable_udf = false;
+            Config.max_varchar_length = savedMaxVarcharLength;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -17,8 +17,11 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.RangeDistributionDesc;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -162,6 +165,36 @@ public class CreateTableAnalyzerTest {
                 "DISTRIBUTED BY HASH(`id`)\n" +
                 "PROPERTIES(\"replication_num\" = \"1\")";
         analyzeSuccess(keyPartitionExprSourceSql);
+    }
+
+    @Test
+    public void testGeneratedPartitionVarcharUsesInferenceLength() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+            String sql = "CREATE TABLE test_create_table_db.t_generated_partition_varchar (\n" +
+                    "  `id` bigint NOT NULL\n" +
+                    ") ENGINE=OLAP\n" +
+                    "DUPLICATE KEY(`id`)\n" +
+                    "PARTITION BY from_unixtime(id)\n" +
+                    "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n" +
+                    "PROPERTIES(\"replication_num\" = \"1\")";
+
+            CreateTableStmt stmt = (CreateTableStmt) com.starrocks.sql.parser.SqlParser
+                    .parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+            CreateTableAnalyzer.analyze(stmt, connectContext);
+
+            ColumnDef generatedColumn = stmt.getColumnDefs().stream()
+                    .filter(column -> column.getName().startsWith(
+                            FeConstants.GENERATED_PARTITION_COLUMN_PREFIX))
+                    .findFirst()
+                    .orElseThrow();
+            Assertions.assertTrue(generatedColumn.getType().isVarchar());
+            Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(),
+                    ((ScalarType) generatedColumn.getType()).getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
     private void testValidComplexDefault(String columnDef) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -29,12 +29,20 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.ShowStmt;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
+import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Deencapsulation;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -88,6 +96,32 @@ public class MaterializedViewAnalyzerTest {
     @AfterAll
     public static void afterClass() {
         ConnectorPlanTestBase.dropAllCatalogs();
+    }
+
+    @Test
+    public void testGeneratedListPartitionVarcharUsesInferenceLength(
+            @Mocked CreateMaterializedViewStatement statement) {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+            new Expectations() {
+                {
+                    statement.getKeysType();
+                    result = KeysType.DUP_KEYS;
+                }
+            };
+
+            FunctionCallExpr partitionExpr = new FunctionCallExpr("mock_partition", List.of());
+            partitionExpr.setType(VarcharType.VARCHAR);
+            Column generatedColumn = Deencapsulation.invoke(MaterializedViewAnalyzer.class,
+                    "getGeneratedPartitionColumn", statement, partitionExpr, 0);
+
+            Assertions.assertTrue(generatedColumn.getType().isVarchar());
+            Assertions.assertEquals(TypeFactory.getOlapVarcharInferenceLength(),
+                    ((ScalarType) generatedColumn.getType()).getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticUtilsTest.java
@@ -17,14 +17,20 @@ package com.starrocks.statistic;
 import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
 
 class StatisticUtilsTest extends PlanTestBase {
 
@@ -78,6 +84,44 @@ class StatisticUtilsTest extends PlanTestBase {
         Assertions.assertEquals("1",
                 starRocksAssert.getTable(StatsConstants.STATISTICS_DB_NAME, tableName).getProperties().get(
                         "replication_num"));
+    }
+
+    @Test
+    void buildStatsColumnDefUsesInferenceLength() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        int inferenceLength = TypeFactory.getOlapVarcharInferenceLength();
+        try {
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+
+            Map<String, List<String>> inferredColumns = Map.of(
+                    StatsConstants.SAMPLE_STATISTICS_TABLE_NAME, List.of("max", "min"),
+                    StatsConstants.FULL_STATISTICS_TABLE_NAME, List.of("max", "min"),
+                    StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME, List.of("max", "min"),
+                    StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME, List.of("buckets", "mcv"),
+                    StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME, List.of("buckets", "mcv"));
+
+            inferredColumns.forEach((tableName, columnNames) -> {
+                List<ColumnDef> columns = StatisticUtils.buildStatsColumnDef(tableName);
+                for (String columnName : columnNames) {
+                    ColumnDef column = columns.stream()
+                            .filter(candidate -> candidate.getName().equals(columnName))
+                            .findFirst()
+                            .orElseThrow();
+                    Assertions.assertEquals(inferenceLength,
+                            ((ScalarType) column.getType()).getLength(), tableName + "." + columnName);
+                }
+            });
+
+            List<ColumnDef> sampleColumns = StatisticUtils.buildStatsColumnDef(
+                    StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
+            ColumnDef columnName = sampleColumns.stream()
+                    .filter(column -> column.getName().equals("column_name"))
+                    .findFirst()
+                    .orElseThrow();
+            Assertions.assertEquals(65530, ((ScalarType) columnName.getType()).getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/type/TypeFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/TypeFactoryTest.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.type;
+
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TypeFactoryTest {
+
+    @Test
+    void testInferenceAndGenericStringLengthsDoNotFollowOlapMax() {
+        int savedMaxVarcharLength = Config.max_varchar_length;
+        StringType savedString = StringType.STRING;
+        try {
+            // Model a future OLAP limit close to 2 GiB before TypeFactory is first used by this test.
+            Config.max_varchar_length = Integer.MAX_VALUE - 1;
+
+            Assertions.assertEquals(Integer.MAX_VALUE - 1, TypeFactory.getOlapMaxVarcharLength());
+            Assertions.assertEquals(StringType.MAX_STRING_LENGTH,
+                    TypeFactory.getOlapVarcharInferenceLength());
+            Assertions.assertSame(savedString, StringType.STRING);
+            Assertions.assertEquals(StringType.MAX_STRING_LENGTH, StringType.STRING.getLength());
+        } finally {
+            Config.max_varchar_length = savedMaxVarcharLength;
+            StringType.STRING = savedString;
+        }
+    }
+}

--- a/fe/fe-type/src/main/java/com/starrocks/type/StringType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/StringType.java
@@ -15,7 +15,7 @@
 package com.starrocks.type;
 
 public class StringType extends ScalarType {
-    // Longest supported VARCHAR and CHAR, chosen to match Hive.
+    // Generic STRING uses a fixed compatibility length.
     public static final int DEFAULT_STRING_LENGTH = 65533;
     public static final int MAX_STRING_LENGTH = 1048576;
 


### PR DESCRIPTION
## What I'm doing:
Use the existing 1 MiB value as a separate policy for system-generated VARCHAR and VARBINARY schemas instead of deriving them from mutable OLAP maximum-length settings.

Apply this policy to file schema sampling, Flat JSON subcolumns, JDBC fallback mappings, CTAS and materialized-view schemas, internal statistics tables, and Java UDAF intermediate states. These inference paths intentionally do not inherit a larger configured OLAP maximum.

User-declared OLAP column lengths remain validated against the configured maximum. This change neither raises that maximum nor adds large-string support; it keeps automatically generated and persisted schemas stable when the maximum changes independently.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
