### PR TITLE
[BugFix][CVE] bump Netty to 4.1.136.Final

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
         set("hive-apache.version", "3.1.2-22")
         set("hudi.version", "1.0.2")
         set("iceberg.version", "1.10.0")
-        set("io.netty.version", "4.1.135.Final")
+        set("io.netty.version", "4.1.136.Final")
         set("jackson.version", "2.21.4")
         set("jackson-annotations.version", "2.21")
         set("jetty.version", "9.4.57.v20241219")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -70,7 +70,7 @@ under the License.
         <kafka-clients.version>3.9.1</kafka-clients.version>
         <arrow.version>18.0.0</arrow.version>
         <grpc.version>1.63.0</grpc.version>
-        <io.netty.version>4.1.135.Final</io.netty.version>
+        <io.netty.version>4.1.136.Final</io.netty.version>
         <puppycrawl.version>10.21.1</puppycrawl.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
         <avro.version>1.12.0</avro.version>

--- a/fs_brokers/apache_hdfs_broker/src/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/src/pom.xml
@@ -51,7 +51,7 @@ under the License.
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <avro.version>1.11.4</avro.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
-        <io.netty.version>4.1.135.Final</io.netty.version>
+        <io.netty.version>4.1.136.Final</io.netty.version>
         <aws-v2-sdk.version>2.42.1</aws-v2-sdk.version>
         <bouncycastle.version>1.84</bouncycastle.version>
     </properties>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -42,7 +42,7 @@
         <jni-connector.version>1.0.0</jni-connector.version>
         <hadoop-ext.version>1.0.0</hadoop-ext.version>
         <java-utils.version>1.0.0</java-utils.version>
-        <io.netty.version>4.1.135.Final</io.netty.version>
+        <io.netty.version>4.1.136.Final</io.netty.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <nimbusds.version>9.37.2</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>


### PR DESCRIPTION
CVE-2026-44891: Netty StompSubframeDecoder does not bound the header count or cumulative header size per STOMP frame, allowing memory exhaustion / denial of service (CVSS 8.1, CWE-400/CWE-770).

- Affected artifact: io.netty:netty-codec-stomp (whole netty 4.1.x family ships in lockstep and is pulled in transitively via netty-all/netty-bom and the Hadoop/Arrow/gRPC stacks).
- Vulnerable range: < 4.1.136 (4.1.x line); >= 4.2.0-Alpha.1, < 4.2.16.
- Fixed version: 4.1.136.Final (verified on Maven Central).

The repo shipped netty-codec-stomp-4.1.135.Final. All three Java build trees manage netty through a single io.netty.version property + netty-bom, so bumping the property forces every netty module (including netty-codec-stomp) to the patched version:

- fe/pom.xml
- java-extensions/pom.xml
- fs_brokers/apache_hdfs_broker/src/pom.xml
- fe/build.gradle.kts

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
