### PR TITLE
[UT] Fix meta_helper_test include path for branch-4.0 backport of #76455

### DIFF
--- a/be/test/formats/parquet/meta_helper_test.cpp
+++ b/be/test/formats/parquet/meta_helper_test.cpp
@@ -18,8 +18,8 @@
 
 #include "formats/parquet/schema.h"
 #include "gen_cpp/Descriptors_types.h"
+#include "runtime/types.h"
 #include "types/logical_type.h"
-#include "types/type_descriptor.h"
 
 namespace starrocks::parquet {
 


### PR DESCRIPTION
## Why I'm doing:

The backport of #76455 fails BE UT on this branch:

```
be/test/formats/parquet/meta_helper_test.cpp:22:10: fatal error: types/type_descriptor.h: No such file or directory
```

`TypeDescriptor` was split into `types/type_descriptor.h` only on `main`. On this release branch it still lives in `runtime/types.h`, so the cherry-picked test does not compile.

## What I'm doing:

Include `runtime/types.h` instead of `types/type_descriptor.h` in the test. Source code is unchanged; the fix is test-only and lets the backport build.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This is a backport pr
