### PR TITLE
[BugFix] Set query_delivery_timeout for external scan plans to bound the QueryContext second-chance tail

### DIFF
--- a/be/src/orchestration/query_orchestrator.cpp
+++ b/be/src/orchestration/query_orchestrator.cpp
@@ -32,6 +32,7 @@
 #include "common/object_pool.h"
 #include "common/system/backend_options.h"
 #include "common/util/thrift_util.h"
+#include "compute_env/query/query_runtime_state.h"
 #include "exec/exec_env.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/InternalService_types.h"
@@ -46,6 +47,25 @@ namespace starrocks::orchestration {
 
 QueryOrchestrator::QueryOrchestrator(ExecEnv* exec_env) : _exec_env(exec_env) {
     DCHECK(_exec_env != nullptr);
+}
+
+TQueryOptions QueryOrchestrator::build_external_query_options(const TScanOpenParams& params) {
+    TQueryOptions query_options;
+    query_options.batch_size = params.batch_size;
+    query_options.query_timeout = params.query_timeout;
+    // All scanners of one external query share the same query_id while each open_scanner request
+    // declares a single-instance fragment, so the QueryContext never satisfies is_dead() and always
+    // waits in the second-chance map after all its delivered fragments finish. Without an explicit
+    // query_delivery_timeout that wait falls back to query_timeout (3600s by default in the
+    // Spark/Flink connectors), which keeps the finished query's mem tracker lingering in query_pool
+    // for up to an hour. Bound the tail with the regular delivery-timeout default instead.
+    query_options.__set_query_delivery_timeout(pipeline::QueryRuntimeState::DEFAULT_EXPIRE_SECONDS);
+    query_options.mem_limit = params.mem_limit;
+    query_options.query_type = TQueryType::EXTERNAL;
+    // For spark sql / flink sql, we dont use page cache.
+    query_options.use_page_cache = false;
+    query_options.enable_profile = config::enable_profile_for_external_plan;
+    return query_options;
 }
 
 /*
@@ -186,15 +206,7 @@ Status QueryOrchestrator::exec_external_plan_fragment(const TScanOpenParams& par
     fragment_exec_params.__set_instances_number(1);
     exec_fragment_params.__set_params(fragment_exec_params);
     // batch_size for one RowBatch
-    TQueryOptions query_options;
-    query_options.batch_size = params.batch_size;
-    query_options.query_timeout = params.query_timeout;
-    query_options.mem_limit = params.mem_limit;
-    query_options.query_type = TQueryType::EXTERNAL;
-    // For spark sql / flink sql, we dont use page cache.
-    query_options.use_page_cache = false;
-    query_options.enable_profile = config::enable_profile_for_external_plan;
-    exec_fragment_params.__set_query_options(query_options);
+    exec_fragment_params.__set_query_options(build_external_query_options(params));
     VLOG_ROW << "external exec_plan_fragment params is "
              << apache::thrift::ThriftDebugString(exec_fragment_params).c_str();
     FragmentExecutor fragment_executor;

--- a/be/src/orchestration/query_orchestrator.h
+++ b/be/src/orchestration/query_orchestrator.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/StarrocksExternalService_types.h"
 #include "gen_cpp/Types_types.h"
 
@@ -32,6 +33,10 @@ public:
 
     Status exec_external_plan_fragment(const TScanOpenParams& params, const TUniqueId& fragment_instance_id,
                                        std::vector<TScanColumnDesc>* selected_columns, TUniqueId* query_id);
+
+    // Build the TQueryOptions used to execute an external scan plan fragment (open_scanner).
+    // Exposed as a static helper so tests can assert the fabricated options.
+    static TQueryOptions build_external_query_options(const TScanOpenParams& params);
 
 private:
     ExecEnv* _exec_env;

--- a/be/test/orchestration/query_orchestrator_test.cpp
+++ b/be/test/orchestration/query_orchestrator_test.cpp
@@ -23,6 +23,7 @@
 #include "base/url_coding.h"
 #include "common/config_thrift_server_fwd.h"
 #include "common/util/thrift_util.h"
+#include "compute_env/query/query_runtime_state.h"
 #include "exec/exec_env.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/Exprs_types.h"
@@ -167,6 +168,32 @@ TEST_F(QueryOrchestratorTest, ExecExternalPlanFragmentLooksUpSlotWithEmptyColNam
 
     EXPECT_EQ(query_plan_info.query_id, out_query_id);
     EXPECT_TRUE(st.is_not_found()) << "expected NotFound from unknown tablet, got: " << st;
+}
+
+TEST_F(QueryOrchestratorTest, BuildExternalQueryOptionsBoundsDeliveryTimeout) {
+    TScanOpenParams params;
+    params.__set_batch_size(4096);
+    params.__set_query_timeout(900);
+    params.__set_mem_limit(2147483648LL);
+
+    TQueryOptions options = QueryOrchestrator::build_external_query_options(params);
+
+    // External scan QueryContexts always take the second-chance path after their fragments finish
+    // (each open_scanner declares a single-instance fragment while all scanners share one query_id),
+    // and without an explicit query_delivery_timeout the delivery deadline falls back to
+    // query_timeout. The fabricated options must bound it with the regular default.
+    ASSERT_TRUE(options.__isset.query_delivery_timeout);
+    EXPECT_EQ(pipeline::QueryRuntimeState::DEFAULT_EXPIRE_SECONDS, options.query_delivery_timeout);
+
+    // FragmentExecutor takes min(query_timeout, query_delivery_timeout), so a connector-provided
+    // query_timeout smaller than the default still wins; verify it is carried through unchanged.
+    EXPECT_TRUE(options.__isset.query_timeout);
+    EXPECT_EQ(900, options.query_timeout);
+
+    EXPECT_EQ(4096, options.batch_size);
+    EXPECT_EQ(2147483648LL, options.mem_limit);
+    EXPECT_EQ(TQueryType::EXTERNAL, options.query_type);
+    EXPECT_FALSE(options.use_page_cache);
 }
 
 } // namespace starrocks::orchestration


### PR DESCRIPTION
## Why I'm doing:

Every `open_scanner` request of a Spark/Flink connector read declares `instances_number = 1`, while all scanners of one external query share the same `query_id`. On the BE this makes `QueryContext::is_dead()` (`_num_fragments == _total_fragments`) never hold — N delivered fragments against a promised total of 1 — so after all fragments finish, the QueryContext always takes the second-chance path and waits for "missing" fragments that can never arrive.

The external plan path only sets `query_options.query_timeout`; `query_delivery_timeout` is left unset, so `FragmentExecutor::_calc_delivery_expired_seconds()` falls back to `query_timeout` — 3600s by default in the connectors. Net effect: **every** external scan query, including perfectly successful ones, leaves its QueryContext and query mem tracker visible in `query_pool` for up to one hour after it finished. Under connector-heavy workloads this inflates the tracker listing with hundreds of stale entries (observed in production: 1400+ `Query<uuid>` rows during an incident, most of them finished-but-lingering external scans), which is highly misleading during memory investigations — the IDs are also invisible to FE audit logs, so they look like leaked queries.

### Why not make `instances_number` correct instead?

We considered fixing the promised total itself, but for client-driven scans the number is fundamentally unknowable on the server side:

1. **The per-BE scanner count is decided by the client after FE returns the plan.** The connector picks a replica BE for each tablet (`selectBeForTablet`) and slices each BE's tablet list into partitions by the client-side config `starrocks.request.tablet.size`. FE knows neither decision at plan time, and the opaqued query plan is a single shared blob with no per-BE slot to carry such a number anyway.
2. **Even a connector-transmitted count cannot be reconciled.** Suppose we added a field to `TScanOpenParams` and taught connectors to send their planned per-BE partition count (old connector jars would never send it, so a fallback must stay forever). The accounting still breaks in both directions at runtime: Spark task retries and speculative execution re-open scanners for the same partition (delivered > promised), while stage aborts leave partitions that never open at all (delivered < promised). The promise/delivery reconciliation of `is_dead()` assumes a single coordinator that controls dispatch exactly — which external scans, driven by a retrying distributed client, do not have.

So instead of pretending a correct total exists, this PR bounds the pointless second-chance wait explicitly.

## What I'm doing:

Set `query_delivery_timeout` in the query options that `exec_external_plan_fragment` fabricates (the option building is extracted into `build_external_query_options()` with a unit test asserting the fabricated options), using the regular delivery-timeout default (`QueryRuntimeState::DEFAULT_EXPIRE_SECONDS` = 300s — the same value as the BE built-in default and the FE session default of `query_delivery_timeout`). The second-chance tail of external scan queries drops from up to 1 hour to 5 minutes. Query deadline semantics (`query_timeout`) are unchanged, and `_calc_delivery_expired_seconds()` still takes `min(query_timeout, query_delivery_timeout)`, so queries with a shorter `query_timeout` behave as before.

Sibling PR born from the same production incident: #76535 (GC fails to cancel abandoned pipeline scanners).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: external scan plans now run with the default query_delivery_timeout (300s) instead of inheriting query_timeout
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


