### PR TITLE
[BugFix] Reuse inferred CTAS columns for recursive CTE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -96,16 +96,20 @@ public class CTASAnalyzer {
         TableName tableNameObject = TableName.fromTableRef(normalizedTableRef);
         CreateTableAnalyzer.analyzeEngineName(createTableStmt, tableNameObject.getCatalog());
 
-        for (int i = 0; i < allFields.size(); i++) {
-            Type type = AnalyzerUtils.transformTableColumnType(allFields.get(i).getType(),
-                    createTableStmt.isOlapEngine(), /* preferStringForVarchar */ false);
-            Expr originExpression = allFields.get(i).getOriginExpression();
-            ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
-                    null, null, originExpression.isNullable(), ColumnDef.DefaultValueDef.NOT_SET, "");
-            if (isPKTable && keysDesc.containsCol(finalColumnNames.get(i))) {
-                columnDef.setAllowNull(false);
+        // Recursive CTE execution rewrites and analyzes the same CTAS AST again. Preserve the columns
+        // inferred from the original query instead of appending columns derived from the rewritten query.
+        if (createTableStmt.getColumnDefs().isEmpty()) {
+            for (int i = 0; i < allFields.size(); i++) {
+                Type type = AnalyzerUtils.transformTableColumnType(allFields.get(i).getType(),
+                        createTableStmt.isOlapEngine(), /* preferStringForVarchar */ false);
+                Expr originExpression = allFields.get(i).getOriginExpression();
+                ColumnDef columnDef = new ColumnDef(finalColumnNames.get(i), new TypeDef(type), false,
+                        null, null, originExpression.isNullable(), ColumnDef.DefaultValueDef.NOT_SET, "");
+                if (isPKTable && keysDesc.containsCol(finalColumnNames.get(i))) {
+                    columnDef.setAllowNull(false);
+                }
+                createTableStmt.addColumnDef(columnDef);
             }
-            createTableStmt.addColumnDef(columnDef);
         }
 
         // For replication_num, The behavior is the same as creating a table

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -514,6 +514,19 @@ public class CTASAnalyzerTest {
         }
     }
 
+    @Test
+    public void testRepeatedAnalysisReusesInferredColumns() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table test_repeated_analysis as select cast('abc' as varchar(10)) as c;";
+        CreateTableAsSelectStmt stmt =
+                (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+
+        Analyzer.analyze(stmt, ctx);
+
+        Assertions.assertEquals(1, stmt.getCreateTableStmt().getColumnDefs().size());
+        assertVarcharLength(stmt.getCreateTableStmt().getColumnDefs().get(0).getTypeDef(), 10);
+    }
+
     private static void assertVarcharLength(TypeDef typeDef, int expectedLength) {
         ScalarType scalarType = (ScalarType) typeDef.getType();
         Assertions.assertEquals(PrimitiveType.VARCHAR, scalarType.getPrimitiveType());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
@@ -19,6 +19,7 @@ import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.recursivecte.RecursiveCTEAstCheck;
 import com.starrocks.qe.recursivecte.RecursiveCTEExecutor;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import org.junit.jupiter.api.Assertions;
@@ -72,6 +73,38 @@ public class RecursiveCTETest extends PlanTestBase {
                 + "FROM `test`.`cte_");
         assertContains(plan, "Outer Statement After Rewriting:\n"
                 + "SELECT `cte`.`id`, `cte`.`parent_id`");
+    }
+
+    @Test
+    public void testRecursiveCteCtasReusesInferredColumns() throws Exception {
+        String sql = "create table recursive_ctas as " +
+                "with recursive cte(s) as " +
+                "(select cast('a' as varchar(10)) " +
+                "union all select cast(concat(s, 'a') as varchar(10)) from cte where length(s) < 2) " +
+                "select s from cte";
+        StatementBase statement = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        CreateTableAsSelectStmt ctas = (CreateTableAsSelectStmt) statement;
+        connectContext.getSessionVariable().setEnableRecursiveCTE(true);
+
+        RecursiveCTEExecutor executor = new RecursiveCTEExecutor(connectContext);
+        executor.splitOuterStmt(statement);
+
+        Assertions.assertEquals(1, ctas.getCreateTableStmt().getColumnDefs().size());
+        Assertions.assertEquals("varchar(10)",
+                ctas.getCreateTableStmt().getColumnDefs().get(0).getType().toSql().toLowerCase());
+    }
+
+    @Test
+    public void testRecursiveCteCtasValidatesOuterStatementBeforeSplit() {
+        String sql = "create table recursive_ctas(a, b) as " +
+                "with recursive cte(n) as " +
+                "(select 1 union all select n + 1 from cte where n < 3) " +
+                "select n from cte";
+        StatementBase statement = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        connectContext.getSessionVariable().setEnableRecursiveCTE(true);
+
+        RecursiveCTEExecutor executor = new RecursiveCTEExecutor(connectContext);
+        Assertions.assertThrows(SemanticException.class, () -> executor.splitOuterStmt(statement));
     }
 
     @Test

--- a/test/sql/test_cte/R/test_recursive_cte
+++ b/test/sql/test_cte/R/test_recursive_cte
@@ -46,6 +46,24 @@ INSERT INTO employees VALUES
 set recursive_cte_throw_limit_exception=false;
 -- result:
 -- !result
+CREATE TABLE recursive_ctas_result_${uuid0} AS
+WITH RECURSIVE numbers(n) AS (
+    SELECT cast(1 as bigint)
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 3
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true)*/ n FROM numbers;
+-- result:
+-- !result
+SELECT n FROM recursive_ctas_result_${uuid0} ORDER BY n;
+-- result:
+1
+2
+3
+-- !result
+DROP TABLE recursive_ctas_result_${uuid0};
+-- result:
+-- !result
 WITH RECURSIVE org_hierarchy AS (
     SELECT employee_id, name, manager_id, title, cast(1 as bigint) AS `level`, name AS path
     FROM employees

--- a/test/sql/test_cte/T/test_recursive_cte
+++ b/test/sql/test_cte/T/test_recursive_cte
@@ -43,6 +43,19 @@ INSERT INTO employees VALUES
 
 set recursive_cte_throw_limit_exception=false;
 
+-- Test 0: Recursive CTE in CTAS
+CREATE TABLE recursive_ctas_result_${uuid0} AS
+WITH RECURSIVE numbers(n) AS (
+    SELECT cast(1 as bigint)
+    UNION ALL
+    SELECT n + 1 FROM numbers WHERE n < 3
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true)*/ n FROM numbers;
+
+SELECT n FROM recursive_ctas_result_${uuid0} ORDER BY n;
+
+DROP TABLE recursive_ctas_result_${uuid0};
+
 -- Test 1: Basic recursive CTE
 WITH RECURSIVE org_hierarchy AS (
     SELECT employee_id, name, manager_id, title, cast(1 as bigint) AS `level`, name AS path


### PR DESCRIPTION
## Why I'm doing:

Recursive CTE statements are analyzed once before `RecursiveCTEExecutor` splits them and again during normal planning. For CTAS, both analyses append inferred columns to the outer `CreateTableStmt`, so the second analysis fails with `Duplicate column name`.

## What I'm doing:

- Keep the complete CTAS analysis before recursive CTE splitting so invalid outer CTAS definitions fail before recursive execution and `EXPLAIN CTAS` keeps its semantic checks.
- Reuse columns inferred from the original query when the rewritten CTAS AST is analyzed again, avoiding duplicate columns and preserving the original type and nullability instead of deriving them from the recursive temporary table.
- Add FE regression tests for repeated CTAS analysis, outer CTAS validation, and preservation of inferred `VARCHAR` length.
- Add a SQL integration regression that creates a table from a recursive CTE and verifies rows `1`, `2`, and `3`.

Fixes #76452

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Validation:

- `./run-fe-ut.sh --test 'com.starrocks.sql.plan.RecursiveCTETest,com.starrocks.sql.analyzer.CTASAnalyzerTest'` — 30 tests passed.
- `cd fe && mvn checkstyle:check -pl fe-core` — 0 violations.
- `test/.venv/bin/python test/run.py -l --file_filter 'test_recursive_cte'` — SQL integration case discovered successfully; execution is left to CI because no source-build cluster is configured locally.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
