### PR TITLE
[BugFix] Advance partition versionEpoch on every non-compaction commit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1547,9 +1547,8 @@ public class DatabaseTransactionMgr {
                             .getTxnCommitAttachment()).getPartitionVersion());
                     // reset data version to visible version
                     partitionCommitInfo.setDataVersion(partitionCommitInfo.getVersion());
-                    // Stamp a fresh version epoch on every INSERT OVERWRITE (a logical data change).
-                    // The epoch is the change watermark consumed by IVM (LocalMetastore.getCurrentTvrSnapshot),
-                    // so it must advance on every commit, not only on TXN_REPLICATION partitions.
+                    // Give this partition a new epoch. IVM uses epochs to spot changes, so every
+                    // real data change (like this overwrite) needs a fresh one.
                     partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
                 } else {
                     // double write logic partition
@@ -1572,10 +1571,8 @@ public class DatabaseTransactionMgr {
                     }
                     // update data version
                     partitionCommitInfo.setDataVersion(partition.getNextDataVersion());
-                    // Stamp a fresh version epoch on every non-compaction commit so the epoch strictly
-                    // advances on every load. This is the change watermark consumed by IVM
-                    // (LocalMetastore.getCurrentTvrSnapshot). A compaction rewrites files without a
-                    // logical data change, so it must NOT bump the epoch.
+                    // Give this partition a new epoch for every real load. Compaction only
+                    // rewrites files without changing data, so skip it.
                     if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
                         partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1547,9 +1547,10 @@ public class DatabaseTransactionMgr {
                             .getTxnCommitAttachment()).getPartitionVersion());
                     // reset data version to visible version
                     partitionCommitInfo.setDataVersion(partitionCommitInfo.getVersion());
-                    if (partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) {
-                        partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
-                    }
+                    // Stamp a fresh version epoch on every INSERT OVERWRITE (a logical data change).
+                    // The epoch is the change watermark consumed by IVM (LocalMetastore.getCurrentTvrSnapshot),
+                    // so it must advance on every commit, not only on TXN_REPLICATION partitions.
+                    partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
                 } else {
                     // double write logic partition
                     Map<Long, Long> doubleWritePartitions = table.getDoubleWritePartitions();
@@ -1571,8 +1572,11 @@ public class DatabaseTransactionMgr {
                     }
                     // update data version
                     partitionCommitInfo.setDataVersion(partition.getNextDataVersion());
-                    if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION &&
-                            partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) {
+                    // Stamp a fresh version epoch on every non-compaction commit so the epoch strictly
+                    // advances on every load. This is the change watermark consumed by IVM
+                    // (LocalMetastore.getCurrentTvrSnapshot). A compaction rewrites files without a
+                    // logical data change, so it must NOT bump the epoch.
+                    if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
                         partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
                     }
                     LOG.debug("set partition {} version to {} in transaction {}",

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -333,6 +333,36 @@ public class GlobalTransactionMgrTest {
         assertTrue(GlobalStateMgrTestUtil.compareState(masterGlobalStateMgr, slaveGlobalStateMgr));
     }
 
+    // Every non-compaction commit must stamp a fresh, strictly-increasing version epoch. The epoch is
+    // the change watermark IVM reads via LocalMetastore.getCurrentTvrSnapshot; before this fix a normal
+    // (TXN_NORMAL) load left the epoch unchanged, so native IVM would never detect newly loaded data.
+    @Test
+    public void testNormalCommitStampsAdvancingVersionEpoch() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        List<TabletCommitInfo> transTablets = Lists.newArrayList(
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1),
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2),
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3));
+
+        long txnId1 = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), GlobalStateMgrTestUtil.testTxnLable1,
+                transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, txnId1, transTablets,
+                Lists.newArrayList(), null);
+        long epoch1 = fakeEditLog.getTransaction(txnId1).getTableCommitInfo(GlobalStateMgrTestUtil.testTableId1)
+                .getIdToPartitionCommitInfo().values().iterator().next().getVersionEpoch();
+        assertTrue(epoch1 > 0, "a normal (TXN_NORMAL) load commit must stamp a version epoch");
+
+        long txnId2 = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), GlobalStateMgrTestUtil.testTxnLable2,
+                transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, txnId2, transTablets,
+                Lists.newArrayList(), null);
+        long epoch2 = fakeEditLog.getTransaction(txnId2).getTableCommitInfo(GlobalStateMgrTestUtil.testTableId1)
+                .getIdToPartitionCommitInfo().values().iterator().next().getVersionEpoch();
+        assertTrue(epoch2 > epoch1, "each commit must advance the version epoch (GTIDs are monotonic)");
+    }
+
     // commit with only two replicas
     @Test
     public void testCommitTransactionWithOneFailed() throws StarRocksException {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -333,9 +333,9 @@ public class GlobalTransactionMgrTest {
         assertTrue(GlobalStateMgrTestUtil.compareState(masterGlobalStateMgr, slaveGlobalStateMgr));
     }
 
-    // Every non-compaction commit must stamp a fresh, strictly-increasing version epoch. The epoch is
-    // the change watermark IVM reads via LocalMetastore.getCurrentTvrSnapshot; before this fix a normal
-    // (TXN_NORMAL) load left the epoch unchanged, so native IVM would never detect newly loaded data.
+    // A normal load must get a new, bigger version epoch each time it commits. IVM uses this
+    // epoch to notice data changes, so before this fix, a normal load's epoch never moved and
+    // IVM could not tell that new data had arrived.
     @Test
     public void testNormalCommitStampsAdvancingVersionEpoch() throws StarRocksException {
         FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
@@ -361,6 +361,29 @@ public class GlobalTransactionMgrTest {
         long epoch2 = fakeEditLog.getTransaction(txnId2).getTableCommitInfo(GlobalStateMgrTestUtil.testTableId1)
                 .getIdToPartitionCommitInfo().values().iterator().next().getVersionEpoch();
         assertTrue(epoch2 > epoch1, "each commit must advance the version epoch (GTIDs are monotonic)");
+    }
+
+    // An INSERT OVERWRITE commit takes a different code path than a normal load, but it must
+    // also stamp a new version epoch.
+    @Test
+    public void testVersionOverwriteCommitStampsVersionEpoch() throws StarRocksException {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        List<TabletCommitInfo> transTablets = Lists.newArrayList(
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId1),
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId2),
+                new TabletCommitInfo(GlobalStateMgrTestUtil.testTabletId1, GlobalStateMgrTestUtil.testBackendId3));
+
+        long txnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(GlobalStateMgrTestUtil.testTableId1), GlobalStateMgrTestUtil.testTxnLable3,
+                transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+        InsertTxnCommitAttachment overwriteAttachment =
+                new InsertTxnCommitAttachment(0, GlobalStateMgrTestUtil.testStartVersion + 5);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, txnId, transTablets,
+                Lists.newArrayList(), overwriteAttachment);
+
+        long epoch = fakeEditLog.getTransaction(txnId).getTableCommitInfo(GlobalStateMgrTestUtil.testTableId1)
+                .getIdToPartitionCommitInfo().values().iterator().next().getVersionEpoch();
+        assertTrue(epoch > 0, "an INSERT OVERWRITE commit must stamp a version epoch too");
     }
 
     // commit with only two replicas


### PR DESCRIPTION
## Why I'm doing:

A partition's `versionEpoch` was bumped only on replication commits, so a normal load into an existing partition never changed it. Any consumer that treats the epoch as a change marker (native IVM's `getCurrentTvrSnapshot` watermark) then sees the table as unchanged and skips work.

## What I'm doing:

Stamp a fresh `versionEpoch` on every commit except lake compaction (which rewrites files without changing data). Replication still mirrors the source epoch, and the log appliers already apply the value, so no replay change is needed.

Related: #73115

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No released version needs this: native IVM (the only consumer of versionEpoch as a change watermark) is not shipped yet, so there is nothing to backport to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
