### PR TITLE
[BugFix] Detect Hive table-not-found by exception type instead of message text

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
@@ -36,6 +37,7 @@ import com.starrocks.thrift.TAnalyzeStatusRes;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -123,8 +125,9 @@ public class AnalyzeStatusSystemTable extends SystemTable {
                 continue;
             } catch (Throwable e) {
                 // TODO: change the exception into an checked exception in MetadataMgr.getTable
-                // The underlying SDK might throw an deep exception with this message
-                if (!(e.getMessage() != null && e.getMessage().contains("table not found"))) {
+                // For hive catalog, a dropped table surfaces as NoSuchObjectException in the cause chain
+                // rather than as a special return value, so skip the warning log for that expected case.
+                if (!LogUtil.isCausedBy(e, NoSuchObjectException.class)) {
                     LOG.warn("failed to get table meta", e);
                 }
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -15,6 +15,7 @@
 package com.starrocks.common.util;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.starrocks.common.Config;
@@ -199,6 +200,14 @@ public class LogUtil {
         } else if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
             sb.append(" ");
         }
+    }
+
+    // Some connectors (e.g. Hive metastore) only ever throw when a table is missing rather than
+    // returning null/empty, wrapping the real signal (e.g. NoSuchObjectException) as a cause several
+    // layers deep. Callers that need to special-case "not found" must check the whole cause chain by
+    // type instead of matching on the outer exception's message, which is not a stable contract.
+    public static boolean isCausedBy(Throwable e, Class<? extends Throwable> exceptionType) {
+        return Throwables.getCausalChain(e).stream().anyMatch(exceptionType::isInstance);
     }
 
     public static List<Throwable> unwindException(Throwable e, int maxDepth) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -37,6 +37,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.LogUtil;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.SRStringUtils;
 import com.starrocks.common.util.TimeUtils;
@@ -120,6 +121,7 @@ import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.util.Box;
 import org.apache.commons.collections4.SetUtils;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1483,13 +1485,10 @@ public class MvUtils {
         try (ConnectContext.ContextScope scope = ConnectContext.enterOnlyReadIcebergCacheScope(ConnectContext.get())) {
             return GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(scope.getContext(), baseTableInfo);
         } catch (Exception e) {
-            // For hive catalog, when meets NoSuchObjectException, we should return empty
-            //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
-            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
-            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
-            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
-            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
-            if (e.getMessage() != null && e.getMessage().contains("NoSuchObjectException")) {
+            // For hive catalog, the metastore client always throws (wrapping NoSuchObjectException as the
+            // cause) instead of returning null when the table doesn't exist, so we must unwrap the cause
+            // chain to tell "table not found" apart from other failures.
+            if (LogUtil.isCausedBy(e, NoSuchObjectException.class)) {
                 return Optional.empty();
             }
             throw e;
@@ -1501,14 +1500,11 @@ public class MvUtils {
             return GlobalStateMgr.getCurrentState().getMetadataMgr()
                     .getTableWithIdentifier(scope.getContext(), baseTableInfo);
         } catch (Exception e) {
-            // For hive catalog, when meets NoSuchObjectException, we should return empty
-            //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
-            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:178)
-            //        at com.starrocks.connector.hive.HiveMetaClient.callRPC(HiveMetaClient.java:163)
-            //        at com.starrocks.connector.hive.HiveMetaClient.getTable(HiveMetaClient.java:272)
-            //        at com.starrocks.connector.hive.HiveMetastore.getTable(HiveMetastore.java:116)
+            // For hive catalog, the metastore client always throws (wrapping NoSuchObjectException as the
+            // cause) instead of returning null when the table doesn't exist, so we must unwrap the cause
+            // chain to tell "table not found" apart from other failures.
             LOG.warn("Failed to get table with baseTableInfo: {}, error: {}", baseTableInfo, e.getMessage());
-            if (e.getMessage() != null && e.getMessage().contains("NoSuchObjectException")) {
+            if (LogUtil.isCausedBy(e, NoSuchObjectException.class)) {
                 return Optional.empty();
             }
             throw e;


### PR DESCRIPTION
## Why I'm doing:
#75490 tightened the exception messages that connector metadata calls (Hive/Delta/Iceberg/etc.) surface to users, dropping the inlined root-cause text from the top-level message and pushing it into the cause chain instead. Two call sites, however, were relying on substring-matching that inlined text (`e.getMessage().contains("NoSuchObjectException")` / `"table not found"`) to detect "the Hive base table was dropped" and treat it as an expected, swallow-able case. Once the message format changed, that detection silently broke: a materialized view whose Hive base table gets dropped no longer gets marked `INACTIVE` on refresh, and refresh failures get logged as noisy errors instead of being handled gracefully. See StarRocksTest#11584.

## What I'm doing:
Stop pattern-matching on exception message text and instead walk the full cause chain by exception type, which is stable regardless of how outer wrapper messages are worded.

- Added `LogUtil.isCausedBy(Throwable, Class<? extends Throwable>)`, a small shared helper that checks whether any exception in the cause chain is an instance of a given type.
- `MvUtils.getTable` / `MvUtils.getTableWithIdentifier`: replaced the message substring check with `LogUtil.isCausedBy(e, NoSuchObjectException.class)` to detect a dropped Hive table and return `Optional.empty()` instead of propagating the exception.
- `AnalyzeStatusSystemTable`: same fix, applied to suppress the (cosmetic) warning log for the same expected "table not found" case.

```
before: SRConnectorException("Failed to get table [...], msg: NoSuchObjectException: ...")
              ^--- substring match on this text, broke after #75490 shortened it

after:  SRConnectorException("Failed to get table [...]")
              └─ cause: InvocationTargetException
                    └─ cause: NoSuchObjectException      <-- matched by type via getCausalChain
```

issue: https://github.com/StarRocks/StarRocksTest/issues/11584

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
