### PR TITLE
[BugFix] Skip unavailable nodes when refreshing dictionary cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DictionaryMgr.java
@@ -165,13 +165,13 @@ public class DictionaryMgr implements Writable, GsonPostProcessable {
     }
 
     public static void fillBackendsOrComputeNodes(List<TNetworkAddress> nodes) {
-        List<Backend> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackends();
+        List<Backend> backends = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableBackends();
         for (Backend backend : backends) {
             nodes.add(backend.getBrpcAddress());
         }
 
         List<ComputeNode> computeNodes =
-                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNodes();
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getAvailableComputeNodes();
         for (ComputeNode cn : computeNodes) {
             nodes.add(cn.getBrpcAddress());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -48,8 +48,14 @@ public class DictionaryMgrTest {
     @Mocked
     private SystemInfoService systemInfoService;
 
-    private List<Backend> backends = Arrays.asList(new Backend(1, "127.0.0.1", 1234));
-    private List<ComputeNode> computeNodes = Arrays.asList(new ComputeNode(2, "127.0.0.2", 1235));
+    private Backend availableBackend = new Backend(1, "127.0.0.1", 1234);
+    private Backend unavailableBackend = new Backend(3, "127.0.0.3", 1234);
+    private ComputeNode availableComputeNode = new ComputeNode(2, "127.0.0.2", 1235);
+    private ComputeNode unavailableComputeNode = new ComputeNode(4, "127.0.0.4", 1235);
+    private List<Backend> backends = Arrays.asList(availableBackend, unavailableBackend);
+    private List<ComputeNode> computeNodes = Arrays.asList(availableComputeNode, unavailableComputeNode);
+    private List<Backend> availableBackends = Arrays.asList(availableBackend);
+    private List<ComputeNode> availableComputeNodes = Arrays.asList(availableComputeNode);
 
     private DictionaryMgr dictionaryMgr = new DictionaryMgr();
 
@@ -101,6 +107,14 @@ public class DictionaryMgrTest {
                 systemInfoService.getComputeNodes();
                 minTimes = 0;
                 result = computeNodes;
+
+                systemInfoService.getAvailableBackends();
+                minTimes = 0;
+                result = availableBackends;
+
+                systemInfoService.getAvailableComputeNodes();
+                minTimes = 0;
+                result = availableComputeNodes;
             }
         };
 
@@ -117,10 +131,18 @@ public class DictionaryMgrTest {
         };
     }
 
+    // Regression: fillBackendsOrComputeNodes must use the available (live) node set. backends/computeNodes
+    // carry an extra unavailable node absent from the available set, so reverting to getBackends/
+    // getComputeNodes would pull it in here and fail this test.
     @Test
     public void testGetBeOrCn() throws Exception {
         List<TNetworkAddress> nodes = Lists.newArrayList();
         dictionaryMgr.fillBackendsOrComputeNodes(nodes);
+
+        Assertions.assertTrue(nodes.contains(availableBackend.getBrpcAddress()));
+        Assertions.assertTrue(nodes.contains(availableComputeNode.getBrpcAddress()));
+        Assertions.assertFalse(nodes.contains(unavailableBackend.getBrpcAddress()));
+        Assertions.assertFalse(nodes.contains(unavailableComputeNode.getBrpcAddress()));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When a single BE/CN is unavailable (crashed or stopped) but still registered, the periodic dictionary cache refresh flips the whole dictionary to `CANCELLED`, and every `dictionary_get()` consumer — plain queries and materialized views alike — is then rejected cluster-wide with `dictionary ... is in CANCELLED state` for as long as the node stays down. Writes, non-dictionary queries, and non-dictionary MVs are unaffected, so the dictionary feature has zero tolerance for a single node failure.

Root cause: `DictionaryMgr.fillBackendsOrComputeNodes` builds the refresh broadcast target set from `getBackends()` / `getComputeNodes()` (no liveness filter), and `processDictionaryCacheInteranl` aborts on the first node whose RPC fails, so one dead node fails the whole refresh and `finish()` sets the dictionary `CANCELLED`; `ExpressionAnalyzer.visitDictionaryGetExpr` then rejects every `dictionary_get` on a `CANCELLED` dictionary.

## What I'm doing:

Build the dictionary refresh broadcast set from `getAvailableBackends()` / `getAvailableComputeNodes()` so dead and decommissioned nodes are excluded. The refresh then succeeds on the available nodes and the dictionary stays queryable; a node that recovers is re-included on the next refresh cycle.

Follow-up hardening tracked in the issue (not in this PR): tolerate a node dying mid-refresh instead of aborting the whole broadcast, add backoff between failed refreshes, and optionally fall back to the last successful version in the consumer gate.

Fixes #76495

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Internal robustness fix: no change to query results, syntax, or configuration. It only prevents a single down node from cancelling the dictionary on the surviving nodes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
