### PR TITLE
[DO NOT MERGE] Build-validate #76094 rebase onto main

### DIFF
--- a/be/src/compute_env/load_spill/load_chunk_spiller.cpp
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.cpp
@@ -204,8 +204,9 @@ Status LoadChunkSpiller::_do_spill(const Chunk& chunk, const spill::SpillOutputD
 
 class BlockGroupIterator : public ChunkIterator {
 public:
-    BlockGroupIterator(Schema schema, spill::Serde& serde, const std::vector<spill::BlockPtr>& blocks)
-            : ChunkIterator(std::move(schema)), _serde(serde), _blocks(blocks) {
+    BlockGroupIterator(Schema schema, spill::Serde& serde, const std::vector<spill::BlockPtr>& blocks,
+                       int64_t slot_idx = -1)
+            : ChunkIterator(std::move(schema)), _serde(serde), _blocks(blocks), _slot_idx(slot_idx) {
         auto& metrics = _serde.parent()->metrics();
         _options.read_io_timer = metrics.read_io_timer;
         _options.read_io_count = metrics.read_io_count;
@@ -244,6 +245,29 @@ public:
         return Status::EndOfFile("End of block group");
     }
 
+    // Like do_get_next(chunk), but also emits a per-row ordering key into `rssid_rowids`.
+    // For separate-sort-key PK tables the spill merge orders output by the sort key, so the
+    // primary keys reach the SST writer out of primary-key order and duplicate PKs within a
+    // load can no longer be collapsed by the merge. To let the downstream unsort SST writer
+    // pick the correct winner (last-flushed row wins), we encode the source flush order into
+    // each row: high 32 bits = slot_idx (memtable flush sequence), low 32 bits = a running
+    // rowid within this block group. Only the slot_idx half participates in the tie-break;
+    // within a single slot the memtable already deduped, so no duplicate PK shares a slot.
+    // NOTE: this reuses the `rssid_rowids` channel whose high bits normally carry a real rssid
+    // in compaction; here there is no source rssid, so we repurpose it to carry slot_idx.
+    Status do_get_next(Chunk* chunk, std::vector<uint64_t>* rssid_rowids) override {
+        RETURN_IF_ERROR(do_get_next(chunk));
+        if (rssid_rowids != nullptr) {
+            const size_t num_rows = chunk->num_rows();
+            rssid_rowids->reserve(rssid_rowids->size() + num_rows);
+            const uint64_t slot_hi = static_cast<uint64_t>(_slot_idx) << 32;
+            for (size_t i = 0; i < num_rows; i++) {
+                rssid_rowids->push_back(slot_hi | (_rowid++));
+            }
+        }
+        return Status::OK();
+    }
+
     void close() override {}
 
 private:
@@ -253,6 +277,9 @@ private:
     std::shared_ptr<spill::BlockReader> _reader;
     const std::vector<spill::BlockPtr>& _blocks;
     size_t _block_idx = 0;
+    int64_t _slot_idx = -1;
+    // Running rowid across all blocks in this group, used to build the low 32 bits of rssid_rowid.
+    uint32_t _rowid = 0;
 };
 
 size_t LoadChunkSpiller::total_bytes() const {
@@ -261,7 +288,8 @@ size_t LoadChunkSpiller::total_bytes() const {
 
 StatusOr<SpillBlockInputTasks> LoadChunkSpiller::generate_spill_block_input_tasks(size_t target_size,
                                                                                   size_t memory_usage_per_merge,
-                                                                                  bool do_sort, bool do_agg) {
+                                                                                  bool do_sort, bool do_agg,
+                                                                                  bool need_rssid_rowids) {
     SpillBlockInputTasks result;
     auto& groups = _block_manager->block_container()->block_groups();
     RETURN_IF(groups.empty(), result);
@@ -275,8 +303,8 @@ StatusOr<SpillBlockInputTasks> LoadChunkSpiller::generate_spill_block_input_task
     std::sort(groups.begin(), groups.end(),
               [](const BlockGroupPtrWithSlot& a, const BlockGroupPtrWithSlot& b) { return a.slot_idx < b.slot_idx; });
     for (auto& group : groups) {
-        merge_inputs.push_back(
-                std::make_shared<BlockGroupIterator>(*_schema, *_spiller->serde(), group.block_group->blocks()));
+        merge_inputs.push_back(std::make_shared<BlockGroupIterator>(*_schema, *_spiller->serde(),
+                                                                    group.block_group->blocks(), group.slot_idx));
         current_input_bytes += group.block_group->data_size();
         result.total_block_bytes += group.block_group->data_size();
         result.total_blocks += group.block_group->blocks().size();
@@ -288,7 +316,8 @@ StatusOr<SpillBlockInputTasks> LoadChunkSpiller::generate_spill_block_input_task
         if (merge_inputs.size() > 0 &&
             (current_input_bytes >= target_size ||
              merge_inputs.size() * config::load_spill_max_chunk_bytes >= memory_usage_per_merge)) {
-            auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+            auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs, need_rssid_rowids)
+                                   : new_union_iterator(merge_inputs);
             auto merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
             RETURN_IF_ERROR(merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
             result.iterators.push_back(merge_itr);
@@ -297,7 +326,8 @@ StatusOr<SpillBlockInputTasks> LoadChunkSpiller::generate_spill_block_input_task
         }
     }
     if (!merge_inputs.empty()) {
-        auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+        auto tmp_itr =
+                do_sort ? new_heap_merge_iterator(merge_inputs, need_rssid_rowids) : new_union_iterator(merge_inputs);
         auto merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
         RETURN_IF_ERROR(merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
         result.iterators.push_back(merge_itr);
@@ -313,7 +343,8 @@ StatusOr<SpillBlockInputTasks> LoadChunkSpiller::generate_spill_block_input_task
 }
 
 Status LoadChunkSpiller::merge_write(size_t target_size, size_t memory_usage_per_merge, bool do_sort, bool do_agg,
-                                     std::function<Status(Chunk*)> write_func, std::function<Status()> flush_func) {
+                                     std::function<Status(Chunk*)> write_func, std::function<Status()> flush_func,
+                                     bool need_rssid_rowids) {
     auto& groups = _block_manager->block_container()->block_groups();
     RETURN_IF(groups.empty(), Status::OK());
 
@@ -344,8 +375,9 @@ Status LoadChunkSpiller::merge_write(size_t target_size, size_t memory_usage_per
         merge_itr->close();
         return flush_func();
     };
-    ASSIGN_OR_RETURN(auto spill_block_iterator_tasks,
-                     generate_spill_block_input_tasks(target_size, memory_usage_per_merge, do_sort, do_agg));
+    ASSIGN_OR_RETURN(
+            auto spill_block_iterator_tasks,
+            generate_spill_block_input_tasks(target_size, memory_usage_per_merge, do_sort, do_agg, need_rssid_rowids));
     for (const auto& itr : spill_block_iterator_tasks.iterators) {
         RETURN_IF_ERROR(merge_func(itr));
     }
@@ -394,7 +426,8 @@ bool LoadChunkSpiller::empty() {
 StatusOr<LoadSpillMergeInputBatch> LoadChunkSpiller::generate_merge_input_batch(size_t target_size,
                                                                                 size_t memory_usage_per_merge,
                                                                                 bool do_sort, bool do_agg,
-                                                                                bool final_round) {
+                                                                                bool final_round,
+                                                                                bool need_rssid_rowids) {
     LoadSpillMergeInputBatch result_batch;
 
     // THREAD SAFETY: Lock held for entire operation because we're both reading and modifying
@@ -439,8 +472,8 @@ StatusOr<LoadSpillMergeInputBatch> LoadChunkSpiller::generate_merge_input_batch(
         last_slot_idx = group.slot_idx;
 
         // Create iterator for this block group's data
-        merge_inputs.push_back(
-                std::make_shared<BlockGroupIterator>(*_schema, *_spiller->serde(), group.block_group->blocks()));
+        merge_inputs.push_back(std::make_shared<BlockGroupIterator>(*_schema, *_spiller->serde(),
+                                                                    group.block_group->blocks(), group.slot_idx));
         current_input_bytes += group.block_group->data_size();
         result_batch.total_block_bytes += group.block_group->data_size();
         result_batch.total_block_groups++;
@@ -458,7 +491,8 @@ StatusOr<LoadSpillMergeInputBatch> LoadChunkSpiller::generate_merge_input_batch(
             (current_input_bytes >= target_size ||
              merge_inputs.size() * config::load_spill_max_chunk_bytes >= memory_usage_per_merge)) {
             // Build the merge iterator chain based on table type requirements
-            auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+            auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs, need_rssid_rowids)
+                                   : new_union_iterator(merge_inputs);
             result_batch.merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
             RETURN_IF_ERROR(result_batch.merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
             merge_inputs.clear();
@@ -471,7 +505,8 @@ StatusOr<LoadSpillMergeInputBatch> LoadChunkSpiller::generate_merge_input_batch(
     // they don't reach target_size. This ensures no orphaned blocks are left behind.
     // Non-final rounds can leave partial batches for next iteration.
     if (final_round && merge_inputs.size() > 0) {
-        auto tmp_itr = do_sort ? new_heap_merge_iterator(merge_inputs) : new_union_iterator(merge_inputs);
+        auto tmp_itr =
+                do_sort ? new_heap_merge_iterator(merge_inputs, need_rssid_rowids) : new_union_iterator(merge_inputs);
         result_batch.merge_itr = do_agg ? new_aggregate_iterator(tmp_itr) : tmp_itr;
         RETURN_IF_ERROR(result_batch.merge_itr->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
         merge_inputs.clear();

--- a/be/src/compute_env/load_spill/load_chunk_spiller.h
+++ b/be/src/compute_env/load_spill/load_chunk_spiller.h
@@ -95,13 +95,16 @@ public:
     // `target_size` controls the maximum amount of data merged per operation,
     // while `memory_usage_per_merge` controls the peak memory usage of each merge.
     Status merge_write(size_t target_size, size_t memory_usage_per_merge, bool do_sort, bool do_agg,
-                       std::function<Status(Chunk*)> write_func, std::function<Status()> flush_func);
+                       std::function<Status(Chunk*)> write_func, std::function<Status()> flush_func,
+                       bool need_rssid_rowids = false);
 
     StatusOr<SpillBlockInputTasks> generate_spill_block_input_tasks(size_t target_size, size_t memory_usage_per_merge,
-                                                                    bool do_sort, bool do_agg);
+                                                                    bool do_sort, bool do_agg,
+                                                                    bool need_rssid_rowids = false);
 
     StatusOr<LoadSpillMergeInputBatch> generate_merge_input_batch(size_t target_size, size_t memory_usage_per_merge,
-                                                                  bool do_sort, bool do_agg, bool final_round);
+                                                                  bool do_sort, bool do_agg, bool final_round,
+                                                                  bool need_rssid_rowids = false);
 
     bool empty();
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,6 +197,7 @@ set(STORAGE_FILES
     lake/general_tablet_writer.cpp
     lake/pk_tablet_writer.cpp
     lake/pk_tablet_sst_writer.cpp
+    lake/pk_tablet_unsort_sst_writer.cpp
     lake/primary_key_compaction_policy.cpp
     lake/tablet_reshard_helper.cpp
     lake/tablet_splitter.cpp

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -37,6 +37,7 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_env.h"
 #include "storage/chunk_helper.h"
+#include "storage/del_vector.h"
 #include "storage/delta_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/load_spill_pipeline_merge_context.h"
@@ -267,12 +268,14 @@ private:
 
     int64_t _max_buffer_size;
 
-    // Snapshot the in-transaction upsert/delete-order feature flag once for the whole load.
-    // lake_enable_pk_preserve_txn_delete_order is a mutable BE config, but it must not change
-    // mid-load: it drives both whether the spill path keeps the __op column (fixing LoadChunkSpiller's
-    // serde/schema from the first chunk) and whether finish() emits the del_op_offsets array. Reading
-    // it live in each place could tear a single load across the legacy and op-aware paths.
-    const bool _preserve_txn_delete_order = config::lake_enable_pk_preserve_txn_delete_order;
+    // Effective "preserve in-transaction upsert/delete order" for this load, snapshotted ONCE (in
+    // build_schema_and_writer, once the schema is known) via pk_preserve_txn_delete_order_enabled(): the
+    // config OR the separate-sort-key load-spill path (which always needs op-aware ordering). It must not
+    // change mid-load: it drives both whether the spill path keeps the __op column (fixing
+    // LoadChunkSpiller's serde/schema from the first chunk) and whether finish() emits del_op_offsets.
+    // Reading the mutable configs live in each place could tear a single load across the legacy and
+    // op-aware paths.
+    bool _preserve_txn_delete_order = false;
 
     std::unique_ptr<TabletWriter> _tablet_writer;
     std::unique_ptr<MemTable> _mem_table;
@@ -401,15 +404,23 @@ const DictColumnsValidMap* DeltaWriterImpl::global_dict_columns_valid_info() con
 //    WHY: Condition merge requires reading old values during ingestion, which conflicts with spilling
 // 2. Partial updates are involved
 //    WHY: Partial updates need to merge with existing data, requiring all columns in memory
-// 3. Separate sort keys are used
-//    WHY: Sort key handling requires special memory layout incompatible with spilling
+// 3. Separate sort keys are used AND eager PK-index build is NOT supported for this schema
+//    Note: separate-sort-key tables normally DO spill -- the spill orders the merge output by the
+//    sort key (primary keys are not adjacent), so duplicate primary keys are resolved by the unsort
+//    SST writer, which runs under eager build. Spilling is disabled only for the narrow case where
+//    eager build is unavailable (V1 single non-VARCHAR/CHAR key, or metadata not yet cached), because
+//    there is then no unsort SST writer to resolve dups and lazy publish rebuild would tie-break by
+//    sort-key order instead of flush order. In that case the load falls back to the non-spill memtable
+//    path, which is correct: for PK tables the memtable sorts by primary key and removes duplicates
+//    first, then re-sorts by the sort key (see MemTable::_sort).
 //
 // For non-PK tables: Always allow spilling if globally enabled (no special constraints)
 bool DeltaWriterImpl::should_enable_load_spill() const {
     return config::enable_load_spill &&
            (_tablet_schema->keys_type() != KeysType::PRIMARY_KEYS ||
             ((config::ignore_merge_condition_inside_same_transaction || _merge_condition.empty()) &&
-             !is_partial_update() && !_tablet_schema->has_separate_sort_key()));
+             !is_partial_update() &&
+             (!_tablet_schema->has_separate_sort_key() || pk_index_eager_build_supported(*_tablet_schema))));
 }
 
 Status DeltaWriterImpl::build_schema_and_writer() {
@@ -418,6 +429,8 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         ASSIGN_OR_RETURN([[maybe_unused]] auto tablet, _tablet_manager->get_tablet(_tablet_id));
         RETURN_IF_ERROR(init_tablet_schema());
         RETURN_IF_ERROR(init_write_schema());
+        // Snapshot the effective preserve-order decision once, now that the schema is known.
+        _preserve_txn_delete_order = pk_preserve_txn_delete_order_enabled(*_tablet_schema);
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
             _tablet_writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_manager, _tablet_id, _write_schema,
                                                                         _txn_id, nullptr, false /** no compaction**/,
@@ -432,6 +445,12 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         }
         RETURN_IF_ERROR(_tablet_writer->open());
         if (should_enable_load_spill()) {
+            // Eager PK-index build (the unsort SST writer that a separate-sort-key spill load needs to
+            // dedup non-adjacent duplicate primary keys) is enabled at merge time by try_enable, which
+            // fires for any spilled load and, for separate-sort-key tables, regardless of size
+            // (merge_blocks_to_segments / init_parallel_merge). A single flush never spills and takes the
+            // direct write_single_flush* path, which does not need it. So there is no build-time force
+            // here; the decision follows the data volume (whether the load actually spills).
             if (_load_spill_block_mgr == nullptr || !_load_spill_block_mgr->is_initialized()) {
                 // Pass txn_id to LoadSpillBlockManager so that spill files are placed under
                 // the flat layout <tablet_root>/load_spill_txns/<txn_id_hex>_<load_id>_<frag_id>_<seq>,
@@ -845,11 +864,13 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
         // Carry the per-del op_offset (parallel to dels_meta, index by del_id) so the apply/persist
         // path can preserve in-transaction upsert/delete ordering. A kUnknownDelOpOffset entry (spill /
         // concurrent flush) keeps the array aligned and is read as "not recorded" -> max segment id.
-        // Downgrade-safety gate: only emit the array when explicitly enabled. While disabled (the
-        // default), it stays empty so apply/persist/rebuild uniformly fall back to the legacy "delete
-        // after all segments" path -- this never writes the new on-disk state that a pre-fix BE
-        // (rollback / not-yet-upgraded node / cross-version OpReplication target) would misread into a
-        // duplicate primary key. See config::lake_enable_pk_preserve_txn_delete_order.
+        // Only emitted when the effective preserve-order snapshot is on (pk_preserve_txn_delete_order_enabled
+        // -- the config, which defaults on, OR any separate-sort-key table). The separate-sort-key path
+        // MUST emit it: its parallel merge can split a key's DELETE and later re-UPSERT across tasks, and
+        // without the offsets the earlier del file would erase the later re-insert. This is new on-disk
+        // state (del_op_offsets) that a pre-feature BE (rollback / not-yet-upgraded node / cross-version
+        // OpReplication target) would misread; its read side must be deployed fleet-wide before relying on
+        // it (see the seg_delvecs read-side backport).
         if (_preserve_txn_delete_order) {
             for (size_t i = 0; i < del_idx; ++i) {
                 op_write->add_del_op_offsets(i < del_op_offsets.size() ? del_op_offsets[i] : kUnknownDelOpOffset);
@@ -861,6 +882,24 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     }
     for (auto& sst_range : _tablet_writer->sst_ranges()) {
         op_write->add_sst_ranges()->CopyFrom(sst_range);
+    }
+    // Per-segment dedup delete vectors from the unsort SST writer (separate-sort-key PK). Kept
+    // parallel to `ssts` by index; an entry with no data means that segment had no dedup losers.
+    // The bitmap version is a placeholder here; publish stamps it with the real tablet version.
+    // Only the separate-sort-key path can leave intra-segment duplicate-PK losers, so only it emits
+    // seg_delvecs: the common sort-key==PK path would otherwise append one empty entry per SST (and hand
+    // a pre-feature publisher an unknown field for no reason). Publish guards missing indices as empty,
+    // so emitting nothing here is equivalent to emitting all-empty entries.
+    if (_tablet_schema->has_separate_sort_key()) {
+        for (const auto& seg_del_rowids : _tablet_writer->seg_delvecs()) {
+            auto* seg_delvec_pb = op_write->add_seg_delvecs();
+            if (!seg_del_rowids.empty()) {
+                DelVector dv;
+                dv.init(0 /* version stamped at publish */, seg_del_rowids.data(), seg_del_rowids.size());
+                seg_delvec_pb->set_version(0);
+                seg_delvec_pb->set_data(dv.save());
+            }
+        }
     }
     op_write->mutable_rowset()->set_num_rows(_tablet_writer->num_rows());
     op_write->mutable_rowset()->set_data_size(_tablet_writer->data_size());

--- a/be/src/storage/lake/load_spill_pipeline_merge_iterator.cpp
+++ b/be/src/storage/lake/load_spill_pipeline_merge_iterator.cpp
@@ -40,6 +40,14 @@ LoadSpillPipelineMergeIterator::LoadSpillPipelineMergeIterator(LoadChunkSpiller*
     // to maintain correctness (combine duplicate keys, apply aggregate functions).
     if (schema->keys_type() == KeysType::DUP_KEYS) {
         _do_agg = false;
+    } else if (schema->keys_type() == KeysType::PRIMARY_KEYS &&
+               _parent_writer->tablet_schema()->has_separate_sort_key()) {
+        // Separate sort key: the merge orders output by the sort key, so primary keys are NOT
+        // adjacent and the aggregate iterator cannot collapse duplicate PKs on the right axis.
+        // Disable aggregation and instead carry a per-row ordering key (rssid_rowids) so the unsort
+        // SST writer resolves duplicate PKs by last-flushed-wins and records losers into a delvec.
+        _do_agg = false;
+        _need_rssid_rowids = true;
     } else {
         _do_agg = true;
     }
@@ -59,9 +67,9 @@ Status LoadSpillPipelineMergeIterator::_generate_next_task() {
     // - true (sort): Whether to sort during merge (always true for correctness)
     // - _do_agg: Whether to perform aggregation (depends on table keys type)
     // - _final_round: Whether this merges to final tablet vs intermediate blocks
-    ASSIGN_OR_RETURN(auto batch, _spiller->generate_merge_input_batch(config::load_spill_max_merge_bytes,
-                                                                      config::load_spill_memory_usage_per_merge,
-                                                                      true /*sort*/, _do_agg, _final_round));
+    ASSIGN_OR_RETURN(auto batch, _spiller->generate_merge_input_batch(
+                                         config::load_spill_max_merge_bytes, config::load_spill_memory_usage_per_merge,
+                                         true /*sort*/, _do_agg, _final_round, _need_rssid_rowids));
 
     // nullptr merge_itr indicates no more block groups available - iteration complete
     if (batch.merge_itr != nullptr) {
@@ -84,7 +92,7 @@ Status LoadSpillPipelineMergeIterator::_generate_next_task() {
         auto task = std::make_unique<LoadSpillMergeInputBatch>(std::move(batch));
         _current_task = std::make_shared<lake::TabletInternalParallelMergeTask>(
                 std::move(writer), std::move(task), _spiller->schema().get(), _quit_flag,
-                _spiller->spiller()->metrics().write_io_timer, _op_aware);
+                _spiller->spiller()->metrics().write_io_timer, _op_aware, _need_rssid_rowids);
     } else {
         // No more data to merge - signal iteration completion by returning nullptr.
         // Pipeline operators check has_more() which tests for nullptr to know when to stop.

--- a/be/src/storage/lake/load_spill_pipeline_merge_iterator.h
+++ b/be/src/storage/lake/load_spill_pipeline_merge_iterator.h
@@ -103,6 +103,12 @@ private:
     // that don't need ordering/deduplication.
     bool _do_agg = false;
 
+    // Separate-sort-key PK path: the merge orders output by sort key (not PK), so the writer needs a
+    // per-row ordering key (rssid_rowids, carrying slot_idx) to resolve duplicate primary keys by
+    // last-flushed-wins. When true, merge inputs emit rssid_rowids and tasks forward them to the
+    // unsort SST writer.
+    bool _need_rssid_rowids = false;
+
     // Currently available task for pipeline operator to consume
     std::shared_ptr<lake::TabletInternalParallelMergeTask> _current_task;
 

--- a/be/src/storage/lake/pk_tablet_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_sst_writer.cpp
@@ -33,10 +33,8 @@
 
 namespace starrocks::lake {
 
-Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
-    if (_pk_sst_builder == nullptr) {
-        return Status::InternalError("pk sst writer not initialized");
-    }
+StatusOr<const Slice*> PkTabletSSTWriter::encode_pk_keys(const Chunk& data, Buffer<Slice>* keys,
+                                                         MutableColumnPtr* owned_column) {
     ASSIGN_OR_RETURN(auto pk_encoding_type, _tablet_schema_ptr->primary_key_encoding_type_or_error());
     if (_pk_column == nullptr) {
         vector<uint32_t> pk_columns;
@@ -51,10 +49,21 @@ Status PkTabletSSTWriter::append_sst_record(const Chunk& data) {
     auto clone_pk_column = _pk_column->clone_empty();
     TRY_CATCH_BAD_ALLOC(
             PrimaryKeyEncoder::encode(_pkey_schema, data, 0, data.num_rows(), clone_pk_column.get(), pk_encoding_type));
-    Buffer<Slice> keys;
     ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(*clone_pk_column, _key_size, 0,
-                                                                             clone_pk_column->size(), &keys));
-    for (size_t i = 0; i < clone_pk_column->size(); i++) {
+                                                                             clone_pk_column->size(), keys));
+    *owned_column = std::move(clone_pk_column);
+    return vkeys;
+}
+
+Status PkTabletSSTWriter::append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                            const std::vector<uint32_t>* column_indexes) {
+    if (_pk_sst_builder == nullptr) {
+        return Status::InternalError("pk sst writer not initialized");
+    }
+    Buffer<Slice> keys;
+    MutableColumnPtr owned_column;
+    ASSIGN_OR_RETURN(const Slice* vkeys, encode_pk_keys(data, &keys, &owned_column));
+    for (size_t i = 0; i < owned_column->size(); i++) {
         RETURN_IF_ERROR(_pk_sst_builder->add(vkeys[i]));
     }
     return Status::OK();

--- a/be/src/storage/lake/pk_tablet_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_sst_writer.h
@@ -33,13 +33,39 @@ class PersistentIndexSstableStreamBuilder;
 class DefaultSSTWriter {
 public:
     virtual ~DefaultSSTWriter() = default;
-    virtual Status append_sst_record(const Chunk& data) { return Status::OK(); }
+    // `rssid_rowids`, when non-null, carries one per-row ordering key aligned with `data`'s rows.
+    // Its high 32 bits encode the source memtable flush order (slot_idx); writers that must resolve
+    // duplicate primary keys by "last-flushed wins" (see PkTabletUnsortSSTWriter) use it. Writers
+    // whose input is already in primary-key order (PkTabletSSTWriter) ignore it.
+    // `column_indexes`, when non-null, gives the tablet column id of each column in `data` (used by
+    // the vertical-compaction key group, whose chunk carries [sort-key columns, then PK columns]).
+    // The unsort writer uses it to locate the PK columns; other writers ignore it because `data`
+    // already has the PK columns at positions [0, num_key_columns).
+    virtual Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
+                                     const std::vector<uint32_t>* column_indexes = nullptr) {
+        return Status::OK();
+    }
+    // Feed DELETE rows to writers that resolve op order themselves (the separate-sort-key unsort
+    // writer). Default is a no-op: other writers receive deletes via the caller's del-file path.
+    virtual Status append_delete_records(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                         const std::vector<uint32_t>* column_indexes = nullptr) {
+        return Status::OK();
+    }
     virtual Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
                                     const std::shared_ptr<FileSystem>& fs) {
         return Status::OK();
     }
     virtual StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> flush_sst_writer() { return Status::OK(); }
     virtual bool has_file_info() const { return false; }
+    // Rowids (within the just-flushed segment) that lost primary-key dedup and must be masked by a
+    // delete vector at publish. Non-empty only for the unsort writer; the caller moves them out once
+    // per segment right after flush_sst_writer().
+    virtual std::vector<uint32_t> take_deleted_rowids() { return {}; }
+    // Encoded primary keys (del-file binary format) of the rows whose latest op is a DELETE, moved out
+    // once per segment right after flush_sst_writer(). Non-empty only for the unsort writer, whose
+    // sort-key-ordered merge cannot route deletes through the caller's del file; the caller writes them
+    // to a del file so publish erases the (possibly pre-existing) rows. nullptr means "no deletes".
+    virtual MutableColumnPtr take_delete_keys() { return nullptr; }
 };
 
 class PkTabletSSTWriter : public DefaultSSTWriter {
@@ -47,20 +73,34 @@ public:
     PkTabletSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
             : _tablet_schema_ptr(std::move(tablet_schema_ptr)), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
     ~PkTabletSSTWriter() override = default;
-    Status append_sst_record(const Chunk& data) override;
+    Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
+                             const std::vector<uint32_t>* column_indexes = nullptr) override;
     Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
                             const std::shared_ptr<FileSystem>& fs) override;
     StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> flush_sst_writer() override;
     bool has_file_info() const override { return _pk_sst_builder != nullptr; }
+
+protected:
+    // Encodes the primary-key columns of `data` into the encoded-key form used by the persistent
+    // index SST. On success returns a pointer to `data.num_rows()` contiguous key slices; the slices
+    // are backed by `keys` and `owned_column`, both of which the caller must keep alive until the
+    // slices are consumed.
+    StatusOr<const Slice*> encode_pk_keys(const Chunk& data, Buffer<Slice>* keys, MutableColumnPtr* owned_column);
+
+    // An empty column in the encoded-PK (del-file binary) format, i.e. the same column type
+    // encode_pk_keys fills, so an encoded key slice can be appended straight back as one del-file cell.
+    // Returns nullptr before the first encode_pk_keys call (when _pk_column is not yet built).
+    MutableColumnPtr clone_empty_pk_column() const { return _pk_column ? _pk_column->clone_empty() : nullptr; }
+
+    TabletSchemaCSPtr _tablet_schema_ptr;
+    TabletManager* _tablet_mgr;
+    int64_t _tablet_id;
 
 private:
     std::unique_ptr<PersistentIndexSstableStreamBuilder> _pk_sst_builder;
     MutableColumnPtr _pk_column;
     Schema _pkey_schema;
     size_t _key_size = 0;
-    TabletSchemaCSPtr _tablet_schema_ptr;
-    TabletManager* _tablet_mgr;
-    int64_t _tablet_id;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -1,0 +1,386 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/pk_tablet_unsort_sst_writer.h"
+
+#include <fmt/format.h>
+
+#include "column/chunk.h"
+#include "common/config_cache_fwd.h"
+#include "common/config_primary_key_fwd.h"
+#include "common/config_rowset_fwd.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "platform/key_cache.h"
+#include "runtime/mem_tracker.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/update_manager.h"
+#include "storage/lake/vacuum.h"
+#include "storage/sstable/comparator.h"
+#include "storage/sstable/filter_policy.h"
+#include "storage/sstable/iterator.h"
+#include "storage/sstable/merger.h"
+#include "storage/sstable/options.h"
+#include "storage/sstable/table.h"
+#include "storage/sstable/table_builder.h"
+#include "storage/storage_metrics.h"
+#include "types/datum.h"
+
+namespace starrocks::lake {
+
+Status PkTabletUnsortSSTWriter::reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
+                                                 const std::shared_ptr<FileSystem>& fs) {
+    _location_provider = location_provider;
+    _fs = fs;
+    WritableFileOptions wopts;
+    _encryption_meta.clear();
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(auto pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        wopts.encryption_info = pair.info;
+        _encryption_meta = std::move(pair.encryption_meta);
+    }
+    if (location_provider && fs) {
+        ASSIGN_OR_RETURN(_wf,
+                         fs->new_writable_file(wopts, location_provider->sst_location(_tablet_id, gen_sst_filename())));
+    } else {
+        ASSIGN_OR_RETURN(_wf, fs::new_writable_file(wopts, _tablet_mgr->sst_location(_tablet_id, gen_sst_filename())));
+    }
+    _map.clear();
+    _deleted_rowids.clear();
+    _delete_keys.reset();
+    _intermediate_ssts.clear();
+    _map_mem_usage = 0;
+    _next_rowid = 0;
+    return Status::OK();
+}
+
+void PkTabletUnsortSSTWriter::collect_delete_key(const Slice& key) {
+    // A map/merge key is already an encoded-PK slice, i.e. exactly one del-file binary cell, so append
+    // it straight into the del-file column (lazily built in the same encoded-PK format as the SST keys).
+    if (_delete_keys == nullptr) {
+        _delete_keys = clone_empty_pk_column();
+    }
+    _delete_keys->append_datum(Datum(key));
+}
+
+Status PkTabletUnsortSSTWriter::append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                                  const std::vector<uint32_t>* column_indexes) {
+    return append_records(data, rssid_rowids, column_indexes, /*is_delete=*/false);
+}
+
+Status PkTabletUnsortSSTWriter::append_delete_records(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                                      const std::vector<uint32_t>* column_indexes) {
+    return append_records(data, rssid_rowids, column_indexes, /*is_delete=*/true);
+}
+
+void PkTabletUnsortSSTWriter::reconcile_entry(std::string_view key, uint64_t order, uint32_t rowid) {
+    // Keep the row with the largest order (last op wins). When an UPSERT loses (its rowid is a real
+    // segment position, not kDeleteRowid), record it so publish masks it with a delete vector. A
+    // DELETE has no segment row (kDeleteRowid), so a losing/superseded DELETE contributes nothing.
+    // The find is heterogeneous (std::less<> transparent comparator), so a duplicate primary key does
+    // not allocate; only a first-seen key materializes the owning std::string on the emplace branch.
+    auto it = _map.find(key);
+    if (it == _map.end()) {
+        // Rough per-entry footprint: encoded key bytes + value + btree node overhead.
+        static constexpr size_t kBtreeEntryOverhead = 24;
+        _map_mem_usage += key.size() + sizeof(Entry) + kBtreeEntryOverhead;
+        _map.emplace(std::string(key), Entry{order, rowid});
+    } else if (order > it->second.order) {
+        if (it->second.rowid != kDeleteRowid) {
+            _deleted_rowids.push_back(it->second.rowid);
+        }
+        it->second = Entry{order, rowid};
+    } else if (rowid != kDeleteRowid) {
+        _deleted_rowids.push_back(rowid);
+    }
+}
+
+Status PkTabletUnsortSSTWriter::append_records(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                               const std::vector<uint32_t>* column_indexes, bool is_delete) {
+    if (_wf == nullptr) {
+        return Status::InternalError("unsort pk sst writer not initialized");
+    }
+    const size_t num_rows = data.num_rows();
+    if (num_rows == 0) {
+        return Status::OK();
+    }
+    if (rssid_rowids == nullptr || rssid_rowids->size() != num_rows) {
+        return Status::InternalError(fmt::format("unsort pk sst writer requires per-row order keys, expected {} got {}",
+                                                 num_rows, rssid_rowids == nullptr ? 0 : rssid_rowids->size()));
+    }
+    // Vertical compaction's key group carries [sort-key columns, then PK columns], so the PK columns
+    // are NOT at chunk positions [0, num_key). Project them out (in primary-key order) using
+    // `column_indexes` -- the tablet column id of each chunk column -- so encode_pk_keys, which
+    // assumes the chunk's first num_key columns are the PK, sees the right columns. The load path
+    // passes the full row without column_indexes and is used directly.
+    Chunk pk_chunk;
+    const Chunk* pk_data = &data;
+    if (column_indexes != nullptr) {
+        RETURN_IF_ERROR(project_pk_columns(data, *column_indexes, &pk_chunk));
+        pk_data = &pk_chunk;
+    }
+    Buffer<Slice> keys;
+    MutableColumnPtr owned_column;
+    ASSIGN_OR_RETURN(const Slice* vkeys, encode_pk_keys(*pk_data, &keys, &owned_column));
+    for (size_t i = 0; i < num_rows; i++) {
+        const uint64_t order = (*rssid_rowids)[i];
+        // DELETE rows occupy no segment position; they only carry order for the per-PK reconciliation.
+        const uint32_t rowid = is_delete ? kDeleteRowid : (_next_rowid + static_cast<uint32_t>(i));
+        reconcile_entry(vkeys[i], order, rowid);
+    }
+    if (!is_delete) {
+        _next_rowid += static_cast<uint32_t>(num_rows);
+    }
+    // Bound memory: once the map reaches the memtable threshold, spill it to an intermediate SST.
+    // The residual map plus all intermediates are k-way merged into the final SST at flush time.
+    if (is_map_full()) {
+        RETURN_IF_ERROR(flush_map_to_intermediate_sst());
+    }
+    return Status::OK();
+}
+
+Status PkTabletUnsortSSTWriter::project_pk_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes,
+                                                   Chunk* out) const {
+    const size_t num_key = _tablet_schema_ptr->num_key_columns();
+    for (uint32_t pk_col = 0; pk_col < num_key; ++pk_col) {
+        // Tablet column ids [0, num_key) are the primary-key columns; find which chunk column carries
+        // this one. The scan is over the (small) key-group width, once per chunk.
+        size_t pos = column_indexes.size();
+        for (size_t i = 0; i < column_indexes.size(); ++i) {
+            if (column_indexes[i] == pk_col) {
+                pos = i;
+                break;
+            }
+        }
+        if (pos == column_indexes.size()) {
+            return Status::InternalError(
+                    fmt::format("unsort pk sst writer: primary-key column {} missing from key group", pk_col));
+        }
+        out->append_column(data.get_column_by_index(pos), static_cast<SlotId>(pk_col));
+    }
+    return Status::OK();
+}
+
+bool PkTabletUnsortSSTWriter::is_map_full() const {
+    // Count the loser rowids too, not just the map: a dup-heavy batch can hold a lot of memory in
+    // _deleted_rowids (which a map spill does not shrink) while _map itself stays small, so spilling the
+    // map keeps the writer's combined footprint near the bound instead of letting _map independently
+    // pile another l0_max_mem_usage on top of the loser vector. (_delete_keys is filled only at flush,
+    // never during append, so it is not part of the footprint at this spill check.)
+    const size_t mem_usage = _map_mem_usage + _deleted_rowids.size() * sizeof(uint32_t);
+    if (mem_usage >= static_cast<size_t>(config::l0_max_mem_usage)) {
+        return true;
+    }
+    // Under memory pressure, spill at a lower bound, mirroring LakePersistentIndex::is_memtable_full.
+    auto* update_mgr = _tablet_mgr->update_mgr();
+    if (update_mgr != nullptr && update_mgr->mem_tracker() != nullptr &&
+        update_mgr->mem_tracker()->limit_exceeded_by_ratio(config::memory_urgent_level) &&
+        mem_usage >= static_cast<size_t>(config::l0_min_mem_usage)) {
+        return true;
+    }
+    return false;
+}
+
+Status PkTabletUnsortSSTWriter::flush_map_to_intermediate_sst() {
+    if (_map.empty()) {
+        return Status::OK();
+    }
+    WritableFileOptions wopts;
+    std::string encryption_meta;
+    if (config::enable_transparent_data_encryption) {
+        ASSIGN_OR_RETURN(auto pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        wopts.encryption_info = pair.info;
+        encryption_meta = std::move(pair.encryption_meta);
+    }
+    const std::string location = (_location_provider && _fs)
+                                         ? _location_provider->sst_location(_tablet_id, gen_sst_filename())
+                                         : _tablet_mgr->sst_location(_tablet_id, gen_sst_filename());
+    std::unique_ptr<WritableFile> wf;
+    if (_location_provider && _fs) {
+        ASSIGN_OR_RETURN(wf, _fs->new_writable_file(wopts, location));
+    } else {
+        ASSIGN_OR_RETURN(wf, fs::new_writable_file(wopts, location));
+    }
+    std::unique_ptr<sstable::FilterPolicy> filter_policy;
+    filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
+    sstable::Options options;
+    options.filter_policy = filter_policy.get();
+    sstable::TableBuilder builder(options, wf.get());
+    // Intermediate SST stores both rowid and the dedup order (in the value's version field) so the
+    // final merge can pick the winner across intermediate SSTs.
+    for (const auto& [k, v] : _map) {
+        IndexValuesWithVerPB index_value_pb;
+        auto* value = index_value_pb.add_values();
+        value->set_rowid(v.rowid);
+        value->set_version(static_cast<int64_t>(v.order));
+        RETURN_IF_ERROR(builder.Add(Slice(k), Slice(index_value_pb.SerializeAsString())));
+    }
+    RETURN_IF_ERROR(builder.Finish());
+    const uint64_t size = builder.FileSize();
+    RETURN_IF_ERROR(wf->close());
+    _intermediate_ssts.push_back({location, size, std::move(encryption_meta)});
+    _map.clear();
+    _map_mem_usage = 0;
+    return Status::OK();
+}
+
+Status PkTabletUnsortSSTWriter::merge_intermediates_into(sstable::TableBuilder* builder) {
+    // Open every intermediate SST for reading. `rfs`/`tables` own the files/tables for the whole
+    // merge. `iter_holders` owns the child iterators ONLY until the merging iterator is built: the
+    // MergingIterator returned by NewMergingIterator takes ownership of the children and deletes them
+    // in its destructor (via IteratorWrapper), so we release the holders once it is created to avoid
+    // freeing each child iterator twice (a double-free that crashes under real allocators). The
+    // holders exist solely so a failed Table::Open before that point still cleans up.
+    std::vector<std::unique_ptr<RandomAccessFile>> rfs;
+    std::vector<std::unique_ptr<sstable::Table>> tables;
+    std::vector<std::unique_ptr<sstable::Iterator>> iter_holders;
+    std::vector<sstable::Iterator*> child_iters;
+    for (const auto& sst : _intermediate_ssts) {
+        RandomAccessFileOptions opts;
+        if (!sst.encryption_meta.empty()) {
+            ASSIGN_OR_RETURN(opts.encryption_info, KeyCache::instance().unwrap_encryption_meta(sst.encryption_meta));
+        }
+        std::unique_ptr<RandomAccessFile> rf;
+        if (_fs) {
+            ASSIGN_OR_RETURN(rf, _fs->new_random_access_file(opts, sst.location));
+        } else {
+            ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, sst.location));
+        }
+        std::unique_ptr<sstable::Table> table;
+        RETURN_IF_ERROR(sstable::Table::Open(sstable::Options{}, rf.get(), sst.size, table));
+        auto* iter = table->NewIterator(sstable::ReadOptions{});
+        iter_holders.emplace_back(iter);
+        child_iters.push_back(iter);
+        rfs.push_back(std::move(rf));
+        tables.push_back(std::move(table));
+    }
+    std::unique_ptr<sstable::Iterator> merged(sstable::NewMergingIterator(
+            sstable::BytewiseComparator(), child_iters.data(), static_cast<int>(child_iters.size())));
+    // Ownership of the child iterators has transferred to `merged` (see comment above); drop our
+    // holders so they are not deleted a second time when this function returns.
+    for (auto& holder : iter_holders) {
+        (void)holder.release();
+    }
+    for (merged->SeekToFirst(); merged->Valid();) {
+        const std::string key = merged->key().to_string();
+        bool has_best = false;
+        uint64_t best_order = 0;
+        uint32_t best_rowid = 0;
+        // All entries sharing this key are adjacent in the merged stream. Keep the one with the
+        // largest order (last flushed wins); the rest are dedup losers -> delete vector.
+        while (merged->Valid() && merged->key() == Slice(key)) {
+            const Slice value = merged->value();
+            IndexValuesWithVerPB index_value_pb;
+            if (!index_value_pb.ParseFromArray(value.data, static_cast<int>(value.size)) ||
+                index_value_pb.values_size() == 0) {
+                return Status::InternalError("failed to parse intermediate unsort sst value");
+            }
+            const uint64_t order = static_cast<uint64_t>(index_value_pb.values(0).version());
+            const uint32_t rowid = index_value_pb.values(0).rowid();
+            if (!has_best || order > best_order) {
+                // A losing UPSERT (real rowid) is masked by the delete vector; a losing DELETE
+                // (kDeleteRowid) has no segment row and is simply dropped.
+                if (has_best && best_rowid != kDeleteRowid) {
+                    _deleted_rowids.push_back(best_rowid);
+                }
+                has_best = true;
+                best_order = order;
+                best_rowid = rowid;
+            } else if (rowid != kDeleteRowid) {
+                _deleted_rowids.push_back(rowid);
+            }
+            merged->Next();
+        }
+        if (best_rowid == kDeleteRowid) {
+            // Latest op for this key is a DELETE: collect it into the del file (see collect_delete_key)
+            // rather than the SST, so publish erases the key -- including a row from an earlier txn.
+            collect_delete_key(Slice(key));
+        } else {
+            IndexValuesWithVerPB out;
+            out.add_values()->set_rowid(best_rowid);
+            RETURN_IF_ERROR(builder->Add(Slice(key), Slice(out.SerializeAsString())));
+        }
+    }
+    return merged->status();
+}
+
+StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> PkTabletUnsortSSTWriter::flush_sst_writer() {
+    if (_wf == nullptr) {
+        return Status::InternalError("unsort pk sst writer not initialized");
+    }
+    std::unique_ptr<sstable::FilterPolicy> filter_policy;
+    filter_policy.reset(const_cast<sstable::FilterPolicy*>(sstable::NewBloomFilterPolicy(10)));
+    sstable::Options options;
+    options.filter_policy = filter_policy.get();
+    sstable::TableBuilder builder(options, _wf.get());
+    if (_intermediate_ssts.empty()) {
+        // Whole segment fit in memory: write the sorted map directly. Keys are added in encoded-PK
+        // order as required by TableBuilder. Only the rowid is stored; rssid/version are projected
+        // from shared_rssid/shared_version at ingest time (single-segment SST).
+        for (const auto& [k, v] : _map) {
+            if (v.rowid == kDeleteRowid) {
+                // Latest op for this key is a DELETE: collect it into the del file (see collect_delete_key)
+                // rather than the SST, so publish erases the key -- including a row from an earlier txn.
+                collect_delete_key(Slice(k));
+                continue;
+            }
+            IndexValuesWithVerPB index_value_pb;
+            index_value_pb.add_values()->set_rowid(v.rowid);
+            RETURN_IF_ERROR(builder.Add(Slice(k), Slice(index_value_pb.SerializeAsString())));
+        }
+    } else {
+        // Spilled: flush the residual map to an intermediate SST too, then k-way merge all
+        // intermediates into this final SST (resolving cross-SST duplicate PKs + delvec). This
+        // round-trips the already-sorted residual through one remote PUT+GET instead of merging it
+        // straight from memory; that keeps peak RAM bounded (the residual is freed before the merge) at
+        // the cost of one extra I/O -- an intentional I/O-vs-memory tradeoff, not an oversight.
+        RETURN_IF_ERROR(flush_map_to_intermediate_sst());
+        RETURN_IF_ERROR(merge_intermediates_into(&builder));
+    }
+    if (auto st = builder.Finish(); !st.ok()) {
+        StorageMetrics::instance()->pk_index_sst_write_error_total.increment(1);
+        LOG(WARNING) << "Failed to finish unsort PersistentIndex SST, error: " << st;
+        return st;
+    }
+    RETURN_IF_ERROR(_wf->close());
+    FileInfo file_info;
+    file_info.path = file_name(_wf->filename());
+    file_info.size = builder.FileSize();
+    file_info.encryption_meta = _encryption_meta;
+    PersistentIndexSstableRangePB range_pb;
+    auto [key_start, key_end] = builder.KeyRange();
+    range_pb.set_start_key(key_start.to_string());
+    range_pb.set_end_key(key_end.to_string());
+    // Best-effort async cleanup of intermediate spill SSTs (non-blocking, off the write path). The
+    // success path removes them here. Orphans left by a crash/error are NOT reclaimed by the scheduled
+    // vacuum daemons -- those skip UUID-named, txn_id==0 persistent-index SSTs (true of any PK load's
+    // SSTs, spill or not) -- so they are reclaimed only by the manual lake_datafile_gc tool.
+    if (!_intermediate_ssts.empty()) {
+        std::vector<std::string> intermediate_paths;
+        intermediate_paths.reserve(_intermediate_ssts.size());
+        for (const auto& sst : _intermediate_ssts) {
+            intermediate_paths.emplace_back(sst.location);
+        }
+        delete_files_async(std::move(intermediate_paths));
+    }
+    _wf.reset();
+    _map.clear();
+    _intermediate_ssts.clear();
+    _map_mem_usage = 0;
+    _next_rowid = 0;
+    return std::make_pair(file_info, range_pb);
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.h
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "base/phmap/btree.h"
+#include "storage/lake/pk_tablet_sst_writer.h"
+#include "storage/sstable/table_builder.h"
+
+namespace starrocks::lake {
+
+// SST writer for separate-sort-key PK tables: primary keys arrive in sort-key order (i.e. NOT in
+// primary-key order), so they cannot be streamed into a sorted SST directly. Instead they are
+// buffered in an in-memory map keyed by encoded primary key, which both sorts them and collapses
+// duplicate primary keys within the segment. The winner of a duplicate is the row with the largest
+// per-row ordering key (rssid_rowid high bits = slot_idx = last memtable flush); the loser's rowid
+// is recorded so publish can mask it with a delete vector. At flush the map is written as one sorted
+// SST for the current segment (still 1 segment : 1 SST). Only the rowid is stored per entry; rssid
+// and version are supplied via shared_rssid/shared_version at ingest time, exactly like the streaming
+// builder.
+// When the map grows past the memtable memory threshold (is_map_full, mirroring
+// LakePersistentIndex::is_memtable_full) it is flushed to an intermediate SST and cleared, bounding
+// memory. At segment finalize the intermediate SSTs (plus the residual map) are k-way merged into the
+// single final SST; duplicate PKs across intermediates are resolved there (last-flushed wins) and the
+// losers appended to the delete vector.
+// Memory: the map is bounded by l0_max_mem_usage (100 MB default) before it spills, and each parallel
+// merge task owns its own writer (and map), so peak usage is up to l0_max_mem_usage x the number of
+// concurrent merge tasks before spilling kicks in. It is charged to the load-spill merge mem tracker.
+class PkTabletUnsortSSTWriter : public PkTabletSSTWriter {
+public:
+    PkTabletUnsortSSTWriter(TabletSchemaCSPtr tablet_schema_ptr, TabletManager* tablet_mgr, int64_t tablet_id)
+            : PkTabletSSTWriter(std::move(tablet_schema_ptr), tablet_mgr, tablet_id) {}
+    ~PkTabletUnsortSSTWriter() override = default;
+    Status append_sst_record(const Chunk& data, const std::vector<uint64_t>* rssid_rowids = nullptr,
+                             const std::vector<uint32_t>* column_indexes = nullptr) override;
+    // Feed the batch's DELETE rows (op-aware separate-sort-key path). They carry a per-row ordering key
+    // (rssid_rowids) but no segment row, so they participate in the per-PK last-op reconciliation
+    // without occupying a rowid. A DELETE that is the latest op for its PK is collected into a del file
+    // (take_delete_keys) so publish erases the (possibly pre-existing) row; a DELETE superseded by a
+    // later UPSERT is dropped.
+    Status append_delete_records(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                                 const std::vector<uint32_t>* column_indexes = nullptr) override;
+    Status reset_sst_writer(const std::shared_ptr<LocationProvider>& location_provider,
+                            const std::shared_ptr<FileSystem>& fs) override;
+    StatusOr<std::pair<FileInfo, PersistentIndexSstableRangePB>> flush_sst_writer() override;
+    bool has_file_info() const override { return _wf != nullptr; }
+    std::vector<uint32_t> take_deleted_rowids() override { return std::move(_deleted_rowids); }
+    MutableColumnPtr take_delete_keys() override { return std::move(_delete_keys); }
+
+private:
+    // A row that has no segment position (a DELETE) stores this reserved rowid, matching the
+    // UINT32_MAX delete-rowid convention used elsewhere in the PK write path. At flush a winning
+    // entry with this rowid is collected into `_delete_keys` (a del file) instead of a PK -> rowid
+    // SST mapping, so publish erases the key -- including a row written by an earlier transaction.
+    static constexpr uint32_t kDeleteRowid = std::numeric_limits<uint32_t>::max();
+
+    // encoded primary key -> {order, rowid}. `order` is the per-row rssid_rowid used to pick the
+    // last-op winner (kept the largest); `rowid` is the position within the current segment, or
+    // kDeleteRowid when the winning op is a DELETE.
+    struct Entry {
+        uint64_t order;
+        uint32_t rowid;
+    };
+    // An intermediate SST spilled from `_map` when it got full. Its entries store both rowid and order
+    // (order in the value's version field) so the final merge can pick the dedup winner across SSTs.
+    struct IntermediateSst {
+        std::string location; // full path, used to reopen for merge and to delete afterwards
+        uint64_t size;
+        std::string encryption_meta;
+    };
+
+    // Project the primary-key columns out of a vertical-compaction key-group chunk into `out` in
+    // primary-key order. `column_indexes[i]` is the tablet column id of `data`'s column i; the PK
+    // columns are those with a tablet column id < num_key_columns. `out` then has the PK columns at
+    // positions [0, num_key), which is what encode_pk_keys expects.
+    Status project_pk_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes, Chunk* out) const;
+    // Shared body of append_sst_record (is_delete=false) and append_delete_records (is_delete=true):
+    // encode each row's PK and reconcile it into `_map` by rssid_rowid order (last op wins). UPSERTs
+    // take a running segment rowid; DELETEs use kDeleteRowid and do not advance the rowid counter.
+    Status append_records(const Chunk& data, const std::vector<uint64_t>* rssid_rowids,
+                          const std::vector<uint32_t>* column_indexes, bool is_delete);
+    // Reconcile one row (already encoded) into `_map`, masking the loser's segment rowid (if any). Takes
+    // a non-owning view: the map's transparent comparator finds without allocating, and a std::string is
+    // materialized only on the insert (miss) branch, so duplicate primary keys cost no heap churn.
+    void reconcile_entry(std::string_view key, uint64_t order, uint32_t rowid);
+    // Append an encoded-PK slice (a winning DELETE's key) as one cell of the del-file column.
+    void collect_delete_key(const Slice& key);
+    // Whether `_map` has reached the memtable memory threshold and should be spilled to an SST.
+    bool is_map_full() const;
+    // Spill the current `_map` to a new intermediate SST (storing order+rowid), then clear the map.
+    Status flush_map_to_intermediate_sst();
+    // K-way merge the intermediate SSTs into `builder` (the final SST), keeping the max-order entry
+    // per key and appending the losing rowids to `_deleted_rowids`.
+    Status merge_intermediates_into(sstable::TableBuilder* builder);
+
+    phmap::btree_map<std::string, Entry, std::less<>> _map;
+    std::vector<uint32_t> _deleted_rowids;
+    // Encoded primary keys (del-file binary format) whose latest op is a DELETE, collected at flush and
+    // moved out via take_delete_keys(). A map/merge key IS an encoded-PK slice, so it is appended
+    // straight into this column (built from clone_empty_pk_column). nullptr until the first winner.
+    MutableColumnPtr _delete_keys;
+    // Rough running estimate of `_map`'s memory footprint, compared against l0_*_mem_usage.
+    size_t _map_mem_usage = 0;
+    std::vector<IntermediateSst> _intermediate_ssts;
+    // Running rowid within the current segment (== rows appended so far); reset per segment.
+    uint32_t _next_rowid = 0;
+    std::unique_ptr<WritableFile> _wf;
+    std::string _encryption_meta;
+    // Saved from reset_sst_writer so intermediate SSTs can be created during append.
+    std::shared_ptr<LocationProvider> _location_provider;
+    std::shared_ptr<FileSystem> _fs;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -17,13 +17,17 @@
 #include <fmt/format.h>
 
 #include "column/chunk.h"
+#include "column/raw_data_visitor.h"
 #include "column/serde/column_array_serde.h"
 #include "common/config_rowset_fwd.h"
 #include "common/runtime_profile.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/Types_types.h"
 #include "platform/key_cache.h"
+#include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/pk_tablet_sst_writer.h"
+#include "storage/lake/pk_tablet_unsort_sst_writer.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/rows_mapper.h"
 #include "storage/rowset/segment_writer.h"
@@ -52,7 +56,7 @@ HorizontalPkTabletWriter::~HorizontalPkTabletWriter() = default;
 Status HorizontalPkTabletWriter::write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids,
                                        SegmentPB* segment) {
     RETURN_IF_ERROR(HorizontalGeneralTabletWriter::write(data, segment));
-    RETURN_IF_ERROR(_pk_sst_writer->append_sst_record(data));
+    RETURN_IF_ERROR(_pk_sst_writer->append_sst_record(data, &rssid_rowids));
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
     }
@@ -63,6 +67,85 @@ Status HorizontalPkTabletWriter::write(const Chunk& data, SegmentPB* segment, bo
     RETURN_IF_ERROR(HorizontalGeneralTabletWriter::write(data, segment, eos));
     RETURN_IF_ERROR(_pk_sst_writer->append_sst_record(data));
     return Status::OK();
+}
+
+Status HorizontalPkTabletWriter::write_single_flush(const Chunk& data, SegmentPB* segment, bool eos) {
+    // See TabletWriter::write_single_flush. A single flush is unique-by-PK, so it does not need the eager
+    // unsort SST writer (whose sole job is cross-flush duplicate-key resolution). Clear the eager-build
+    // flag so reset_segment_writer builds a DefaultSSTWriter -> no eager PK-index SST; publish then
+    // rebuilds the index lazily via the order-independent parallel_upsert -- identical to the
+    // eager-build-off path. Safe to clear here: a single-flush load never spills/merges/clones, so
+    // reset_segment_writer (during this write) is the only remaining reader of the flag.
+    _enable_pk_index_eager_build = false;
+    return HorizontalGeneralTabletWriter::write(data, segment, eos);
+}
+
+Status HorizontalPkTabletWriter::write_single_flush_with_op(const Chunk& chunk_with_op, SegmentPB* segment, bool eos) {
+    // See TabletWriter::write_single_flush_with_op. The memtable already deduplicated this flush by
+    // primary key (last-op-wins), so it is unique-by-PK and each key is EITHER an upsert OR a delete --
+    // the unsort SST writer's cross-flush dedup is unnecessary. Split __op and route each part through the
+    // single-flush write: upserts to a plain sort-key-ordered segment (eager SST skipped), deletes encoded
+    // to a del file. Mirrors MemTable::_split_upserts_deletes + the flush_chunk_with_deletes shortcut.
+
+    // Work on a mutable copy: RawDataVisitor reads the op column via mutable_raw_data(), and we drop the
+    // __op column before writing the segment.
+    auto data_chunk = chunk_with_op.clone_unique();
+    const size_t op_col_id = data_chunk->num_columns() - 1;
+    const size_t nrows = data_chunk->num_rows();
+
+    // Read the trailing __op column (0 == UPSERT, otherwise DELETE) and partition rows BEFORE removing it
+    // (the raw-data pointer is invalidated by remove_column_by_index). Same as MemTable::_split_upserts_deletes.
+    RawDataVisitor visitor;
+    RETURN_IF_ERROR(data_chunk->get_column_by_index(op_col_id)->accept(&visitor));
+    const auto* ops = visitor.result();
+    std::vector<uint32_t> upsert_idx;
+    std::vector<uint32_t> delete_idx;
+    for (uint32_t i = 0; i < nrows; i++) {
+        (ops[i] == TOpType::DELETE ? delete_idx : upsert_idx).push_back(i);
+    }
+    const size_t ndel = delete_idx.size();
+
+    // Drop __op so the chunk matches the segment schema (data columns only).
+    data_chunk->remove_column_by_index(op_col_id);
+
+    if (ndel == 0) {
+        // All upserts: write the whole flush as one segment.
+        return write_single_flush(*data_chunk, segment, eos);
+    }
+
+    // Encode the delete rows' primary keys to a del file (same encoding the primary index uses).
+    ASSIGN_OR_RETURN(auto pk_encoding_type, tablet_schema()->primary_key_encoding_type_or_error());
+    std::vector<uint32_t> pk_columns;
+    pk_columns.reserve(tablet_schema()->num_key_columns());
+    for (size_t i = 0; i < tablet_schema()->num_key_columns(); i++) {
+        pk_columns.push_back(static_cast<uint32_t>(i));
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema(), pk_columns);
+    MutableColumnPtr deletes;
+    RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &deletes, pk_encoding_type));
+    PrimaryKeyEncoder::encode_selective(pkey_schema, *data_chunk, delete_idx.data(), delete_idx.size(), deletes.get(),
+                                        pk_encoding_type);
+    RETURN_IF_ERROR(flush_del_file(*deletes, kUnknownDelOpOffset));
+
+    // Write only the upsert rows to the segment.
+    const size_t nupsert = upsert_idx.size();
+    auto upserts = data_chunk->clone_empty_with_schema(nupsert);
+    upserts->append_selective(*data_chunk, upsert_idx.data(), 0, nupsert);
+    return write_single_flush(*upserts, segment, eos);
+}
+
+Status HorizontalPkTabletWriter::append_pk_index_deletes(const Chunk& data, const std::vector<uint64_t>& rssid_rowids) {
+    // The op-aware merge can feed DELETE rows before the first write() that lazily sets up the segment
+    // and SST writers (a delete-first or delete-only batch), so _pk_sst_writer may still be null here.
+    // Do the same lazy init write() does; guarding on _seg_writer == nullptr means the following upsert
+    // write() reuses this same segment/SST writer rather than resetting it (which would drop the deletes).
+    if (_seg_writer == nullptr) {
+        RETURN_IF_ERROR(reset_segment_writer(false));
+    }
+    // DELETE rows are only fed to the eager PK-index SST writer (to resolve the latest op per key);
+    // they are NOT written to a segment. Only the unsort SST writer acts on them; other SST writers
+    // no-op (deletes reach them via the caller's del file instead).
+    return _pk_sst_writer->append_delete_records(data, &rssid_rowids);
 }
 
 Status HorizontalPkTabletWriter::flush_del_file(const Column& deletes, uint32_t op_offset) {
@@ -101,7 +184,13 @@ Status HorizontalPkTabletWriter::reset_segment_writer(bool eos) {
     // reset sst file writer
     if (_pk_sst_writer == nullptr) {
         if (enable_pk_index_eager_build()) {
-            _pk_sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            if (tablet_schema()->has_separate_sort_key()) {
+                // Separate sort key: primary keys arrive in sort-key (not PK) order, so buffer+sort
+                // them in the unsort writer instead of streaming into a sorted SST.
+                _pk_sst_writer = std::make_unique<PkTabletUnsortSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            } else {
+                _pk_sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            }
         } else {
             _pk_sst_writer = std::make_unique<DefaultSSTWriter>();
         }
@@ -152,6 +241,15 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         auto [sst_file_info, sst_range] = std::move(sst_ret);
         _ssts.emplace_back(sst_file_info);
         _sst_ranges.emplace_back(sst_range);
+        // Keep _seg_delvecs positionally aligned with _ssts (empty for the sort-key==PK path).
+        _seg_delvecs.emplace_back(_pk_sst_writer->take_deleted_rowids());
+        // The unsort writer (separate-sort-key op-aware path) cannot route deletes through the merge
+        // task's del file, so it hands back the winning DELETEs' encoded keys here; write them to a del
+        // file so publish erases the rows (including any written by an earlier transaction). op_offset is
+        // kUnknownDelOpOffset -- the real value is assigned when this batch is consolidated (merge_other_writer).
+        if (auto del_keys = _pk_sst_writer->take_delete_keys(); del_keys != nullptr && !del_keys->empty()) {
+            RETURN_IF_ERROR(flush_del_file(*del_keys, kUnknownDelOpOffset));
+        }
     }
     return Status::OK();
 }
@@ -200,14 +298,22 @@ Status VerticalPkTabletWriter::write_columns(const Chunk& data, const std::vecto
     if (_pk_sst_writers.size() <= _current_writer_index) {
         std::unique_ptr<DefaultSSTWriter> sst_writer;
         if (enable_pk_index_eager_build()) {
-            sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            if (tablet_schema()->has_separate_sort_key()) {
+                // Separate sort key: the vertical compaction task moves the PK columns into the key
+                // column group (appended after the sort-key columns), so this writer sees them here
+                // but not at chunk positions [0, num_key). The unsort writer buffers+sorts the PKs
+                // (they arrive in sort-key order) and projects them via `column_indexes`.
+                sst_writer = std::make_unique<PkTabletUnsortSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            } else {
+                sst_writer = std::make_unique<PkTabletSSTWriter>(tablet_schema(), _tablet_mgr, _tablet_id);
+            }
         } else {
             sst_writer = std::make_unique<DefaultSSTWriter>();
         }
         RETURN_IF_ERROR(sst_writer->reset_sst_writer(_location_provider, _fs));
         _pk_sst_writers.emplace_back(std::move(sst_writer));
     }
-    RETURN_IF_ERROR(_pk_sst_writers[_current_writer_index]->append_sst_record(data));
+    RETURN_IF_ERROR(_pk_sst_writers[_current_writer_index]->append_sst_record(data, &rssid_rowids, &column_indexes));
     if (_rows_mapper_builder != nullptr) {
         RETURN_IF_ERROR(_rows_mapper_builder->append(rssid_rowids));
     }
@@ -221,6 +327,7 @@ Status VerticalPkTabletWriter::finish(SegmentPB* segment) {
             auto [sst_file_info, sst_range] = std::move(sst_ret);
             _ssts.emplace_back(sst_file_info);
             _sst_ranges.emplace_back(sst_range);
+            _seg_delvecs.emplace_back(sst_writer->take_deleted_rowids());
         }
     }
     _pk_sst_writers.clear();

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -44,8 +44,13 @@ public:
     DISALLOW_COPY(HorizontalPkTabletWriter);
 
     Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids, SegmentPB* segment = nullptr) override;
+    Status append_pk_index_deletes(const Chunk& data, const std::vector<uint64_t>& rssid_rowids) override;
 
     Status write(const Chunk& data, SegmentPB* segment = nullptr, bool eos = false) override;
+
+    Status write_single_flush(const Chunk& data, SegmentPB* segment, bool eos) override;
+
+    Status write_single_flush_with_op(const Chunk& chunk_with_op, SegmentPB* segment, bool eos) override;
 
     Status flush_del_file(const Column& deletes, uint32_t op_offset) override;
 

--- a/be/src/storage/lake/spill_mem_table_sink.cpp
+++ b/be/src/storage/lake/spill_mem_table_sink.cpp
@@ -54,15 +54,27 @@ SpillMemTableSink::~SpillMemTableSink() {
 }
 
 bool SpillMemTableSink::keep_op_column() const {
+    // _keep_op_column is the EFFECTIVE preserve-order snapshot (pk_preserve_txn_delete_order_enabled):
+    // it is already true for the separate-sort-key load-spill path, which MUST run op-aware. That path's
+    // unsort SST writer resolves duplicate primary keys by flush order in its own per-PK reconciliation
+    // (a DELETE loses to a later re-UPSERT of the same key) and routes only winning deletes to a del
+    // file whose del_op_offsets are serialized (also gated by the effective snapshot in finish_with_txnlog),
+    // so a delete-then-reinsert applies consistently even when the two ops split across parallel merge
+    // tasks. The legacy path taken when this returns false (sort-key==PK with preserve off:
+    // _split_upserts_deletes -> flush_chunk_with_deletes) splits deletes off at the memtable and writes a
+    // del file applied "after all segments" -- unchanged from before this feature.
     return _keep_op_column;
 }
 
 Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* segment, bool eos,
                                       int64_t* flush_data_size, int64_t slot_idx) {
     if (eos && _load_chunk_spiller->empty() && slot_idx == 0) {
-        // Optimization: If there is only one flush, write directly to segment without spilling
-        // This avoids the overhead of spill/merge for single-chunk loads
-        RETURN_IF_ERROR(_writer->write(chunk, segment, eos));
+        // Only one flush: write directly to a segment without the spill/merge round trip. A single flush
+        // is unique-by-PK (memtable dedup), so no cross-flush merge/dedup is needed; write_single_flush
+        // writes a plain segment with the eager PK-index SST skipped (publish rebuilds it lazily), which
+        // also lets a separate-sort-key eager load take this path -- the unsort SST writer is only needed
+        // for the multi-flush spill+merge.
+        RETURN_IF_ERROR(_writer->write_single_flush(chunk, segment, eos));
         return _writer->flush(segment);
     }
     return _spill_and_maybe_eager_merge(chunk, slot_idx, flush_data_size);
@@ -70,12 +82,19 @@ Status SpillMemTableSink::flush_chunk(const Chunk& chunk, starrocks::SegmentPB* 
 
 Status SpillMemTableSink::flush_chunk_with_op(const Chunk& chunk_with_op, starrocks::SegmentPB* segment, bool eos,
                                               int64_t* flush_data_size, int64_t slot_idx) {
-    // The chunk still carries the trailing __op column. Always spill (skip the single-flush
-    // direct-write shortcut, which cannot handle __op): the op-aware merge resolves upsert/delete
-    // order per key by slot, then splits the merged output into segments + del files (see
-    // TabletInternalParallelMergeTask). __op is REPLACE-aggregated through the merge.
-    // The memtable only calls this when it actually kept the hidden __op column, so this is the
-    // authoritative op-aware signal handed to the merge tasks (see _op_aware).
+    // The chunk carries the trailing __op column. A single memtable flush is already unique-by-PK
+    // (last-op-wins), so the unsort SST writer's cross-flush duplicate-key resolution -- the only reason
+    // a separate-sort-key load must otherwise take the spill+merge path -- is unnecessary for it. So on a
+    // single flush, write directly: split __op (upserts -> plain sort-key-ordered segment with the eager
+    // PK-index SST skipped so publish rebuilds the index lazily; deletes -> del file), avoiding the
+    // spill + unsort-SST merge round trip that makes small (e.g. realtime) batches far slower.
+    if (eos && _load_chunk_spiller->empty() && slot_idx == 0) {
+        RETURN_IF_ERROR(_writer->write_single_flush_with_op(chunk_with_op, segment, eos));
+        return _writer->flush(segment);
+    }
+    // Multi-flush (bulk) load: the op-aware merge resolves upsert/delete order per key by slot, then
+    // splits the merged output into segments + del files (see TabletInternalParallelMergeTask) and keeps
+    // the eager-SST speedup. This is the authoritative op-aware signal handed to the merge tasks.
     _op_aware = true;
     return _spill_and_maybe_eager_merge(chunk_with_op, slot_idx, flush_data_size);
 }
@@ -132,9 +151,11 @@ Status SpillMemTableSink::flush_chunk_with_deletes(const Chunk& upserts, const C
                                                    starrocks::SegmentPB* segment, bool eos, int64_t* flush_data_size,
                                                    int64_t slot_idx) {
     if (eos && _load_chunk_spiller->empty() && slot_idx == 0) {
-        // If there is only one flush, flush it to segment directly
+        // Only one flush: write directly (deletes were already split out by the memtable). Upserts go
+        // through write_single_flush -> plain segment, eager SST skipped, lazy publish rebuild (see
+        // flush_chunk).
         RETURN_IF_ERROR(_writer->flush_del_file(deletes, kUnknownDelOpOffset));
-        RETURN_IF_ERROR(_writer->write(upserts, segment, eos));
+        RETURN_IF_ERROR(_writer->write_single_flush(upserts, segment, eos));
         return _writer->flush(segment);
     }
     // 1. flush upsert
@@ -159,8 +180,12 @@ Status SpillMemTableSink::merge_blocks_to_segments() {
     // Manual flush control needed because we're coordinating multiple parallel writers
     _writer->set_auto_flush(false);
 
-    if (_load_chunk_spiller->total_bytes() >= config::pk_index_eager_build_threshold_bytes) {
-        // When bulk load happens, try to enable eager PK index build
+    if (_load_chunk_spiller->total_bytes() >= config::pk_index_eager_build_threshold_bytes ||
+        _writer->tablet_schema()->has_separate_sort_key()) {
+        // When bulk load happens, try to enable eager PK index build.
+        // For separate-sort-key PK tables eager build is MANDATORY regardless of size: the
+        // sort-key-ordered merge cannot collapse duplicate primary keys, so the unsort SST writer
+        // must run to resolve them (last-flushed wins) and emit the per-segment dedup delvec.
         _writer->try_enable_pk_index_eager_build();
     }
 

--- a/be/src/storage/lake/spill_mem_table_sink.h
+++ b/be/src/storage/lake/spill_mem_table_sink.h
@@ -34,8 +34,9 @@ class TabletWriter;
 // The slot_idx parameter is used to track the original flush order for correct merging.
 class SpillMemTableSink : public MemTableSink {
 public:
-    // @param keep_op_column: snapshot of config::lake_enable_pk_preserve_txn_delete_order taken once by
-    // the DeltaWriter for the whole load, so the __op-keeping decision cannot change mid-load (see below).
+    // @param keep_op_column: the EFFECTIVE preserve-order snapshot (pk_preserve_txn_delete_order_enabled)
+    // taken once by the DeltaWriter for the whole load, so the __op-keeping decision cannot change
+    // mid-load (see keep_op_column()).
     SpillMemTableSink(LoadSpillBlockManager* block_manager, TabletWriter* writer, RuntimeProfile* profile,
                       bool keep_op_column);
     ~SpillMemTableSink() override;
@@ -51,14 +52,15 @@ public:
                                     starrocks::SegmentPB* segment = nullptr, bool eos = false,
                                     int64_t* flush_data_size = nullptr, int64_t slot_idx = -1) override;
 
-    // The spill sink keeps the __op column so the merge resolves upsert/delete order by slot.
-    // Keep the __op column (drive the op-aware merge) only when the in-transaction upsert/delete order
-    // feature is enabled. When it is off (the default), return false so the memtable takes the legacy
-    // _split_upserts_deletes path (deletes split into a del file, applied after all segments) -- keeping
-    // the spill path's behavior, del-file layout, and delete-with-merge-condition rejection identical to
-    // before this feature. Backed by _keep_op_column, a per-load snapshot of
-    // config::lake_enable_pk_preserve_txn_delete_order taken by the DeltaWriter, so the decision is
-    // stable for the whole load even if the mutable config is flipped mid-load.
+    // Whether the spill sink keeps the __op column (drives the op-aware merge that resolves upsert/delete
+    // order by slot). Returns the EFFECTIVE preserve-order snapshot (_keep_op_column): the config, OR the
+    // separate-sort-key load-spill path, which MUST use the op-aware path -- its unsort SST writer
+    // resolves a delete-then-reinsert of the same key by flush order, whereas the legacy
+    // _split_upserts_deletes path would drop the re-inserted row. When false (the common sort-key==PK
+    // path with preserve off), the memtable takes the legacy path (deletes split into a del file applied
+    // after all segments), keeping behavior/del-file layout/merge-condition rejection identical to before
+    // this feature. The snapshot is taken once by the DeltaWriter so the decision is stable for the whole
+    // load even if the mutable configs are flipped mid-load.
     bool keep_op_column() const override;
 
     // Spill a chunk that still carries the trailing __op column (see keep_op_column()).
@@ -79,7 +81,7 @@ private:
 
     TabletWriter* _writer;
 
-    // Per-load snapshot of config::lake_enable_pk_preserve_txn_delete_order (see keep_op_column()).
+    // Per-load snapshot of the effective preserve-order decision (see keep_op_column()).
     const bool _keep_op_column;
 
     // Set once when flush_chunk_with_op() is first called, i.e. the memtable actually kept a hidden __op

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.cpp
@@ -35,13 +35,15 @@ namespace starrocks::lake {
 TabletInternalParallelMergeTask::TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
                                                                  std::unique_ptr<LoadSpillMergeInputBatch> task,
                                                                  const Schema* schema, std::atomic<bool>* quit_flag,
-                                                                 RuntimeProfile::Counter* write_io_timer, bool op_aware)
+                                                                 RuntimeProfile::Counter* write_io_timer, bool op_aware,
+                                                                 bool need_rssid_rowids)
         : _writer(std::move(writer)),
           _task(std::move(task)),
           _schema(schema),
           _quit_flag(quit_flag),
           _write_io_timer(write_io_timer),
-          _op_aware(op_aware) {
+          _op_aware(op_aware),
+          _need_rssid_rowids(need_rssid_rowids) {
     std::string tracker_label =
             "LoadSpillMerge-" + std::to_string(_writer->tablet_id()) + "-" + std::to_string(_writer->txn_id());
     _merge_mem_tracker = std::make_unique<MemTracker>(MemTrackerType::COMPACTION_TASK, -1, std::move(tracker_label),
@@ -63,9 +65,15 @@ namespace {
 // the PK encoder, which reads only the leading key columns); `write_schema` is the segment schema.
 Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, const Schema& merge_schema,
                               const Schema& write_schema, const std::vector<size_t>& char_field_indexes,
-                              PrimaryKeyEncodingType pk_enc, MutableColumnPtr* deletes, bool* wrote_upsert) {
+                              PrimaryKeyEncodingType pk_enc, MutableColumnPtr* deletes, bool* wrote_upsert,
+                              bool* had_deletes, const std::vector<uint64_t>* rssid_rowids) {
     if (!has_op) {
         ChunkHelper::padding_char_columns(char_field_indexes, write_schema, writer->tablet_schema(), chunk);
+        // Separate-sort-key unsort path forwards per-row ordering keys so the writer can resolve
+        // duplicate primary keys by last-flushed-wins; otherwise the plain write overload is used.
+        if (rssid_rowids != nullptr) {
+            return writer->write(*chunk, *rssid_rowids);
+        }
         return writer->write(*chunk, nullptr);
     }
     // Split the merged chunk by __op (last column).
@@ -80,13 +88,35 @@ Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, c
     for (uint32_t i = 0; i < nrows; i++) {
         (ops[i] == TOpType::UPSERT ? up_idx : del_idx).push_back(i);
     }
-    // Encode net-deleted keys.
+    // Net-deleted keys.
     if (!del_idx.empty()) {
-        if (*deletes == nullptr) {
-            RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(merge_schema, deletes, pk_enc));
+        *had_deletes = true;
+        if (writer->tablet_schema()->has_separate_sort_key()) {
+            // Separate-sort-key unsort path: the merge is ordered by sort key, so a DELETE and a later
+            // UPSERT of the same PK are not adjacent and cannot be REPLACE-aggregated to the latest op
+            // before this split. Instead feed the DELETE rows (with their per-row ordering keys) to the
+            // eager SST writer, which reconciles them against the upserts by order (last op wins) and,
+            // for a PK whose latest op is a DELETE, hands the key back at flush to be written to this
+            // batch's del file (see flush_segment_writer) so publish erases even a pre-existing row.
+            // rssid_rowids is always present on this path.
+            DCHECK(rssid_rowids != nullptr);
+            auto del_chunk = chunk->clone_empty_with_schema(del_idx.size());
+            del_chunk->append_selective(*chunk, del_idx.data(), 0, del_idx.size());
+            std::vector<uint64_t> del_rssid_rowids;
+            del_rssid_rowids.reserve(del_idx.size());
+            for (uint32_t i : del_idx) {
+                del_rssid_rowids.push_back((*rssid_rowids)[i]);
+            }
+            RETURN_IF_ERROR(writer->append_pk_index_deletes(*del_chunk, del_rssid_rowids));
+        } else {
+            // sort-key == PK: the merge already reduced each PK to its latest op, so all DELETEs here
+            // are net deletes; encode them for this batch's del file.
+            if (*deletes == nullptr) {
+                RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(merge_schema, deletes, pk_enc));
+            }
+            PrimaryKeyEncoder::encode_selective(merge_schema, *chunk, del_idx.data(), del_idx.size(), deletes->get(),
+                                                pk_enc);
         }
-        PrimaryKeyEncoder::encode_selective(merge_schema, *chunk, del_idx.data(), del_idx.size(), deletes->get(),
-                                            pk_enc);
     }
     // Write upsert rows as a chunk without __op. Copy the upsert rows into a temp chunk (Chunk-level
     // append_selective handles the immutable columns), then repackage its leading data columns into a
@@ -99,7 +129,18 @@ Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, c
         Columns up_cols(tmp->columns().begin(), tmp->columns().begin() + write_schema.num_fields()); // drop __op
         auto up_chunk = std::make_shared<Chunk>(std::move(up_cols), std::make_shared<Schema>(write_schema));
         ChunkHelper::padding_char_columns(char_field_indexes, write_schema, writer->tablet_schema(), up_chunk.get());
-        RETURN_IF_ERROR(writer->write(*up_chunk, nullptr));
+        if (rssid_rowids != nullptr) {
+            // Both op-aware split and the unsort path are active: forward only the upsert rows' ordering
+            // keys, aligned with the rows selected into up_chunk.
+            std::vector<uint64_t> up_rssid_rowids;
+            up_rssid_rowids.reserve(up_idx.size());
+            for (uint32_t i : up_idx) {
+                up_rssid_rowids.push_back((*rssid_rowids)[i]);
+            }
+            RETURN_IF_ERROR(writer->write(*up_chunk, up_rssid_rowids));
+        } else {
+            RETURN_IF_ERROR(writer->write(*up_chunk, nullptr));
+        }
         *wrote_upsert = true;
     }
     return Status::OK();
@@ -112,10 +153,13 @@ Status write_one_merged_chunk(TabletWriter* writer, Chunk* chunk, bool has_op, c
 // sort after, and wrongly erase, a key re-upserted in that later segment. Mirrors the serial path, which
 // writes a 0-row segment for a delete-only flush.
 Status finalize_merged_batch(TabletWriter* writer, bool has_op, const Schema& write_schema,
-                             const MutableColumnPtr& deletes, bool wrote_upsert,
+                             const MutableColumnPtr& deletes, bool wrote_upsert, bool had_deletes,
                              RuntimeProfile::Counter* write_io_timer) {
-    const bool has_deletes = has_op && deletes != nullptr && deletes->size() > 0;
-    if (has_deletes && !wrote_upsert) {
+    // A batch that produced deletes but no upsert segment still needs a 0-row anchor segment so its
+    // SST and del file attach to a real segment index rather than colliding with a later batch's
+    // segment 0. `had_deletes` covers both del-file sinks: the column encoded here (sort-key==PK) and
+    // the winning keys the unsort writer writes during flush() (separate-sort-key).
+    if (has_op && had_deletes && !wrote_upsert) {
         SCOPED_TIMER(write_io_timer);
         auto empty_chunk = ChunkFactory::new_chunk(write_schema, 0);
         RETURN_IF_ERROR(writer->write(*empty_chunk, nullptr));
@@ -124,7 +168,9 @@ Status finalize_merged_batch(TabletWriter* writer, bool has_op, const Schema& wr
         SCOPED_TIMER(write_io_timer);
         RETURN_IF_ERROR(writer->flush());
     }
-    if (has_deletes) {
+    // Only the sort-key==PK path routes deletes through this `deletes` column; the separate-sort-key
+    // path's writer wrote its own del file during flush() above, so there is nothing to write here.
+    if (deletes != nullptr && deletes->size() > 0) {
         SCOPED_TIMER(write_io_timer);
         // op_offset is a placeholder here; the real (global) value is assigned in merge_other_writer when
         // this batch's writer is consolidated into the parent, based on the cumulative segment count.
@@ -192,13 +238,27 @@ void TabletInternalParallelMergeTask::run() {
     auto chunk_shared_ptr = ChunkFactory::new_chunk(*_schema, config::vector_chunk_size);
     auto chunk = chunk_shared_ptr.get();
     auto st = Status::OK();
-    MutableColumnPtr deletes;  // accumulates net-deleted keys for this batch's del file
+
+    // Per-row ordering keys for the separate-sort-key unsort path (empty otherwise); pulled alongside
+    // each chunk so the writer resolves duplicate primary keys by last-flushed-wins.
+    std::vector<uint64_t> rssid_rowids;
+    MutableColumnPtr deletes;  // accumulates net-deleted keys for this batch's del file (sort-key==PK)
     bool wrote_upsert = false; // whether this batch produced any upsert segment
-    // Read and write each merged chunk. _quit_flag (when non-null) lets a sibling task's error abort the
-    // loop early; when nullptr, cancellation is unsupported and we run to completion.
+    bool had_deletes = false;  // whether this batch saw any DELETE rows (either delete sink)
+    // CANCELLATION CHECK: read and write each merged chunk. _quit_flag (when non-null) lets a sibling
+    // task's error abort the loop early; when nullptr, cancellation is unsupported and we run to completion.
     while (_quit_flag == nullptr || !_quit_flag->load()) {
         chunk->reset();
-        auto itr_st = _task->merge_itr->get_next(chunk);
+        // For the separate-sort-key unsort path, pull per-row ordering keys (rssid_rowids) alongside
+        // the chunk so the writer can resolve duplicate primary keys by last-flushed-wins. Kept in
+        // lockstep with the chunk rows; no row filtering happens between here and append_sst_record.
+        Status itr_st;
+        if (_need_rssid_rowids) {
+            rssid_rowids.clear();
+            itr_st = _task->merge_itr->get_next(chunk, &rssid_rowids);
+        } else {
+            itr_st = _task->merge_itr->get_next(chunk);
+        }
         if (itr_st.is_end_of_file()) {
             break;
         }
@@ -208,13 +268,15 @@ void TabletInternalParallelMergeTask::run() {
         }
         SCOPED_TIMER(_write_io_timer);
         st = write_one_merged_chunk(_writer.get(), chunk, has_op, *_schema, write_schema, char_field_indexes, pk_enc,
-                                    &deletes, &wrote_upsert);
+                                    &deletes, &wrote_upsert, &had_deletes,
+                                    _need_rssid_rowids ? &rssid_rowids : nullptr);
         if (!st.ok()) {
             break;
         }
     }
     if (st.ok()) {
-        st = finalize_merged_batch(_writer.get(), has_op, write_schema, deletes, wrote_upsert, _write_io_timer);
+        st = finalize_merged_batch(_writer.get(), has_op, write_schema, deletes, wrote_upsert, had_deletes,
+                                   _write_io_timer);
     }
     if (st.ok()) {
         hot_delete_merged_spill_files(_writer.get(), _task.get());

--- a/be/src/storage/lake/tablet_internal_parallel_merge_task.h
+++ b/be/src/storage/lake/tablet_internal_parallel_merge_task.h
@@ -63,7 +63,7 @@ public:
     TabletInternalParallelMergeTask(std::unique_ptr<TabletWriter> writer,
                                     std::unique_ptr<LoadSpillMergeInputBatch> task, const Schema* schema,
                                     std::atomic<bool>* quit_flag, RuntimeProfile::Counter* write_io_timer,
-                                    bool op_aware);
+                                    bool op_aware, bool need_rssid_rowids = false);
 
     ~TabletInternalParallelMergeTask() override;
 
@@ -120,6 +120,11 @@ private:
     // Whether the merge input carries a trailing hidden __op column (see ctor). Drives the op-aware
     // upsert/delete split in run(); never inferred from the last column name.
     const bool _op_aware = false;
+
+    // When true (separate-sort-key PK unsort path), the merge output carries a per-row ordering key
+    // (rssid_rowids) that the writer needs to resolve duplicate primary keys by last-flushed-wins.
+    // Independent of _op_aware; when both are set, the op-split forwards the selected rssid_rowids.
+    bool _need_rssid_rowids = false;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -20,35 +20,43 @@
 
 namespace starrocks::lake {
 
+bool pk_index_eager_build_supported(const TabletSchema& schema) {
+    if (!config::enable_pk_index_eager_build || schema.keys_type() != KeysType::PRIMARY_KEYS) {
+        return false;
+    }
+    // Eager PK index build only supports the cloud-native persistent index, and shared-data primary-key
+    // tables always use it (enforced since #75940/#76260). So there is no need to read tablet metadata to
+    // confirm the index type -- and the eager decision no longer depends on the metadata cache being warm.
+    // V2 encoding guarantees correct ordering for all column types after encoding,
+    // so eager PK index build is always safe.
+    if (schema.has_valid_primary_key_encoding_type() &&
+        schema.primary_key_encoding_type() == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
+        return true;
+    }
+    // For V1 encoding, a single non-VARCHAR/CHAR key column does not use big-endian encoding, which
+    // may result in incorrect ordering between the sst and segment files, so eager build is unsafe.
+    return schema.num_key_columns() > 1 || schema.column(0).type() == LogicalType::TYPE_VARCHAR ||
+           schema.column(0).type() == LogicalType::TYPE_CHAR;
+}
+
+bool pk_preserve_txn_delete_order_enabled(const TabletSchema& schema) {
+    // A separate-sort-key load's op-aware merge resolves duplicate primary keys by flush order and can
+    // split a key's DELETE and later re-UPSERT across parallel merge tasks, so it MUST preserve
+    // in-transaction op order (and serialize del_op_offsets) regardless of the general config -- otherwise
+    // the earlier del file would erase the later re-insert.
+    return config::lake_enable_pk_preserve_txn_delete_order || schema.has_separate_sort_key();
+}
+
 void TabletWriter::try_enable_pk_index_eager_build() {
     // Guard against multiple calls when writers are reused or merged in different pipeline phases
     // (e.g., eager merge and final merge); this method is intentionally idempotent.
     if (_enable_pk_index_eager_build) {
         return;
     }
-    if (!config::enable_pk_index_eager_build || _schema->keys_type() != KeysType::PRIMARY_KEYS ||
-        _schema->has_separate_sort_key()) {
-        return;
-    }
-    auto metadata = _tablet_mgr->get_latest_cached_tablet_metadata(_tablet_id);
-    if (metadata != nullptr) {
-        // Eager PK index build only supports cloud native pk index.
-        if (!metadata->enable_persistent_index() ||
-            metadata->persistent_index_type() != PersistentIndexTypePB::CLOUD_NATIVE) {
-            return;
-        }
-    }
-    // V2 encoding guarantees correct ordering for all column types after encoding,
-    // so eager PK index build is always safe.
-    if (_schema->has_valid_primary_key_encoding_type() &&
-        _schema->primary_key_encoding_type() == PrimaryKeyEncodingType::PK_ENCODING_TYPE_V2) {
-        _enable_pk_index_eager_build = true;
-        return;
-    }
-    // For V1 encoding, single-key column of non-VARCHAR/CHAR type does not use big-endian encoding,
-    // which may result in incorrect ordering between sst and segment files.
-    if (_schema->num_key_columns() > 1 || _schema->column(0).type() == LogicalType::TYPE_VARCHAR ||
-        _schema->column(0).type() == LogicalType::TYPE_CHAR) {
+    // NOTE: separate sort key is now supported via PkTabletUnsortSSTWriter, which buffers+sorts the
+    // primary keys (they arrive in sort-key, not PK, order) before building the SST. It is selected
+    // in the PK writer's reset path when eager build is enabled and the schema has a separate sort key.
+    if (pk_index_eager_build_supported(*_schema)) {
         _enable_pk_index_eager_build = true;
     }
 }
@@ -92,6 +100,7 @@ Status TabletWriter::merge_other_writer(const TabletWriter* other_writer) {
     }
     _ssts.insert(_ssts.end(), other_writer->_ssts.begin(), other_writer->_ssts.end());
     _sst_ranges.insert(_sst_ranges.end(), other_writer->_sst_ranges.begin(), other_writer->_sst_ranges.end());
+    _seg_delvecs.insert(_seg_delvecs.end(), other_writer->_seg_delvecs.begin(), other_writer->_seg_delvecs.end());
     _num_rows += other_writer->_num_rows;
     _data_size += other_writer->_data_size;
     // _global_dict_columns_valid_info

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -24,6 +24,7 @@
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_metadata.h"
 #include "storage/rowset/segment_file_info.h"
 #include "storage/tablet_schema.h"
 
@@ -39,6 +40,23 @@ struct OlapWriterStatistics;
 namespace lake {
 
 class TabletManager;
+
+// Whether eager PK-index SST build is supported for `schema`. Encapsulates the primary-key-encoding (and
+// separate-sort-key opt-in) preconditions shared by eager build enablement
+// (TabletWriter::try_enable_pk_index_eager_build) and separate-sort-key load spill
+// (DeltaWriterImpl::should_enable_load_spill), which is only correct when the unsort SST writer runs to
+// resolve duplicate primary keys. Needs no tablet metadata: shared-data PK tables are always cloud-native
+// (the only index eager build supports), so the decision is a pure function of config + schema.
+bool pk_index_eager_build_supported(const TabletSchema& schema);
+
+// Whether a load into `schema` must preserve in-transaction upsert/delete order. True when the mutable
+// config lake_enable_pk_preserve_txn_delete_order is on, OR when the separate-sort-key load-spill
+// optimization is enabled for a separate-sort-key table: that path's unsort SST writer resolves
+// duplicate primary keys by flush order (last-op-wins), so it ALWAYS needs the op-aware merge and the
+// serialized del_op_offsets, regardless of the preserve config -- otherwise a DELETE and a later re-UPSERT
+// of the same key that split across parallel merge tasks would resolve inconsistently. Snapshot the
+// result once per load (both configs are mutable).
+bool pk_preserve_txn_delete_order_enabled(const TabletSchema& schema);
 
 enum WriterType : int { kHorizontal = 0, kVertical = 1 };
 
@@ -84,6 +102,11 @@ public:
 
     const std::vector<PersistentIndexSstableRangePB>& sst_ranges() const { return _sst_ranges; }
 
+    // Parallel to ssts(): per-segment rowids that lost primary-key dedup inside the unsort SST
+    // writer and must be masked by a delete vector at publish. Empty vectors for segments/paths
+    // that produced no such losers (e.g. the sort-key==PK eager path). PK table only.
+    const std::vector<std::vector<uint32_t>>& seg_delvecs() const { return _seg_delvecs; }
+
     // The sum of all segment file sizes, in bytes.
     int64_t data_size() const { return _data_size; }
 
@@ -107,6 +130,32 @@ public:
     // For horizontal writer.
     virtual Status write(const Chunk& data, const std::vector<uint64_t>& rssid_rowids,
                          SegmentPB* segment = nullptr) = 0;
+
+    // Single-flush direct-write fast path (no __op column). The whole load is a single flush, which a
+    // lake PK memtable already deduplicated by primary key, so no cross-flush merge/dedup is needed. For
+    // a PK writer this writes a plain (sort-key-ordered) segment and SKIPS the eager PK-index SST, so
+    // publish rebuilds the index lazily via the order-independent parallel_upsert -- avoiding the
+    // spill+merge round trip and, for separate-sort-key eager writers, the unsort SST writer's per-row
+    // order-key requirement. Default (non-PK, or writers with no eager SST): same as write().
+    virtual Status write_single_flush(const Chunk& data, SegmentPB* segment, bool eos) {
+        return write(data, segment, eos);
+    }
+
+    // Same single-flush fast path for a load whose chunk still carries the trailing __op column (the
+    // op-aware path). Splits __op: upserts go through write_single_flush() (plain segment, eager SST
+    // skipped), deletes are encoded to a del file. A single flush is unique-by-PK, so each key has
+    // exactly one op and the split is unambiguous. Only the horizontal PK writer implements it.
+    virtual Status write_single_flush_with_op(const Chunk& chunk_with_op, SegmentPB* segment, bool eos) {
+        return Status::NotSupported("write_single_flush_with_op not implemented");
+    }
+
+    // Feeds the batch's DELETE rows (with their per-row ordering key) to the eager PK-index SST
+    // writer so it can resolve the latest op per primary key (op-aware separate-sort-key spill path).
+    // Unlike write(), these rows are NOT written to a segment. Default no-op: only the PK writer with
+    // the unsort SST writer consumes them; other writers receive deletes via the caller's del file.
+    virtual Status append_pk_index_deletes(const Chunk& data, const std::vector<uint64_t>& rssid_rowids) {
+        return Status::OK();
+    }
 
     // Writes partial columns data to this rowset.
     //
@@ -211,6 +260,8 @@ protected:
     std::mutex _dels_mutex;
     std::vector<FileInfo> _ssts;
     std::vector<PersistentIndexSstableRangePB> _sst_ranges;
+    // Parallel to _ssts: dedup-loser rowids per segment (see seg_delvecs()).
+    std::vector<std::vector<uint32_t>> _seg_delvecs;
     // lake compaction row mapper file
     FileInfo _lcrm_file;
     int64_t _num_rows = 0;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -14,10 +14,15 @@
 
 #include "storage/lake/vertical_compaction_task.h"
 
+#include <algorithm>
+#include <numeric>
+#include <unordered_set>
+
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/chunk_schema_helper.h"
+#include "column/schema.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_storage_fwd.h"
@@ -75,6 +80,13 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     std::vector<std::vector<uint32_t>> column_groups;
     CompactionUtils::split_column_into_groups(_tablet_schema->num_columns(), _tablet_schema->sort_key_idxes(),
                                               config::vertical_compaction_max_columns_per_group, &column_groups);
+    // Separate-sort-key PK tables with eager index build: the PK columns are non-sort columns and
+    // would otherwise land in value groups where the eager SST writer (which only sees the key group)
+    // cannot reach them. Move them into the key group so compaction builds the PK-index SST eagerly.
+    const bool pk_in_key_group = writer->enable_pk_index_eager_build() && _tablet_schema->has_separate_sort_key();
+    if (pk_in_key_group) {
+        move_pk_columns_into_key_group(&column_groups);
+    }
     auto column_group_size = column_groups.size();
 
     VLOG(3) << "Start vertical compaction. tablet: " << _tablet.id()
@@ -91,7 +103,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
             RETURN_IF_ERROR(mask_buffer->flip_to_read());
         }
         RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer, mask_buffer.get(),
-                                             source_masks.get(), cancel_func));
+                                             source_masks.get(), cancel_func, pk_in_key_group));
     }
 
     RETURN_IF_ERROR(writer->finish());
@@ -189,13 +201,25 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                                     std::unique_ptr<TabletWriter>& writer,
                                                     RowSourceMaskBuffer* mask_buffer,
                                                     std::vector<RowSourceMask>* source_masks,
-                                                    const CancelFunc& cancel_func) {
+                                                    const CancelFunc& cancel_func, bool pk_in_key_group) {
     ASSIGN_OR_RETURN(auto chunk_size, calculate_chunk_size_for_column_group(column_group));
 
-    Schema schema = column_group_index == 0 ? (_tablet_schema->sort_key_idxes().empty()
-                                                       ? ChunkHelper::convert_schema(_tablet_schema, column_group)
-                                                       : ChunkHelper::get_sort_key_schema(_tablet_schema))
-                                            : ChunkHelper::convert_schema(_tablet_schema, column_group);
+    Schema schema;
+    if (column_group_index != 0) {
+        schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
+    } else if (_tablet_schema->sort_key_idxes().empty()) {
+        schema = ChunkHelper::convert_schema(_tablet_schema, column_group);
+    } else if (pk_in_key_group) {
+        // Key group has been widened to [sort-key columns, then PK columns]. Select those columns
+        // (in `column_group` order) and mark only the leading sort-key columns as the sort keys, so
+        // the merge still orders rows by the sort key -- the appended PK columns are carried along
+        // for the eager SST writer but do not affect ordering.
+        std::vector<ColumnId> sort_key_positions(_tablet_schema->sort_key_idxes().size());
+        std::iota(sort_key_positions.begin(), sort_key_positions.end(), 0);
+        schema = Schema(_tablet_schema->schema(), column_group, sort_key_positions);
+    } else {
+        schema = ChunkHelper::get_sort_key_schema(_tablet_schema);
+    }
     TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets, is_key, mask_buffer,
                         _tablet_schema);
     RETURN_IF_ERROR(reader.prepare());
@@ -305,6 +329,39 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         RETURN_IF_ERROR(mask_buffer->flush());
     }
     return Status::OK();
+}
+
+void VerticalCompactionTask::move_pk_columns_into_key_group(std::vector<std::vector<uint32_t>>* column_groups) const {
+    DCHECK(!column_groups->empty());
+    const auto& sort_key_idxes = _tablet_schema->sort_key_idxes();
+    std::unordered_set<uint32_t> sort_key_set(sort_key_idxes.begin(), sort_key_idxes.end());
+    // PK columns are tablet column ids [0, num_key); collect the ones not already in the sort key
+    // (those are already in the key group).
+    std::vector<uint32_t> pk_to_move;
+    for (uint32_t i = 0; i < _tablet_schema->num_key_columns(); ++i) {
+        if (sort_key_set.find(i) == sort_key_set.end()) {
+            pk_to_move.push_back(i);
+        }
+    }
+    if (pk_to_move.empty()) {
+        return;
+    }
+    std::unordered_set<uint32_t> pk_set(pk_to_move.begin(), pk_to_move.end());
+    // Remove the moved PK columns from the value groups so each column is written exactly once.
+    for (size_t g = 1; g < column_groups->size(); ++g) {
+        auto& group = (*column_groups)[g];
+        group.erase(
+                std::remove_if(group.begin(), group.end(), [&](uint32_t c) { return pk_set.find(c) != pk_set.end(); }),
+                group.end());
+    }
+    // Drop any value group emptied by the move.
+    column_groups->erase(std::remove_if(column_groups->begin() + 1, column_groups->end(),
+                                        [](const std::vector<uint32_t>& g) { return g.empty(); }),
+                         column_groups->end());
+    // Append the PK columns to the key group, after the sort-key columns (which stay first so the
+    // merge order remains sort-key-first).
+    auto& key_group = (*column_groups)[0];
+    key_group.insert(key_group.end(), pk_to_move.begin(), pk_to_move.end());
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -44,10 +44,19 @@ public:
 private:
     StatusOr<int32_t> calculate_chunk_size_for_column_group(const std::vector<uint32_t>& column_group);
 
+    // When `pk_in_key_group` is true (separate-sort-key PK table with eager index build), the key
+    // column group has been widened to [sort-key columns, then PK columns]; the key-group schema is
+    // built accordingly so the eager SST writer can read the PK columns.
     Status compact_column_group(bool is_key, int column_group_index, size_t num_column_groups,
                                 const std::vector<uint32_t>& column_group, std::unique_ptr<TabletWriter>& writer,
                                 RowSourceMaskBuffer* mask_buffer, std::vector<RowSourceMask>* source_masks,
-                                const CancelFunc& cancel_func);
+                                const CancelFunc& cancel_func, bool pk_in_key_group);
+
+    // For a separate-sort-key PK table with eager PK-index SST build, move the PK columns (tablet
+    // column ids [0, num_key) not already in the sort key) out of the value groups and into the key
+    // group (group 0), appended after the sort-key columns. Empty value groups are dropped. This lets
+    // the eager SST writer, which only sees the key group, read the PK columns.
+    void move_pk_columns_into_key_group(std::vector<std::vector<uint32_t>>* column_groups) const;
     int64_t _total_num_rows = 0;
     int64_t _total_data_size = 0;
     int64_t _total_input_segs = 0;

--- a/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
+++ b/be/test/storage/lake/pk_tablet_sst_writer_test.cpp
@@ -17,7 +17,9 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <map>
 #include <random>
+#include <tuple>
 
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
@@ -34,12 +36,14 @@
 #include "common/logging.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
+#include "runtime/descriptors.h"
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/pk_tablet_unsort_sst_writer.h"
 #include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
@@ -983,5 +987,667 @@ TEST_P(PkTabletSSTWriterBigintKeyTest, test_write_with_eager_build_single_bigint
 INSTANTIATE_TEST_SUITE_P(PkEncodingType, PkTabletSSTWriterBigintKeyTest,
                          ::testing::Values(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V1,
                                            PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2));
+
+// ---------------------------------------------------------------------------
+// PkTabletUnsortSSTWriter (separate-sort-key path) unit tests
+// ---------------------------------------------------------------------------
+
+// Builds a chunk from explicit (key, value) rows; keys may repeat.
+static Chunk make_kv_chunk(const std::shared_ptr<Schema>& schema,
+                           const std::vector<std::pair<std::string, int>>& rows) {
+    auto c0 = BinaryColumn::create();
+    auto c1 = Int32Column::create();
+    for (const auto& [k, v] : rows) {
+        c0->append(k);
+        c1->append(v);
+    }
+    return Chunk({std::move(c0), std::move(c1)}, schema);
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_basic_no_dup) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+
+    auto chunk = generate_data(100);
+    std::vector<uint64_t> order(chunk.num_rows());
+    for (uint32_t i = 0; i < chunk.num_rows(); i++) {
+        order[i] = (static_cast<uint64_t>(1) << 32) | i; // slot_idx=1, rowid=i
+    }
+    ASSERT_OK(w->append_sst_record(chunk, &order));
+
+    ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+    auto [file_info, sst_range] = std::move(ret);
+    ASSERT_FALSE(file_info.path.empty());
+    ASSERT_GT(file_info.size, 0);
+    // Distinct keys -> no dedup losers.
+    EXPECT_TRUE(w->take_deleted_rowids().empty());
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_requires_order) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+
+    auto chunk = generate_data(10);
+    // Missing per-row order keys must be rejected (the sort-key-ordered merge cannot resolve dup PKs
+    // without them).
+    ASSERT_ERROR(w->append_sst_record(chunk));
+    std::vector<uint64_t> wrong_size(5);
+    ASSERT_ERROR(w->append_sst_record(chunk, &wrong_size));
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_dedup_last_flushed_wins) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+
+    // Two rows share the same primary key; the one with the larger order (later memtable flush) wins,
+    // and the loser's rowid is recorded for the delete vector.
+    // Case A: row 1 has the larger order -> loser is rowid 0.
+    {
+        auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+        ASSERT_OK(w->reset_sst_writer(lp, _fs));
+        auto chunk = make_kv_chunk(_schema, {{"dup_key", 10}, {"dup_key", 20}});
+        std::vector<uint64_t> order = {(static_cast<uint64_t>(1) << 32) | 0, (static_cast<uint64_t>(2) << 32) | 1};
+        ASSERT_OK(w->append_sst_record(chunk, &order));
+        ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+        auto dels = w->take_deleted_rowids();
+        ASSERT_EQ(dels.size(), 1u);
+        EXPECT_EQ(dels[0], 0u);
+    }
+    // Case B: row 0 has the larger order -> loser is rowid 1.
+    {
+        auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+        ASSERT_OK(w->reset_sst_writer(lp, _fs));
+        auto chunk = make_kv_chunk(_schema, {{"dup_key", 10}, {"dup_key", 20}});
+        std::vector<uint64_t> order = {(static_cast<uint64_t>(2) << 32) | 0, (static_cast<uint64_t>(1) << 32) | 1};
+        ASSERT_OK(w->append_sst_record(chunk, &order));
+        ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+        auto dels = w->take_deleted_rowids();
+        ASSERT_EQ(dels.size(), 1u);
+        EXPECT_EQ(dels[0], 1u);
+    }
+}
+
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_overflow_merge_dedup) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    // Force the map to spill to an intermediate SST on every append, so the duplicate key below is
+    // split across two intermediate SSTs and must be resolved by the finish-time k-way merge.
+    ConfigResetGuard<int64_t> guard(&config::l0_max_mem_usage, 1);
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+
+    // append 1: key "A" at segment rowid 0, slot_idx 1 -> spilled to intermediate SST #1.
+    auto chunk1 = make_kv_chunk(_schema, {{"A", 10}});
+    std::vector<uint64_t> order1 = {(static_cast<uint64_t>(1) << 32) | 0};
+    ASSERT_OK(w->append_sst_record(chunk1, &order1));
+    // append 2: key "A" again at segment rowid 1, slot_idx 2 (later flush) -> intermediate SST #2.
+    auto chunk2 = make_kv_chunk(_schema, {{"A", 20}});
+    std::vector<uint64_t> order2 = {(static_cast<uint64_t>(2) << 32) | 1};
+    ASSERT_OK(w->append_sst_record(chunk2, &order2));
+
+    ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+    auto [file_info, sst_range] = std::move(ret);
+    ASSERT_FALSE(file_info.path.empty());
+    // Cross-SST merge: later-flushed row (rowid 1) wins, rowid 0 loses.
+    auto dels = w->take_deleted_rowids();
+    ASSERT_EQ(dels.size(), 1u);
+    EXPECT_EQ(dels[0], 0u);
+}
+
+// Op-aware reconciliation (separate-sort-key spill path): DELETE rows are fed via append_delete_records
+// and reconciled against the upserts by rssid_rowid order (latest op per PK wins). An UPSERT that lost
+// to a later DELETE (or a later UPSERT) is masked by the delete vector; a DELETE superseded by a later
+// UPSERT contributes nothing. A PK whose latest op is a DELETE is collected into the del-file column
+// (take_delete_keys) so publish erases it, including a row from an earlier transaction.
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_op_aware_reconcile) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+    auto order = [](uint32_t slot, uint32_t rowid) { return (static_cast<uint64_t>(slot) << 32) | rowid; };
+
+    // Upserts, in segment-rowid order (rowid == append position):
+    //   "up_only"  @rowid0 slot1  -> live (no matching delete)
+    //   "del_wins" @rowid1 slot1  -> a later DELETE at slot3 supersedes it -> masked (loser)
+    //   "up_after" @rowid2 slot4  -> a DELETE at slot2 precedes it -> upsert wins, live
+    auto up_chunk = make_kv_chunk(_schema, {{"up_only", 1}, {"del_wins", 2}, {"up_after", 3}});
+    std::vector<uint64_t> up_order = {order(1, 0), order(1, 1), order(4, 2)};
+    ASSERT_OK(w->append_sst_record(up_chunk, &up_order));
+
+    // Deletes (no segment rowid). Orders decide the winner per PK:
+    //   "del_wins" @slot3  > its upsert slot1  -> DELETE wins  -> upsert rowid1 masked
+    //   "up_after" @slot2  < its upsert slot4  -> DELETE loses -> dropped, upsert stays live
+    //   "del_only" @slot5  (no upsert)         -> DELETE wins  -> del-file key, nothing masked
+    auto del_chunk = make_kv_chunk(_schema, {{"del_wins", 0}, {"up_after", 0}, {"del_only", 0}});
+    std::vector<uint64_t> del_order = {order(3, 0), order(2, 0), order(5, 0)};
+    ASSERT_OK(w->append_delete_records(del_chunk, &del_order));
+
+    ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+
+    // The only masked segment row is "del_wins"'s upsert at rowid 1: it lost to a later DELETE.
+    // up_only has no delete; up_after's delete is older so the upsert wins; del_only has no segment row.
+    auto dels = w->take_deleted_rowids();
+    ASSERT_EQ(dels.size(), 1u);
+    EXPECT_EQ(dels[0], 1u);
+
+    // Two PKs have DELETE as their latest op -> collected as del-file keys: "del_wins" (supersedes its
+    // upsert) and "del_only" (no upsert at all). "up_after"'s DELETE lost to a later upsert, so it is
+    // not present. These keys drive publish's erase of pre-existing rows.
+    auto del_keys = w->take_delete_keys();
+    ASSERT_NE(del_keys, nullptr);
+    EXPECT_EQ(del_keys->size(), 2u);
+}
+
+// merge_intermediates_into's winning-DELETE branch: with the map forced to spill on every append, a
+// DELETE and its earlier UPSERT of the same key land in SEPARATE intermediate SSTs, so the winning
+// DELETE is resolved by the finish-time k-way merge (not the in-memory map path in flush_sst_writer).
+// Asserts the delete is collected into the del file and the superseded upsert's rowid is masked.
+TEST_F(PkTabletSSTWriterTest, test_unsort_sst_writer_overflow_merge_delete_wins) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<int64_t> guard(&config::l0_max_mem_usage, 1);
+    auto lp = std::make_shared<FixedLocationProvider>(kTestDirectory);
+    auto w = std::make_unique<PkTabletUnsortSSTWriter>(_tablet_schema, _tablet_mgr.get(), tablet_id);
+    ASSERT_OK(w->reset_sst_writer(lp, _fs));
+    auto order = [](uint32_t slot, uint32_t rowid) { return (static_cast<uint64_t>(slot) << 32) | rowid; };
+
+    // UPSERT "A" @rowid0 slot1 -> spilled to intermediate SST #1.
+    auto up = make_kv_chunk(_schema, {{"A", 10}});
+    std::vector<uint64_t> up_order = {order(1, 0)};
+    ASSERT_OK(w->append_sst_record(up, &up_order));
+    // DELETE "A" @slot3 (later flush) -> intermediate SST #2. Across SSTs, the DELETE is the latest op.
+    auto del = make_kv_chunk(_schema, {{"A", 0}});
+    std::vector<uint64_t> del_order = {order(3, 0)};
+    ASSERT_OK(w->append_delete_records(del, &del_order));
+
+    ASSIGN_OR_ABORT(auto ret, w->flush_sst_writer());
+    // Latest op is the DELETE -> collected into the del file (not written to the SST as a rowid).
+    auto del_keys = w->take_delete_keys();
+    ASSERT_NE(del_keys, nullptr);
+    EXPECT_EQ(del_keys->size(), 1u);
+    // The superseded UPSERT's segment rowid 0 is masked by the delete vector.
+    auto dels = w->take_deleted_rowids();
+    ASSERT_EQ(dels.size(), 1u);
+    EXPECT_EQ(dels[0], 0u);
+}
+
+// Tablet with a separate sort key (ORDER BY the value column c1, which differs from the PK c0).
+inline std::shared_ptr<TabletMetadataPB> generate_separate_sort_key_tablet_metadata() {
+    auto metadata = generate_tablet_metadata(PRIMARY_KEYS);
+    // PK is c0 (index 0); sort by c1 (index 1) -> has_separate_sort_key() == true.
+    metadata->mutable_schema()->add_sort_key_idxes(1);
+    return metadata;
+}
+
+class PkTabletUnsortWriterE2ETest : public TestBase {
+public:
+    PkTabletUnsortWriterE2ETest() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_separate_sort_key_tablet_metadata();
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+        ASSIGN_OR_ABORT(_fs, FileSystemFactory::CreateSharedFromString(kTestDirectory));
+    }
+
+protected:
+    void SetUp() override {
+        clear_and_init_test_dir();
+        StorageEnv::GetInstance()->parallel_compact_mgr()->TEST_set_tablet_mgr(_tablet_mgr.get());
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+    // `val_bias` offsets the sort-key/value column so a re-load of the same primary keys carries a
+    // DISTINCT value; a dedup test can then assert (via read_key_values) that the later-flushed value
+    // wins, which a same-value load could not distinguish.
+    Chunk generate_data(int64_t chunk_size, int64_t start_index = 0, int32_t val_bias = 0) {
+        auto c0 = BinaryColumn::create();
+        auto c1 = Int32Column::create();
+        for (int i = 0; i < chunk_size; i++) {
+            c0->append(fmt::format("key_{:10d}", start_index + i));
+            c1->append(static_cast<int32_t>((start_index + i) * 3) + val_bias);
+        }
+        return Chunk({std::move(c0), std::move(c1)}, _schema);
+    }
+    static int32_t expected_val(int64_t pk, int32_t val_bias = 0) { return static_cast<int32_t>(pk * 3) + val_bias; }
+
+    int64_t read_rows(int64_t tablet_id, int64_t version) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        int64_t rows = 0;
+        while (true) {
+            auto tmp = ChunkFactory::new_chunk(*_schema, 128);
+            auto st = reader->get_next(tmp.get());
+            if (st.is_end_of_file()) break;
+            CHECK_OK(st);
+            rows += tmp->num_rows();
+        }
+        return rows;
+    }
+
+    // Read back the whole table as PK(string) -> sort-key(int32), so a test can verify not just the row
+    // count but the surviving value per key (catches a wrong dedup winner, which a count check misses).
+    std::map<std::string, int32_t> read_key_values(int64_t tablet_id, int64_t version) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        CHECK_OK(reader->prepare());
+        CHECK_OK(reader->open(TabletReaderParams()));
+        std::map<std::string, int32_t> out;
+        while (true) {
+            auto tmp = ChunkFactory::new_chunk(*_schema, 128);
+            auto st = reader->get_next(tmp.get());
+            if (st.is_end_of_file()) break;
+            CHECK_OK(st);
+            auto cols = tmp->columns();
+            for (size_t i = 0; i < tmp->num_rows(); i++) {
+                out[cols[0]->get(i).get_slice().to_string()] = cols[1]->get(i).get_int32();
+            }
+        }
+        return out;
+    }
+
+    constexpr static const char* const kTestDirectory = "test_pk_tablet_unsort_writer_e2e";
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    int64_t _partition_id = 456;
+    RuntimeProfile _dummy_runtime_profile{"dummy"};
+    std::shared_ptr<FileSystem> _fs;
+};
+
+// End-to-end: a separate-sort-key PK load with spill + eager build produces the unsort SST and
+// publishes the correct number of rows.
+TEST_F(PkTabletUnsortWriterE2ETest, test_load_spill_eager_build_distinct_keys) {
+    ASSERT_TRUE(_tablet_schema->has_separate_sort_key());
+    const int64_t tablet_id = _tablet_metadata->id();
+    // Small buffer forces multiple memtable flushes -> spill; eager build forced for separate sort key.
+    ConfigResetGuard<bool> guard0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> guard(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> guard2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> guard3(&config::pk_index_eager_build_threshold_bytes, 1);
+
+    auto chunk0 = generate_data(100, 0);
+    auto chunk1 = generate_data(100, 100);
+    auto chunk2 = generate_data(100, 200);
+    std::vector<uint32_t> indexes(chunk0.num_rows());
+    for (uint32_t i = 0, n = chunk0.num_rows(); i < n; i++) {
+        indexes[i] = i;
+    }
+
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->write(chunk2, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    // The unsort SST writer ran for the separate-sort-key spill path.
+    EXPECT_GT(txn_log->op_write().ssts_size(), 0);
+
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+    EXPECT_EQ(300, read_rows(tablet_id, 2));
+}
+
+// End-to-end: duplicate primary keys across the load are deduped to the last-written value; the row
+// count reflects only distinct primary keys.
+TEST_F(PkTabletUnsortWriterE2ETest, test_load_spill_eager_build_duplicate_keys) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<bool> guard0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> guard(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> guard2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> guard3(&config::pk_index_eager_build_threshold_bytes, 1);
+
+    // Overlapping key ranges across chunks: keys [0,100), [50,150) -> 150 distinct primary keys. The
+    // later chunk carries a DISTINCT value (val_bias) for the overlap [50,100) so the read-back can
+    // confirm the later-flushed row won the dedup (not just that the count is right).
+    constexpr int32_t kBias = 1000000;
+    auto chunk0 = generate_data(100, 0);
+    auto chunk1 = generate_data(100, 50, kBias);
+    std::vector<uint32_t> indexes(chunk0.num_rows());
+    for (uint32_t i = 0, n = chunk0.num_rows(); i < n; i++) {
+        indexes[i] = i;
+    }
+
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+    // 150 distinct primary keys after dedup (loser rows masked by the per-segment delete vector).
+    auto kv = read_key_values(tablet_id, 2);
+    EXPECT_EQ(150u, kv.size());
+    for (int64_t k = 0; k < 50; k++) { // only in chunk0
+        auto it = kv.find(fmt::format("key_{:10d}", k));
+        ASSERT_NE(it, kv.end()) << k;
+        EXPECT_EQ(expected_val(k), it->second) << k;
+    }
+    for (int64_t k = 50; k < 150; k++) { // chunk1 (later flush) wins for the [50,100) overlap
+        auto it = kv.find(fmt::format("key_{:10d}", k));
+        ASSERT_NE(it, kv.end()) << k;
+        EXPECT_EQ(expected_val(k, kBias), it->second) << "key " << k << " kept the wrong (earlier) value";
+    }
+}
+
+// Regression for the delvec cardinality check: an unsort load whose incoming segment carries
+// duplicate primary keys that ALSO exist in a prior version. `_do_update(read_only=true)` probes
+// every physical row (including the duplicates), so the same historical rowid is collected multiple
+// times into new_deletes; publish must dedupe it before the `cur_old + cur_add == cur_new` check,
+// otherwise it fails with "delvec inconsistent".
+TEST_F(PkTabletUnsortWriterE2ETest, test_load_spill_dup_keys_over_existing_data) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<bool> guard0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> guard(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> guard2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> guard3(&config::pk_index_eager_build_threshold_bytes, 1);
+
+    auto load_chunks = [&](int64_t txn_id, const std::vector<Chunk*>& chunks) {
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        ASSERT_OK(dw->open());
+        for (auto* c : chunks) {
+            std::vector<uint32_t> idx(c->num_rows());
+            for (uint32_t i = 0, n = c->num_rows(); i < n; i++) idx[i] = i;
+            ASSERT_OK(dw->write(*c, idx.data(), idx.size()));
+        }
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+    };
+
+    // Txn 1: seed 100 distinct keys [0, 100).
+    auto seed = generate_data(100, 0);
+    int64_t txn1 = next_id();
+    load_chunks(txn1, {&seed});
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn1).status());
+
+    // Txn 2: load the same 100 keys TWICE in one txn -> the incoming segment holds duplicate PKs that
+    // also exist historically (from txn 1). Publish must not trip the delvec cardinality check. dup_b
+    // carries a DISTINCT value (val_bias) and is flushed after dup_a, so the read-back also confirms the
+    // later copy won the dedup.
+    constexpr int32_t kBias = 1000000;
+    auto dup_a = generate_data(100, 0);
+    auto dup_b = generate_data(100, 0, kBias);
+    int64_t txn2 = next_id();
+    load_chunks(txn2, {&dup_a, &dup_b});
+    ASSERT_OK(publish_single_version(tablet_id, 3, txn2).status());
+
+    auto kv = read_key_values(tablet_id, 3);
+    EXPECT_EQ(100u, kv.size());
+    for (int64_t k = 0; k < 100; k++) {
+        auto it = kv.find(fmt::format("key_{:10d}", k));
+        ASSERT_NE(it, kv.end()) << k;
+        EXPECT_EQ(expected_val(k, kBias), it->second) << "key " << k << " kept the wrong (earlier) value";
+    }
+}
+
+// End-to-end op-aware DELETE through spill + publish on a separate-sort-key table -- the path the
+// del-file fix targets. It exercises what a writer-level test cannot:
+//   * a DELETE of a row written by an EARLIER transaction must erase it (an SST tombstone shadows the
+//     key in the index but never masks the pre-existing segment row; only a del file does);
+//   * the sort key (c1) DECREASES as the PK increases, so sort-key order is the reverse of PK order --
+//     the "primary keys arrive out of PK order" premise is actually exercised;
+//   * updated rows get a distinct new value that is verified on read-back, so choosing the wrong dedup
+//     winner is visible (a row-count check alone would miss it).
+TEST_F(PkTabletUnsortWriterE2ETest, test_load_spill_op_aware_delete) {
+    ASSERT_TRUE(_tablet_schema->has_separate_sort_key());
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<bool> g0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> g1(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> g2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> g3(&config::pk_index_eager_build_threshold_bytes, 1);
+    ConfigResetGuard<bool> g4(&config::lake_enable_pk_preserve_txn_delete_order, true);
+
+    // __op column values (on-wire convention: 0 == UPSERT, 1 == DELETE).
+    constexpr int8_t kUpsert = 0;
+    constexpr int8_t kDelete = 1;
+    // Sort key decreases as PK increases -> sort-key order is the reverse of PK order.
+    auto seed_sk = [](int64_t pk) { return static_cast<int32_t>(1000000 - pk); };
+    auto updated_sk = [](int64_t pk) { return static_cast<int32_t>(2000000 - pk); };
+    auto key_of = [](int64_t pk) { return fmt::format("key_{:10d}", pk); };
+
+    std::vector<SlotDescriptor> op_slots;
+    op_slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_VARCHAR});
+    op_slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+    op_slots.emplace_back(2, "__op", TypeDescriptor{LogicalType::TYPE_TINYINT});
+    std::vector<SlotDescriptor*> op_slot_ptrs{&op_slots[0], &op_slots[1], &op_slots[2]};
+
+    // rows: (pk, sort_key, op). The chunk carries c0, c1 and the trailing __op column.
+    auto make_op_chunk = [&](const std::vector<std::tuple<int64_t, int32_t, int8_t>>& rows) {
+        auto c0 = BinaryColumn::create();
+        auto c1 = Int32Column::create();
+        auto cop = Int8Column::create();
+        for (const auto& [pk, sk, op] : rows) {
+            c0->append(key_of(pk));
+            c1->append(sk);
+            cop->append(op);
+        }
+        Chunk::SlotHashMap m;
+        m[0] = 0;
+        m[1] = 1;
+        m[2] = 2;
+        return std::make_shared<Chunk>(Columns{std::move(c0), std::move(c1), std::move(cop)}, m);
+    };
+    auto load = [&](int64_t txn_id, const ChunkPtr& chunk) {
+        std::vector<uint32_t> idx(chunk->num_rows());
+        for (uint32_t i = 0, n = chunk->num_rows(); i < n; i++) idx[i] = i;
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&op_slot_ptrs)
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(*chunk, idx.data(), idx.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+    };
+
+    // Txn 1: seed keys [0, 100) as upserts.
+    std::vector<std::tuple<int64_t, int32_t, int8_t>> seed;
+    for (int64_t k = 0; k < 100; k++) seed.emplace_back(k, seed_sk(k), kUpsert);
+    int64_t txn1 = next_id();
+    load(txn1, make_op_chunk(seed));
+    ASSERT_OK(publish_single_version(tablet_id, 2, txn1).status());
+    ASSERT_EQ(100, read_rows(tablet_id, 2));
+
+    // Txn 2 (op-aware, spilled): DELETE the first 50 historical keys, UPSERT the next 50 with a NEW
+    // sort-key value, and INSERT 50 brand-new keys -- all in one transaction.
+    std::vector<std::tuple<int64_t, int32_t, int8_t>> mixed;
+    for (int64_t k = 0; k < 50; k++) mixed.emplace_back(k, 0, kDelete);               // historical deletes
+    for (int64_t k = 50; k < 100; k++) mixed.emplace_back(k, updated_sk(k), kUpsert); // updates
+    for (int64_t k = 100; k < 150; k++) mixed.emplace_back(k, seed_sk(k), kUpsert);   // new inserts
+    int64_t txn2 = next_id();
+    load(txn2, make_op_chunk(mixed));
+    ASSERT_OK(publish_single_version(tablet_id, 3, txn2).status());
+
+    auto kv = read_key_values(tablet_id, 3);
+    EXPECT_EQ(100u, kv.size());
+    for (int64_t k = 0; k < 50; k++) {
+        EXPECT_EQ(0u, kv.count(key_of(k))) << "historical key " << k << " should be deleted";
+    }
+    for (int64_t k = 50; k < 100; k++) {
+        auto it = kv.find(key_of(k));
+        ASSERT_NE(it, kv.end()) << "updated key " << k << " missing";
+        EXPECT_EQ(updated_sk(k), it->second) << "updated key " << k << " kept the wrong (stale) value";
+    }
+    for (int64_t k = 100; k < 150; k++) {
+        EXPECT_EQ(1u, kv.count(key_of(k))) << "new key " << k << " missing";
+    }
+}
+
+// VERTICAL compaction of a separate-sort-key table with eager PK-index build. The vertical key
+// column group is normally just the SORT-KEY columns (not the PK), so the compaction task moves the
+// PK columns into the key group (appended after the sort-key columns) and the vertical PK writer
+// builds the eager unsort SST from them. This forces vertical compaction by lowering
+// vertical_compaction_max_columns_per_group below the table's column count, then asserts that
+// compaction (a) produced the eager SST, (b) kept the row count correct, and (c) built a correct PK
+// index -- verified by re-upserting existing keys and confirming they dedup (a wrong-column SST
+// would key the index on the sort-key column, so the re-upsert would not find the rows and the count
+// would grow).
+TEST_F(PkTabletUnsortWriterE2ETest, test_vertical_compaction_orderby_eager_sst) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<bool> g0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> g1(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> g2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> g3(&config::pk_index_eager_build_threshold_bytes, 1);
+    ConfigResetGuard<int64_t> g4(&config::vertical_compaction_max_columns_per_group, 1); // force vertical
+    ConfigResetGuard<int64_t> g5(&config::lake_pk_compaction_min_input_segments, 2);
+
+    auto load_one = [&](const Chunk& chunk, int64_t txn_id) {
+        std::vector<uint32_t> idx(chunk.num_rows());
+        for (uint32_t j = 0, n = chunk.num_rows(); j < n; j++) idx[j] = j;
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk, idx.data(), idx.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+    };
+
+    int version = 1;
+    for (int i = 0; i < 3; i++) {
+        auto chunk = generate_data(100, static_cast<int64_t>(i) * 100); // distinct keys per rowset
+        int64_t txn_id = next_id();
+        load_one(chunk, txn_id);
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Vertical compaction of the separate-sort-key table.
+    int64_t compaction_txn_id = next_id();
+    auto ctx = std::make_unique<CompactionTaskContext>(compaction_txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    // (a) The eager PK-index SST was built during compaction (not rebuilt lazily at publish).
+    ASSIGN_OR_ABORT(auto compaction_txn_log, _tablet_mgr->get_txn_log(tablet_id, compaction_txn_id));
+    EXPECT_GT(compaction_txn_log->op_compaction().ssts_size(), 0);
+
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, compaction_txn_id).status());
+    version++;
+    // (b) Row count preserved by compaction.
+    EXPECT_EQ(300, read_rows(tablet_id, version));
+
+    // (c) Re-upsert 100 already-present keys [0, 100). If the compaction-built index is keyed on the
+    // PK column, these dedup against the existing rows and the count stays 300; a wrong-column SST
+    // would miss them and the count would grow to 400.
+    auto dup = generate_data(100, 0);
+    int64_t reupsert_txn_id = next_id();
+    load_one(dup, reupsert_txn_id);
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, reupsert_txn_id).status());
+    version++;
+    EXPECT_EQ(300, read_rows(tablet_id, version));
+}
+
+// HORIZONTAL compaction of a separate-sort-key table with eager PK-index build. Compaction of a
+// separate-sort-key PK table also routes through the unsort SST writer -- here via
+// HorizontalPkTabletWriter::write(data, rssid_rowids), with the real rssid|rowid as the ordering key --
+// so it needs its own coverage alongside the vertical path. Force horizontal by keeping all columns in
+// one group (vertical_compaction_max_columns_per_group above the column count). Asserts the same
+// invariants as the vertical case: (a) the eager SST was built, (b) the row count is preserved, and
+// (c) the built PK index is keyed on the PK (re-upserting existing keys dedups instead of growing).
+TEST_F(PkTabletUnsortWriterE2ETest, test_horizontal_compaction_orderby_eager_sst) {
+    const int64_t tablet_id = _tablet_metadata->id();
+    ConfigResetGuard<bool> g0(&config::enable_load_spill, true);
+    ConfigResetGuard<int64_t> g1(&config::write_buffer_size, 1);
+    ConfigResetGuard<bool> g2(&config::enable_pk_index_eager_build, true);
+    ConfigResetGuard<int64_t> g3(&config::pk_index_eager_build_threshold_bytes, 1);
+    ConfigResetGuard<int64_t> g4(&config::vertical_compaction_max_columns_per_group, 100); // force horizontal
+    ConfigResetGuard<int64_t> g5(&config::lake_pk_compaction_min_input_segments, 2);
+
+    auto load_one = [&](const Chunk& chunk, int64_t txn_id) {
+        std::vector<uint32_t> idx(chunk.num_rows());
+        for (uint32_t j = 0, n = chunk.num_rows(); j < n; j++) idx[j] = j;
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        ASSERT_OK(dw->open());
+        ASSERT_OK(dw->write(chunk, idx.data(), idx.size()));
+        ASSERT_OK(dw->finish_with_txnlog());
+        dw->close();
+    };
+
+    int version = 1;
+    for (int i = 0; i < 3; i++) {
+        auto chunk = generate_data(100, static_cast<int64_t>(i) * 100); // distinct keys per rowset
+        int64_t txn_id = next_id();
+        load_one(chunk, txn_id);
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    int64_t compaction_txn_id = next_id();
+    auto ctx = std::make_unique<CompactionTaskContext>(compaction_txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    // (a) The eager PK-index SST was built during horizontal compaction.
+    ASSIGN_OR_ABORT(auto compaction_txn_log, _tablet_mgr->get_txn_log(tablet_id, compaction_txn_id));
+    EXPECT_GT(compaction_txn_log->op_compaction().ssts_size(), 0);
+
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, compaction_txn_id).status());
+    version++;
+    // (b) Row count preserved by compaction.
+    EXPECT_EQ(300, read_rows(tablet_id, version));
+
+    // (c) Re-upsert already-present keys [0, 100): a PK-keyed index dedups them (count stays 300); a
+    // wrong-column SST would miss them and the count would grow.
+    auto dup = generate_data(100, 0);
+    int64_t reupsert_txn_id = next_id();
+    load_one(dup, reupsert_txn_id);
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, reupsert_txn_id).status());
+    version++;
+    EXPECT_EQ(300, read_rows(tablet_id, version));
+}
 
 } // namespace starrocks::lake


### PR DESCRIPTION
**DO NOT MERGE — throwaway build-validation PR.**

This exists only to give TSP a build target for the rebased form of #76094
(separate-sort-key load spill + eager PK-index SST), collapsed onto current
`main` after the reader (#76474) merged. It will be closed once the compile is
confirmed; the validated commit is force-pushed to #76094's own branch.
