### PR TITLE
[UT] Isolate resource group tests from warehouse implementations

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -207,6 +207,28 @@ public class ResourceGroupStmtTest {
         }
     }
 
+    private static WarehouseManager installTestWarehouseManager() {
+        WarehouseManager warehouseManager = new WarehouseManager() {
+            @Override
+            public void replayDropWarehouse(DropWarehouseLog log) {
+                try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+                    Warehouse warehouse = nameToWh.remove(log.getWarehouseName());
+                    if (warehouse != null) {
+                        idToWh.remove(warehouse.getId());
+                    }
+                }
+            }
+        };
+        warehouseManager.initDefaultWarehouse();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public WarehouseManager getWarehouseMgr() {
+                return warehouseManager;
+            }
+        };
+        return warehouseManager;
+    }
+
     private static String rowsToString(List<List<String>> rows) {
         List<String> lines = rows.stream().map(
                 row -> {
@@ -573,7 +595,7 @@ public class ResourceGroupStmtTest {
 
     @Test
     public void testChooseResourceGroupFiltersByCurrentWarehouse() throws Exception {
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        WarehouseManager warehouseManager = installTestWarehouseManager();
         warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
         BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
 
@@ -657,7 +679,7 @@ public class ResourceGroupStmtTest {
 
     @Test
     public void testChooseResourceGroupByNameAndIdFiltersByCurrentWarehouse() throws Exception {
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        WarehouseManager warehouseManager = installTestWarehouseManager();
         warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
         BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
 
@@ -2735,24 +2757,7 @@ public class ResourceGroupStmtTest {
 
     @Test
     public void testWarehouses() throws Exception {
-        WarehouseManager warehouseManager = new WarehouseManager() {
-            @Override
-            public void replayDropWarehouse(DropWarehouseLog log) {
-                try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
-                    Warehouse wg = nameToWh.remove(log.getWarehouseName());
-                    if (wg != null) {
-                        idToWh.remove(wg.getId());
-                    }
-                }
-            }
-        };
-        warehouseManager.initDefaultWarehouse();
-        new MockUp<GlobalStateMgr>() {
-            @Mock
-            public WarehouseManager getWarehouseMgr() {
-                return warehouseManager;
-            }
-        };
+        WarehouseManager warehouseManager = installTestWarehouseManager();
 
         warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
         warehouseManager.addWarehouse(new DefaultWarehouse(3, "wh3"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSetVariableTest.java
@@ -14,8 +14,10 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.staros.util.LockCloseable;
 import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.persist.DropWarehouseLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SetExecutor;
@@ -30,6 +32,7 @@ import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.DefaultWarehouse;
+import com.starrocks.warehouse.Warehouse;
 import com.uber.m3.util.ImmutableMap;
 import mockit.Mock;
 import mockit.MockUp;
@@ -51,6 +54,28 @@ public class AnalyzeSetVariableTest {
         UtFrameUtils.createMinStarRocksCluster();
         AnalyzeTestUtil.init();
         starRocksAssert = new StarRocksAssert(UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT));
+    }
+
+    private static WarehouseManager installTestWarehouseManager() {
+        WarehouseManager warehouseManager = new WarehouseManager() {
+            @Override
+            public void replayDropWarehouse(DropWarehouseLog log) {
+                try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+                    Warehouse warehouse = nameToWh.remove(log.getWarehouseName());
+                    if (warehouse != null) {
+                        idToWh.remove(warehouse.getId());
+                    }
+                }
+            }
+        };
+        warehouseManager.initDefaultWarehouse();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public WarehouseManager getWarehouseMgr() {
+                return warehouseManager;
+            }
+        };
+        return warehouseManager;
     }
 
     @Test
@@ -243,7 +268,7 @@ public class AnalyzeSetVariableTest {
 
     @Test
     public void testSetResourceGroupNameIgnoresWarehouse() throws Exception {
-        WarehouseManager warehouseManager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
+        WarehouseManager warehouseManager = installTestWarehouseManager();
         warehouseManager.addWarehouse(new DefaultWarehouse(2, "wh2"));
         BackendResourceStat.getInstance().setNumCoresOfBe(2, 2, 32);
 
@@ -262,7 +287,7 @@ public class AnalyzeSetVariableTest {
             analyzeSuccess("SET resource_group_id = " + rgId);
         } finally {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP IF EXISTS rg_set_wh2");
-            warehouseManager.replayDropWarehouse(new com.starrocks.persist.DropWarehouseLog("wh2"));
+            warehouseManager.replayDropWarehouse(new DropWarehouseLog("wh2"));
             BackendResourceStat.getInstance().reset();
         }
     }


### PR DESCRIPTION
## Why I'm doing:

Resource group tests that exercise warehouse filtering currently use the `WarehouseManager` instance installed by `GlobalStateMgr`. Other variant builds can provide different warehouse implementations with stricter warehouse subtype requirements. Adding `DefaultWarehouse` test objects to those managers makes cleanup implementation-dependent and can fail outside the behavior under test.

## What I'm doing:

- Install a test-scoped base `WarehouseManager` for resource group warehouse tests.
- Mock `GlobalStateMgr#getWarehouseMgr` so analysis and cleanup use the same test manager.
- Reuse the fixture across the affected resource group and SET-variable tests.
- Use the write lock while removing test warehouses.

Validation:

- `./run-fe-ut.sh --test com.starrocks.analysis.ResourceGroupStmtTest,com.starrocks.sql.analyzer.AnalyzeSetVariableTest`

Fixes N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

