### PR TITLE
[Enhancement] Support complex type for paimon table (backport #66784)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -15,15 +15,14 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.connector.paimon.PaimonUtils;
 import com.starrocks.planner.PaimonScanNode;
-import com.starrocks.thrift.TIcebergSchema;
-import com.starrocks.thrift.TIcebergSchemaField;
 import com.starrocks.thrift.TPaimonTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
-import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.table.DataTable;
 import org.apache.paimon.types.DataField;
 
@@ -41,6 +40,7 @@ public class PaimonTable extends Table {
     private String databaseName;
     private String tableName;
     private org.apache.paimon.table.Table paimonNativeTable;
+    private String uuid;
     private List<String> partColumnNames;
     private List<String> paimonFieldNames;
     private Map<String, String> properties;
@@ -88,11 +88,10 @@ public class PaimonTable extends Table {
 
     @Override
     public String getUUID() {
-        if (!new Identifier(databaseName, tableName).isSystemTable()) {
-            return String.join(".", catalogName,  paimonNativeTable.uuid());
-        } else {
-            return String.join(".", catalogName, databaseName, tableName, paimonNativeTable.uuid());
+        if (Strings.isNullOrEmpty(this.uuid)) {
+            this.uuid = String.join(".", catalogName, databaseName, tableName, paimonNativeTable.uuid().replace(".", "_"));
         }
+        return this.uuid;
     }
 
     @Override
@@ -153,27 +152,12 @@ public class PaimonTable extends Table {
         tPaimonTable.setPaimon_native_table(encodedTable);
         tPaimonTable.setTime_zone(TimeUtils.getSessionTimeZone());
 
-        // reuse TIcebergSchema directly for compatibility.
-        TIcebergSchema tPaimonSchema = new TIcebergSchema();
-        List<DataField> paimonFields = paimonNativeTable.rowType().getFields();
-        List<TIcebergSchemaField> tIcebergFields = new ArrayList<>(paimonFields.size());
-        for (DataField field : paimonFields) {
-            tIcebergFields.add(getTIcebergSchemaField(field));
-        }
-        tPaimonSchema.setFields(tIcebergFields);
-        tPaimonTable.setPaimon_schema(tPaimonSchema);
+        tPaimonTable.setPaimon_schema(PaimonUtils.getTPaimonSchema(this.paimonNativeTable.rowType()));
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.PAIMON_TABLE,
                 fullSchema.size(), 0, tableName, databaseName);
         tTableDescriptor.setPaimonTable(tPaimonTable);
         return tTableDescriptor;
-    }
-
-    private TIcebergSchemaField getTIcebergSchemaField(DataField field) {
-        TIcebergSchemaField tPaimonSchemaField = new TIcebergSchemaField();
-        tPaimonSchemaField.setField_id(field.id());
-        tPaimonSchemaField.setName(field.name());
-        return tPaimonSchemaField;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonUtils.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.paimon;
+
+import com.starrocks.thrift.TIcebergSchema;
+import com.starrocks.thrift.TIcebergSchemaField;
+import org.apache.paimon.format.parquet.ParquetSchemaConverter;
+import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PaimonUtils {
+
+    public static TIcebergSchema getTPaimonSchema(RowType rowType) {
+        // reuse TIcebergSchema directly for compatibility.
+        TIcebergSchema tPaimonSchema = new TIcebergSchema();
+        List<DataField> paimonFields = rowType.getFields();
+        List<TIcebergSchemaField> tIcebergFields = new ArrayList<>(paimonFields.size());
+        for (DataField field : paimonFields) {
+            tIcebergFields.add(getTPaimonSchemaField(field.name(), field.type(), field.id(), 0, -1));
+        }
+        tPaimonSchema.setFields(tIcebergFields);
+        return tPaimonSchema;
+    }
+
+    public static TIcebergSchemaField getTPaimonSchemaField(String name, DataType type, int fieldId, int depth, int parentId) {
+        TIcebergSchemaField tPaimonSchemaField = new TIcebergSchemaField();
+        if (parentId != -1) {
+            tPaimonSchemaField.setField_id(parentId);
+        } else {
+            tPaimonSchemaField.setField_id(fieldId);
+        }
+        tPaimonSchemaField.setName(name);
+        if (type.getTypeRoot() == DataTypeRoot.MAP) {
+            org.apache.paimon.types.MapType mapType = (MapType) type;
+            DataType keyType = mapType.getKeyType();
+            DataType valueType = mapType.getValueType();
+            int mapKeyFieldId = SpecialFields.getMapKeyFieldId(fieldId, depth + 1);
+            int mapValueFieldId = SpecialFields.getMapValueFieldId(fieldId, depth + 1);
+            List<TIcebergSchemaField> children = new ArrayList<>(2);
+            children.add(getTPaimonSchemaField(ParquetSchemaConverter.MAP_KEY_NAME, keyType, fieldId, depth + 1, mapKeyFieldId));
+            children.add(getTPaimonSchemaField(ParquetSchemaConverter.MAP_VALUE_NAME, valueType, fieldId,
+                    depth + 1, mapValueFieldId));
+            tPaimonSchemaField.setChildren(children);
+        }
+        if (type.getTypeRoot() == DataTypeRoot.ARRAY) {
+            org.apache.paimon.types.ArrayType arrayType = (ArrayType) type;
+            DataType elementType = arrayType.getElementType();
+            int elementId = SpecialFields.getArrayElementFieldId(fieldId, depth + 1);
+            List<TIcebergSchemaField> children = new ArrayList<>(1);
+            children.add(getTPaimonSchemaField(ParquetSchemaConverter.LIST_ELEMENT_NAME, elementType, fieldId,
+                    depth + 1, elementId));
+            tPaimonSchemaField.setChildren(children);
+        }
+        // the parent id of row type is always -1, refer to: org.apache.paimon.format.parquet.ParquetSchemaConverter
+        if (type.getTypeRoot() == DataTypeRoot.ROW) {
+            RowType rowType = (RowType) type;
+            List<DataField> childrenFields = rowType.getFields();
+            List<TIcebergSchemaField> children = new ArrayList<>(rowType.getFieldCount());
+            for (DataField childrenField : childrenFields) {
+                children.add(getTPaimonSchemaField(childrenField.name(), childrenField.type(), childrenField.id(),
+                        depth + 1, -1));
+            }
+            tPaimonSchemaField.setChildren(children);
+        }
+        return tPaimonSchemaField;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -112,6 +112,12 @@ public class PaimonTableTest {
     public void testEquals(@Mocked FileStoreTable paimonNativeTable) {
         String dbName = "testDB";
         String tableName = "testTable";
+        new Expectations() {
+            {
+                paimonNativeTable.uuid();
+                result = "fake_uuid";
+            }
+        };
         PaimonTable table = new PaimonTable("testCatalog", dbName, tableName, null, paimonNativeTable);
         PaimonTable table2 = new PaimonTable("testCatalog", dbName, tableName, null, paimonNativeTable);
         org.junit.jupiter.api.Assertions.assertEquals(table, table2);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -160,13 +160,13 @@ public class PaimonMetadataTest {
         writer.writeInt(1, 5555);
         writer.complete();
         List<DataFileMeta> meta1 = new ArrayList<>();
-        meta1.add(DataFileMeta.create("file1", 100L, 200L, EMPTY_MIN_KEY, EMPTY_MAX_KEY, 
+        meta1.add(DataFileMeta.create("file1", 100L, 200L, EMPTY_MIN_KEY, EMPTY_MAX_KEY,
                 EMPTY_STATS, EMPTY_STATS, 100L, 200L, 1L, DUMMY_LEVEL, 0L, null, null, null, null, null));
-        meta1.add(DataFileMeta.create("file2", 100L, 300L, EMPTY_MIN_KEY, EMPTY_MAX_KEY, 
+        meta1.add(DataFileMeta.create("file2", 100L, 300L, EMPTY_MIN_KEY, EMPTY_MAX_KEY,
                 EMPTY_STATS, EMPTY_STATS, 100L, 300L, 1L, DUMMY_LEVEL, 0L, null, null, null, null, null));
 
         List<DataFileMeta> meta2 = new ArrayList<>();
-        meta2.add(DataFileMeta.create("file3", 100L, 400L, EMPTY_MIN_KEY, EMPTY_MAX_KEY, 
+        meta2.add(DataFileMeta.create("file3", 100L, 400L, EMPTY_MIN_KEY, EMPTY_MAX_KEY,
                 EMPTY_STATS, EMPTY_STATS, 100L, 400L, 1L, DUMMY_LEVEL, 0L, null, null, null, null, null));
         this.splits.add(DataSplit.builder().withSnapshot(1L).withPartition(row1).withBucket(1)
                 .withBucketPath("not used").withDataFiles(meta1).isStreaming(false).build());
@@ -201,6 +201,8 @@ public class PaimonMetadataTest {
                 result = "hdfs://127.0.0.1:10000/paimon";
                 paimonNativeTable.primaryKeys();
                 result = List.of("col2");
+                paimonNativeTable.uuid();
+                result = "fake_uuid";
             }
         };
         com.starrocks.catalog.Table table = metadata.getTable(connectContext, "db1", "tbl1");
@@ -222,7 +224,7 @@ public class PaimonMetadataTest {
         assertEquals(ScalarType.DOUBLE, paimonTable.getBaseSchema().get(1).getType());
         org.junit.jupiter.api.Assertions.assertTrue(paimonTable.getBaseSchema().get(1).isAllowNull());
         assertEquals("paimon_catalog", paimonTable.getCatalogName());
-        assertEquals("paimon_catalog.null", paimonTable.getUUID());
+        assertEquals("paimon_catalog.db1.tbl1.fake_uuid", paimonTable.getUUID());
 
         // Verify DESC shows primary key
         ExternalSchemaProcNode descNode = new ExternalSchemaProcNode(paimonTable);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonUtilsTest.java
@@ -1,0 +1,233 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.paimon;
+
+import com.starrocks.thrift.TIcebergSchema;
+import com.starrocks.thrift.TIcebergSchemaField;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class PaimonUtilsTest {
+
+    @Test
+    public void testGetTPaimonSchemaWithSimpleTypes() {
+        // Create a simple schema with basic types
+        Schema.Builder builder = new Schema.Builder();
+        builder.column("id", new IntType());
+        builder.column("name", new VarCharType(255));
+        builder.column("score", new DoubleType());
+        Schema paimonSchema = builder.build();
+
+        RowType rowType = paimonSchema.rowType();
+        TIcebergSchema schema = PaimonUtils.getTPaimonSchema(rowType);
+
+        Assertions.assertNotNull(schema);
+        Assertions.assertEquals(3, schema.getFields().size());
+
+        // Verify field details
+        TIcebergSchemaField idField = schema.getFields().get(0);
+        Assertions.assertEquals(0, idField.getField_id());
+        Assertions.assertEquals("id", idField.getName());
+
+        TIcebergSchemaField nameField = schema.getFields().get(1);
+        Assertions.assertEquals(1, nameField.getField_id());
+        Assertions.assertEquals("name", nameField.getName());
+
+        TIcebergSchemaField scoreField = schema.getFields().get(2);
+        Assertions.assertEquals(2, scoreField.getField_id());
+        Assertions.assertEquals("score", scoreField.getName());
+    }
+
+    @Test
+    public void testGetTPaimonSchemaWithMapType() {
+        // Create a schema with a map type
+        Schema.Builder builder = new Schema.Builder();
+        builder.column("id", new IntType());
+        builder.column("tags", new MapType(new VarCharType(50), new IntType()));
+        Schema paimonSchema = builder.build();
+
+        RowType rowType = paimonSchema.rowType();
+        TIcebergSchema schema = PaimonUtils.getTPaimonSchema(rowType);
+
+        Assertions.assertNotNull(schema);
+        Assertions.assertEquals(2, schema.getFields().size());
+
+        TIcebergSchemaField idField = schema.getFields().get(0);
+        Assertions.assertEquals(0, idField.getField_id());
+        Assertions.assertEquals("id", idField.getName());
+
+        // Verify map field and its children
+        TIcebergSchemaField mapField = schema.getFields().get(1);
+        Assertions.assertEquals(1, mapField.getField_id());
+        Assertions.assertEquals("tags", mapField.getName());
+        Assertions.assertNotNull(mapField.getChildren());
+        Assertions.assertEquals(2, mapField.getChildren().size());
+
+        // Verify map key and value fields
+        TIcebergSchemaField keyField = mapField.getChildren().get(0);
+        Assertions.assertEquals("key", keyField.getName());
+        Assertions.assertEquals(536869886, keyField.getField_id());
+
+        TIcebergSchemaField valueField = mapField.getChildren().get(1);
+        Assertions.assertEquals("value", valueField.getName());
+        Assertions.assertEquals(536871936, valueField.getField_id());
+    }
+
+    @Test
+    public void testGetTPaimonSchemaWithArrayType() {
+        // Create a schema with an array type
+        Schema.Builder builder = new Schema.Builder();
+        builder.column("id", new IntType());
+        builder.column("properties", new ArrayType(new VarCharType(100)));
+        Schema paimonSchema = builder.build();
+
+        RowType rowType = paimonSchema.rowType();
+        TIcebergSchema schema = PaimonUtils.getTPaimonSchema(rowType);
+
+        Assertions.assertNotNull(schema);
+        Assertions.assertEquals(2, schema.getFields().size());
+
+        TIcebergSchemaField idField = schema.getFields().get(0);
+        Assertions.assertEquals(0, idField.getField_id());
+        Assertions.assertEquals("id", idField.getName());
+
+        // Verify array field and its children
+        TIcebergSchemaField arrayField = schema.getFields().get(1);
+        Assertions.assertEquals(1, arrayField.getField_id());
+        Assertions.assertEquals("properties", arrayField.getName());
+        Assertions.assertNotNull(arrayField.getChildren());
+        Assertions.assertEquals(1, arrayField.getChildren().size());
+
+        // Verify array element field
+        TIcebergSchemaField elementField = arrayField.getChildren().get(0);
+        Assertions.assertEquals("element", elementField.getName());
+        Assertions.assertEquals(536871936, elementField.getField_id());
+    }
+
+    @Test
+    public void testGetTPaimonSchemaWithNestedStruct1() {
+        // Create a schema with a nested struct
+        Schema.Builder builder = new Schema.Builder();
+        builder.column("id", new IntType());
+
+        Schema.Builder innerBuilder = new Schema.Builder();
+        innerBuilder.column("name", new VarCharType(255));
+        innerBuilder.column("age", new IntType());
+
+        builder.column("ex", new ArrayType(new MapType(new IntType(),
+                new ArrayType(new RowType(innerBuilder.build().fields())))));
+        Schema paimonSchema = builder.build();
+
+        RowType rowType = paimonSchema.rowType();
+        TIcebergSchema schema = PaimonUtils.getTPaimonSchema(rowType);
+
+        Assertions.assertNotNull(schema);
+        Assertions.assertEquals(2, schema.getFields().size());
+
+        // Verify field details
+        TIcebergSchemaField idField = schema.getFields().get(0);
+        Assertions.assertEquals(0, idField.getField_id());
+        Assertions.assertEquals("id", idField.getName());
+
+        // Verify struct field and its children
+        TIcebergSchemaField outerArrayField = schema.getFields().get(1);
+        Assertions.assertEquals(1, outerArrayField.getField_id());
+        Assertions.assertEquals("ex", outerArrayField.getName());
+        Assertions.assertNotNull(outerArrayField.getChildren());
+        Assertions.assertEquals(1, outerArrayField.getChildren().size());
+
+        // Verify nested fields
+        TIcebergSchemaField mapField = outerArrayField.getChildren().get(0);
+        Assertions.assertEquals(536871936, mapField.getField_id());
+        Assertions.assertEquals("element", mapField.getName());
+        Assertions.assertNotNull(mapField.getChildren());
+        Assertions.assertEquals(2, mapField.getChildren().size());
+
+        // Verify map key and value fields
+        TIcebergSchemaField mapKeyField = mapField.getChildren().get(0);
+        Assertions.assertEquals(536869885, mapKeyField.getField_id());
+        Assertions.assertEquals("key", mapKeyField.getName());
+
+        TIcebergSchemaField mapValueField = mapField.getChildren().get(1);
+        Assertions.assertEquals(536871937, mapValueField.getField_id());
+        Assertions.assertEquals("value", mapValueField.getName());
+        Assertions.assertNotNull(mapValueField.getChildren());
+        Assertions.assertEquals(1, mapValueField.getChildren().size());
+
+        TIcebergSchemaField rowTypeField = mapValueField.getChildren().get(0);
+        Assertions.assertEquals(536871938, rowTypeField.getField_id());
+        Assertions.assertEquals("element", rowTypeField.getName());
+        Assertions.assertNotNull(rowTypeField.getChildren());
+        Assertions.assertEquals(2, rowTypeField.getChildren().size());
+
+        TIcebergSchemaField nameField = rowTypeField.getChildren().get(0);
+        Assertions.assertEquals(2, nameField.getField_id());
+        Assertions.assertEquals("name", nameField.getName());
+        TIcebergSchemaField ageField = rowTypeField.getChildren().get(1);
+        Assertions.assertEquals(3, ageField.getField_id());
+        Assertions.assertEquals("age", ageField.getName());
+    }
+
+    @Test
+    public void testGetTPaimonSchemaWithNestedStruct2() {
+        // Create a schema with a nested struct
+        Schema.Builder builder = new Schema.Builder();
+        builder.column("ex", new ArrayType(new MapType(new IntType(), new ArrayType(new IntType()))));
+        Schema paimonSchema = builder.build();
+
+        RowType rowType = paimonSchema.rowType();
+        TIcebergSchema schema = PaimonUtils.getTPaimonSchema(rowType);
+
+        Assertions.assertNotNull(schema);
+        Assertions.assertEquals(1, schema.getFields().size());
+
+        // Verify struct field and its children
+        TIcebergSchemaField outerArrayField = schema.getFields().get(0);
+        Assertions.assertEquals(0, outerArrayField.getField_id());
+        Assertions.assertEquals("ex", outerArrayField.getName());
+        Assertions.assertNotNull(outerArrayField.getChildren());
+        Assertions.assertEquals(1, outerArrayField.getChildren().size());
+
+        // Verify nested fields
+        TIcebergSchemaField mapField = outerArrayField.getChildren().get(0);
+        Assertions.assertEquals(536870912, mapField.getField_id());
+        Assertions.assertEquals("element", mapField.getName());
+        Assertions.assertNotNull(mapField.getChildren());
+        Assertions.assertEquals(2, mapField.getChildren().size());
+
+        // Verify map key and value fields
+        TIcebergSchemaField mapKeyField = mapField.getChildren().get(0);
+        Assertions.assertEquals(536870909, mapKeyField.getField_id());
+        Assertions.assertEquals("key", mapKeyField.getName());
+
+        TIcebergSchemaField mapValueField = mapField.getChildren().get(1);
+        Assertions.assertEquals(536870913, mapValueField.getField_id());
+        Assertions.assertEquals("value", mapValueField.getName());
+        Assertions.assertNotNull(mapValueField.getChildren());
+        Assertions.assertEquals(1, mapValueField.getChildren().size());
+
+        TIcebergSchemaField innerArrayField = mapValueField.getChildren().get(0);
+        Assertions.assertEquals(536870914, innerArrayField.getField_id());
+        Assertions.assertEquals("element", innerArrayField.getName());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Support complex type for paimon table

## What I'm doing:

Without this PR, querying Paimon complex types may result in the following core dump：
```
*** Aborted at 1750398852 (unix time) try "date -d @1750398852" if you are using GNU date ***
PC: @          0x72eef74 starrocks::parquet::LakeMetaHelper::_is_valid_type(starrocks::parquet::ParquetField const*, starrocks::TIcebergSchemaField const*, starrocks::TypeDescriptor const*) const
*** SIGSEGV (@0x30) received by PID 8 (TID 0x7f2edadfc700) from PID 48; stack trace: ***
    @     0x7f302b40620b __pthread_once_slow
    @          0x7efc4a0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f302f148c65 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f302f14dc61 JVM_handle_linux_signal
    @     0x7f302f140bd8 signalHandler(int, siginfo_t*, void*)
    @     0x7f302b40f630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0x72eef74 starrocks::parquet::LakeMetaHelper::_is_valid_type(starrocks::parquet::ParquetField const*, starrocks::TIcebergSchemaField const*, starrocks::TypeDescriptor const*) const
    @          0x72eef7d starrocks::parquet::LakeMetaHelper::_is_valid_type(starrocks::parquet::ParquetField const*, starrocks::TIcebergSchemaField const*, starrocks::TypeDescriptor const*) const
    @          0x72ef2d6 starrocks::parquet::LakeMetaHelper::prepare_read_columns(std::vector<starrocks::HdfsScannerContext::ColumnInfo, std::allocator<starrocks::HdfsScannerContext::ColumnInfo> > const&, std::vector<starrocks::parquet::GroupReaderParam::Column, std::allocator<sta�Y�
    @          0x72c0f5b starrocks::parquet::FileReader::init(starrocks::HdfsScannerContext*)
    @          0x70ec6ae starrocks::HdfsParquetScanner::do_open(starrocks::RuntimeState*)
    @          0x70ddf10 starrocks::HdfsScanner::open(starrocks::RuntimeState*)
    @          0x706ab88 starrocks::connector::HiveDataSource::_init_scanner(starrocks::RuntimeState*)
    @          0x706b71c starrocks::connector::HiveDataSource::open(starrocks::RuntimeState*)
    @          0x4590364 starrocks::pipeline::ConnectorChunkSource::_open_data_source(starrocks::RuntimeState*, bool*)
    @          0x4590ad9 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0x48aa858 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x457fb2d auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone .constprop.0]
    @          0x467a6eb starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x3aa1bf3 starrocks::ThreadPool::dispatch_thread()
```

https://github.com/StarRocks/starrocks/pull/66784

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


---

> [!NOTE]
> Adds robust schema serialization for Paimon tables and aligns UUID formatting.
> 
> - Introduces `PaimonUtils` with `getTPaimonSchema` to convert Paimon `RowType` (including nested `MAP`/`ARRAY`/`ROW`) into `TIcebergSchema` using `SpecialFields` and Parquet naming
> - Updates `PaimonTable.toThrift` to use `PaimonUtils` and removes the prior inline schema field builder
> - Revises `PaimonTable.getUUID` to cache and return `catalog.database.table.<native_uuid>` (replacing `.` with `_`)
> - Adjusts `PaimonMetadataTest` expectations and adds `PaimonUtilsTest` covering simple, map, array, and deeply nested types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7f6181b6c3c5901dd2f06ee24881acc371415b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
