### PR TITLE
[BugFix] Resolve Iceberg columns via schema.name-mapping.default to fix NULLs from Fabric Warehouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -1087,6 +1087,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return physicalName;
     }
 
+    public void setPhysicalName(String physicalName) {
+        this.physicalName = physicalName;
+    }
+
     // return max unique id of all fields
     public int getMaxUniqueId() {
         return Math.max(this.uniqueId, type.getMaxUniqueId());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -330,6 +330,7 @@ public class IcebergApiConverter {
 
     public static List<Column> toFullSchemas(Schema schema, Table table) {
         List<Column> fullSchema = toFullSchemas(schema);
+        applyIcebergNameMapping(fullSchema, schema, table.properties());
         if (table instanceof BaseTable) {
             addMetaColumns(fullSchema);
             if (((BaseTable) table).operations().current().formatVersion() >= 3) {
@@ -349,6 +350,41 @@ public class IcebergApiConverter {
             }
         }
         return fullSchema;
+    }
+
+    // Populate physicalName on each column from schema.name-mapping.default so the BE
+    // can resolve columns by their physical Parquet name when the Parquet file does not
+    // carry embedded Iceberg field-ids (e.g. Parquet files produced by a Delta-to-Iceberg
+    // metadata shim, where physical columns are named using Delta's column-mapping IDs).
+    private static void applyIcebergNameMapping(
+            List<Column> fullSchema, Schema schema, Map<String, String> tableProperties) {
+        String nameMappingJson = tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING);
+        if (Strings.isNullOrEmpty(nameMappingJson)) {
+            return;
+        }
+        try {
+            org.apache.iceberg.mapping.NameMapping nameMapping =
+                    org.apache.iceberg.mapping.NameMappingParser.fromJson(nameMappingJson);
+            for (Column column : fullSchema) {
+                Types.NestedField field = schema.findField(column.getName());
+                if (field == null) {
+                    continue;
+                }
+                org.apache.iceberg.mapping.MappedField mappedField =
+                        nameMapping.asMappedFields().field(field.fieldId());
+                if (mappedField == null) {
+                    continue;
+                }
+                for (String name : mappedField.names()) {
+                    if (!name.equals(column.getName())) {
+                        column.setPhysicalName(name);
+                        break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse Iceberg name mapping: {}", e.getMessage());
+        }
     }
 
     public static List<Column> toFullSchemas(Schema schema) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -42,6 +42,7 @@ import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarbinaryType;
 import com.starrocks.type.VarcharType;
 import com.starrocks.type.VariantType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -50,6 +51,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -72,6 +74,7 @@ import static com.starrocks.connector.PartitionUtil.convertIcebergPartitionToPar
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -700,6 +703,61 @@ public class IcebergApiConverterTest {
         assertFalse(columns.get(0).isAllowNull());
         assertTrue(columns.get(1).isAllowNull());
         assertEquals("9", IcebergApiConverter.getWriteDefaultValue(schema, "c_optional"));
+    }
+
+    @Test
+    public void testToFullSchemasAppliesNameMappingPhysicalName() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("DateID").withId(1).ofType(Types.IntegerType.get()).build());
+        fields.add(Types.NestedField.optional("Temperature").withId(2).ofType(Types.DoubleType.get()).build());
+        Schema schema = new Schema(fields);
+
+        // Column "DateID" (field-id 1) is physically stored in the Parquet file under the
+        // Delta column-mapping name "col-11111111-1111-1111-1111-111111111111", while
+        // "Temperature" (field-id 2) has only a single, matching name.
+        String nameMappingJson = "["
+                + "{\"field-id\":1,\"names\":[\"DateID\",\"col-11111111-1111-1111-1111-111111111111\"]},"
+                + "{\"field-id\":2,\"names\":[\"Temperature\"]}"
+                + "]";
+
+        Table table = mock(Table.class);
+        when(table.properties()).thenReturn(ImmutableMap.of(DEFAULT_NAME_MAPPING, nameMappingJson));
+
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema, table);
+
+        Column dateId = columns.stream().filter(c -> c.getName().equals("DateID")).findFirst().orElseThrow();
+        Column temperature = columns.stream().filter(c -> c.getName().equals("Temperature")).findFirst().orElseThrow();
+
+        assertEquals("col-11111111-1111-1111-1111-111111111111", dateId.getPhysicalName());
+        // Only one (matching) name in the mapping entry -> no alias, physicalName stays unset.
+        assertTrue(StringUtils.isEmpty(temperature.getPhysicalName()));
+    }
+
+    @Test
+    public void testToFullSchemasSkipsNameMappingWhenPropertyAbsent() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("DateID").withId(1).ofType(Types.IntegerType.get()).build());
+        Schema schema = new Schema(fields);
+
+        Table table = mock(Table.class);
+        when(table.properties()).thenReturn(ImmutableMap.of());
+
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema, table);
+        assertTrue(StringUtils.isEmpty(columns.get(0).getPhysicalName()));
+    }
+
+    @Test
+    public void testToFullSchemasIgnoresMalformedNameMapping() {
+        List<Types.NestedField> fields = Lists.newArrayList();
+        fields.add(Types.NestedField.optional("DateID").withId(1).ofType(Types.IntegerType.get()).build());
+        Schema schema = new Schema(fields);
+
+        Table table = mock(Table.class);
+        when(table.properties()).thenReturn(ImmutableMap.of(DEFAULT_NAME_MAPPING, "not-a-valid-json"));
+
+        // Should not throw; malformed name-mapping is logged and ignored.
+        List<Column> columns = IcebergApiConverter.toFullSchemas(schema, table);
+        assertTrue(StringUtils.isEmpty(columns.get(0).getPhysicalName()));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When querying a Microsoft Fabric Warehouse table through its Iceberg endpoint (OneLake exposes Warehouse tables as read-only Iceberg tables via a Delta-to-Iceberg metadata shim), StarRocks returns NULL for columns that
actually contain data.

Root cause: Fabric Warehouse's underlying storage is Delta Lake with column mapping enabled, so the physical Parquet columns are named using Delta's column-mapping IDs (e.g. `col-<uuid>`) instead of the logical column name (e.g. `DateID`), and the Parquet files do not carry embedded Iceberg field-ids. The Iceberg metadata shim correctly publishes a `schema.name-mapping.default` table property (per the Iceberg spec) so readers can resolve each field-id to its physical column name(s) in this
case — but StarRocks' Iceberg connector never reads this property at all.
As a result, column resolution falls back to matching by logical name only, fails to find `col-<uuid>` under the name `DateID`, and the column is silently treated as missing and filled with NULL.

Note this is not specific to Fabric — any Iceberg table backed by Parquet files without embedded field-ids that relies on `schema.name-mapping.default` (e.g. Delta-to-Iceberg conversions in general) hits the same issue.

## What I'm doing:

Fixes #issue

- Add `Column.setPhysicalName()` (the getter already existed, but there was no setter).
- Add `IcebergApiConverter.applyIcebergNameMapping()`, called from `toFullSchemas(Schema, Table)`, which:
  - Reads the `schema.name-mapping.default` table property, if present.
  - Parses it into an Iceberg `NameMapping`.
  - For each converted `Column`, looks up the corresponding Iceberg field-id's `MappedField` and, if the mapping lists an alias name different from the logical column name, sets it as the column's `physicalName`.
- This lets the existing BE `col_physical_name` fallback (in `ParquetMetaHelper`, today only populated by the Delta Lake connector) correctly resolve the column against the Parquet file's actual physical name when the file has no embedded field-id for that column.
- Added unit tests covering: alias resolution from a mapping, no-op when the property is absent, and safe handling of a malformed mapping.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5