### PR TITLE
[Enhancement] Apply op_write.seg_delvecs at lake primary-key publish

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -412,7 +412,29 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         rowset_segment_ids.push_back(global_segment_id);
         uint32_t rssid = rowset_id + global_segment_id;
         new_rowset_rssids.insert(rssid);
-        new_deletes[rssid] = {};
+        // Seed this segment's deletes with the unsort SST writer's per-segment dedup losers
+        // (separate-sort-key PK), if any. The unsort writer already resolved duplicate primary keys
+        // within the segment (the SST points at the winner); the losing rows remain in the segment and
+        // must be masked by its delete vector. The index update below appends historical-duplicate
+        // deletes on top via push_back, so this seed is preserved. Absent/empty (the sort-key==PK path,
+        // or a pre-feature writer) -> the legacy empty init below, i.e. no behavior change.
+        if (local_id < op_write.seg_delvecs_size() && !op_write.seg_delvecs(local_id).data().empty()) {
+            const auto& seg_delvec_pb = op_write.seg_delvecs(local_id);
+            DelVector writer_dv;
+            RETURN_IF_ERROR(
+                    writer_dv.load(metadata->version(), seg_delvec_pb.data().data(), seg_delvec_pb.data().size()));
+            auto& seg_deletes = new_deletes[rssid];
+            // A serialized *empty* DelVector has non-empty bytes but loads to a null roaring (empty()),
+            // so guard before dereferencing: an empty entry (a no-loser segment) is treated as empty,
+            // not a null deref. The index update below still appends historical-duplicate deletes.
+            if (!writer_dv.empty()) {
+                for (const auto rowid : *writer_dv.roaring()) {
+                    seg_deletes.push_back(rowid);
+                }
+            }
+        } else {
+            new_deletes[rssid] = {};
+        }
     }
     // A delete file's rssid is `rowset_id + op_offset`, where op_offset is the in-transaction segment
     // index the delete logically follows (delete sorts after that segment via the reserved UINT32_MAX
@@ -618,8 +640,26 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     size_t new_del = 0;
     size_t total_del = 0;
     std::map<uint32_t, size_t> segment_id_to_add_dels;
+    // Separate-sort-key spill (the unsort SST writer, signalled by op_write.seg_delvecs) is the only
+    // path that can leave duplicate primary keys in one incoming segment: the writer dedups the PK
+    // INDEX (SST points at the winner), but the segment DATA file still physically holds the loser
+    // rows -- they are only masked by a delete vector, not removed. A read-only index lookup over that
+    // segment's PK column (duplicates included) can push a historical rowid into new_deletes once per
+    // occurrence, so cur_add (the raw vector size) would exceed the deduplicated bitmap cardinality and
+    // trip the "cur_old + cur_add != cur_new" consistency check below. Deduplicate the rowids here so
+    // the count matches the bitmap; the delvec content is unchanged (a roaring bitmap dedups anyway).
+    // Gated on the load carrying any seg_delvecs at all: the common sort-key==PK path (and any
+    // pre-feature writer) emits none, so seg_delvecs_size() == 0 and this stays a no-op -- unchanged
+    // behavior. (When seg_delvecs are present, deduping every entry is harmless: the new-segment entries
+    // come from a roaring bitmap and are already unique.)
+    const bool dedupe_new_deletes = op_write.seg_delvecs_size() > 0;
     for (auto& new_delete : new_deletes) {
         uint32_t rssid = new_delete.first;
+        if (dedupe_new_deletes) {
+            auto& del_ids = new_delete.second;
+            std::sort(del_ids.begin(), del_ids.end());
+            del_ids.erase(std::unique(del_ids.begin(), del_ids.end()), del_ids.end());
+        }
         if (new_rowset_rssids.contains(rssid)) {
             // it's newly added rowset's segment, do not have latest delvec yet
             new_del_vecs[idx].first = rssid;

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -38,6 +38,7 @@
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
 #include "storage/chunk_helper.h"
+#include "storage/del_vector.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/delta_writer.h"
@@ -252,6 +253,107 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
         EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
     }
     EXPECT_TRUE(_update_mgr->update_state_mem_tracker()->consumption() == 0);
+}
+
+// A separate-sort-key spill load leaves duplicate-primary-key loser rows physically in a segment (the
+// eager PK-index SST points at the winner) and carries their rowids in op_write.seg_delvecs. Publish must
+// fold those rowids into the segment's delete vector so the losers are masked. Here we synthesize a single
+// segment plus a seg_delvecs entry masking two of its rows, and assert those rows are gone after publish.
+// This exercises the reader/apply path only (no eager-SST write side needed). Without the seg_delvecs
+// handling, all rows would remain visible.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_applies_seg_delvecs) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<int> v0{10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(txn_id);
+    auto op_write = txn_log->mutable_op_write();
+    for (const auto& f : writer->segments()) {
+        op_write->mutable_rowset()->add_segment_metas()->set_filename(f.path);
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+
+    // Mask the rows at rowid 2 and 6 (keys 3 and 7) via a seg_delvecs entry for local segment 0.
+    std::vector<uint32_t> losers{2, 6};
+    DelVector dv;
+    dv.init(/*version=*/1, losers.data(), losers.size());
+    auto* seg_delvec_pb = op_write->add_seg_delvecs();
+    seg_delvec_pb->set_version(1);
+    seg_delvec_pb->set_data(dv.save());
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+    writer->close();
+
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
+    // Two of the ten rows are masked by seg_delvecs -> eight visible.
+    EXPECT_EQ(k0.size() - losers.size(), read_rows(_tablet_metadata->id(), 2));
+}
+
+// Regression: a serialized *empty* DelVector (a seg_delvecs entry for a segment with no dedup losers)
+// has non-empty bytes but loads to a null roaring. Publish must treat it as empty (mask nothing) rather
+// than dereference the null roaring and crash.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_seg_delvecs_empty_entry) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    std::vector<int> k0{1, 2, 3, 4, 5};
+    std::vector<int> v0{10, 20, 30, 40, 50};
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    Chunk chunk0({std::move(c0), std::move(c1)}, _schema);
+
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(txn_id);
+    auto op_write = txn_log->mutable_op_write();
+    for (const auto& f : writer->segments()) {
+        op_write->mutable_rowset()->add_segment_metas()->set_filename(f.path);
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+
+    // A serialized empty DelVector: save() writes a non-empty payload, load() leaves roaring() null.
+    DelVector dv;
+    dv.set_empty();
+    auto* seg_delvec_pb = op_write->add_seg_delvecs();
+    seg_delvec_pb->set_version(1);
+    seg_delvec_pb->set_data(dv.save());
+    EXPECT_FALSE(seg_delvec_pb->data().empty()); // the payload really is non-empty (the crash precondition)
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+    writer->close();
+
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
+    // No masking, no crash: all rows visible.
+    EXPECT_EQ(k0.size(), read_rows(_tablet_metadata->id(), 2));
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -421,6 +421,14 @@ message TxnLogPB {
         // (see config::lake_enable_pk_preserve_txn_delete_order). The persisted per-del order
         // lives on DelfileWithRowsetId.op_offset, derived from this at apply/persist time.
         repeated uint32 del_op_offsets = 21;
+        // Per-incoming-segment delete vector carrying the duplicate-primary-key loser rowids that a
+        // separate-sort-key (ORDER BY != PK) spill+eager-SST load leaves physically in the segment: the
+        // eager PK-index SST points at the winning row, but the losing rows stay in the segment data and
+        // must be masked at publish. Indexed by local segment id, parallel to the incoming segments;
+        // empty (or size 0) for the sort-key==PK path, which has no intra-segment duplicates. A publisher
+        // that does not apply this leaves live duplicate primary keys, so this must be understood
+        // fleet-wide (including downgrade / cross-version OpReplication targets) before the writer emits it.
+        repeated DelvecDataPB seg_delvecs = 22;
     }
 
     message OpCompaction {


### PR DESCRIPTION
## Why I'm doing:

A follow-on feature (separate-sort-key load spill + eager PK-index SST) makes cloud-native primary-key publish emit a new `op_write.seg_delvecs` — the per-segment delete vector that masks the duplicate-primary-key loser rows a separate-sort-key spill leaves physically in the segment (the eager SST points at the winner). A BE that does not apply `seg_delvecs` at publish would leave those rows live, i.e. **silent duplicate primary keys** — not caught by any consistency check.

To make that feature safe across versions, the **read/apply side must be deployed before any peer writes `seg_delvecs`** (rollback to an older BE, a mixed-version cluster, or a cross-version OpReplication target). This PR is that read side, split out so it can be **backported to branch-4.1** (and merged/deployed) ahead of the writer.

## What I'm doing:

- Add `repeated DelvecDataPB seg_delvecs = 22;` to `TxnLogPB.OpWrite` (field 22 is free; `DelvecDataPB` already exists).
- In `UpdateManager::publish_primary_key_tablet`, seed each incoming segment's delete vector from its `op_write.seg_delvecs(local_id)` entry (indexed like `ssts`), and deduplicate the per-segment delete rowids when any `seg_delvec` is present so the raw count matches the roaring bitmap and does not trip the `cur_old + cur_add != cur_new` consistency check.
- Add a focused UT (`test_publish_applies_seg_delvecs`) that publishes a synthetic rowset carrying a non-empty `seg_delvecs` and asserts the masked rows are gone.

Read side only — no writer. Empty/absent `seg_delvecs` (the sort-key==PK path, or any pre-feature writer) takes the unchanged empty-init path, so this is a **zero-behavior-change, safe backport**.

## What type of PR is this:

- [ ] BugFix
- [x] Enhancement
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes
- [ ] Parameter changes
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility (enables older BEs to read `seg_delvecs` written by a newer BE)

## Checklist:

- [x] I have added test cases for my new feature
- [ ] This pr needs user documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFEZ9kSVr4RqXqGeV9ebvF
