### PR TITLE
[BugFix] Fix Finished Queries CSV download escaping and full-statement export

### DIFF
--- a/webroot/static/starrocks.js
+++ b/webroot/static/starrocks.js
@@ -17,15 +17,23 @@
 
 function download_query() {
     let tableThs = Array.from($('table th')).map(v=>{return v.textContent})
-    let tableTds = Array.from($('table td')).map(v=>{return v.textContent})
+    let cellValue = (el)=>{
+        let titled = el.querySelector('[title]')
+        return titled ? titled.getAttribute('title') : el.textContent
+    }
+    let tableTds = Array.from($('table td')).map(cellValue)
     let combine = tableThs.concat(tableTds)
     let csv = ''
-    let colWidth = 9
+    let colWidth = tableThs.length
     let column = []
+    let escapeCsv = (v)=>{
+        v = (v == null ? '' : v).toString()
+        return /[",\r\n]/.test(v) ? '"' + v.replace(/"/g, '""') + '"' : v
+    }
     combine.map((v,i)=>{
-        column.push(v.trim())
+        column.push(escapeCsv(v.trim()))
         if((i+1)%colWidth === 0){
-            csv += column.join(",")+'\n'
+            csv += column.join(",")+'\r\n'
             column = []
         }
     })


### PR DESCRIPTION
## Why I'm doing:

The **Download CSV** button on the FE web UI `/query` (Finished Queries) page produces a corrupted file:

1. **Broken alignment / field splitting.** `download_query()` joins cell text with commas without any escaping, and groups fields using a hard-coded column count of `9` while the table actually renders `11` columns. As a result every row is misaligned, and any SQL statement containing a comma or newline (e.g. a multi-line query) spills across cells and rows.
2. **Truncated statements for heavy queries.** A long SQL statement is rendered truncated on screen (`ui_queries_sql_statement_max_length`, default 128), with the full text kept only in the child element's `title` attribute. The export reads `textContent`, so heavy queries are captured only up to the truncated `... ` prefix.

Example (before), a single multi-line query breaks into multiple physical CSV lines and shifts all following columns; the standard CSV parser reads far more "rows" than there are queries.

## What I'm doing:

Fix `webroot/static/starrocks.js` `download_query()`:

- Escape each field per **RFC 4180** — wrap values containing a comma, double quote, or newline in double quotes and double any inner quotes.
- Derive the column count from the header row (`table th`) instead of the hard-coded `9`.
- Read the full statement from the child element's `title` attribute when present, so heavy (truncated) queries are exported in full.

Verified against a StarRocks 4.1.1 cluster: short, long single-line, and long multi-line queries all export as well-formed CSV — a standard parser reads exactly one record per query, each with 11 columns, with newlines/commas and the full statement preserved.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
