### PR TITLE
[BugFix] Fix analysis time nullability for ROLLUP keys (backport #76149)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -87,6 +87,7 @@ public class SelectAnalyzer {
 
         List<Expr> groupByExpressions = new ArrayList<>(
                 analyzeGroupBy(groupByClause, analyzeState, sourceScope, outputScope, outputExpressions));
+        widenGroupingKeyNullability(groupByClause, outputScope, outputExpressions, groupByExpressions);
 
         boolean distinctWithoutGroupBy = selectList.isDistinct() && groupByExpressions.isEmpty();
         if (selectList.isDistinct()) {
@@ -579,6 +580,42 @@ public class SelectAnalyzer {
         }
         analyzeState.setGroupBy(groupByExpressions);
         return groupByExpressions;
+    }
+
+    /**
+     * ROLLUP/CUBE/GROUPING SETS produce super-aggregate rows where grouping-key columns are NULL,
+     * regardless of whether the underlying column is declared NOT NULL. The Repeat operator already
+     * accounts for this widening at plan/fragment-build time, but analysis-time nullability is
+     * otherwise derived solely from the grouping expression itself, so it must be widened here too.
+     *
+     * <p>Two analysis-time signals need widening: the output {@link Field} on the scope (consumed by
+     * materialized-view schema building and, via QueryAnalyzer.visitView, by view queries), and the
+     * output {@link Expr} itself (consumed directly by the Arrow Flight prepared-statement schema,
+     * which reads getOutputExpression().isNullable()). Without the latter, a direct
+     * {@code GROUP BY ROLLUP} query that is not wrapped in a view still reports the grouping key as
+     * NOT NULL while the executed result delivers NULLs.
+     */
+    private void widenGroupingKeyNullability(GroupByClause groupByClause, Scope outputScope,
+                                             List<Expr> outputExpressions, List<Expr> groupByExpressions) {
+        if (groupByClause == null || groupByExpressions.isEmpty()) {
+            return;
+        }
+        GroupByClause.GroupingType groupingType = groupByClause.getGroupingType();
+        if (groupingType != GroupByClause.GroupingType.ROLLUP
+                && groupingType != GroupByClause.GroupingType.CUBE
+                && groupingType != GroupByClause.GroupingType.GROUPING_SETS) {
+            return;
+        }
+        List<Field> outputFields = outputScope.getRelationFields().getAllFields();
+        for (int i = 0; i < outputExpressions.size() && i < outputFields.size(); i++) {
+            Expr outputExpr = outputExpressions.get(i);
+            if (groupByExpressions.stream().anyMatch(outputExpr::equals)) {
+                outputFields.get(i).setNullable(true);
+                if (outputExpr instanceof SlotRef) {
+                    ((SlotRef) outputExpr).setNullable(true);
+                }
+            }
+        }
     }
 
     private List<Expr> rewriteGroupByAlias(List<Expr> groupingExprs, AnalyzeState analyzeState, Scope sourceScope,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeViewNullabilityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeViewNullabilityTest.java
@@ -62,7 +62,12 @@ public class AnalyzeViewNullabilityTest {
                 .withView("CREATE VIEW `nn_join_view` AS " +
                         "SELECT a.id AS a_id, b.label AS b_label " +
                         "FROM nn_base a LEFT JOIN nn_base2 b ON a.id = b.id")
-                .withView("CREATE VIEW `nn_expr_view` AS SELECT id + 1 AS id_plus, name FROM nn_base");
+                .withView("CREATE VIEW `nn_expr_view` AS SELECT id + 1 AS id_plus, name FROM nn_base")
+                .withView("CREATE VIEW `nn_rollup_view` AS " +
+                        "SELECT id, tenant_id, count(*) AS cnt FROM nn_base GROUP BY ROLLUP(id, tenant_id)")
+                .withView("CREATE VIEW `nn_grouping_sets_view` AS " +
+                        "SELECT id, tenant_id, count(*) AS cnt FROM nn_base " +
+                        "GROUP BY GROUPING SETS ((id, tenant_id), (id), ())");
     }
 
     /** Analysis-time nullability (what buildSchemaFromQuery reads) must match the expected pattern. */
@@ -136,5 +141,56 @@ public class AnalyzeViewNullabilityTest {
     public void testViewWithExpressionColumn() throws Exception {
         assertAnalysisNullability("SELECT id_plus, name FROM nn_expr_view",
                 new boolean[] {false, true});
+    }
+
+    @Test
+    public void testViewOverRollupWidensGroupingKeyNullability() throws Exception {
+        // id and tenant_id are NOT NULL in nn_base, but the ROLLUP super-aggregate rows produce
+        // NULL grouping keys, so the view's output fields must stay nullable despite the base
+        // columns being NOT NULL.
+        // (No exec-plan check: like the outer-join case above, the optimizer conservatively widens
+        // the aggregate output's nullability across the Repeat operator, even though count(*) can
+        // never actually be NULL.)
+        assertAnalysisNullability("SELECT id, tenant_id, cnt FROM nn_rollup_view",
+                new boolean[] {true, true, false});
+    }
+
+    @Test
+    public void testViewOverGroupingSetsWidensGroupingKeyNullability() throws Exception {
+        assertAnalysisNullability("SELECT id, tenant_id, cnt FROM nn_grouping_sets_view",
+                new boolean[] {true, true, false});
+    }
+
+    @Test
+    public void testDirectRollupWidensGroupingKeyNullability() throws Exception {
+        // The widening must also apply to a direct GROUP BY ROLLUP query (not wrapped in a view):
+        // the Arrow Flight prepared-statement schema reads the output expression nullability, so a
+        // NOT NULL grouping key must be reported nullable to match the executed result.
+        assertAnalysisNullability(
+                "SELECT id, tenant_id, count(*) AS cnt FROM nn_base GROUP BY ROLLUP(id, tenant_id)",
+                new boolean[] {true, true, false});
+    }
+
+    @Test
+    public void testDirectGroupingSetsWidensGroupingKeyNullability() throws Exception {
+        assertAnalysisNullability(
+                "SELECT id, tenant_id, count(*) AS cnt FROM nn_base " +
+                        "GROUP BY GROUPING SETS ((id, tenant_id), (id), ())",
+                new boolean[] {true, true, false});
+    }
+
+    @Test
+    public void testDirectCubeWidensGroupingKeyNullability() throws Exception {
+        assertAnalysisNullability(
+                "SELECT id, tenant_id, count(*) AS cnt FROM nn_base GROUP BY CUBE(id, tenant_id)",
+                new boolean[] {true, true, false});
+    }
+
+    @Test
+    public void testPlainGroupByDoesNotWiden() throws Exception {
+        // Non-super-aggregate GROUP BY must NOT widen: plain grouping keys keep base nullability.
+        assertAnalysisNullability(
+                "SELECT id, tenant_id, count(*) AS cnt FROM nn_base GROUP BY id, tenant_id",
+                new boolean[] {false, false, false});
     }
 }


### PR DESCRIPTION
## Why I'm doing:
#75684 introduced a bug for GROUP BY ROLLUP / CUBE / GROUPING SETS produces NULLs in the grouping key columns, while SelectAnalyzer derives output field nullability solely from the expression itself (item.getExpr().isNullable(), i.e. the base column's nullability). This widening normally happens at the optimizer level, but due to ArrowFlight, the schema needs to be correct at analysis time.
## What I'm doing:
Fix the bug for nullable columns when there are grouping clauses.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
