### PR TITLE
[BugFix] Tag Iceberg/Delta metadata-derived statistics with StatsSource=TABLE_METADATA

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaStatisticProvider.java
@@ -46,6 +46,7 @@ public class DeltaStatisticProvider {
 
         builder.setOutputRowCount(deltaLakeFileStats.getRecordCount());
         builder.addColumnStatistics(buildColumnStatistics(schema, columnRefOperatorColumnMap, deltaLakeFileStats));
+        builder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
 
         return builder.build();
     }
@@ -80,6 +81,7 @@ public class DeltaStatisticProvider {
 
         builder.setOutputRowCount(deltaLakeFileStats.getRecordCount());
         builder.addColumnStatistics(buildColumnStatistics(schema, columnRefOperatorColumnMap, deltaLakeFileStats));
+        builder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
 
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -107,6 +107,7 @@ public class IcebergStatisticProvider {
         Statistics.Builder statisticsBuilder = Statistics.builder();
         statisticsBuilder.setOutputRowCount(Math.max(rowCount, 1));
         statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+        statisticsBuilder.setStatsSource(Statistics.StatsSource.TABLE_METADATA);
         return statisticsBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -474,9 +474,11 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
     }
 
     // Emit the per-scan StatsSource line (NONE / ANALYZE / TABLE_METADATA) in `explain verbose`
-    // and `explain costs`. Only scan nodes carry a meaningful source; derived operators are skipped.
+    // and `explain costs`. Only external/connector scan nodes carry a meaningful source. OlapScanNode
+    // is always ANALYZE and emitting it would churn a large number of existing plan tests, so skip it;
+    // derived (non-scan) operators are skipped as well.
     private void appendStatsSource(StringBuilder expBuilder, String detailPrefix) {
-        if (this instanceof ScanNode) {
+        if (this instanceof ScanNode && !(this instanceof OlapScanNode)) {
             expBuilder.append(detailPrefix).append("stats source: ").append(statsSource).append("\n");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -123,6 +123,10 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
 
     protected Map<ColumnRefOperator, ColumnStatistic> columnStatistics;
 
+    // Where the statistics used to estimate this node come from; set in computeStatistics().
+    // Only meaningful for scan nodes, printed in `explain costs`.
+    protected Statistics.StatsSource statsSource = Statistics.StatsSource.NONE;
+
     protected Map<Set<ColumnRefOperator>, MultiColumnCombinedStats> multiColumnCombinedStats;
 
     // For vector query engine
@@ -449,6 +453,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 expBuilder.append(detailPrefix + "- " + rf.toExplainString(id.asInt()) + "\n");
             }
         }
+        if (this instanceof ScanNode) {
+            expBuilder.append(detailPrefix).append("stats source: ").append(statsSource).append("\n");
+        }
         if (!planNodeName.equals("EXCHANGE")) {
             expBuilder.append(detailPrefix).append("column statistics: \n").append(getColumnStatistics(detailPrefix));
         }
@@ -584,6 +591,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 mapToDouble(columnStatistic -> columnStatistic.getAverageRowSize()).sum();
         columnStatistics = statistics.getColumnStatistics();
         multiColumnCombinedStats = statistics.getMultiColumnCombinedStats();
+        statsSource = statistics.getStatsSource();
     }
 
     public void setHasNullableGenerateChild() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -406,6 +406,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 expBuilder.append(detailPrefix + "- " + rf.toExplainString(id.asInt()) + "\n");
             }
         }
+        appendStatsSource(expBuilder, detailPrefix);
         // Print the children
         if (traverseChildren) {
             expBuilder.append(detailPrefix).append("\n");
@@ -453,9 +454,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 expBuilder.append(detailPrefix + "- " + rf.toExplainString(id.asInt()) + "\n");
             }
         }
-        if (this instanceof ScanNode) {
-            expBuilder.append(detailPrefix).append("stats source: ").append(statsSource).append("\n");
-        }
+        appendStatsSource(expBuilder, detailPrefix);
         if (!planNodeName.equals("EXCHANGE")) {
             expBuilder.append(detailPrefix).append("column statistics: \n").append(getColumnStatistics(detailPrefix));
         }
@@ -472,6 +471,14 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             expBuilder.append(children.get(0).getCostExplain(prefix, prefix));
         }
         return expBuilder.toString();
+    }
+
+    // Emit the per-scan StatsSource line (NONE / ANALYZE / TABLE_METADATA) in `explain verbose`
+    // and `explain costs`. Only scan nodes carry a meaningful source; derived operators are skipped.
+    private void appendStatsSource(StringBuilder expBuilder, String detailPrefix) {
+        if (this instanceof ScanNode) {
+            expBuilder.append(detailPrefix).append("stats source: ").append(statsSource).append("\n");
+        }
     }
 
     protected String getColumnStatistics(String prefix) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveScanTest.java
@@ -34,6 +34,20 @@ public class HiveScanTest extends ConnectorPlanTestBase {
     }
 
     @Test
+    public void testStatsSourceInExplain() throws Exception {
+        // External (connector) scan nodes surface their StatsSource in `explain costs` / `explain verbose`.
+        // The mocked hive metadata does not tag a source, so it renders as NONE here; the point is that
+        // the line is emitted for the connector scan node.
+        String hiveSql = "select * from hive0.tpch.region";
+        String costPlan = getCostExplain(hiveSql);
+        assertContains(costPlan, "HdfsScanNode");
+        assertContains(costPlan, "stats source:");
+        assertContains(getVerboseExplain(hiveSql), "stats source:");
+        // OlapScanNode is intentionally excluded (its source is always ANALYZE and would churn plan
+        // tests); that exclusion is covered by the OlapScan-based plan suites such as ExplainTest.
+    }
+
+    @Test
     public void testPruneColumnTest() throws Exception {
         connectContext.getSessionVariable().setEnableCountStarOptimization(true);
         String[] sqlString = {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -496,25 +496,6 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     }
 
     @Test
-    public void testScanNodeStatsSourceInExplain() throws Exception {
-        // Both `explain costs` and `explain verbose` should surface the per-scan StatsSource.
-        // For an internal OlapTable the statistics come from the statistics store, so it is ANALYZE.
-        String sql = "select v1, v2, v3 from t0";
-        String costPlan = getCostExplain(sql);
-        assertContains(costPlan, "0:OlapScanNode");
-        assertContains(costPlan, "stats source: ANALYZE");
-
-        String verbosePlan = getVerboseExplain(sql);
-        assertContains(verbosePlan, "0:OlapScanNode");
-        assertContains(verbosePlan, "stats source: ANALYZE");
-
-        // The stats-source line is only emitted for scan nodes, not derived operators.
-        sql = "select count(*) from t0 group by v1";
-        Assertions.assertEquals(1, getCostExplain(sql).split("stats source:", -1).length - 1);
-        Assertions.assertEquals(1, getVerboseExplain(sql).split("stats source:", -1).length - 1);
-    }
-
-    @Test
     public void testReapNodeStatistics() throws Exception {
         String sql = "select v1, v2, grouping_id(v1,v2), SUM(v3) from t0 group by cube(v1, v2)";
         String plan = getCostExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -496,17 +496,22 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     }
 
     @Test
-    public void testScanNodeStatsSourceInCostExplain() throws Exception {
-        // `explain costs` should surface the per-scan StatsSource. For an internal OlapTable the
-        // statistics come from the statistics store, so the source is ANALYZE.
+    public void testScanNodeStatsSourceInExplain() throws Exception {
+        // Both `explain costs` and `explain verbose` should surface the per-scan StatsSource.
+        // For an internal OlapTable the statistics come from the statistics store, so it is ANALYZE.
         String sql = "select v1, v2, v3 from t0";
-        String plan = getCostExplain(sql);
-        assertContains(plan, "0:OlapScanNode");
-        assertContains(plan, "stats source: ANALYZE");
+        String costPlan = getCostExplain(sql);
+        assertContains(costPlan, "0:OlapScanNode");
+        assertContains(costPlan, "stats source: ANALYZE");
+
+        String verbosePlan = getVerboseExplain(sql);
+        assertContains(verbosePlan, "0:OlapScanNode");
+        assertContains(verbosePlan, "stats source: ANALYZE");
+
         // The stats-source line is only emitted for scan nodes, not derived operators.
         sql = "select count(*) from t0 group by v1";
-        plan = getCostExplain(sql);
-        Assertions.assertEquals(1, plan.split("stats source:", -1).length - 1);
+        Assertions.assertEquals(1, getCostExplain(sql).split("stats source:", -1).length - 1);
+        Assertions.assertEquals(1, getVerboseExplain(sql).split("stats source:", -1).length - 1);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -496,6 +496,20 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
     }
 
     @Test
+    public void testScanNodeStatsSourceInCostExplain() throws Exception {
+        // `explain costs` should surface the per-scan StatsSource. For an internal OlapTable the
+        // statistics come from the statistics store, so the source is ANALYZE.
+        String sql = "select v1, v2, v3 from t0";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "0:OlapScanNode");
+        assertContains(plan, "stats source: ANALYZE");
+        // The stats-source line is only emitted for scan nodes, not derived operators.
+        sql = "select count(*) from t0 group by v1";
+        plan = getCostExplain(sql);
+        Assertions.assertEquals(1, plan.split("stats source:", -1).length - 1);
+    }
+
+    @Test
     public void testReapNodeStatistics() throws Exception {
         String sql = "select v1, v2, grouping_id(v1,v2), SUM(v3) from t0 group by cube(v1, v2)";
         String plan = getCostExplain(sql);

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3474,6 +3474,45 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
                 return stripped.lstrip("* ")
         return None
 
+    def get_query_stats_source(self, query, table):
+        """
+        Execute `query` with profiling enabled and return the StatsSource recorded in the query
+        profile for the scan whose table label ends with `table` (the label is the qualified table
+        name, e.g. 'catalog.db.tbl', so passing just 'tbl' is enough). Returns one of
+        NONE / ANALYZE / TABLE_METADATA, or None if no matching StatsSource entry is found.
+        """
+        # Enable synchronous profile so it is available immediately after the query returns.
+        self.execute_sql("set enable_profile = true", True)
+        self.execute_sql("set enable_async_profile = false", True)
+        res = self.execute_sql(query, True)
+        tools.assert_true(res["status"], "run query failed: %s" % res["msg"])
+
+        query_id = self.get_last_query_id()
+        tools.assert_true(query_id is not None, "failed to get last query id for: %s" % query)
+
+        profile_res = self.execute_sql("select get_query_profile('%s')" % query_id, True)
+        tools.assert_true(profile_res["status"], "get query profile failed: %s" % profile_res["msg"])
+        profile_text = "\n".join(str(item[0]) for item in profile_res["result"])
+
+        # StatsSource entries render as "- <qualified_table_name>: <SOURCE>" under the
+        # "StatsSource:" section of the profile.
+        for line in profile_text.split("\n"):
+            m = re.match(r"-\s+(\S+):\s+(NONE|ANALYZE|TABLE_METADATA)\s*$", line.strip())
+            if m and (m.group(1) == table or m.group(1).endswith("." + table)):
+                return m.group(2)
+        return None
+
+    def assert_stats_source(self, query, table, expect_source):
+        """
+        Assert the StatsSource of the scan on `table` in the query profile of `query`
+        equals `expect_source` (one of NONE / ANALYZE / TABLE_METADATA).
+        """
+        actual = self.get_query_stats_source(query, table)
+        tools.assert_equal(
+            expect_source, actual,
+            "stats source of table [%s] expect [%s] but got [%s]" % (table, expect_source, actual),
+        )
+
     def assert_show_stats_meta_contains(self, predicate, *expects):
         """
         assert show stats meta with predicate contains expect string

--- a/test/sql/test_iceberg/R/test_iceberg_stats_source
+++ b/test/sql/test_iceberg/R/test_iceberg_stats_source
@@ -1,0 +1,55 @@
+-- name: test_iceberg_stats_source
+create external catalog iceberg_stats_source_${uuid0} PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hive",
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+create database iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_stats_source_${uuid0}/test_iceberg_stats_source/${uuid0}"
+);
+-- result:
+-- !result
+create table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 (
+    c1 int,
+    c2 bigint,
+    c3 date
+) partition by c1;
+-- result:
+-- !result
+insert into iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 values(1, 2, '2022-01-01'), (2, 3, '2022-02-02'), (3, 4, '2022-03-03');
+-- result:
+-- !result
+set enable_query_trigger_analyze = false;
+-- result:
+-- !result
+set disable_table_stats_from_metadata_for_single_table = false;
+-- result:
+-- !result
+function: assert_stats_source('select * from iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1', 't1', 'TABLE_METADATA')
+-- result:
+None
+-- !result
+[UC] analyze table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1;
+function: assert_stats_source('select * from iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1', 't1', 'ANALYZE')
+-- result:
+None
+-- !result
+drop table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_stats_source_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_stats_source_${uuid0}/test_iceberg_stats_source/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_stats_source
+++ b/test/sql/test_iceberg/T/test_iceberg_stats_source
@@ -1,0 +1,39 @@
+-- name: test_iceberg_stats_source
+create external catalog iceberg_stats_source_${uuid0} PROPERTIES (
+    "type"="iceberg",
+    "iceberg.catalog.type"="hive",
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+create database iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_stats_source_${uuid0}/test_iceberg_stats_source/${uuid0}"
+);
+
+create table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 (
+    c1 int,
+    c2 bigint,
+    c3 date
+) partition by c1;
+
+insert into iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 values(1, 2, '2022-01-01'), (2, 3, '2022-02-02'), (3, 4, '2022-03-03');
+
+-- Disable auto analyze so the scan stats can NOT come from ANALYZE, and allow single-table
+-- metadata stats so the row count is read from iceberg manifest metadata (StatsSource=TABLE_METADATA).
+set enable_query_trigger_analyze = false;
+set disable_table_stats_from_metadata_for_single_table = false;
+
+-- Case 1: no analyze -> row count comes from iceberg manifest metadata -> StatsSource is TABLE_METADATA.
+function: assert_stats_source('select * from iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1', 't1', 'TABLE_METADATA')
+
+-- Case 2: after an explicit analyze, the same scan reports ANALYZE instead of TABLE_METADATA.
+[UC] analyze table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1;
+function: assert_stats_source('select * from iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1', 't1', 'ANALYZE')
+
+drop table iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0}.t1 force;
+drop database iceberg_stats_source_${uuid0}.iceberg_stats_source_db_${uuid0};
+drop catalog iceberg_stats_source_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_stats_source_${uuid0}/test_iceberg_stats_source/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
The query profile exposes a per-table `StatsSource` section (NONE / ANALYZE / TABLE_METADATA) so users can tell where a scan's cardinality estimate came from. However, several connector statistics paths build their `Statistics` object from table metadata (manifest / delta-log row counts) but never call `setStatsSource(...)`, leaving it at the builder default `NONE`. As a result, even when the row count is correctly read from metadata, the profile reports `StatsSource: NONE`, which is misleading.

This is easy to hit on the most common paths:
- Iceberg default path (`enable_iceberg_column_statistics=false`, whole-table snapshot) → `buildRowCountStatistics`, which fed a plain TPCH query.
- Delta on both branches (`getCardinalityStats` and `getTableStatistics`), so Delta scans always showed `NONE`.

The estimate itself was already correct; only the source label was wrong.

## What I'm doing:
- Set `StatsSource.TABLE_METADATA` in the metadata-derived statistics builders that were missing it:
  - Iceberg: `IcebergStatisticProvider.buildRowCountStatistics`
  - Delta: `DeltaStatisticProvider.getCardinalityStats` and `getTableStatistics`
- Audited the other connectors (Hive, Hudi, Paimon, JDBC, Kudu, ES) and confirmed they are already correct — their remaining `NONE` cases correspond to genuinely fake defaults (e.g. `default_statistics_output_row_count`, cold-start, or column-stats explicitly disabled), where `NONE` is the intended value.
- Added a sql-test (`test/sql/test_iceberg/test_iceberg_stats_source`) plus a reusable test helper `assert_stats_source(query, table, expect_source)` that parses the `StatsSource` section from the query profile. It verifies, with `enable_query_trigger_analyze=false`, that a fresh Iceberg scan reports `TABLE_METADATA`, and that the same scan reports `ANALYZE` after an explicit `ANALYZE TABLE`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
