### PR TITLE
[Enhancement] Allow Kafka Routine Load concurrency to exceed node count

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -1263,6 +1263,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum time for each Routine Load task within the cluster to consume data. Since v3.1.0, Routine Load job supports a new parameter `task_consume_second` in `job_properties`. This parameter applies to individual load tasks within a Routine Load job, which is more flexible.
 - Introduced in: -
 
+### `routine_load_task_ignore_node_num`
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to exclude the number of alive execution nodes when calculating the task concurrency of a Kafka Routine Load job. If this parameter is `false`, task concurrency is the minimum of the number of alive execution nodes, the number of Kafka partitions, `desired_concurrent_number`, and `max_routine_load_task_concurrent_num`. If this parameter is `true`, the number of alive execution nodes is excluded from the calculation. The number of tasks assigned to each node is still limited by `max_routine_load_task_num_per_be`. Enable this parameter only when the execution nodes have sufficient CPU and memory resources.
+- Introduced in: -
+
 ### `routine_load_task_timeout_second`
 
 - Default: 60

--- a/docs/ja/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/management/FE_parameters/user_query_loading.md
@@ -1235,6 +1235,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：クラスター内の各ルーチンロードタスクがデータを消費する最大時間。v3.1.0 以降、ルーチンロードジョブは `job_properties` に新しいパラメーター `task_consume_second` をサポートしています。このパラメーターはルーチンロードジョブ内の個々のロードタスクに適用され、より柔軟です。
 - 導入時期：-
 
+### `routine_load_task_ignore_node_num`
+
+- デフォルト：false
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：Kafka Routine Load ジョブのタスク同時実行数を計算するときに、稼働中の実行ノード数を除外するかどうかを指定します。このパラメーターが `false` の場合、タスク同時実行数は、稼働中の実行ノード数、Kafka パーティション数、`desired_concurrent_number`、および `max_routine_load_task_concurrent_num` の最小値になります。`true` の場合、稼働中の実行ノード数は計算から除外されます。ただし、各ノードに割り当てられるタスク数は引き続き `max_routine_load_task_num_per_be` によって制限されます。実行ノードに十分な CPU とメモリリソースがある場合にのみ、このパラメーターを有効にしてください。
+- 導入時期：-
+
 ### `routine_load_task_timeout_second`
 
 - デフォルト：60

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -1262,6 +1262,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 集群中每个 Routine Load 任务消耗数据的最大时间。从 v3.1.0 开始，Routine Load 作业在 `job_properties` 中支持一个新的参数 `task_consume_second`。此参数适用于 Routine Load 作业中的单个加载任务，更加灵活。
 - 引入版本: -
 
+### `routine_load_task_ignore_node_num`
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否在计算 Kafka Routine Load 作业的任务并发数时排除存活执行节点数。此参数为 `false` 时，任务并发数取存活执行节点数、Kafka 分区数、`desired_concurrent_number` 和 `max_routine_load_task_concurrent_num` 的最小值。此参数为 `true` 时，计算过程不再受存活执行节点数限制，但分配到每个节点的任务数仍受 `max_routine_load_task_num_per_be` 限制。仅当执行节点具有充足的 CPU 和内存资源时才建议启用此参数。
+- 引入版本: -
+
 ### `routine_load_task_timeout_second`
 
 - 默认值: 60

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2177,6 +2177,13 @@ public class Config extends ConfigBase {
     public static long routine_load_task_timeout_second = 60;
 
     /**
+     * Whether to ignore the number of alive nodes when calculating Kafka Routine Load task concurrency.
+     */
+    @ConfField(mutable = true, comment = "Whether to ignore the number of alive nodes when calculating "
+            + "Kafka Routine Load task concurrency")
+    public static boolean routine_load_task_ignore_node_num = false;
+
+    /**
      * kafka util request timeout
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -356,11 +356,17 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             desireTaskConcurrentNum = Config.max_routine_load_task_concurrent_num;
         }
 
-        LOG.debug("current concurrent task number is min"
-                        + "(partition num: {}, desire task concurrent num: {}, alive be num: {}, config: {})",
-                partitionNum, desireTaskConcurrentNum, aliveNodeNum, Config.max_routine_load_task_concurrent_num);
-        currentTaskConcurrentNum = Math.min(Math.min(partitionNum, Math.min(desireTaskConcurrentNum, aliveNodeNum)),
-                Config.max_routine_load_task_concurrent_num);
+        LOG.debug("calculate current concurrent task number with partition num: {}, desire task concurrent num: {}, "
+                        + "alive node num: {}, max task concurrent num: {}, ignore node num: {}",
+                partitionNum, desireTaskConcurrentNum, aliveNodeNum, Config.max_routine_load_task_concurrent_num,
+                Config.routine_load_task_ignore_node_num);
+        if (Config.routine_load_task_ignore_node_num) {
+            currentTaskConcurrentNum = Math.min(Math.min(partitionNum, desireTaskConcurrentNum),
+                    Config.max_routine_load_task_concurrent_num);
+        } else {
+            currentTaskConcurrentNum = Math.min(Math.min(partitionNum, Math.min(desireTaskConcurrentNum, aliveNodeNum)),
+                    Config.max_routine_load_task_concurrent_num);
+        }
         return currentTaskConcurrentNum;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.LoadException;
@@ -162,6 +163,18 @@ public class KafkaRoutineLoadJobTest {
                 1L, "127.0.0.1:9020", "topic1");
         Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList4);
         Assertions.assertEquals(4, routineLoadJob.calculateCurrentConcurrentTaskNum());
+
+        // 7 partitions, 4 BEs, and the alive node limit is ignored.
+        Config.routine_load_task_ignore_node_num = true;
+        try {
+            routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                    1L, "127.0.0.1:9020", "topic1");
+            Deencapsulation.setField(routineLoadJob, "currentKafkaPartitions", partitionList4);
+            Assertions.assertEquals(Config.max_routine_load_task_concurrent_num,
+                    routineLoadJob.calculateCurrentConcurrentTaskNum());
+        } finally {
+            Config.routine_load_task_ignore_node_num = false;
+        }
     }
 
     @Test 


### PR DESCRIPTION
## Why I'm doing:

Kafka Routine Load currently limits the task concurrency of a single job by the number of alive execution nodes. This prevents a job from using multiple task slots on each node even when the nodes have sufficient resources and `max_routine_load_task_num_per_be` allows it.

## What I'm doing:

Add the mutable FE configuration `routine_load_task_ignore_node_num`, which defaults to `false` to preserve the existing behavior.

When enabled, Kafka Routine Load task concurrency is calculated as the minimum of:

- Kafka partition count
- `desired_concurrent_number`
- `max_routine_load_task_concurrent_num`

The per-node task slot limit `max_routine_load_task_num_per_be` is still enforced by the scheduler.

This PR also adds a unit test for both configuration states and documents the configuration in English, Chinese, and Japanese.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The existing behavior remains the default. The new behavior is enabled only when `routine_load_task_ignore_node_num` is explicitly set to `true`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This PR needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport PR

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the PR will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

## Testing:

- `git diff --check`: passed
- FE Checkstyle: passed with zero violations
- `./run-fe-ut.sh --test com.starrocks.load.routineload.KafkaRoutineLoadJobTest`: blocked before test execution because the local Thrift compiler is 0.13.0 while this branch requires 0.23.0; generated service sources fail compilation due to that toolchain mismatch.