### PR TITLE
[BugFix] Reserve dict size + 1 for NULL-absorbing dict-mapping groupby keys (backport #75357)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/ApplyMinMaxStatisticRule.java
@@ -85,7 +85,11 @@ public class ApplyMinMaxStatisticRule implements TreeRewriteRule {
                         if (globalDicts.containsKey(column.getId())) {
                             final ConstantOperator min = ConstantOperator.createVarchar("0");
                             final ColumnDict columnDict = globalDicts.get(column.getId());
-                            final ConstantOperator max = ConstantOperator.createVarchar("" + columnDict.getDictSize());
+                            // A value-adding dict-mapping key (e.g. `case when x is null then '-'`)
+                            // can add one code beyond the base dict; reserve it, or the compressed
+                            // group-by key width overflows and decode fails on "key :0".
+                            final ConstantOperator max =
+                                    ConstantOperator.createVarchar("" + (columnDict.getDictSize() + 1));
                             infos.put(entry.getKey().getId(), new Pair<>(min, max));
                         }
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1245,6 +1245,23 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testDictMappingGroupByReservesExtraCode() throws Exception {
+        connectContext.getSessionVariable().setNewPlanerAggStage(2);
+        try {
+            // A value-adding dict-mapping group-by key (e.g. `case when x is null then '-'`)
+            // can grow the derived dict to base dict size + 1 codes. The compressed group-by
+            // key range must reserve that extra code, otherwise the code overflows the packed
+            // key width and decode fails with "Dict can't take cover all key".
+            String sql = "select count(*) from supplier group by "
+                    + "case when S_ADDRESS is null then '-' else S_ADDRESS end";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "group by min-max stats:\n" + "  |  - 0:2");
+        } finally {
+            connectContext.getSessionVariable().setNewPlanerAggStage(0);
+        }
+    }
+
+    @Test
     public void testGroupByWithOrderBy() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         try {
@@ -1286,7 +1303,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                     "result: VARBINARY; args nullable: false; result nullable: false]\n" +
                     "  |  group by: [12: upper, INT, true]\n" +
                     "  |  group by min-max stats:\n" +
-                    "  |  - 0:1\n" +
+                    "  |  - 0:2\n" +
                     "  |  cardinality: 1\n");
             assertContains(plan, "Global Dict Exprs:\n" +
                     "    12: DictDefine(11: S_ADDRESS, [upper(<place-holder>)])");


### PR DESCRIPTION
## Why I'm doing:
A group-by on a low-cardinality dict-mapping column uses the compressed group-by key path, whose key range is sized by ApplyMinMaxStatisticRule as (0, baseDictSize). For a NULL-absorbing mapping expression (IS NULL / ifnull / coalesce / nullif / concat_ws) the dict's NULL slot is mapped to an extra value, so the derived dict can hold baseDictSize + 1 codes. That extra code overflows the packed compressed-key width, the producer emits a code the decode dict cannot cover, and the query fails with "Dict Decode failed, Dict can't take cover all key".

## What I'm doing:
Reserve baseDictSize + 1 for such keys. A single expression maps each input code (including the NULL slot) to at most one output, so the derived dict is always <= baseDictSize + 1, which makes the bound exact. Non NULL-absorbing mappings keep baseDictSize unchanged.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4

