### PR TITLE
[BugFix] Recover Iceberg REST catalog from a dead OAuth2 token-refresh session

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -65,6 +65,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -220,6 +221,21 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 .build();
 
         this.backgroundExecutor = executorService;
+        if (delegate instanceof IcebergRESTCatalog) {
+            // Cached Table entries hold the REST session that loaded them, so drop them when the REST
+            // catalog replaces its session after an auth failure. The rebuild can run inside this cache's
+            // own loader, where mutating the cache in place could deadlock Caffeine, so dispatch the
+            // invalidation instead. Best effort: a load racing the rebuild may re-insert a stale entry
+            // until refreshAfterWrite replaces it.
+            ((IcebergRESTCatalog) delegate).setDelegateRebuildListener(() -> {
+                try {
+                    backgroundExecutor.execute(tables::invalidateAll);
+                } catch (RejectedExecutionException e) {
+                    LOG.debug("table cache invalidation after delegate rebuild rejected, catalog {} is closing",
+                            catalogName);
+                }
+            });
+        }
     }
 
     @Override
@@ -375,7 +391,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     new IcebergTableName(icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), snapshotId);
             Map<String, Partition> cacheValue = partitionCache.getIfPresent(key);
             if (cacheValue == null) {
-                backgroundExecutor.submit(() -> partitionCache.refresh(key));
+                try {
+                    backgroundExecutor.submit(() -> partitionCache.refresh(key));
+                } catch (RejectedExecutionException e) {
+                    // the catalog is being closed (e.g. ALTER/DROP CATALOG); losing the async refresh is harmless
+                    LOG.debug("background refresh rejected for {}, catalog {} is closing", key, catalogName);
+                }
                 return null;
             }
         }
@@ -522,6 +543,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public void invalidateCache(String dbName, String tableName) {
         IcebergTableName key = new IcebergTableName(dbName, tableName);
         invalidateCache(key);
+    }
+
+    @Override
+    public void close() {
+        backgroundExecutor.shutdown();
+        delegate.close();
     }
 
     private void invalidateCache(IcebergTableName key) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -266,6 +266,13 @@ public interface IcebergCatalog extends MemoryTrackable {
     default void invalidateCache(String dbName, String tableName) {
     }
 
+    /**
+     * Releases resources held by this catalog, e.g. network connections and background refresh threads.
+     * The default is a no-op for implementations without releasable resources.
+     */
+    default void close() {
+    }
+
     default StarRocksIcebergTableScan getTableScan(Table table, StarRocksIcebergTableScanContext srScanContext) {
         return new StarRocksIcebergTableScan(
                 table,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -164,6 +164,9 @@ public class IcebergConnector implements Connector {
         if (icebergJobPlanningExecutor != null) {
             icebergJobPlanningExecutor.shutdown();
         }
+        if (icebergNativeCatalog != null) {
+            icebergNativeCatalog.close();
+        }
         if (commitQueueManager != null) {
             commitQueueManager.shutdownAll();
             LOG.info("IcebergCommitQueueManager shutdown for catalog {}", catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
@@ -55,6 +56,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,13 +87,24 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     private String catalogName = null;
     private final Configuration conf;
-    private final RESTSessionCatalog delegate;
+    private final AtomicReference<RESTSessionCatalog> delegateRef = new AtomicReference<>();
+    // Bumped whenever the delegate is rebuilt after an OAuth2 auth failure, to keep concurrent
+    // requests that observed the same failure from rebuilding the delegate more than once.
+    private volatile long delegateGeneration = 0;
+    // Serializes delegate rebuilds without holding the "this" monitor across network I/O.
+    private final ReentrantLock rebuildLock = new ReentrantLock();
+    // Guarded by "this". Once closed, the delegate must not be rebuilt (the replacement would leak).
+    private boolean closed = false;
+    // Notified after a successful delegate rebuild, so wrappers can drop state bound to the old delegate
+    // (e.g. the table cache, whose entries hold REST sessions of the replaced client).
+    private final AtomicReference<Runnable> delegateRebuildListener = new AtomicReference<>();
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
     private final boolean viewEndpointsEnabled;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
+        this.catalogName = name;
         this.conf = conf;
         restCatalogProperties = Maps.newHashMap(properties);
 
@@ -122,9 +137,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         restCatalogProperties.putAll(securityProperties.get());
 
         try {
-            delegate = new RESTSessionCatalog();
-            configureHadoopConf(delegate, conf);
-            delegate.initialize(name, restCatalogProperties);
+            RESTSessionCatalog restSessionCatalog = new RESTSessionCatalog();
+            configureHadoopConf(restSessionCatalog, conf);
+            restSessionCatalog.initialize(name, restCatalogProperties);
+            delegateRef.set(restSessionCatalog);
         } catch (Exception re) {
             LOG.error("Failed to rest load catalog", re);
             throw new StarRocksConnectorException("Failed to load rest catalog", re);
@@ -133,7 +149,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     // for ut
     public IcebergRESTCatalog(RESTSessionCatalog restCatalog, Configuration conf) {
-        this.delegate = restCatalog;
+        this.delegateRef.set(restCatalog);
         this.conf = conf;
         this.nestedNamespaceEnabled = false;
         this.viewEndpointsEnabled = true;
@@ -147,13 +163,14 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public Map<String, String> getCatalogProperties() {
-        return delegate.properties();
+        return delegate().properties();
     }
 
     @Override
     public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return callWithAuthRetry(() -> delegate().loadTable(
+                    buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to load table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to load table using REST Catalog", re);
@@ -163,7 +180,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean tableExists(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
-            return delegate.tableExists(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return callWithAuthRetry(() -> delegate().tableExists(
+                    buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to check tableExists REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to check tableExists using REST Catalog", re);
@@ -174,10 +192,11 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public List<String> listAllDatabases(ConnectContext context) {
         try {
             if (nestedNamespaceEnabled) {
-                return listNamespaces(buildContext(context), Namespace.empty());
+                return callWithAuthRetry(() -> listNamespaces(buildContext(context), Namespace.empty()));
             } else {
-                return delegate.listNamespaces(buildContext(context)).stream().map(ns -> ns.level(0))
-                        .collect(Collectors.toList());
+                return callWithAuthRetry(() -> delegate().listNamespaces(buildContext(context)).stream()
+                        .map(ns -> ns.level(0))
+                        .collect(Collectors.toList()));
             }
         } catch (RESTException re) {
             LOG.error("Failed to list databases using REST Catalog ", re);
@@ -186,7 +205,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     private List<String> listNamespaces(SessionCatalog.SessionContext sessionContext, Namespace parent) {
-        return delegate.listNamespaces(sessionContext, parent).stream().
+        return delegate().listNamespaces(sessionContext, parent).stream().
                 flatMap(child -> Stream.concat(Stream.of(child.toString()),
                         listNamespaces(sessionContext, child).stream()))
                 .collect(toImmutableList());
@@ -194,8 +213,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public void createDB(ConnectContext context, String dbName, Map<String, String> properties) {
-        properties = properties == null ? new HashMap<>() : properties;
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
+        Map<String, String> dbProperties = properties == null ? new HashMap<>() : properties;
+        for (Map.Entry<String, String> entry : dbProperties.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
             if (key.equalsIgnoreCase(LOCATION_PROPERTY)) {
@@ -212,7 +231,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             }
         }
         try {
-            delegate.createNamespace(buildContext(context), convertDbNameToNamespace(dbName), properties);
+            runWithAuthRetry(() ->
+                    delegate().createNamespace(buildContext(context), convertDbNameToNamespace(dbName), dbProperties));
         } catch (RESTException re) {
             LOG.error("Failed to list create namespace using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to create namespace using REST Catalog", re);
@@ -238,7 +258,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             throw new MetaNotFoundException("Database location is empty");
         }
         try {
-            delegate.dropNamespace(buildContext(context), convertDbNameToNamespace(dbName));
+            runWithAuthRetry(() -> delegate().dropNamespace(buildContext(context), convertDbNameToNamespace(dbName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop database using REST Catalog, for dbName {}", dbName, re);
             throw new StarRocksConnectorException("Failed to drop database using REST Catalog", re);
@@ -248,7 +268,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public Database getDB(ConnectContext context, String dbName) {
         try {
-            Map<String, String> dbMeta = delegate.loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName));
+            Map<String, String> dbMeta = callWithAuthRetry(() ->
+                    delegate().loadNamespaceMetadata(buildContext(context), convertDbNameToNamespace(dbName)));
             return new Database(CONNECTOR_ID_GENERATOR.getNextId().asLong(), dbName, dbMeta.get(LOCATION_PROPERTY));
         } catch (RESTException re) {
             LOG.error("Failed to get database using REST Catalog, for dbName {}", dbName, re);
@@ -261,7 +282,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
         List<TableIdentifier> tableIdentifiers = null;
         try {
-            tableIdentifiers = delegate.listTables(buildContext(context), ns);
+            tableIdentifiers = callWithAuthRetry(() -> delegate().listTables(buildContext(context), ns));
         } catch (RESTException re) {
             LOG.error("Failed to list tables using REST Catalog, for dbName {}", dbName, re);
             // creating a new RuntimeException with the custom message, as in the upstream code, it picks the `exception.getCause().getMessage()`
@@ -272,7 +293,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
         if (viewEndpointsEnabled) {
             try {
-                viewIdentifiers = delegate.listViews(buildContext(context), ns);
+                viewIdentifiers = callWithAuthRetry(() -> delegate().listViews(buildContext(context), ns));
             } catch (BadRequestException e) {
                 LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
                         "Ask the user to check it, or you can disable view endpoints by setting '{}' to false",
@@ -306,13 +327,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         Table nativeTable = null;
         try {
-            nativeTable = delegate.buildTable(buildContext(context),
+            nativeTable = callWithAuthRetry(() -> delegate().buildTable(buildContext(context),
                             TableIdentifier.of(convertDbNameToNamespace(dbName), tableName), schema)
                     .withLocation(location)
                     .withPartitionSpec(partitionSpec)
                     .withSortOrder(sortOrder)
                     .withProperties(properties)
-                    .create();
+                    .create());
         } catch (RESTException re) {
             LOG.error("Failed to create table using REST Catalog, for dbName {} schema {} tableName {}",
                     dbName, schema, tableName, re);
@@ -325,8 +346,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropTable(ConnectContext context, String dbName, String tableName, boolean purge) {
         try {
-            return delegate.dropTable(buildContext(context),
-                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));
+            return callWithAuthRetry(() -> delegate().dropTable(buildContext(context),
+                    TableIdentifier.of(convertDbNameToNamespace(dbName), tableName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop table using REST Catalog, for dbName {} tableName {}", dbName, tableName, re);
             throw new StarRocksConnectorException("Failed to drop table using REST Catalog", re);
@@ -339,7 +360,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         Namespace ns = convertDbNameToNamespace(dbName);
 
         try {
-            delegate.renameTable(buildContext(context), TableIdentifier.of(ns, tblName), TableIdentifier.of(ns, newTblName));
+            runWithAuthRetry(() -> delegate().renameTable(
+                    buildContext(context), TableIdentifier.of(ns, tblName), TableIdentifier.of(ns, newTblName)));
         } catch (RESTException re) {
             LOG.error("Failed to rename table using REST Catalog, for dbName {} tableName {} newTblName {}",
                     dbName, tblName, newTblName, re);
@@ -349,7 +371,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public ViewBuilder getViewBuilder(ConnectContext context, TableIdentifier identifier) {
-        return delegate.buildView(buildContext(context), identifier);
+        return delegate().buildView(buildContext(context), identifier);
     }
 
     @Override
@@ -360,7 +382,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     "' to true to enable view endpoints");
         }
         try {
-            return delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
+            return callWithAuthRetry(() -> delegate().loadView(
+                    buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to load view using REST Catalog", re);
@@ -370,7 +393,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     @Override
     public boolean dropView(ConnectContext context, String dbName, String viewName) {
         try {
-            return delegate.dropView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
+            return callWithAuthRetry(() -> delegate().dropView(
+                    buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName)));
         } catch (RESTException re) {
             LOG.error("Failed to drop view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
             throw new StarRocksConnectorException("Failed to drop view using REST Catalog", re);
@@ -400,7 +424,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public boolean registerTable(ConnectContext context, String dbName, String tableName, String metadataFileLocation) {
         try {
             TableIdentifier tableIdentifier = TableIdentifier.of(convertDbNameToNamespace(dbName), tableName);
-            Table table = delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation);
+            Table table = callWithAuthRetry(() ->
+                    delegate().registerTable(buildContext(context), tableIdentifier, metadataFileLocation));
             return table != null;
         } catch (RESTException re) {
             LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
@@ -410,13 +435,13 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     public String toString() {
-        return delegate.toString();
+        return delegate().toString();
     }
 
     @Override
     public Map<String, String> loadNamespaceMetadata(ConnectContext context, Namespace ns) {
         try {
-            return ImmutableMap.copyOf(delegate.loadNamespaceMetadata(buildContext(context), ns));
+            return ImmutableMap.copyOf(callWithAuthRetry(() -> delegate().loadNamespaceMetadata(buildContext(context), ns)));
         } catch (RESTException re) {
             LOG.error("Failed to load table metadata using REST Catalog, for namespace {}", ns, re);
             throw new StarRocksConnectorException(
@@ -447,5 +472,109 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         return new SessionCatalog.SessionContext(sessionId, context.getQualifiedUser(), credentials, ImmutableMap.of(),
                 context.getCurrentUserIdentity());
+    }
+
+    private RESTSessionCatalog delegate() {
+        return delegateRef.get();
+    }
+
+    private <T> T callWithAuthRetry(Supplier<T> action) {
+        long observedGeneration = delegateGeneration;
+        try {
+            return action.get();
+        } catch (NotAuthorizedException e) {
+            if (!isOAuth2Security()) {
+                throw e;
+            }
+            rebuildDelegate(observedGeneration, e);
+            return action.get();
+        }
+    }
+
+    private void runWithAuthRetry(Runnable action) {
+        callWithAuthRetry(() -> {
+            action.run();
+            return null;
+        });
+    }
+
+    private boolean isOAuth2Security() {
+        return Security.OAUTH2.name().equalsIgnoreCase(
+                restCatalogProperties.getOrDefault(ICEBERG_CATALOG_SECURITY, Security.NONE.name()));
+    }
+
+    // With "iceberg.catalog.security" = "oauth2" every request shares the catalog-level OAuth2 session of the
+    // delegate, and Iceberg stops the background token refresh permanently after one fully failed refresh cycle
+    // (AuthSession.refresh() returns null and scheduleTokenRefresh() never re-schedules). Once that happens the
+    // delegate keeps failing with 401 even after the auth server recovers, so the only way to heal without an FE
+    // restart is to rebuild the delegate, which mints a fresh token and a fresh refresh schedule.
+    private void rebuildDelegate(long observedGeneration, NotAuthorizedException cause) {
+        if (!rebuildLock.tryLock()) {
+            // another request is already rebuilding the delegate; fail this request the same way it
+            // would have failed without the self-heal instead of queueing behind network I/O
+            throw cause;
+        }
+        try {
+            synchronized (this) {
+                if (closed) {
+                    throw cause;
+                }
+                if (observedGeneration != delegateGeneration) {
+                    // another request already rebuilt the delegate after this failure was observed
+                    return;
+                }
+            }
+            LOG.warn("Authentication against the REST catalog failed. Rebuilding the REST session catalog of " +
+                    "catalog {} to recover", catalogName, cause);
+            // initialize() performs network I/O, so it must not run under the monitor shared with close()
+            RESTSessionCatalog newDelegate = new RESTSessionCatalog();
+            try {
+                configureHadoopConf(newDelegate, conf);
+                newDelegate.initialize(catalogName, restCatalogProperties);
+            } catch (Exception e) {
+                closeQuietly(newDelegate);
+                LOG.error("Failed to rebuild the REST session catalog of catalog {}", catalogName, e);
+                throw new StarRocksConnectorException("Failed to rebuild rest catalog", e);
+            }
+            RESTSessionCatalog oldDelegate;
+            synchronized (this) {
+                if (closed) {
+                    closeQuietly(newDelegate);
+                    throw cause;
+                }
+                oldDelegate = delegateRef.get();
+                delegateRef.set(newDelegate);
+                delegateGeneration++;
+            }
+            Runnable listener = delegateRebuildListener.get();
+            try {
+                if (listener != null) {
+                    // let wrappers drop state bound to the old delegate (e.g. cached tables)
+                    listener.run();
+                }
+            } finally {
+                closeQuietly(oldDelegate);
+            }
+        } finally {
+            rebuildLock.unlock();
+        }
+    }
+
+    public void setDelegateRebuildListener(Runnable listener) {
+        this.delegateRebuildListener.set(listener);
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        closeQuietly(delegateRef.get());
+    }
+
+    private static void closeQuietly(RESTSessionCatalog sessionCatalog) {
+        try {
+            sessionCatalog.close();
+        } catch (Exception e) {
+            LOG.warn("Failed to close the REST session catalog", e);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.iceberg;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.MetaNotFoundException;
@@ -32,6 +33,7 @@ import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mocked;
 import mockit.Verifications;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.MetadataTableType;
@@ -44,7 +46,9 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -1181,5 +1185,43 @@ public class CachingIcebergCatalogTest {
         } finally {
             es.shutdownNow();
         }
+    }
+
+    @Test
+    public void testCloseClosesDelegateAndStopsBackgroundExecutor(@Mocked IcebergCatalog icebergCatalog) {
+        ExecutorService backgroundExecutor = Executors.newSingleThreadExecutor();
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, backgroundExecutor);
+
+        cachingIcebergCatalog.close();
+
+        Assertions.assertTrue(backgroundExecutor.isShutdown());
+        new Verifications() {
+            {
+                icebergCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testDelegateRebuildInvalidatesTableCache(@Mocked RESTSessionCatalog restSessionCatalog,
+                                                         @Mocked Table nativeTable) {
+        IcebergRESTCatalog restCatalog = new IcebergRESTCatalog(restSessionCatalog, new Configuration());
+        // a direct executor makes the asynchronously dispatched cache invalidation run inline
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
+                DEFAULT_CATALOG_PROPERTIES, MoreExecutors.newDirectExecutorService());
+
+        LoadingCache<IcebergTableName, Table> tables = Deencapsulation.getField(cachingIcebergCatalog, "tables");
+        tables.put(new IcebergTableName("db", "tbl"), nativeTable);
+        tables.cleanUp();
+        Assertions.assertEquals(1, tables.estimatedSize());
+
+        // a table cached through the old delegate must be dropped when the REST session is rebuilt
+        Deencapsulation.invoke(restCatalog, "rebuildDelegate", 0L,
+                new NotAuthorizedException("Not authorized: %s", "token expired"));
+
+        tables.cleanUp();
+        Assertions.assertEquals(0, tables.estimatedSize());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -20,11 +20,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergView;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -43,11 +45,14 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.RESTSessionCatalog;
 import org.apache.iceberg.types.Types;
@@ -62,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.starrocks.catalog.Table.TableType.ICEBERG_VIEW;
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
@@ -751,5 +757,269 @@ public class IcebergRESTCatalogTest {
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Failed to load table metadata using REST Catalog",
                 () -> icebergRESTCatalog.loadNamespaceMetadata(connectContext, Namespace.of("db")));
+    }
+
+    @Test
+    public void testOAuth2AuthFailureRebuildsDelegateAndRetries(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = ImmutableMap.of("location", "s3://bucket/db");
+            }
+        };
+
+        // the 401 from the dead OAuth2 session triggers a delegate rebuild and one retry, which succeeds
+        Database db = icebergRESTCatalog.getDB(connectContext, "db");
+        Assertions.assertEquals("s3://bucket/db", db.getLocation());
+
+        new Verifications() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                times = 2;
+
+                // the dead delegate is closed after the rebuild
+                restCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testOAuth2AuthFailurePropagatesWhenRetryFails(@Mocked RESTSessionCatalog restCatalog) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "auth server still down");
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to get database using REST Catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        new Verifications() {
+            {
+                // exactly one retry: the original attempt plus one attempt on the rebuilt delegate
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                times = 2;
+            }
+        };
+    }
+
+    @Test
+    public void testAuthFailureWithoutOAuth2DoesNotRebuild(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        // security defaults to NONE, so a 401 is not recoverable by rebuilding the catalog-level session
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), new HashMap<>());
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "bad token");
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to get database using REST Catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        new Verifications() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                times = 1;
+
+                restCatalog.close();
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testForbiddenDoesNotTriggerRebuild(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new ForbiddenException("Forbidden: %s", "not allowed");
+            }
+        };
+
+        // 403 means the principal is not authorized; rebuilding the session cannot help
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to get database using REST Catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        new Verifications() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                times = 1;
+
+                restCatalog.close();
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testDelegateRebuildNotifiesListener(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+        AtomicBoolean notified = new AtomicBoolean(false);
+        icebergRESTCatalog.setDelegateRebuildListener(() -> notified.set(true));
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                result = ImmutableMap.of("location", "s3://bucket/db");
+            }
+        };
+
+        icebergRESTCatalog.getDB(connectContext, "db");
+
+        Assertions.assertTrue(notified.get(), "a successful delegate rebuild must notify the listener");
+    }
+
+    @Test
+    public void testRebuildFailurePropagatesAndClosesNewDelegate(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+
+                restCatalog.initialize(anyString, (Map<String, String>) any);
+                result = new RESTException("auth server still down");
+            }
+        };
+
+        // the rebuild itself fails: the replacement is discarded and the failure surfaces to the query
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to rebuild rest catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        new Verifications() {
+            {
+                // only the partially-initialized replacement is closed; the original delegate stays in place
+                restCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testStaleGenerationSkipsRebuild(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        NotAuthorizedException cause = new NotAuthorizedException("Not authorized: %s", "token expired");
+
+        // a rebuild that observed a stale generation is skipped (another request already rebuilt the delegate)
+        Deencapsulation.invoke(icebergRESTCatalog, "rebuildDelegate", 999L, cause);
+        new Verifications() {
+            {
+                restCatalog.close();
+                times = 0;
+            }
+        };
+
+        // a rebuild that observed the current generation replaces the delegate and closes the old one
+        Deencapsulation.invoke(icebergRESTCatalog, "rebuildDelegate", 0L, cause);
+        new Verifications() {
+            {
+                restCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testCloseClosesDelegate(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+
+        icebergRESTCatalog.close();
+
+        new Verifications() {
+            {
+                restCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testNoRebuildAfterClose(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ICEBERG_CATALOG_SECURITY, "oauth2");
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "test_catalog", new Configuration(), properties);
+
+        new Expectations() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                result = new NotAuthorizedException("Not authorized: %s", "token expired");
+                minTimes = 0;
+            }
+        };
+
+        icebergRESTCatalog.close();
+
+        // a 401 racing with close() must not resurrect the delegate (the replacement would leak)
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Failed to get database using REST Catalog",
+                () -> icebergRESTCatalog.getDB(connectContext, "db"));
+
+        new Verifications() {
+            {
+                restCatalog.loadNamespaceMetadata((SessionContext) any, (Namespace) any);
+                times = 1;
+
+                // only the explicit close(); no rebuilt-and-closed replacement
+                restCatalog.close();
+                times = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testConnectorShutdownClosesNativeCatalog(@Mocked RESTSessionCatalog restCatalog) throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "iceberg");
+        properties.put(ICEBERG_CATALOG_TYPE, "rest");
+        IcebergConnector connector = new IcebergConnector(
+                new ConnectorContext("test_shutdown_catalog", "iceberg", properties));
+        connector.getNativeCatalog();
+
+        connector.shutdown();
+
+        new Verifications() {
+            {
+                restCatalog.close();
+                times = 1;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Why I'm doing:

With `iceberg.catalog.security = "oauth2"`, every request on an FE shares the catalog-level OAuth2 session of the `RESTSessionCatalog` that `IcebergConnector` builds once and caches forever. Iceberg's background token refresh stops permanently after a single fully failed refresh cycle (`OAuth2Util.AuthSession.refresh()` returns null and `scheduleTokenRefresh()` only re-schedules on a non-null result), so after one transient auth-server hiccup the token expires and every metadata request on that FE fails with 401 (`Failed to get database using REST Catalog`) until the FE process is restarted. There is no rebuild path: `IcebergRESTCatalog.delegate` was `private final`, and `NotAuthorizedException` (401) is swallowed by the generic `catch (RESTException)` blocks, so a recoverable auth failure is indistinguishable from a permanent error. Even the `ALTER CATALOG` workaround leaks the old client because `IcebergConnector.shutdown()` never closes the native catalog, leaving the old `<catalog>-token-refresh` thread and HTTP pool alive forever. Full analysis, reproduction against Apache Polaris, and prior art (Doris `resetToUninitialized()`/`onClose()` lifecycle, Trino session-timeout knobs) are in #76438.
## What I'm doing:

Fixes #76438

Make the recovery local to `IcebergRESTCatalog`, and give the connector lifecycle a real close path:

- `IcebergRESTCatalog`: on `NotAuthorizedException` in `oauth2` security mode, rebuild the internal `RESTSessionCatalog` delegate and retry the operation exactly once. The new delegate is fully initialized (fresh token, fresh refresh schedule) before it replaces the old one, and only then is the old one closed; if the rebuild itself fails, the replacement is closed and the query fails exactly as today. `initialize()` performs network I/O, so the build runs outside the monitor shared with `close()` (a rebuild happening exactly when the auth server is unhealthy must not stall `DROP/ALTER CATALOG`, which calls `close()` while holding `CatalogMgr`/`ConnectorMgr` write locks). A `tryLock` keeps rebuilds single-flight (concurrent 401s fail as they do today instead of queueing behind network I/O), a generation counter stops late 401s from triggering duplicate rebuilds, and a closed flag prevents a 401 racing `DROP/ALTER CATALOG` from resurrecting a delegate that nobody would ever close. A second 401 after the rebuild propagates as before (no retry loops).
- `IcebergCatalog`: add a default no-op `close()` so the connector lifecycle can release catalog resources (additive; other implementations are unaffected).
- `CachingIcebergCatalog`: `close()` forwards to the inner catalog and shuts down the background refresh executor; the async partition-refresh submit is guarded so a request racing a catalog drop degrades to a synchronous miss instead of throwing `RejectedExecutionException`.
- `IcebergConnector.shutdown()`: close the native catalog. Since `ALTER CATALOG` already rebuilds the connector through `ConnectorMgr.removeConnector()` -> `shutdown()`, this also turns `ALTER CATALOG` into a leak-free manual recovery path, matching the Doris `resetToUninitialized()`/`onClose()` lifecycle.

JWT security mode is deliberately excluded: a 401 there means the user's own token is invalid, and token refresh is already disabled for JWT in `OAuth2SecurityProperties`, so rebuilding the shared client cannot help (kept orthogonal to #75792 and #71409).

Out of scope / notes for reviewers:

- The Iceberg-side scheduler latch itself is an upstream iceberg-core issue and is not changed here; this PR makes StarRocks recover regardless of it.
- The old delegate is closed right after the swap. An FE-side planning operation that raced the swap may fail once on its closed `FileIO`; those operations were already failing with 401 during the outage window, and Doris's `onClose()` has the same semantics. A deferred close was considered and left out for simplicity.
- Retrying a mutation after a 401 assumes the rejected request had no server-side effect. The narrow exception is a multi-step operation (e.g. `createTable`) whose POST succeeded but whose response handling hit the expired session; the retry then surfaces `AlreadyExistsException`. The pre-patch behavior for that case is equally confusing (the statement fails but the table exists), so no special-casing is added.
- The `getViewBuilder()`/`createViewDefault()` view-builder path is not wrapped (the builder is consumed by an interface default method); a 401 there still surfaces the original error as today.

How I tested (all green locally, macOS, `cd fe && PYTHON=$(which python3) mvn ...`):

- `mvn test -pl fe-core -am -Dtest='IcebergRESTCatalogTest,CachingIcebergCatalogTest,IcebergRESTCatalogRegisterTableTest,IcebergMetadataTest' -Dsurefire.failIfNoSpecifiedTests=false` — new tests: 401 -> rebuild -> retry succeeds and the old delegate is closed exactly once; two consecutive 401s -> exactly two attempts then the same `StarRocksConnectorException` as today; 403 and non-oauth2 modes -> no rebuild; stale generation -> no duplicate rebuild; 401 after `close()` -> no resurrection; rebuild failure -> replacement closed, original delegate kept; `IcebergConnector.shutdown()` closes the native catalog through the caching wrapper; `CachingIcebergCatalog.close()` stops the background executor. Pre-existing `testRESTExceptionPropagation` (14 operations) still passes, pinning that non-401 `RESTException` handling is unchanged.
- `mvn test -pl fe-core -am -Dtest='*Iceberg*'` — 693 tests, 0 failures.
- `mvn checkstyle:check -pl fe-core` — 0 violations; full `fe` reactor builds with `mvn package -DskipTests`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
