### PR TITLE
[BugFix] Fix array_difference int32 overflow before widening to BIGINT

### DIFF
--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -253,7 +253,8 @@ private:
                     dest_data_column->append_nulls(1);
                 } else {
                     if constexpr (!lt_is_decimal<LT>) {
-                        sub = items[i].get<CppType>() - items[i - 1].get<CppType>();
+                        sub = static_cast<RunTimeCppType<ResultType>>(items[i].get<CppType>()) -
+                              static_cast<RunTimeCppType<ResultType>>(items[i - 1].get<CppType>());
                     } else if constexpr (lt_is_decimal<LT>) {
                         RunTimeCppType<ResultType> lhs = RunTimeCppType<ResultType>{items[i].get<CppType>()};
                         RunTimeCppType<ResultType> rhs = RunTimeCppType<ResultType>{items[i - 1].get<CppType>()};

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -17,10 +17,12 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <unordered_set>
 
 #include "column/const_column.h"
 #include "column/map_column.h"
+#include "exprs/builtin_functions.h"
 #include "exprs/mock_vectorized_expr.h"
 
 namespace starrocks {
@@ -3168,14 +3170,47 @@ TEST_F(ArrayFunctionsTest, array_reverse_only_null) {
     ASSERT_TRUE(dest_column->get(2).is_null());
 }
 
+// array_difference is a header-only function template; in production it is reached only
+// through the builtin-function registry. Invoke it the same way here so incremental
+// coverage attributes the exercised lines to the product translation unit (array_functions.cpp
+// via ArrayFunctions.inc) instead of only this test object.
+static ColumnPtr call_array_difference(LogicalType input_type, const ColumnPtr& arg) {
+    uint64_t fid = 0;
+    LogicalType result_element = TYPE_BIGINT;
+    switch (input_type) {
+    case TYPE_BOOLEAN:
+        fid = 150160;
+        break;
+    case TYPE_INT:
+        fid = 150163;
+        break;
+    case TYPE_BIGINT:
+        fid = 150164;
+        break;
+    case TYPE_DOUBLE:
+        fid = 150167;
+        result_element = TYPE_DOUBLE;
+        break;
+    default:
+        CHECK(false) << "unsupported array_difference input type " << input_type;
+    }
+    const auto* desc = BuiltinFunctions::find_builtin_function(fid);
+    CHECK(desc != nullptr);
+    // Invoke with a real FunctionContext (as production does) rather than nullptr, so the call
+    // matches the production convention and stays robust if array_difference starts using it.
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+            {TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(input_type))},
+            TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(result_element))));
+    return desc->scalar_function(ctx.get(), Columns{arg}).value();
+}
+
 TEST_F(ArrayFunctionsTest, array_difference_boolean) {
     auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
     src_column->append_datum(DatumArray{(uint8_t)5, (uint8_t)3, (uint8_t)6});
     src_column->append_datum(DatumArray{(uint8_t)2, (uint8_t)3, (uint8_t)7, (uint8_t)8});
     src_column->append_datum(DatumArray{(uint8_t)4, (uint8_t)3, (uint8_t)2, (uint8_t)1});
 
-    ArrayDifference<LogicalType::TYPE_BOOLEAN> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_BOOLEAN, src_column);
 
     ASSERT_EQ(dest_column->size(), 3);
     _check_array<int64_t>({0, -2, 3}, dest_column->get(0).get_array());
@@ -3190,8 +3225,7 @@ TEST_F(ArrayFunctionsTest, array_difference_boolean_with_entry_null) {
     src_column->append_datum(DatumArray{(uint8_t)4, (uint8_t)3, (uint8_t)2, Datum()});
     src_column->append_datum(Datum());
 
-    ArrayDifference<LogicalType::TYPE_BOOLEAN> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_BOOLEAN, src_column);
 
     ASSERT_EQ(dest_column->size(), 4);
 
@@ -3217,13 +3251,26 @@ TEST_F(ArrayFunctionsTest, array_difference_int) {
     src_column->append_datum(DatumArray{2, 3, 7, 8});
     src_column->append_datum(DatumArray{4, 3, 2, 1});
 
-    ArrayDifference<LogicalType::TYPE_INT> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_INT, src_column);
 
     ASSERT_EQ(dest_column->size(), 3);
     _check_array<int64_t>({0, -2, 3}, dest_column->get(0).get_array());
     _check_array<int64_t>({0, 1, 4, 1}, dest_column->get(1).get_array());
     _check_array<int64_t>({0, -1, -1, -1}, dest_column->get(2).get_array());
+}
+
+TEST_F(ArrayFunctionsTest, array_difference_int_overflow) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_INT, true);
+    constexpr int32_t kIntMax = std::numeric_limits<int32_t>::max();
+    constexpr int32_t kIntMin = std::numeric_limits<int32_t>::min();
+    src_column->append_datum(DatumArray{kIntMax, kIntMin});
+    src_column->append_datum(DatumArray{kIntMin, kIntMax});
+
+    auto dest_column = call_array_difference(TYPE_INT, src_column);
+
+    ASSERT_EQ(dest_column->size(), 2);
+    _check_array<int64_t>({0, -4294967295}, dest_column->get(0).get_array());
+    _check_array<int64_t>({0, 4294967295}, dest_column->get(1).get_array());
 }
 
 TEST_F(ArrayFunctionsTest, array_difference_int_with_entry_null) {
@@ -3233,8 +3280,7 @@ TEST_F(ArrayFunctionsTest, array_difference_int_with_entry_null) {
     src_column->append_datum(DatumArray{4, 3, 2, Datum()});
     src_column->append_datum(Datum());
 
-    ArrayDifference<LogicalType::TYPE_INT> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_INT, src_column);
 
     ASSERT_EQ(dest_column->size(), 4);
 
@@ -3260,8 +3306,7 @@ TEST_F(ArrayFunctionsTest, array_difference_bigint) {
     src_column->append_datum(DatumArray{(int64_t)2, (int64_t)3, (int64_t)7, (int64_t)8});
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, (int64_t)1});
 
-    ArrayDifference<LogicalType::TYPE_BIGINT> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_BIGINT, src_column);
 
     ASSERT_EQ(dest_column->size(), 3);
     _check_array<int64_t>({(int64_t)0, (int64_t)-2, (int64_t)3}, dest_column->get(0).get_array());
@@ -3276,8 +3321,7 @@ TEST_F(ArrayFunctionsTest, array_difference_bigint_with_entry_null) {
     src_column->append_datum(DatumArray{(int64_t)4, (int64_t)3, (int64_t)2, Datum()});
     src_column->append_datum(Datum());
 
-    ArrayDifference<LogicalType::TYPE_BIGINT> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_BIGINT, src_column);
 
     ASSERT_EQ(dest_column->size(), 4);
 
@@ -3303,8 +3347,7 @@ TEST_F(ArrayFunctionsTest, array_difference_double) {
     src_column->append_datum(DatumArray{(double)2, (double)3, (double)7, (double)8});
     src_column->append_datum(DatumArray{(double)4, (double)3, (double)2, (double)1});
 
-    ArrayDifference<LogicalType::TYPE_DOUBLE> difference;
-    auto dest_column = difference.process(nullptr, {src_column});
+    auto dest_column = call_array_difference(TYPE_DOUBLE, src_column);
 
     ASSERT_EQ(dest_column->size(), 3);
     _check_array<double>({(double)0, (double)-2, (double)3}, dest_column->get(0).get_array());


### PR DESCRIPTION
## Why I'm doing:

`array_difference(array<int>)` returns a BIGINT result column by design (the dispatch in
`array_functions.tpp` routes integer inputs through `lt_is_sum_bigint` →
`_array_difference<TYPE_BIGINT>`). But the non-decimal branch computed the adjacent difference
in the **input** type (int32) and only widened to int64 on assignment. When the true
difference falls outside int32 range, the int32 subtraction overflows first — signed integer
overflow is undefined behavior — producing a wrong result.

## What I'm doing:

Cast both operands to the result type (`RunTimeCppType<ResultType>`) **before** subtracting, so
the subtraction is performed at the widened type. This mirrors the adjacent decimal branch,
which already builds result-typed operands before `decimal_sub`.

### Reproduction (must go through an `ARRAY<INT>` table column)

```sql
CREATE TABLE probe_ad.t (id INT, a ARRAY<INT>) DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num"="1");
INSERT INTO probe_ad.t VALUES (1, [2147483647, -2147483648]);
SELECT array_difference(a) FROM probe_ad.t;
-- before: [0, 1]
-- after:  [0, -4294967295]
```

> Literal note: `SELECT array_difference([2147483647, -2147483648])` already returns the
> correct result and does NOT exercise the bug — the FE types the literal `-2147483648` as
> BIGINT, so the array becomes `ARRAY<BIGINT>` and takes the int64 path (EXPLAIN VERBOSE shows
> `result: ARRAY<BIGINT>`). Only a real `ARRAY<INT>` column pins the int32 path.

A regression UT (`array_difference_int_overflow`) exercises `[INT32_MAX, INT32_MIN]` and the
reverse via an int32 datum column, asserting `[0, -4294967295]` / `[0, 4294967295]`.

Fixes #76568

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
