### PR TITLE
[BugFix] Mask iceberg.catalog s3/rest credential keys in SHOW CREATE CATALOG

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -21,6 +21,7 @@ import com.starrocks.connector.odps.OdpsProperties;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.azure.AzureStoragePath;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -73,6 +74,14 @@ public class CredentialUtil {
                 AwsProperties.REST_ACCESS_KEY_ID);
         doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
                 AwsProperties.REST_SECRET_ACCESS_KEY);
+        doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                AwsProperties.REST_SESSION_TOKEN);
+        doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.ACCESS_KEY_ID);
+        doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.SECRET_ACCESS_KEY);
+        doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.SESSION_TOKEN);
 
         // Mask for iceberg jdbc catalog credential
         doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -20,6 +20,7 @@ import com.starrocks.connector.iceberg.rest.OAuth2SecurityConfig;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.credential.azure.AzureStoragePath;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +77,30 @@ public class CredentialUtilTest {
 
         key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
                 AwsProperties.REST_SECRET_ACCESS_KEY;
+        properties.put(key, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("77******58", properties.get(key));
+
+        key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                AwsProperties.REST_SESSION_TOKEN;
+        properties.put(key, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("77******58", properties.get(key));
+
+        key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.ACCESS_KEY_ID;
+        properties.put(key, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("77******58", properties.get(key));
+
+        key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.SECRET_ACCESS_KEY;
+        properties.put(key, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assertions.assertEquals("77******58", properties.get(key));
+
+        key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                S3FileIOProperties.SESSION_TOKEN;
         properties.put(key, "7758258");
         CredentialUtil.maskCredential(properties);
         Assertions.assertEquals("77******58", properties.get(key));


### PR DESCRIPTION
## Why I'm doing:

`SHOW CREATE CATALOG` masks credentials through `CredentialUtil.maskCredential`, and for Iceberg REST catalogs it already covers `iceberg.catalog.oauth2.credential` / `oauth2.token` and `iceberg.catalog.rest.access-key-id` / `rest.secret-access-key`. The `S3FileIOProperties` keys `s3.access-key-id` / `s3.secret-access-key` / `s3.session-token` and the SigV4 signing key `rest.session-token` are missing from the list, so a catalog configured with any of them prints the secrets in plaintext to anyone allowed to run `SHOW CREATE CATALOG`.

## What I'm doing:

Add the four keys to `CredentialUtil.maskCredential`, mirroring the existing `rest.access-key-id` / `rest.secret-access-key` entries (added in #60306; #74696 most recently extended the list the same way), and extend `CredentialUtilTest` accordingly.

Fixes #76482

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
