### PR TITLE
[Enhancement] Support registering fragment instances after execution DAG finalization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/GrowableMarkedLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/GrowableMarkedLatch.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.starrocks.common.Status;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A {@link MarkedCountDownLatch} variant whose mark set can still grow while the latch has not
+ * completed. The count is the number of outstanding marks, so there is no fixed initial count:
+ * {@link #addMark} raises the count, {@link #markedCountDown} lowers it, and waiters are released
+ * when no marks remain.
+ *
+ * <p>Once the latch has completed — all marks counted down after at least one was ever added, or
+ * forced by {@link #countDownToZero} — it is sealed: {@link #addMark} returns false and completion
+ * can never be revoked. This mirrors the invariant needed by schedulers that add fragment
+ * instances to a running query: an instance may only be attached while the query is still running.
+ */
+public class GrowableMarkedLatch<K, V> {
+    private static final Logger LOG = LogManager.getLogger(GrowableMarkedLatch.class);
+
+    private final Multimap<K, V> marks = HashMultimap.create();
+    private final List<Runnable> listeners = Lists.newArrayList();
+    private Status st = Status.OK;
+    private boolean everMarked = false;
+    private boolean forcedZero = false;
+
+    /**
+     * Adds a mark, raising the count by one. Returns false without adding when the latch has
+     * already completed.
+     */
+    public synchronized boolean addMark(K key, V value) {
+        if (isSealed()) {
+            return false;
+        }
+        marks.put(key, value);
+        everMarked = true;
+        return true;
+    }
+
+    public synchronized boolean markedCountDown(K key, V value) {
+        if (marks.remove(key, value)) {
+            onStateChanged();
+            return true;
+        }
+        return false;
+    }
+
+    public synchronized boolean markedCountDown(K key, V value, Status status) {
+        if (st.ok()) {
+            st = status;
+        }
+        return markedCountDown(key, value);
+    }
+
+    public synchronized void countDownToZero(Status status) {
+        // update status first before completing, so that waiting threads observe it.
+        if (st.ok()) {
+            st = status;
+        }
+        forcedZero = true;
+        marks.clear();
+        onStateChanged();
+    }
+
+    public synchronized long getCount() {
+        return marks.size();
+    }
+
+    public synchronized List<Entry<K, V>> getLeftMarks() {
+        return Lists.newArrayList(marks.entries());
+    }
+
+    public synchronized Status getStatus() {
+        return st;
+    }
+
+    public synchronized void addListener(Runnable listener) {
+        listeners.add(new OneShotListener(listener));
+        triggerListeners();
+    }
+
+    public synchronized boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        long deadlineNs = System.nanoTime() + unit.toNanos(timeout);
+        while (!marks.isEmpty()) {
+            long remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNs - System.nanoTime());
+            if (remainingMs <= 0) {
+                return false;
+            }
+            wait(remainingMs);
+        }
+        return true;
+    }
+
+    private boolean isSealed() {
+        return forcedZero || (everMarked && marks.isEmpty());
+    }
+
+    private void onStateChanged() {
+        if (marks.isEmpty()) {
+            notifyAll();
+            triggerListeners();
+        }
+    }
+
+    private void triggerListeners() {
+        if (!marks.isEmpty()) {
+            return;
+        }
+        for (Runnable listener : listeners) {
+            try {
+                listener.run();
+            } catch (Throwable e) {
+                LOG.warn("Listener invoke failed", e);
+            }
+        }
+    }
+
+    private static final class OneShotListener implements Runnable {
+        private final AtomicBoolean hasRun = new AtomicBoolean(false);
+        private final Runnable runnable;
+
+        public OneShotListener(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void run() {
+            if (hasRun.compareAndSet(false, true)) {
+                runnable.run();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -230,8 +230,14 @@ public class QueryRuntimeProfile {
         // to keep things simple, make async Cancel() calls wait until plan fragment
         // execution has been initiated, otherwise we might try to cancel fragment
         // execution at backends where it hasn't even started
-        profileDoneSignal = new GrowableMarkedLatch<>();
-        instanceIds.forEach(instanceId -> profileDoneSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
+        //
+        // Populate the latch fully before publishing it: a GrowableMarkedLatch with no marks
+        // reads as complete (count 0), so if it were assigned to the field before the marks were
+        // added, a concurrent cancel could seal it via countDownToZero in that window and the
+        // subsequent addMark calls would be dropped, losing all instance tracking.
+        GrowableMarkedLatch<TUniqueId, Long> latch = new GrowableMarkedLatch<>();
+        instanceIds.forEach(instanceId -> latch.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
+        profileDoneSignal = latch;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -28,7 +28,7 @@ import com.starrocks.common.util.ProfileKeyDictionary;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
-import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.common.util.concurrent.GrowableMarkedLatch;
 import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.datacache.LoadDataCacheMetrics;
 import com.starrocks.load.loadv2.LoadJob;
@@ -81,7 +81,7 @@ public class QueryRuntimeProfile {
                     "profile-worker", true);
 
     /**
-     * The value is meaningless, and it is just used as a value placeholder of {@link MarkedCountDownLatch}.
+     * The value is meaningless, and it is just used as a value placeholder of {@link GrowableMarkedLatch}.
      */
     private static final Long MARKED_COUNT_DOWN_VALUE = -1L;
 
@@ -110,8 +110,10 @@ public class QueryRuntimeProfile {
     /**
      * The number of instances of this query.
      * <p> It is equal to the number of backends executing plan fragments on behalf of this query.
+     * <p> Growable so that instances registered while the query is running (elastic scan
+     * instances) can still be attached; growth is rejected once the query has finished.
      */
-    private MarkedCountDownLatch<TUniqueId, Long> profileDoneSignal = null;
+    private GrowableMarkedLatch<TUniqueId, Long> profileDoneSignal = null;
 
     private Supplier<RuntimeProfile> topProfileSupplier;
     private ExecPlan execPlan;
@@ -228,8 +230,17 @@ public class QueryRuntimeProfile {
         // to keep things simple, make async Cancel() calls wait until plan fragment
         // execution has been initiated, otherwise we might try to cancel fragment
         // execution at backends where it hasn't even started
-        profileDoneSignal = new MarkedCountDownLatch<>(instanceIds.size());
+        profileDoneSignal = new GrowableMarkedLatch<>();
         instanceIds.forEach(instanceId -> profileDoneSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE));
+    }
+
+    /**
+     * Attaches one more instance after {@link #attachInstances(Collection)}, for instances
+     * registered while the query is running. Returns false when the query has already finished,
+     * in which case the late instance must not be deployed.
+     */
+    public boolean attachInstance(TUniqueId instanceId) {
+        return profileDoneSignal != null && profileDoneSignal.addMark(instanceId, MARKED_COUNT_DOWN_VALUE);
     }
 
     public void attachExecutionProfiles(Collection<FragmentInstanceExecState> executions) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -714,13 +714,32 @@ public class ExecutionDAG {
      * <p>Must be called on the schedule thread, serialized with scan-range assignment.
      */
     public FragmentInstance registerLateInstance(ExecutionFragment fragment, ComputeNode worker) {
-        Preconditions.checkState(nextIndexInJob > 0, "registerLateInstance requires a finalized DAG");
+        return registerLateInstance(fragment, worker, reserveLateIndexInJob());
+    }
+
+    /**
+     * Variant taking an indexInJob previously obtained from {@link #reserveLateIndexInJob()},
+     * for callers that must announce the sender identity (be_number) to downstream exchanges
+     * before the instance exists anywhere.
+     */
+    public FragmentInstance registerLateInstance(ExecutionFragment fragment, ComputeNode worker,
+                                                 int reservedIndexInJob) {
         FragmentInstance instance = new FragmentInstance(worker, fragment);
         setInstanceId(instance);
-        instance.setIndexInJob(nextIndexInJob++);
+        instance.setIndexInJob(reservedIndexInJob);
         fragment.addInstanceLate(instance);
         workerIdToNumInstances.merge(instance.getWorkerId(), 1, Integer::sum);
         return instance;
+    }
+
+    /**
+     * Reserves the next dense indexInJob without creating an instance yet. An aborted late add
+     * simply burns the reserved index — gaps are harmless because report routing looks indices
+     * up by exact key, never by density.
+     */
+    public int reserveLateIndexInJob() {
+        Preconditions.checkState(nextIndexInJob > 0, "reserveLateIndexInJob requires a finalized DAG");
+        return nextIndexInJob++;
     }
 
     private void setInstanceId(FragmentInstance instance) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -724,6 +724,15 @@ public class ExecutionDAG {
      */
     public FragmentInstance registerLateInstance(ExecutionFragment fragment, ComputeNode worker,
                                                  int reservedIndexInJob) {
+        // A fragment that builds a global runtime filter sizes its merge layout (numInstances,
+        // bucketSeqToInstance) once at first deploy via ExecutionFragment#setLayoutInfosForRuntimeFilters.
+        // Growing the builder set afterwards would leave the RF merger expecting the plan-time count and
+        // the new builder hashing against a stale layout; recomputing only the late instance's view does
+        // not fix the already-deployed builders or the merger. Refuse to grow such fragments — this keeps
+        // the primitive safe for any caller (elastic scheduling already gates them out at eligibility, and
+        // probe-only runtime-filter fragments carry no build filters and are unaffected).
+        Preconditions.checkState(fragment.getPlanFragment().getBuildRuntimeFilters().isEmpty(),
+                "cannot register a late instance on a fragment that builds runtime filters");
         FragmentInstance instance = new FragmentInstance(worker, fragment);
         setInstanceId(instance);
         instance.setIndexInJob(reservedIndexInJob);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
@@ -85,9 +86,17 @@ public class ExecutionDAG {
     /**
      * {@code instanceIdToInstance} and {@link #workerIdToNumInstances} will be calculated in {@link #finalizeDAG()},
      * after all the fragment instances have already been added to the DAG .
+     * <p> Both are concurrent because {@link #registerLateInstance(ExecutionFragment, ComputeNode)} may grow
+     * them while report and cancel threads read them.
      */
     private final Map<TUniqueId, FragmentInstance> instanceIdToInstance;
-    private Map<Long, Integer> workerIdToNumInstances = Maps.newHashMap();
+    private Map<Long, Integer> workerIdToNumInstances = Maps.newConcurrentMap();
+
+    /**
+     * The next dense indexInJob, retained after {@link #finalizeDAG()} so that
+     * {@link #registerLateInstance(ExecutionFragment, ComputeNode)} can keep the sequence.
+     */
+    private int nextIndexInJob = 0;
 
     /**
      * The executions will be added to {@code indexInJobToExecState}, when it is deploying.
@@ -111,7 +120,7 @@ public class ExecutionDAG {
         this.fragments = Lists.newArrayList();
         this.preExecutedFragments = Lists.newArrayList();
         this.idToFragment = Maps.newHashMap();
-        this.instanceIdToInstance = Maps.newHashMap();
+        this.instanceIdToInstance = Maps.newConcurrentMap();
     }
 
     public static ExecutionDAG build(JobSpec jobSpec) {
@@ -343,11 +352,10 @@ public class ExecutionDAG {
      */
     public void finalizeDAG() throws SchedulerException {
         // Assign monotonic unique indexInJob to fragment instances to keep consistent order with indexInFragment.
-        int index = 0;
         for (ExecutionFragment fragment : fragments) {
             for (FragmentInstance instance : fragment.getInstances()) {
                 setInstanceId(instance);
-                instance.setIndexInJob(index++);
+                instance.setIndexInJob(nextIndexInJob++);
             }
         }
 
@@ -357,12 +365,12 @@ public class ExecutionDAG {
 
         computeFetchFragmentForLookUpNode();
 
-        workerIdToNumInstances = fragments.stream()
+        workerIdToNumInstances = new ConcurrentHashMap<>(fragments.stream()
                 .flatMap(fragment -> fragment.getInstances().stream())
                 .collect(Collectors.groupingBy(
                         FragmentInstance::getWorkerId,
                         Collectors.summingInt(instance -> 1)
-                ));
+                )));
 
         if (jobSpec.isStreamLoad()) {
             fragments.stream()
@@ -690,6 +698,29 @@ public class ExecutionDAG {
                 }
             }
         }
+    }
+
+    /**
+     * Registers one more instance for {@code fragment} after {@link #finalizeDAG()}, for schedulers
+     * that grow a running query (e.g. adding scan instances on newly joined compute nodes).
+     *
+     * <p>The instance gets the next dense indexInJob (the BE-to-FE report routing key) and a fresh
+     * instance id; existing instances are never reordered, so global-runtime-filter component
+     * ordinals derived from the original ordering stay valid. The destination fragment's
+     * {@code numSendersPerExchange} is deliberately NOT updated: downstream receivers were already
+     * created with the plan-time sender count, and the wire-side sender set is grown through the
+     * BE's dynamic sender-registration RPC instead.
+     *
+     * <p>Must be called on the schedule thread, serialized with scan-range assignment.
+     */
+    public FragmentInstance registerLateInstance(ExecutionFragment fragment, ComputeNode worker) {
+        Preconditions.checkState(nextIndexInJob > 0, "registerLateInstance requires a finalized DAG");
+        FragmentInstance instance = new FragmentInstance(worker, fragment);
+        setInstanceId(instance);
+        instance.setIndexInJob(nextIndexInJob++);
+        fragment.addInstanceLate(instance);
+        workerIdToNumInstances.merge(instance.getWorkerId(), 1, Integer::sum);
+        return instance;
     }
 
     private void setInstanceId(FragmentInstance instance) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -70,7 +70,9 @@ public class ExecutionFragment {
     private final Map<Integer, Integer> numSendersPerExchange;
     private final Map<Integer, Integer> numFetchersPerLookUp;
 
-    private final List<FragmentInstance> instances;
+    // Volatile because addInstanceLate publishes a copied list while report and cancel
+    // threads may be iterating; the prepare-time addInstance path still mutates in place.
+    private volatile List<FragmentInstance> instances;
 
     private final FragmentScanRangeAssignment scanRangeAssignment;
     private ColocatedBackendSelector.Assignment colocatedAssignment = null;
@@ -274,6 +276,19 @@ public class ExecutionFragment {
     public void addInstance(FragmentInstance instance) {
         instance.setIndexInFragment(instances.size());
         instances.add(instance);
+    }
+
+    /**
+     * Adds an instance after {@link ExecutionDAG#finalizeDAG()}. Publishes a new list instead of
+     * mutating in place, so concurrent readers iterating {@link #getInstances()} (report handling,
+     * cancel fan-out) never observe a partially updated list. Appending keeps the existing
+     * instances' indexInFragment stable.
+     */
+    public void addInstanceLate(FragmentInstance instance) {
+        instance.setIndexInFragment(instances.size());
+        List<FragmentInstance> copied = Lists.newArrayList(instances);
+        copied.add(instance);
+        instances = copied;
     }
 
     public void shuffleInstances(Random random) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/GrowableMarkedLatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/GrowableMarkedLatchTest.java
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import com.starrocks.common.Status;
+import com.starrocks.thrift.TStatusCode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GrowableMarkedLatchTest {
+
+    @Test
+    public void testGrowWhileRunning() throws Exception {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        Assertions.assertTrue(latch.addMark("b", 1L));
+        Assertions.assertEquals(2, latch.getCount());
+
+        Assertions.assertTrue(latch.markedCountDown("a", 1L));
+        // still running: growth allowed
+        Assertions.assertTrue(latch.addMark("c", 1L));
+        Assertions.assertEquals(2, latch.getCount());
+
+        Assertions.assertTrue(latch.markedCountDown("b", 1L));
+        Assertions.assertTrue(latch.markedCountDown("c", 1L));
+        Assertions.assertEquals(0, latch.getCount());
+        Assertions.assertTrue(latch.await(0, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testSealedAfterCompletion() {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        Assertions.assertTrue(latch.markedCountDown("a", 1L));
+        // completed: growth rejected, completion irrevocable
+        Assertions.assertFalse(latch.addMark("b", 1L));
+        Assertions.assertEquals(0, latch.getCount());
+    }
+
+    @Test
+    public void testCountDownToZeroSealsAndSetsStatus() {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        Assertions.assertTrue(latch.addMark("b", 1L));
+        latch.countDownToZero(new Status(TStatusCode.CANCELLED, "cancelled"));
+        Assertions.assertEquals(0, latch.getCount());
+        Assertions.assertFalse(latch.addMark("c", 1L));
+        Assertions.assertEquals(TStatusCode.CANCELLED, latch.getStatus().getErrorCode());
+    }
+
+    @Test
+    public void testUnknownMarkCountDownReturnsFalse() {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        Assertions.assertFalse(latch.markedCountDown("unknown", 1L));
+        Assertions.assertEquals(1, latch.getCount());
+    }
+
+    @Test
+    public void testAwaitBlocksUntilLastMark() throws Exception {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        Assertions.assertFalse(latch.await(10, TimeUnit.MILLISECONDS));
+
+        Thread t = new Thread(() -> latch.markedCountDown("a", 1L));
+        t.start();
+        Assertions.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        t.join();
+    }
+
+    @Test
+    public void testListenersFireOnceOnCompletion() {
+        GrowableMarkedLatch<String, Long> latch = new GrowableMarkedLatch<>();
+        AtomicInteger fired = new AtomicInteger();
+        Assertions.assertTrue(latch.addMark("a", 1L));
+        latch.addListener(fired::incrementAndGet);
+        Assertions.assertEquals(0, fired.get());
+
+        Assertions.assertTrue(latch.markedCountDown("a", 1L));
+        Assertions.assertEquals(1, fired.get());
+        // registering after completion fires immediately, and completion listeners are one-shot
+        latch.addListener(fired::incrementAndGet);
+        Assertions.assertEquals(2, fired.get());
+        latch.countDownToZero(Status.OK);
+        Assertions.assertEquals(2, fired.get());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
@@ -66,6 +66,12 @@ public class RegisterLateInstanceTest extends SchedulerTestBase {
         Assertions.assertEquals(totalInstances + 1, late2.getIndexInJob());
         Assertions.assertEquals(fragmentInstances + 1, late2.getIndexInFragment());
         Assertions.assertNotEquals(late.getInstanceId(), late2.getInstanceId());
+
+        // A reserved index that is never used just leaves a gap in the sequence.
+        int reserved = dag.reserveLateIndexInJob();
+        Assertions.assertEquals(totalInstances + 2, reserved);
+        FragmentInstance late3 = dag.registerLateInstance(scanFragment, backend2);
+        Assertions.assertEquals(totalInstances + 3, late3.getIndexInJob());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.planner.ScanNode;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionDAG;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
+import com.starrocks.thrift.TUniqueId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RegisterLateInstanceTest extends SchedulerTestBase {
+
+    private static ExecutionFragment findScanFragment(ExecutionDAG dag) {
+        return dag.getFragmentsInPostorder().stream()
+                .filter(fragment -> !fragment.getScanNodes().isEmpty())
+                .filter(fragment -> fragment.getScanNodes().stream().map(ScanNode::getId).findAny().isPresent())
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Test
+    public void testRegisterLateInstanceInvariants() throws Exception {
+        DefaultCoordinator coordinator = startScheduling("select L_ORDERKEY from lineitem");
+        ExecutionDAG dag = coordinator.getExecutionDAG();
+        ExecutionFragment scanFragment = findScanFragment(dag);
+
+        int totalInstances = dag.getInstanceIds().size();
+        int fragmentInstances = scanFragment.getInstances().size();
+        Set<TUniqueId> existingIds = new HashSet<>(dag.getInstanceIds());
+        int workerInstancesBefore = countInstancesOfWorker(dag, backend2.getId());
+
+        FragmentInstance late = dag.registerLateInstance(scanFragment, backend2);
+
+        // Dense indexInJob continues after the last finalized instance.
+        Assertions.assertEquals(totalInstances, late.getIndexInJob());
+        // Appended to the fragment without reordering existing instances.
+        Assertions.assertEquals(fragmentInstances, late.getIndexInFragment());
+        Assertions.assertEquals(fragmentInstances + 1, scanFragment.getInstances().size());
+        Assertions.assertSame(late, scanFragment.getInstances().get(fragmentInstances));
+        // Fresh, collision-free instance id, registered for lookups.
+        Assertions.assertFalse(existingIds.contains(late.getInstanceId()));
+        Assertions.assertSame(late, dag.getInstanceByInstanceId(late.getInstanceId()));
+        // Worker instance accounting includes the late instance.
+        Assertions.assertEquals(workerInstancesBefore + 1, dag.getNumInstancesOfWorkerId(backend2.getId()));
+
+        // A second registration keeps the sequence dense.
+        FragmentInstance late2 = dag.registerLateInstance(scanFragment, backend3);
+        Assertions.assertEquals(totalInstances + 1, late2.getIndexInJob());
+        Assertions.assertEquals(fragmentInstances + 1, late2.getIndexInFragment());
+        Assertions.assertNotEquals(late.getInstanceId(), late2.getInstanceId());
+    }
+
+    @Test
+    public void testExistingInstancesUntouchedByLateRegistration() throws Exception {
+        DefaultCoordinator coordinator = startScheduling("select L_ORDERKEY from lineitem");
+        ExecutionDAG dag = coordinator.getExecutionDAG();
+        ExecutionFragment scanFragment = findScanFragment(dag);
+
+        int[] indexInJobBefore = scanFragment.getInstances().stream()
+                .mapToInt(FragmentInstance::getIndexInJob).toArray();
+        int[] indexInFragmentBefore = scanFragment.getInstances().stream()
+                .mapToInt(FragmentInstance::getIndexInFragment).toArray();
+
+        dag.registerLateInstance(scanFragment, backend2);
+
+        // GRF component ordinals depend on the original ordering: it must be unchanged.
+        for (int i = 0; i < indexInJobBefore.length; i++) {
+            Assertions.assertEquals(indexInJobBefore[i], scanFragment.getInstances().get(i).getIndexInJob());
+            Assertions.assertEquals(indexInFragmentBefore[i],
+                    scanFragment.getInstances().get(i).getIndexInFragment());
+        }
+    }
+
+    private static int countInstancesOfWorker(ExecutionDAG dag, long workerId) {
+        return (int) dag.getInstances().stream().filter(instance -> instance.getWorkerId() == workerId).count();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/RegisterLateInstanceTest.java
@@ -95,6 +95,22 @@ public class RegisterLateInstanceTest extends SchedulerTestBase {
         }
     }
 
+    @Test
+    public void testRejectLateInstanceOnRuntimeFilterBuilder() throws Exception {
+        // A hash join builds a global runtime filter; its build fragment sizes the RF merge layout at
+        // plan time and cannot safely grow the builder set mid-query.
+        DefaultCoordinator coordinator =
+                startScheduling("select count(*) from lineitem join orders on l_orderkey = o_orderkey");
+        ExecutionDAG dag = coordinator.getExecutionDAG();
+        ExecutionFragment rfBuilder = dag.getFragmentsInPostorder().stream()
+                .filter(fragment -> !fragment.getPlanFragment().getBuildRuntimeFilters().isEmpty())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected a runtime-filter build fragment"));
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> dag.registerLateInstance(rfBuilder, backend2));
+    }
+
     private static int countInstancesOfWorker(ExecutionDAG dag, long workerId) {
         return (int) dag.getInstances().stream().filter(instance -> instance.getWorkerId() == workerId).count();
     }


### PR DESCRIPTION
## Why I'm doing:

A query's fragment-instance set is frozen in `ExecutionDAG.finalizeDAG()`: the dense `indexInJob` routing space, instance-id allocation, worker instance counts, and the profile completion barrier (`MarkedCountDownLatch`, fixed size) are all materialized exactly once. That makes it structurally impossible to add a fragment instance to a running query — the FE-side prerequisite for mid-query CN elasticity (#76485), where scan instances are added on compute nodes that join the warehouse while a query runs.

This is the "unfreeze" refactor of that series: pure mechanism, **zero behavior change**, no production caller yet (the orchestration lands in a follow-up).

## What I'm doing:

- **`ExecutionDAG.registerLateInstance(fragment, worker)`**: retains the dense `indexInJob` sequence after `finalizeDAG()` and continues it for late instances (keeping BE→FE report routing by `backend_num` consistent); reuses the existing monotonic instance-id allocator (collision-free by construction); appends to the fragment so existing instances are never reordered — global-runtime-filter component ordinals derived from the original ordering stay valid. The destination fragment's `numSendersPerExchange` is deliberately NOT updated: downstream receivers already hold the plan-time sender count, and the wire-side sender set grows through the BE dynamic sender-registration RPC (#76493) instead.
- **Concurrency without penalizing the common path**: `instanceIdToInstance` / `workerIdToNumInstances` become concurrent maps (point lookups only, no ordered iteration — golden scheduler tests unchanged); `ExecutionFragment.addInstanceLate` publishes a copied instance list (volatile field) so report and cancel threads iterating `getInstances()` never observe a partially updated list. The prepare-time `addInstance` path still mutates in place — no O(n²) copying for wide fragments.
- **`GrowableMarkedLatch`**: replaces the fixed-count `MarkedCountDownLatch` for `QueryRuntimeProfile.profileDoneSignal`. The count is the number of outstanding marks; marks can be added while the query runs and the latch is sealed on completion, so `QueryRuntimeProfile.attachInstance(id)` fails once the query has finished (a late instance must not be deployed then). Same API surface (`markedCountDown`, `countDownToZero`, `getLeftMarks`, listeners, timed `await`). `MarkedCountDownLatch` itself is untouched (other users: load jobs).

Tests: `GrowableMarkedLatchTest` (grow-while-running, seal-on-completion, forced completion + status, unknown-mark, blocking await, one-shot listeners) and `RegisterLateInstanceTest` on the scheduler harness (dense index continuation, fresh id + lookup registration, appended `indexInFragment`, worker accounting, existing instances untouched). Byte-identical proof: `QueryRuntimeProfileTest`, `StartSchedulingTest`, `PhasedScheduleTest`, `ExecutionDAGTest`, `DeployerTest`, `GetNextTest`, `SingleNodeScheduleTest`, `QueryQueueManagerTest`, `IncrementalDeployHiveTest` all pass unchanged.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

