### PR TITLE
[BugFix] Honor file bundling in lake index fast-path publish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -356,6 +356,15 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
             txnInfo.combinedTxnLog = false;
             txnInfo.commitTime = System.currentTimeMillis() / 1000;
             txnInfo.txnType = TxnTypePB.TXN_NORMAL;
+            // A file-bundling table stores each version's tablet metadata in a
+            // single bundle file ({0}_{version}.meta) written by the aggregate
+            // publish path -- exactly like loads and metadata-alter jobs. The
+            // metadata vacuum for such a table only reclaims bundle-named files,
+            // so this fast path must publish the same way; publishing per-tablet
+            // ({tablet}_{version}.meta) instead leaves metadata the bundling
+            // vacuum never cleans up. Keyed on the table's current format,
+            // matching this class's cancel path (lakePublishVersionWithSkip).
+            boolean useAggregatePublish = table.isFileBundling();
             for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
                 PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
                 if (pp == null) {
@@ -367,10 +376,22 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
                 // so every base + rollup + sync-MV tablet has an in-flight alter
                 // task. Publish must mirror that set or non-base indexes get left
                 // on stale visible versions while FE/base advance, eventually
-                // causing read/planning inconsistencies on those indexes.
+                // causing read/planning inconsistencies on those indexes. For a
+                // file-bundling table all of the partition's tablets must land in
+                // ONE aggregate publish: BE truncate-overwrites the bundle, so a
+                // per-index aggregate call would drop earlier indexes' tablets.
+                List<Tablet> tablets = new ArrayList<>();
                 for (MaterializedIndex idx : pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)) {
-                    Utils.publishVersion(idx.getTablets(), txnInfo, commitVersion - 1,
-                            commitVersion, computeResource, false);
+                    if (useAggregatePublish) {
+                        tablets.addAll(idx.getTablets());
+                    } else {
+                        Utils.publishVersion(idx.getTablets(), txnInfo, commitVersion - 1,
+                                commitVersion, computeResource, false);
+                    }
+                }
+                if (useAggregatePublish) {
+                    Utils.publishVersion(tablets, txnInfo, commitVersion - 1,
+                            commitVersion, computeResource, true);
                 }
             }
             return true;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableIndexFastPathJobBaseTest.java
@@ -41,6 +41,7 @@ import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionIdGenerator;
 import com.starrocks.warehouse.Warehouse;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -64,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1172,6 +1174,9 @@ public class LakeTableIndexFastPathJobBaseTest {
 
         Database db = new Database(2L, "db");
         OlapTable table = mock(OlapTable.class);
+        // Stub isFileBundling so lakePublishVersion reaches the partition lookup
+        // rather than unboxing a null and returning false from the catch.
+        when(table.isFileBundling()).thenReturn(false);
         when(table.getPhysicalPartition(100L)).thenReturn(null);
 
         GlobalStateMgr gsm = mock(GlobalStateMgr.class);
@@ -1182,6 +1187,8 @@ public class LakeTableIndexFastPathJobBaseTest {
         try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class)) {
             gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
             assertFalse(job.lakePublishVersion());
+            // Confirm we returned false via the partition-disappeared branch, not the catch.
+            verify(table).getPhysicalPartition(100L);
         }
     }
 
@@ -1195,6 +1202,10 @@ public class LakeTableIndexFastPathJobBaseTest {
 
         Database db = new Database(2L, "db");
         OlapTable table = mock(OlapTable.class);
+        // Non-file-bundling table: the per-tablet publish path (useAggregatePublish=false)
+        // must be used, unchanged. isFileBundling() returns a boxed Boolean, so it must be
+        // stubbed or the new unbox would NPE into lakePublishVersion's catch and return false.
+        when(table.isFileBundling()).thenReturn(false);
         PhysicalPartition pp = mock(PhysicalPartition.class);
         MaterializedIndex idx = mock(MaterializedIndex.class);
         when(idx.getTablets()).thenReturn(new ArrayList<>());
@@ -1216,8 +1227,11 @@ public class LakeTableIndexFastPathJobBaseTest {
             utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), anyBoolean()))
                     .thenAnswer(inv -> null);
             assertTrue(job.lakePublishVersion());
-            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), eq(4L), eq(5L), any(), anyBoolean()),
+            // Per-tablet publish (useAggregatePublish=false); the aggregate path is NOT used.
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), eq(4L), eq(5L), any(), eq(false)),
                     times(1));
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), eq(true)),
+                    never());
         }
     }
 
@@ -1230,6 +1244,7 @@ public class LakeTableIndexFastPathJobBaseTest {
 
         Database db = new Database(2L, "db");
         OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(false);
         PhysicalPartition pp = mock(PhysicalPartition.class);
         MaterializedIndex idx = mock(MaterializedIndex.class);
         when(idx.getTablets()).thenReturn(new ArrayList<>());
@@ -1248,6 +1263,193 @@ public class LakeTableIndexFastPathJobBaseTest {
             utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), anyBoolean()))
                     .thenThrow(new RuntimeException("rpc fail"));
             assertFalse(job.lakePublishVersion());
+        }
+    }
+
+    @Test
+    public void testLakePublishVersion_FileBundlingUsesAggregateForAllTablets() throws Exception {
+        // A file-bundling table stores every version as a single bundle
+        // {0}_{version}.meta written by the aggregate publish path. The index
+        // fast path must publish that way too (like loads and meta-alters), or
+        // it writes per-tablet {tablet}_{version}.meta files that the bundling
+        // metadata vacuum never reclaims. All of the partition's tablets (across
+        // every visible index) must go into ONE aggregate publish, because BE
+        // truncate-overwrites the bundle -- a per-index aggregate call would drop
+        // earlier indexes' tablets.
+        LakeTableAddIndexJob job = newJob();
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(true);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        // Two visible indexes, each with a distinct tablet.
+        Tablet t1 = mock(Tablet.class);
+        Tablet t2 = mock(Tablet.class);
+        MaterializedIndex idx1 = mock(MaterializedIndex.class);
+        when(idx1.getTablets()).thenReturn(Collections.singletonList(t1));
+        MaterializedIndex idx2 = mock(MaterializedIndex.class);
+        when(idx2.getTablets()).thenReturn(Collections.singletonList(t2));
+        List<MaterializedIndex> indices = new ArrayList<>();
+        indices.add(idx1);
+        indices.add(idx2);
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)).thenReturn(indices);
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = mock(GlobalStateMgr.class);
+        LocalMetastore lm = mock(LocalMetastore.class);
+        when(lm.getDb(anyLong())).thenReturn(db);
+        when(lm.getTable(anyLong(), anyLong())).thenReturn(table);
+        when(gsm.getLocalMetastore()).thenReturn(lm);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), anyBoolean()))
+                    .thenAnswer(inv -> null);
+
+            assertTrue(job.lakePublishVersion());
+
+            // Exactly one aggregate publish (useAggregatePublish=true) for the partition,
+            // carrying every tablet from both indexes; the per-tablet path is NOT used.
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Tablet>> tabletsCaptor = ArgumentCaptor.forClass(List.class);
+            utilsStatic.verify(() -> Utils.publishVersion(tabletsCaptor.capture(), any(), eq(4L), eq(5L),
+                    any(), eq(true)), times(1));
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), eq(false)),
+                    never());
+            List<Tablet> published = tabletsCaptor.getValue();
+            assertEquals(2, published.size());
+            assertTrue(published.contains(t1));
+            assertTrue(published.contains(t2));
+        }
+    }
+
+    @Test
+    public void testLakePublishVersion_FileBundlingIsolatesPartitions() throws Exception {
+        // Each physical partition writes its own bundle at its own commit version;
+        // the per-partition tablet list must reset so one partition's tablets never
+        // leak into another's aggregate publish.
+        LakeTableAddIndexJob job = new LakeTableAddIndexJob(1L, 2L, 3L, "t", 60_000L,
+                new ArrayList<>(), new ArrayList<>());
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        commit.put(101L, 8L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(true);
+
+        Tablet tA = mock(Tablet.class);
+        MaterializedIndex idxA = mock(MaterializedIndex.class);
+        when(idxA.getTablets()).thenReturn(Collections.singletonList(tA));
+        PhysicalPartition ppA = mock(PhysicalPartition.class);
+        when(ppA.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idxA));
+        when(table.getPhysicalPartition(100L)).thenReturn(ppA);
+
+        Tablet tB = mock(Tablet.class);
+        MaterializedIndex idxB = mock(MaterializedIndex.class);
+        when(idxB.getTablets()).thenReturn(Collections.singletonList(tB));
+        PhysicalPartition ppB = mock(PhysicalPartition.class);
+        when(ppB.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idxB));
+        when(table.getPhysicalPartition(101L)).thenReturn(ppB);
+
+        GlobalStateMgr gsm = mock(GlobalStateMgr.class);
+        LocalMetastore lm = mock(LocalMetastore.class);
+        when(lm.getDb(anyLong())).thenReturn(db);
+        when(lm.getTable(anyLong(), anyLong())).thenReturn(table);
+        when(gsm.getLocalMetastore()).thenReturn(lm);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), anyBoolean()))
+                    .thenAnswer(inv -> null);
+
+            assertTrue(job.lakePublishVersion());
+
+            // Exactly one aggregate publish per partition, each carrying only its own
+            // tablet at its own base->commit version; no cross-partition mixing.
+            utilsStatic.verify(() -> Utils.publishVersion(
+                    argThat(l -> l.size() == 1 && l.contains(tA)), any(), eq(4L), eq(5L), any(), eq(true)), times(1));
+            utilsStatic.verify(() -> Utils.publishVersion(
+                    argThat(l -> l.size() == 1 && l.contains(tB)), any(), eq(7L), eq(8L), any(), eq(true)), times(1));
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), eq(true)),
+                    times(2));
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), eq(false)),
+                    never());
+        }
+    }
+
+    @Test
+    public void testLakePublishVersion_FileBundlingAggregateThrowsReturnsFalse() throws Exception {
+        LakeTableAddIndexJob job = newJob();
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(true);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        Tablet t1 = mock(Tablet.class);
+        MaterializedIndex idx = mock(MaterializedIndex.class);
+        when(idx.getTablets()).thenReturn(Collections.singletonList(t1));
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idx));
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = mock(GlobalStateMgr.class);
+        LocalMetastore lm = mock(LocalMetastore.class);
+        when(lm.getDb(anyLong())).thenReturn(db);
+        when(lm.getTable(anyLong(), anyLong())).thenReturn(table);
+        when(gsm.getLocalMetastore()).thenReturn(lm);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), eq(true)))
+                    .thenThrow(new RuntimeException("rpc fail"));
+            assertFalse(job.lakePublishVersion());
+        }
+    }
+
+    @Test
+    public void testLakePublishVersion_DropIndexFileBundlingUsesAggregate() throws Exception {
+        // The bundling-aware publish lives in the shared base, so DROP INDEX
+        // inherits it too.
+        LakeTableDropIndexJob job = new LakeTableDropIndexJob(1L, 2L, 3L, "t", 60_000L,
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+        Map<Long, Long> commit = new HashMap<>();
+        commit.put(100L, 5L);
+        setField(job, "commitVersionMap", commit);
+
+        Database db = new Database(2L, "db");
+        OlapTable table = mock(OlapTable.class);
+        when(table.isFileBundling()).thenReturn(true);
+        PhysicalPartition pp = mock(PhysicalPartition.class);
+        Tablet t1 = mock(Tablet.class);
+        MaterializedIndex idx = mock(MaterializedIndex.class);
+        when(idx.getTablets()).thenReturn(Collections.singletonList(t1));
+        when(pp.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE))
+                .thenReturn(Collections.singletonList(idx));
+        when(table.getPhysicalPartition(100L)).thenReturn(pp);
+
+        GlobalStateMgr gsm = mock(GlobalStateMgr.class);
+        LocalMetastore lm = mock(LocalMetastore.class);
+        when(lm.getDb(anyLong())).thenReturn(db);
+        when(lm.getTable(anyLong(), anyLong())).thenReturn(table);
+        when(gsm.getLocalMetastore()).thenReturn(lm);
+        try (MockedStatic<GlobalStateMgr> gsmStatic = Mockito.mockStatic(GlobalStateMgr.class);
+                MockedStatic<Utils> utilsStatic = Mockito.mockStatic(Utils.class)) {
+            gsmStatic.when(GlobalStateMgr::getCurrentState).thenReturn(gsm);
+            utilsStatic.when(() -> Utils.publishVersion(any(), any(), anyLong(), anyLong(), any(), anyBoolean()))
+                    .thenAnswer(inv -> null);
+            assertTrue(job.lakePublishVersion());
+            utilsStatic.verify(() -> Utils.publishVersion(any(), any(), eq(4L), eq(5L), any(), eq(true)),
+                    times(1));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

On a shared-data ("lake") table with `"file_bundling" = "true"`, every version's tablet
metadata is expected to be written as a single bundle file `{0}_{version}.meta` by the
aggregate publish path — this is how normal loads and metadata-alter jobs publish. The lake
index fast path (`ALTER TABLE ... ADD INDEX / DROP INDEX` for `BITMAP` / `NGRAMBF`), however,
published via the per-tablet path unconditionally: `LakeTableIndexFastPathJobBase.lakePublishVersion()`
called `Utils.publishVersion(..., /*useAggregatePublish=*/ false)` regardless of the table's
`file_bundling` property. Both `LakeTableAddIndexJob` and `LakeTableDropIndexJob` inherit this
base publish, so both were affected.

As a result, a file-bundling table ended up with a mixed metadata history: bundle files for
loads/meta-alters, but per-tablet `{tablet}_{version}.meta` files for index add/drop versions —
violating the invariant that a file-bundling table's metadata is bundled. The metadata vacuum
for a file-bundling table only reclaims bundle-named files, so the stray per-tablet metadata
files written by an index add/drop are not reclaimed by normal auto-vacuum (a metadata residue
left on object storage). The read path is unaffected — it already falls back between the two
layouts — so this is not a read-availability or data-loss issue.

The same class's cancel / force-skip path (`lakePublishVersionWithSkip`) was already
file-bundling-aware; only the normal publish was missed.

## What I'm doing:

Make `LakeTableIndexFastPathJobBase.lakePublishVersion()` honor the table's `file_bundling`
property, mirroring `LakeTableAlterMetaJobBase.lakePublishVersion()` and this class's own cancel
path:

- Choose `useAggregatePublish = table.isFileBundling()` — the fast path never toggles the
  property, so checking the table's current format is the right predicate (the same one the
  cancel path uses).
- For a file-bundling table, accumulate all of a partition's tablets across every visible
  materialized index and publish them in one aggregate call per partition (BE truncate-overwrites
  the bundle, so a per-index call would drop earlier indexes' tablets), via the existing
  `Utils.publishVersion(..., /*useAggregatePublish=*/ true)` overload — which also preserves async
  vector-index publish completion.
- Non-file-bundling tables keep the existing per-tablet publish, unchanged.

No BE change is needed: the vacuum is correct given the restored invariant. This is a forward
fix (it stops new per-tablet index-alter versions); it does not retroactively reclaim
previously-written per-tablet metadata (Full Vacuum can do that if ever needed).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
