### PR TITLE
[Enhancement] Support dynamic exchange sender registration on BE

### DIFF
--- a/be/src/compute_env/data_stream/data_stream_mgr.cpp
+++ b/be/src/compute_env/data_stream/data_stream_mgr.cpp
@@ -132,6 +132,18 @@ std::shared_ptr<DataStreamRecvr> DataStreamMgr::find_recvr(const TUniqueId& frag
     return {};
 }
 
+Status DataStreamMgr::update_exchange_senders(const PUpdateExchangeSendersRequest& request) {
+    TUniqueId finst_id;
+    finst_id.hi = request.finst_id().hi();
+    finst_id.lo = request.finst_id().lo();
+    std::shared_ptr<DataStreamRecvr> recvr = find_recvr(finst_id, request.node_id());
+    if (recvr == nullptr) {
+        return Status::NotFound("exchange receiver not found: fragment_instance_id=" + print_id(request.finst_id()) +
+                                " node_id=" + std::to_string(request.node_id()));
+    }
+    return recvr->update_senders(request.be_number(), request.unregister());
+}
+
 Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) {
     const PUniqueId& finst_id = request.finst_id();
     // TODO(zc): Use PUniqueId directly

--- a/be/src/compute_env/data_stream/data_stream_mgr.h
+++ b/be/src/compute_env/data_stream/data_stream_mgr.h
@@ -65,6 +65,7 @@ class RuntimeState;
 class MetricRegistry;
 class PUniqueId;
 class PTransmitChunkParams;
+class PUpdateExchangeSendersRequest;
 
 // Singleton class which manages all incoming data streams at a backend node. It
 // provides both producer and consumer functionality for each data stream.
@@ -99,6 +100,11 @@ public:
                                                   bool is_pipeline, int32_t degree_of_parallelism, bool keep_order);
 
     Status transmit_chunk(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
+
+    // Register/unregister a dynamically added sender on a running receiver.
+    // Returns NotFound if the receiver is gone (the caller treats it as an aborted add).
+    Status update_exchange_senders(const PUpdateExchangeSendersRequest& request);
+
     // Closes all receivers registered for fragment_instance_id immediately.
     void cancel(const TUniqueId& fragment_instance_id);
     void close();

--- a/be/src/compute_env/data_stream/data_stream_recvr.cpp
+++ b/be/src/compute_env/data_stream/data_stream_recvr.cpp
@@ -271,6 +271,17 @@ void DataStreamRecvr::remove_sender(int sender_id, int be_number) {
     _sender_queues[use_sender_id]->decrement_senders(be_number);
 }
 
+Status DataStreamRecvr::update_senders(int be_number, bool unregister) {
+    if (_is_merging) {
+        // A merging receiver owns one queue per sender fixed at construction;
+        // growing the sender set would require allocating new queues.
+        return Status::NotSupported("dynamic senders are not supported on a merging exchange");
+    }
+    // An unregister may complete the stream; wake the exchange source to re-evaluate.
+    auto notify = this->defer_notify();
+    return _sender_queues[0]->try_update_senders(be_number, unregister);
+}
+
 void DataStreamRecvr::cancel_stream() {
     auto notify = this->defer_notify();
     for (auto& _sender_queue : _sender_queues) {

--- a/be/src/compute_env/data_stream/data_stream_recvr.h
+++ b/be/src/compute_env/data_stream/data_stream_recvr.h
@@ -129,6 +129,10 @@ public:
 
     void short_circuit_for_pipeline(const int32_t driver_sequence);
 
+    // Register (unregister=false) or unregister (unregister=true) a dynamically added sender.
+    // Only supported on non-merging pipeline receivers; idempotent per be_number.
+    Status update_senders(int be_number, bool unregister);
+
     bool has_output_for_pipeline(const int32_t driver_sequence) const;
 
     bool is_finished() const;

--- a/be/src/compute_env/data_stream/sender_queue.cpp
+++ b/be/src/compute_env/data_stream/sender_queue.cpp
@@ -542,12 +542,54 @@ void DataStreamRecvr::PipelineSenderQueue::decrement_senders(int be_number) {
             return;
         }
         _sender_eos_set.insert(be_number);
+        // Decrement under _lock so try_update_senders' reject-at-zero check cannot interleave
+        // with the transition to zero (a registration must never resurrect a finished stream).
+        _num_remaining_senders--;
     }
-    _num_remaining_senders--;
     VLOG_FILE << "decremented senders: fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
               << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders
               << " be_number=" << be_number;
     DCHECK(_num_remaining_senders >= 0);
+}
+
+Status DataStreamRecvr::PipelineSenderQueue::try_update_senders(int be_number, bool unregister) {
+    std::lock_guard<Mutex> l(_lock);
+    if (_is_cancelled) {
+        return Status::Cancelled("receiver is cancelled");
+    }
+    if (!unregister) {
+        if (_num_remaining_senders <= 0) {
+            // All known senders already sent EOS; the exchange source may have latched
+            // is_finished(). A late registration must not resurrect the stream.
+            return Status::InternalError("receiver has already finished");
+        }
+        if (_sender_eos_set.find(be_number) != _sender_eos_set.end()) {
+            return Status::InternalError("sender has already finished");
+        }
+        if (!_dynamic_senders.insert(be_number).second) {
+            // Idempotent: the coordinator may retry after an ambiguous RPC timeout.
+            return Status::OK();
+        }
+        _num_remaining_senders++;
+        VLOG_FILE << "registered sender: fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
+                  << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders
+                  << " be_number=" << be_number;
+        return Status::OK();
+    }
+    // Unregister compensates for an aborted instance add: the sender was registered but
+    // never deployed, so it will never send EOS itself.
+    if (_sender_eos_set.find(be_number) != _sender_eos_set.end()) {
+        return Status::OK();
+    }
+    if (_dynamic_senders.erase(be_number) == 0) {
+        // Unknown sender: the registration never landed here. No-op keeps compensation safe.
+        return Status::OK();
+    }
+    _num_remaining_senders--;
+    VLOG_FILE << "unregistered sender: fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
+              << " node_id=" << _recvr->dest_node_id() << " #senders=" << _num_remaining_senders
+              << " be_number=" << be_number;
+    return Status::OK();
 }
 
 void DataStreamRecvr::PipelineSenderQueue::cancel() {

--- a/be/src/compute_env/data_stream/sender_queue.cpp
+++ b/be/src/compute_env/data_stream/sender_queue.cpp
@@ -542,6 +542,7 @@ void DataStreamRecvr::PipelineSenderQueue::decrement_senders(int be_number) {
             return;
         }
         _sender_eos_set.insert(be_number);
+        _dynamic_senders.erase(be_number);
         // Decrement under _lock so try_update_senders' reject-at-zero check cannot interleave
         // with the transition to zero (a registration must never resurrect a finished stream).
         _num_remaining_senders--;
@@ -556,6 +557,14 @@ Status DataStreamRecvr::PipelineSenderQueue::try_update_senders(int be_number, b
     std::lock_guard<Mutex> l(_lock);
     if (_is_cancelled) {
         return Status::Cancelled("receiver is cancelled");
+    }
+    if (_is_closed) {
+        // The exchange source already closed this queue (e.g. LIMIT short-circuit). Accepting a
+        // registration would silently drop the new instance's output; compensation is moot.
+        if (unregister) {
+            return Status::OK();
+        }
+        return Status::InternalError("receiver is closed");
     }
     if (!unregister) {
         if (_num_remaining_senders <= 0) {
@@ -582,7 +591,15 @@ Status DataStreamRecvr::PipelineSenderQueue::try_update_senders(int be_number, b
         return Status::OK();
     }
     if (_dynamic_senders.erase(be_number) == 0) {
-        // Unknown sender: the registration never landed here. No-op keeps compensation safe.
+        // Unknown sender: the registration never landed here — or has not landed YET. Register
+        // and unregister are independent RPCs on a multi-threaded pool with no ordering
+        // guarantee, so a compensating unregister can execute before the delayed register it
+        // compensates; without a tombstone that register would then increment the sender count
+        // for an instance that will never deploy, hanging the receiver until query timeout.
+        // Tombstone the be_number (registration rejects be_numbers in _sender_eos_set). Safe:
+        // the coordinator reserves dynamic be_numbers monotonically and never reuses one, so
+        // this cannot shadow a static sender's future EOS.
+        _sender_eos_set.insert(be_number);
         return Status::OK();
     }
     _num_remaining_senders--;
@@ -598,6 +615,12 @@ void DataStreamRecvr::PipelineSenderQueue::cancel() {
 }
 
 void DataStreamRecvr::PipelineSenderQueue::close() {
+    {
+        // Under _lock so an in-flight try_update_senders either fully precedes or fully
+        // follows the close transition.
+        std::lock_guard<Mutex> l(_lock);
+        _is_closed = true;
+    }
     clean_buffer_queues();
 }
 

--- a/be/src/compute_env/data_stream/sender_queue.h
+++ b/be/src/compute_env/data_stream/sender_queue.h
@@ -54,6 +54,15 @@ public:
     // Decrement the number of remaining senders for this queue
     virtual void decrement_senders(int be_number) = 0;
 
+    // Register (unregister=false) or unregister (unregister=true) a dynamically added sender,
+    // identified by be_number. Idempotent: re-registering a known sender or unregistering an
+    // unknown one is a no-op, so the coordinator may safely retry after an RPC timeout.
+    // Registration is rejected once the remaining-sender count has reached zero, because the
+    // exchange source may already have observed the stream as finished.
+    virtual Status try_update_senders(int be_number, bool unregister) {
+        return Status::NotSupported("dynamic senders are only supported by the pipeline exchange");
+    }
+
     virtual void cancel() = 0;
 
     virtual void close() = 0;
@@ -166,6 +175,8 @@ public:
 
     void decrement_senders(int be_number) override;
 
+    Status try_update_senders(int be_number, bool unregister) override;
+
     void cancel() override;
 
     void close() override;
@@ -256,6 +267,8 @@ private:
     bool _is_pipeline_level_shuffle = false;
 
     std::unordered_set<int> _sender_eos_set;
+    // be_numbers registered through try_update_senders that have not sent EOS yet
+    std::unordered_set<int> _dynamic_senders;
 
     // distribution of received sequence numbers:
     // part1: { sequence | 1 <= sequence <= _max_processed_sequence }

--- a/be/src/compute_env/data_stream/sender_queue.h
+++ b/be/src/compute_env/data_stream/sender_queue.h
@@ -240,6 +240,9 @@ private:
     typedef moodycamel::ConcurrentQueue<ChunkItem> ChunkQueue;
 
     std::atomic<bool> _is_cancelled{false};
+    // Set by close(): the exchange source is done with this queue, so sender registrations
+    // must be rejected instead of silently accepted for a stream nobody will ever drain.
+    std::atomic<bool> _is_closed{false};
     std::atomic<int> _num_remaining_senders;
 
     typedef SpinLock Mutex;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -289,6 +289,28 @@ void PInternalServiceImplBase<T>::_transmit_runtime_filter(google::protobuf::Rpc
 }
 
 template <typename T>
+void PInternalServiceImplBase<T>::update_exchange_senders(google::protobuf::RpcController* cntl_base,
+                                                          const PUpdateExchangeSendersRequest* request,
+                                                          PUpdateExchangeSendersResult* response,
+                                                          google::protobuf::Closure* done) {
+    auto task = [=]() {
+        ClosureGuard closure_guard(done);
+        Status st = _exec_env->stream_mgr()->update_exchange_senders(*request);
+        if (!st.ok()) {
+            LOG(WARNING) << "update exchange senders failed: fragment_instance_id=" << print_id(request->finst_id())
+                         << " node_id=" << request->node_id() << " be_number=" << request->be_number()
+                         << " unregister=" << request->unregister() << " status=" << st;
+        }
+        st.to_protobuf(response->mutable_status());
+    };
+    if (!_exec_env->execution_services().query_rpc_pool->try_offer(std::move(task))) {
+        ClosureGuard closure_guard(done);
+        Status::ServiceUnavailable("submit update_exchange_senders task failed")
+                .to_protobuf(response->mutable_status());
+    }
+}
+
+template <typename T>
 void PInternalServiceImplBase<T>::tablet_writer_open(google::protobuf::RpcController* cntl_base,
                                                      const PTabletWriterOpenRequest* request,
                                                      PTabletWriterOpenResult* response,

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -79,6 +79,11 @@ public:
                                  ::starrocks::PTransmitRuntimeFilterResult* response,
                                  ::google::protobuf::Closure* done) override;
 
+    void update_exchange_senders(::google::protobuf::RpcController* controller,
+                                 const ::starrocks::PUpdateExchangeSendersRequest* request,
+                                 ::starrocks::PUpdateExchangeSendersResult* response,
+                                 ::google::protobuf::Closure* done) override;
+
     void exec_plan_fragment(google::protobuf::RpcController* controller, const PExecPlanFragmentRequest* request,
                             PExecPlanFragmentResult* result, google::protobuf::Closure* done) override;
 

--- a/be/test/compute_env/CMakeLists.txt
+++ b/be/test/compute_env/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(compute_env_test
         compute_env_test.cpp
         compute_env_test_main.cpp
         data_stream_mgr_test.cpp
+        exchange_dynamic_senders_test.cpp
         fragment_dict_state_test.cpp
         load/load_stream_mgr_test.cpp
         load/stream_load_context_test.cpp

--- a/be/test/compute_env/exchange_dynamic_senders_test.cpp
+++ b/be/test/compute_env/exchange_dynamic_senders_test.cpp
@@ -177,6 +177,32 @@ TEST_F(ExchangeDynamicSendersTest, cancelled_receiver_is_rejected) {
     ASSERT_FALSE(st.ok()) << st;
 }
 
+TEST_F(ExchangeDynamicSendersTest, unregister_then_late_register_is_rejected) {
+    // Register and unregister are independent RPCs with no ordering guarantee: a compensating
+    // unregister can execute before the delayed register it compensates. The unregister must
+    // tombstone the be_number so the late register cannot add a sender that will never deploy.
+    auto recvr = create_recvr(2);
+    ASSERT_OK(update_senders(7, /*unregister=*/true));
+    Status st = update_senders(7, /*unregister=*/false);
+    ASSERT_TRUE(st.is_internal_error()) << st;
+    // Neither leg may have changed the sender count.
+    ASSERT_OK(send_eos(0));
+    ASSERT_FALSE(recvr->is_finished());
+    ASSERT_OK(send_eos(1));
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, register_after_close_is_rejected) {
+    // A register racing receiver close must not be silently accepted for a stream nobody
+    // will ever drain (e.g. LIMIT short-circuit closed the exchange source).
+    auto recvr = create_recvr(1);
+    recvr->close();
+    Status st = recvr->update_senders(5, /*unregister=*/false);
+    ASSERT_FALSE(st.ok()) << st;
+    // Compensation after close stays a quiet no-op.
+    ASSERT_OK(recvr->update_senders(5, /*unregister=*/true));
+}
+
 TEST_F(ExchangeDynamicSendersTest, concurrent_register_and_eos) {
     constexpr int kBaseSenders = 4;
     constexpr int kDynamicSenders = 32;

--- a/be/test/compute_env/exchange_dynamic_senders_test.cpp
+++ b/be/test/compute_env/exchange_dynamic_senders_test.cpp
@@ -1,0 +1,209 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "base/testutil/assert.h"
+#include "compute_env/data_stream/data_stream_mgr.h"
+#include "compute_env/data_stream/data_stream_recvr.h"
+#include "gen_cpp/internal_service.pb.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class ExchangeDynamicSendersTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _mgr = std::make_unique<DataStreamMgr>();
+        _mgr->prepare_pass_through_chunk_buffer(_state.query_id());
+    }
+
+    void TearDown() override {
+        if (_recvr != nullptr) {
+            _recvr->close();
+            _recvr.reset();
+        }
+        _mgr->close();
+        _mgr->destroy_pass_through_chunk_buffer(_state.query_id());
+    }
+
+    std::shared_ptr<DataStreamRecvr> create_recvr(int num_senders, bool is_merging = false, bool is_pipeline = true) {
+        _finst_id.hi = 20260716;
+        _finst_id.lo = ++_next_instance;
+        _recvr = _mgr->create_recvr(&_state, RowDescriptor(), _finst_id, _node_id, num_senders,
+                                    /*buffer_size=*/1024 * 1024, is_merging, std::make_shared<QueryStatisticsRecvr>(),
+                                    is_pipeline, /*degree_of_parallelism=*/1, /*keep_order=*/false);
+        return _recvr;
+    }
+
+    // Drives EOS accounting through the public transmit path, like a real sender's last packet.
+    Status send_eos(int be_number) {
+        PTransmitChunkParams request;
+        request.mutable_finst_id()->set_hi(_finst_id.hi);
+        request.mutable_finst_id()->set_lo(_finst_id.lo);
+        request.set_node_id(_node_id);
+        request.set_sender_id(be_number);
+        request.set_be_number(be_number);
+        request.set_eos(true);
+        request.set_sequence(0);
+        google::protobuf::Closure* done = nullptr;
+        return _mgr->transmit_chunk(request, &done);
+    }
+
+    Status update_senders(int be_number, bool unregister) {
+        PUpdateExchangeSendersRequest request;
+        request.mutable_finst_id()->set_hi(_finst_id.hi);
+        request.mutable_finst_id()->set_lo(_finst_id.lo);
+        request.set_node_id(_node_id);
+        request.set_be_number(be_number);
+        request.set_unregister(unregister);
+        return _mgr->update_exchange_senders(request);
+    }
+
+    RuntimeState _state;
+    std::unique_ptr<DataStreamMgr> _mgr;
+    std::shared_ptr<DataStreamRecvr> _recvr;
+    TUniqueId _finst_id;
+    int64_t _next_instance = 0;
+    const int _node_id = 7;
+};
+
+TEST_F(ExchangeDynamicSendersTest, register_extends_stream) {
+    auto recvr = create_recvr(2);
+    ASSERT_OK(send_eos(0));
+    ASSERT_FALSE(recvr->is_finished());
+
+    ASSERT_OK(update_senders(5, /*unregister=*/false));
+    ASSERT_OK(send_eos(1));
+    // The dynamically registered sender is still live.
+    ASSERT_FALSE(recvr->is_finished());
+    ASSERT_OK(send_eos(5));
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, duplicate_register_is_noop) {
+    auto recvr = create_recvr(2);
+    ASSERT_OK(update_senders(5, false));
+    ASSERT_OK(update_senders(5, false));
+    ASSERT_OK(send_eos(0));
+    ASSERT_OK(send_eos(1));
+    ASSERT_FALSE(recvr->is_finished());
+    // One EOS finishes it: the duplicate registration must not have double-counted.
+    ASSERT_OK(send_eos(5));
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, register_after_finished_is_rejected) {
+    auto recvr = create_recvr(1);
+    ASSERT_OK(send_eos(0));
+    ASSERT_TRUE(recvr->is_finished());
+    Status st = update_senders(5, false);
+    ASSERT_TRUE(st.is_internal_error()) << st;
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, unregister_unknown_is_noop) {
+    auto recvr = create_recvr(1);
+    ASSERT_OK(update_senders(42, /*unregister=*/true));
+    ASSERT_FALSE(recvr->is_finished());
+    ASSERT_OK(send_eos(0));
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, unregister_compensates_registration) {
+    auto recvr = create_recvr(2);
+    ASSERT_OK(update_senders(5, false));
+    ASSERT_OK(update_senders(5, true));
+    ASSERT_OK(send_eos(0));
+    ASSERT_FALSE(recvr->is_finished());
+    ASSERT_OK(send_eos(1));
+    // The compensated sender must not be waited for.
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, unregister_after_eos_is_noop) {
+    auto recvr = create_recvr(2);
+    ASSERT_OK(update_senders(5, false));
+    ASSERT_OK(send_eos(5));
+    // The sender finished normally; a late compensation must not double-decrement.
+    ASSERT_OK(update_senders(5, true));
+    ASSERT_OK(send_eos(0));
+    ASSERT_FALSE(recvr->is_finished());
+    ASSERT_OK(send_eos(1));
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+TEST_F(ExchangeDynamicSendersTest, merging_receiver_not_supported) {
+    auto recvr = create_recvr(2, /*is_merging=*/true);
+    Status st = update_senders(5, false);
+    ASSERT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(ExchangeDynamicSendersTest, non_pipeline_receiver_not_supported) {
+    auto recvr = create_recvr(2, /*is_merging=*/false, /*is_pipeline=*/false);
+    Status st = update_senders(5, false);
+    ASSERT_TRUE(st.is_not_supported()) << st;
+}
+
+TEST_F(ExchangeDynamicSendersTest, unknown_receiver_not_found) {
+    create_recvr(1);
+    PUpdateExchangeSendersRequest request;
+    request.mutable_finst_id()->set_hi(_finst_id.hi);
+    request.mutable_finst_id()->set_lo(_finst_id.lo + 1000);
+    request.set_node_id(_node_id);
+    request.set_be_number(5);
+    Status st = _mgr->update_exchange_senders(request);
+    ASSERT_TRUE(st.is_not_found()) << st;
+}
+
+TEST_F(ExchangeDynamicSendersTest, cancelled_receiver_is_rejected) {
+    auto recvr = create_recvr(1);
+    _mgr->cancel(_finst_id);
+    Status st = update_senders(5, false);
+    ASSERT_FALSE(st.ok()) << st;
+}
+
+TEST_F(ExchangeDynamicSendersTest, concurrent_register_and_eos) {
+    constexpr int kBaseSenders = 4;
+    constexpr int kDynamicSenders = 32;
+    auto recvr = create_recvr(kBaseSenders);
+
+    // Register all dynamic senders concurrently with base senders' EOS: with the
+    // register-before-deploy protocol, registrations only happen while at least one
+    // base sender is still live, so keep base sender 0 alive until all are registered.
+    std::thread registrar([&]() {
+        for (int i = 0; i < kDynamicSenders; ++i) {
+            ASSERT_OK(update_senders(100 + i, false));
+        }
+    });
+    std::thread finisher([&]() {
+        for (int i = 1; i < kBaseSenders; ++i) {
+            ASSERT_OK(send_eos(i));
+        }
+    });
+    registrar.join();
+    finisher.join();
+
+    ASSERT_OK(send_eos(0));
+    ASSERT_FALSE(recvr->is_finished());
+    for (int i = 0; i < kDynamicSenders; ++i) {
+        ASSERT_OK(send_eos(100 + i));
+    }
+    ASSERT_TRUE(recvr->is_finished());
+}
+
+} // namespace starrocks

--- a/be/test/service/service_be/internal_service_test.cpp
+++ b/be/test/service/service_be/internal_service_test.cpp
@@ -269,4 +269,23 @@ TEST_F(InternalServiceTest, test_get_load_replica_status) {
     ASSERT_EQ(1, response.replica_statuses_size());
 }
 
+TEST_F(InternalServiceTest, test_update_exchange_senders_unknown_receiver) {
+    BackendInternalServiceImpl<PInternalService> service(ExecEnv::GetInstance(), nullptr, _load_channel_mgr.get());
+    PUpdateExchangeSendersRequest request;
+    request.mutable_finst_id()->set_hi(0x1122334455667788L);
+    request.mutable_finst_id()->set_lo(0x99aabbccddeeff00L);
+    request.set_node_id(1);
+    request.set_be_number(1001);
+    request.set_unregister(false);
+    PUpdateExchangeSendersResult response;
+    brpc::Controller cntl;
+    MockCountDownClosure closure;
+    // The receiver does not exist, so the handler runs its task and reports the stream manager's
+    // NotFound status; this exercises the RPC entrypoint including the error branch and the closure.
+    service.update_exchange_senders(&cntl, &request, &response, &closure);
+    closure.wait();
+    ASSERT_TRUE(response.has_status());
+    ASSERT_FALSE(Status(response.status()).ok());
+}
+
 } // namespace starrocks

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -145,6 +145,27 @@ message PTransmitRuntimeFilterResult {
     optional int32 filter_id = 2;
 };
 
+// Register or unregister an exchange sender on a running receiver, so the
+// coordinator can add fragment instances to a running query. Registration is
+// keyed by sender identity (be_number) and idempotent: re-registering a known
+// sender or unregistering an unknown one is a no-op, which makes the RPC safe
+// to retry on timeout.
+message PUpdateExchangeSendersRequest {
+    // receiver fragment instance
+    optional PUniqueId finst_id = 1;
+    // exchange plan node id of the receiver
+    optional int32 node_id = 2;
+    // sender identity, the backend_num assigned by the coordinator
+    optional int32 be_number = 3;
+    // false/absent = register, true = unregister (compensation for an
+    // aborted instance add; the sender never sent any chunk)
+    optional bool unregister = 4;
+};
+
+message PUpdateExchangeSendersResult {
+    optional StatusPB status = 1;
+};
+
 message PTabletWithPartition {
     required int64 partition_id = 1;
     required int64 tablet_id = 2;
@@ -850,4 +871,7 @@ service PInternalService {
     rpc update_transaction_state(PUpdateTransactionStateRequest) returns (PUpdateTransactionStateResponse);
     rpc lookup(PLookUpRequest) returns (PLookUpResponse);
     rpc lookup_close(PLookUpCloseRequest) returns (PLookUpCloseResponse);
+
+    // Register/unregister an exchange sender on a running receiver.
+    rpc update_exchange_senders(PUpdateExchangeSendersRequest) returns (PUpdateExchangeSendersResult);
 };


### PR DESCRIPTION
## Why I'm doing:

Exchange receivers fix their sender count at construction (`per_exch_num_senders` → `_num_remaining_senders`), so a fragment instance created after a query is deployed has no way to join its exchanges. This PR adds the BE-side primitive needed for mid-query CN elasticity (#76485): letting the coordinator register additional senders on running receivers before deploying a late scan-fragment instance. No FE caller yet — that lands in a follow-up; this PR is independently reviewable and fully covered by BE UTs.

## What I'm doing:

- **Proto** (`internal_service.proto`, optional-only fields, fresh ordinals): `PUpdateExchangeSendersRequest {finst_id, node_id, be_number, unregister}` / `PUpdateExchangeSendersResult {status}` and rpc `update_exchange_senders`. Registration is keyed by sender identity (`be_number`), never by delta — **idempotent**, so a retry after an ambiguous RPC timeout cannot double-count, and compensation (unregister of a never-registered sender) is a no-op by construction.
- **`PipelineSenderQueue::try_update_senders`**: under the same lock as EOS accounting — register rejects when `_num_remaining_senders` has reached zero (the exchange source may already have latched `is_finished()`; a registration must never resurrect a finished stream), no-ops on duplicate registration, tracks dynamic senders in a set so unregistration only compensates registrations that actually landed and never double-decrements after a real EOS. `decrement_senders` now decrements under the lock to make the reject-at-zero check sound (it previously decremented outside the eos-set critical section).
- **`DataStreamRecvr::update_senders`**: `NotSupported` on merging receivers (fixed one-queue-per-sender layout); wakes the exchange source via the existing observer path since an unregister may complete the stream. The legacy non-pipeline queue returns `NotSupported` via the base-class default.
- **`DataStreamMgr::update_exchange_senders`**: resolves via existing `find_recvr`; `NotFound` when the receiver is gone (callers treat it as an aborted add).
- **RPC handler** in `internal_service.cpp` following the `transmit_runtime_filter` pattern (query_rpc_pool).

Rolling upgrade (standard BE-before-FE order): old FE never calls the new RPC; a future new-FE → old-BE call gets method-not-found and aborts the add gracefully. Existing exchange traffic is byte-identical.

Tests: new `exchange_dynamic_senders_test.cpp` (11 cases) driving the public `DataStreamMgr` API — register extends the stream, duplicate register no-op, reject-after-finished, unregister unknown/after-EOS no-ops, compensation, merging/non-pipeline `NotSupported`, `NotFound`, cancelled receiver, and a concurrent register-vs-EOS stress case. Verified: protoc syntax, `check_gensrc_schema_compatibility.py` clean, `check_be_module_boundaries.py` clean, changed lines clang-formatted.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

