### PR TITLE
[BugFix] Skip string-type histogram buckets when loading histogram stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/HistogramUtils.java
@@ -19,7 +19,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.type.Type;
 import org.apache.logging.log4j.LogManager;
@@ -35,11 +34,19 @@ import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 public class HistogramUtils {
     private static final Logger LOG = LogManager.getLogger(HistogramUtils.class);
 
-    public static List<Bucket> convertBuckets(String histogramString, Type type) throws AnalysisException {
+    public static List<Bucket> convertBuckets(String histogramString, Type type) {
         JsonObject jsonObject = JsonParser.parseString(histogramString).getAsJsonObject();
 
         JsonElement jsonElement = jsonObject.get("buckets");
         if (jsonElement.isJsonNull()) {
+            return Collections.emptyList();
+        }
+
+        // Bucket bounds are interpolated as doubles (see the parsing below and Bucket#getRowCountInBucket).
+        // CHAR/VARCHAR bounds cannot be parsed into doubles - doing so threw NumberFormatException on every
+        // stats-cache refresh. Buckets are unusable for string columns (only MCV is), so skip them. This
+        // covers histograms persisted by older versions that still carry string bucket bounds.
+        if (type.isStringType()) {
             return Collections.emptyList();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -305,18 +305,22 @@ public class HistogramStatisticsTest {
         // only one bucket in histogram can cover the predicate range
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithGreaterThan(columnStatistic,
                 Optional.of(new ConstantOperator(18, IntegerType.BIGINT)), true);
-        Assertions.assertEquals(exist.get().getBuckets().size(), 1);
+        Assertions.assertTrue(exist.isPresent());
+        Assertions.assertEquals(1, exist.get().getBuckets().size());
         exist = BinaryPredicateStatisticCalculator.updateHistWithLessThan(columnStatistic,
                 Optional.of(new ConstantOperator(3, IntegerType.BIGINT)), true);
-        Assertions.assertEquals(exist.get().getBuckets().size(), 1);
+        Assertions.assertTrue(exist.isPresent());
+        Assertions.assertEquals(1, exist.get().getBuckets().size());
 
         // all the two bucket in histogram can cover the predicate range
         exist = BinaryPredicateStatisticCalculator.updateHistWithGreaterThan(columnStatistic,
                 Optional.of(new ConstantOperator(3, IntegerType.BIGINT)), true);
-        Assertions.assertEquals(exist.get().getBuckets().size(), 2);
+        Assertions.assertTrue(exist.isPresent());
+        Assertions.assertEquals(2, exist.get().getBuckets().size());
         exist = BinaryPredicateStatisticCalculator.updateHistWithLessThan(columnStatistic,
                 Optional.of(new ConstantOperator(18, IntegerType.BIGINT)), true);
-        Assertions.assertEquals(exist.get().getBuckets().size(), 2);
+        Assertions.assertTrue(exist.isPresent());
+        Assertions.assertEquals(2, exist.get().getBuckets().size());
     }
 
     @Test
@@ -339,14 +343,14 @@ public class HistogramStatisticsTest {
         Optional<Histogram> exist = BinaryPredicateStatisticCalculator.updateHistWithEqual(columnStatistic,
                 Optional.of(new ConstantOperator(22, IntegerType.BIGINT)));
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertEquals(exist.get().getBuckets().size(), 0);
+        Assertions.assertEquals(0, exist.get().getBuckets().size());
         Assertions.assertEquals(exist.get().getMCV(), mcv);
 
         // histogram contains the constant in a bucket
         exist = BinaryPredicateStatisticCalculator.updateHistWithEqual(columnStatistic,
                 Optional.of(new ConstantOperator(2, IntegerType.BIGINT)));
         Assertions.assertTrue(exist.isPresent());
-        Assertions.assertEquals(exist.get().getBuckets().size(), 0);
+        Assertions.assertEquals(0, exist.get().getBuckets().size());
         Assertions.assertTrue(exist.get().getMCV().containsKey("2"));
     }
 
@@ -536,8 +540,8 @@ public class HistogramStatisticsTest {
                 columnStatisticLeft, IntegerType.BIGINT, columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
         Assertions.assertNull(exist.get().getBuckets());
-        Assertions.assertEquals(exist.get().getMCV().size(), 1);
-        Assertions.assertEquals(exist.get().getMCV().get("22").longValue(), 100 * 80);
+        Assertions.assertEquals(1, exist.get().getMCV().size());
+        Assertions.assertEquals(100 * 80, exist.get().getMCV().get("22").longValue());
 
         // MCV to bucket intersection (upper).
         bucketListLeft = new ArrayList<>();
@@ -564,9 +568,9 @@ public class HistogramStatisticsTest {
                 columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
         Assertions.assertTrue(exist.get().getBuckets().isEmpty());
-        Assertions.assertEquals(exist.get().getMCV().size(), 2);
-        Assertions.assertEquals(exist.get().getMCV().get("10").longValue(), 300 * 20);
-        Assertions.assertEquals(exist.get().getMCV().get("23").longValue(), 80 * 20);
+        Assertions.assertEquals(2, exist.get().getMCV().size());
+        Assertions.assertEquals(300 * 20, exist.get().getMCV().get("10").longValue());
+        Assertions.assertEquals(80 * 20, exist.get().getMCV().get("23").longValue());
 
         // MCV to bucket intersection (not upper).
         bucketListLeft = new ArrayList<>();
@@ -593,9 +597,9 @@ public class HistogramStatisticsTest {
                 columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
         Assertions.assertTrue(exist.get().getBuckets().isEmpty());
-        Assertions.assertEquals(exist.get().getMCV().size(), 2);
-        Assertions.assertEquals(exist.get().getMCV().get("10").longValue(), 300 * 14);
-        Assertions.assertEquals(exist.get().getMCV().get("23").longValue(), 80 * 9);
+        Assertions.assertEquals(2, exist.get().getMCV().size());
+        Assertions.assertEquals(300 * 14, exist.get().getMCV().get("10").longValue());
+        Assertions.assertEquals(80 * 9, exist.get().getMCV().get("23").longValue());
 
         // bucket to bucket intersection (upper).
         bucketListLeft = new ArrayList<>();
@@ -616,12 +620,12 @@ public class HistogramStatisticsTest {
                 columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
         Assertions.assertTrue(exist.get().getMCV().isEmpty());
-        Assertions.assertEquals(exist.get().getBuckets().size(), 1);
+        Assertions.assertEquals(1, exist.get().getBuckets().size());
         Bucket joinBucket = exist.get().getBuckets().get(0);
-        Assertions.assertEquals(joinBucket.getLower(), 5D, 0.001);
-        Assertions.assertEquals(joinBucket.getUpper(), 5D, 0.001);
-        Assertions.assertEquals(joinBucket.getCount().longValue(), 20L * 14L);
-        Assertions.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+        Assertions.assertEquals(5D, joinBucket.getLower(), 0.001);
+        Assertions.assertEquals(5D, joinBucket.getUpper(), 0.001);
+        Assertions.assertEquals(20L * 14L, joinBucket.getCount().longValue());
+        Assertions.assertEquals(20L * 14L, joinBucket.getUpperRepeats().longValue());
 
         // bucket to bucket intersection (not upper).
         bucketListLeft = new ArrayList<>();
@@ -642,16 +646,16 @@ public class HistogramStatisticsTest {
                 columnStatisticRight, IntegerType.BIGINT);
         Assertions.assertTrue(exist.isPresent());
         Assertions.assertTrue(exist.get().getMCV().isEmpty());
-        Assertions.assertEquals(exist.get().getBuckets().size(), 1);
+        Assertions.assertEquals(1, exist.get().getBuckets().size());
         joinBucket = exist.get().getBuckets().get(0);
-        Assertions.assertEquals(joinBucket.getLower(), 5D, 0.001);
-        Assertions.assertEquals(joinBucket.getUpper(), 9D, 0.001);
-        Assertions.assertEquals(joinBucket.getCount().longValue(), 833);
-        Assertions.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+        Assertions.assertEquals(5D, joinBucket.getLower(), 0.001);
+        Assertions.assertEquals(9D, joinBucket.getUpper(), 0.001);
+        Assertions.assertEquals(833, joinBucket.getCount().longValue());
+        Assertions.assertEquals(20L * 14L, joinBucket.getUpperRepeats().longValue());
     }
 
     @Test
-    public void testConvertBucketsSkipsStringTypeHistogram() throws Exception {
+    public void testConvertBucketsSkipsStringTypeHistogram() {
         // A histogram persisted by an older version for a CHAR/VARCHAR column carries string bucket
         // bounds. Parsing them used to throw NumberFormatException on every stats-cache refresh; the
         // guard must skip such buckets (returning empty) while MCV stays readable.
@@ -665,7 +669,7 @@ public class HistogramStatisticsTest {
     }
 
     @Test
-    public void testConvertBucketsParsesNumericTypeHistogram() throws Exception {
+    public void testConvertBucketsParsesNumericTypeHistogram() {
         // Non-string columns must still parse normally - the string guard must not over-skip.
         String histogram = "{\"buckets\": [[\"1\",\"10\",\"100\",\"20\"],"
                 + "[\"15\",\"20\",\"200\",\"20\"]], \"mcv\": null}";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -647,5 +648,32 @@ public class HistogramStatisticsTest {
         Assertions.assertEquals(joinBucket.getUpper(), 9D, 0.001);
         Assertions.assertEquals(joinBucket.getCount().longValue(), 833);
         Assertions.assertEquals(joinBucket.getUpperRepeats().longValue(), 20L * 14L);
+    }
+
+    @Test
+    public void testConvertBucketsSkipsStringTypeHistogram() throws Exception {
+        // A histogram persisted by an older version for a CHAR/VARCHAR column carries string bucket
+        // bounds. Parsing them used to throw NumberFormatException on every stats-cache refresh; the
+        // guard must skip such buckets (returning empty) while MCV stays readable.
+        String histogram = "{\"buckets\": [[\"hot_a\",\"hot_z\",\"100\",\"10\"],"
+                + "[\"tail_a\",\"tail_z\",\"200\",\"10\"]], \"mcv\": [[\"hot_001\",\"260\"]]}";
+        List<Bucket> buckets = HistogramUtils.convertBuckets(histogram, VarcharType.VARCHAR);
+        Assertions.assertTrue(buckets.isEmpty());
+
+        Map<String, Long> mcv = HistogramUtils.convertMCV(histogram);
+        Assertions.assertEquals(260L, mcv.get("hot_001").longValue());
+    }
+
+    @Test
+    public void testConvertBucketsParsesNumericTypeHistogram() throws Exception {
+        // Non-string columns must still parse normally - the string guard must not over-skip.
+        String histogram = "{\"buckets\": [[\"1\",\"10\",\"100\",\"20\"],"
+                + "[\"15\",\"20\",\"200\",\"20\"]], \"mcv\": null}";
+        List<Bucket> buckets = HistogramUtils.convertBuckets(histogram, IntegerType.BIGINT);
+        Assertions.assertEquals(2, buckets.size());
+        Assertions.assertEquals(1D, buckets.get(0).getLower(), 0.001);
+        Assertions.assertEquals(10D, buckets.get(0).getUpper(), 0.001);
+        Assertions.assertEquals(100L, buckets.get(0).getCount().longValue());
+        Assertions.assertEquals(20L, buckets.get(0).getUpperRepeats().longValue());
     }
 }


### PR DESCRIPTION
  ## Why I'm doing:

  `ANALYZE ... UPDATE HISTOGRAM ON <char/varchar col>` can produce equi-height
  buckets whose bounds are strings (e.g. `["tail_014997","tail_015000","6640","10"]`).

  On the read path, `HistogramUtils.convertBuckets()` only special-cases date /
  datetime and otherwise calls `Double.parseDouble()` on the bucket bounds. For a
  string column that throws `NumberFormatException`, which is caught and logged as
  a WARN on **every** stats-cache load/refresh:

```
  WARN (stats-cache-refresher-x) [HistogramUtils.convertBuckets():..]
    Failed to parse histogram bucket: ["hot_a","hot_z","100","10"]
    java.lang.NumberFormatException: For input string: "hot_a"
      at java.lang.Double.parseDouble(...)
      at com.starrocks.sql.optimizer.statistics.HistogramUtils.convertBuckets(HistogramUtils.java:..)
      at com.starrocks.sql.optimizer.statistics.ColumnHistogramStatsCacheLoader.convert2Histogram(..)
```

  Histogram buckets are only meaningful for types whose bounds map onto the
  continuous double axis the optimizer interpolates over (`Bucket#getRowCountInBucket`).
  String columns can never contribute usable buckets — only their MCV is used — so
  the parse attempt is pure log noise / wasted work, and it keeps firing for
  histograms already persisted in `_statistics_.histogram_statistics` by earlier
  versions.

  ## What I'm doing:

  - In `HistogramUtils.convertBuckets()`, skip string-type columns early and return
    an empty bucket list instead of trying to parse string bounds. MCV is unaffected.
  - This fixes the WARN for histograms already stored (no re-`ANALYZE` needed) as
    well as any freshly collected string histograms.
  - Removed the now-vestigial `throws AnalysisException` from `convertBuckets`
    (the method never throws it; callers keep their own `throws` because
    `ErrorReport.reportAnalysisException` is unrelated).

  ## Relationship to #75968:
  
  Complementary, not overlapping. #75968 fixes the **collection** path so string
  columns stop producing buckets going forward. This PR fixes the **read** path:
  it stops the `NumberFormatException` for histograms **already persisted** by older
  versions (which #75968 does not touch), and acts as a defensive guard regardless
  of how the bucket data was written. The two can be merged independently.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
