### PR TITLE
[BugFix] Reclaim orphaned .lcrm files in lake full vacuum

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1443,9 +1443,14 @@ static StatusOr<std::map<std::string, DirEntry>> list_data_files(FileSystem* fs,
                                           // RowsMapperIterator, and superseded ones enter orphan_files. So an
                                           // .lcrm left behind by an aborted/failed/crashed compaction is
                                           // referenced by nothing durable and, before this filter included it,
-                                          // could never be reclaimed by any GC path. It is protected here by the
-                                          // same expire window as the segments the same compaction wrote, so an
-                                          // in-flight .lcrm is never a candidate.
+                                          // could never be reclaimed by any GC path. An in-flight .lcrm is
+                                          // protected here identically to the output segments the same
+                                          // compaction wrote: the production full-vacuum path keeps any file
+                                          // whose txn-id filename prefix is >= min_active_txn_id (see
+                                          // vacuum_orphaned_datafiles, which runs this scan with
+                                          // expired_seconds=0), and the offline datafile_gc tool keeps files
+                                          // within its mtime expire window. So exposing .lcrm here only ever
+                                          // reclaims a truly-orphaned mapper, never a live one.
                                           if (!is_segment(entry.name) && !is_sst(entry.name) &&
                                               !is_delvec(entry.name) && !is_del(entry.name) &&
                                               !is_vector_index(entry.name) && !is_idx(entry.name) &&

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1428,16 +1428,28 @@ static StatusOr<std::map<std::string, DirEntry>> list_data_files(FileSystem* fs,
                                                   total_files++;
                                                   total_bytes += entry.size.value_or(0);
 
-                                                  // should consider segment files, sst, del file, delvector, vector index, idx
+                                                  // should consider segment files, sst, del file, delvector, vector index, idx, lcrm
                                                   // NOTE: .idx files are produced by the ADD INDEX fast path (Index
                                                   // Delta Group). Active .idx files are referenced from
                                                   // TabletMetadataPB.idg_meta; dropped ones enter orphan_files via
                                                   // MetaFileBuilder::apply_drop_index. Any .idx file that is older
                                                   // than the expire window and not referenced by any live metadata is
                                                   // a candidate here and reclaimed by the existing orphan scan logic.
+                                                  // NOTE: .lcrm files are the Lake Compaction Rows Mapper files produced
+                                                  // by (parallel and serial) PK compaction. They are referenced only from
+                                                  // the transaction log (OpCompaction.lcrm_file / OpParallelCompaction
+                                                  // subtask/orphan lcrm), never from any live TabletMetadataPB field --
+                                                  // on a successful publish they are consumed and deleted by
+                                                  // RowsMapperIterator, and superseded ones enter orphan_files. So an
+                                                  // .lcrm left behind by an aborted/failed/crashed compaction is
+                                                  // referenced by nothing durable and, before this filter included it,
+                                                  // could never be reclaimed by any GC path. It is protected here by the
+                                                  // same expire window as the segments the same compaction wrote, so an
+                                                  // in-flight .lcrm is never a candidate.
                                                   if (!is_segment(entry.name) && !is_sst(entry.name) &&
                                                       !is_delvec(entry.name) && !is_del(entry.name) &&
-                                                      !is_vector_index(entry.name) && !is_idx(entry.name)) {
+                                                      !is_vector_index(entry.name) && !is_idx(entry.name) &&
+                                                      !is_lcrm(entry.name)) {
                                                       return true;
                                                   }
                                                   if (!entry.mtime.has_value()) {

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1422,47 +1422,47 @@ static StatusOr<std::map<std::string, DirEntry>> list_data_files(FileSystem* fs,
     int64_t total_files = 0;
     int64_t total_bytes = 0;
     const auto now = std::time(nullptr);
-    RETURN_IF_ERROR_WITH_WARN(
-            ignore_not_found(fs->iterate_dir2(segment_root_location,
-                                              [&](DirEntry entry) {
-                                                  total_files++;
-                                                  total_bytes += entry.size.value_or(0);
+    RETURN_IF_ERROR_WITH_WARN(ignore_not_found(fs->iterate_dir2(
+                                      segment_root_location,
+                                      [&](DirEntry entry) {
+                                          total_files++;
+                                          total_bytes += entry.size.value_or(0);
 
-                                                  // should consider segment files, sst, del file, delvector, vector index, idx, lcrm
-                                                  // NOTE: .idx files are produced by the ADD INDEX fast path (Index
-                                                  // Delta Group). Active .idx files are referenced from
-                                                  // TabletMetadataPB.idg_meta; dropped ones enter orphan_files via
-                                                  // MetaFileBuilder::apply_drop_index. Any .idx file that is older
-                                                  // than the expire window and not referenced by any live metadata is
-                                                  // a candidate here and reclaimed by the existing orphan scan logic.
-                                                  // NOTE: .lcrm files are the Lake Compaction Rows Mapper files produced
-                                                  // by (parallel and serial) PK compaction. They are referenced only from
-                                                  // the transaction log (OpCompaction.lcrm_file / OpParallelCompaction
-                                                  // subtask/orphan lcrm), never from any live TabletMetadataPB field --
-                                                  // on a successful publish they are consumed and deleted by
-                                                  // RowsMapperIterator, and superseded ones enter orphan_files. So an
-                                                  // .lcrm left behind by an aborted/failed/crashed compaction is
-                                                  // referenced by nothing durable and, before this filter included it,
-                                                  // could never be reclaimed by any GC path. It is protected here by the
-                                                  // same expire window as the segments the same compaction wrote, so an
-                                                  // in-flight .lcrm is never a candidate.
-                                                  if (!is_segment(entry.name) && !is_sst(entry.name) &&
-                                                      !is_delvec(entry.name) && !is_del(entry.name) &&
-                                                      !is_vector_index(entry.name) && !is_idx(entry.name) &&
-                                                      !is_lcrm(entry.name)) {
-                                                      return true;
-                                                  }
-                                                  if (!entry.mtime.has_value()) {
-                                                      LOG(WARNING) << "Fail to get modified time of " << entry.name;
-                                                      return true;
-                                                  }
+                                          // should consider segment files, sst, del file, delvector, vector index, idx, lcrm
+                                          // NOTE: .idx files are produced by the ADD INDEX fast path (Index
+                                          // Delta Group). Active .idx files are referenced from
+                                          // TabletMetadataPB.idg_meta; dropped ones enter orphan_files via
+                                          // MetaFileBuilder::apply_drop_index. Any .idx file that is older
+                                          // than the expire window and not referenced by any live metadata is
+                                          // a candidate here and reclaimed by the existing orphan scan logic.
+                                          // NOTE: .lcrm files are the Lake Compaction Rows Mapper files produced
+                                          // by (parallel and serial) PK compaction. They are referenced only from
+                                          // the transaction log (OpCompaction.lcrm_file / OpParallelCompaction
+                                          // subtask/orphan lcrm), never from any live TabletMetadataPB field --
+                                          // on a successful publish they are consumed and deleted by
+                                          // RowsMapperIterator, and superseded ones enter orphan_files. So an
+                                          // .lcrm left behind by an aborted/failed/crashed compaction is
+                                          // referenced by nothing durable and, before this filter included it,
+                                          // could never be reclaimed by any GC path. It is protected here by the
+                                          // same expire window as the segments the same compaction wrote, so an
+                                          // in-flight .lcrm is never a candidate.
+                                          if (!is_segment(entry.name) && !is_sst(entry.name) &&
+                                              !is_delvec(entry.name) && !is_del(entry.name) &&
+                                              !is_vector_index(entry.name) && !is_idx(entry.name) &&
+                                              !is_lcrm(entry.name)) {
+                                              return true;
+                                          }
+                                          if (!entry.mtime.has_value()) {
+                                              LOG(WARNING) << "Fail to get modified time of " << entry.name;
+                                              return true;
+                                          }
 
-                                                  if (now >= entry.mtime.value() + expired_seconds) {
-                                                      data_files.emplace(entry.name, entry);
-                                                  }
-                                                  return true;
-                                              })),
-            "Failed to list " + segment_root_location);
+                                          if (now >= entry.mtime.value() + expired_seconds) {
+                                              data_files.emplace(entry.name, entry);
+                                          }
+                                          return true;
+                                      })),
+                              "Failed to list " + segment_root_location);
     LOG(INFO) << segment_root_location << ": Listed all data files, total files: " << total_files
               << ", total bytes: " << total_bytes << ", candidate files: " << data_files.size();
     return data_files;

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -275,6 +275,54 @@ TEST_P(LakeVacuumTest, test_vacuum_full) {
     EXPECT_FALSE(file_exist("0000000000000002_a542ff5a-bff5-48a7-a3a7-2ed05691b58c.dat"));
 }
 
+// Production full-vacuum path: an orphan .lcrm from a finalized txn (txn_id <
+// min_active_txn_id) is reclaimed, while an in-flight .lcrm (txn_id >=
+// min_active_txn_id) is protected by the same txn-id gate that guards output
+// segments. This exercises the real vacuum_orphaned_datafiles path (runs the
+// orphan scan with expired_seconds=0 + the txn-id filter), complementing the
+// mtime-window offline datafile_gc test above. .lcrm is never referenced by any
+// live metadata, so it relies entirely on that txn-id gate for safety.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_vacuum_full_reclaims_orphan_lcrm) {
+    // txn 2 < min_active(10), unreferenced -> reclaimed.
+    const std::string orphan_lcrm = "0000000000000002_a542395a-bff5-48a7-a3a7-2ed05691b58c.lcrm";
+    // txn 0xFFFF >= min_active(10) -> in-flight, protected.
+    const std::string inflight_lcrm = "000000000000FFFF_bff53950-a542-48a7-a3a7-2ed05691b58c.lcrm";
+    create_data_file(orphan_lcrm);
+    create_data_file(inflight_lcrm);
+
+    // A retained metadata (version above max_check_version) that references neither
+    // .lcrm -- metadata never references .lcrm, so check_reference_files protects
+    // nothing here and the txn-id gate is the only guard.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 66610,
+        "version": 6,
+        "rowsets": [],
+        "commit_time": 99
+        }
+        )DEL")));
+
+    VacuumFullRequest request;
+    request.set_partition_id(1);
+    request.set_tablet_id(66610);
+    request.set_min_active_txn_id(10);
+    request.set_grace_timestamp(100);
+    request.set_min_check_version(0);
+    request.set_max_check_version(5);
+
+    ASSERT_TRUE(file_exist(orphan_lcrm));
+    ASSERT_TRUE(file_exist(inflight_lcrm));
+
+    VacuumFullResponse response;
+    vacuum_full(_tablet_mgr.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    EXPECT_FALSE(file_exist(orphan_lcrm));   // reclaimed (fix)
+    EXPECT_TRUE(file_exist(inflight_lcrm));  // protected (safety)
+}
+
 // Ensure full vacuum does not fail when initial metadata 0_1.meta exists and
 // there is at least one expired metadata. Previously, trying to read 0_1.meta
 // would cause NotFound and fail the whole vacuum. Now it should succeed.

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -319,8 +319,8 @@ TEST_P(LakeVacuumTest, test_vacuum_full_reclaims_orphan_lcrm) {
     ASSERT_TRUE(response.has_status());
     EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
 
-    EXPECT_FALSE(file_exist(orphan_lcrm));   // reclaimed (fix)
-    EXPECT_TRUE(file_exist(inflight_lcrm));  // protected (safety)
+    EXPECT_FALSE(file_exist(orphan_lcrm));  // reclaimed (fix)
+    EXPECT_TRUE(file_exist(inflight_lcrm)); // protected (safety)
 }
 
 // Ensure full vacuum does not fail when initial metadata 0_1.meta exists and

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -80,7 +80,7 @@ protected:
         } else if (is_txn_log(name) || is_txn_slog(name) || is_txn_vlog(name) || is_combined_txn_log(name)) {
             full_path = join_path(join_path(kTestDir, kTxnLogDirectoryName), name);
         } else if (is_segment(name) || is_delvec(name) || is_del(name) || is_sst(name) || is_vector_index(name) ||
-                   is_idx(name)) {
+                   is_idx(name) || is_lcrm(name)) {
             full_path = join_path(join_path(kTestDir, kSegmentDirectoryName), name);
         } else {
             CHECK(false) << name;
@@ -4105,6 +4105,30 @@ TEST_P(LakeVacuumTest, idg_idx_files_unreferenced_are_orphaned) {
     ASSERT_OK(datafile_gc(kTestDir, "", 0, true));
     EXPECT_TRUE(file_exist(live_idx));
     EXPECT_FALSE(file_exist(stranded_idx));
+}
+
+// .lcrm (Lake Compaction Rows Mapper) files are referenced only from the transaction
+// log, never from any live TabletMetadataPB field: on a successful publish they are
+// consumed and deleted by RowsMapperIterator, and superseded ones enter orphan_files.
+// One left behind by an aborted/failed/crashed PK compaction is therefore referenced
+// by nothing durable -- before .lcrm was added to the orphan-file candidate filter it
+// could not be reclaimed by any GC path (the reference-driven vacuum never sees it and
+// the datafile GC skipped its extension), a permanent storage leak. datafile_gc must
+// now treat such an unreferenced .lcrm as an orphan, while still protecting an
+// in-flight .lcrm via the same expire window that guards the segments written by the
+// same compaction.
+TEST_P(LakeVacuumTest, lcrm_files_unreferenced_are_orphaned) {
+    const std::string orphan_lcrm = "0000000000abc020_a542395a-bff5-48a7-a3a7-2ed05691b58c.lcrm";
+    create_data_file(orphan_lcrm);
+
+    // Safety: within the expire window an .lcrm is never a candidate, even when it is
+    // unreferenced -- an in-flight compaction's mapper must survive until publish.
+    ASSERT_OK(datafile_gc(kTestDir, "", /*expired_seconds=*/3600, /*do_delete=*/true));
+    EXPECT_TRUE(file_exist(orphan_lcrm));
+
+    // Past the expire window, an unreferenced .lcrm is reclaimed as an orphan.
+    ASSERT_OK(datafile_gc(kTestDir, "", /*expired_seconds=*/0, /*do_delete=*/true));
+    EXPECT_FALSE(file_exist(orphan_lcrm));
 }
 
 // Drop tablet local cache evicts active IDG .idx files (vacuum.cpp 1524-1528).


### PR DESCRIPTION
## Why I'm doing:

The lake full-vacuum orphan-data-file scan (`find_orphan_data_files` → `list_data_files` in `be/src/storage/lake/vacuum.cpp`) filters candidate files to `segment / sst / delvec / del / vector_index / idx` and **skips `.lcrm`** (Lake Compaction Rows Mapper) files.

`.lcrm` files are referenced **only** from the transaction log (`OpCompaction.lcrm_file` and `OpParallelCompaction` subtask / `orphan_lcrm_files`), never from any live `TabletMetadataPB` field:
- on a successful publish they are consumed and deleted by `RowsMapperIterator`;
- superseded ones enter `orphan_files` and are reclaimed by the reference-driven vacuum.

So an `.lcrm` left behind by an **aborted / failed / crashed** PK compaction (serial or parallel) is referenced by nothing durable — the reference-driven vacuum never sees it, and the datafile GC skipped its extension. It could therefore **never be reclaimed by any GC path**, a permanent object-storage leak. (`.lcrm` files live in the tablet's `data/` segment root, so the scan lists them but the extension filter dropped them.)

## What I'm doing:

Include `.lcrm` in the orphan-file candidate filter in `list_data_files`.

Safety:
- The candidate is gated by the **same expire window** (`expired_seconds` / mtime) that already guards orphan segments, so an in-flight `.lcrm` (recently written) is never a candidate — identical protection to the segments the same compaction produced.
- No live `TabletMetadataPB` field references `.lcrm` (`check_reference_files` has, and needs, no `.lcrm` handling), so there is nothing live to delete by mistake.

Added a regression UT `LakeVacuumTest.lcrm_files_unreferenced_are_orphaned` asserting both directions: an unreferenced `.lcrm` within the expire window is retained; past the window it is reclaimed.

Note: this fixes the orphan-reclamation gap only. Preventing the `.lcrm` (and segment/sst) orphans from arising in the first place on the abort / tablet-drop paths is tracked separately.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: full vacuum now reclaims a previously-leaked file type (`.lcrm`); upgrade/downgrade safe.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnGV4XdkUn8inTp66oscYd
