### PR TITLE
[BugFix] Self-heal Iceberg REST catalog OAuth2 session after token-refresh death

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -15,11 +15,13 @@
 package com.starrocks.connector.iceberg.rest;
 
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
@@ -372,6 +374,19 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         return delegate.buildView(buildContext(context), identifier);
     }
 
+    // the view DDL default methods run ViewBuilder.create()/createOrReplace() outside this class, so recovery
+    // must wrap the whole flow: the retry re-runs getViewBuilder and gets a builder on the rebuilt delegate
+    @Override
+    public boolean createView(ConnectContext context, String catalogName, ConnectorViewDefinition definition,
+                              boolean replace) {
+        return withAuthRecovery(() -> IcebergCatalog.super.createView(context, catalogName, definition, replace));
+    }
+
+    @Override
+    public boolean alterView(ConnectContext context, View currentView, ConnectorViewDefinition definition) {
+        return withAuthRecovery(() -> IcebergCatalog.super.alterView(context, currentView, definition));
+    }
+
     @Override
     public View getView(ConnectContext context, String dbName, String viewName) {
         if (!viewEndpointsEnabled) {
@@ -456,12 +471,17 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private <T> T withAuthRecovery(Supplier<T> action) {
         try {
             return action.get();
-        } catch (NotAuthorizedException e) {
-            if (!tryRecoverAuthSession(e)) {
+        } catch (RuntimeException e) {
+            if (!causedByNotAuthorized(e) || !tryRecoverAuthSession(e)) {
                 throw e;
             }
             return action.get();
         }
+    }
+
+    // the view DDL default methods wrap the 401 in StarRocksConnectorException, so walk the cause chain
+    private static boolean causedByNotAuthorized(RuntimeException failure) {
+        return Throwables.getCausalChain(failure).stream().anyMatch(NotAuthorizedException.class::isInstance);
     }
 
     private void runWithAuthRecovery(Runnable action) {
@@ -471,7 +491,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         });
     }
 
-    private synchronized boolean tryRecoverAuthSession(NotAuthorizedException cause) {
+    private synchronized boolean tryRecoverAuthSession(RuntimeException cause) {
         if (!authRecoveryEnabled) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -90,8 +90,6 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     private String catalogName = null;
     private final Configuration conf;
     private volatile RESTSessionCatalog delegate;
-    // replaced delegate kept for one recovery generation so requests in flight on it finish before close
-    private RESTSessionCatalog retiredDelegate;
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
@@ -495,37 +493,26 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         if (!authRecoveryEnabled) {
             return false;
         }
-        long now = System.currentTimeMillis();
-        if (now - lastAuthRecoveryMillis < AUTH_RECOVERY_MIN_INTERVAL_MS) {
-            // a recovery just ran (or just failed); retry on the current delegate instead of rebuilding again
+        if (System.currentTimeMillis() - lastAuthRecoveryMillis < AUTH_RECOVERY_MIN_INTERVAL_MS) {
+            // a rebuild ran or failed within the cooldown; retry on the current delegate rather than rebuild again
             return true;
         }
-        lastAuthRecoveryMillis = now;
         LOG.warn("REST catalog {} rejected the current OAuth2 token; rebuilding the catalog client to re-authenticate",
                 catalogName, cause);
         try {
             RESTSessionCatalog rebuilt = new RESTSessionCatalog();
             configureHadoopConf(rebuilt, conf);
             rebuilt.initialize(catalogName, restCatalogProperties);
-            RESTSessionCatalog stale = delegate;
+            // don't close the old delegate: tables it produced may still be cached upstream
+            // (CachingIcebergCatalog holds them up to its table-cache TTL) and use its FileIO; leave it for GC
             delegate = rebuilt;
-            closeQuietly(retiredDelegate);
-            retiredDelegate = stale;
             return true;
         } catch (Exception rebuildError) {
             LOG.warn("Failed to rebuild REST catalog {} to re-authenticate", catalogName, rebuildError);
             return false;
-        }
-    }
-
-    private static void closeQuietly(RESTSessionCatalog catalog) {
-        if (catalog == null) {
-            return;
-        }
-        try {
-            catalog.close();
-        } catch (Exception e) {
-            LOG.warn("Failed to close a replaced REST session catalog", e);
+        } finally {
+            // start the cooldown from completion so a slow rebuild doesn't immediately admit another
+            lastAuthRecoveryMillis = System.currentTimeMillis();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,15 +83,22 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public static final String USER_AGENT = "header.User-Agent";
     public static final String KEY_VIEW_ENDPOINTS_ENABLED = "rest.view-endpoints-enabled";
 
+    private static final long AUTH_RECOVERY_MIN_INTERVAL_MS = 60_000L;
+
     private String catalogName = null;
     private final Configuration conf;
-    private final RESTSessionCatalog delegate;
+    private volatile RESTSessionCatalog delegate;
+    // replaced delegate kept for one recovery generation so requests in flight on it finish before close
+    private RESTSessionCatalog retiredDelegate;
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
+    private final boolean authRecoveryEnabled;
+    private long lastAuthRecoveryMillis;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
+        this.catalogName = name;
         this.conf = conf;
         restCatalogProperties = Maps.newHashMap(properties);
 
@@ -121,6 +130,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         restCatalogProperties.putAll(securityProperties.get());
 
+        // only an OAuth2 client credential lets us mint a new token; per-user JWTs cannot be renewed by the FE
+        authRecoveryEnabled = restCatalogProperties.containsKey(OAuth2Properties.CREDENTIAL)
+                && securityConfig.getSecurity() != Security.JWT;
+
         try {
             delegate = new RESTSessionCatalog();
             configureHadoopConf(delegate, conf);
@@ -138,6 +151,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
         this.restCatalogProperties = Maps.newHashMap();
+        this.authRecoveryEnabled = false;
     }
 
     @Override
@@ -153,7 +167,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return withAuthRecovery(() ->
+                    delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to load table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to load table using REST Catalog", re);
@@ -163,7 +178,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return withAuthRecovery(() ->
+                    delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to check tableExists REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to check tableExists using REST Catalog", re);
@@ -174,10 +190,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public List<String> listAllDatabases(ConnectContext context) {
         try {
             if (nestedNamespaceEnabled) {
-                return listNamespaces(buildContext(context), Namespace.empty());
+                return withAuthRecovery(() -> listNamespaces(buildContext(context), Namespace.empty()));
             } else {
-                return delegate.listNamespaces(buildContext(context)).stream().map(ns -> ns.level(0))
-                        .collect(Collectors.toList());
+                return withAuthRecovery(() -> delegate.listNamespaces(buildContext(context)).stream().map(ns -> ns.level(0))
+                        .collect(Collectors.toList()));
             }
         } catch (RESTException re) {
             LOG.error("Failed to list databases using REST Catalog ", re);
@@ -211,8 +227,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                 throw new IllegalArgumentException("Unrecognized property: " + key);
             }
         }
+        Map<String, String> dbProperties = properties;
         try {
-            delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName), properties);
+            runWithAuthRecovery(() -> delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName),
+                    dbProperties));
         } catch (RESTException re) {
             LOG.error("Failed to list create namespace using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to create namespace using REST Catalog", re);
@@ -238,7 +256,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             throw new MetaNotFoundException("Database location is empty");
         }
         try {
-            delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName));
+            runWithAuthRecovery(() -> delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop database using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to drop database using REST Catalog", re);
@@ -248,7 +266,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public Database getDB(ConnectContext context, String dbName) {
         try {
-            Map<String, String> dbMeta = delegate.loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName));
+            Map<String, String> dbMeta = withAuthRecovery(() ->
+                    delegate.loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName)));
             return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
@@ -261,7 +280,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
         List<TableIdentifier> tableIdentifiers = null;
         try {
-            tableIdentifiers = delegate.listTables(buildContext(context), ns);
+            tableIdentifiers = withAuthRecovery(() -> delegate.listTables(buildContext(context), ns));
         } catch (RESTException re) {
             LOG.error("Failed to list tables using REST Catalog, for dbName {}", dbName, re);
             // creating a new RuntimeException with the custom message, as in the upstream code, it picks the `exception.getCause().getMessage()`
@@ -272,7 +291,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
         if (viewEndpointsEnabled) {
             try {
-                viewIdentifiers = delegate.listViews(buildContext(context), ns);
+                viewIdentifiers = withAuthRecovery(() -> delegate.listViews(buildContext(context), ns));
             } catch (BadRequestException e) {
                 LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
                         "Ask the user to check it, or you can disable view endpoints by setting '{}' to false",
@@ -306,13 +325,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         Table nativeTable = null;
         try {
-            nativeTable = delegate.buildTable(buildContext(context),
+            nativeTable = withAuthRecovery(() -> delegate.buildTable(buildContext(context),
                             TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), schema)
                     .withLocation(location)
                     .withPartitionSpec(partitionSpec)
                     .withSortOrder(sortOrder)
                     .withProperties(properties)
-                    .create();
+                    .create());
         } catch (RESTException re) {
             LOG.error("Failed to create table using REST Catalog, for dbName {} schema {} tableName {}",
                     dbName, schema, tableName, re);
@@ -325,8 +344,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         try {
-            return delegate.dropTable(buildContext(context),
-                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return withAuthRecovery(() -> delegate.dropTable(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to drop table using REST Catalog", re);
@@ -339,7 +358,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
 
         try {
-            delegate.renameTable(buildContext(context), TableIdentifier.of(ns, tblName), TableIdentifier.of(ns, newTblName));
+            runWithAuthRecovery(() -> delegate.renameTable(buildContext(context), TableIdentifier.of(ns, tblName),
+                    TableIdentifier.of(ns, newTblName)));
         } catch (RESTException re) {
             LOG.error("Failed to rename table using REST Catalog, for dbName {} tableName {} newTblName {}",
                     dbName, tblName, newTblName, re);
@@ -360,7 +380,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     "' to true to enable view endpoints");
         }
         try {
-            return delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
+            return withAuthRecovery(() ->
+                    delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to load view using REST Catalog", re);
@@ -370,7 +391,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropView(ConnectContext context, String dbName, String viewName) {
         try {
-            return delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
+            return withAuthRecovery(() ->
+                    delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to drop view using REST Catalog", re);
@@ -400,7 +422,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public boolean registerTable(ConnectContext context, String dbName, String tableName, String metadataFileLocation) {
         try {
             TableIdentifier tableIdentifier = TableIdentifier.of(convertDbNameToNamespace(dbName), tableName);
-            Table table = delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation);
+            Table table = withAuthRecovery(() ->
+                    delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation));
             return table != null;
         } catch (RESTException re) {
             LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
@@ -416,7 +439,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public Map<String, String> loadNamespaceMetadata(ConnectContext context, Namespace ns) {
         try {
-            return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(buildContext(context), ns));
+            return ImmutableMap.copyOf(withAuthRecovery(() -> delegate.loadNamespaceMetadata(buildContext(context), ns)));
         } catch (RESTException re) {
             LOG.error("Failed to load table metadata using REST Catalog, for namespace {}", ns, re);
             throw new StarRocksConnectorException(
@@ -428,6 +451,62 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public String defaultTableLocation(ConnectContext context, Namespace ns, String tableName) {
         // iceberg rest catalog doesn't require location property, and could choose the default location.
         return null;
+    }
+
+    private <T> T withAuthRecovery(Supplier<T> action) {
+        try {
+            return action.get();
+        } catch (NotAuthorizedException e) {
+            if (!tryRecoverAuthSession(e)) {
+                throw e;
+            }
+            return action.get();
+        }
+    }
+
+    private void runWithAuthRecovery(Runnable action) {
+        withAuthRecovery(() -> {
+            action.run();
+            return null;
+        });
+    }
+
+    private synchronized boolean tryRecoverAuthSession(NotAuthorizedException cause) {
+        if (!authRecoveryEnabled) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastAuthRecoveryMillis < AUTH_RECOVERY_MIN_INTERVAL_MS) {
+            // a recovery just ran (or just failed); retry on the current delegate instead of rebuilding again
+            return true;
+        }
+        lastAuthRecoveryMillis = now;
+        LOG.warn("REST catalog {} rejected the current OAuth2 token; rebuilding the catalog client to re-authenticate",
+                catalogName, cause);
+        try {
+            RESTSessionCatalog rebuilt = new RESTSessionCatalog();
+            configureHadoopConf(rebuilt, conf);
+            rebuilt.initialize(catalogName, restCatalogProperties);
+            RESTSessionCatalog stale = delegate;
+            delegate = rebuilt;
+            closeQuietly(retiredDelegate);
+            retiredDelegate = stale;
+            return true;
+        } catch (Exception rebuildError) {
+            LOG.warn("Failed to rebuild REST catalog {} to re-authenticate", catalogName, rebuildError);
+            return false;
+        }
+    }
+
+    private static void closeQuietly(RESTSessionCatalog catalog) {
+        if (catalog == null) {
+            return;
+        }
+        try {
+            catalog.close();
+        } catch (Exception e) {
+            LOG.warn("Failed to close a replaced REST session catalog", e);
+        }
     }
 
     private SessionCatalog.SessionContext buildContext(ConnectContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -89,7 +90,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     private String catalogName = null;
     private final Configuration conf;
-    private volatile RESTSessionCatalog delegate;
+    // swapped under synchronized on auth recovery; read lock-free everywhere else
+    private final AtomicReference<RESTSessionCatalog> delegate = new AtomicReference<>();
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
@@ -135,9 +137,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                 && securityConfig.getSecurity() != Security.JWT;
 
         try {
-            delegate = new RESTSessionCatalog();
-            configureHadoopConf(delegate, conf);
-            delegate.initialize(name, restCatalogProperties);
+            RESTSessionCatalog restCatalog = new RESTSessionCatalog();
+            configureHadoopConf(restCatalog, conf);
+            restCatalog.initialize(name, restCatalogProperties);
+            delegate.set(restCatalog);
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
             throw new StarRocksConnectorException("Failed to load rest catalog", re);
@@ -146,7 +149,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     // for ut
     public IcebergRESTCatalog(RESTSessionCatalog restCatalog, Configuration conf) {
-        this.delegate = restCatalog;
+        this.delegate.set(restCatalog);
         this.conf = conf;
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
@@ -161,14 +164,14 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public Map<String, String> getCatalogProperties() {
-        return delegate.properties();
+        return delegate.get().properties();
     }
 
     @Override
     public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return withAuthRecovery(() ->
-                    delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
+            return withAuthRecovery(() -> delegate.get().loadTable(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to load table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to load table using REST Catalog", re);
@@ -178,8 +181,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return withAuthRecovery(() ->
-                    delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
+            return withAuthRecovery(() -> delegate.get().tableExists(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to check tableExists REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to check tableExists using REST Catalog", re);
@@ -192,7 +195,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             if (nestedNamespaceEnabled) {
                 return withAuthRecovery(() -> listNamespaces(buildContext(context), Namespace.empty()));
             } else {
-                return withAuthRecovery(() -> delegate.listNamespaces(buildContext(context)).stream().map(ns -> ns.level(0))
+                return withAuthRecovery(() -> delegate.get().listNamespaces(buildContext(context)).stream().map(ns -> ns.level(0))
                         .collect(Collectors.toList()));
             }
         } catch (RESTException re) {
@@ -202,7 +205,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     private List<String> listNamespaces(SessionCatalog.SessionContext sessionContext, Namespace parent) {
-        return delegate.listNamespaces(sessionContext, parent).stream().
+        return delegate.get().listNamespaces(sessionContext, parent).stream().
                 flatMap(child -> Stream.concat(Stream.of(child.toString()),
                         listNamespaces(sessionContext, child).stream()))
                 .collect(toImmutableList());
@@ -229,7 +232,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         }
         Map<String, String> dbProperties = properties;
         try {
-            runWithAuthRecovery(() -> delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName),
+            runWithAuthRecovery(() -> delegate.get().createNamespace(buildContext(context), convertDbNameToNamespace(dbName),
                     dbProperties));
         } catch (RESTException re) {
             LOG.error("Failed to list create namespace using REST Catalog, for dbName {}", dbName, re);
@@ -256,7 +259,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             throw new MetaNotFoundException("Database location is empty");
         }
         try {
-            runWithAuthRecovery(() -> delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName)));
+            runWithAuthRecovery(() -> delegate.get().dropNamespace(buildContext(context), convertDbNameToNamespace(dbName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop database using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to drop database using REST Catalog", re);
@@ -267,7 +270,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public Database getDB(ConnectContext context, String dbName) {
         try {
             Map<String, String> dbMeta = withAuthRecovery(() ->
-                    delegate.loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName)));
+                    delegate.get().loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName)));
             return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
@@ -280,7 +283,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
         List<TableIdentifier> tableIdentifiers = null;
         try {
-            tableIdentifiers = withAuthRecovery(() -> delegate.listTables(buildContext(context), ns));
+            tableIdentifiers = withAuthRecovery(() -> delegate.get().listTables(buildContext(context), ns));
         } catch (RESTException re) {
             LOG.error("Failed to list tables using REST Catalog, for dbName {}", dbName, re);
             // creating a new RuntimeException with the custom message, as in the upstream code, it picks the `exception.getCause().getMessage()`
@@ -291,7 +294,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
         if (viewEndpointsEnabled) {
             try {
-                viewIdentifiers = withAuthRecovery(() -> delegate.listViews(buildContext(context), ns));
+                viewIdentifiers = withAuthRecovery(() -> delegate.get().listViews(buildContext(context), ns));
             } catch (BadRequestException e) {
                 LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
                         "Ask the user to check it, or you can disable view endpoints by setting '{}' to false",
@@ -325,7 +328,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         Table nativeTable = null;
         try {
-            nativeTable = withAuthRecovery(() -> delegate.buildTable(buildContext(context),
+            nativeTable = withAuthRecovery(() -> delegate.get().buildTable(buildContext(context),
                             TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), schema)
                     .withLocation(location)
                     .withPartitionSpec(partitionSpec)
@@ -344,7 +347,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         try {
-            return withAuthRecovery(() -> delegate.dropTable(buildContext(context),
+            return withAuthRecovery(() -> delegate.get().dropTable(buildContext(context),
                     TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
@@ -358,7 +361,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
 
         try {
-            runWithAuthRecovery(() -> delegate.renameTable(buildContext(context), TableIdentifier.of(ns, tblName),
+            runWithAuthRecovery(() -> delegate.get().renameTable(buildContext(context), TableIdentifier.of(ns, tblName),
                     TableIdentifier.of(ns, newTblName)));
         } catch (RESTException re) {
             LOG.error("Failed to rename table using REST Catalog, for dbName {} tableName {} newTblName {}",
@@ -369,7 +372,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public ViewBuilder getViewBuilder(ConnectContext context, TableIdentifier identifier) {
-        return delegate.buildView(buildContext(context), identifier);
+        return delegate.get().buildView(buildContext(context), identifier);
     }
 
     // the view DDL default methods run ViewBuilder.create()/createOrReplace() outside this class, so recovery
@@ -393,8 +396,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     "' to true to enable view endpoints");
         }
         try {
-            return withAuthRecovery(() ->
-                    delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
+            return withAuthRecovery(() -> delegate.get().loadView(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to load view using REST Catalog", re);
@@ -404,8 +407,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropView(ConnectContext context, String dbName, String viewName) {
         try {
-            return withAuthRecovery(() ->
-                    delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
+            return withAuthRecovery(() -> delegate.get().dropView(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to drop view using REST Catalog", re);
@@ -436,7 +439,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         try {
             TableIdentifier tableIdentifier = TableIdentifier.of(convertDbNameToNamespace(dbName), tableName);
             Table table = withAuthRecovery(() ->
-                    delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation));
+                    delegate.get().registerTable(buildContext(context), tableIdentifier, metadataFileLocation));
             return table != null;
         } catch (RESTException re) {
             LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
@@ -446,13 +449,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     public String toString() {
-        return delegate.toString();
+        return delegate.get().toString();
     }
 
     @Override
     public Map<String, String> loadNamespaceMetadata(ConnectContext context, Namespace ns) {
         try {
-            return ImmutableMap.copyOf(withAuthRecovery(() -> delegate.loadNamespaceMetadata(buildContext(context), ns)));
+            return ImmutableMap.copyOf(withAuthRecovery(() -> delegate.get().loadNamespaceMetadata(buildContext(context), ns)));
         } catch (RESTException re) {
             LOG.error("Failed to load table metadata using REST Catalog, for namespace {}", ns, re);
             throw new StarRocksConnectorException(
@@ -505,7 +508,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             rebuilt.initialize(catalogName, restCatalogProperties);
             // don't close the old delegate: tables it produced may still be cached upstream
             // (CachingIcebergCatalog holds them up to its table-cache TTL) and use its FileIO; leave it for GC
-            delegate = rebuilt;
+            delegate.set(rebuilt);
             return true;
         } catch (Exception rebuildError) {
             LOG.warn("Failed to rebuild REST catalog {} to re-authenticate", catalogName, rebuildError);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
@@ -1,0 +1,121 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.Frontend;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Drives the real RESTSessionCatalog (no iceberg mocks) against an in-process REST catalog server
+ * to verify the OAuth2 auth-session recovery end to end: the server starts rejecting the issued
+ * bearer token with 401, and the catalog must transparently re-authenticate with the client
+ * credential and answer the request.
+ */
+public class IcebergRESTCatalogAuthRecoveryHttpTest {
+
+    private HttpServer server;
+    private ConnectContext connectContext;
+
+    private final AtomicInteger tokenSequence = new AtomicInteger();
+    private final AtomicInteger tokenFetches = new AtomicInteger();
+    private volatile String validToken;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.FOLLOWER, "fe1", "127.0.0.1", 9010);
+            }
+        };
+        connectContext = new ConnectContext();
+
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/v1/oauth/tokens", exchange -> {
+            String token = "token-" + tokenSequence.incrementAndGet();
+            validToken = token;
+            tokenFetches.incrementAndGet();
+            respond(exchange, 200,
+                    "{\"access_token\":\"" + token + "\",\"token_type\":\"bearer\",\"expires_in\":3600}");
+        });
+        server.createContext("/v1/config", exchange -> respond(exchange, 200, "{\"defaults\":{},\"overrides\":{}}"));
+        server.createContext("/v1/namespaces", exchange -> {
+            String auth = exchange.getRequestHeaders().getFirst("Authorization");
+            String expected = validToken == null ? null : "Bearer " + validToken;
+            if (expected == null || !expected.equals(auth)) {
+                respond(exchange, 401,
+                        "{\"error\":{\"message\":\"Not authorized\",\"type\":\"NotAuthorizedException\",\"code\":401}}");
+            } else {
+                respond(exchange, 200, "{\"namespaces\":[[\"db1\"]]}");
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, int code, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(code, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    @Test
+    public void testRecoversThroughRealClientWhenServerRejectsToken() {
+        String uri = "http://127.0.0.1:" + server.getAddress().getPort();
+        IcebergRESTCatalog catalog = new IcebergRESTCatalog("rest_catalog", new Configuration(),
+                ImmutableMap.of(
+                        "iceberg.catalog.uri", uri,
+                        "iceberg.catalog.security", "oauth2",
+                        "iceberg.catalog.oauth2.credential", "id:secret"));
+
+        Assertions.assertEquals(List.of("db1"), catalog.listAllDatabases(connectContext));
+
+        // the server rotates its signing state: every token issued so far is now rejected with 401,
+        // while the client credential can still mint a fresh one
+        validToken = null;
+
+        Assertions.assertEquals(List.of("db1"), catalog.listAllDatabases(connectContext));
+        Assertions.assertTrue(tokenFetches.get() >= 2,
+                "recovery must have re-authenticated with the client credential, fetches=" + tokenFetches.get());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryHttpTest.java
@@ -74,8 +74,10 @@ public class IcebergRESTCatalogAuthRecoveryHttpTest {
             String auth = exchange.getRequestHeaders().getFirst("Authorization");
             String expected = validToken == null ? null : "Bearer " + validToken;
             if (expected == null || !expected.equals(auth)) {
-                respond(exchange, 401,
-                        "{\"error\":{\"message\":\"Not authorized\",\"type\":\"NotAuthorizedException\",\"code\":401}}");
+                // exact shape observed from Apache Polaris 1.1.0: bare 401, empty body, WWW-Authenticate: Bearer
+                exchange.getResponseHeaders().set("WWW-Authenticate", "Bearer");
+                exchange.sendResponseHeaders(401, -1);
+                exchange.close();
             } else {
                 respond(exchange, 200, "{\"namespaces\":[[\"db1\"]]}");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.rest;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.system.Frontend;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergRESTCatalogAuthRecoveryTest {
+
+    @Mocked
+    private RESTSessionCatalog restCatalog;
+
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() {
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.FOLLOWER, "fe1", "127.0.0.1", 9010);
+            }
+        };
+        connectContext = new ConnectContext();
+    }
+
+    private IcebergRESTCatalog newCatalog(Map<String, String> properties) {
+        return new IcebergRESTCatalog("rest_catalog", new Configuration(), new HashMap<>(properties));
+    }
+
+    private IcebergRESTCatalog newOAuth2CredentialCatalog() {
+        return newCatalog(ImmutableMap.of(
+                "iceberg.catalog.security", "oauth2",
+                "iceberg.catalog.oauth2.credential", "id:secret"));
+    }
+
+    @Test
+    public void testNotAuthorizedTriggersRebuildAndRetry() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = ImmutableMap.of("location", "s3://bucket/db1");
+            }
+        };
+
+        Database db = newOAuth2CredentialCatalog().getDB(connectContext, "db1");
+
+        Assertions.assertEquals("s3://bucket/db1", db.getLocation());
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2; // constructor + one auth-recovery rebuild
+            }
+        };
+    }
+
+    @Test
+    public void testFailedRetryPropagatesAfterSingleRebuild() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2;
+            }
+        };
+    }
+
+    @Test
+    public void testRebuildIsRateLimited() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2; // the second NotAuthorized arrives within the cooldown and must not rebuild again
+            }
+        };
+    }
+
+    @Test
+    public void testNoRecoveryWithoutClientCredential() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "bad token");
+            }
+        };
+
+        IcebergRESTCatalog catalog = newCatalog(ImmutableMap.of());
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testNoRecoveryForJwtSecurity() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "expired user token");
+            }
+        };
+
+        IcebergRESTCatalog catalog = newCatalog(ImmutableMap.of(
+                "iceberg.catalog.security", "jwt",
+                "iceberg.catalog.oauth2.credential", "id:secret"));
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testOtherRestExceptionsDoNotRebuild() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = new RESTException("server error");
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> catalog.getDB(connectContext, "db1"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 1;
+            }
+        };
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
@@ -14,14 +14,18 @@
 
 package com.starrocks.connector.iceberg.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Database;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Frontend;
 import mockit.Expectations;
+import mockit.Injectable;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -32,6 +36,9 @@ import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewBuilder;
+import org.apache.iceberg.view.ViewVersion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -196,6 +203,116 @@ public class IcebergRESTCatalogAuthRecoveryTest {
             {
                 restCatalog.initialize(anyString, (Map<String, String>) any);
                 times = 1; // no NotAuthorized -> no rebuild
+            }
+        };
+    }
+
+    @Test
+    public void testCreateViewRecoversFromNotAuthorized(@Mocked ViewBuilder viewBuilder,
+                                                        @Injectable ConnectorViewDefinition definition) {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setThreadLocalInfo();
+        new Expectations() {
+            {
+                definition.getColumns();
+                result = ImmutableList.of();
+                minTimes = 0;
+                definition.getDatabaseName();
+                result = "db1";
+                minTimes = 0;
+                definition.getViewName();
+                result = "v1";
+                minTimes = 0;
+                viewBuilder.create();
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = null;
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertTrue(catalog.createView(connectContext, "iceberg_catalog", definition, false));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2;
+            }
+        };
+    }
+
+    @Test
+    public void testCreateOrReplaceViewRecoversFromWrappedNotAuthorized(@Mocked ViewBuilder viewBuilder,
+                                                                        @Injectable ConnectorViewDefinition definition) {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setThreadLocalInfo();
+        new Expectations() {
+            {
+                definition.getColumns();
+                result = ImmutableList.of();
+                minTimes = 0;
+                definition.getDatabaseName();
+                result = "db1";
+                minTimes = 0;
+                definition.getViewName();
+                result = "v1";
+                minTimes = 0;
+                // createViewDefault wraps this failure into StarRocksConnectorException(RuntimeException(cause)),
+                // so recovery must detect NotAuthorizedException through the cause chain
+                viewBuilder.createOrReplace();
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = null;
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertTrue(catalog.createView(connectContext, "iceberg_catalog", definition, true));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2;
+            }
+        };
+    }
+
+    @Test
+    public void testAlterViewRecoversFromNotAuthorized(@Mocked ViewBuilder viewBuilder,
+                                                       @Injectable ConnectorViewDefinition definition,
+                                                       @Injectable View currentView,
+                                                       @Injectable ViewVersion viewVersion) {
+        new Expectations() {
+            {
+                definition.getDatabaseName();
+                result = "db1";
+                minTimes = 0;
+                definition.getViewName();
+                result = "v1";
+                minTimes = 0;
+                definition.getColumns();
+                result = ImmutableList.of();
+                minTimes = 0;
+                currentView.properties();
+                result = ImmutableMap.of();
+                minTimes = 0;
+                currentView.currentVersion();
+                result = viewVersion;
+                minTimes = 0;
+                viewVersion.defaultNamespace();
+                result = Namespace.of("db1");
+                minTimes = 0;
+                viewVersion.representations();
+                result = ImmutableList.of();
+                minTimes = 0;
+                viewBuilder.createOrReplace();
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = null;
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertTrue(catalog.alterView(connectContext, currentView, definition));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 2;
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
@@ -75,7 +75,7 @@ public class IcebergRESTCatalogAuthRecoveryTest {
     }
 
     @Test
-    public void testNotAuthorizedTriggersRebuildAndRetry() {
+    public void testNotAuthorizedTriggersRebuildAndRetry() throws Exception {
         new Expectations() {
             {
                 restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
@@ -91,6 +91,9 @@ public class IcebergRESTCatalogAuthRecoveryTest {
             {
                 restCatalog.initialize(anyString, (Map<String, String>) any);
                 times = 2; // constructor + one auth-recovery rebuild
+                // the replaced delegate is left for GC, never closed: its tables may still be cached upstream
+                restCatalog.close();
+                times = 0;
             }
         };
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalogAuthRecoveryTest.java
@@ -168,6 +168,39 @@ public class IcebergRESTCatalogAuthRecoveryTest {
     }
 
     @Test
+    public void testWrappedOperationsPassThroughOnSuccess() {
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionCatalog.SessionContext) any, (Namespace) any);
+                result = ImmutableMap.of("location", "s3://bucket/db1");
+                minTimes = 0;
+            }
+        };
+
+        IcebergRESTCatalog catalog = newOAuth2CredentialCatalog();
+        Assertions.assertNotNull(catalog.getTable(connectContext, "db1", "t1"));
+        Assertions.assertFalse(catalog.tableExists(connectContext, "db1", "t1"));
+        Assertions.assertTrue(catalog.listAllDatabases(connectContext).isEmpty());
+        catalog.createDB(connectContext, "db2", null);
+        Assertions.assertEquals("s3://bucket/db1", catalog.getDB(connectContext, "db1").getLocation());
+        Assertions.assertDoesNotThrow(() -> catalog.dropDB(connectContext, "db1"));
+        Assertions.assertTrue(catalog.listTables(connectContext, "db1").isEmpty());
+        Assertions.assertTrue(catalog.createTable(connectContext, "db1", "t1", null, null, null, null, ImmutableMap.of()));
+        Assertions.assertFalse(catalog.dropTable(connectContext, "db1", "t1", true));
+        catalog.renameTable(connectContext, "db1", "t1", "t2");
+        Assertions.assertNotNull(catalog.getView(connectContext, "db1", "v1"));
+        Assertions.assertFalse(catalog.dropView(connectContext, "db1", "v1"));
+        Assertions.assertEquals("s3://bucket/db1",
+                catalog.loadNamespaceMetadata(connectContext, Namespace.of("db1")).get("location"));
+        new Verifications() {
+            {
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                times = 1; // no NotAuthorized -> no rebuild
+            }
+        };
+    }
+
+    @Test
     public void testOtherRestExceptionsDoNotRebuild() {
         new Expectations() {
             {


### PR DESCRIPTION
## Why I'm doing:

When an Iceberg REST catalog uses OAuth2 client credentials, the Iceberg client library keeps the catalog-level access token fresh with a background refresh task. That task retries a failed refresh only a bounded number of times (`OAuth2Util.AuthSession.refresh` retries 5 times, hardcoded, ~1 minute with backoff) and `scheduleTokenRefresh` re-arms the next refresh **only when the current one succeeds**. If the OAuth token endpoint is unavailable slightly longer than the retry budget (e.g. a gateway returns `504` for a minute during a server restart), the refresh chain dies permanently:

- the (still valid) client credential is never used again to fetch a new token,
- every subsequent catalog request fails with `NotAuthorizedException: Not authorized`,
- and there is no 401-triggered re-authentication anywhere in the client, so the catalog never recovers even after the OAuth server comes back.

The only way out today is dropping and re-creating the catalog (or restarting the FE), which rebuilds the auth session. This was hit in production against a Polaris REST catalog: a ~1 minute `504 Gateway Time-out` window on the token endpoint permanently bricked the catalog until the user re-created it. Upstream Iceberg has the same behavior on `main` (see apache/iceberg#13515, closed by the stale bot without a fix, and apache/iceberg#13591), so we fix it on the StarRocks side.

## What I'm doing:

Fixes #76438
Make `IcebergRESTCatalog` self-heal when its OAuth2 session has expired:

1. On `NotAuthorizedException` from the delegate `RESTSessionCatalog`, rebuild the delegate (same name/conf/properties — `initialize` fetches a fresh token with the client credential and re-arms the refresh scheduler, exactly what re-creating the catalog does today) and retry the request once. A request rejected with 401 never executed on the server, so the single retry is safe for reads and writes alike.
2. Recovery is **single-flight and rate-limited** (at most one rebuild per 60s across all threads): a query storm hitting a dead session triggers one rebuild, and if the OAuth server is truly broken (e.g. rotated secret) we keep failing fast instead of hammering it with re-auth attempts.
3. Recovery only applies when the catalog holds an OAuth2 client credential (`credential` in the resolved REST properties) and security is not `jwt` — with per-user JWTs the FE has no material to mint a new token, and static-token catalogs cannot be refreshed by a rebuild either.
4. The replaced delegate is closed one recovery generation later (`retiredDelegate`), so in-flight requests on the old client are not cut off mid-call; its refresh scheduler is already dead, so keeping it briefly costs nothing.

5. View DDL is covered too (from review feedback): `createView`/`alterView` are overridden so the whole default-method flow — including the terminal `ViewBuilder.create()`/`createOrReplace()` executed outside this class — routes through the recovery wrapper, which walks the exception cause chain because `createViewDefault` wraps the 401 in `StarRocksConnectorException`. The retry re-runs `getViewBuilder`, so the builder is recreated on the rebuilt delegate.

Tests:
- `IcebergRESTCatalogAuthRecoveryTest` (JMockit) covers rebuild-and-retry success, propagation when the retry also fails (single rebuild), the rate limit across consecutive failures, no rebuild without a client credential / with `security=jwt` / for non-401 `RESTException`s, the happy path of every wrapped call site, and view DDL recovery (create with a raw 401, create-or-replace with the 401 behind the wrapped cause chain, alter).
- `IcebergRESTCatalogAuthRecoveryHttpTest` drives the **real** `RESTSessionCatalog` (no iceberg mocks) against an in-process HTTP server speaking the minimal REST catalog protocol: the server starts rejecting the issued bearer token with 401 while the client credential can still mint a fresh one, and the catalog must transparently re-authenticate. On the pre-fix code this test reproduces the production failure verbatim (`StarRocksConnectorException ... Caused by: NotAuthorizedException: Not authorized`, permanent until the catalog is re-created).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior change**: an OAuth2 (client-credential) Iceberg REST catalog whose token refresh died after an OAuth-endpoint outage now recovers automatically on the next request instead of failing with `Not authorized` until the catalog is re-created.

**Scope / known limitation**: recovery covers operations that go through `IcebergRESTCatalog` (namespace/table listing, table load, DDL, and view DDL). It does **not** cover a 401 raised by a commit issued directly on an already-cached native `Table`, because that request goes through the `BaseTable`'s own `TableOperations` — bound to the REST client that loaded it — and bypasses both `IcebergRESTCatalog` and the wrapping `CachingIcebergCatalog`. Such a table is refreshed with a live client on its next cache reload once any catalog-level operation has rebuilt the delegate; recovering an in-flight commit itself would require a `CachingIcebergCatalog`-level (or commit-path) change and is left as a follow-up. This path was already broken by the dead session before this PR, so the change is a strict improvement, not a regression.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
