### PR TITLE
[BugFix] Fail fast when array serialized size exceeds 4GB as agg/set/partition key (uint32 overflow)

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -319,7 +319,7 @@ public:
 
     uint32_t max_one_element_serialize_size() const override {
         materialized_nullable();
-        return sizeof(bool) + _data_column->max_one_element_serialize_size();
+        return saturate_serialize_size(sizeof(bool) + _data_column->max_one_element_serialize_size());
     }
 
     uint32_t serialize(size_t idx, uint8_t* pos) const override;
@@ -338,7 +338,7 @@ public:
         if (_null_column->immutable_data()[idx]) {
             return sizeof(uint8_t);
         }
-        return sizeof(uint8_t) + _data_column->serialize_size(idx);
+        return saturate_serialize_size(sizeof(uint8_t) + _data_column->serialize_size(idx));
     }
 
     MutableColumnPtr clone_empty() const override {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -277,11 +277,11 @@ uint32_t ArrayColumn::serialize_size(size_t idx) const {
     uint32_t offset = offsets[idx];
     uint32_t array_size = offsets[idx + 1] - offset;
 
-    uint32_t ser_size = sizeof(array_size);
+    size_t ser_size = sizeof(array_size);
     for (size_t i = 0; i < array_size; ++i) {
         ser_size += _elements->serialize_size(offset + i);
     }
-    return ser_size;
+    return saturate_serialize_size(ser_size);
 }
 
 void ArrayColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -1026,19 +1026,15 @@ int BinaryColumnBase<T>::compare_at(size_t left, size_t right, const Column& rhs
 
 template <typename T>
 uint32_t BinaryColumnBase<T>::max_one_element_serialize_size() const {
-    uint32_t max_size = 0;
+    size_t max_size = 0;
     size_t length = _offsets.size() - 1;
     _offsets.visit_storage([&](const auto& offsets_buf) {
         const auto* __restrict offsets = offsets_buf.data();
         for (size_t i = 0; i < length; ++i) {
-            // it's safe to cast, because max size of one string is 2^32
-            const size_t curr_length = offsets[i + 1] - offsets[i];
-            DCHECK_LE(curr_length, std::numeric_limits<uint32_t>::max());
-            max_size = std::max(max_size, static_cast<uint32_t>(curr_length));
+            max_size = std::max<size_t>(max_size, offsets[i + 1] - offsets[i]);
         }
     });
-    // TODO: may be overflow here, i will solve it later
-    return max_size + sizeof(uint32_t);
+    return saturate_serialize_size(max_size + sizeof(uint32_t));
 }
 
 template <bool IsNullable, typename Offset>

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -325,8 +325,7 @@ public:
                                                bool& has_null) override;
 
     uint32_t serialize_size(size_t idx) const override {
-        // max size of one string is 2^32, so use sizeof(uint32_t) not sizeof(T)
-        return static_cast<uint32_t>(sizeof(uint32_t) + _offsets[idx + 1] - _offsets[idx]);
+        return saturate_serialize_size(sizeof(uint32_t) + _offsets[idx + 1] - _offsets[idx]);
     }
 
     MutableColumnPtr clone_empty() const override { return BinaryColumnBase<T>::create(); }

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 
@@ -63,6 +64,8 @@ public:
 
     static const uint64_t MAX_CAPACITY_LIMIT = static_cast<uint64_t>(UINT32_MAX) + 1;
     static const uint64_t MAX_LARGE_CAPACITY_LIMIT = UINT64_MAX;
+
+    static constexpr uint32_t SERIALIZE_SIZE_LIMIT = UINT32_MAX;
 
     static const int EQUALS_FALSE = 0;
     static const int EQUALS_NULL = -1;
@@ -505,6 +508,24 @@ using ColumnPtr = Column::Ptr;
 using Columns = std::vector<ColumnPtr>;
 using MutableColumnPtr = Column::MutablePtr;
 using MutableColumns = std::vector<MutableColumnPtr>;
+
+inline bool serialize_size_overflow(size_t serialize_size) {
+    return serialize_size >= Column::SERIALIZE_SIZE_LIMIT;
+}
+
+inline uint32_t saturate_serialize_size(size_t serialize_size) {
+    return serialize_size >= Column::SERIALIZE_SIZE_LIMIT ? Column::SERIALIZE_SIZE_LIMIT
+                                                          : static_cast<uint32_t>(serialize_size);
+}
+
+inline const char* serialize_key_size_overflow_message() {
+    return "the serialized size of a single row exceeds the 4GB (uint32) limit, which is not supported; "
+           "reduce the size of array/map/string values used as group by / distinct / set / partition-by keys";
+}
+
+[[noreturn]] inline void throw_serialize_key_size_overflow() {
+    throw std::runtime_error(serialize_key_size_overflow_message());
+}
 
 template <typename... Args>
 struct IsMutableColumns;

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -334,12 +334,12 @@ uint32_t MapColumn::serialize_size(size_t idx) const {
     uint32_t offset = offsets_data[idx];
     uint32_t map_size = offsets_data[idx + 1] - offset;
 
-    uint32_t ser_size = sizeof(map_size);
+    size_t ser_size = sizeof(map_size);
     for (size_t i = 0; i < map_size; ++i) {
         ser_size += _keys->serialize_size(offset + i);
         ser_size += _values->serialize_size(offset + i);
     }
-    return ser_size;
+    return saturate_serialize_size(ser_size);
 }
 
 void MapColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -184,7 +184,7 @@ public:
     void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override {
-        return sizeof(bool) + _data_column->max_one_element_serialize_size();
+        return saturate_serialize_size(sizeof(bool) + _data_column->max_one_element_serialize_size());
     }
 
     uint32_t serialize(size_t idx, uint8_t* pos) const override;
@@ -202,7 +202,7 @@ public:
         if (immutable_null_column_data()[idx]) {
             return sizeof(uint8_t);
         }
-        return sizeof(uint8_t) + _data_column->serialize_size(idx);
+        return saturate_serialize_size(sizeof(uint8_t) + _data_column->serialize_size(idx));
     }
 
     MutableColumnPtr clone_empty() const override {

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -292,19 +292,19 @@ void StructColumn::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chun
 }
 
 uint32_t StructColumn::max_one_element_serialize_size() const {
-    uint32_t max_size = 0;
+    size_t max_size = 0;
     for (const auto& column : _fields) {
         max_size += column->max_one_element_serialize_size();
     }
-    return max_size;
+    return saturate_serialize_size(max_size);
 }
 
 uint32_t StructColumn::serialize_size(size_t idx) const {
-    uint32_t ser_size = 0;
+    size_t ser_size = 0;
     for (const ColumnPtr& column : _fields) {
         ser_size += column->serialize_size(idx);
     }
-    return ser_size;
+    return saturate_serialize_size(ser_size);
 }
 
 MutableColumnPtr StructColumn::clone_empty() const {

--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -705,6 +705,9 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
                             Buffer<AggDataPtr>* agg_states, ExtraAggParam* extra) {
         slice_sizes.assign(_chunk_size, 0);
         size_t cur_max_one_row_size = get_max_serialize_size(key_columns);
+        if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+            throw_serialize_key_size_overflow();
+        }
         if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
             size_t batch_allocate_size = (size_t)cur_max_one_row_size * _chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING;
             // too large, process by rows
@@ -885,11 +888,11 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
     }
 
     uint32_t get_max_serialize_size(const Columns& key_columns) {
-        uint32_t max_size = 0;
+        size_t max_size = 0;
         for (const auto& key_column : key_columns) {
             max_size += key_column->max_one_element_serialize_size();
         }
-        return max_size;
+        return saturate_serialize_size(max_size);
     }
 
     void insert_keys_to_columns(ResultVector& keys, MutableColumns& key_columns, int32_t chunk_size) {

--- a/be/src/exec/aggregate/agg_hash_set.h
+++ b/be/src/exec/aggregate/agg_hash_set.h
@@ -563,6 +563,9 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
         }
 
         max_one_row_size = get_max_serialize_size(key_columns);
+        if (UNLIKELY(serialize_size_overflow(max_one_row_size))) {
+            throw_serialize_key_size_overflow();
+        }
         size_t new_buffer_size = max_one_row_size * chunk_size + SLICE_MEMEQUAL_OVERFLOW_PADDING;
         if (UNLIKELY(new_buffer_size > _mem_pool->total_allocated_bytes())) {
             _mem_pool->clear();
@@ -629,7 +632,7 @@ struct AggHashSetOfSerializedKey : public AggHashSet<HashSet, AggHashSetOfSerial
         for (const auto& key_column : key_columns) {
             max_size += key_column->max_one_element_serialize_size();
         }
-        return max_size;
+        return saturate_serialize_size(max_size);
     }
 
     void insert_keys_to_columns(ResultVector& keys, MutableColumns& key_columns, int32_t chunk_size) {

--- a/be/src/exec/except_hash_set.cpp
+++ b/be/src/exec/except_hash_set.cpp
@@ -38,6 +38,9 @@ void ExceptHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& chun
     buffer_state->slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
+    if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+        throw_serialize_key_size_overflow();
+    }
     if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
@@ -70,6 +73,9 @@ Status ExceptHashSet<HashSet>::erase_duplicate_row(RuntimeState* state, const Ch
     buffer_state->slice_sizes.assign(state->chunk_size(), 0);
 
     size_t cur_max_one_row_size = _get_max_serialize_size(chunk, exprs);
+    if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+        return Status::InternalError(serialize_key_size_overflow_message());
+    }
     if (UNLIKELY(cur_max_one_row_size > buffer_state->max_one_row_size)) {
         buffer_state->max_one_row_size = cur_max_one_row_size;
         buffer_state->mem_pool.clear();
@@ -133,7 +139,7 @@ size_t ExceptHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunk, co
             max_size += sizeof(bool);
         }
     }
-    return max_size;
+    return saturate_serialize_size(max_size);
 }
 
 template <typename HashSet>

--- a/be/src/exec/intersect_hash_set.cpp
+++ b/be/src/exec/intersect_hash_set.cpp
@@ -36,6 +36,9 @@ void IntersectHashSet<HashSet>::build_set(RuntimeState* state, const ChunkPtr& c
 
     _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
+    if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+        throw_serialize_key_size_overflow();
+    }
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
@@ -61,6 +64,9 @@ Status IntersectHashSet<HashSet>::refine_intersect_row(RuntimeState* state, cons
     size_t chunk_size = chunkPtr->num_rows();
     _slice_sizes.assign(state->chunk_size(), 0);
     size_t cur_max_one_row_size = _get_max_serialize_size(chunkPtr, exprs);
+    if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+        return Status::InternalError(serialize_key_size_overflow_message());
+    }
     if (UNLIKELY(cur_max_one_row_size > _max_one_row_size)) {
         _max_one_row_size = cur_max_one_row_size;
         _mem_pool->clear();
@@ -124,7 +130,7 @@ size_t IntersectHashSet<HashSet>::_get_max_serialize_size(const ChunkPtr& chunkP
             max_size += sizeof(bool);
         }
     }
-    return max_size;
+    return saturate_serialize_size(max_size);
 }
 
 template <typename HashSet>

--- a/be/src/exec/partition/partition_hash_map.h
+++ b/be/src/exec/partition/partition_hash_map.h
@@ -510,6 +510,9 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
         slice_sizes.assign(num_rows, 0);
 
         uint32_t cur_max_one_row_size = get_max_serialize_size(key_columns);
+        if (UNLIKELY(serialize_size_overflow(cur_max_one_row_size))) {
+            return Status::InternalError(serialize_key_size_overflow_message());
+        }
         if (UNLIKELY(cur_max_one_row_size > max_one_row_size)) {
             max_one_row_size = cur_max_one_row_size;
             inner_mem_pool->clear();
@@ -539,11 +542,11 @@ struct PartitionHashMapWithSerializedKey : public PartitionHashMapBase<false, fa
     }
 
     uint32_t get_max_serialize_size(const Columns& key_columns) {
-        uint32_t max_size = 0;
+        size_t max_size = 0;
         for (const auto& key_column : key_columns) {
             max_size += key_column->max_one_element_serialize_size();
         }
-        return max_size;
+        return saturate_serialize_size(max_size);
     }
 };
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -121,7 +121,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_streaming(co
 Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregation(const size_t chunk_size) {
     SCOPED_TIMER(_aggregator->agg_compute_timer());
 
-    _aggregator->build_hash_set(chunk_size);
+    TRY_CATCH_BAD_ALLOC(_aggregator->build_hash_set(chunk_size));
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_skew_compactor.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_skew_compactor.cpp
@@ -22,6 +22,7 @@
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "common/runtime_profile.h"
+#include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
@@ -61,9 +62,9 @@ spill::SpillSkewChunkCompactor make_spill_aggregate_skew_compactor(AggregatorPar
             if (!chunk_merging->is_empty()) {
                 RETURN_IF_ERROR(merger->evaluate_groupby_exprs(chunk_merging.get()));
                 if (merger->only_group_by_exprs()) {
-                    merger->build_hash_set(chunk_merging->num_rows());
+                    TRY_CATCH_BAD_ALLOC(merger->build_hash_set(chunk_merging->num_rows()));
                 } else {
-                    merger->build_hash_map(chunk_merging->num_rows(), false);
+                    TRY_CATCH_BAD_ALLOC(merger->build_hash_map(chunk_merging->num_rows(), false));
                     RETURN_IF_ERROR(merger->compute_batch_agg_states(chunk_merging.get(), chunk_merging->num_rows()));
                 }
             }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -44,6 +44,8 @@ set(EXEC_FILES
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/agg_hash_map_test.cpp
+        ./exec/partition_hash_map_test.cpp
+        ./exec/set_hash_set_overflow_test.cpp
         ./exec/hash_variant_test.cpp
         ./exec/pipeline/olap_scan_operator_test.cpp
         ./exec/analytor_test.cpp

--- a/be/test/column/adaptive_nullable_column_core_test.cpp
+++ b/be/test/column/adaptive_nullable_column_core_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "column/adaptive_nullable_column.h"
+#include "column/binary_column.h"
 
 namespace starrocks {
 
@@ -54,6 +55,27 @@ TEST(AdaptiveNullableColumnCoreTest, NotConstantPathAndDefaultNotNullValue) {
     EXPECT_EQ(AdaptiveNullableColumn::State::kMaterialized, col->state());
     EXPECT_TRUE(col->has_null());
     EXPECT_EQ(1, col->null_count());
+}
+
+TEST(AdaptiveNullableColumnCoreTest, SerializeSizeSaturatesOnHugeElement) {
+    // One non-null element whose serialized size exceeds the uint32 (4GB) limit. The offset is
+    // faked (no bytes allocated); serialize_size()/max_one_element_serialize_size() only read
+    // offsets. Without saturation, sizeof(null flag) + UINT32_MAX would wrap to a tiny value and
+    // the serialized-key overflow guard would be bypassed; expect the saturated sentinel instead.
+    auto data = LargeBinaryColumn::create();
+    auto* data_ptr = data.get();
+    data->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+    auto null = NullColumn::create();
+    null->append_datum(Datum(uint8_t(0)));
+
+    ColumnPtr col = AdaptiveNullableColumn::create(std::move(data), std::move(null));
+
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, col->max_one_element_serialize_size());
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, col->serialize_size(0));
+    EXPECT_TRUE(serialize_size_overflow(col->serialize_size(0)));
+
+    // ~BinaryColumnBase() DCHECKs bytes/offsets consistency; reset before the column is destroyed.
+    data_ptr->reset_column();
 }
 
 } // namespace starrocks

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 
 #include "base/testutil/parallel_test.h"
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
@@ -26,6 +27,87 @@
 #include "column/vectorized_fwd.h"
 
 namespace starrocks {
+
+// The element offsets claim ~2.5GB each (bytes buffer stays empty; serialize_size only reads offsets)
+// so their sum overflows uint32 without allocating multi-GB. |*out_data| lets the caller
+// reset_column() before scope end, since ~BinaryColumnBase() DCHECKs bytes/offsets consistency.
+static ArrayColumn::MutablePtr make_oversized_serialize_array(LargeBinaryColumn** out_data) {
+    auto data = LargeBinaryColumn::create();
+    *out_data = data.get();
+    data->get_offset().push_back(2'500'000'000ULL);
+    data->get_offset().push_back(5'000'000'000ULL);
+    auto nulls = NullColumn::create();
+    nulls->append(0);
+    nulls->append(0);
+    auto elements = NullableColumn::create(std::move(data), std::move(nulls));
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(2);
+    return ArrayColumn::create(std::move(elements), std::move(offsets));
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayColumnTest, test_serialize_size_saturates_on_overflow) {
+    LargeBinaryColumn* data = nullptr;
+    auto column = make_oversized_serialize_array(&data);
+    ASSERT_EQ(1, column->size());
+    ASSERT_LT(column->elements_column_raw_ptr()->serialize_size(0), Column::SERIALIZE_SIZE_LIMIT);
+    ASSERT_LT(column->elements_column_raw_ptr()->serialize_size(1), Column::SERIALIZE_SIZE_LIMIT);
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->max_one_element_serialize_size());
+    EXPECT_TRUE(serialize_size_overflow(column->serialize_size(0)));
+    data->reset_column();
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayColumnTest, test_serialize_size_normal_not_saturated) {
+    auto offsets = UInt32Column::create();
+    auto elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    auto column = ArrayColumn::create(std::move(elements), std::move(offsets));
+    column->elements_column_raw_ptr()->append_datum("ab");
+    column->elements_column_raw_ptr()->append_datum("cde");
+    column->offsets_column_raw_ptr()->append(2);
+    // 4 (array header) + [1 + 4 + 2] + [1 + 4 + 3]
+    EXPECT_EQ(19u, column->serialize_size(0));
+    EXPECT_FALSE(serialize_size_overflow(column->serialize_size(0)));
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayColumnTest, test_nullable_serialize_size_saturates_on_overflow) {
+    LargeBinaryColumn* data = nullptr;
+    auto array = make_oversized_serialize_array(&data);
+    auto null_col = NullColumn::create();
+    null_col->append(0);
+    auto nullable = NullableColumn::create(std::move(array), std::move(null_col));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, nullable->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, nullable->max_one_element_serialize_size());
+    data->reset_column();
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayColumnTest, test_serialize_size_overflow_helper) {
+    EXPECT_EQ(UINT32_MAX, Column::SERIALIZE_SIZE_LIMIT);
+    EXPECT_FALSE(serialize_size_overflow(0));
+    EXPECT_FALSE(serialize_size_overflow(static_cast<size_t>(UINT32_MAX) - 1));
+    EXPECT_TRUE(serialize_size_overflow(static_cast<size_t>(UINT32_MAX)));
+    EXPECT_TRUE(serialize_size_overflow(static_cast<size_t>(UINT32_MAX) + 1));
+    EXPECT_TRUE(serialize_size_overflow(static_cast<size_t>(5) * 1024 * 1024 * 1024));
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayColumnTest, test_nullable_serialize_size_null_row) {
+    // A null row short-circuits to the 1-byte null flag and must not be flagged as overflow.
+    auto elements = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(0);
+    auto array = ArrayColumn::create(std::move(elements), std::move(offsets));
+    auto null_col = NullColumn::create();
+    null_col->append(1); // row 0 is NULL
+    auto nullable = NullableColumn::create(std::move(array), std::move(null_col));
+    EXPECT_EQ(sizeof(uint8_t), nullable->serialize_size(0));
+    EXPECT_FALSE(serialize_size_overflow(nullable->serialize_size(0)));
+}
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(ArrayColumnTest, test_create) {

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -750,4 +750,33 @@ PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_large_to_binary_unsupport
     ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), "incompatible column type");
 }
 
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_serialize_size_saturates_on_huge_element) {
+    // Offset claims 5GB with no bytes allocated (serialize_size only reads offsets); reset_column()
+    // before scope end since ~BinaryColumnBase() DCHECKs bytes/offsets consistency.
+    auto column = BinaryColumn::create();
+    column->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+    ASSERT_EQ(1, column->size());
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->max_one_element_serialize_size());
+    EXPECT_TRUE(serialize_size_overflow(column->serialize_size(0)));
+    column->reset_column();
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_serialize_size_boundary) {
+    // Exactly UINT32_MAX - 1 stays representable; exactly UINT32_MAX saturates.
+    auto below = BinaryColumn::create();
+    below->get_offset().push_back(static_cast<uint64_t>(UINT32_MAX) - 1 - sizeof(uint32_t));
+    EXPECT_EQ(UINT32_MAX - 1, below->serialize_size(0));
+    EXPECT_FALSE(serialize_size_overflow(below->serialize_size(0)));
+    below->reset_column();
+
+    auto at = BinaryColumn::create();
+    at->get_offset().push_back(static_cast<uint64_t>(UINT32_MAX) - sizeof(uint32_t));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, at->serialize_size(0));
+    EXPECT_TRUE(serialize_size_overflow(at->serialize_size(0)));
+    at->reset_column();
+}
+
 } // namespace starrocks

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -20,13 +20,104 @@
 
 #include "base/testutil/parallel_test.h"
 #include "column/array_column.h"
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
+#include "column/struct_column.h"
 #include "column/vectorized_fwd.h"
 
 namespace starrocks {
+
+// A nullable LargeBinaryColumn with one element claiming `claimed_size` bytes via its offset only
+// (bytes buffer stays empty). |*out_data| lets the caller reset_column() before scope end, since
+// ~BinaryColumnBase() DCHECKs bytes/offsets consistency.
+static NullableColumn::MutablePtr make_oversized_serialize_binary(uint64_t claimed_size, LargeBinaryColumn** out_data) {
+    auto data = LargeBinaryColumn::create();
+    *out_data = data.get();
+    data->get_offset().push_back(claimed_size);
+    auto nulls = NullColumn::create();
+    nulls->append(0);
+    return NullableColumn::create(std::move(data), std::move(nulls));
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(MapColumnTest, test_serialize_size_saturates_on_overflow) {
+    LargeBinaryColumn* key_data = nullptr;
+    LargeBinaryColumn* value_data = nullptr;
+    auto keys = make_oversized_serialize_binary(2'500'000'000ULL, &key_data);
+    auto values = make_oversized_serialize_binary(2'500'000'000ULL, &value_data);
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(1);
+    auto column = MapColumn::create(std::move(keys), std::move(values), std::move(offsets));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_LT(column->keys_column()->serialize_size(0), Column::SERIALIZE_SIZE_LIMIT);
+    ASSERT_LT(column->values_column()->serialize_size(0), Column::SERIALIZE_SIZE_LIMIT);
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->max_one_element_serialize_size());
+    EXPECT_TRUE(serialize_size_overflow(column->serialize_size(0)));
+    key_data->reset_column();
+    value_data->reset_column();
+}
+
+// nullable(array<map<binary,binary>>): the saturated map size must propagate up through map -> array
+// -> nullable, covering deep nesting.
+// NOLINTNEXTLINE
+PARALLEL_TEST(MapColumnTest, test_nested_serialize_size_saturates) {
+    LargeBinaryColumn* key_data = nullptr;
+    LargeBinaryColumn* value_data = nullptr;
+    auto keys = make_oversized_serialize_binary(2'500'000'000ULL, &key_data);
+    auto values = make_oversized_serialize_binary(2'500'000'000ULL, &value_data);
+    auto map_offsets = UInt32Column::create();
+    map_offsets->append(0);
+    map_offsets->append(1);
+    auto map = MapColumn::create(std::move(keys), std::move(values), std::move(map_offsets));
+
+    auto map_null = NullColumn::create();
+    map_null->append(0);
+    auto elements = NullableColumn::create(std::move(map), std::move(map_null));
+    auto array_offsets = UInt32Column::create();
+    array_offsets->append(0);
+    array_offsets->append(1);
+    auto array = ArrayColumn::create(std::move(elements), std::move(array_offsets));
+    auto arr_null = NullColumn::create();
+    arr_null->append(0);
+    auto nullable = NullableColumn::create(std::move(array), std::move(arr_null));
+
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, nullable->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, nullable->max_one_element_serialize_size());
+    key_data->reset_column();
+    value_data->reset_column();
+}
+
+// map<binary, struct<binary>>: the struct field claims ~5GB, so the value (and then the map) saturate.
+// NOLINTNEXTLINE
+PARALLEL_TEST(MapColumnTest, test_map_of_struct_serialize_size_saturates) {
+    auto keys = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    keys->append_datum("k");
+
+    auto field = LargeBinaryColumn::create();
+    auto* field_ptr = field.get();
+    field->get_offset().push_back(5'000'000'000ULL);
+    MutableColumns fields;
+    fields.emplace_back(std::move(field));
+    auto st = StructColumn::create(std::move(fields), std::vector<std::string>{"f"});
+    auto val_null = NullColumn::create();
+    val_null->append(0);
+    auto values = NullableColumn::create(std::move(st), std::move(val_null));
+
+    auto offsets = UInt32Column::create();
+    offsets->append(0);
+    offsets->append(1);
+    auto column = MapColumn::create(std::move(keys), std::move(values), std::move(offsets));
+
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->max_one_element_serialize_size());
+    field_ptr->reset_column();
+}
 
 // NOLINTNEXTLINE
 PARALLEL_TEST(MapColumnTest, test_create) {

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -434,4 +434,30 @@ TEST(StructColumnTest, test_reference_memory_usage) {
     ASSERT_EQ(0, column->Column::reference_memory_usage());
 }
 
+// NOLINTNEXTLINE
+TEST(StructColumnTest, test_serialize_size_saturates_on_overflow) {
+    // Each field claims ~2.5GB via its offset only (bytes buffer stays empty). reset_column() before
+    // scope end since ~BinaryColumnBase() DCHECKs bytes/offsets consistency.
+    std::vector<std::string> field_name{"a", "b"};
+    auto a = LargeBinaryColumn::create();
+    auto* a_ptr = a.get();
+    a->get_offset().push_back(2'500'000'000ULL);
+    auto b = LargeBinaryColumn::create();
+    auto* b_ptr = b.get();
+    b->get_offset().push_back(2'500'000'000ULL);
+    MutableColumns fields;
+    fields.emplace_back(std::move(a));
+    fields.emplace_back(std::move(b));
+    auto column = StructColumn::create(std::move(fields), std::move(field_name));
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_LT(column->field_column_raw_ptr(0)->serialize_size(0), Column::SERIALIZE_SIZE_LIMIT);
+    ASSERT_LT(column->field_column_raw_ptr(1)->serialize_size(0), Column::SERIALIZE_SIZE_LIMIT);
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->serialize_size(0));
+    EXPECT_EQ(Column::SERIALIZE_SIZE_LIMIT, column->max_one_element_serialize_size());
+    EXPECT_TRUE(serialize_size_overflow(column->serialize_size(0)));
+    a_ptr->reset_column();
+    b_ptr->reset_column();
+}
+
 } // namespace starrocks

--- a/be/test/exec/agg_hash_map_test.cpp
+++ b/be/test/exec/agg_hash_map_test.cpp
@@ -18,6 +18,7 @@
 
 #include <any>
 
+#include "column/binary_column.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
@@ -327,6 +328,56 @@ TEST_F(AggHashMapKeyNotFoundsTest, TestAllocateAndComputeNonFounds_FixedSize16Sl
     using TestAggHashMap = FixedSize16SliceAggHashMap<PhmapSeed1>;
     using TestAggHashMapKey = AggHashMapWithSerializedKeyFixedSize<TestAggHashMap>;
     TestAggHashMapKeyWithIntType<TestAggHashMapKey>(true);
+}
+
+// A key column whose serialized size overflows uint32 (fake 5GB offset, no bytes allocated) must make
+// the serialized-key GROUP BY / DISTINCT build path fail fast (throw) instead of under-allocating.
+TEST_F(AggHashMapKeyNotFoundsTest, SerializedKeyAggHashMapOverflowGuardThrows) {
+    RuntimeProfile profile("guard");
+    AggStatistics statis(&profile);
+    SerializedKeyAggHashMap<PhmapSeed1> key(4, &statis);
+    Buffer<AggDataPtr> agg_states(4);
+    MemPool pool;
+
+    auto fake = LargeBinaryColumn::create();
+    auto* data_ptr = fake.get();
+    fake->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+    Columns key_columns;
+    key_columns.emplace_back(std::move(fake));
+
+    bool threw = false;
+    try {
+        key.build_hash_map(1, key_columns, &pool, TestAllocateState<SerializedKeyAggHashMap<PhmapSeed1>>(&pool),
+                           &agg_states);
+    } catch (const std::runtime_error& e) {
+        threw = true;
+        EXPECT_NE(std::string(e.what()).find("exceeds the 4GB"), std::string::npos);
+    }
+    EXPECT_TRUE(threw);
+    data_ptr->reset_column();
+}
+
+TEST_F(AggHashMapKeyNotFoundsTest, SerializedKeyAggHashSetOverflowGuardThrows) {
+    RuntimeProfile profile("guard");
+    AggStatistics statis(&profile);
+    SerializedKeyAggHashSet<PhmapSeed1> set(4, &statis);
+    MemPool pool;
+
+    auto fake = LargeBinaryColumn::create();
+    auto* data_ptr = fake.get();
+    fake->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+    Columns key_columns;
+    key_columns.emplace_back(std::move(fake));
+
+    bool threw = false;
+    try {
+        set.build_set<true>(1, key_columns, &pool, nullptr);
+    } catch (const std::runtime_error& e) {
+        threw = true;
+        EXPECT_NE(std::string(e.what()).find("exceeds the 4GB"), std::string::npos);
+    }
+    EXPECT_TRUE(threw);
+    data_ptr->reset_column();
 }
 
 } // namespace starrocks

--- a/be/test/exec/partition_hash_map_test.cpp
+++ b/be/test/exec/partition_hash_map_test.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "exec/partition/partition_hash_variant.h"
+#include "runtime/mem_pool.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+// A partition key column whose serialized size overflows uint32 (fake 5GB offset, no bytes allocated)
+// must make LocalPartitionTopn's append_chunk return an error instead of under-allocating.
+TEST(PartitionHashMapOverflowTest, AppendChunkGuardReturnsError) {
+    SerializedKeyPartitionHashMap<PhmapSeed1> hm(4);
+
+    auto fake = LargeBinaryColumn::create();
+    auto* data_ptr = fake.get();
+    fake->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+    Columns key_columns;
+    key_columns.emplace_back(std::move(fake));
+
+    auto probe = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+    probe->append_datum(Datum(int32_t(1)));
+    Columns chunk_cols;
+    chunk_cols.emplace_back(std::move(probe));
+    Chunk::SlotHashMap map;
+    map[0] = 0;
+    auto chunk = std::make_shared<Chunk>(std::move(chunk_cols), map);
+
+    MemPool mem_pool;
+    ObjectPool obj_pool;
+    auto res = hm.append_chunk<false>(chunk, key_columns, &mem_pool, &obj_pool, nullptr, nullptr);
+    EXPECT_FALSE(res.ok());
+    EXPECT_NE(res.status().to_string().find("exceeds the 4GB"), std::string::npos);
+    data_ptr->reset_column(); // restore bytes/offsets consistency before destruction
+}
+
+} // namespace starrocks

--- a/be/test/exec/set_hash_set_overflow_test.cpp
+++ b/be/test/exec/set_hash_set_overflow_test.cpp
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/vectorized_fwd.h"
+#include "exec/except_hash_set.h"
+#include "exec/intersect_hash_set.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
+#include "runtime/mem_pool.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+// Regression coverage for the >4GB serialized-key overflow guards in the set operators
+// (except / intersect). It fabricates a single-row chunk whose key column reports a serialized
+// size beyond the uint32 (4GB) limit -- via a fake offset, without allocating 4GB -- and drives
+// the guarded methods to hit the fail-fast throw / InternalError branches.
+class SetHashSetOverflowTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = 4096;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        _runtime_state->init_instance_mem_tracker();
+    }
+
+    void make_overflow_input(ChunkPtr* chunk, std::vector<ExprContext*>* exprs) {
+        auto fake = LargeBinaryColumn::create();
+        // One logical element whose length exceeds the uint32 serialize-size limit.
+        fake->get_offset().push_back(5ULL * 1024 * 1024 * 1024);
+
+        *chunk = std::make_shared<Chunk>();
+        (*chunk)->append_column(std::move(fake), 0);
+
+        auto* col_ref = _pool.add(new ColumnRef(TypeDescriptor(TYPE_VARCHAR), 0));
+        auto* ctx = _pool.add(new ExprContext(col_ref));
+        ASSERT_TRUE(ctx->prepare(_runtime_state.get()).ok());
+        ASSERT_TRUE(ctx->open(_runtime_state.get()).ok());
+        exprs->push_back(ctx);
+    }
+
+    std::shared_ptr<RuntimeState> _runtime_state;
+    ObjectPool _pool;
+};
+
+TEST_F(SetHashSetOverflowTest, ExceptBuildSetThrowsOnOverflow) {
+    ExceptHashSerializeSet hash_set;
+    ASSERT_TRUE(hash_set.init(_runtime_state.get()).ok());
+    ExceptBufferState buffer_state;
+    ASSERT_TRUE(buffer_state.init(_runtime_state.get()).ok());
+    MemPool pool;
+
+    ChunkPtr chunk;
+    std::vector<ExprContext*> exprs;
+    make_overflow_input(&chunk, &exprs);
+
+    bool threw = false;
+    try {
+        hash_set.build_set(_runtime_state.get(), chunk, exprs, &pool, &buffer_state);
+    } catch (const std::runtime_error& e) {
+        threw = true;
+        EXPECT_NE(std::string(e.what()).find("exceeds the 4GB"), std::string::npos);
+    }
+    EXPECT_TRUE(threw);
+}
+
+TEST_F(SetHashSetOverflowTest, ExceptEraseDuplicateRowReturnsErrorOnOverflow) {
+    ExceptHashSerializeSet hash_set;
+    ASSERT_TRUE(hash_set.init(_runtime_state.get()).ok());
+    ExceptBufferState buffer_state;
+    ASSERT_TRUE(buffer_state.init(_runtime_state.get()).ok());
+
+    ChunkPtr chunk;
+    std::vector<ExprContext*> exprs;
+    make_overflow_input(&chunk, &exprs);
+
+    auto st = hash_set.erase_duplicate_row(_runtime_state.get(), chunk, exprs, &buffer_state);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("exceeds the 4GB"), std::string::npos);
+}
+
+TEST_F(SetHashSetOverflowTest, IntersectBuildSetThrowsOnOverflow) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_TRUE(hash_set.init(_runtime_state.get()).ok());
+    MemPool pool;
+
+    ChunkPtr chunk;
+    std::vector<ExprContext*> exprs;
+    make_overflow_input(&chunk, &exprs);
+
+    bool threw = false;
+    try {
+        hash_set.build_set(_runtime_state.get(), chunk, exprs, &pool);
+    } catch (const std::runtime_error& e) {
+        threw = true;
+        EXPECT_NE(std::string(e.what()).find("exceeds the 4GB"), std::string::npos);
+    }
+    EXPECT_TRUE(threw);
+}
+
+TEST_F(SetHashSetOverflowTest, IntersectRefineIntersectRowReturnsErrorOnOverflow) {
+    IntersectHashSerializeSet hash_set;
+    ASSERT_TRUE(hash_set.init(_runtime_state.get()).ok());
+
+    ChunkPtr chunk;
+    std::vector<ExprContext*> exprs;
+    make_overflow_input(&chunk, &exprs);
+
+    auto st = hash_set.refine_intersect_row(_runtime_state.get(), chunk, exprs, 1);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("exceeds the 4GB"), std::string::npos);
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`Column::serialize_size()` / `max_one_element_serialize_size()` for the container columns accumulate a single row's serialized size in a `uint32_t`. When one row's serialized bytes reach 2^32 (4GB), the accumulator **silently wraps** to a small value. The "serialized-key" operators (GROUP BY, DISTINCT, EXCEPT, INTERSECT, local-partition Top-N) then allocate a key buffer sized by that wrapped value, while `serialize()` writes the real (>4GB) size via a `size_t` cursor — **overflowing the heap** (SIGSEGV / memory corruption), or turning the wrapped value × chunk_size into a huge allocation that trips the mem limit.

The uint64 byte-account gate (`MAX_CAPACITY_LIMIT`) already protects JOIN and window/analytic; only this per-row "serialized-size account" was still on `uint32_t`.

**Cluster-reproduced with `ARRAY` keys** (main build, 251GB machine, mem_limit 90%):
- GROUP BY (`agg_hash_map`): SIGSEGV in `AggHashMapWithSerializedKey::compute_agg_states`
- DISTINCT (`agg_hash_set`): SIGSEGV in `BinaryColumnBase::serialize`, via `AggregateDistinctBlockingSinkOperator::build_hash_set`
- LocalPartitionTopn (`partition_hash_map`): SIGSEGV in `append_chunk` / `flush`
- EXCEPT / INTERSECT (`except_hash_set` / `intersect_hash_set`): same root cause; wrapped value × chunk_size (4096) → huge allocation trips mem limit (observed try-consume 512GB / 1TB)

**Same root cause, not cluster-reproduced (covered defensively + unit tests):** `MapColumn`, `StructColumn` (whose `max_one_element_serialize_size` also sums fields), and `NullableColumn` (its null-flag byte can wrap `UINT32_MAX` back to 0) share the identical `uint32_t` serialize-size accounting and are fixed together with `ARRAY`.

Fixes #76515

## What I'm doing:

Fail-fast rather than support a pathological >=4GB serialized key:

- **Column layer:** accumulate `serialize_size` / `max_one_element_serialize_size` in 64 bits and saturate to a `UINT32_MAX` sentinel (`Column::SERIALIZE_SIZE_LIMIT`) instead of wrapping. Applied to `ArrayColumn`, `MapColumn`, `StructColumn` (serialize_size + field-summing max), and `NullableColumn` (serialize_size + max). Saturation propagates through nested containers.
- **Consumers:** the `get_max_serialize_size` helpers also saturate (a multi-column sum can exceed `UINT32_MAX` even when each column is below it). On hitting the sentinel each build path fails fast — void build paths wrapped in `TRY_CATCH_*` throw `std::runtime_error` (converted to a query-level `Status`); `Status`/`StatusOr` paths return `Status::InternalError`. Two previously unwrapped void agg build calls (`aggregate_distinct_streaming_sink_operator`, `spillable_aggregate_skew_compactor`) are wrapped so the throw cannot escape.

Verification: BE builds; `column_test` passes including 6 new saturation/propagation tests (array/map/struct/nullable + sentinel helper); `check_be_module_boundaries.py --mode full` clean.

Note: a separate incomplete crash stack was also seen on the array **scan read-back** path (`ArrayColumnIterator::next_batch`); it looks like a distinct issue and is tracked separately, not touched here.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a query whose single-row serialized key reaches >=4GB now fails fast with a clear error instead of crashing the BE / corrupting memory.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
