### PR TITLE
[BugFix] Reject row-level DELETE on non-V2 Iceberg tables at plan time

### DIFF
--- a/docs/en/data_source/catalog/iceberg/DML.md
+++ b/docs/en/data_source/catalog/iceberg/DML.md
@@ -222,6 +222,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### Usage notes
+
+- Row-level DELETE (position deletes) requires Iceberg **format version 2**. On tables with other format versions, DELETE is supported only when the predicate matches entire files or partitions (executed as a metadata-only delete); otherwise the statement is rejected.
+
 ## UPDATE
 
 You can use the UPDATE statement to modify rows in an Iceberg table based on specified conditions. This feature is supported from v4.2 and later.

--- a/docs/en/data_source/catalog/iceberg/DML.md
+++ b/docs/en/data_source/catalog/iceberg/DML.md
@@ -223,6 +223,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### Usage notes
+
+- Row-level DELETE (position deletes) requires Iceberg **format version 2**. On tables with other format versions, DELETE is supported only when the predicate matches entire files or partitions (executed as a metadata-only delete); otherwise the statement is rejected.
+
 ## UPDATE
 
 You can use the UPDATE statement to modify rows in an Iceberg table based on specified conditions. This feature is supported from v4.2 and later.

--- a/docs/ja/data_source/catalog/iceberg/DML.md
+++ b/docs/ja/data_source/catalog/iceberg/DML.md
@@ -211,6 +211,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### 使用上の注意
+
+- 行レベル DELETE（position delete）は **format-version 2** の Iceberg テーブルのみサポートされます。それ以外のバージョンのテーブルでは、述語がファイルまたはパーティション全体に一致する場合（メタデータのみの削除として実行）に限り DELETE がサポートされ、それ以外は拒否されます。
+
 ## UPDATE
 
 指定された条件に基づいて Iceberg テーブルの行を更新するには、UPDATE ステートメントを使用できます。この機能は v4.2 以降でサポートされています。

--- a/docs/ja/data_source/catalog/iceberg/DML.md
+++ b/docs/ja/data_source/catalog/iceberg/DML.md
@@ -212,6 +212,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### 使用上の注意
+
+- 行レベル DELETE（position delete）は **format-version 2** の Iceberg テーブルのみサポートされます。それ以外のバージョンのテーブルでは、述語がファイルまたはパーティション全体に一致する場合（メタデータのみの削除として実行）に限り DELETE がサポートされ、それ以外は拒否されます。
+
 ## UPDATE
 
 指定された条件に基づいて Iceberg テーブルの行を更新するには、UPDATE ステートメントを使用できます。この機能は v4.2 以降でサポートされています。

--- a/docs/zh/data_source/catalog/iceberg/DML.md
+++ b/docs/zh/data_source/catalog/iceberg/DML.md
@@ -211,6 +211,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### 使用说明
+
+- 行级 DELETE（position delete）仅支持 **format-version 2** 的 Iceberg 表。对于其他版本的表，仅当谓词能匹配完整文件或分区（以元数据方式删除）时才支持 DELETE，否则语句会被拒绝。
+
 ## UPDATE
 
 您可以使用 UPDATE 语句根据指定条件更新 Iceberg 表中的数据。此功能从 v4.2 起支持。

--- a/docs/zh/data_source/catalog/iceberg/DML.md
+++ b/docs/zh/data_source/catalog/iceberg/DML.md
@@ -212,6 +212,10 @@ DELETE FROM iceberg_catalog.db.table1 WHERE id IN (SELECT id FROM temp_table WHE
 DELETE FROM iceberg_catalog.db.table1 t1 WHERE EXISTS (SELECT user_id FROM inactive_users t2 WHERE t2.user_id = t1.user_id);
 ```
 
+### 使用说明
+
+- 行级 DELETE（position delete）仅支持 **format-version 2** 的 Iceberg 表。对于其他版本的表，仅当谓词能匹配完整文件或分区（以元数据方式删除）时才支持 DELETE，否则语句会被拒绝。
+
 ## UPDATE
 
 您可以使用 UPDATE 语句根据指定条件更新 Iceberg 表中的数据。此功能从 v4.2 起支持。

--- a/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/DeletePlanner.java
@@ -109,6 +109,16 @@ public class DeletePlanner {
                 }
             }
 
+            // Row-level DELETE writes position-delete files, which only format version 2 supports:
+            // v1 has no row-level deletes and v3 forbids adding position-delete files. The metadata
+            // (whole-file) delete above works on any format version, so it must stay reachable.
+            if (icebergTable.getFormatVersion() != 2) {
+                throw new SemanticException(
+                        "Row-level DELETE is only supported for Iceberg V2 tables, but table format version is "
+                                + icebergTable.getFormatVersion()
+                                + ". Only DELETE predicates that match entire files/partitions are supported on this table");
+            }
+
             // For Iceberg, create shuffled property based on partitioning
             List<ColumnRefOperator> outputColumns = logicalPlan.getOutputColumn();
             requiredProperty = IcebergPlannerUtils.createShuffleProperty(icebergTable, outputColumns);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -84,6 +84,7 @@ public class MockIcebergMetadata implements ConnectorMetadata {
 
     public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
     public static final String MOCKED_UNPARTITIONED_V2_TABLE_NAME = "t0_v2";
+    public static final String MOCKED_UNPARTITIONED_V1_TABLE_NAME = "t0_v1";
     public static final String MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME = "variant_t0";
     public static final String MOCKED_UNPARTITIONED_TABLE_NUMERIC = "t_numeric";
     public static final String MOCKED_UNKNOWN_TYPE_TABLE_NAME = "t_unknown_types";
@@ -194,6 +195,15 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                         required(4, "data", Types.StringType.get()),
                         required(5, "date", Types.StringType.get())),
                 2);
+        // V1 unpartitioned table: format version 1 has no row-level deletes at all
+        registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_V1_TABLE_NAME,
+                ImmutableList.of(new Column("id", IntegerType.INT, true),
+                        new Column("data", StringType.STRING, true),
+                        new Column("date", StringType.STRING, true)),
+                new Schema(required(3, "id", Types.IntegerType.get()),
+                        required(4, "data", Types.StringType.get()),
+                        required(5, "date", Types.StringType.get())),
+                1);
         registerUnpartitionedTable(icebergTableInfoMap, MOCKED_UNPARTITIONED_VARIANT_TABLE_NAME,
                 ImmutableList.of(new Column("id", IntegerType.INT, true),
                         new Column("v", VariantType.VARIANT, true)),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
@@ -64,10 +64,10 @@ public class DeletePlanTest extends PlanTestBase {
     public void testIcebergDeleteWithMultipleConditions() throws Exception {
         // Test DELETE with multiple WHERE conditions
         String[] deleteStatements = {
-                "delete from iceberg0.unpartitioned_db.t0 where id = 1",
-                "delete from iceberg0.unpartitioned_db.t0 where id > 100",
-                "delete from iceberg0.unpartitioned_db.t0 where id between 10 and 100",
-                "delete from iceberg0.unpartitioned_db.t0 where data like '%test%'"
+                "delete from iceberg0.unpartitioned_db.t0_v2 where id = 1",
+                "delete from iceberg0.unpartitioned_db.t0_v2 where id > 100",
+                "delete from iceberg0.unpartitioned_db.t0_v2 where id between 10 and 100",
+                "delete from iceberg0.unpartitioned_db.t0_v2 where data like '%test%'"
         };
 
         for (String sql : deleteStatements) {
@@ -81,9 +81,9 @@ public class DeletePlanTest extends PlanTestBase {
     public void testPartitionedIcebergTableDelete() throws Exception {
         // Test DELETE on partitioned Iceberg tables
         String[] deleteStatements = {
-                "delete from iceberg0.partitioned_db.t1 where id = 1",
-                "delete from iceberg0.partitioned_db.t1 where `date` = '2023-01-01'",
-                "delete from iceberg0.partitioned_db.t1 where id > 100 and `date` >= '2023-01-01'"
+                "delete from iceberg0.partitioned_db.t1_v2 where id = 1",
+                "delete from iceberg0.partitioned_db.t1_v2 where `date` = '2023-01-01'",
+                "delete from iceberg0.partitioned_db.t1_v2 where id > 100 and `date` >= '2023-01-01'"
         };
 
         for (String sql : deleteStatements) {
@@ -99,7 +99,7 @@ public class DeletePlanTest extends PlanTestBase {
     @Test
     public void testIcebergDeleteWithSubquery() throws Exception {
         // Test DELETE with subquery (like: DELETE WHERE id IN (SELECT id FROM other_table))
-        String sql = "delete from iceberg0.unpartitioned_db.t0 where id in (select id from iceberg0.partitioned_db.t1)";
+        String sql = "delete from iceberg0.unpartitioned_db.t0_v2 where id in (select id from iceberg0.partitioned_db.t1)";
         String explainString = getDeleteExecPlanString(sql);
         assertTrue(explainString.contains("ICEBERG DELETE SINK"));
     }
@@ -107,7 +107,7 @@ public class DeletePlanTest extends PlanTestBase {
     @Test
     public void testIcebergDeleteOutputColumns() throws Exception {
         // Test that DELETE returns _file and _pos columns for Iceberg position delete
-        String sql = "delete from iceberg0.unpartitioned_db.t0 where id = 1";
+        String sql = "delete from iceberg0.unpartitioned_db.t0_v2 where id = 1";
         ExecPlan execPlan = getDeleteExecPlan(sql);
 
         assertNotNull(execPlan);
@@ -122,7 +122,7 @@ public class DeletePlanTest extends PlanTestBase {
         int previousSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
         try {
             connectContext.getSessionVariable().setPipelineSinkDop(8);
-            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0_v2 where id = 1");
             FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
             Assertions.assertEquals(8, instance.getTableSinkDop());
         } finally {
@@ -144,7 +144,7 @@ public class DeletePlanTest extends PlanTestBase {
             connectContext.getSessionVariable().setPipelineSinkDop(0);
             connectContext.getSessionVariable().setPipelineDop(0);
 
-            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0_v2 where id = 1");
             FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
             Assertions.assertEquals(6, instance.getTableSinkDop());
         } finally {
@@ -158,7 +158,7 @@ public class DeletePlanTest extends PlanTestBase {
         int previousSinkDop = connectContext.getSessionVariable().getPipelineSinkDop();
         try {
             connectContext.getSessionVariable().setPipelineSinkDop(0);
-            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.partitioned_db.t1 where id = 1");
+            ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.partitioned_db.t1_v2 where id = 1");
             FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
             Assertions.assertEquals(0, instance.getTableSinkDop());
         } finally {
@@ -168,7 +168,7 @@ public class DeletePlanTest extends PlanTestBase {
 
     @Test
     public void testIcebergDeleteFallsBackToFragmentDopWhenConnectContextIsMissing() throws Exception {
-        ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0 where id = 1");
+        ExecPlan execPlan = getDeleteExecPlan("delete from iceberg0.unpartitioned_db.t0_v2 where id = 1");
         FragmentInstance instance = createFragmentInstance(execPlan.getTopFragment());
         int fragmentDop = execPlan.getTopFragment().getPipelineDop();
 
@@ -183,7 +183,7 @@ public class DeletePlanTest extends PlanTestBase {
     @Test
     public void testIsIcebergDeleteOperation() throws Exception {
         // Test case 1: Output columns contain _file and _pos
-        String sql1 = "delete from iceberg0.unpartitioned_db.t0 where id = 1";
+        String sql1 = "delete from iceberg0.unpartitioned_db.t0_v2 where id = 1";
         ExecPlan execPlan1 = getDeleteExecPlan(sql1);
         assertNotNull(execPlan1);
         

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDeleteFormatVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDeleteFormatVersionTest.java
@@ -1,0 +1,75 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.planner.IcebergDeleteSink;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the format-version guard on the Iceberg row-level DELETE plan path: row-level
+ * DELETE writes position-delete files, which only format version 2 supports, so planning
+ * must reject it on non-v2 tables. The guard sits after the metadata (whole-file) delete
+ * branch in DeletePlanner, which is format-version-agnostic and must stay reachable.
+ */
+public class IcebergDeleteFormatVersionTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    private static ExecPlan getExecPlanOf(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
+        connectContext.getDumpInfo().setOriginStmt(sql);
+        return StatementPlanner.plan(statementBase, connectContext);
+    }
+
+    @Test
+    public void testRowLevelDeleteOnNonV2TableRejected() {
+        // t0 is format version 3; its predicate does not qualify for metadata delete
+        // (MockIcebergMetadata keeps the ConnectorMetadata default canDeleteUsingMetadata=false),
+        // so the planner takes the row-level path and must reject the non-v2 table.
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> getExecPlanOf("DELETE FROM iceberg0.unpartitioned_db.t0 WHERE id = 1"));
+        assertTrue(exception.getMessage().contains("V2 tables"),
+                "Expected the format-version error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testRowLevelDeleteOnV2TablePlanned() throws Exception {
+        // The same row-level path on a format version 2 table must keep planning normally.
+        ExecPlan execPlan = getExecPlanOf("DELETE FROM iceberg0.unpartitioned_db.t0_v2 WHERE id = 1");
+        assertNotNull(execPlan);
+        assertInstanceOf(IcebergDeleteSink.class, execPlan.getFragments().get(0).getSink());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDeleteFormatVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergDeleteFormatVersionTest.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
+import com.starrocks.planner.IcebergDeleteSink;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the format-version guard on the Iceberg row-level DELETE plan path: row-level
+ * DELETE writes position-delete files, which only format version 2 supports, so planning
+ * must reject it on non-v2 tables. The guard sits after the metadata (whole-file) delete
+ * branch in DeletePlanner, which is format-version-agnostic and must stay reachable.
+ */
+public class IcebergDeleteFormatVersionTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
+    }
+
+    private static ExecPlan getExecPlanOf(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode())
+                        .get(0);
+        connectContext.getDumpInfo().setOriginStmt(sql);
+        return StatementPlanner.plan(statementBase, connectContext);
+    }
+
+    @Test
+    public void testRowLevelDeleteOnNonV2TableRejected() {
+        // t0 is format version 3; its predicate does not qualify for metadata delete
+        // (MockIcebergMetadata keeps the ConnectorMetadata default canDeleteUsingMetadata=false),
+        // so the planner takes the row-level path and must reject the non-v2 table.
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> getExecPlanOf("DELETE FROM iceberg0.unpartitioned_db.t0 WHERE id = 1"));
+        assertTrue(exception.getMessage().contains("V2 tables"),
+                "Expected the format-version error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testRowLevelDeleteOnV1TableRejected() {
+        // Format version 1 has no row-level deletes at all, so the guard must cover it too,
+        // not just the v3 case above.
+        SemanticException exception = assertThrows(SemanticException.class,
+                () -> getExecPlanOf("DELETE FROM iceberg0.unpartitioned_db.t0_v1 WHERE id = 1"));
+        assertTrue(exception.getMessage().contains("V2 tables"),
+                "Expected the format-version error, got: " + exception.getMessage());
+    }
+
+    @Test
+    public void testRowLevelDeleteOnV2TablePlanned() throws Exception {
+        // The same row-level path on a format version 2 table must keep planning normally.
+        ExecPlan execPlan = getExecPlanOf("DELETE FROM iceberg0.unpartitioned_db.t0_v2 WHERE id = 1");
+        assertNotNull(execPlan);
+        assertInstanceOf(IcebergDeleteSink.class, execPlan.getFragments().get(0).getSink());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Iceberg DELETE has two execution paths. The metadata (whole-file) delete rewrites manifests and is legal on any format version. The row-level fallback commits Parquet position-delete files via `FileMetadata.deleteFileBuilder(spec).ofPositionDeletes()` (`IcebergMetadata.java:2661`), and only format version 2 defines those: v1 has no row-level deletes, and the v3 spec forbids adding position delete files to v3 tables. That path had no format-version check, so a DELETE that did not qualify for the metadata path wrote delete metadata the table format does not define, and other engines then either fail to read the table or ignore those files, resurrecting the deleted rows.

`UpdateAnalyzer.analyzeIcebergTable` (`UpdateAnalyzer.java:86`) and `MergeIntoAnalyzer.analyzeIcebergTable` (`MergeIntoAnalyzer.java:91`) already reject non-v2 tables, so DELETE was the outlier. The existing tests codified the defect: `DeletePlanTest` planned Iceberg DELETE against the mock tables `t0`/`t1`, which `MockIcebergMetadata` registers at format version 3, and asserted success.

Fixes #76551

## What I'm doing:

- `DeletePlanner.java`: reject a row-level DELETE when `getFormatVersion() != 2`, placed **after** the `canDeleteUsingMetadata(...)` branch. Position placement is the whole point of the fix: an earlier guard in `DeleteAnalyzer` would also have rejected whole-file deletes that are valid on v1 and v3, for example a partition-predicate delete on a v1 table.
- `IcebergDeleteFormatVersionTest.java` (new): pins the rejection on both non-v2 directions, v1 and v3, and pins that a v2 table still plans down to `IcebergDeleteSink`. The rejection cases fail without the guard.
- `MockIcebergMetadata.java`: register a format version 1 table (`t0_v1`); the mock only had v2 and v3 tables.
- `DeletePlanTest.java`: repoint the existing Iceberg DELETE cases at the v2 mock tables, since they were asserting success on v3 tables.
- `docs/{en,zh,ja}/data_source/catalog/iceberg/DML.md`: state that row-level DELETE requires format version 2, mirroring the existing UPDATE note.

Behaviour on v2 tables is unchanged, and metadata (whole-file) deletes stay reachable on every format version. The only statements that now fail are the ones that previously committed delete files the table format does not define.

Backport: 4.1 only. Iceberg DELETE landed in 4.1 and `branch-4.1` carries the same unguarded path. `branch-4.0` and `branch-3.5` have no Iceberg DELETE path at all, so there is nothing to fix there.

Suggested release-note bullet: Iceberg: row-level `DELETE` on non-V2 (v1/v3) tables is now rejected at plan time with a clear error, matching `UPDATE` and `MERGE INTO`. Metadata-only deletes are unaffected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5