### PR TITLE
[BugFix] Only clear mv's metadata in schema changing (backport #57371)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -540,7 +540,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                 // for manual refresh type, do not refresh
                 if (materializedView.getRefreshScheme().getType() != MaterializedView.RefreshType.MANUAL) {
                     GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .refreshMaterializedView(dbName, materializedView.getName(), true, null,
+                            .refreshMaterializedView(dbName, materializedView.getName(), false, null,
                                     Constants.TaskRunPriority.NORMAL.value(), true, false);
                 }
             } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -866,6 +866,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
                             mvColumn.getName(), tbl.getName());
                     mv.setInactiveAndReason(
                             MaterializedViewExceptions.inactiveReasonForColumnChanged(modifiedColumns));
+                    // clear version map to make sure the MV will be refreshed
+                    mv.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
                     return;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -17,8 +17,12 @@ package com.starrocks.analysis;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobMgr;
+import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.scheduler.MVActiveChecker;
@@ -38,6 +42,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -184,6 +189,110 @@ public class AlterMaterializedViewTest extends MVTestBase  {
                     (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
             Assertions.assertThrows(SemanticException.class, () -> currentState.getLocalMetastore().alterMaterializedView(stmt));
         }
+    }
+
+
+    @Test
+    public void testInactiveMV() throws Exception {
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS par_tbl1\n" +
+                        "(\n" +
+                        "    datekey DATETIME,\n" +
+                        "    item_id STRING,\n" +
+                        "    v1      INT\n" +
+                        ")PRIMARY KEY (`datekey`,`item_id`)\n" +
+                        "    PARTITION BY date_trunc('day', `datekey`);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl1 values ('2025-01-01', '1', 1);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl1 values ('2025-01-02', '1', 1);");
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS par_tbl2\n" +
+                        "(\n" +
+                        "    datekey DATETIME,\n" +
+                        "    item_id STRING,\n" +
+                        "    v1      INT\n" +
+                        ")PRIMARY KEY (`datekey`,`item_id`)\n" +
+                        "    PARTITION BY date_trunc('day', `datekey`);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl2 values ('2025-01-01', '1', 2);");
+        executeInsertSql(connectContext, "INSERT INTO par_tbl2 values ('2025-01-02', '1', 1);");
+
+        starRocksAssert
+                .withTable("CREATE TABLE IF NOT EXISTS dim_data\n" +
+                        "(\n" +
+                        "    item_id STRING,\n" +
+                        "    v1 INT\n" +
+                        ")PRIMARY KEY (`item_id`);");
+        executeInsertSql(connectContext, "INSERT INTO dim_data values ('1', 4);");
+
+        starRocksAssert
+                .withMaterializedView("CREATE\n" +
+                        "MATERIALIZED VIEW mv_dim_data1\n" +
+                        "REFRESH ASYNC EVERY(INTERVAL 60 MINUTE)\n" +
+                        "AS\n" +
+                        "select *\n" +
+                        "from dim_data;");
+
+        starRocksAssert
+                .withMaterializedView("CREATE\n" +
+                        "MATERIALIZED VIEW mv_test1\n" +
+                        "REFRESH ASYNC EVERY(INTERVAL 60 MINUTE)\n" +
+                        "PARTITION BY p_time\n" +
+                        "PROPERTIES (\n" +
+                        "\"excluded_trigger_tables\" = \"mv_dim_data1\",\n" +
+                        "\"excluded_refresh_tables\" = \"mv_dim_data1\",\n" +
+                        "\"partition_refresh_number\" = \"1\"\n" +
+                        ")\n" +
+                        "AS\n" +
+                        "select date_trunc(\"day\", a.datekey) as p_time, sum(a.v1) + sum(b.v1) as v1\n" +
+                        "from par_tbl1 a\n" +
+                        "         left join par_tbl2 b on a.datekey = b.datekey and a.item_id = b.item_id\n" +
+                        "         left join mv_dim_data1 d on a.item_id = d.item_id\n" +
+                        "group by date_trunc(\"day\", a.datekey), a.item_id;");
+
+        starRocksAssert.refreshMV("refresh materialized view mv_test1");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "mv_test1");
+        Assertions.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assertions.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        String alterMvSql = "alter materialized view mv_test1 INACTIVE";
+        AlterMaterializedViewStmt stmt =
+                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assertions.assertFalse(mv.isActive());
+
+        alterMvSql = "alter materialized view mv_test1 ACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assertions.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+        Assertions.assertTrue(mv.isActive());
+        baseTableVisibleVersionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assertions.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        alterMvSql = "alter materialized view mv_test1 INACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assertions.assertFalse(mv.isActive());
+
+        alterMvSql = "alter materialized view mv_test1 ACTIVE";
+        stmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+        currentState.getLocalMetastore().alterMaterializedView(stmt);
+        Assertions.assertTrue(starRocksAssert.waitRefreshFinished(mv.getId()));
+        Assertions.assertTrue(mv.isActive());
+        // Don't refresh base table version map
+        baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assertions.assertTrue(!baseTableVisibleVersionMap.isEmpty());
+
+        // inactive mv when base table's schema changed
+        Database db = starRocksAssert.getDb(connectContext.getDatabase());
+        Table parTbl1 = starRocksAssert.getTable(connectContext.getDatabase(), "par_tbl1");
+        AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, (OlapTable) parTbl1, Set.of("item_id"));
+        baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assertions.assertTrue(baseTableVisibleVersionMap.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #57371 to branch-3.5. branch-3.5 was cut from main shortly before #57371 merged and only branch-3.4 received the backport, so branch-3.5 still force-refreshes an MV on activation.

Since 3.5.15 the async MV reload on FE restart (#64217, backported via #64315) makes this a serious regression: during image load `MaterializedView.onReload()` sets `active = false` first and restores it asynchronously, leaving a minutes-long window in which MVs are transiently inactive. `MVActiveChecker` (default on, 60s interval, empty grace-period map after restart) picks them up and runs `ALTER MATERIALIZED VIEW xxx ACTIVE`, and the activation path calls `refreshMaterializedView(..., force=true, ...)` — so every FE leader restart triggers a FORCE full refresh of all async MVs. Reported by an enterprise customer on 3.5.18 with multi-layer nested MVs (hours of data delay); not reproducible on 3.3/3.4 (no async reload) or on main/4.x (which carry #57371).

## What I'm doing:

Cherry-pick 24d76e1febf9d85ba47b3e5e9a32915ffa2dd1b3 with conflicts resolved against branch-3.5:

- `AlterMVJobExecutor`: activation-triggered refresh uses `force=false` (normal incremental semantics). A schema-changed MV still gets an effectively-full refresh because its version map was cleared at inactivation time.
- `LakeTableSchemaChangeJob`: clear the MV's visible version map when inactivating it due to a base table column change (this path bypasses `doInactiveMaterializedView` and was still missing the clear on branch-3.5).
- Dropped the original loop-wide `finally { clearVisibleVersionMap() }` hunk in `AlterMVJobExecutor.inactiveRelatedMaterializedViews`: branch-3.5's `doInactiveMaterializedView` already clears the version map for MVs it inactivates, and current main has since refined the clear to exactly that per-inactivated-MV scope, so the loop-wide clear would spuriously full-refresh unaffected MVs.
- Dropped the `AlterJobMgr` hunk (removal of `clearVisibleVersionMap` on activate): already absent on branch-3.5.
- `AlterMaterializedViewTest#testInactiveMV`: ported to branch-3.5's JUnit5 / `MVTestBase` style.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
