### PR TITLE
[BugFix] Fix graceful exit crash in SinkBuffer (backport #73202)

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -364,28 +364,32 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             _first_send_time = MonotonicNanos();
         }
 
-        closure->addFailedHandler([this](const ClosureContext& ctx, std::string_view rpc_error_msg) noexcept {
-            auto query_ctx = _fragment_ctx->runtime_state()->query_ctx();
-            auto query_ctx_guard = query_ctx->shared_from_this();
-            auto notify = this->defer_notify();
+        auto query_ctx_weak = _fragment_ctx->runtime_state()->query_ctx()->weak_from_this();
 
-            auto defer = DeferOp([this]() { --_total_in_flight_rpc; });
-            _is_finishing = true;
-            auto& context = sink_ctx(ctx.instance_id.lo);
-            ++context.num_finished_rpcs;
-            --context.num_in_flight_rpcs;
+        closure->addFailedHandler(
+                [this, query_ctx_weak](const ClosureContext& ctx, std::string_view rpc_error_msg) noexcept {
+                    auto query_ctx_guard = query_ctx_weak.lock();
+                    RETURN_IF(!query_ctx_guard, (void)0);
+                    auto notify = this->defer_notify();
 
-            const auto& dest_addr = context.dest_addrs;
-            std::string err_msg =
-                    fmt::format("transmit chunk rpc failed [dest_instance_id={}] [dest={}:{}] detail:{}",
-                                print_id(ctx.instance_id), dest_addr.hostname, dest_addr.port, rpc_error_msg);
+                    auto defer = DeferOp([this]() { --_total_in_flight_rpc; });
+                    _is_finishing = true;
+                    auto& context = sink_ctx(ctx.instance_id.lo);
+                    ++context.num_finished_rpcs;
+                    --context.num_in_flight_rpcs;
 
-            _fragment_ctx->cancel(Status::ThriftRpcError(err_msg));
-            LOG(WARNING) << err_msg;
-        });
-        closure->addSuccessHandler([this](const ClosureContext& ctx, const PTransmitChunkResult& result) noexcept {
-            auto query_ctx = _fragment_ctx->runtime_state()->query_ctx();
-            auto query_ctx_guard = query_ctx->shared_from_this();
+                    const auto& dest_addr = context.dest_addrs;
+                    std::string err_msg =
+                            fmt::format("transmit chunk rpc failed [dest_instance_id={}] [dest={}:{}] detail:{}",
+                                        print_id(ctx.instance_id), dest_addr.hostname, dest_addr.port, rpc_error_msg);
+
+                    _fragment_ctx->cancel(Status::ThriftRpcError(err_msg));
+                    LOG(WARNING) << err_msg;
+                });
+        closure->addSuccessHandler([this, query_ctx_weak](const ClosureContext& ctx,
+                                                          const PTransmitChunkResult& result) noexcept {
+            auto query_ctx_guard = query_ctx_weak.lock();
+            RETURN_IF(!query_ctx_guard, (void)0);
             auto notify = this->defer_notify();
 
             auto defer = DeferOp([this]() { --_total_in_flight_rpc; });


### PR DESCRIPTION
## Why I'm doing:

During BE/CN graceful exit (e.g. K8s rolling restart), the shutdown sequence in `starrocks_be.cpp` proceeds as:

1. `exec_env->wait_for_finish()` — drain running fragments
2. `brpc_server->Stop(0)` — stop accepting new connections
3. `exec_env->stop()` — destroy QueryContext / FragmentContext / SinkBuffer
4. `brpc_server->Join()` — wait for pending brpc closures to complete

Between step 3 and step 4, pending brpc closure callbacks from SinkBuffer's async RPCs may still execute. These closures capture a raw `this` pointer to SinkBuffer and call `shared_from_this()` on the already-destroyed QueryContext, throwing `std::bad_weak_ptr`. Since the closure is `noexcept`, this triggers `std::terminate()` → SIGABRT.

This is the `sink_buffer.cpp` fix from #73202. It landed on main / branch-4.1 (#73326) / branch-4.0 (#73328), but the branch-3.5 backport #73327 modified `runtime_filter_worker.cpp` instead of `sink_buffer.cpp`, so the crash was never actually fixed on branch-3.5. This PR applies the missing `sink_buffer.cpp` change.

**Crash stack:**
```
2026-07-16 03:43:34 throws exception: std::bad_weak_ptr, trace:
    @  __wrap___cxa_throw
    @  std::__throw_bad_weak_ptr()
    @  starrocks::pipeline::SinkBuffer::_try_to_send_rpc(starrocks::TUniqueId const&, std::function<void ()> const&)::{lambda(starrocks::pipeline::ClosureContext const&, starrocks::PTransmitChunkResult const&)#5}::operator()(...)
    @  starrocks::DisposableClosure<starrocks::PTransmitChunkResult, starrocks::pipeline::ClosureContext>::Run()
    @  starrocks::RecoverableClosure::Run()
    @  brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&)
    @  brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*)
    @  brpc::ProcessInputMessage(void*)
    @  brpc::InputMessenger::OnNewMessages(brpc::Socket*)
    @  brpc::Socket::ProcessEvent(void*)
    @  bthread::TaskGroup::task_runner(long)
    @  bthread_make_fcontext
terminate called after throwing an instance of 'std::bad_weak_ptr'
  what():  bad_weak_ptr
pr2545-3.5-cc-dc87d685_RC00 RELEASE (build 00d502f distro ubuntu arch aarch64)
*** SIGABRT (@0x3e80000002a) received by PID 42 ...
```

## What I'm doing:

Fix #61764

Capture `weak_from_this()` at RPC send time (when QueryContext is guaranteed alive) and `lock()` it in the brpc closure callback. If QueryContext has already been destroyed, return gracefully instead of crashing. Identical to the change already present on branch-4.0/4.1.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?
- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport PR

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4