### PR TITLE
[BugFix] Fix native parquet reader crash on incomplete nested lake schema

### DIFF
--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -204,6 +204,11 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
 
     if (parquet_field->type == ColumnType::ARRAY || parquet_field->type == ColumnType::MAP) {
         for (size_t idx = 0; idx < parquet_field->children.size(); idx++) {
+            // Never index past the end of any of the three vectors -- a mismatch means we cannot
+            // validate this nested type, so stop and report it as invalid.
+            if (idx >= field_schema->children.size() || idx >= type_descriptor->children.size()) {
+                break;
+            }
             if (_is_valid_type(&parquet_field->children[idx], &field_schema->children[idx],
                                &type_descriptor->children[idx])) {
                 has_valid_child = true;

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -206,8 +206,7 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
         // ARRAY always has one child (element) and MAP always has two (key, value). The downstream
         // reader (ColumnReaderFactory::create) reads those children by fixed index.
         const size_t required_children = parquet_field->type == ColumnType::MAP ? 2 : 1;
-        if (parquet_field->children.size() < required_children ||
-            field_schema->children.size() < required_children ||
+        if (parquet_field->children.size() < required_children || field_schema->children.size() < required_children ||
             type_descriptor->children.size() < required_children) {
             return false;
         }

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -203,12 +203,15 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
     bool has_valid_child = false;
 
     if (parquet_field->type == ColumnType::ARRAY || parquet_field->type == ColumnType::MAP) {
-        for (size_t idx = 0; idx < parquet_field->children.size(); idx++) {
-            // Never index past the end of any of the three vectors -- a mismatch means we cannot
-            // validate this nested type, so stop and report it as invalid.
-            if (idx >= field_schema->children.size() || idx >= type_descriptor->children.size()) {
-                break;
-            }
+        // ARRAY always has one child (element) and MAP always has two (key, value). The downstream
+        // reader (ColumnReaderFactory::create) reads those children by fixed index.
+        const size_t required_children = parquet_field->type == ColumnType::MAP ? 2 : 1;
+        if (parquet_field->children.size() < required_children ||
+            field_schema->children.size() < required_children ||
+            type_descriptor->children.size() < required_children) {
+            return false;
+        }
+        for (size_t idx = 0; idx < required_children; idx++) {
             if (_is_valid_type(&parquet_field->children[idx], &field_schema->children[idx],
                                &type_descriptor->children[idx])) {
                 has_valid_child = true;

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -101,6 +101,8 @@ public:
                               std::unordered_set<std::string>& existed_column_names) const override;
 
 private:
+    friend class LakeMetaHelperTest;
+
     void _init_field_mapping();
     bool _is_valid_type(const ParquetField* parquet_field, const TIcebergSchemaField* field_schema,
                         const TypeDescriptor* type_descriptor) const;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -98,6 +98,7 @@ set(EXEC_FILES
         ./formats/parquet/encoding_test.cpp
         ./formats/parquet/page_reader_test.cpp
         ./formats/parquet/metadata_test.cpp
+        ./formats/parquet/meta_helper_test.cpp
         ./formats/parquet/group_reader_test.cpp
         ./formats/parquet/complex_column_reader_test.cpp
         ./formats/parquet/file_reader_test.cpp

--- a/be/test/formats/parquet/meta_helper_test.cpp
+++ b/be/test/formats/parquet/meta_helper_test.cpp
@@ -71,6 +71,31 @@ protected:
         return TypeDescriptor::create_array_type(struct_type);
     }
 
+    // Build the parquet-file view of MAP<VARCHAR, VARCHAR>: two children (key, value).
+    static ParquetField make_map_parquet_field() {
+        ParquetField key;
+        key.name = "key";
+        key.type = ColumnType::SCALAR;
+        key.field_id = 101;
+
+        ParquetField value;
+        value.name = "value";
+        value.type = ColumnType::SCALAR;
+        value.field_id = 102;
+
+        ParquetField map;
+        map.name = "col";
+        map.type = ColumnType::MAP;
+        map.field_id = 1;
+        map.children = {key, value};
+        return map;
+    }
+
+    static TypeDescriptor make_map_type() {
+        TypeDescriptor varchar = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+        return TypeDescriptor::create_map_type(varchar, varchar);
+    }
+
     // Helper to call the private method under test on a minimally-constructed helper.
     static bool is_valid_type(const TIcebergSchema& schema, const ParquetField& field,
                               const TIcebergSchemaField& top_field, const TypeDescriptor& type) {
@@ -126,6 +151,53 @@ TEST_F(LakeMetaHelperTest, CompleteNestedSchemaIsValid) {
 
     ParquetField parquet_field = make_array_of_struct_parquet_field();
     TypeDescriptor type = make_array_of_struct_type();
+
+    EXPECT_TRUE(is_valid_type(schema, parquet_field, top_field, type));
+}
+
+// Regression: a partial MAP lake schema carrying only the key child must be rejected.
+// The downstream reader reads lake_schema_field->children[1] (the value) unconditionally,
+// so accepting a one-child MAP would still crash even though the key alone validates.
+TEST_F(LakeMetaHelperTest, PartialMapSchemaWithOnlyKeyIsRejected) {
+    TIcebergSchemaField key;
+    key.__set_field_id(101);
+    key.__set_name("key");
+
+    // Only the key child is present -- the value child is missing.
+    TIcebergSchemaField top_field;
+    top_field.__set_field_id(1);
+    top_field.__set_name("col");
+    top_field.__set_children({key});
+
+    TIcebergSchema schema;
+    schema.__set_fields({top_field});
+
+    ParquetField parquet_field = make_map_parquet_field();
+    TypeDescriptor type = make_map_type();
+
+    EXPECT_FALSE(is_valid_type(schema, parquet_field, top_field, type));
+}
+
+// A complete MAP lake schema (both key and value children) validates.
+TEST_F(LakeMetaHelperTest, CompleteMapSchemaIsValid) {
+    TIcebergSchemaField key;
+    key.__set_field_id(101);
+    key.__set_name("key");
+
+    TIcebergSchemaField value;
+    value.__set_field_id(102);
+    value.__set_name("value");
+
+    TIcebergSchemaField top_field;
+    top_field.__set_field_id(1);
+    top_field.__set_name("col");
+    top_field.__set_children({key, value});
+
+    TIcebergSchema schema;
+    schema.__set_fields({top_field});
+
+    ParquetField parquet_field = make_map_parquet_field();
+    TypeDescriptor type = make_map_type();
 
     EXPECT_TRUE(is_valid_type(schema, parquet_field, top_field, type));
 }

--- a/be/test/formats/parquet/meta_helper_test.cpp
+++ b/be/test/formats/parquet/meta_helper_test.cpp
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/meta_helper.h"
+
+#include <gtest/gtest.h>
+
+#include "formats/parquet/schema.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks::parquet {
+
+// LakeMetaHelperTest is a friend of LakeMetaHelper so it can drive the private
+// _is_valid_type() directly. That function is where a crash was reported when the
+// FE ships an incomplete nested lake schema (e.g. Paimon complex columns before
+// #66784): the FE only carried the top-level field id/name and no children, while
+// the parquet file still described the full nesting, so the ARRAY/MAP branch used
+// the file's children count as the loop bound and then indexed the (empty) FE
+// children vector out of bounds, producing a null pointer that was dereferenced
+// one level down in the STRUCT branch (SIGSEGV @0x30).
+class LakeMetaHelperTest : public testing::Test {
+public:
+    LakeMetaHelperTest() = default;
+    ~LakeMetaHelperTest() override = default;
+
+protected:
+    // Build the parquet-file view of ARRAY<STRUCT<a VARCHAR, b VARCHAR>>. The file
+    // schema is always complete, so every level has its children populated.
+    static ParquetField make_array_of_struct_parquet_field() {
+        ParquetField a;
+        a.name = "a";
+        a.type = ColumnType::SCALAR;
+        a.field_id = 101;
+
+        ParquetField b;
+        b.name = "b";
+        b.type = ColumnType::SCALAR;
+        b.field_id = 102;
+
+        ParquetField element;
+        element.name = "element";
+        element.type = ColumnType::STRUCT;
+        element.field_id = 100;
+        element.children = {a, b};
+
+        ParquetField array;
+        array.name = "col";
+        array.type = ColumnType::ARRAY;
+        array.field_id = 1;
+        array.children = {element};
+        return array;
+    }
+
+    // The matching slot type: ARRAY<STRUCT<a VARCHAR, b VARCHAR>>.
+    static TypeDescriptor make_array_of_struct_type() {
+        TypeDescriptor varchar = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+        TypeDescriptor struct_type = TypeDescriptor::create_struct_type({"a", "b"}, {varchar, varchar});
+        return TypeDescriptor::create_array_type(struct_type);
+    }
+
+    // Helper to call the private method under test on a minimally-constructed helper.
+    static bool is_valid_type(const TIcebergSchema& schema, const ParquetField& field,
+                              const TIcebergSchemaField& top_field, const TypeDescriptor& type) {
+        LakeMetaHelper helper(/*file_metadata=*/nullptr, /*case_sensitive=*/false, &schema);
+        return helper._is_valid_type(&field, &top_field, &type);
+    }
+};
+
+// Regression: an incomplete lake schema (top-level field only, no nested children)
+// must be reported as an invalid/unsupported type instead of crashing.
+TEST_F(LakeMetaHelperTest, IncompleteNestedSchemaIsRejectedInsteadOfCrashing) {
+    // FE lake schema carrying only the top-level ARRAY column: field id + name, no children.
+    TIcebergSchemaField top_field;
+    top_field.__set_field_id(1);
+    top_field.__set_name("col");
+    // children intentionally left empty -- this is the pre-#66784 Paimon shape.
+    EXPECT_TRUE(top_field.children.empty());
+
+    TIcebergSchema schema;
+    schema.__set_fields({top_field});
+
+    ParquetField parquet_field = make_array_of_struct_parquet_field();
+    TypeDescriptor type = make_array_of_struct_type();
+
+    // Before the fix this dereferenced a null pointer and crashed; now it simply
+    // reports the nested type as invalid so the caller can skip the column.
+    EXPECT_FALSE(is_valid_type(schema, parquet_field, top_field, type));
+}
+
+// A complete lake schema (children recursively filled, as FE ships after #66784)
+// still validates the nested type as usable.
+TEST_F(LakeMetaHelperTest, CompleteNestedSchemaIsValid) {
+    TIcebergSchemaField a;
+    a.__set_field_id(101);
+    a.__set_name("a");
+
+    TIcebergSchemaField b;
+    b.__set_field_id(102);
+    b.__set_name("b");
+
+    TIcebergSchemaField element;
+    element.__set_field_id(100);
+    element.__set_name("element");
+    element.__set_children({a, b});
+
+    TIcebergSchemaField top_field;
+    top_field.__set_field_id(1);
+    top_field.__set_name("col");
+    top_field.__set_children({element});
+
+    TIcebergSchema schema;
+    schema.__set_fields({top_field});
+
+    ParquetField parquet_field = make_array_of_struct_parquet_field();
+    TypeDescriptor type = make_array_of_struct_type();
+
+    EXPECT_TRUE(is_valid_type(schema, parquet_field, top_field, type));
+}
+
+// A scalar column never enters the complex-type branches and is always valid,
+// regardless of the (empty) children vector.
+TEST_F(LakeMetaHelperTest, ScalarTypeIsAlwaysValid) {
+    TIcebergSchemaField top_field;
+    top_field.__set_field_id(1);
+    top_field.__set_name("col");
+
+    TIcebergSchema schema;
+    schema.__set_fields({top_field});
+
+    ParquetField scalar;
+    scalar.name = "col";
+    scalar.type = ColumnType::SCALAR;
+    scalar.field_id = 1;
+
+    TypeDescriptor type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+
+    EXPECT_TRUE(is_valid_type(schema, scalar, top_field, type));
+}
+
+} // namespace starrocks::parquet


### PR DESCRIPTION
## Why I'm doing:

When the FE ships an incomplete nested lake schema for a complex column — only the top-level field id/name with no children (e.g. Paimon complex columns such as `ARRAY<STRUCT<...>>` before #66784) — the native parquet reader crashes with SIGSEGV while validating the column type.

`LakeMetaHelper::_is_valid_type()` iterates the ARRAY/MAP children using the parquet-file field's children count as the loop bound, but indexes the FE `field_schema->children[idx]` with the same index. The FE `field_schema` children vector can be empty (or shorter) than the file's, so `&field_schema->children[idx]` reads past the end of the vector and produces a null pointer, which is then dereferenced one level down in the STRUCT branch:

```
PC: starrocks::parquet::LakeMetaHelper::_is_valid_type(...)
*** SIGSEGV (@0x30) received by PID ...
```

## What I'm doing:

Bounds-check every index access in the ARRAY/MAP branch against all three vectors (`parquet_field`, `field_schema`, `type_descriptor`). When the FE lake schema does not fully describe the nesting, stop and report the type as invalid instead of indexing out of bounds; the caller already handles an invalid type gracefully by skipping the column.

Note: #66784 fixed the FE side (recursively filling nested children), so the well-formed path no longer produces a truncated schema. This PR hardens the CN side so a truncated schema can never crash the BE.

Adds `LakeMetaHelperTest` with a regression case that reproduces the crash, plus coverage for the complete-schema and scalar paths.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
