### PR TITLE
[Refactor] Use OlapTable colocate-group property for ALTER-time colocate guards

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -17,7 +17,6 @@ package com.starrocks.alter;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
-import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
@@ -950,7 +949,6 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             throws DdlException, AnalysisException {
         Locker locker = new Locker();
         Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
-        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
         List<ModifyPartitionInfo> modifyPartitionInfos = Lists.newArrayList();
         if (olapTable.getState() != OlapTable.OlapTableState.NORMAL
                 && olapTable.getState() != OlapTable.OlapTableState.TABLET_RESHARD) {
@@ -1032,7 +1030,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             }
             // 2. replication num
             if (newReplicationNum != (short) -1) {
-                if (colocateTableIndex.isColocateTable(olapTable.getId())) {
+                if (olapTable.hasColocateGroup()) {
                     throw new DdlException(
                             "table " + olapTable.getName() + " is colocate table, cannot change replicationNum");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -357,7 +357,7 @@ public class MaterializedViewHandler extends AlterHandler {
         // never a synchronous materialized view, which carries a query statement.)
         return olapTable.isRangeDistribution()
                 && olapTable.isCloudNativeTable()
-                && !GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(olapTable.getId())
+                && !olapTable.hasColocateGroup()
                 && !olapTable.hasAutoIncrementColumn()
                 && olapTable.getKeysType() != KeysType.PRIMARY_KEYS;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2148,7 +2148,7 @@ public class SchemaChangeHandler extends AlterHandler {
             Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
             if (col.isPresent() && !col.get().equals(distributionCol)) {
                 if (incrVarcharLenColNames != null && incrVarcharLenColNames.contains(normalizedColName)) {
-                    if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(olapTable.getId())) {
+                    if (olapTable.hasColocateGroup()) {
                         throw new DdlException("Can not modify distribution column[" + colName
                                 + "] for colocate table. index["
                                 + olapTable.getIndexNameByMetaId(alterIndexMetaId) + "]");
@@ -4842,7 +4842,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // table's tablets must stay range-aligned with its ColocateRangeMgr expected ranges; the rewrite
         // samples a fresh K-tablet layout independently, which would desync colocate scan/join routing
         // after the flip. AUTO_INCREMENT columns are likewise out of scope for the re-route.
-        if (GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(table.getId())
+        if (table.hasColocateGroup()
                 || table.hasAutoIncrementColumn()) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1619,6 +1619,21 @@ public class OlapTable extends Table {
         this.colocateGroup = colocateGroup;
     }
 
+    // Whether this table declares a colocate group. For a real catalog OlapTable this matches
+    // ColocateTableIndex.isColocateTable(getId()): the group name and the index's table2Group membership
+    // are set together on create/ALTER-set and cleared together on ALTER-unset. It is NOT a drop-in
+    // replacement for the index everywhere -- two boundaries make them diverge:
+    //   - a query-time copy is not valid input: OlapTable.copyOnlyForQuery() does not carry colocateGroup;
+    //   - a crash between the OP_CREATE_TABLE and OP_COLOCATE_ADD_TABLE_V2 journal records can replay a
+    //     table with the property set but no index membership (the index is the durable source of truth).
+    // So this is used only by fail-closed ALTER-time guards that hold the table write lock on the real
+    // catalog object, where the declared property is authoritative (and in the crash-orphan corner makes
+    // the guard strictly more conservative). Named hasColocateGroup, not isColocateTable, since it is a
+    // pure property read with no GroupId/stability/range semantics -- use ColocateTableIndex when needed.
+    public boolean hasColocateGroup() {
+        return !Strings.isNullOrEmpty(colocateGroup);
+    }
+
     public boolean isEnableColocateMVIndex() {
         if (!isOlapTableOrMaterializedView()) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4429,7 +4429,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     // The caller need to hold the db write lock
     public void modifyTableReplicationNum(Database db, OlapTable table, Map<String, String> properties)
             throws DdlException {
-        if (colocateTableIndex.isColocateTable(table.getId())) {
+        if (table.hasColocateGroup()) {
             throw new DdlException("table " + table.getName() + " is colocate table, cannot change replicationNum");
         }
 
@@ -4478,7 +4478,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throws DdlException {
         Locker locker = new Locker();
         Preconditions.checkArgument(locker.isDbWriteLockHeldByCurrentThread(db));
-        if (colocateTableIndex.isColocateTable(table.getId())) {
+        if (table.hasColocateGroup()) {
             throw new DdlException("table " + table.getName() + " is colocate table, cannot change replicationNum");
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -239,12 +239,11 @@ public class RangeDistributionGuardTest {
     @Test
     public void testRangeRollupOnColocateRejected() throws Exception {
         starRocksAssert.withTable(rangeTableDdl("t_guard_rollup_colocate"));
-        new MockUp<ColocateTableIndex>() {
-            @Mock
-            public boolean isColocateTable(long tableId) {
-                return true;
-            }
-        };
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable("test", "t_guard_rollup_colocate");
+        // Simulate colocate membership via the table's group property: the routing predicate now reads
+        // OlapTable.hasColocateGroup(), equivalent to ColocateTableIndex.isColocateTable for a live table.
+        table.setColocateGroup("t_guard_rollup_colocate_group");
         assertAlterRejectedWithRangeDistribution(
                 "alter table t_guard_rollup_colocate add rollup r1(k1, k2, v1) order by (k2, k1)");
     }
@@ -376,12 +375,11 @@ public class RangeDistributionGuardTest {
     @Test
     public void testColocateRangeTableRejectsSortKeyReorder() throws Exception {
         starRocksAssert.withTable(rangeTableDdl("t_guard_colocate"));
-        new MockUp<ColocateTableIndex>() {
-            @Mock
-            public boolean isColocateTable(long tableId) {
-                return true;
-            }
-        };
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable("test", "t_guard_colocate");
+        // Simulate colocate membership via the table's group property: the routing predicate now reads
+        // OlapTable.hasColocateGroup(), equivalent to ColocateTableIndex.isColocateTable for a live table.
+        table.setColocateGroup("t_guard_colocate_group");
         assertAlterRejectedWithRangeDistribution("alter table t_guard_colocate order by (k2, k1)");
     }
 
@@ -1472,6 +1470,10 @@ public class RangeDistributionGuardTest {
     @Test
     public void testColocateRangeAddKeyColUnaffected() throws Exception {
         starRocksAssert.withTable(dupRangeKeyDerivedDdl("t_add_meta_colo"));
+        // needsRangeRewriteSchemaChange reads the table's colocate-group property while
+        // isMetadataOnlyTrailingKeyAdd reads ColocateTableIndex; set both so the table is colocate to
+        // each guard and the ADD COLUMN KEY stays on the existing range-distribution rejection.
+        getTable("t_add_meta_colo").setColocateGroup("t_add_meta_colo_group");
         new MockUp<ColocateTableIndex>() {
             @Mock
             public boolean isColocateTable(long tableId) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/RangeColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/RangeColocateTableTest.java
@@ -100,6 +100,24 @@ public class RangeColocateTableTest {
     }
 
     @Test
+    public void testHasColocateGroupMatchesIndexForRange() throws Exception {
+        String sql = "create table t_colocate_range_prop (k1 int, k2 int, v1 int)\n" +
+                "order by(k1, k2)\n" +
+                "properties('replication_num' = '1', 'colocate_with' = 'rg_prop:k1');";
+        starRocksAssert.withTable(sql);
+
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "t_colocate_range_prop");
+        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+
+        // A range-colocate table joins table2Group and gets its group property set on the same
+        // addTableToGroup path as hash-colocate, so hasColocateGroup() stays equivalent to
+        // isColocateTable() for the range case too.
+        Assertions.assertTrue(table.hasColocateGroup());
+        Assertions.assertEquals(colocateTableIndex.isColocateTable(table.getId()), table.hasColocateGroup());
+    }
+
+    @Test
     public void testSecondTableJoinsExistingRangeColocateGroup() throws Exception {
         String sql1 = "create table t_colocate_join1 (k1 int, k2 int, v1 int)\n" +
                 "order by(k1, k2)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableTest.java
@@ -141,6 +141,57 @@ public class ColocateTableTest {
         Assertions.assertEquals(1, groupSchema.getReplicationNum());
     }
 
+    // OlapTable.hasColocateGroup() must stay equivalent to ColocateTableIndex.isColocateTable(id) for a
+    // live table across create / ALTER-set / ALTER-unset, since callers replace the index boolean with the
+    // property read.
+    @Test
+    public void testHasColocateGroupMatchesIndex() throws Exception {
+        ColocateTableIndex index = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(fullDbName);
+
+        // A freshly created colocate table: property and index agree (both true).
+        createTable("create table " + dbName + "." + tableName1 + " (\n" +
+                " `k1` int NULL,\n" +
+                " `k2` varchar(10) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\", \"colocate_with\" = \"" + groupName + "\");");
+        OlapTable colocateTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName1);
+        Assertions.assertTrue(colocateTable.hasColocateGroup());
+        Assertions.assertEquals(index.isColocateTable(colocateTable.getId()), colocateTable.hasColocateGroup());
+
+        // A non-colocate table: property and index agree (both false).
+        createTable("create table " + dbName + "." + tableName2 + " (\n" +
+                " `k1` int NULL,\n" +
+                " `k2` varchar(10) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+        OlapTable plainTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName2);
+        Assertions.assertFalse(plainTable.hasColocateGroup());
+        Assertions.assertEquals(index.isColocateTable(plainTable.getId()), plainTable.hasColocateGroup());
+
+        // ALTER SET colocate_with joins the group: property and index flip to true together.
+        starRocksAssert.alterTableProperties("alter table " + dbName + "." + tableName2
+                + " set (\"colocate_with\" = \"" + groupName + "\")");
+        plainTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName2);
+        Assertions.assertTrue(plainTable.hasColocateGroup());
+        Assertions.assertEquals(index.isColocateTable(plainTable.getId()), plainTable.hasColocateGroup());
+
+        // ALTER SET colocate_with = "" leaves the group: property and index flip to false together.
+        starRocksAssert.alterTableProperties("alter table " + dbName + "." + tableName1
+                + " set (\"colocate_with\" = \"\")");
+        colocateTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName1);
+        Assertions.assertFalse(colocateTable.hasColocateGroup());
+        Assertions.assertEquals(index.isColocateTable(colocateTable.getId()), colocateTable.hasColocateGroup());
+    }
+
     @Test
     public void testCreateTwoTableWithSameGroup() throws Exception {
         createTable("create table " + dbName + "." + tableName1 + " (\n" +


### PR DESCRIPTION
## Why I'm doing:

Outside the colocate module, several ALTER-time guards answered "is this a colocate table?" by calling the global singleton `GlobalStateMgr.getCurrentState().getColocateTableIndex().isColocateTable(tableId)`. That takes the `ColocateTableIndex` read lock and makes `alter`/`server` code depend on the colocate singleton just to read a boolean.

`OlapTable` already persists the `colocateGroup` field. For a real catalog table the group name and the index's `table2Group` membership are maintained together — set on create / ALTER-set (`addTableToGroup` + `setColocateGroup`) and cleared on ALTER-unset (`removeTable` + `setColocateGroup(null)`), for both hash and range colocate. So at these guards a lock-free `!Strings.isNullOrEmpty(colocateGroup)` read is equivalent to `isColocateTable(getId())`, without the global read lock or the cross-module dependency.

## What I'm doing:

Add `OlapTable.hasColocateGroup()` and use it at the six ALTER-time colocate guards that hold the table write lock on the real catalog object:

- `AlterJobExecutor` — modify-partition replication-num guard
- `LocalMetastore#modifyTableReplicationNum` / `modifyTableDefaultReplicationNum`
- `SchemaChangeHandler` — modify-distribution-column guard
- `MaterializedViewHandler#isRangeRollupRoutable` and `SchemaChangeHandler#needsRangeRewriteSchemaChange` (shared-data range rollup/rewrite routing predicates)

Scope is deliberately limited to fail-closed ALTER guards on the real catalog object. The following intentionally keep using `ColocateTableIndex` and are **not** touched:

- **Query planning** (`PlanFragmentBuilder`): planning runs on `OlapTable.copyOnlyForQuery()` snapshots, which do not carry `colocateGroup`, so the property would be wrong there.
- **Tablet-report recovery** (`ReportHandler`): a lock-free report-traversal read where the index's synchronized snapshot is preferable.
- **tableId-only sites** (`HashDistributionSpec`, `DistributionSpecHelper`, `BestMvSelector`) and sites that immediately need the `GroupId`/stability/range/bucket-seq/schema (`TabletScheduler`, `RestoreJob`, `LocalMetastore` colocation/tablet-creation, `ColocateTableBalancer`).

The property equals the index for every validly-created table. In the only corner where they can differ — a crash between the `OP_CREATE_TABLE` and `OP_COLOCATE_ADD_TABLE_V2` journal records replays a table with the property set but no index membership — these fail-closed guards simply become more conservative (they reject replication/distribution/reshard changes on a table that declares `colocate_with`), which is the safe direction.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
