### PR TITLE
[Enhancement] Pre-split: meta-tier path for the multi-partition flow (footer stats, no data scan)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReader.java
@@ -287,7 +287,18 @@ public final class ParquetRowGroupStatisticsReader {
                     // the BE unsigned memcmp + shorter-prefix tiebreak, and a CHAR StringVariant is
                     // canonicalized (truncated at the first '\0') to match the BE's strnlen view of a
                     // CHAR value, so a CHAR boundary separates rows exactly as a VARCHAR one does.
-                    yield starRocksPrimitive.isCharFamily();
+                    //
+                    // A UTF8 string can also back a StarRocks DATE / DATETIME sort key -- some Parquet
+                    // exports store timestamps as strings. The footer min/max are the lexicographically
+                    // min/max strings; for canonical ISO-8601 text ("yyyy-MM-dd[ HH:mm:ss]") that equals
+                    // chronological order, so they loosely bound the row group's date/datetime range.
+                    // toVariant coerces them with the same Variant.of the data tier applies to a
+                    // projected string (unparseable / out-of-range datetime -> throws -> data-tier
+                    // fallback). A non-canonical string only degrades tablet balance -- the BE still
+                    // routes every row by its true value, so no row is misplaced.
+                    yield starRocksPrimitive.isCharFamily()
+                            || starRocksPrimitive == PrimitiveType.DATE
+                            || starRocksPrimitive == PrimitiveType.DATETIME;
                 }
                 yield isSignedByteArrayDecimal(logicalAnnotation, sortKeyColumn, typeDefinedColumnOrder);
             }
@@ -396,6 +407,9 @@ public final class ParquetRowGroupStatisticsReader {
                 ? ((Binary) parquetValue).toStringUsingUTF8()
                 : parquetValue.toString();
         // A CHAR value is NUL-canonicalized in the StringVariant constructor; VARCHAR keeps raw bytes.
+        // A UTF8 string backing a DATE / DATETIME sort key is parsed here by Variant.of -- the same
+        // coercion the data tier applies to a projected string value; an unparseable or out-of-range
+        // datetime throws IllegalArgumentException, which convertBlock turns into a data-tier fallback.
         return Variant.of(location.starRocksColumn.getType(), rendered);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -71,6 +71,15 @@ final class PreSplitFlow {
 
     private static final Logger LOG = LogManager.getLogger(PreSplitFlow.class);
 
+    // Target total number of weighted (min,max) endpoint pairs the meta-tier multi-partition sampler
+    // emits, apportioned across row groups by row count so the boundary planner's row-quantiles
+    // reflect row DENSITY (not row-group count). Kept in the same order of magnitude as the data-tier
+    // reservoir target so per-partition boundary resolution is comparable.
+    private static final int META_WEIGHTED_ENDPOINT_BUDGET = 40_000;
+    // Per-row-group cap on emitted endpoint copies, so a single dominant row group cannot balloon the
+    // FE-side sample and the pair count stays bounded even for a heavily skewed input.
+    private static final long META_MAX_ENDPOINT_WEIGHT = 2048L;
+
     private PreSplitFlow() {
     }
 
@@ -252,12 +261,22 @@ final class PreSplitFlow {
             if (rowGroups == null || rowGroups.isEmpty()) {
                 return null;
             }
+            long totalRows = 0L;
             List<RowGroupStatistics> usableRowGroups = new ArrayList<>(rowGroups.size());
             for (RowGroupStatistics rowGroup : rowGroups) {
-                if (rowGroup != null && rowGroup.getRowCount() > 0L && !rowGroup.isTruncated()
-                        && rowGroup.getMinTuple() != null && rowGroup.getMaxTuple() != null) {
-                    usableRowGroups.add(rowGroup);
+                if (rowGroup == null || rowGroup.getRowCount() <= 0L) {
+                    // No rows -> nothing to place a boundary from; safe to skip (empty / all-null group).
+                    continue;
                 }
+                if (rowGroup.isTruncated() || rowGroup.getMinTuple() == null || rowGroup.getMaxTuple() == null) {
+                    // A row group that HAS rows but no usable min/max would leave those rows
+                    // unrepresented in the boundaries (they could fall into an unsplit or mis-sized
+                    // partition). Fall back to the data tier -- matching the single-partition meta tier,
+                    // which treats any missing stats on a non-empty row group as meta-unavailable.
+                    return null;
+                }
+                usableRowGroups.add(rowGroup);
+                totalRows += rowGroup.getRowCount();
             }
             if (usableRowGroups.size() < 2) {
                 return null;
@@ -278,10 +297,20 @@ final class PreSplitFlow {
             List<Tuple> sortKeyTuples = new ArrayList<>();
             List<Tuple> partitionSourceTuples = new ArrayList<>();
             for (RowGroupStatistics rowGroup : usableRowGroups) {
-                addRowGroupEndpoint(rowGroup.getMinTuple(), partitionSourceIndexInSortKey,
-                        sortKeyTuples, partitionSourceTuples);
-                addRowGroupEndpoint(rowGroup.getMaxTuple(), partitionSourceIndexInSortKey,
-                        sortKeyTuples, partitionSourceTuples);
+                // Weight each group's endpoints by its share of total rows so the boundary planner's
+                // row-quantiles reflect row DENSITY, not row-group count (the data tier samples actual
+                // rows, density-weighted by construction; unweighted endpoints let a 1M-row group and a
+                // 100-row group each contribute the same two points, under-splitting the dense region).
+                // >= 1 so every group still contributes both ends; capped so one dominant group cannot
+                // balloon the FE-side sample, keeping the total pair count bounded regardless of skew.
+                long weight = Math.min(META_MAX_ENDPOINT_WEIGHT, Math.max(1L, Math.round(
+                        (double) rowGroup.getRowCount() / totalRows * META_WEIGHTED_ENDPOINT_BUDGET)));
+                for (long copy = 0; copy < weight; copy++) {
+                    addRowGroupEndpoint(rowGroup.getMinTuple(), partitionSourceIndexInSortKey,
+                            sortKeyTuples, partitionSourceTuples);
+                    addRowGroupEndpoint(rowGroup.getMaxTuple(), partitionSourceIndexInSortKey,
+                            sortKeyTuples, partitionSourceTuples);
+                }
             }
             if (sortKeyTuples.size() < 2) {
                 // Too few usable endpoints to place any interior boundary; let the data tier try.

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -251,12 +252,32 @@ final class PreSplitFlow {
             if (rowGroups == null || rowGroups.isEmpty()) {
                 return null;
             }
+            List<RowGroupStatistics> usableRowGroups = new ArrayList<>(rowGroups.size());
+            for (RowGroupStatistics rowGroup : rowGroups) {
+                if (rowGroup != null && rowGroup.getRowCount() > 0L && !rowGroup.isTruncated()
+                        && rowGroup.getMinTuple() != null && rowGroup.getMaxTuple() != null) {
+                    usableRowGroups.add(rowGroup);
+                }
+            }
+            if (usableRowGroups.size() < 2) {
+                return null;
+            }
+            // Fall back to the data tier when the row groups' sort-key [min,max] ranges overlap too
+            // much: min/max endpoints then cannot place interior boundaries. This happens when the
+            // source is not ordered by the sort key -- every row group spans nearly the whole range,
+            // so the endpoints collapse to a couple of values and the boundary planner produces few,
+            // uneven tablets. Mirrors the single-partition meta tier's overlap gate
+            // (ParquetMetadataSampler + Config.tablet_pre_split_meta_tier_overlap_threshold).
+            double overlapFraction = rowGroupOverlapFraction(usableRowGroups);
+            if (overlapFraction > Config.tablet_pre_split_meta_tier_overlap_threshold) {
+                LOG.info("Pre-split meta tier (multi-partition) row-group overlap {} > threshold {} for "
+                                + "table {} (source likely unordered by sort key); falling back to data tier",
+                        overlapFraction, Config.tablet_pre_split_meta_tier_overlap_threshold, table.getName());
+                return null;
+            }
             List<Tuple> sortKeyTuples = new ArrayList<>();
             List<Tuple> partitionSourceTuples = new ArrayList<>();
-            for (RowGroupStatistics rowGroup : rowGroups) {
-                if (rowGroup == null || rowGroup.getRowCount() == 0L || rowGroup.isTruncated()) {
-                    continue;
-                }
+            for (RowGroupStatistics rowGroup : usableRowGroups) {
                 addRowGroupEndpoint(rowGroup.getMinTuple(), partitionSourceIndexInSortKey,
                         sortKeyTuples, partitionSourceTuples);
                 addRowGroupEndpoint(rowGroup.getMaxTuple(), partitionSourceIndexInSortKey,
@@ -302,5 +323,30 @@ final class PreSplitFlow {
             }
         }
         return -1;
+    }
+
+    /**
+     * Fraction of row groups (sorted by sort-key min) whose min falls below the running max of the
+     * preceding groups — i.e. how much the row groups' sort-key ranges overlap. Near 0 means the
+     * source is well ordered by the sort key (tight, non-overlapping min/max, so endpoint boundaries
+     * are meaningful); near 1 means it is not (every group spans nearly the whole range, so min/max
+     * endpoints cannot place interior boundaries and the caller falls back to the data tier). Same
+     * definition the single-partition meta tier uses in {@link ParquetMetadataSampler}.
+     */
+    private static double rowGroupOverlapFraction(List<RowGroupStatistics> rowGroups) {
+        List<RowGroupStatistics> sorted = new ArrayList<>(rowGroups);
+        sorted.sort(Comparator.comparing(RowGroupStatistics::getMinTuple));
+        Tuple maxSeen = sorted.get(0).getMaxTuple();
+        int overlapping = 0;
+        for (int i = 1; i < sorted.size(); i++) {
+            RowGroupStatistics current = sorted.get(i);
+            if (current.getMinTuple().compareTo(maxSeen) < 0) {
+                overlapping++;
+            }
+            if (current.getMaxTuple().compareTo(maxSeen) > 0) {
+                maxSeen = current.getMaxTuple();
+            }
+        }
+        return (double) overlapping / (sorted.size() - 1);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -18,6 +18,8 @@ import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.qe.ConnectContext;
@@ -25,6 +27,7 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -142,7 +145,16 @@ final class PreSplitFlow {
     static void runMultiPartitionFlow(Database database, OlapTable table, Prepared prepared,
                                       LoadKind loadKind, BooleanSupplier shouldAbort, ConnectContext context) {
         int activeComputeNodeCount = TabletReshardUtils.computeNodeCount(prepared.computeResource());
-        SampleSet samples = runDataTierSampler(table, prepared, loadKind);
+        // Try the meta tier first (row-group footer statistics, no data scan), mirroring the
+        // single-partition flow's meta-tier-first routing; fall back to the exact data tier for
+        // any shape the footer path cannot serve.
+        SampleSet samples = runMetaTierMultiPartitionSampler(table, prepared, loadKind);
+        if (samples != null) {
+            LOG.info("Sample-Based Tablet Pre-Split ({}, multi-partition) served by META tier "
+                    + "(row-group footer stats, no data scan) for table {}", loadKind, table.getName());
+        } else {
+            samples = runDataTierSampler(table, prepared, loadKind);
+        }
         if (samples == null) {
             return;
         }
@@ -186,5 +198,109 @@ final class PreSplitFlow {
             PreSplitMetrics.recordSamplerFailed(SkipReason.SAMPLE_FAILED);
             return null;
         }
+    }
+
+    /**
+     * Meta-tier producer for the multi-partition flow, tried before the data tier (mirroring the
+     * single-partition flow's meta-tier-first routing). Reads only Parquet row-group min/max
+     * footer statistics (no data scan) and emits one synthetic sample per row-group endpoint, so
+     * the existing {@link PartitionSampleGrouper} (partition attribution +
+     * auto-create) and {@link TabletPreSplitCoordinator} (boundary planning + submission) consume
+     * the result unchanged. The partition-source value for each endpoint is lifted out of the
+     * sort-key tuple — the partition source column is part of the sort key for time-partitioned
+     * tables — so the grouper applies the partition expression and buckets endpoints exactly as it
+     * would per-row samples; a row group straddling a boundary contributes its min endpoint to the
+     * lower partition and its max endpoint to the upper one. Boundaries stay full sort-key arity
+     * (the footer min/max tuples span the whole sort key), so the BE's {@code
+     * validate_new_tablet_ranges} accepts them just as it does data-tier boundaries.
+     *
+     * <p>Returns {@code null} — the caller then falls back to the exact data tier — for any shape
+     * the footer path cannot serve: a load kind without Parquet footers, a rollup target
+     * (secondary-index sort keys the footer path does not carry), a partition source column absent
+     * from the sort key, or too few usable footer statistics.
+     */
+    static SampleSet runMetaTierMultiPartitionSampler(OlapTable table, Prepared prepared, LoadKind loadKind) {
+        if (loadKind != LoadKind.INSERT_FROM_FILES) {
+            return null;
+        }
+        if (!prepared.secondaryIndexSpecs().isEmpty()) {
+            return null;
+        }
+        List<Column> sortKeyColumns = prepared.sortKeyColumns();
+        List<Column> partitionSourceColumns = prepared.partitionColumns();
+        if (sortKeyColumns.isEmpty() || partitionSourceColumns.isEmpty()) {
+            return null;
+        }
+        int[] partitionSourceIndexInSortKey = new int[partitionSourceColumns.size()];
+        for (int i = 0; i < partitionSourceColumns.size(); i++) {
+            int indexInSortKey = indexOfColumnByName(sortKeyColumns, partitionSourceColumns.get(i).getName());
+            if (indexInSortKey < 0) {
+                // Partition source column is not part of the sort key, so its per-row-group value is
+                // absent from the min/max tuple: the footer path cannot attribute row groups to
+                // partitions. Let the data tier (which projects partition source columns) handle it.
+                return null;
+            }
+            partitionSourceIndexInSortKey[i] = indexInSortKey;
+        }
+        try {
+            SampleRequest request = new SampleRequest(
+                    prepared.scanContext(), sortKeyColumns, prepared.secondaryIndexSpecs(),
+                    partitionSourceColumns, Config.tablet_pre_split_sample_byte_limit, /*seed*/ 0L)
+                    .withQueryTimeoutSeconds((int) Config.tablet_pre_split_pre_submit_timeout_seconds);
+            List<RowGroupStatistics> rowGroups = new InsertFromFilesRowGroupStatisticsProvider().fetch(request);
+            if (rowGroups == null || rowGroups.isEmpty()) {
+                return null;
+            }
+            List<Tuple> sortKeyTuples = new ArrayList<>();
+            List<Tuple> partitionSourceTuples = new ArrayList<>();
+            for (RowGroupStatistics rowGroup : rowGroups) {
+                if (rowGroup == null || rowGroup.getRowCount() == 0L || rowGroup.isTruncated()) {
+                    continue;
+                }
+                addRowGroupEndpoint(rowGroup.getMinTuple(), partitionSourceIndexInSortKey,
+                        sortKeyTuples, partitionSourceTuples);
+                addRowGroupEndpoint(rowGroup.getMaxTuple(), partitionSourceIndexInSortKey,
+                        sortKeyTuples, partitionSourceTuples);
+            }
+            if (sortKeyTuples.size() < 2) {
+                // Too few usable endpoints to place any interior boundary; let the data tier try.
+                return null;
+            }
+            return new SampleSet(sortKeyTuples, partitionSourceTuples,
+                    new Estimates(prepared.estimatedBytes(), 0L));
+        } catch (StarRocksException | RuntimeException metaTierFailure) {
+            LOG.info("Pre-split meta tier (multi-partition) unavailable for table {}; falling back to "
+                    + "data tier: {}", table.getName(), metaTierFailure.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Appends one synthetic sample built from a row-group endpoint tuple: the full sort-key tuple
+     * plus the partition-source values lifted out of it by their sort-key positions. The two lists
+     * grow in lock-step so {@code sortKeyTuples} and {@code partitionSourceTuples} stay parallel,
+     * as {@link SampleSet} requires.
+     */
+    private static void addRowGroupEndpoint(Tuple endpointTuple, int[] partitionSourceIndexInSortKey,
+                                            List<Tuple> sortKeyTuples, List<Tuple> partitionSourceTuples) {
+        if (endpointTuple == null) {
+            return;
+        }
+        List<Variant> sortKeyValues = endpointTuple.getValues();
+        List<Variant> partitionSourceValues = new ArrayList<>(partitionSourceIndexInSortKey.length);
+        for (int indexInSortKey : partitionSourceIndexInSortKey) {
+            partitionSourceValues.add(sortKeyValues.get(indexInSortKey));
+        }
+        sortKeyTuples.add(endpointTuple);
+        partitionSourceTuples.add(new Tuple(partitionSourceValues));
+    }
+
+    private static int indexOfColumnByName(List<Column> columns, String columnName) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).getName().equalsIgnoreCase(columnName)) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/presplit/PreSplitFlow.java
@@ -332,8 +332,9 @@ final class PreSplitFlow {
      * are meaningful); near 1 means it is not (every group spans nearly the whole range, so min/max
      * endpoints cannot place interior boundaries and the caller falls back to the data tier). Same
      * definition the single-partition meta tier uses in {@link ParquetMetadataSampler}.
+     * Package-private so {@code PreSplitFlowTest} can assert the fraction directly.
      */
-    private static double rowGroupOverlapFraction(List<RowGroupStatistics> rowGroups) {
+    static double rowGroupOverlapFraction(List<RowGroupStatistics> rowGroups) {
         List<RowGroupStatistics> sorted = new ArrayList<>(rowGroups);
         sorted.sort(Comparator.comparing(RowGroupStatistics::getMinTuple));
         Tuple maxSeen = sorted.get(0).getMaxTuple();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/ParquetRowGroupStatisticsReaderTest.java
@@ -719,6 +719,66 @@ class ParquetRowGroupStatisticsReaderTest {
     }
 
     @Test
+    void readsDatetimeStatisticsForUtf8StringColumn() throws Exception {
+        // Some Parquet exports store timestamps as UTF8 strings. The footer min/max are the
+        // lexicographically min/max strings; for canonical ISO-8601 text ("yyyy-MM-dd HH:mm:ss")
+        // that equals chronological order, so a BINARY(UTF8) column backs a DATETIME sort key.
+        // toVariant coerces each bound with the same Variant.of the data tier applies to a
+        // projected string, rendering the canonical datetime boundary text.
+        Path parquetPath = writeParquet(
+                "message schema { required binary event_ts (UTF8); }",
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("event_ts", String.format("2025-%02d-01 12:30:00", rowIndex + 1)));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_ts", DateType.DATETIME)), null);
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertFalse(stats.get(0).isTruncated());
+        Assertions.assertEquals("2025-01-01 12:30:00",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("2025-03-01 12:30:00",
+                stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void readsDateStatisticsForUtf8StringColumn() throws Exception {
+        // Same string-backed footer path into a StarRocks DATE sort key: the lexicographic
+        // "yyyy-MM-dd" min/max render as canonical date boundaries.
+        Path parquetPath = writeParquet(
+                "message schema { required binary event_day (UTF8); }",
+                /*rowCount=*/ 3,
+                (group, rowIndex) -> group.append("event_day", String.format("2025-%02d-01", rowIndex + 1)));
+
+        List<RowGroupStatistics> stats = ParquetRowGroupStatisticsReader.read(
+                PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                List.of(new Column("event_day", DateType.DATE)), null);
+
+        Assertions.assertEquals(1, stats.size());
+        Assertions.assertEquals("2025-01-01",
+                stats.get(0).getMinTuple().getValues().get(0).getStringValue());
+        Assertions.assertEquals("2025-03-01",
+                stats.get(0).getMaxTuple().getValues().get(0).getStringValue());
+    }
+
+    @Test
+    void unparseableStringForDatetimeSortKeyFallsBackToDataTier() throws Exception {
+        // A UTF8 string that is not a parseable datetime: DateVariant's parseStrictDateTime throws
+        // IllegalArgumentException, which convertBlock wraps as MetaTierUnavailableException so the
+        // pipeline falls back to the exact data tier (which coerces the same value at query time).
+        Path parquetPath = writeParquet(
+                "message schema { required binary event_ts (UTF8); }",
+                /*rowCount=*/ 2,
+                (group, rowIndex) -> group.append("event_ts", "not-a-datetime-" + rowIndex));
+
+        Assertions.assertThrows(MetaTierUnavailableException.class, () ->
+                ParquetRowGroupStatisticsReader.read(
+                        PresplitTestSupport.statusOf(parquetPath), new Configuration(),
+                        List.of(new Column("event_ts", DateType.DATETIME)), null));
+    }
+
+    @Test
     void readsDecimalStatisticsForInt32Decimal() throws Exception {
         // INT32-backed DECIMAL(9,2): precision 9 fits int32. Unscaled (rowIndex+1)*100 → 1.00..3.00.
         Path parquetPath = writeParquet(

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintColumn;
+import static com.starrocks.alter.reshard.presplit.PresplitTestSupport.bigintTuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -421,6 +422,94 @@ public class PreSplitFlowTest {
         }
     }
 
+    @Test
+    public void rowGroupOverlapFractionIsZeroForOrderedGroups() {
+        // Non-overlapping, ascending [min,max] ranges (source ordered by the sort key): every group's
+        // min is at/above the running max, so nothing overlaps and endpoint boundaries are meaningful.
+        List<RowGroupStatistics> ordered = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(9), 100L, false),
+                new RowGroupStatistics(bigintTuple(10), bigintTuple(19), 100L, false),
+                new RowGroupStatistics(bigintTuple(20), bigintTuple(29), 100L, false));
+        Assertions.assertEquals(0.0, PreSplitFlow.rowGroupOverlapFraction(ordered), 1e-9);
+    }
+
+    @Test
+    public void rowGroupOverlapFractionIsOneForFullyOverlappingGroups() {
+        // Every group spans the whole range (source not ordered by the sort key): each group after the
+        // first has its min below the running max, so the overlap fraction is 1 -> caller falls back.
+        List<RowGroupStatistics> overlapping = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false),
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false),
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false));
+        Assertions.assertEquals(1.0, PreSplitFlow.rowGroupOverlapFraction(overlapping), 1e-9);
+    }
+
+    @Test
+    public void rowGroupOverlapFractionCountsPartialOverlap() {
+        // g0=[0,20], g1=[10,30] (min 10 < running max 20 -> overlaps), g2=[40,50] (min 40 >= max 30
+        // -> disjoint). 1 of the 2 groups after the first overlaps -> 0.5.
+        List<RowGroupStatistics> mixed = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(20), 100L, false),
+                new RowGroupStatistics(bigintTuple(10), bigintTuple(30), 100L, false),
+                new RowGroupStatistics(bigintTuple(40), bigintTuple(50), 100L, false));
+        Assertions.assertEquals(0.5, PreSplitFlow.rowGroupOverlapFraction(mixed), 1e-9);
+    }
+
+    @Test
+    public void metaTierMultiPartitionFallsBackWhenRowGroupsOverlap() {
+        // Fully-overlapping row groups (unordered source): the overlap gate returns null so the
+        // caller uses the data tier instead of collapsing every endpoint onto a couple of values.
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
+        List<RowGroupStatistics> overlapping = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false),
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false),
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(100), 100L, false));
+
+        try (MockedConstruction<InsertFromFilesRowGroupStatisticsProvider> ignored =
+                Mockito.mockConstruction(InsertFromFilesRowGroupStatisticsProvider.class,
+                        (provider, ctx) -> when(provider.fetch(any(SampleRequest.class))).thenReturn(overlapping))) {
+            Assertions.assertNull(
+                    PreSplitFlow.runMetaTierMultiPartitionSampler(table, prepared, LoadKind.INSERT_FROM_FILES),
+                    "overlapping row groups must fall back to the data tier");
+        }
+    }
+
+    @Test
+    public void metaTierMultiPartitionEmitsEndpointsWhenOrdered() {
+        // Ordered, non-overlapping row groups (source sorted by the sort key): the meta tier emits a
+        // min + max endpoint per row group (2 per group) as both the sort-key tuples and the parallel
+        // partition-source tuples, with no data scan.
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
+        List<RowGroupStatistics> ordered = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(9), 100L, false),
+                new RowGroupStatistics(bigintTuple(10), bigintTuple(19), 100L, false));
+
+        try (MockedConstruction<InsertFromFilesRowGroupStatisticsProvider> ignored =
+                Mockito.mockConstruction(InsertFromFilesRowGroupStatisticsProvider.class,
+                        (provider, ctx) -> when(provider.fetch(any(SampleRequest.class))).thenReturn(ordered))) {
+            SampleSet result = PreSplitFlow.runMetaTierMultiPartitionSampler(
+                    table, prepared, LoadKind.INSERT_FROM_FILES);
+
+            Assertions.assertNotNull(result, "ordered row groups must stay on the meta tier");
+            Assertions.assertEquals(4, result.getTuples().size(), "2 endpoints per row group");
+            Assertions.assertEquals(result.getTuples().size(), result.getPartitionSourceTuples().size(),
+                    "sort-key and partition-source tuples must stay parallel");
+        }
+    }
+
+    @Test
+    public void metaTierMultiPartitionSkipsNonInsertFromFiles() {
+        // The meta-tier multi-partition path is INSERT-from-FILES only; other load kinds return null
+        // immediately (no provider construction, no footer read).
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
+        Assertions.assertNull(
+                PreSplitFlow.runMetaTierMultiPartitionSampler(table, prepared, LoadKind.INSERT_FROM_TABLE),
+                "non-INSERT_FROM_FILES load kinds must not use the meta tier");
+    }
+
     // ---------- helpers ----------
 
     /**
@@ -442,6 +531,17 @@ public class PreSplitFlowTest {
         List<Column> sortKey = List.of(bigintColumn("sort_col"));
         return new PreSplitFlow.Prepared(scanContext, sortKey, List.of(),
                 /*estimatedBytes*/ 0L, mock(ComputeResource.class));
+    }
+
+    /**
+     * A {@link PreSplitFlow.Prepared} whose partition source column is also the sort key — the shape
+     * the meta-tier multi-partition sampler requires (it lifts each partition value out of the
+     * row-group min/max sort-key tuple by position).
+     */
+    private static PreSplitFlow.Prepared preparedWithPartitionInSortKey(ScanContext scanContext) {
+        Column sortCol = bigintColumn("sort_col");
+        return new PreSplitFlow.Prepared(scanContext, List.of(sortCol), List.of(sortCol),
+                /*estimatedBytes*/ 4096L, mock(ComputeResource.class));
     }
 
     /** Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target for {@code table}. */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -477,8 +477,8 @@ public class PreSplitFlowTest {
 
     @Test
     public void metaTierMultiPartitionEmitsEndpointsWhenOrdered() {
-        // Ordered, non-overlapping row groups (source sorted by the sort key): the meta tier emits a
-        // min + max endpoint per row group (2 per group) as both the sort-key tuples and the parallel
+        // Ordered, non-overlapping row groups (source sorted by the sort key): the meta tier emits
+        // paired min/max endpoints per row group as both the sort-key tuples and the parallel
         // partition-source tuples, with no data scan.
         OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
         PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
@@ -493,9 +493,57 @@ public class PreSplitFlowTest {
                     table, prepared, LoadKind.INSERT_FROM_FILES);
 
             Assertions.assertNotNull(result, "ordered row groups must stay on the meta tier");
-            Assertions.assertEquals(4, result.getTuples().size(), "2 endpoints per row group");
+            Assertions.assertFalse(result.getTuples().isEmpty(), "ordered row groups must emit endpoints");
+            Assertions.assertEquals(0, result.getTuples().size() % 2, "endpoints are emitted as min/max pairs");
             Assertions.assertEquals(result.getTuples().size(), result.getPartitionSourceTuples().size(),
                     "sort-key and partition-source tuples must stay parallel");
+        }
+    }
+
+    @Test
+    public void metaTierMultiPartitionWeightsEndpointsByRowCount() {
+        // A dense row group must contribute more endpoint copies than a sparse one so the boundary
+        // planner's row-quantiles reflect row density, not row-group count.
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
+        List<RowGroupStatistics> unevenSizes = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(9), 1_000_000L, false),    // dense
+                new RowGroupStatistics(bigintTuple(10), bigintTuple(19), 100L, false));        // sparse
+
+        try (MockedConstruction<InsertFromFilesRowGroupStatisticsProvider> ignored =
+                Mockito.mockConstruction(InsertFromFilesRowGroupStatisticsProvider.class,
+                        (provider, ctx) -> when(provider.fetch(any(SampleRequest.class))).thenReturn(unevenSizes))) {
+            SampleSet result = PreSplitFlow.runMetaTierMultiPartitionSampler(
+                    table, prepared, LoadKind.INSERT_FROM_FILES);
+
+            Assertions.assertNotNull(result);
+            long denseMinCopies = result.getTuples().stream()
+                    .filter(t -> "0".equals(t.getValues().get(0).getStringValue())).count();
+            long sparseMinCopies = result.getTuples().stream()
+                    .filter(t -> "10".equals(t.getValues().get(0).getStringValue())).count();
+            Assertions.assertTrue(denseMinCopies > sparseMinCopies,
+                    "dense row group copies (" + denseMinCopies + ") must exceed sparse (" + sparseMinCopies + ")");
+        }
+    }
+
+    @Test
+    public void metaTierMultiPartitionFallsBackWhenPositiveRowGroupLacksStats() {
+        // A row group that has rows but no usable min/max (here: truncated stats) would leave those
+        // rows unrepresented in the boundaries -> fall back to the data tier rather than planning from
+        // the remaining groups.
+        OlapTable table = mockTable(/*partitioned*/ true, /*automatic*/ true);
+        PreSplitFlow.Prepared prepared = preparedWithPartitionInSortKey(mock(ScanContext.class));
+        List<RowGroupStatistics> withBadGroup = List.of(
+                new RowGroupStatistics(bigintTuple(0), bigintTuple(9), 100L, false),
+                new RowGroupStatistics(bigintTuple(10), bigintTuple(19), 100L, /*truncated*/ true),
+                new RowGroupStatistics(bigintTuple(20), bigintTuple(29), 100L, false));
+
+        try (MockedConstruction<InsertFromFilesRowGroupStatisticsProvider> ignored =
+                Mockito.mockConstruction(InsertFromFilesRowGroupStatisticsProvider.class,
+                        (provider, ctx) -> when(provider.fetch(any(SampleRequest.class))).thenReturn(withBadGroup))) {
+            Assertions.assertNull(
+                    PreSplitFlow.runMetaTierMultiPartitionSampler(table, prepared, LoadKind.INSERT_FROM_FILES),
+                    "a positive-row group without usable stats must fall back to the data tier");
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

The Sample-Based Tablet Pre-Split **multi-partition flow** (partitioned / auto-partitioned tables) always samples via a full **data-tier scan** of the source Parquet. Under expression-based partitioning (e.g. `PARTITION BY date_trunc('month', __time)`) the meta tier is disabled, so the data tier must full-scan the source to project per-row `(sort-key, partition-source)` tuples. On wide sort keys this scan dominates load latency — hundreds of seconds per table observed on a ~80 GB source. The single-partition flow already routes meta-tier-first; only the multi-partition flow was left on the data tier.

## What I'm doing:

Make the multi-partition flow **try the meta tier first**, mirroring the meta-tier-first / data-tier-fallback routing the single-partition flow already uses (neither path has an on/off switch — the two are now consistent). Three commits:

1. **Meta-tier path for the multi-partition flow** — read only Parquet row-group **min/max footer statistics** (no data scan) and emit one synthetic sample per row-group endpoint. The existing `PartitionSampleGrouper` (partition attribution + auto-create) and `TabletPreSplitCoordinator` (boundary planning + submission) consume the result **unchanged**:
   - The partition-source value for each endpoint is lifted out of the sort-key min/max tuple (the partition source column is part of the sort key for time-partitioned tables), so the grouper applies the partition expression and buckets endpoints exactly as it would per-row samples.
   - A row group straddling a partition boundary contributes its **min** endpoint to the lower partition and its **max** endpoint to the upper one.
   - Min/max tuples span the **full** sort key, so boundaries stay full-arity and the BE `validate_new_tablet_ranges` accepts them exactly as data-tier boundaries.

2. **Accept Parquet UTF8 string min/max for DATE/DATETIME sort keys** — some Parquet exports store timestamps as UTF8 strings. The footer reader previously rejected `BINARY(STRING) -> DATE/DATETIME`, forcing the data-tier full scan even though the data tier coerces the same string at query time. The footer min/max are lexicographic string bounds (== chronological order for canonical ISO-8601 text), coerced by the same `Variant.of` the data tier uses; an unparseable / out-of-range value throws and falls back to the data tier.

3. **Fall back to the data tier when row groups overlap** — min/max endpoints can only place interior boundaries when the source is ordered by the sort key. When it is not, every row group spans nearly the whole range, the endpoints collapse to a couple of values, and the boundary planner produces few, uneven tablets. Add the same overlap gate the single-partition meta tier already applies (`tablet_pre_split_meta_tier_overlap_threshold`): if the fraction of row groups whose sort-key min falls below the running max exceeds the threshold, return null so the caller uses the exact data tier. Well-ordered sources still take the fast footer path.

The flow **falls back to the exact data tier** for any shape the footer path cannot serve: non-INSERT-from-FILES loads, rollup targets (secondary-index sort keys the footer path does not carry), a partition source column absent from the sort key, too few usable footer statistics, or overlapping row groups.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The multi-partition pre-split flow now tries the meta tier before the data tier (previously it always used the data tier). This is a transparent optimization automatically enabled for INSERT-from-FILES loads: results are the same shape (per-partition tablet boundaries) and it falls back to the exact data tier whenever the footer path cannot serve a load.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

### Test plan

**Unit tests** (`./run-fe-ut.sh`, `com.starrocks.alter.reshard.presplit`):
- `ParquetRowGroupStatisticsReaderTest` — `readsDatetimeStatisticsForUtf8StringColumn`, `readsDateStatisticsForUtf8StringColumn`, `unparseableStringForDatetimeSortKeyFallsBackToDataTier` (commit 2).
- `PreSplitFlowTest` — `rowGroupOverlapFraction{IsZeroForOrderedGroups,IsOneForFullyOverlappingGroups,CountsPartialOverlap}`, `metaTierMultiPartition{FallsBackWhenRowGroupsOverlap,EmitsEndpointsWhenOrdered,SkipsNonInsertFromFiles}` (commits 1 & 3).

**On-cluster** (shared-data, 3 CN; Pinterest date-partitioned schema, ~80 GB Parquet source):
- Meta tier routes correctly (meta-first, data-tier fallback) and produces per-partition boundaries of the same shape as the data tier.
- Overlap gate verified on the unordered source: row-group overlap `1.0 > 0.3` → the flow correctly falls back to the data tier, so there is **no tablet-skew regression** on unordered inputs.
- The full end-to-end sampling speedup (322 s → 59 s observed) is realized together with the stacked footer-parallel PR #76565, which reads the footers concurrently.

> Note: #76565 is stacked on top of this PR — merge this PR first, then rebase #76565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
