### PR TITLE
[BugFix] Restore Operator salt to avoid Memo self-reference in CBO table prune

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -19,6 +19,10 @@ import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.RowOutputInfo;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.property.DomainProperty;
@@ -28,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class Operator {
     public static final long DEFAULT_LIMIT = -1;
@@ -40,6 +45,7 @@ public abstract class Operator {
     // common sub operators in predicate
     protected Map<ColumnRefOperator, ScalarOperator> predicateCommonOperators = null;
 
+    private static final AtomicLong SALT_GENERATOR = new AtomicLong(0);
     /**
      * Before entering the Cascades search framework,
      * we need to merge LogicalProject and child children into one node
@@ -49,6 +55,13 @@ public abstract class Operator {
     protected Projection projection;
 
     protected RowOutputInfo rowOutputInfo;
+
+    // Add salt make the original equivalent operators nonequivalent to avoid Group
+    // mutual reference in Memo.
+    // Only LogicalScanOperator/PhysicalScanOperator yielded by CboTablePruneRule has salt.
+    // if no salt, two different Groups will be merged into one, that leads to mutual reference
+    // or self reference of groups
+    protected long salt = 0;
 
     // mark which rule(bit) has been applied to the operator.
     protected BitSet opRuleBits = new BitSet();
@@ -134,6 +147,28 @@ public abstract class Operator {
 
     public void setProjection(Projection projection) {
         this.projection = projection;
+    }
+
+    public void addSalt() {
+        if ((this instanceof LogicalJoinOperator) || (this instanceof LogicalScanOperator)) {
+            this.salt = SALT_GENERATOR.incrementAndGet();
+        }
+    }
+
+    public void setSalt(long salt) {
+        if ((this instanceof LogicalJoinOperator) ||
+                (this instanceof LogicalScanOperator) ||
+                (this instanceof PhysicalScanOperator) ||
+                (this instanceof PhysicalJoinOperator)) {
+            this.salt = salt;
+        }
+    }
+    public boolean hasSalt() {
+        return salt > 0;
+    }
+
+    public long getSalt() {
+        return salt;
     }
 
     public void setOpRuleBit(int bit) {
@@ -249,12 +284,13 @@ public abstract class Operator {
         Operator operator = (Operator) o;
         return limit == operator.limit && opType == operator.opType &&
                 Objects.equals(predicate, operator.predicate) &&
-                Objects.equals(projection, operator.projection);
+                Objects.equals(projection, operator.projection) &&
+                Objects.equals(salt, operator.salt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(opType.ordinal(), limit, predicate, projection);
+        return Objects.hash(opType.ordinal(), limit, predicate, projection, salt);
     }
 
     public abstract static class Builder<O extends Operator, B extends Builder> {
@@ -271,6 +307,7 @@ public abstract class Operator {
             // defined and the plan fails InputDependenciesChecker.
             builder.predicateCommonOperators = operator.predicateCommonOperators;
             builder.projection = operator.projection;
+            builder.salt = operator.salt;
             builder.equivalentOp = operator.equivalentOp;
             builder.opRuleBits.or(operator.opRuleBits);
             builder.opAppliedMVs.addAll(operator.opAppliedMVs);
@@ -311,6 +348,11 @@ public abstract class Operator {
 
         public B setProjection(Projection projection) {
             builder.projection = projection;
+            return (B) this;
+        }
+
+        public B addSalt() {
+            builder.salt = SALT_GENERATOR.incrementAndGet();
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
@@ -36,6 +36,7 @@ public class OlapScanImplementationRule extends ImplementationRule {
         LogicalOlapScanOperator scan = (LogicalOlapScanOperator) input.getOp();
         PhysicalOlapScanOperator physicalOlapScan = new PhysicalOlapScanOperator(scan);
 
+        physicalOlapScan.setSalt(scan.getSalt());
         physicalOlapScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalOlapScan);
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/pruner/CboTablePruneRule.java
@@ -352,6 +352,7 @@ public class CboTablePruneRule extends TransformationRule {
         // set new ColumnRefToColumnMap in case that when the same tables join on UK/PK
         newColRefToColumnMap.ifPresent(newOpBuilder::setColRefToColumnMetaMap);
         Operator newScan = newOpBuilder.build();
+        newScan.addSalt();
         return Collections.singletonList(OptExpression.create(newScan));
     }
 
@@ -378,6 +379,7 @@ public class CboTablePruneRule extends TransformationRule {
 
         Operator newScan = OperatorBuilderFactory.build(retainOpt.getOp()).withOperator(retainOpt.getOp())
                 .setProjection(newProjection).build();
+        newScan.addSalt();
         return Collections.singletonList(OptExpression.create(newScan));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/CboTablePruneMemoSelfRefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/CboTablePruneMemoSelfRefTest.java
@@ -1,0 +1,131 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
+
+/**
+ * Regression test for a CBO table-prune Memo self-reference crash.
+ *
+ * <p>A query over a view that LEFT OUTER JOINs a fact table to several dimension tables carrying
+ * unique / foreign-key constraints, combined with {@code enable_cbo_table_prune=true} and an
+ * {@code IN (subquery)} predicate, could fail during planning with an unmessaged
+ * {@code IllegalStateException at Memo.copyIn} — the {@code checkState(group != targetGroup)}.
+ *
+ * <p>Mechanism: when only the fact columns are referenced, CboTablePruneRule collapses the prunable
+ * {@code Join(Scan, Scan)} into a single Scan. If that scan hash-collides with an existing group
+ * expression, the Memo merges the two groups and a child group can collapse into its own target
+ * group; a surviving JoinCommutativityRule task then copies in an expression whose input group is
+ * the target group itself, forming a self-reference cycle.
+ *
+ * <p>All four cases below must PLAN SUCCESSFULLY. The two view cases are the ones that regressed;
+ * the base-table and prune-disabled cases are controls.
+ */
+public class CboTablePruneMemoSelfRefTest {
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    private static String readDdl(String name) throws Exception {
+        try (InputStream in = CboTablePruneMemoSelfRefTest.class.getClassLoader()
+                .getResourceAsStream("sql/memo_self_ref/" + name + ".sql")) {
+            return IOUtils.toString(in, StandardCharsets.UTF_8);
+        }
+    }
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .useDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .withTable(DEFAULT_CREATE_TABLE_TEMPLATE);
+        starRocksAssert.withDatabase("test_prune").useDatabase("test_prune");
+        starRocksAssert.withTable(readDdl("t_fact"));
+        starRocksAssert.withTable(readDdl("t_dim_a"));
+        starRocksAssert.withTable(readDdl("t_dim_b"));
+        starRocksAssert.withTable(readDdl("t_dim_c"));
+        starRocksAssert.withTable(readDdl("t_drive"));
+        starRocksAssert.withView(readDdl("v_fact"));
+
+        ctx.getSessionVariable().setEnableCboTablePrune(true);
+        ctx.getSessionVariable().setEnableUKFKOpt(true);
+    }
+
+    private static final String SELECT_FROM_JOIN_FMT = "SELECT\n" +
+            "  `b`.`name` AS `name`,\n" +
+            "  `a`.`fk_id` AS `fk_id`\n" +
+            "FROM\n" +
+            "  `default_catalog`.`test_prune`.`t_drive` AS `a`\n" +
+            "  INNER JOIN `default_catalog`.`test_prune`.`%s` AS `b` ON `a`.`fk_id` = `b`.`id`\n" +
+            "  AND `a`.`part_key` = `b`.`part_key`\n" +
+            "WHERE\n" +
+            "  `b`.`part_key` = CAST(100 AS BIGINT)\n" +
+            "  AND `a`.`part_key` = CAST(100 AS BIGINT)\n" +
+            "  AND `b`.`name` IN %s";
+
+    /** With the fix, planning succeeds (non-null plan). Without it, getFragmentPlan throws. */
+    private void assertPlans(String sql) throws Exception {
+        String plan = UtFrameUtils.getFragmentPlan(ctx, sql);
+        Assertions.assertNotNull(plan);
+    }
+
+    /** view + IN (inline subselect) + cbo_table_prune — the regressed case; must plan. */
+    @Test
+    public void testViewWithInlineInSubqueryPlans() throws Exception {
+        assertPlans(String.format(SELECT_FROM_JOIN_FMT, "v_fact", "(SELECT 'x' AS name)"));
+    }
+
+    /** view + IN (CTE subselect) + cbo_table_prune — the regressed case; must plan. */
+    @Test
+    public void testViewWithCteInSubqueryPlans() throws Exception {
+        String sql = "WITH `cte` AS (SELECT 'x' AS name)\n" +
+                String.format(SELECT_FROM_JOIN_FMT, "v_fact",
+                        "(SELECT `cte`.`name` FROM `cte` AS `cte`)");
+        assertPlans(sql);
+    }
+
+    /** base fact table (no prunable joins) — control. */
+    @Test
+    public void testBaseTableWithInlineInSubqueryPlans() throws Exception {
+        assertPlans(String.format(SELECT_FROM_JOIN_FMT, "t_fact", "(SELECT 'x' AS name)"));
+    }
+
+    /** view with cbo_table_prune OFF — control; planned fine before and after the fix. */
+    @Test
+    public void testViewWithCboTablePruneDisabledPlans() throws Exception {
+        ctx.getSessionVariable().setEnableCboTablePrune(false);
+        try {
+            assertPlans(String.format(SELECT_FROM_JOIN_FMT, "v_fact", "(SELECT 'x' AS name)"));
+        } finally {
+            ctx.getSessionVariable().setEnableCboTablePrune(true);
+        }
+    }
+}

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_a.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_a.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `t_dim_a` (
+  `id` bigint(20) NOT NULL,
+  `part_key` bigint(20) NOT NULL,
+  `a1` double NULL,
+  `a2` varchar(65533) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`part_key`, `id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"foreign_key_constraints" = "(id,part_key) REFERENCES default_catalog.test_prune.t_fact(id,part_key)",
+"unique_constraints" = "default_catalog.test_prune.t_dim_a.id,part_key"
+);

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_b.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_b.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `t_dim_b` (
+  `id` bigint(20) NOT NULL,
+  `part_key` bigint(20) NOT NULL,
+  `b1` varchar(65533) NULL,
+  `b2` varchar(65533) NULL,
+  `b3` double NULL,
+  `b4` datetime NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `part_key`)
+DISTRIBUTED BY HASH(`part_key`, `id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_c.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/t_dim_c.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `t_dim_c` (
+  `id` bigint(20) NOT NULL,
+  `part_key` bigint(20) NOT NULL,
+  `c1` json NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`part_key`, `id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"foreign_key_constraints" = "(id,part_key) REFERENCES default_catalog.test_prune.t_fact(id,part_key)",
+"unique_constraints" = "default_catalog.test_prune.t_dim_c.part_key,id"
+);

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/t_drive.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/t_drive.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `t_drive` (
+  `d_time` datetime NULL,
+  `part_key` bigint(20) NOT NULL,
+  `fk_id` bigint(20) NULL,
+  `d_id` bigint(20) NULL,
+  `amt` float NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`d_time`)
+DISTRIBUTED BY HASH(`part_key`, `fk_id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/t_fact.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/t_fact.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `t_fact` (
+  `id` bigint(20) NOT NULL,
+  `part_key` bigint(20) NOT NULL,
+  `name` varchar(1048576) NULL,
+  `s1` varchar(1048576) NULL,
+  `s2` varchar(30) NULL,
+  `d1` double NULL,
+  `t1` datetime NULL
+) ENGINE=OLAP
+PRIMARY KEY(`id`, `part_key`)
+DISTRIBUTED BY HASH(`part_key`, `id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"unique_constraints" = "default_catalog.test_prune.t_fact.id,part_key"
+);

--- a/fe/fe-core/src/test/resources/sql/memo_self_ref/v_fact.sql
+++ b/fe/fe-core/src/test/resources/sql/memo_self_ref/v_fact.sql
@@ -1,0 +1,22 @@
+CREATE VIEW `v_fact` AS
+SELECT
+  `test_prune`.`t_fact`.`id`,
+  `test_prune`.`t_fact`.`part_key`,
+  `test_prune`.`t_fact`.`name`,
+  COALESCE(`test_prune`.`t_dim_b`.`b1`, `test_prune`.`t_fact`.`s1`) AS `s1`,
+  COALESCE(`test_prune`.`t_dim_b`.`b3`, `test_prune`.`t_fact`.`d1`) AS `d1`,
+  COALESCE(`test_prune`.`t_dim_b`.`b2`, `test_prune`.`t_fact`.`s2`) AS `s2`,
+  COALESCE(`test_prune`.`t_dim_b`.`b4`, `test_prune`.`t_fact`.`t1`) AS `t1`,
+  `test_prune`.`t_dim_a`.`a1`,
+  `test_prune`.`t_dim_a`.`a2`,
+  `test_prune`.`t_dim_c`.`c1`
+FROM `test_prune`.`t_fact`
+LEFT OUTER JOIN `test_prune`.`t_dim_a`
+  ON  `test_prune`.`t_dim_a`.`id` = `test_prune`.`t_fact`.`id`
+  AND `test_prune`.`t_dim_a`.`part_key` = `test_prune`.`t_fact`.`part_key`
+LEFT OUTER JOIN `test_prune`.`t_dim_b`
+  ON  `test_prune`.`t_fact`.`id` = `test_prune`.`t_dim_b`.`id`
+  AND `test_prune`.`t_dim_b`.`part_key` = `test_prune`.`t_fact`.`part_key`
+LEFT OUTER JOIN `test_prune`.`t_dim_c`
+  ON  `test_prune`.`t_dim_c`.`id` = `test_prune`.`t_fact`.`id`
+  AND `test_prune`.`t_dim_c`.`part_key` = `test_prune`.`t_fact`.`part_key`;


### PR DESCRIPTION
## Why I'm doing:

With `enable_cbo_table_prune=true`, a query over a view that LEFT OUTER JOINs a fact table to dimension tables carrying unique / foreign-key constraints can fail during planning with a client-visible `Error 1064 (HY000) Unknown error`.

The real FE-side exception is an unmessaged `IllegalStateException` at `Memo.copyIn` (the `checkState(group != targetGroup)`):

```
java.lang.IllegalStateException
    at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
    at com.starrocks.sql.optimizer.Memo.copyIn(Memo.java:144)
    at com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:112)
    ...
    at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:110)
```

Root cause: `CboTablePruneRule` collapses a prunable `Join(Scan, Scan)` into a single Scan. PR #67095 removed the Operator `salt` that used to keep that pruned scan from ever hash-colliding with an existing group expression. Without it the collision makes the Memo merge the two groups, so a child group collapses into its own target group; a surviving `JoinCommutativityRule` task then copies in an expression whose input group **is** the target group itself — a self-reference cycle — and `Memo.copyIn` asserts.

## What I'm doing:

Partially restore the salt de-dup barrier for the CBO table-prune path, while **keeping** the `Memo.removeSelfReferencing()` cleanup that guards a different self-reference path:

- `Operator`: restore `salt` and its participation in `equals`/`hashCode` (+ `addSalt`/`setSalt`/`hasSalt`/`getSalt`).
- `CboTablePruneRule`: restore `addSalt()` on pruned scans.
- `OlapScanImplementationRule`: restore salt propagation from logical to physical scan.
- `Memo.removeSelfReferencing()`: unchanged (kept).

### Why not just extend `removeSelfReferencing()` to cover this?

`removeSelfReferencing()` only drops the GroupExpressions that are *already* self-referencing in the merged group at merge time. In this bug the offending expression does not exist yet at that point: after the merge, a still-queued `JoinCommutativityRule` task fires and produces `RIGHT_JOIN(child = targetGroup)` — the self-reference is created *later*, inside `copyIn`, so the merge-time cleanup never sees it. (Confirmed: adding `setUnused(true)` in `removeSelfReferencing` does not stop the crash, because the crashing task holds a live, non-removed `LEFT JOIN` group expression.)

Preventing the merge at the source (salt) is therefore the reliable fix. Conversely, simply dropping the cyclic expression when `copyIn` detects `input == targetGroup` is not enough either — it leaves already-scheduled tasks and an incomplete Memo, and merely moves the crash to a later stage (`DeriveStatsTask`).

This is intentionally a partial restore, not a full revert: the two mechanisms coexist — salt prevents the CBO table-prune merge at the source, while `removeSelfReferencing` remains the backstop for the path it already covered.

New `CboTablePruneMemoSelfRefTest` reproduces the crash (without this fix the two view cases throw at `Memo.copyIn`; with it they plan). The existing `ReplayFromDumpTest#testMemoGroupRefSelf` still passes, confirming the two mechanisms coexist without conflict.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
