### PR TITLE
[BugFix] Reconnect before get_table_req fallback in Hive getTable()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -660,6 +660,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             throw e;
         } catch (Exception e) {
             LOG.warn("Using get_table() failed, fail over to use get_table_req()", e);
+            // Reconnect first: get_table() may have failed on a read timeout that left an
+            // undrained response on the socket; reusing it for get_table_req() desyncs the
+            // Thrift seqid ("out of sequence response").
+            reconnect();
             GetTableRequest req = new GetTableRequest(dbName, tableName);
             req.setCapabilities(version);
             return client.get_table_req(req).getTable();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
@@ -21,12 +21,18 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.net.SocketTimeoutException;
 
 public class HiveMetastoreClientTest {
     @Test
@@ -51,5 +57,52 @@ public class HiveMetastoreClientTest {
         ExceptionChecker.expectThrowsWithMsg(NoSuchObjectException.class,
                 "Table not found",
                 () -> metaStoreClient.getTable("db", "table"));
+    }
+
+    @Test
+    public void testReconnectBeforeGetTableReqFallback(@Mocked ThriftHiveMetastore.Iface client) throws TException {
+        new MockUp<TSocket>() {
+            @Mock
+            public boolean isOpen() {
+                return true;
+            }
+        };
+
+        boolean[] reconnected = {false};
+        boolean[] reqRanAfterReconnect = {false};
+
+        new MockUp<ThriftHiveMetastore.Client>() {
+            @Mock
+            Table get_table(String dbName, String tblName) throws TException {
+                // get_table() read times out, leaving the connection in an unknown state.
+                throw new TTransportException(new SocketTimeoutException("Read timed out"));
+            }
+
+            @Mock
+            GetTableResult get_table_req(GetTableRequest req) {
+                reqRanAfterReconnect[0] = reconnected[0];
+                GetTableResult result = new GetTableResult();
+                result.setTable(new Table());
+                return result;
+            }
+        };
+
+        new MockUp<HiveMetaStoreClient>() {
+            @Mock
+            public void reconnect() {
+                reconnected[0] = true;
+            }
+        };
+
+        Configuration configuration = new HiveConf();
+        configuration.set("metastore.thrift.uris", "thrift://127.0.0.1:1234");
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(configuration);
+
+        Table table = metaStoreClient.getTable("db", "table");
+        Assertions.assertNotNull(table);
+        // The fallback must reconnect before issuing get_table_req on a fresh connection;
+        // otherwise get_table_req reads get_table's stale response and the Thrift seqid desyncs.
+        Assertions.assertTrue(reconnected[0], "reconnect() should be invoked before the get_table_req fallback");
+        Assertions.assertTrue(reqRanAfterReconnect[0], "get_table_req() must run after reconnect()");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Querying an Iceberg table in a Hive catalog (Thrift HMS) intermittently fails with `out of sequence response`, and downstream with `ERROR 5502 ... Unknown table`.

`HiveMetaStoreClient.getTable()` tries `get_table()` first and, on any exception, falls over to `get_table_req()` **on the same Thrift connection without reconnecting**. When `get_table()` read-times-out, its request was already sent and the HMS response arrives late, staying buffered on the socket. The fallback `get_table_req()` then reads that stale response, desyncing the Thrift seqid → `TApplicationException.BAD_SEQUENCE_ID` (`out of sequence response: expected N+1 but got N`). Because it happens on the background Iceberg metadata-refresh threads, the failed refresh leaves the cached table unusable and user queries fail with `Unknown table`.

`RetryingMetaStoreClient` treats `BAD_SEQUENCE_ID` as retriable and reconnects, so it usually self-heals; it surfaces to the user when the HMS is slow enough that the retry also fails.

For reference: Apache Hive's `getTable()` calls `get_table_req()` directly (no fallback), and Trino's thrift metastore client reconnects (`disconnect(); connect();`) before trying an alternative call, with the comment "Client that threw exception is in an unknown state."

## What I'm doing:

Reconnect before the `get_table_req()` fallback so it runs on a clean connection instead of reading `get_table()`'s stale buffered response.

Fixes #76454

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
