### PR TITLE
[BugFix] Fix NPE on ALTER TABLE RENAME for Iceberg REST catalogs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -318,7 +318,8 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
 
     @Override
     public Void visitTableRenameClause(TableRenameClause clause, ConnectContext context) {
-        icebergCatalog.renameTable(context, tableName.getDb(), tableName.getTbl(), clause.getNewTableName());
+        ConnectContext ctx = this.context != null ? this.context : ConnectContext.get();
+        icebergCatalog.renameTable(ctx, tableName.getDb(), tableName.getTbl(), clause.getNewTableName());
         return null;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -136,6 +136,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
@@ -2275,6 +2276,16 @@ public class IcebergMetadataTest extends TableTestBase {
         TableRenameClause tableRenameClause = new TableRenameClause("newTbl");
         clauses.add(tableRenameClause);
         metadata.alterTable(new ConnectContext(), new AlterTableStmt(createTableRef(tableName), clauses));
+
+        new Verifications() {
+            {
+                List<ConnectContext> renameContexts = new ArrayList<>();
+                icebergHiveCatalog.renameTable(withCapture(renameContexts), anyString, anyString, anyString);
+                Assertions.assertFalse(renameContexts.isEmpty(), "renameTable should have been invoked");
+                renameContexts.forEach(renameContext ->
+                        Assertions.assertNotNull(renameContext, "rename must pass a non-null ConnectContext"));
+            }
+        };
 
         // modify table properties/comment
         clauses.clear();


### PR DESCRIPTION
## Why I'm doing:

`ALTER TABLE ... RENAME` on an Iceberg REST catalog (and any catalog reached through `CachingIcebergCatalog`) always fails with a `NullPointerException`, regardless of whether the target name exists — table rename is effectively unusable on REST catalogs.

Root cause:

- `ConnectorAlterTableExecutor.applyClauses()` visits every clause with a null `ConnectContext` argument by design; the real context is stored in the executor's `context` field (set in the constructor).
- Other visitors honor this — e.g. `visitAlterTableOperationClause` uses `context != null ? context : ConnectContext.get()`.
- But `visitTableRenameClause` forwarded the null argument straight to `icebergCatalog.renameTable(context, ...)`.
- On REST catalogs, `IcebergRESTCatalog.renameTable` → `buildContext(context)` dereferences `context.getQualifiedUser()`, producing the NPE.

Observed stack (StarRocks 4.1.1, Iceberg REST catalog):

```
java.lang.NullPointerException: Cannot invoke "ConnectContext.getQualifiedUser()" because "context" is null
  at IcebergRESTCatalog.buildContext(IcebergRESTCatalog.java)
  at IcebergRESTCatalog.renameTable(IcebergRESTCatalog.java)
  at CachingIcebergCatalog.renameTable(CachingIcebergCatalog.java)
  at IcebergAlterTableExecutor.visitTableRenameClause(IcebergAlterTableExecutor.java)
```

## What I'm doing:

In `IcebergAlterTableExecutor.visitTableRenameClause`, use the executor's own context (falling back to `ConnectContext.get()`), the same defensive pattern already used by `visitAlterTableOperationClause`, so `renameTable` always
receives a non-null context:

```java
ConnectContext ctx = this.context != null ? this.context : ConnectContext.get();
icebergCatalog.renameTable(ctx, tableName.getDb(), tableName.getTbl(), clause.getNewTableName());
```

Added a regression check in `IcebergMetadataTest#testAlterTable`: it captures the context passed to `renameTable` and asserts it is non-null. Because the test uses a mocked catalog (which does not dereference the context), the previous test passed despite the bug; the new assertion fails without the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
