### PR TITLE
[BugFix] Inactivate and suspend incremental MV on a non-append-only base change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -1230,9 +1230,6 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         }
     }
 
-    /**
-     * Inactive the materialized view and its related materialized views.
-     */
     private static void doInactiveMaterializedViewRecursive(MaterializedView mv, String reason,
                                                             boolean isClearVersionMap,
                                                             Set<MvId> visited) {
@@ -1482,13 +1479,15 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (mv == null) {
             return;
         }
-        final String inactiveReason = MaterializedViewExceptions.inactiveReasonForConsecutiveFailures(mv.getName());
-        // write edit log
+        inactiveMvAndLog(mv, MaterializedViewExceptions.inactiveReasonForConsecutiveFailures(mv.getName()));
+    }
+
+    // Mark the MV inactive and journal the transition, so the inactive state survives a leader restart
+    // or failover instead of reverting to active until the next refresh re-detects the condition.
+    public static void inactiveMvAndLog(MaterializedView mv, String inactiveReason) {
         AlterMaterializedViewStatusLog log = new AlterMaterializedViewStatusLog(mv.getDbId(),
                 mv.getId(), AlterMaterializedViewStatusClause.INACTIVE, inactiveReason);
-        GlobalStateMgr.getCurrentState().getEditLog().logAlterMvStatus(log, wal -> {
-            // inactive related mv
-            mv.setInactiveAndReason(inactiveReason);
-        });
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterMvStatus(log,
+                wal -> mv.setInactiveAndReason(inactiveReason));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -33,6 +33,9 @@ public class MaterializedViewExceptions {
 
     public static final String INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES = "mv consecutive failures: ";
 
+    public static final String INACTIVE_REASON_FOR_INCREMENTAL_BREAKING =
+            "incremental refresh broken by non-append-only base change: ";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -65,6 +68,29 @@ public class MaterializedViewExceptions {
 
     public static String inactiveReasonForBaseTableReorderColumns(String tableName) {
         return INACTIVE_REASON_FOR_BASE_TABLE_REORDER_COLUMNS + tableName;
+    }
+
+    public static String inactiveReasonForIncrementalBreaking(String mvName) {
+        return INACTIVE_REASON_FOR_INCREMENTAL_BREAKING + mvName;
+    }
+
+    // Canonical marker for a permanently-breaking (non-append-only) base change. MVIVMRefreshProcessor builds
+    // its message from this constant and isIncrementalBreakingFailure matches it, so wording and detection can't drift.
+    public static final String FE_NON_APPEND_ONLY_MARKER = "do not support non-append-only base changes";
+
+    /**
+     * Whether an MV refresh failure is a non-append-only breakage that permanently disables incremental
+     * refresh (vs. a transient error), so a single caller can inactivate the MV. Walks the cause chain
+     * since the marker may be wrapped by the refresh pipeline.
+     */
+    public static boolean isIncrementalBreakingFailure(Throwable e) {
+        for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+            String msg = t.getMessage();
+            if (msg != null && msg.contains(FE_NON_APPEND_ONLY_MARKER)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static String inactiveReasonForMetadataTableRestoreCorrupted(String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -71,7 +71,8 @@ public class MVActiveChecker extends LeaderDaemon {
     private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(
             MV_BACKUP_INACTIVE_REASON,
             MaterializedViewExceptions.INACTIVE_REASON_FOR_BASE_TABLE_OPTIMIZED,
-            MaterializedViewExceptions.INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES
+            MaterializedViewExceptions.INACTIVE_REASON_FOR_CONSECUTIVE_FAILURES,
+            MaterializedViewExceptions.INACTIVE_REASON_FOR_INCREMENTAL_BREAKING
     );
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
@@ -439,6 +440,17 @@ public class TaskRun implements Comparable<TaskRun> {
             task.incConsecutiveFailCount();
             LOG.warn("Failed to execute task run, task_id: {}, task_run_id: {}, failCount:{}",
                     taskId, taskRunId, task.getConsecutiveFailCount(), e);
+            if (Constants.TaskSource.MV.equals(task.getSource())
+                    && MaterializedViewExceptions.isIncrementalBreakingFailure(e)) {
+                MaterializedView mv = TaskBuilder.getMvFromTask(task);
+                // Permanent incremental breakage: inactivate the MV and rethrow. Don't kill/suspend the running
+                // refresh here -- that would eat the actionable error; the consecutive-failure path suspends the task.
+                if (mv != null && mv.isActive()) {
+                    AlterMVJobExecutor.inactiveMvAndLog(mv,
+                            MaterializedViewExceptions.inactiveReasonForIncrementalBreaking(mv.getName()));
+                    throw e;
+                }
+            }
             if (Constants.TaskSource.MV.equals(task.getSource()) && Config.max_task_consecutive_fail_count > 0 &&
                     task.getConsecutiveFailCount() >= Config.max_task_consecutive_fail_count) {
                 LOG.warn("Task {} has failed {} times continuously, so we disable it",

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMRefreshProcessor.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.tvr.TvrTableDelta;
@@ -284,7 +285,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
                             maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
         } catch (StarRocksConnectorException e) {
             if (isAncestryBrokenError(e)) {
-                throw new SemanticException(formatPartitionShapeChangeError(
+                throw new SemanticException(formatNonAppendOnlyBreakingError(
                         String.format("snapshot ancestry broken for base table %s.%s (%s)",
                                 baseTableInfo.getDbName(), baseTableInfo.getTableName(), e.getMessage())),
                         e);
@@ -294,7 +295,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
             logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
                     baseTableInfo.getDbName());
-            throw new SemanticException(formatPartitionShapeChangeError(
+            throw new SemanticException(formatNonAppendOnlyBreakingError(
                     String.format("no tvr delta traits found for base table %s.%s",
                             baseTableInfo.getDbName(), baseTableInfo.getTableName())));
         }
@@ -304,7 +305,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         if (!lastTvrDeltaSnapshot.equals(maxTvrDelta.toSnapshot())) {
             logger.warn("The last tvr delta snapshot: {} is not equal to the max tvr delta snapshot: {}",
                     lastTvrDeltaSnapshot, maxTvrDelta.toSnapshot());
-            throw new SemanticException(formatPartitionShapeChangeError(
+            throw new SemanticException(formatNonAppendOnlyBreakingError(
                     String.format("tvr delta lineage inconsistent for base table %s.%s "
                                     + "(last delta snapshot %s != max delta snapshot %s)",
                             baseTableInfo.getDbName(), baseTableInfo.getTableName(),
@@ -313,7 +314,7 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         for (TvrTableDeltaTrait deltaTrait : tableDeltaTraits) {
             if (!deltaTrait.isAppendOnly()) {
                 if (refreshMode.isIncremental()) {
-                    throw new SemanticException(formatPartitionShapeChangeError(
+                    throw new SemanticException(formatNonAppendOnlyBreakingError(
                             String.format("non-append-only change on base table %s.%s (delta: %s)",
                                     baseTableInfo.getDbName(), baseTableInfo.getTableName(), deltaTrait)));
                 } else {
@@ -337,13 +338,13 @@ public final class MVIVMRefreshProcessor extends MVRefreshProcessor {
         return message != null && message.contains("is not a parent ancestor");
     }
 
-    private String formatPartitionShapeChangeError(String reasonFragment) {
+    private String formatNonAppendOnlyBreakingError(String reasonFragment) {
         return String.format(
                 "Cannot incrementally refresh materialized view %s: %s. "
-                        + "INCREMENTAL materialized views do not support partition-shape changes "
+                        + "INCREMENTAL materialized views %s "
                         + "(DELETE / OVERWRITE / DROP PARTITION / snapshot expiration / table replacement). "
                         + "Drop and recreate the materialized view to recover.",
-                mv.getName(), reasonFragment);
+                mv.getName(), reasonFragment, MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER);
     }
 
     public TvrTableDelta getBaseTableMaxChangedDelta(BaseTableSnapshotInfo snapshotInfo,

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.scheduler.Constants;
@@ -895,5 +896,43 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         Assertions.assertNotEquals(Constants.TaskState.PAUSE, task.getState());
         Assertions.assertTrue(mv.isActive());
         Config.max_task_consecutive_fail_count = 10;
+    }
+
+    @Test
+    public void testMvInactivatedOnIncrementalBreaking() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_brk_t1 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_brk_mv1\n" +
+                "REFRESH MANUAL\n" +
+                "AS select sum(k1), k2, k3 from base_brk_t1 group by k2, k3;");
+        executeInsertSql("insert into base_brk_t1 values(1, '2020-06-02','BJ'),(3,'2020-06-02','SZ');");
+        MaterializedView mv = getMv("test_brk_mv1");
+
+        // Breaking failure must inactivate the MV yet leave the running refresh (and its error) intact.
+        new MockUp<MVTaskRunProcessor>() {
+            @Mock
+            public void executePlan(ExecPlan execPlan, InsertStmt insertStmt) throws Exception {
+                throw new RuntimeException("INCREMENTAL materialized views "
+                        + MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER);
+            }
+        };
+        Exception thrown = null;
+        try {
+            refreshMV("test", mv);
+        } catch (Exception e) {
+            thrown = e;
+        }
+
+        Assertions.assertNotNull(thrown, "the breaking error must propagate, not be swallowed");
+        Task task = GlobalStateMgr.getCurrentState().getTaskManager().getTask(mv);
+        Assertions.assertEquals(1, task.getConsecutiveFailCount());
+        Assertions.assertNotEquals(Constants.TaskState.PAUSE, task.getState());
+        Assertions.assertFalse(mv.isActive());
+        Assertions.assertTrue(mv.getInactiveReason().contains("incremental refresh broken"),
+                "inactive reason: " + mv.getInactiveReason());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/MaterializedViewExceptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/MaterializedViewExceptionsTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MaterializedViewExceptionsTest {
+
+    @Test
+    public void testIsIncrementalBreakingFailure() {
+        // FE-detected non-append-only breakage; built from the shared marker so the test can't drift from detection.
+        assertTrue(MaterializedViewExceptions.isIncrementalBreakingFailure(new RuntimeException(
+                "Cannot incrementally refresh materialized view mv1: non-append-only change on base table db.t. "
+                        + "INCREMENTAL materialized views " + MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER
+                        + " (DELETE / OVERWRITE / DROP PARTITION / snapshot expiration / table replacement).")));
+        // the marker may be wrapped deeper in the cause chain
+        assertTrue(MaterializedViewExceptions.isIncrementalBreakingFailure(
+                new RuntimeException("refresh failed",
+                        new IllegalStateException("... " + MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER + " ..."))));
+
+        // transient / unrelated failures must not be treated as breaking
+        assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(
+                new RuntimeException("get database write lock timeout")));
+        assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(
+                new RuntimeException("No checkpoint found for base table: db.t during IVM planning")));
+        assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(new RuntimeException()));
+        assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.tvr.TvrDeltaStats;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableDeltaTrait;
@@ -1702,7 +1703,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                 "drop-and-recreate hint must not apply to non-ancestry connector failures, got: " + chain);
         Assertions.assertFalse(chain.contains("snapshot ancestry broken"),
                 "ancestry-broken framing must not apply to non-ancestry connector failures, got: " + chain);
-        Assertions.assertFalse(chain.contains("INCREMENTAL materialized views do not support partition-shape"),
-                "partition-shape framing must not apply to non-ancestry connector failures, got: " + chain);
+        Assertions.assertFalse(chain.contains(MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER),
+                "non-append-only breaking framing must not apply to non-ancestry connector failures, got: " + chain);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

An INCREMENTAL materialized view requires its base table to be append-only. When the base gets a non-append-only change that the planner reports as RETRACTABLE (`DROP PARTITION` / `OVERWRITE` / snapshot expiration / table replacement), every subsequent incremental refresh fails permanently with a "non-append-only change ... Drop and recreate" error. But the refresh only fails the task run and never touches the MV state, so the MV stays `IS_ACTIVE=true` and silently stops updating — the user has no visible signal it is permanently broken, and the task keeps firing failing runs. The only backstop is the generic consecutive-failure counter (`Config.max_task_consecutive_fail_count`, default 10), which is delayed, resettable, scheduler-dependent, and reports an opaque reason.

Root cause: `MVIVMRefreshProcessor` detects `!TvrTableDeltaTrait.isAppendOnly()` and throws, but nothing marks the MV inactive or suspends its task; no existing inactivation path fires for a base *data* change (they cover schema/identity/existence only).

## What I'm doing:

Handle the breakage once, in `TaskRun`'s failure handler: when an MV refresh fails with a partition-shape (non-append-only) breakage, inactivate the MV (`MaterializedViewExceptions.inactiveReasonForIncrementalBreaking`) and suspend its refresh task, journaling the transition so it survives a leader failover. `IS_ACTIVE=false` + `INACTIVE_REASON` then surface the breakage via `information_schema.materialized_views` / `SHOW MATERIALIZED VIEWS`, and the reason is added to `MVActiveChecker.MV_NO_AUTOMATIC_ACTIVE_REASONS` so the active-checker does not thrash reactivating an MV that only a drop & recreate can fix.

Doing this in the failure handler rather than at the detection point keeps detection (`MVIVMRefreshProcessor` throws the error) separate from the reaction, and reuses the exact site the consecutive-failure path and `ALTER MATERIALIZED VIEW ... INACTIVE` already suspend from (the refresh processor has fully unwound, so it avoids the self-archiving a suspend from inside the running planner would cause). `isIncrementalBreakingFailure` recognizes the breakage by the planner's partition-shape marker and walks the cause chain; it is scoped to that deterministic signal, so transient errors (lock timeout, snapshot-ancestry connector failures) leave a healthy MV untouched, PCT MVs never enter, and an AUTO MV's IVM-leg error — absorbed by its PCT fallback — never reaches it.

This does **not** change the append-only limitation itself — it only makes the resulting broken state observable and stops the task from firing failing runs until the generic consecutive-failure threshold. A manual `ALTER MATERIALIZED VIEW ... ACTIVE` resumes the MV.

Fixes #76499

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
