### PR TITLE
[BugFix] Cancel pipeline fragments when reaping expired external scan contexts

### DIFF
--- a/be/src/orchestration/external_scan_context_mgr.cpp
+++ b/be/src/orchestration/external_scan_context_mgr.cpp
@@ -49,13 +49,11 @@
 #include "exec/pipeline/query_context.h"
 #include "exec/runtime/fragment_context_manager.h"
 #include "exec/runtime/query_context_manager.h"
-#include "orchestration/fragment_mgr.h"
 #include "runtime/runtime_metrics.h"
 
 namespace starrocks::orchestration {
 
-ExternalScanContextMgr::ExternalScanContextMgr(ExecEnv* exec_env, MetricRegistry* metrics, FragmentMgr* fragment_mgr)
-        : _exec_env(exec_env), _fragment_mgr(fragment_mgr) {
+ExternalScanContextMgr::ExternalScanContextMgr(ExecEnv* exec_env, MetricRegistry* metrics) : _exec_env(exec_env) {
     // start the reaper thread for gc the expired context
     _keep_alive_reaper = std::make_unique<std::thread>(
             std::bind<void>(std::mem_fn(&ExternalScanContextMgr::gc_expired_context), this));
@@ -122,21 +120,29 @@ Status ExternalScanContextMgr::clear_scan_context(const std::string& context_id)
         }
     }
     if (context != nullptr) {
-        // cancel pipeline
-        const auto& fragment_instance_id = context->fragment_instance_id;
-        if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
-            if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id); fragment_ctx != nullptr) {
-                std::stringstream msg;
-                msg << "FragmentContext(id=" << print_id(fragment_instance_id) << ") cancelled by close_scanner";
-                pipeline::cancel_fragment_context(fragment_ctx.get(), Status::Cancelled(msg.str()));
-            }
-        }
         LOG(INFO) << "close scan context: context id [ " << context_id << " ], fragment instance id [ "
-                  << print_id(fragment_instance_id) << " ]";
-        // clear the fragment instance's related result queue
-        RETURN_IF_ERROR(_exec_env->result_queue_mgr()->cancel(fragment_instance_id));
+                  << print_id(context->fragment_instance_id) << " ]";
+        RETURN_IF_ERROR(_cancel_scan_context(context, "close_scanner"));
     }
     return Status::OK();
+}
+
+Status ExternalScanContextMgr::_cancel_scan_context(const std::shared_ptr<ScanContext>& context,
+                                                    const std::string& reason) {
+    const auto& fragment_instance_id = context->fragment_instance_id;
+    // The fragment opened by open_scanner always runs on the pipeline engine, so it must be cancelled
+    // through the pipeline QueryContext/FragmentContext. Cancelling through the non-pipeline
+    // FragmentMgr is a silent no-op for pipeline fragments, which leaves an abandoned scanner holding
+    // all its buffered memory until the query deadline expires.
+    if (auto query_ctx = _exec_env->query_context_mgr()->get(context->query_id); query_ctx != nullptr) {
+        if (auto fragment_ctx = query_ctx->fragment_mgr()->get(fragment_instance_id); fragment_ctx != nullptr) {
+            std::stringstream msg;
+            msg << "FragmentContext(id=" << print_id(fragment_instance_id) << ") cancelled by " << reason;
+            pipeline::cancel_fragment_context(fragment_ctx.get(), Status::Cancelled(msg.str()));
+        }
+    }
+    // clear the fragment instance's related result queue
+    return _exec_env->result_queue_mgr()->cancel(fragment_instance_id);
 }
 
 void ExternalScanContextMgr::gc_expired_context() {
@@ -174,16 +180,12 @@ void ExternalScanContextMgr::gc_expired_context() {
             }
         }
         for (const auto& expired_context : expired_contexts) {
-            // must cancel the fragment instance, otherwise return thrift transport TTransportException
-            DCHECK(_fragment_mgr != nullptr);
-            WARN_IF_ERROR(
-                    _fragment_mgr->cancel(expired_context->fragment_instance_id),
-                    strings::Substitute("Fail to cancel fragment $0", print_id(expired_context->fragment_instance_id)));
-            WARN_IF_ERROR(_exec_env->result_queue_mgr()->cancel(expired_context->fragment_instance_id),
+            WARN_IF_ERROR(_cancel_scan_context(expired_context, "expired scan context gc"),
                           strings::Substitute("Fail to cancel fragment $0 in result queue mgr",
                                               print_id(expired_context->fragment_instance_id)));
         }
     }
 #endif
 }
+
 } // namespace starrocks::orchestration

--- a/be/src/orchestration/external_scan_context_mgr.h
+++ b/be/src/orchestration/external_scan_context_mgr.h
@@ -42,6 +42,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "common/status.h"
 #include "gen_cpp/Types_types.h"
@@ -52,8 +53,6 @@ namespace starrocks {
 class MetricRegistry;
 
 namespace orchestration {
-
-class FragmentMgr;
 
 struct ScanContext {
 public:
@@ -70,7 +69,7 @@ public:
 
 class ExternalScanContextMgr {
 public:
-    ExternalScanContextMgr(ExecEnv* exec_env, MetricRegistry* metrics, FragmentMgr* fragment_mgr);
+    ExternalScanContextMgr(ExecEnv* exec_env, MetricRegistry* metrics);
 
     ~ExternalScanContextMgr();
 
@@ -81,8 +80,12 @@ public:
     Status clear_scan_context(const std::string& context_id);
 
 private:
+    // Cancel the pipeline fragment of the scan context and clear its result queue. Shared by
+    // close_scanner (clear_scan_context) and the keep-alive reaper (gc_expired_context); the caller
+    // must have already removed the context from the active map.
+    Status _cancel_scan_context(const std::shared_ptr<ScanContext>& context, const std::string& reason);
+
     ExecEnv* _exec_env;
-    [[maybe_unused]] FragmentMgr* _fragment_mgr;
     std::map<std::string, std::shared_ptr<ScanContext>> _active_contexts;
     void gc_expired_context();
     std::unique_ptr<std::thread> _keep_alive_reaper;

--- a/be/src/orchestration/orchestration_env.cpp
+++ b/be/src/orchestration/orchestration_env.cpp
@@ -76,7 +76,7 @@ Status OrchestrationEnv::init(ExecEnv* exec_env, MetricRegistry* metrics, Stream
             metrics, [this] { return _runtime_filter_worker == nullptr ? nullptr : _runtime_filter_worker->metrics(); },
             [this] { return _runtime_filter_worker == nullptr ? 0 : _runtime_filter_worker->queue_size(); });
 
-    _external_scan_context_mgr = std::make_unique<ExternalScanContextMgr>(exec_env, metrics, _fragment_mgr.get());
+    _external_scan_context_mgr = std::make_unique<ExternalScanContextMgr>(exec_env, metrics);
     _external_scan_orchestrator =
             std::make_unique<ExternalScanOrchestrator>(exec_env, _external_scan_context_mgr.get());
 

--- a/be/test/orchestration/external_scan_context_mgr_test.cpp
+++ b/be/test/orchestration/external_scan_context_mgr_test.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 
 #include "base/metrics.h"
+#include "base/testutil/assert.h"
 #include "common/config_exec_env_fwd.h"
 #include "common/config_runtime_fwd.h"
 #include "common/status.h"
@@ -49,12 +50,15 @@
 #include "exec/exec_env.h"
 #include "exec/pipeline/driver_executor_factory.h"
 #include "exec/pipeline/driver_queue_factory.h"
+#include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/fragment_context_cancel.h"
 #include "exec/pipeline/query_context.h"
+#include "exec/runtime/fragment_context_manager.h"
 #include "exec/runtime/query_context_manager.h"
-#include "orchestration/fragment_mgr.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_env.h"
 #include "runtime/runtime_env_test_util.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::orchestration {
 
@@ -115,13 +119,11 @@ protected:
         options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
         ASSERT_TRUE(_compute_env.init(options).ok());
         _exec_env.set_compute_env(&_compute_env);
-        _fragment_mgr = std::make_unique<FragmentMgr>(&_exec_env, nullptr);
         _exec_env._query_context_mgr = new pipeline::QueryContextManager(5);
         _exec_env._refresh_service_contexts();
     }
 
     void TearDown() override {
-        _fragment_mgr.reset();
         delete _exec_env._query_context_mgr;
         _exec_env._query_context_mgr = nullptr;
         _exec_env.set_compute_env(nullptr);
@@ -131,7 +133,6 @@ protected:
 private:
     ExecEnv _exec_env;
     ComputeEnv _compute_env;
-    std::unique_ptr<FragmentMgr> _fragment_mgr;
     static std::shared_ptr<MemTracker> _previous_process_mem_tracker;
     static std::shared_ptr<MemTracker> _previous_query_pool_mem_tracker;
     static std::shared_ptr<MemTracker> _process_mem_tracker;
@@ -145,7 +146,7 @@ std::shared_ptr<MemTracker> ExternalScanContextMgrTest::_query_pool_mem_tracker;
 
 TEST_F(ExternalScanContextMgrTest, create_normal) {
     std::shared_ptr<ScanContext> context;
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     Status st = context_mgr.create_scan_context(&context);
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(context != nullptr);
@@ -153,7 +154,7 @@ TEST_F(ExternalScanContextMgrTest, create_normal) {
 
 TEST_F(ExternalScanContextMgrTest, get_normal) {
     std::shared_ptr<ScanContext> context;
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     Status st = context_mgr.create_scan_context(&context);
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(context != nullptr);
@@ -168,7 +169,7 @@ TEST_F(ExternalScanContextMgrTest, get_normal) {
 TEST_F(ExternalScanContextMgrTest, get_abnormal) {
     std::string context_id = "not_exist";
     std::shared_ptr<ScanContext> result;
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     Status st = context_mgr.get_scan_context(context_id, &result);
     ASSERT_TRUE(!st.ok());
     ASSERT_TRUE(result == nullptr);
@@ -176,7 +177,7 @@ TEST_F(ExternalScanContextMgrTest, get_abnormal) {
 
 TEST_F(ExternalScanContextMgrTest, clear_context) {
     std::shared_ptr<ScanContext> context;
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     Status st = context_mgr.create_scan_context(&context);
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(context != nullptr);
@@ -189,5 +190,45 @@ TEST_F(ExternalScanContextMgrTest, clear_context) {
     st = context_mgr.get_scan_context(context_id, &result);
     ASSERT_TRUE(!st.ok());
     ASSERT_TRUE(result == nullptr);
+}
+
+TEST_F(ExternalScanContextMgrTest, clear_scan_context_cancels_pipeline_fragment) {
+    TUniqueId query_id;
+    query_id.__set_hi(2026);
+    query_id.__set_lo(715);
+    TUniqueId fragment_id;
+    fragment_id.__set_hi(2026);
+    fragment_id.__set_lo(716);
+
+    pipeline::QueryContext* query_ctx = nullptr;
+    ASSIGN_OR_ASSERT_FAIL(query_ctx, _exec_env.query_context_mgr()->get_or_register(query_id));
+    query_ctx->query_runtime_state().set_delivery_expire_seconds(60);
+    query_ctx->query_runtime_state().set_query_expire_seconds(60);
+    query_ctx->query_runtime_state().extend_delivery_lifetime();
+    query_ctx->query_runtime_state().extend_query_lifetime();
+    query_ctx->init_mem_tracker(RuntimeEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                RuntimeEnv::GetInstance()->query_pool_mem_tracker());
+
+    auto fragment_ctx = std::make_shared<pipeline::FragmentContext>();
+    auto* raw_fragment_ctx = fragment_ctx.get();
+    fragment_ctx->set_query_id(query_id);
+    fragment_ctx->set_fragment_instance_id(fragment_id);
+    fragment_ctx->set_workgroup(_exec_env.workgroup_manager()->get_default_workgroup());
+    fragment_ctx->set_runtime_state(std::make_unique<RuntimeState>(query_id, fragment_id, TQueryOptions(),
+                                                                   TQueryGlobals(),
+                                                                   &_exec_env.query_execution_services(), &_exec_env));
+    ASSERT_OK(query_ctx->fragment_mgr()->register_ctx(fragment_id, std::move(fragment_ctx)));
+
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
+    std::shared_ptr<ScanContext> context;
+    ASSERT_OK(context_mgr.create_scan_context(&context));
+    context->query_id = query_id;
+    context->fragment_instance_id = fragment_id;
+
+    // clear_scan_context and the expired-context reaper share the same cancellation path
+    // (_cancel_scan_context): the pipeline fragment must be cancelled, not the non-pipeline one.
+    ASSERT_OK(context_mgr.clear_scan_context(context->context_id));
+
+    ASSERT_TRUE(raw_fragment_ctx->final_status().is_cancelled());
 }
 } // namespace starrocks::orchestration

--- a/be/test/orchestration/external_scan_orchestrator_test.cpp
+++ b/be/test/orchestration/external_scan_orchestrator_test.cpp
@@ -33,7 +33,6 @@
 #include "exec/runtime/query_context_manager.h"
 #include "gen_cpp/StatusCode_types.h"
 #include "orchestration/external_scan_context_mgr.h"
-#include "orchestration/fragment_mgr.h"
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_env.h"
 #include "runtime/runtime_env_test_util.h"
@@ -93,13 +92,11 @@ protected:
         options.driver_executor_factory = pipeline::create_workgroup_driver_executor;
         ASSERT_TRUE(_compute_env.init(options).ok());
         _exec_env.set_compute_env(&_compute_env);
-        _fragment_mgr = std::make_unique<FragmentMgr>(&_exec_env, nullptr);
         _exec_env._query_context_mgr = new pipeline::QueryContextManager(5);
         _exec_env._refresh_service_contexts();
     }
 
     void TearDown() override {
-        _fragment_mgr.reset();
         delete _exec_env._query_context_mgr;
         _exec_env._query_context_mgr = nullptr;
         _exec_env.set_compute_env(nullptr);
@@ -108,7 +105,6 @@ protected:
 
     ExecEnv _exec_env;
     ComputeEnv _compute_env;
-    std::unique_ptr<FragmentMgr> _fragment_mgr;
     static std::shared_ptr<MemTracker> _previous_process_mem_tracker;
     static std::shared_ptr<MemTracker> _previous_query_pool_mem_tracker;
     static std::shared_ptr<MemTracker> _process_mem_tracker;
@@ -121,7 +117,7 @@ std::shared_ptr<MemTracker> ExternalScanOrchestratorTest::_process_mem_tracker;
 std::shared_ptr<MemTracker> ExternalScanOrchestratorTest::_query_pool_mem_tracker;
 
 TEST_F(ExternalScanOrchestratorTest, open_scanner_returns_context_for_invalid_batch_size) {
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     ExternalScanOrchestrator orchestrator(&_exec_env, &context_mgr);
 
     TScanOpenParams params;
@@ -138,7 +134,7 @@ TEST_F(ExternalScanOrchestratorTest, open_scanner_returns_context_for_invalid_ba
 }
 
 TEST_F(ExternalScanOrchestratorTest, get_next_missing_context_returns_not_found) {
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     ExternalScanOrchestrator orchestrator(&_exec_env, &context_mgr);
 
     TScanNextBatchParams params;
@@ -151,7 +147,7 @@ TEST_F(ExternalScanOrchestratorTest, get_next_missing_context_returns_not_found)
 }
 
 TEST_F(ExternalScanOrchestratorTest, get_next_offset_mismatch_returns_not_found_and_refreshes_access_time) {
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     ExternalScanOrchestrator orchestrator(&_exec_env, &context_mgr);
 
     std::shared_ptr<ScanContext> context;
@@ -171,7 +167,7 @@ TEST_F(ExternalScanOrchestratorTest, get_next_offset_mismatch_returns_not_found_
 }
 
 TEST_F(ExternalScanOrchestratorTest, close_scanner_clears_context) {
-    ExternalScanContextMgr context_mgr(&_exec_env, nullptr, _fragment_mgr.get());
+    ExternalScanContextMgr context_mgr(&_exec_env, nullptr);
     ExternalScanOrchestrator orchestrator(&_exec_env, &context_mgr);
 
     std::shared_ptr<ScanContext> context;


### PR DESCRIPTION
## Why I'm doing:

When a Spark/Flink connector reader dies without calling `close_scanner` (task killed, stage aborted, executor lost), the abandoned scanner's `ScanContext` is reaped by the keep-alive GC in `ExternalScanContextMgr::gc_expired_context()`. The reaper cancels the fragment through the **non-pipeline** `FragmentMgr` — but external scan fragments opened by `open_scanner` always run on the **pipeline** engine (`QueryOrchestrator::exec_external_plan_fragment` → `FragmentExecutor`) and never register in the non-pipeline `FragmentMgr`, so `FragmentMgr::cancel()` finds no match and silently returns OK.

The GC therefore only shuts down the result queue. The pipeline `FragmentContext` keeps running/blocked, and its `QueryContext` keeps holding all buffered scan memory (GBs per query for wide-table scans) until the query deadline (`query_timeout`, 3600s by default in the connectors) finally cancels it via the driver poller — or until the BE restarts.

We hit this in production: a burst of abandoned connector scanners (Spark stage aborts during BE memory pressure, then app-level retries) kept 100–240 GB pinned in `query_pool` for hours. The log signature is conclusive: abandoned fragments do get `gc expired scan context` (the reaper ran and erased the context), yet they die exactly `query_timeout` seconds after open via `[Driver] Timeout` — the GC's cancel never took effect.

Note that `clear_scan_context()` (the `close_scanner` path) was already fixed to cancel through the pipeline managers in #20264; the GC path was left behind.

## What I'm doing:

- Extract the cancellation into a private `_cancel_scan_context()` — cancel through the pipeline `QueryContextManager` / `FragmentContext` plus clear the result queue — **shared by both `close_scanner` (`clear_scan_context`) and the reaper**, so the two paths can no longer diverge. The reaper passes a distinguishable cancel reason (`cancelled by expired scan context gc`).
- Drop the non-pipeline `FragmentMgr` dependency from `ExternalScanContextMgr`: its only use was this no-op cancel (the member was already marked `[[maybe_unused]]`).
- Add a test asserting the shared cancellation path actually cancels the registered pipeline fragment (exercised via `clear_scan_context`; the reaper loop itself is compiled out under `BE_TEST`).

With this fix an abandoned scanner is reclaimed within `keep_alive_min` (default 5 min) + one GC interval, instead of `query_timeout` (1 hour).

Known limitations (intentionally out of scope): a context stuck in an in-flight `get_next` (`last_access_time == -1`) is still skipped by the GC and only reclaimed at the query deadline.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: abandoned external scanners are reclaimed at keep-alive expiry instead of query timeout

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


