### PR TITLE
[Enhancement] Cache views in Iceberg Catalog (FE)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -83,6 +83,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private final String catalogName;
     private final IcebergCatalog delegate;
     private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Table> tables;
+    private final com.github.benmanes.caffeine.cache.Cache<IcebergTableName, View> views;
     private final com.github.benmanes.caffeine.cache.Cache<String, Database> databases;
     private final ExecutorService backgroundExecutor;
 
@@ -107,6 +108,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         long tableCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
                 icebergProperties.getIcebergTableCacheMemoryUsageRatio());
         this.databases = newCacheBuilderWithMaximumSize(
+                icebergProperties.getIcebergMetaCacheTtlSec(),
+                NEVER_CACHE, DEFAULT_CACHE_NUM).build();
+        this.views = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 NEVER_CACHE, DEFAULT_CACHE_NUM).build();
         long tableCacheTtlSec = icebergProperties.getIcebergMetaCacheTtlSec();
@@ -332,17 +336,26 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                               String catalogName,
                               ConnectorViewDefinition connectorViewDefinition,
                               boolean replace) {
-        return delegate.createView(connectContext, catalogName, connectorViewDefinition, replace);
+        boolean created = delegate.createView(connectContext, catalogName, connectorViewDefinition, replace);
+        // A create-or-replace can overwrite an existing definition, so we drop any stale cached entry.
+        views.invalidate(new IcebergTableName(connectorViewDefinition.getDatabaseName(),
+                connectorViewDefinition.getViewName()));
+        return created;
     }
 
     @Override
     public boolean alterView(ConnectContext connectContext, View currentView, ConnectorViewDefinition connectorViewDefinition) {
-        return delegate.alterView(connectContext, currentView, connectorViewDefinition);
+        boolean altered = delegate.alterView(connectContext, currentView, connectorViewDefinition);
+        views.invalidate(new IcebergTableName(connectorViewDefinition.getDatabaseName(),
+                connectorViewDefinition.getViewName()));
+        return altered;
     }
 
     @Override
     public boolean dropView(ConnectContext connectContext, String dbName, String viewName) {
-        return delegate.dropView(connectContext, dbName, viewName);
+        boolean dropped = delegate.dropView(connectContext, dbName, viewName);
+        views.invalidate(new IcebergTableName(dbName, viewName));
+        return dropped;
     }
 
     @Override
@@ -351,7 +364,24 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     public View getView(ConnectContext connectContext, String dbName, String viewName) {
-        return delegate.getView(connectContext, dbName, viewName);
+        IcebergTableName viewKey = new IcebergTableName(dbName, viewName);
+
+        // We do not cache if a per-request auth token is used AND it is a REST Catalog.
+        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
+                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
+        if (!cacheAllowed) {
+            return delegate.getView(connectContext, dbName, viewName);
+        }
+
+        View cachedView = views.getIfPresent(viewKey);
+        if (cachedView != null) {
+            return cachedView;
+        }
+        View view = delegate.getView(connectContext, dbName, viewName);
+        if (view != null && !shouldOnlyReadCache(connectContext)) {
+            views.put(viewKey, view);
+        }
+        return view;
     }
 
     @Override
@@ -526,6 +556,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
 
     private void invalidateCache(IcebergTableName key) {
         tables.invalidate(key);
+        // Tables and views share a namespace, so drop any cached view under the same identifier.
+        views.invalidate(key);
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
         tableLatestAccessTime.remove(key);
@@ -683,6 +715,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         List<List<String>> partitionNames = getAllCachedPartitionNames();
         counter.put("Database", databases.estimatedSize());
         counter.put("Table", tables.estimatedSize());
+        counter.put("View", views.estimatedSize());
         counter.put("TableSnapshot", tables.asMap().values()
                 .stream()
                 .mapToLong(this::countSnapshotsSafe)
@@ -705,6 +738,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     @Override
     public long estimateSize() {
         return Estimator.estimate(tables.asMap(), 10) +
+                Estimator.estimate(views.asMap(), 10) +
                 Estimator.estimate(databases.asMap(), 10) +
                 estimateDataFileCacheSize() +
                 estimateDeleteFileCacheSize() +

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -111,15 +111,28 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         this.databases = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
                 NEVER_CACHE, DEFAULT_CACHE_NUM).build();
+        // Refresh on the same interval as the table cache so a view replaced out-of-band (without a peer
+        // invalidation) is reloaded in the background rather than served stale until the TTL expires.
         this.views = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
-                NEVER_CACHE, DEFAULT_CACHE_NUM)
+                icebergProperties.getIcebergTableCacheRefreshIntervalSec(), DEFAULT_CACHE_NUM)
+                .executor(executorService)
                 .build(new com.github.benmanes.caffeine.cache.CacheLoader<ViewCacheKey, View>() {
                     @Override
                     public View load(ViewCacheKey key) {
                         ConnectContext context = VIEW_LOAD_CONTEXT.get();
                         return delegate.getView(context != null ? context : new ConnectContext(),
                                 key.dbName, key.viewName);
+                    }
+
+                    @Override
+                    public View reload(ViewCacheKey key, View oldValue) {
+                        try {
+                            return delegate.getView(new ConnectContext(), key.dbName, key.viewName);
+                        } catch (Exception e) {
+                            LOG.warn("refresh view {}.{} failed", key.dbName, key.viewName, e);
+                            return oldValue;
+                        }
                     }
                 });
         long tableCacheTtlSec = icebergProperties.getIcebergMetaCacheTtlSec();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -80,10 +80,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     // idle entry can't outlive its token. Provider-agnostic: bounds cache lifetime, no per-cloud expiry parse.
     private static final long REST_TABLE_CACHE_MAX_TTL_SEC = 3000;
     private static final ThreadLocal<ConnectContext> TABLE_LOAD_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<ConnectContext> VIEW_LOAD_CONTEXT = new ThreadLocal<>();
     private final String catalogName;
     private final IcebergCatalog delegate;
     private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Table> tables;
-    private final com.github.benmanes.caffeine.cache.Cache<IcebergTableName, View> views;
+    private final com.github.benmanes.caffeine.cache.LoadingCache<ViewCacheKey, View> views;
     private final com.github.benmanes.caffeine.cache.Cache<String, Database> databases;
     private final ExecutorService backgroundExecutor;
 
@@ -112,7 +113,15 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                 NEVER_CACHE, DEFAULT_CACHE_NUM).build();
         this.views = newCacheBuilderWithMaximumSize(
                 icebergProperties.getIcebergMetaCacheTtlSec(),
-                NEVER_CACHE, DEFAULT_CACHE_NUM).build();
+                NEVER_CACHE, DEFAULT_CACHE_NUM)
+                .build(new com.github.benmanes.caffeine.cache.CacheLoader<ViewCacheKey, View>() {
+                    @Override
+                    public View load(ViewCacheKey key) {
+                        ConnectContext context = VIEW_LOAD_CONTEXT.get();
+                        return delegate.getView(context != null ? context : new ConnectContext(),
+                                key.dbName, key.viewName);
+                    }
+                });
         long tableCacheTtlSec = icebergProperties.getIcebergMetaCacheTtlSec();
         if (delegate instanceof IcebergRESTCatalog) {
             tableCacheTtlSec = Math.min(tableCacheTtlSec, REST_TABLE_CACHE_MAX_TTL_SEC);
@@ -338,7 +347,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                               boolean replace) {
         boolean created = delegate.createView(connectContext, catalogName, connectorViewDefinition, replace);
         // A create-or-replace can overwrite an existing definition, so we drop any stale cached entry.
-        views.invalidate(new IcebergTableName(connectorViewDefinition.getDatabaseName(),
+        views.invalidate(viewCacheKey(connectorViewDefinition.getDatabaseName(),
                 connectorViewDefinition.getViewName()));
         return created;
     }
@@ -346,7 +355,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     @Override
     public boolean alterView(ConnectContext connectContext, View currentView, ConnectorViewDefinition connectorViewDefinition) {
         boolean altered = delegate.alterView(connectContext, currentView, connectorViewDefinition);
-        views.invalidate(new IcebergTableName(connectorViewDefinition.getDatabaseName(),
+        views.invalidate(viewCacheKey(connectorViewDefinition.getDatabaseName(),
                 connectorViewDefinition.getViewName()));
         return altered;
     }
@@ -354,7 +363,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     @Override
     public boolean dropView(ConnectContext connectContext, String dbName, String viewName) {
         boolean dropped = delegate.dropView(connectContext, dbName, viewName);
-        views.invalidate(new IcebergTableName(dbName, viewName));
+        views.invalidate(viewCacheKey(dbName, viewName));
         return dropped;
     }
 
@@ -364,24 +373,26 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     public View getView(ConnectContext connectContext, String dbName, String viewName) {
-        IcebergTableName viewKey = new IcebergTableName(dbName, viewName);
-
-        // We do not cache if a per-request auth token is used AND it is a REST Catalog.
+        // Skip the cache for a REST catalog using a per-request auth token.
         boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() &&
                 (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
         if (!cacheAllowed) {
             return delegate.getView(connectContext, dbName, viewName);
         }
 
-        View cachedView = views.getIfPresent(viewKey);
-        if (cachedView != null) {
-            return cachedView;
+        ViewCacheKey viewKey = viewCacheKey(dbName, viewName);
+        if (shouldOnlyReadCache(connectContext)) {
+            View cachedView = views.getIfPresent(viewKey);
+            return cachedView != null ? cachedView : delegate.getView(connectContext, dbName, viewName);
         }
-        View view = delegate.getView(connectContext, dbName, viewName);
-        if (view != null && !shouldOnlyReadCache(connectContext)) {
-            views.put(viewKey, view);
+        // Load through the cache so the fill and any concurrent invalidation stay coordinated per key.
+        // A racing DDL or refresh can't leave a stale definition behind.
+        try {
+            VIEW_LOAD_CONTEXT.set(connectContext);
+            return views.get(viewKey);
+        } finally {
+            VIEW_LOAD_CONTEXT.remove();
         }
-        return view;
     }
 
     @Override
@@ -557,7 +568,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private void invalidateCache(IcebergTableName key) {
         tables.invalidate(key);
         // Tables and views share a namespace, so drop any cached view under the same identifier.
-        views.invalidate(key);
+        views.invalidate(viewCacheKey(key.dbName, key.tableName));
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
         tableLatestAccessTime.remove(key);
@@ -605,6 +616,16 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return context != null && context.isOnlyReadIcebergCache();
     }
 
+    // Hive and Glue fold identifiers to lower case; every other catalog (e.g. REST) keeps them
+    // case-sensitive, so V and v are distinct views and must not share a cache entry.
+    private ViewCacheKey viewCacheKey(String dbName, String viewName) {
+        IcebergCatalogType type = delegate.getIcebergCatalogType();
+        if (type == IcebergCatalogType.HIVE_CATALOG || type == IcebergCatalogType.GLUE_CATALOG) {
+            return new ViewCacheKey(dbName.toLowerCase(Locale.ROOT), viewName.toLowerCase(Locale.ROOT));
+        }
+        return new ViewCacheKey(dbName, viewName);
+    }
+
     public static class IcebergTableName {
         private final String dbName;
         private final String tableName;
@@ -650,6 +671,40 @@ public class CachingIcebergCatalog implements IcebergCatalog {
             sb.append(", tableName='").append(tableName).append('\'');
             sb.append('}');
             return sb.toString();
+        }
+    }
+
+    // Unlike IcebergTableName, this key compares identifiers case-sensitively. Callers fold the case for
+    // catalogs that normalize identifiers (see viewCacheKey), so REST views keep V and v as separate entries.
+    private static class ViewCacheKey {
+        private final String dbName;
+        private final String viewName;
+
+        ViewCacheKey(String dbName, String viewName) {
+            this.dbName = dbName;
+            this.viewName = viewName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ViewCacheKey that = (ViewCacheKey) o;
+            return dbName.equals(that.dbName) && viewName.equals(that.viewName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, viewName);
+        }
+
+        @Override
+        public String toString() {
+            return "ViewCacheKey{dbName='" + dbName + "', viewName='" + viewName + "'}";
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.view.View;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -129,6 +130,12 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                     public View reload(ViewCacheKey key, View oldValue) {
                         try {
                             return delegate.getView(new ConnectContext(), key.dbName, key.viewName);
+                        } catch (NoSuchViewException e) {
+                            // The view was dropped out-of-band. Returning null evicts the entry; returning
+                            // oldValue would reset the write time and keep the stale definition past the TTL.
+                            LOG.info("iceberg view {}.{} no longer exists, evicting from cache",
+                                    key.dbName, key.viewName);
+                            return null;
                         } catch (Exception e) {
                             LOG.warn("refresh view {}.{} failed", key.dbName, key.viewName, e);
                             return oldValue;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -346,7 +346,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                               ConnectorViewDefinition connectorViewDefinition,
                               boolean replace) {
         boolean created = delegate.createView(connectContext, catalogName, connectorViewDefinition, replace);
-        // A create-or-replace can overwrite an existing definition, so we drop any stale cached entry.
+        // A create/replace can overwrite an existing definition, so we drop any stale cached entry.
         views.invalidate(viewCacheKey(connectorViewDefinition.getDatabaseName(),
                 connectorViewDefinition.getViewName()));
         return created;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -370,6 +370,8 @@ public class IcebergMetadata implements ConnectorMetadata {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
 
+        // The existence check shouldn't be fooled by a stale cached entry.
+        icebergCatalog.invalidateCache(dbName, viewName);
         if (getView(context, dbName, viewName) != null) {
             if (stmt.isSetIfNotExists()) {
                 LOG.info("create view[{}] which already exists", viewName);
@@ -383,6 +385,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         ConnectorViewDefinition viewDefinition = ConnectorViewDefinition.fromCreateViewStmt(stmt);
         icebergCatalog.createView(context, catalogName, viewDefinition, stmt.isReplace());
+        asyncRefreshOthersFeMetadataCache(dbName, viewName);
     }
 
     @Override
@@ -394,6 +397,9 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (db == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
         }
+        // ALTER is a read-modify-write that rebuilds the view on top of its current definition, so drop any
+        // cached copy first and read it fresh; a stale copy could silently drop a concurrent out-of-band change.
+        icebergCatalog.invalidateCache(dbName, viewName);
         if (getView(context, dbName, viewName) == null) {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_TABLE_ERROR, dbName + "." + viewName);
         }
@@ -405,6 +411,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         } else {
             throw new DdlException("ALTER VIEW <viewName> AS is not supported. Use CREATE OR REPLACE VIEW instead");
         }
+        asyncRefreshOthersFeMetadataCache(dbName, viewName);
     }
 
     @Override
@@ -739,6 +746,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         if (icebergTable != null && icebergTable.isIcebergView()) {
             icebergCatalog.dropView(context, stmt.getDbName(), stmt.getTableName());
+            asyncRefreshOthersFeMetadataCache(stmt.getDbName(), stmt.getTableName());
             return;
         }
 
@@ -2304,6 +2312,12 @@ public class IcebergMetadata implements ConnectorMetadata {
     public void refreshTable(String srDbName, Table table, List<String> partitionNames, boolean onlyCachedPartitions) {
         if (isResourceMappingCatalog(catalogName)) {
             refreshTableWithResource(table);
+        } else if (table.isIcebergView()) {
+            // The catalog stores a view under its fully-qualified name (e.g., catalog.db.view), but the cache is
+            // keyed by the simple view name, so we strip any qualifier before invalidating.
+            String viewName = table.getName();
+            viewName = viewName.substring(viewName.lastIndexOf('.') + 1);
+            icebergCatalog.invalidateCache(srDbName, viewName);
         } else {
             IcebergTable icebergTable = (IcebergTable) table;
             String dbName = icebergTable.getCatalogDBName();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -2313,10 +2313,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (isResourceMappingCatalog(catalogName)) {
             refreshTableWithResource(table);
         } else if (table.isIcebergView()) {
-            // The catalog stores a view under its fully-qualified name (e.g., catalog.db.view), but the cache is
-            // keyed by the simple view name, so we strip any qualifier before invalidating.
-            String viewName = table.getName();
-            viewName = viewName.substring(viewName.lastIndexOf('.') + 1);
+            // The catalog returns a view under its fully-qualified name (catalog.db.view). Strip the known
+            // catalog and database prefix rather than the last dot, so a quoted view name like "a.b" stays intact.
+            String prefix = catalogName + "." + srDbName + ".";
+            String qualifiedName = table.getName();
+            String viewName = qualifiedName.startsWith(prefix) ? qualifiedName.substring(prefix.length()) : qualifiedName;
             icebergCatalog.invalidateCache(srDbName, viewName);
         } else {
             IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -2315,9 +2315,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         } else if (table.isIcebergView()) {
             // The catalog returns a view under its fully-qualified name (catalog.db.view). Strip the known
             // catalog and database prefix rather than the last dot, so a quoted view name like "a.b" stays intact.
+            // Hive/Glue fold identifiers, so match the prefix case-insensitively to line up with the cache key.
+            IcebergCatalogType catalogType = icebergCatalog.getIcebergCatalogType();
+            boolean caseFolding = catalogType == IcebergCatalogType.HIVE_CATALOG
+                    || catalogType == IcebergCatalogType.GLUE_CATALOG;
             String prefix = catalogName + "." + srDbName + ".";
             String qualifiedName = table.getName();
-            String viewName = qualifiedName.startsWith(prefix) ? qualifiedName.substring(prefix.length()) : qualifiedName;
+            boolean hasPrefix = caseFolding
+                    ? qualifiedName.regionMatches(true, 0, prefix, 0, prefix.length())
+                    : qualifiedName.startsWith(prefix);
+            String viewName = hasPrefix ? qualifiedName.substring(prefix.length()) : qualifiedName;
             icebergCatalog.invalidateCache(srDbName, viewName);
         } else {
             IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2905,7 +2905,8 @@ public class GlobalStateMgr {
 
     private boolean supportRefreshTableType(Table table) {
         return table.isHiveTable() || table.isHudiTable() || table.isHiveView() || table.isIcebergTable()
-                || table.isJDBCTable() || table.isDeltalakeTable() || table.isPaimonTable() || table.isOdpsTable();
+                || table.isIcebergView() || table.isJDBCTable() || table.isDeltalakeTable() || table.isPaimonTable()
+                || table.isOdpsTable();
     }
 
     public void refreshExternalTable(ConnectContext context, TableName tableName, List<String> partitions) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -22,6 +22,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
+import com.starrocks.connector.ConnectorViewDefinition;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
@@ -45,6 +46,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -473,6 +475,104 @@ public class CachingIcebergCatalogTest {
         cachingIcebergCatalog.getTable(connectContext, "db2", "tbl2");
         Map<String, Long> counts = cachingIcebergCatalog.estimateCount();
         Assertions.assertEquals(1L, counts.get("Table"));
+    }
+
+    @Test
+    public void testGetViewUsesCache(@Mocked IcebergCatalog icebergCatalog, @Mocked View view) {
+        new Expectations() {
+            {
+                icebergCatalog.getView(connectContext, "db", "v");
+                result = view;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(connectContext, "db", "v"));
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(connectContext, "db", "v"));
+    }
+
+    @Test
+    public void testGetViewInvalidatedOnDrop(@Mocked IcebergCatalog icebergCatalog, @Mocked View view) {
+        new Expectations() {
+            {
+                icebergCatalog.getView(connectContext, "db", "v");
+                result = view;
+                times = 2;
+
+                icebergCatalog.dropView(connectContext, "db", "v");
+                result = true;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        cachingIcebergCatalog.getView(connectContext, "db", "v");
+        cachingIcebergCatalog.dropView(connectContext, "db", "v");
+        cachingIcebergCatalog.getView(connectContext, "db", "v");
+    }
+
+    @Test
+    public void testCreateOrReplaceViewInvalidatesStaleCache(@Mocked IcebergCatalog icebergCatalog,
+                                                             @Mocked View view,
+                                                             @Mocked ConnectorViewDefinition definition) {
+        new Expectations() {
+            {
+                icebergCatalog.getView(connectContext, "db", "v");
+                result = view;
+                times = 2;
+
+                definition.getDatabaseName();
+                result = "db";
+                minTimes = 0;
+                definition.getViewName();
+                result = "v";
+                minTimes = 0;
+
+                icebergCatalog.createView(connectContext, CATALOG_NAME, definition, true);
+                result = true;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        cachingIcebergCatalog.getView(connectContext, "db", "v");
+        cachingIcebergCatalog.createView(connectContext, CATALOG_NAME, definition, true);
+        cachingIcebergCatalog.getView(connectContext, "db", "v");
+    }
+
+    @Test
+    public void testGetViewBypassCacheForRestCatalogWhenAuthToken(@Mocked IcebergRESTCatalog restCatalog,
+                                                                  @Mocked View view) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setAuthToken("token");
+        new Expectations() {
+            {
+                restCatalog.getView(ctx, "db", "v");
+                result = view;
+                times = 2;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(ctx, "db", "v"));
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(ctx, "db", "v"));
+    }
+
+    @Test
+    public void testEstimateCountReflectsViewCache(@Mocked IcebergCatalog icebergCatalog, @Mocked View view) {
+        new Expectations() {
+            {
+                icebergCatalog.getView(connectContext, "db2", "v2");
+                result = view;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        cachingIcebergCatalog.getView(connectContext, "db2", "v2");
+        Map<String, Long> counts = cachingIcebergCatalog.estimateCount();
+        Assertions.assertEquals(1L, counts.get("View"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -576,6 +576,54 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
+    public void testGetViewCaseSensitiveForRestCatalog(@Mocked IcebergRESTCatalog restCatalog,
+                                                       @Mocked View upperView, @Mocked View lowerView) {
+        ConnectContext ctx = new ConnectContext();
+        new Expectations() {
+            {
+                restCatalog.getIcebergCatalogType();
+                result = IcebergCatalogType.REST_CATALOG;
+                minTimes = 0;
+
+                restCatalog.getView(ctx, "db", "V");
+                result = upperView;
+                times = 1;
+
+                restCatalog.getView(ctx, "db", "v");
+                result = lowerView;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, restCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        // REST keeps identifiers case-sensitive, so "V" and "v" get separate entries; re-reads hit the cache.
+        Assertions.assertSame(upperView, cachingIcebergCatalog.getView(ctx, "db", "V"));
+        Assertions.assertSame(lowerView, cachingIcebergCatalog.getView(ctx, "db", "v"));
+        Assertions.assertSame(upperView, cachingIcebergCatalog.getView(ctx, "db", "V"));
+        Assertions.assertSame(lowerView, cachingIcebergCatalog.getView(ctx, "db", "v"));
+    }
+
+    @Test
+    public void testGetViewFoldsCaseForHiveCatalog(@Mocked IcebergCatalog icebergCatalog, @Mocked View view) {
+        new Expectations() {
+            {
+                icebergCatalog.getIcebergCatalogType();
+                result = IcebergCatalogType.HIVE_CATALOG;
+                minTimes = 0;
+
+                icebergCatalog.getView(connectContext, "db", "v");
+                result = view;
+                times = 1;
+            }
+        };
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        // Hive folds case, so "V" and "v" resolve to one entry and the delegate is hit once.
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(connectContext, "db", "V"));
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(connectContext, "db", "v"));
+    }
+
+    @Test
     public void testGetTableBypassCacheForRestCatalogWhenAuthToken(@Mocked IcebergRESTCatalog restCatalog) {
         ConnectContext ctx = new ConnectContext();
         ctx.setAuthToken("token");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.Assertions;
@@ -632,6 +633,39 @@ public class CachingIcebergCatalogTest {
         LoadingCache<?, ?> viewCache = Deencapsulation.getField(cachingIcebergCatalog, "views");
         long refreshSec = viewCache.policy().refreshAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
         Assertions.assertEquals(DEFAULT_CATALOG_PROPERTIES.getIcebergTableCacheRefreshIntervalSec(), refreshSec);
+    }
+
+    @Test
+    public void testViewCacheEvictsWhenViewDroppedOnRefresh(@Mocked IcebergCatalog delegate, @Mocked View view)
+            throws Exception {
+        ConnectContext ctx = new ConnectContext();
+        AtomicInteger calls = new AtomicInteger();
+        new Expectations() {
+            {
+                delegate.getView((ConnectContext) any, "db", "v");
+                result = new Delegate<View>() {
+                    View get(ConnectContext c, String db, String v) {
+                        // First call populates the cache; the reload sees the view as dropped.
+                        if (calls.getAndIncrement() == 0) {
+                            return view;
+                        }
+                        throw new NoSuchViewException("dropped");
+                    }
+                };
+            }
+        };
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, delegate,
+                DEFAULT_CATALOG_PROPERTIES, refreshExecutor);
+        LoadingCache<Object, Object> viewCache = Deencapsulation.getField(cachingIcebergCatalog, "views");
+
+        Assertions.assertSame(view, cachingIcebergCatalog.getView(ctx, "db", "v"));
+        Object key = viewCache.asMap().keySet().iterator().next();
+        viewCache.refresh(key);
+        // refresh dispatches reload() onto refreshExecutor; this FIFO barrier returns once it has run.
+        refreshExecutor.submit(() -> { }).get();
+        Assertions.assertNull(viewCache.getIfPresent(key),
+                "a view dropped out-of-band must be evicted on refresh, not kept until the TTL");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/CachingIcebergCatalogTest.java
@@ -624,6 +624,17 @@ public class CachingIcebergCatalogTest {
     }
 
     @Test
+    public void testViewCacheRefreshesOnInterval(@Mocked IcebergCatalog icebergCatalog) {
+        // The view cache must refresh on the meta cache interval so an out-of-band view change is reloaded
+        // in the background instead of being served stale until the TTL expires.
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(CATALOG_NAME, icebergCatalog,
+                DEFAULT_CATALOG_PROPERTIES, Executors.newSingleThreadExecutor());
+        LoadingCache<?, ?> viewCache = Deencapsulation.getField(cachingIcebergCatalog, "views");
+        long refreshSec = viewCache.policy().refreshAfterWrite().get().getExpiresAfter(TimeUnit.SECONDS);
+        Assertions.assertEquals(DEFAULT_CATALOG_PROPERTIES.getIcebergTableCacheRefreshIntervalSec(), refreshSec);
+    }
+
+    @Test
     public void testGetTableBypassCacheForRestCatalogWhenAuthToken(@Mocked IcebergRESTCatalog restCatalog) {
         ConnectContext ctx = new ConnectContext();
         ctx.setAuthToken("token");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2237,10 +2237,8 @@ public class IcebergMetadataTest extends TableTestBase {
     public void testRefreshViewInvalidatesCache(@Mocked CachingIcebergCatalog icebergCatalog) {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
                 Executors.newSingleThreadExecutor(), null);
-        // A view is a ConnectorView, not an IcebergTable, so the refresh path must invalidate the cache
-        // by name instead of casting to IcebergTable (which would throw ClassCastException). The catalog
-        // stores the view under its fully-qualified name, so the refresh path must strip the qualifier down
-        // to the simple name the cache is keyed by ("v").
+        // A view is a ConnectorView, not an IcebergTable, so refresh must invalidate by name, not cast.
+        // The stored name is fully-qualified, so it strips down to the simple key ("v").
         IcebergView view = new IcebergView(1, CATALOG_NAME, "db", CATALOG_NAME + ".db.v", new ArrayList<>(),
                 "select 1", CATALOG_NAME, "db", "s3://loc", Maps.newHashMap());
         metadata.refreshTable("db", view, null, true);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergPartitionKey;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.IcebergView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
@@ -142,6 +143,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
@@ -2229,6 +2231,26 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "db_name",
                 "table_name", "", new ArrayList<>(), mockedNativeTableD, Maps.newHashMap());
         metadata.refreshTable("db", icebergTable, null, true);
+    }
+
+    @Test
+    public void testRefreshViewInvalidatesCache(@Mocked CachingIcebergCatalog icebergCatalog) {
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        // A view is a ConnectorView, not an IcebergTable, so the refresh path must invalidate the cache
+        // by name instead of casting to IcebergTable (which would throw ClassCastException). The catalog
+        // stores the view under its fully-qualified name, so the refresh path must strip the qualifier down
+        // to the simple name the cache is keyed by ("v").
+        IcebergView view = new IcebergView(1, CATALOG_NAME, "db", CATALOG_NAME + ".db.v", new ArrayList<>(),
+                "select 1", CATALOG_NAME, "db", "s3://loc", Maps.newHashMap());
+        metadata.refreshTable("db", view, null, true);
+
+        new Verifications() {
+            {
+                icebergCatalog.invalidateCache("db", "v");
+                times = 1;
+            }
+        };
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2238,14 +2238,14 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
                 Executors.newSingleThreadExecutor(), null);
         // A view is a ConnectorView, not an IcebergTable, so refresh must invalidate by name, not cast.
-        // The stored name is fully-qualified, so it strips down to the simple key ("v").
-        IcebergView view = new IcebergView(1, CATALOG_NAME, "db", CATALOG_NAME + ".db.v", new ArrayList<>(),
+        // The catalog.db. prefix is stripped (not the last dot), so a quoted view name like "a.b" stays intact.
+        IcebergView view = new IcebergView(1, CATALOG_NAME, "db", CATALOG_NAME + ".db.a.b", new ArrayList<>(),
                 "select 1", CATALOG_NAME, "db", "s3://loc", Maps.newHashMap());
         metadata.refreshTable("db", view, null, true);
 
         new Verifications() {
             {
-                icebergCatalog.invalidateCache("db", "v");
+                icebergCatalog.invalidateCache("db", "a.b");
                 times = 1;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2252,6 +2252,31 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testRefreshViewInvalidatesCacheCaseFolding(@Mocked CachingIcebergCatalog icebergCatalog) {
+        new Expectations() {
+            {
+                icebergCatalog.getIcebergCatalogType();
+                result = IcebergCatalogType.HIVE_CATALOG;
+                minTimes = 0;
+            }
+        };
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        // Hive folds case: the qualified name's db segment can differ in case from the requested db, so the
+        // prefix must match case-insensitively to strip it and invalidate the right (folded) key.
+        IcebergView view = new IcebergView(1, CATALOG_NAME, "db", CATALOG_NAME + ".DB.v", new ArrayList<>(),
+                "select 1", CATALOG_NAME, "db", "s3://loc", Maps.newHashMap());
+        metadata.refreshTable("db", view, null, true);
+
+        new Verifications() {
+            {
+                icebergCatalog.invalidateCache("db", "v");
+                times = 1;
+            }
+        };
+    }
+
+    @Test
     public void testAlterTable(@Mocked IcebergHiveCatalog icebergHiveCatalog) throws StarRocksException {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), null);


### PR DESCRIPTION
## Why I'm doing:
`CachingIcebergCatalog` caches Iceberg tables but not views. Every view resolution during planning hits the remote catalog (Hive/Glue/REST `loadView`), adding RPC latency under high concurrency. Tables already avoid this via the cache but views were just never wired up.

## What I'm doing:
Add a view cache to `CachingIcebergCatalog`, mirroring the existing table cache (TTL from `iceberg_meta_cache_ttl_sec`.

Invalidation:
- Locally on `createView`/`alterView`/`dropView`.
- Across FEs on view DDL via `asyncRefreshOthersFeMetadataCache`, same as tables. This required teaching the refresh path to handle views (`refreshTable` no longer assumes an `IcebergTable`) and allowing iceberg views through `supportRefreshTableType`.
- `ALTER`/`CREATE` read the current fresh definition fresh. No staleness allowed, so a cached copy can't overwrites a concurrent out-of-band change.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

---