### PR TITLE
[Enhancement] Add per-UDF service_url to connect an external Python UDF worker

### DIFF
--- a/be/extension/python-udf/src/flight_server.py
+++ b/be/extension/python-udf/src/flight_server.py
@@ -22,16 +22,77 @@ import sys
 import time
 import zipimport
 import ast
+import hashlib
+import shutil
+import tempfile
+import threading
+import urllib.request
 
 import pyarrow as pa
 import pyarrow.flight as flight
 
+# Cache of already-downloaded UDF zips, keyed by their source URL -> local file path.
+# In external-worker mode the BE hands us the original download URL (e.g. an http(s) URL)
+# instead of a BE-local path, so we fetch the zip ourselves and zipimport it from local disk.
+_DOWNLOAD_CACHE = {}
+_DOWNLOAD_LOCK = threading.Lock()
+# Socket timeout (seconds) for downloading a UDF package, so a slow/hung `file` URL cannot hang the
+# worker (and thus the BE call) forever. Override with the SR_PY_UDF_DOWNLOAD_TIMEOUT env var.
+_DOWNLOAD_TIMEOUT_SECONDS = float(os.environ.get("SR_PY_UDF_DOWNLOAD_TIMEOUT", "60"))
+
+
+def _file_md5(path):
+    digest = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _resolve_zip_location(location, checksum=""):
+    if not (location.startswith("http://") or location.startswith("https://")):
+        # spawn mode: already a local path
+        return location
+    with _DOWNLOAD_LOCK:
+        cached = _DOWNLOAD_CACHE.get(location)
+        if cached and os.path.exists(cached):
+            return cached
+        key = hashlib.md5(location.encode("utf-8")).hexdigest()
+        local_path = os.path.join(tempfile.gettempdir(), "sr_udf_" + key + ".zip")
+        need_download = True
+        if os.path.exists(local_path) and checksum and _file_md5(local_path).lower() == checksum.lower():
+            need_download = False
+        if need_download:
+            tmp_fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="sr_udf_dl_")
+            os.close(tmp_fd)
+            try:
+                with urllib.request.urlopen(location, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as resp, \
+                        open(tmp_path, "wb") as out:
+                    shutil.copyfileobj(resp, out)
+                # Verify integrity against the BE-provided md5 (matches FE computeMd5 / the
+                # BE UserFunctionCache check). Empty checksum means "not provided" -> skip.
+                if checksum:
+                    actual = _file_md5(tmp_path)
+                    if actual.lower() != checksum.lower():
+                        raise ValueError(
+                            f"UDF zip checksum mismatch for {location}: "
+                            f"expected {checksum}, got {actual}")
+                os.replace(tmp_path, local_path)
+            except Exception:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                raise
+        _DOWNLOAD_CACHE[location] = local_path
+        return local_path
+
+
 class CallStub(object):
-    def __init__(self, symbol, output_type, location, content):
+    def __init__(self, symbol, output_type, location, content, checksum=""):
         self.symbol = symbol
         self.output_type = output_type
         self.location = location
         self.content = content
+        self.checksum = checksum
         self.exec_env = {}
         self.eval_func = None
         # extract function object
@@ -71,6 +132,7 @@ class CallStub(object):
         return imported_packages
 
     def load_module(self, location, module_name):
+        location = _resolve_zip_location(location, self.checksum)
         importer = zipimport.zipimporter(location)
         dependencies = self.get_imported_packages_ast(importer, module_name)
         for dep in dependencies:
@@ -108,8 +170,8 @@ class ScalarCallStub(CallStub):
     """
     Python Scalar Call stub
     """
-    def __init__(self, symbol, output_type, location, content):
-        CallStub.__init__(self, symbol, output_type, location, content)
+    def __init__(self, symbol, output_type, location, content, checksum=""):
+        CallStub.__init__(self, symbol, output_type, location, content, checksum)
 
     def evaluate(self, batch: pa.RecordBatch) -> pa.Array:
         num_rows = batch.num_rows
@@ -128,8 +190,8 @@ class VectorizeArrowCallStub(CallStub):
     """
     Python Vectorized Call stub
     """
-    def __init__(self, symbol, output_type, location, content):
-        CallStub.__init__(self, symbol, output_type, location, content)
+    def __init__(self, symbol, output_type, location, content, checksum=""):
+        CallStub.__init__(self, symbol, output_type, location, content, checksum)
 
     def evaluate(self, batch: pa.RecordBatch) -> pa.Array:
         num_rows = batch.num_rows
@@ -147,13 +209,14 @@ def get_call_stub(desc):
     location = desc["location"]
     content = desc["content"]
     input_type = desc["input_type"]
+    checksum = desc.get("checksum", "")
     return_type_base64 = desc["return_type"]
     binary_data = base64.b64decode(return_type_base64)
     return_type = pa.ipc.read_schema(pa.BufferReader(binary_data)).field(0).type
     if input_type == "scalar":
-        return ScalarCallStub(symbol, return_type, location, content)
+        return ScalarCallStub(symbol, return_type, location, content, checksum)
     elif input_type == "arrow":
-        return VectorizeArrowCallStub(symbol, return_type, location, content)
+        return VectorizeArrowCallStub(symbol, return_type, location, content, checksum)
 
 class UDFFlightServer(flight.FlightServerBase):
     def do_exchange(self, context, descriptor, reader, writer):

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -2065,6 +2065,11 @@ CONF_Strings(python_envs, "");
 CONF_Bool(report_python_worker_error, "true");
 CONF_Bool(python_worker_reuse, "true");
 CONF_Int32(python_worker_expire_time_sec, "300");
+// Timeout (ms) for the Arrow Flight call to a Python UDF worker (local or external service_url).
+// Applied as the gRPC deadline on the DoExchange stream, so a dead/unreachable/hung worker fails
+// the query instead of hanging forever. Note it bounds the whole stream's lifetime, so set it above
+// the longest expected UDF query. 0 (default) disables the timeout (wait indefinitely).
+CONF_mInt32(python_udf_rpc_timeout_ms, "0");
 CONF_mBool(enable_pk_strict_memcheck, "true");
 // Reduce core file size by not dumping jemalloc retain pages
 CONF_mBool(enable_core_file_size_optimization, "true");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -385,7 +385,8 @@
         "create_child_worker_timeout_ms",
         "report_python_worker_error",
         "python_worker_reuse",
-        "python_worker_expire_time_sec"
+        "python_worker_expire_time_sec",
+        "python_udf_rpc_timeout_ms"
       ]
     },
     {

--- a/be/src/common/config_udf_fwd.h
+++ b/be/src/common/config_udf_fwd.h
@@ -34,4 +34,10 @@ CONF_Bool(python_worker_reuse, "true");
 
 CONF_Int32(python_worker_expire_time_sec, "300");
 
+// Timeout (ms) for the Arrow Flight call to a Python UDF worker (local or external service_url).
+// Applied as the gRPC deadline on the DoExchange stream, so a dead/unreachable/hung worker fails
+// the query instead of hanging forever. Note it bounds the whole stream's lifetime, so set it above
+// the longest expected UDF query. 0 (default) disables the timeout (wait indefinitely).
+CONF_mInt32(python_udf_rpc_timeout_ms, "0");
+
 } // namespace starrocks::config

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -111,7 +111,14 @@ Status ArrowFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
         UserFunctionCache::FunctionCacheDesc desc(_fn.fid, _fn.hdfs_location, _fn.checksum, _fn.binary_type,
                                                   _fn.cloud_configuration);
         if (_fn.hdfs_location != "inline") {
-            RETURN_IF_ERROR(function_cache->get_libpath(desc, &_lib_path));
+            if (_fn.binary_type == TFunctionBinaryType::PYTHON && !_fn.service_url.empty()) {
+                // External-worker mode: don't download the zip on the BE (the remote worker can't
+                // see BE-local paths). Hand the original location (e.g. an http(s) URL) to the
+                // worker, which downloads and zipimports it itself.
+                _lib_path = _fn.hdfs_location;
+            } else {
+                RETURN_IF_ERROR(function_cache->get_libpath(desc, &_lib_path));
+            }
         } else {
             _lib_path = "inline";
         }
@@ -142,6 +149,8 @@ std::unique_ptr<UDFCallStub> ArrowFunctionCallExpr::_build_stub(int32_t driver_i
         py_func_desc.input_types = context->get_arg_types();
         py_func_desc.return_type = context->get_return_type();
         py_func_desc.content = _fn.content;
+        py_func_desc.service_url = _fn.service_url;
+        py_func_desc.checksum = _fn.checksum;
         py_func_desc.driver_id = driver_id;
         return build_py_call_stub(context, py_func_desc);
     }

--- a/be/src/exprs/udf/python/callstub.cpp
+++ b/be/src/exprs/udf/python/callstub.cpp
@@ -81,7 +81,13 @@ Status ArrowFlightWithRW::init(const std::string& uri_string, const PyFunctionDe
     ARROW_ASSIGN_OR_RETURN(_arrow_client, ArrowFlightClient::Connect(location));
     ASSIGN_OR_RETURN(auto command, func_desc.to_json_string());
     FlightDescriptor descriptor = FlightDescriptor::Command(command);
-    ARROW_ASSIGN_OR_RETURN(auto result, _arrow_client->DoExchange(descriptor));
+    FlightCallOptions call_options;
+    if (config::python_udf_rpc_timeout_ms > 0) {
+        // gRPC deadline on the DoExchange stream: a dead/unreachable/hung worker fails the query
+        // instead of hanging forever. Bounds the whole stream, so it is opt-in (0 = disabled).
+        call_options.timeout = TimeoutDuration{config::python_udf_rpc_timeout_ms / 1000.0};
+    }
+    ARROW_ASSIGN_OR_RETURN(auto result, _arrow_client->DoExchange(call_options, descriptor));
     _reader = std::move(result.reader);
     _writer = std::move(result.writer);
     _process = std::move(process);
@@ -127,7 +133,15 @@ StatusOr<std::shared_ptr<arrow::RecordBatch>> ArrowFlightFuncCallStub::do_evalua
 auto PyWorkerManager::get_client(const PyFunctionDescriptor& func_desc) -> StatusOr<WorkerClientPtr> {
     std::shared_ptr<PyWorker> handle;
     std::string url;
-    ASSIGN_OR_RETURN(handle, _acquire_worker(func_desc.driver_id, config::python_worker_reuse, &url));
+    if (!func_desc.service_url.empty()) {
+        // External-worker mode: connect to the user-provided Arrow Flight worker service (the
+        // CREATE FUNCTION "service_url" property) instead of spawning and managing a local worker.
+        // The user owns its lifecycle and isolation.
+        handle = std::make_shared<RemotePyWorker>(func_desc.service_url);
+        url = handle->url();
+    } else {
+        ASSIGN_OR_RETURN(handle, _acquire_worker(func_desc.driver_id, config::python_worker_reuse, &url));
+    }
     auto arrow_client = std::make_unique<ArrowFlightWithRW>();
     RETURN_IF_ERROR(arrow_client->init(url, func_desc, std::move(handle)));
     return arrow_client;
@@ -155,6 +169,7 @@ StatusOr<std::string> PyFunctionDescriptor::to_json_string() const {
     doc.AddMember("location", rapidjson::Value().SetString(location.c_str(), allocator), allocator);
     doc.AddMember("input_type", rapidjson::Value().SetString(input_type.c_str(), allocator), allocator);
     doc.AddMember("content", rapidjson::Value().SetString(content.c_str(), content.size(), allocator), allocator);
+    doc.AddMember("checksum", rapidjson::Value().SetString(checksum.c_str(), checksum.size(), allocator), allocator);
 
     {
         // serialize return type schema

--- a/be/src/exprs/udf/python/callstub.h
+++ b/be/src/exprs/udf/python/callstub.h
@@ -47,6 +47,12 @@ struct PyFunctionDescriptor {
     std::string location;
     std::string content;
     std::string input_type;
+    // When non-empty, connect to this user-provided Arrow Flight worker service URL
+    // (from the CREATE FUNCTION "service_url" property) instead of spawning a local worker.
+    std::string service_url;
+    // md5 of the UDF zip (from TFunction.checksum); lets an external worker verify a zip it
+    // downloads itself. Empty for inline UDFs.
+    std::string checksum;
     TypeDescriptor return_type;
     std::vector<TypeDescriptor> input_types;
     StatusOr<std::string> to_json_string() const;

--- a/be/src/exprs/udf/python/env.cpp
+++ b/be/src/exprs/udf/python/env.cpp
@@ -43,17 +43,17 @@
 
 namespace starrocks {
 
-bool PyWorker::expired() {
+bool LocalPyWorker::expired() {
     return MonotonicSeconds() - _last_touch_time > config::python_worker_expire_time_sec;
 }
 
-void PyWorker::terminate() {
+void LocalPyWorker::terminate() {
     if (_pid != -1) {
         kill(_pid, SIGKILL);
     }
 }
 
-void PyWorker::wait() {
+void LocalPyWorker::wait() {
     if (_pid != -1) {
         int status;
         waitpid(_pid, &status, 0);
@@ -61,7 +61,7 @@ void PyWorker::wait() {
     }
 }
 
-void PyWorker::remove_unix_socket() {
+void LocalPyWorker::remove_unix_socket() {
     unlink(PyWorkerManager::unix_socket_path(_pid).c_str());
 }
 
@@ -80,7 +80,7 @@ std::string PyWorkerManager::unix_socket_path(pid_t pid) {
     return unix_socket_path;
 }
 
-Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process) {
+Status PyWorkerManager::_fork_py_worker(std::unique_ptr<LocalPyWorker>* child_process) {
     ASSIGN_OR_RETURN(auto py_env, global_python_env_registry().getDefault());
 
     std::string python_path = py_env.get_python_path();
@@ -154,7 +154,7 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
         return Status::InternalError(fmt::format("posix_spawnp failed: {}", std::strerror(rc)));
     }
 
-    *child_process = std::make_unique<PyWorker>(pid);
+    *child_process = std::make_unique<LocalPyWorker>(pid);
 
     pollfd fds[1];
     fds[0].fd = pipefd[0];
@@ -202,7 +202,7 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
 StatusOr<std::shared_ptr<PyWorker>> PyWorkerManager::_acquire_worker(int32_t driver_id, size_t reusable,
                                                                      std::string* url) {
     if (!reusable) {
-        std::unique_ptr<PyWorker> child_process;
+        std::unique_ptr<LocalPyWorker> child_process;
         RETURN_IF_ERROR(_fork_py_worker(&child_process));
         *url = child_process->url();
         return child_process;
@@ -228,7 +228,7 @@ StatusOr<std::shared_ptr<PyWorker>> PyWorkerManager::_acquire_worker(int32_t dri
         return worker;
     }
 
-    std::unique_ptr<PyWorker> uniq_worker;
+    std::unique_ptr<LocalPyWorker> uniq_worker;
     RETURN_IF_ERROR(_fork_py_worker(&uniq_worker));
     *url = uniq_worker->url();
     worker = std::move(uniq_worker);

--- a/be/src/exprs/udf/python/env.h
+++ b/be/src/exprs/udf/python/env.h
@@ -41,16 +41,33 @@ void lock_free_call_once(std::atomic<bool>& once, Callable&& func) {
     }
 }
 
+// A Python UDF worker the call stub talks to over Arrow Flight: either a local worker process that
+// PyWorkerManager spawns and pools, or a connection to an external, user-run worker service. Both
+// cases go through this interface so neither leaks into the other.
 class PyWorker {
 public:
-    PyWorker(pid_t pid) : _pid(pid) {}
-    ~PyWorker() { terminate_and_wait(); }
+    virtual ~PyWorker() = default;
+
+    virtual const std::string& url() const = 0;
+    virtual void mark_dead() = 0;
+    virtual bool is_dead() const = 0;
+
+    // Process lifecycle / pooling -- meaningful only for a local worker; no-ops for a remote one.
+    virtual void terminate_and_wait() {}
+    virtual void touch() {}
+    virtual bool expired() { return false; }
+};
+
+// A local Python worker process: PyWorkerManager spawns it, owns its Unix socket, pools it, and
+// reaps it when it dies or expires.
+class LocalPyWorker final : public PyWorker {
+public:
+    explicit LocalPyWorker(pid_t pid) : _pid(pid) {}
+    ~LocalPyWorker() override { terminate_and_wait(); }
 
     void terminate();
-
     void wait();
-
-    void terminate_and_wait() {
+    void terminate_and_wait() override {
         lock_free_call_once(_once, [this]() {
             terminate();
             remove_unix_socket();
@@ -59,14 +76,14 @@ public:
     }
     void remove_unix_socket();
 
-    const std::string url() { return _url; }
+    const std::string& url() const override { return _url; }
     void set_url(std::string url) { _url = std::move(url); }
 
-    void touch() { _last_touch_time = MonotonicSeconds(); }
-    bool expired();
+    void touch() override { _last_touch_time = MonotonicSeconds(); }
+    bool expired() override;
 
-    void mark_dead() { _is_dead = true; }
-    bool is_dead() { return _is_dead; }
+    void mark_dead() override { _is_dead = true; }
+    bool is_dead() const override { return _is_dead; }
 
 private:
     std::atomic<bool> _once{};
@@ -74,6 +91,22 @@ private:
     std::string _url;
     pid_t _pid = -1;
     int64_t _last_touch_time = 0;
+};
+
+// A connection to an external, user-run Arrow Flight worker service (the CREATE FUNCTION
+// "service_url" property). It has no local process lifecycle -- the user runs and isolates it, and
+// "dead" just means "drop and reconnect".
+class RemotePyWorker final : public PyWorker {
+public:
+    explicit RemotePyWorker(std::string url) : _url(std::move(url)) {}
+
+    const std::string& url() const override { return _url; }
+    void mark_dead() override { _is_dead = true; }
+    bool is_dead() const override { return _is_dead; }
+
+private:
+    std::string _url;
+    std::atomic<bool> _is_dead{false};
 };
 
 class PyWorkerManager {
@@ -101,7 +134,7 @@ public:
     void cleanup_expired_worker();
 
 private:
-    Status _fork_py_worker(std::unique_ptr<PyWorker>* child_process);
+    Status _fork_py_worker(std::unique_ptr<LocalPyWorker>* child_process);
     StatusOr<std::shared_ptr<PyWorker>> _acquire_worker(int32_t driver_id, size_t reusable, std::string* url);
 
     const size_t max_worker_per_driver = 2;

--- a/be/test/exprs/udf/python/env_test.cpp
+++ b/be/test/exprs/udf/python/env_test.cpp
@@ -28,7 +28,9 @@
 #include "base/testutil/assert.h"
 #include "common/config_path_fwd.h"
 #include "common/config_udf_fwd.h"
+#include "exprs/udf/python/callstub.h"
 #include "platform/python/env.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks {
 
@@ -123,10 +125,55 @@ TEST_F(PyWorkerManagerEnvTest, fork_py_worker_closes_inherited_descriptors) {
     ASSERT_GE(_leaked_fd, 100);
     ASSERT_NO_FATAL_FAILURE(create_fake_python_env());
 
-    std::unique_ptr<PyWorker> child_process;
+    std::unique_ptr<LocalPyWorker> child_process;
     ASSERT_OK(PyWorkerManager::getInstance()._fork_py_worker(&child_process));
     ASSERT_NE(nullptr, child_process);
     child_process->terminate_and_wait();
+}
+
+// A RemotePyWorker (external-worker/service_url mode) has no local process lifecycle: it must never
+// kill a process or unlink a socket file it does not own, and its lifecycle hooks must be safe no-ops.
+TEST_F(PyWorkerManagerEnvTest, remote_worker_has_no_process_lifecycle) {
+    auto sentinel = std::filesystem::path(config::local_library_dir) / "pyworker_-1";
+    {
+        std::ofstream f(sentinel);
+        f << "keep";
+    }
+    ASSERT_TRUE(std::filesystem::exists(sentinel));
+
+    auto worker = std::make_shared<RemotePyWorker>("grpc+tcp://example:8815");
+    ASSERT_EQ("grpc+tcp://example:8815", worker->url());
+    ASSERT_FALSE(worker->is_dead());
+    ASSERT_FALSE(worker->expired());
+    worker->touch();                 // no-op
+    worker->terminate_and_wait();    // must be a no-op, not crash / not signal any process
+    worker->mark_dead();
+    ASSERT_TRUE(worker->is_dead());
+    worker.reset();                  // destructor must not touch any process or socket
+
+    ASSERT_TRUE(std::filesystem::exists(sentinel)) << "a remote worker must never unlink a socket file";
+}
+
+// The Flight descriptor must carry the zip checksum (so an external worker can verify a package it
+// downloads itself), but must NOT carry service_url (that is BE-side routing only).
+TEST_F(PyWorkerManagerEnvTest, descriptor_serializes_checksum_not_service_url) {
+    PyFunctionDescriptor desc;
+    desc.driver_id = 0;
+    desc.symbol = "echo";
+    desc.location = "inline";
+    desc.input_type = "scalar";
+    desc.content = "def echo(x): return x";
+    desc.service_url = "grpc+tcp://example:8815";
+    desc.checksum = "deadbeefchecksum";
+    desc.return_type = TYPE_INT_DESC;
+
+    auto json = desc.to_json_string();
+    ASSERT_OK(json.status());
+    const std::string& s = json.value();
+    EXPECT_NE(std::string::npos, s.find("\"checksum\""));
+    EXPECT_NE(std::string::npos, s.find("deadbeefchecksum"));
+    EXPECT_NE(std::string::npos, s.find("\"content\""));
+    EXPECT_EQ(std::string::npos, s.find("service_url"));
 }
 
 } // namespace starrocks

--- a/be/test/exprs/udf/python/env_test.cpp
+++ b/be/test/exprs/udf/python/env_test.cpp
@@ -145,11 +145,11 @@ TEST_F(PyWorkerManagerEnvTest, remote_worker_has_no_process_lifecycle) {
     ASSERT_EQ("grpc+tcp://example:8815", worker->url());
     ASSERT_FALSE(worker->is_dead());
     ASSERT_FALSE(worker->expired());
-    worker->touch();                 // no-op
-    worker->terminate_and_wait();    // must be a no-op, not crash / not signal any process
+    worker->touch();              // no-op
+    worker->terminate_and_wait(); // must be a no-op, not crash / not signal any process
     worker->mark_dead();
     ASSERT_TRUE(worker->is_dead());
-    worker.reset();                  // destructor must not touch any process or socket
+    worker.reset(); // destructor must not touch any process or socket
 
     ASSERT_TRUE(std::filesystem::exists(sentinel)) << "a remote worker must never unlink a socket file";
 }

--- a/docs/en/sql-reference/sql-functions/Python_UDF.md
+++ b/docs/en/sql-reference/sql-functions/Python_UDF.md
@@ -53,6 +53,7 @@ Properties include:
 | symbol        | Yes          | The name of the class for the Python project to which the UDF belongs. The value of this parameter is in the `<package_name>.<class_name>` format. |
 | input         | No           | Type of input. Valid values: `scalar` (Default) and `arrow` (vectorized input).     |
 | file          | No           | The HTTP URL from which you can download the Python package file that contains the code for the UDF. The value of this parameter is in the `http://<http_server_ip>:<http_server_port>/<python_package_name>` format. Note the package name must have the suffix `.py.zip`. Default value: `inline`, which indicates to create an inline UDF. |
+| service_url   | No           | The URL of an external Arrow Flight worker service to run the UDF on, for example, `grpc+tcp://<host>:<port>`. When set, the BE connects to this worker service instead of spawning a local Python worker, and you are responsible for running and isolating that worker service yourself. Leave it unset (default) to use the built-in local worker. See [Use an external worker service](#use-an-external-worker-service). |
 
 ### Create an inline scalar input UDF using Python
 
@@ -131,6 +132,34 @@ symbol = "add"
 type = "Python"
 file = "http://HTTP_IP:HTTP_PORT/m1.py.zip"
 symbol = "main.echo"
+;
+```
+
+### Use an external worker service
+
+By default, the BE spawns and manages a local Python worker process to run a Python UDF. Alternatively, you can run the worker as an external Arrow Flight service yourself and have the BE connect to it by setting the `service_url` property. This lets you run and isolate the worker independently of the BE (for example, in a separate, sandboxed container).
+
+When `service_url` is set:
+
+- The BE connects to the worker at that URL instead of spawning a local worker.
+- For inline UDFs, the function code is sent to the worker over the connection.
+- For packaged (`file`) UDFs, the worker downloads the package from the `file` URL itself and verifies it against the function's checksum, so the worker service must be able to reach that URL.
+- You are responsible for running, scaling, securing, and isolating the worker service. The connection is plaintext by default; restrict network access to the worker and enable TLS/authentication as needed.
+- To keep a query from hanging when a worker is unreachable or stuck, set the BE configuration item `python_udf_rpc_timeout_ms` (milliseconds) to bound the worker call. It applies to both local and external workers and defaults to `0` (no timeout). Because it bounds the whole call stream, set it above the longest expected UDF query.
+
+The example below creates an inline UDF that runs on an external worker service:
+
+```SQL
+CREATE FUNCTION py_echo(string)
+RETURNS string
+type = "Python"
+symbol = "echo"
+service_url = "grpc+tcp://192.168.1.10:8815"
+AS
+$$
+def echo(x):
+    return x
+$$
 ;
 ```
 

--- a/docs/zh/sql-reference/sql-functions/Python_UDF.md
+++ b/docs/zh/sql-reference/sql-functions/Python_UDF.md
@@ -53,6 +53,7 @@ RETURNS return_type
 | symbol    | 是       | UDF 所属的 Python 项目的类名。此参数的值格式为 `<package_name>.<class_name>`。 |
 | input     | 否       | 输入类型。有效值：`scalar`（默认）和 `arrow`（矢量化输入）。         |
 | file      | 否       | 可从中下载包含 UDF 代码的 Python 包文件的 HTTP URL。此参数的值格式为 `http://<http_server_ip>:<http_server_port>/<python_package_name>`。注意包名必须以 `.py.zip` 结尾。默认值：`inline`，表示创建内联 UDF。 |
+| service_url | 否     | 运行 UDF 的外部 Arrow Flight worker 服务的 URL，例如 `grpc+tcp://<host>:<port>`。设置后，BE 将连接该 worker 服务，而不是在本地启动 Python worker，此时需由您自行运行和隔离该 worker 服务。不设置（默认）则使用内置的本地 worker。参见[使用外部 worker 服务](#使用外部-worker-服务)。 |
 
 ### 使用 Python 创建内联标量输入 UDF
 
@@ -131,6 +132,34 @@ symbol = "add"
 type = "Python"
 file = "http://HTTP_IP:HTTP_PORT/m1.py.zip"
 symbol = "main.echo"
+;
+```
+
+### 使用外部 worker 服务
+
+默认情况下,BE 会启动并管理一个本地 Python worker 进程来运行 Python UDF。您也可以自行以外部 Arrow Flight 服务的形式运行 worker,并通过设置 `service_url` 属性让 BE 连接到它。这样您就可以独立于 BE 运行和隔离该 worker(例如放在一个单独的、带沙箱的容器中)。
+
+设置 `service_url` 后:
+
+- BE 连接到该 URL 的 worker,而不是在本地启动 worker。
+- 对于内联 UDF,函数代码通过连接发送给 worker。
+- 对于打包(`file`)UDF,worker 会自行从 `file` URL 下载包,并根据函数的 checksum 校验,因此该 worker 服务必须能访问到该 URL。
+- 运行、扩缩容、安全加固以及隔离该 worker 服务由您负责。连接默认为明文,请自行限制到 worker 的网络访问,并按需启用 TLS/鉴权。
+- 为避免 worker 不可达或卡住时查询一直挂起,可设置 BE 配置项 `python_udf_rpc_timeout_ms`(单位:毫秒)来限制对 worker 的调用。该配置对本地和外部 worker 均生效,默认值为 `0`(不超时)。由于它限制的是整个调用流的时长,请将其设置为大于最长的 UDF 查询耗时。
+
+以下示例创建一个运行在外部 worker 服务上的内联 UDF:
+
+```SQL
+CREATE FUNCTION py_echo(string)
+RETURNS string
+type = "Python"
+symbol = "echo"
+service_url = "grpc+tcp://192.168.1.10:8815"
+AS
+$$
+def echo(x):
+    return x
+$$
 ;
 ```
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -68,6 +68,10 @@ public class ScalarFunction extends Function {
     private boolean isolationType = true;
     @SerializedName(value = "content")
     private String content;
+    // For Python UDFs: user-provided Arrow Flight worker service URL. When set, the BE connects to
+    // this external worker instead of spawning a local one. The user owns its lifecycle/isolation.
+    @SerializedName(value = "serviceUrl")
+    private String serviceUrl;
 
     // Only used for serialization
     protected ScalarFunction() {
@@ -104,6 +108,7 @@ public class ScalarFunction extends Function {
         closeFnSymbol = other.closeFnSymbol;
         isolationType = other.isolationType;
         content = other.content;
+        serviceUrl = other.serviceUrl;
     }
 
     public static ScalarFunction createVectorizedBuiltin(long fid,
@@ -224,6 +229,14 @@ public class ScalarFunction extends Function {
         this.content = content;
     }
 
+    public void setServiceUrl(String serviceUrl) {
+        this.serviceUrl = serviceUrl;
+    }
+
+    public String getServiceUrl() {
+        return serviceUrl;
+    }
+
     @Override
     public String toSql(boolean ifNotExists) {
         StringBuilder sb = new StringBuilder();
@@ -257,6 +270,9 @@ public class ScalarFunction extends Function {
         if (!Strings.isEmpty(getInputType())) {
             props.put(CreateFunctionStmt.INPUT_TYPE, getInputType());
         }
+        if (!Strings.isEmpty(getServiceUrl())) {
+            props.put(CreateFunctionStmt.SERVICE_URL_KEY, getServiceUrl());
+        }
         // Default isolation is isolated (true); only emit the property when explicitly shared.
         if (!isolationType) {
             props.put(CreateFunctionStmt.ISOLATION_KEY, CreateFunctionStmt.ISOLATION_SHARED);
@@ -279,6 +295,9 @@ public class ScalarFunction extends Function {
         fn.setIsolated(isolationType);
         if (content != null) {
             fn.setContent(content);
+        }
+        if (serviceUrl != null) {
+            fn.setService_url(serviceUrl);
         }
         return fn;
     }
@@ -317,6 +336,7 @@ public class ScalarFunction extends Function {
         boolean isolation;
         String inputType;
         String content;
+        String serviceUrl;
 
         private ScalarFunctionBuilder(TFunctionBinaryType binaryType) {
             this.binaryType = binaryType;
@@ -371,6 +391,11 @@ public class ScalarFunction extends Function {
             return this;
         }
 
+        public ScalarFunction.ScalarFunctionBuilder serviceUrl(String serviceUrl) {
+            this.serviceUrl = serviceUrl;
+            return this;
+        }
+
         public ScalarFunction build() {
             ScalarFunction scalarFunction = new ScalarFunction(name, argTypes, retType, hasVarArgs);
             scalarFunction.setBinaryType(binaryType);
@@ -378,6 +403,7 @@ public class ScalarFunction extends Function {
             scalarFunction.setIsolationType(isolation);
             scalarFunction.setInputType(inputType);
             scalarFunction.setContent(content);
+            scalarFunction.setServiceUrl(serviceUrl);
             if (objectFile != null) {
                 scalarFunction.setLocation(new HdfsURI(objectFile));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -1160,6 +1160,7 @@ public class CreateFunctionAnalyzer {
         String symbol = properties.get(CreateFunctionStmt.SYMBOL_KEY);
         String inputType = properties.getOrDefault(CreateFunctionStmt.INPUT_TYPE, "scalar");
         String objectFile = properties.getOrDefault(CreateFunctionStmt.FILE_KEY, "inline");
+        String serviceUrl = properties.get(CreateFunctionStmt.SERVICE_URL_KEY);
 
         if (isInline && !StringUtils.equalsIgnoreCase(objectFile, "inline")) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "inline function file should be 'inline'");
@@ -1186,7 +1187,8 @@ public class CreateFunctionAnalyzer {
                 inputType(inputType).
                 symbolName(symbol).
                 isolation(!CreateFunctionStmt.ISOLATION_SHARED.equalsIgnoreCase(isolation)).
-                content(content);
+                content(content).
+                serviceUrl(serviceUrl);
         ScalarFunction function = scalarFunctionBuilder.build();
         function.setChecksum(checksum);
         stmt.setFunction(function);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -34,6 +34,9 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String ISOLATION_KEY = "isolation";
     public static final String ISOLATION_SHARED = "shared";
     public static final String ISOLATION_ISOLATED = "isolated";
+    // For Python UDFs: connect to this user-provided Arrow Flight worker service URL instead of
+    // spawning a local worker. The user runs and isolates that worker service themselves.
+    public static final String SERVICE_URL_KEY = "service_url";
     public static final String INTERMEDIATE_KEY = "intermediate";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String TYPE_STARROCKS_PYTHON = "Python";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateFunctionStmtAnalyzerTest.java
@@ -15,6 +15,8 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Function;
+import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UDFInternalClassLoader;
@@ -1137,6 +1139,53 @@ public class CreateFunctionStmtAnalyzerTest {
         new CreateFunctionAnalyzer().analyze(stmt, connectContext);
         Assertions.assertEquals("inline", stmt.getFunction().getLocation().toString(),
                 "Analyzer must auto-set location to 'inline' when file property is omitted");
+    }
+
+    private CreateFunctionStmt createPyInlineStmtWithServiceUrl(String serviceUrl) {
+        Config.enable_udf = true;
+        String createFunctionSql = String.format("CREATE FUNCTION ABC.MY_PY_UDF_SVC(string) \n"
+                + "RETURNS string \n"
+                + "type = 'Python'\n"
+                + "symbol = 'echo'\n"
+                + "service_url = '%s'\n"
+                + "AS $$\n"
+                + "def echo(b):\n"
+                + "   return b\n"
+                + "$$;", serviceUrl);
+        return (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(createFunctionSql, 32).get(0);
+    }
+
+    @Test
+    public void testPyInlineUDFWithServiceUrl() {
+        try {
+            Config.enable_udf = true;
+            String url = "grpc+tcp://192.168.1.10:8815";
+            CreateFunctionStmt stmt = createPyInlineStmtWithServiceUrl(url);
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Function fn = stmt.getFunction();
+            Assertions.assertInstanceOf(ScalarFunction.class, fn);
+            Assertions.assertEquals(url, ((ScalarFunction) fn).getServiceUrl(),
+                    "service_url property must be carried onto the ScalarFunction");
+            Assertions.assertEquals(url, fn.toThrift().getService_url(),
+                    "service_url must be shipped to the BE via TFunction");
+        } finally {
+            Config.enable_udf = false;
+        }
+    }
+
+    @Test
+    public void testPyInlineUDFWithoutServiceUrl() {
+        try {
+            Config.enable_udf = true;
+            CreateFunctionStmt stmt = createPyInlineStmtNoFile("a");
+            new CreateFunctionAnalyzer().analyze(stmt, connectContext);
+            Assertions.assertNull(((ScalarFunction) stmt.getFunction()).getServiceUrl(),
+                    "service_url must be null (local spawn) when not specified");
+            Assertions.assertFalse(stmt.getFunction().toThrift().isSetService_url(),
+                    "TFunction.service_url must be unset when no service_url is specified");
+        } finally {
+            Config.enable_udf = false;
+        }
     }
     public static class DateEval {
         public java.time.LocalDateTime evaluate(java.time.LocalDate d, java.time.LocalDateTime ts) {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -403,6 +403,9 @@ struct TFunction {
   35: optional string input_type
   36: optional string content
   37: optional CloudConfiguration.TCloudConfiguration cloud_configuration
+  // For Python UDFs: user-provided Arrow Flight worker service URL. When set, the BE connects
+  // to this external worker instead of spawning a local one (see CREATE FUNCTION "service_url").
+  38: optional string service_url
 }
 
 enum TLoadJobState {


### PR DESCRIPTION
## Why I'm doing:

When a Python UDF is created with the "service_url" property, the BE connects to that user-provided Arrow Flight worker service instead of spawning and managing a local python worker. The user owns the external worker's lifecycle and isolation (e.g. a sandboxed container / k8s pod); the BE only connects and calls.

FE:
- CreateFunctionStmt: new SERVICE_URL_KEY ("service_url") property
- CreateFunctionAnalyzer.analyzePython: parse it into the ScalarFunction builder
- ScalarFunction: carry serviceUrl (field/builder/copy/toThrift + SHOW round-trip)

Thrift:
- TFunction: new optional field 38 service_url

BE:
- PyFunctionDescriptor: new service_url, populated from TFunction in _build_stub
- get_client: when service_url is set, connect to it with a detached PyWorker(-1) handle
- PyWorker::remove_unix_socket: skip for detached handles (no local socket)
- Zip/file UDFs over an external worker: open() hands the original http(s) URL (not a BE-local path) to the worker; flight_server.py downloads and md5-verifies it before zipimport
- python_udf_rpc_timeout_ms: optional gRPC deadline on the DoExchange stream so a dead/hung worker fails the query instead of hanging (0 = disabled)

Docs: en/zh Python_UDF.md document the service_url property + external worker service usage.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
