### PR TITLE
[Doc] Update shared-data FAQ for full vacuum .lcrm cleanup

### DIFF
--- a/docs/en/faq/shared_data_faq.md
+++ b/docs/en/faq/shared_data_faq.md
@@ -216,6 +216,7 @@ However, if the difference is excessively large, it could be caused by the follo
 
 - Compaction may be lagging.
 - Vacuum tasks may be backlogged (check queue size).
+- Failed, aborted, or interrupted Primary Key compaction tasks may leave expired, unreferenced `.lcrm` files in object storage. Lake full vacuum reclaims these orphaned files after the expiration window.
 
 You may consider tuning compaction or vacuum thread pools if necessary.
 

--- a/docs/en/faq/shared_data_faq.md
+++ b/docs/en/faq/shared_data_faq.md
@@ -216,7 +216,7 @@ However, if the difference is excessively large, it could be caused by the follo
 
 - Compaction may be lagging.
 - Vacuum tasks may be backlogged (check queue size).
-- Failed, aborted, or interrupted Primary Key compaction tasks may leave expired, unreferenced `.lcrm` files in object storage. Lake full vacuum reclaims these orphaned files after the expiration window.
+- Failed, aborted, or interrupted Primary Key compaction tasks may leave expired, unreferenced `.lcrm` files in object storage. Full vacuum reclaims these orphaned `.lcrm` files after they have passed the expiration window.
 
 You may consider tuning compaction or vacuum thread pools if necessary.
 


### PR DESCRIPTION
## Summary

This PR updates the shared-data FAQ to document that full vacuum reclaims expired, unreferenced `.lcrm` files left behind by failed, aborted, or interrupted Primary Key compaction tasks after the expiration window.

Closes #76583