### PR TITLE
[BugFix] Refresh vended cloud credentials mid-query for long connector scans

### DIFF
--- a/be/src/connector/hive/hive_connector.cpp
+++ b/be/src/connector/hive/hive_connector.cpp
@@ -800,8 +800,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     }
 
     const auto& hdfs_scan_node = _provider->_hdfs_scan_node;
-    auto fsOptions =
-            FSOptions(hdfs_scan_node.__isset.cloud_configuration ? &hdfs_scan_node.cloud_configuration : nullptr);
+    // Prefer the mid-query refreshed cloud configuration so file opens use a fresh vended token.
+    auto fsOptions = FSOptions(_provider->effective_cloud_configuration(&_cloud_configuration_holder));
 
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateUniqueFromString(native_file_path, fsOptions));
     if (hdfs_scan_node.__isset.column_access_paths && _scanner_ctx.format_scan_context.column_access_paths.empty()) {
@@ -1094,6 +1094,23 @@ void HiveDataSourceProvider::prepare_scan_ranges(const std::vector<TScanRangePar
         const THdfsScanRange& y = x.hdfs_scan_range;
         _max_file_length = std::max(_max_file_length, y.file_length);
     }
+}
+
+void HiveDataSourceProvider::set_refreshed_cloud_configuration(const TCloudConfiguration& cloud_configuration) {
+    std::lock_guard<std::mutex> l(_refreshed_cloud_config_mutex);
+    _refreshed_cloud_configuration = cloud_configuration;
+    _has_refreshed_cloud_configuration = true;
+}
+
+const TCloudConfiguration* HiveDataSourceProvider::effective_cloud_configuration(TCloudConfiguration* holder) const {
+    {
+        std::lock_guard<std::mutex> l(_refreshed_cloud_config_mutex);
+        if (_has_refreshed_cloud_configuration) {
+            *holder = _refreshed_cloud_configuration;
+            return holder;
+        }
+    }
+    return _hdfs_scan_node.__isset.cloud_configuration ? &_hdfs_scan_node.cloud_configuration : nullptr;
 }
 
 void HiveDataSourceProvider::default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) {

--- a/be/src/connector/hive/hive_connector.h
+++ b/be/src/connector/hive/hive_connector.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <unordered_map>
 
 #include "column/column_access_path.h"
@@ -56,6 +57,13 @@ public:
     void prepare_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     void default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) override;
 
+    // Thread-safe: the RPC thread writes, scan threads read via effective_cloud_configuration().
+    void set_refreshed_cloud_configuration(const TCloudConfiguration& cloud_configuration) override;
+
+    // Returns the refreshed cloud configuration (copied into `holder`) when one has arrived,
+    // otherwise the plan-time configuration, or nullptr if neither is set.
+    const TCloudConfiguration* effective_cloud_configuration(TCloudConfiguration* holder) const;
+
     friend class HiveDataSource;
 
 protected:
@@ -63,6 +71,10 @@ protected:
     const THdfsScanNode _hdfs_scan_node;
     int64_t _max_file_length = 0;
     mutable std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
+
+    mutable std::mutex _refreshed_cloud_config_mutex;
+    TCloudConfiguration _refreshed_cloud_configuration;
+    bool _has_refreshed_cloud_configuration = false;
 };
 
 class HiveDataSource final : public DataSource {
@@ -114,6 +126,10 @@ private:
     // _scanner_ctx during destruction (JniScanner::~JniScanner → close()).
     HdfsScannerContext _scanner_ctx;
     ObjectPool _pool;
+    // Owns the refreshed-cloud-configuration snapshot that FSOptions references by raw pointer;
+    // the FileSystem created in _init_scanner lives in _pool and opens files lazily, so a stack
+    // holder would dangle.
+    TCloudConfiguration _cloud_configuration_holder;
     RuntimeState* _runtime_state = nullptr;
 
     HdfsScanner* _scanner = nullptr;

--- a/be/src/connector_primitive/data_source_provider.h
+++ b/be/src/connector_primitive/data_source_provider.h
@@ -22,6 +22,7 @@
 #include "common/statusor.h"
 #include "connector_primitive/data_source.h"
 #include "exec_primitive/pipeline/scan/morsel_queue_builder.h"
+#include "gen_cpp/CloudConfiguration_types.h"
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/runtime_state_fwd.h"
@@ -71,6 +72,10 @@ public:
     virtual bool always_shared_scan() const { return true; }
 
     virtual void prepare_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {}
+
+    // Deliver a re-vended cloud credential mid-query. No-op by default; providers that open
+    // files with vended credentials override it.
+    virtual void set_refreshed_cloud_configuration(const TCloudConfiguration& cloud_configuration) {}
 
     virtual void default_data_source_mem_bytes(int64_t* min_value, int64_t* max_value) {
         *min_value = MIN_DATA_SOURCE_MEM_BYTES;

--- a/be/src/orchestration/fragment_executor.cpp
+++ b/be/src/orchestration/fragment_executor.cpp
@@ -40,6 +40,7 @@
 #include "data_sink/tablet/olap_table_sink.h"
 #include "data_workflows/load/batch_write/batch_write_mgr.h"
 #include "exec/capture_version_node.h"
+#include "exec/connector_scan_node.h"
 #include "exec/cross_join_node.h"
 #include "exec/exchange_node.h"
 #include "exec/exec_env.h"
@@ -54,6 +55,7 @@
 #include "exec/pipeline/pipeline_driver_instantiator.h"
 #include "exec/pipeline/query_context.h"
 #include "exec/pipeline/scan/morsel_queue_factory.h"
+#include "exec/pipeline/scan/scan_operator.h"
 #include "exec/pipeline/schedule/timeout_tasks.h"
 #include "exec/pipeline/sink/result_sink_operator.h"
 #include "exec/runtime/fragment_context_manager.h"
@@ -1039,6 +1041,26 @@ void FragmentExecutor::_fail_cleanup(bool fragment_has_registed) {
     }
 }
 
+void FragmentExecutor::apply_refreshed_cloud_configurations(
+        pipeline::FragmentContext* fragment_ctx,
+        const std::map<TPlanNodeId, TCloudConfiguration>& node_to_cloud_configuration) {
+    fragment_ctx->iterate_pipeline([&](Pipeline* pipeline) {
+        auto* scan_factory = dynamic_cast<pipeline::ScanOperatorFactory*>(pipeline->source_operator_factory());
+        if (scan_factory == nullptr) {
+            return;
+        }
+        auto cc_iter = node_to_cloud_configuration.find(scan_factory->plan_node_id());
+        if (cc_iter == node_to_cloud_configuration.end()) {
+            return;
+        }
+        auto* connector_scan_node = dynamic_cast<ConnectorScanNode*>(scan_factory->scan_node());
+        if (connector_scan_node == nullptr) {
+            return;
+        }
+        connector_scan_node->data_source_provider()->set_refreshed_cloud_configuration(cc_iter->second);
+    });
+}
+
 Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const TExecPlanFragmentParams& request,
                                                         TExecPlanFragmentResult* response) {
     DCHECK(!request.__isset.fragment);
@@ -1059,6 +1081,12 @@ Status FragmentExecutor::append_incremental_scan_ranges(ExecEnv* exec_env, const
                                                  print_id(query_id), print_id(instance_id)));
     }
     RuntimeState* runtime_state = fragment_ctx->runtime_state();
+
+    // Apply re-vended cloud credentials before publishing any new scan ranges, so a scan driver
+    // that picks up an appended morsel immediately opens files with the fresh token.
+    if (params.__isset.node_to_cloud_configuration && !params.node_to_cloud_configuration.empty()) {
+        apply_refreshed_cloud_configurations(fragment_ctx.get(), params.node_to_cloud_configuration);
+    }
 
     std::unordered_set<int> notify_ids;
     std::vector<int32_t> closed_scan_nodes;

--- a/be/src/orchestration/fragment_executor.h
+++ b/be/src/orchestration/fragment_executor.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -69,6 +70,13 @@ public:
     // Exposed here so unit tests can pin the contract; the production caller is
     // _prepare_pipeline_driver.
     static bool is_final_sink_type(TDataSinkType::type type);
+
+    // Apply re-vended cloud credentials (scan-node-id -> config) to the matching connector scan
+    // providers so subsequent file opens use the fresh token. Exposed for unit testing; production
+    // callers reach it through append_incremental_scan_ranges.
+    static void apply_refreshed_cloud_configurations(
+            pipeline::FragmentContext* fragment_ctx,
+            const std::map<TPlanNodeId, TCloudConfiguration>& node_to_cloud_configuration);
 
     Status prepare_global_state(ExecEnv* exec_env, const TExecPlanFragmentParams& common_request);
     void _fail_cleanup(bool fragment_has_registed);

--- a/be/test/connector/hive/hive_connector_test.cpp
+++ b/be/test/connector/hive/hive_connector_test.cpp
@@ -107,4 +107,38 @@ TEST_F(HiveConnectorTest, test_scan_range_indicate_const_column_index) {
     EXPECT_EQ(data_source->scan_range_indicate_const_column_index(99), -1); // Not found
 }
 
+// A mid-query refreshed cloud configuration overrides the plan-time one, including when delivered
+// through the DataSourceProvider base pointer (the incremental scan-range RPC path).
+TEST_F(HiveConnectorTest, test_refreshed_cloud_configuration) {
+    TCloudConfiguration holder;
+
+    // No plan-time config and no refresh: nullptr.
+    THdfsScanNode bare_scan_node;
+    HiveDataSourceProvider bare_provider(0, bare_scan_node);
+    EXPECT_EQ(bare_provider.effective_cloud_configuration(&holder), nullptr);
+
+    // Plan-time config only: returned directly.
+    TCloudConfiguration plan_time;
+    plan_time.__set_cloud_properties({{"fs.gs.temporary.access.token", "tok1"}});
+    THdfsScanNode scan_node;
+    scan_node.__set_cloud_configuration(plan_time);
+    HiveDataSourceProvider provider(0, scan_node);
+    const TCloudConfiguration* effective = provider.effective_cloud_configuration(&holder);
+    ASSERT_NE(effective, nullptr);
+    EXPECT_EQ(effective->cloud_properties.at("fs.gs.temporary.access.token"), "tok1");
+
+    // A refresh delivered through the base interface wins over the plan-time config and is
+    // copied into the caller's holder.
+    TCloudConfiguration refreshed;
+    refreshed.__set_cloud_properties({{"fs.gs.temporary.access.token", "tok2"}});
+    static_cast<DataSourceProvider*>(&provider)->set_refreshed_cloud_configuration(refreshed);
+    effective = provider.effective_cloud_configuration(&holder);
+    ASSERT_EQ(effective, &holder);
+    EXPECT_EQ(effective->cloud_properties.at("fs.gs.temporary.access.token"), "tok2");
+
+    // A refresh also applies when the plan carried no cloud configuration at all.
+    bare_provider.set_refreshed_cloud_configuration(refreshed);
+    EXPECT_EQ(bare_provider.effective_cloud_configuration(&holder), &holder);
+}
+
 } // namespace starrocks::connector

--- a/be/test/orchestration/fragment_executor_test.cpp
+++ b/be/test/orchestration/fragment_executor_test.cpp
@@ -18,8 +18,15 @@
 
 #include "base/testutil/assert.h"
 #include "common/config_exec_fwd.h"
+#include "connector/hive/hive_connector.h"
+#include "exec/connector_scan_node.h"
 #include "exec/exec_env.h"
 #include "exec/pipeline/query_context.h"
+#include "exec/pipeline/scan/scan_operator.h"
+#include "exec/runtime/fragment_context.h"
+#include "exec/runtime/group_execution/execution_group.h"
+#include "exec/runtime/group_execution/execution_group_builder.h"
+#include "exec/runtime/pipeline.h"
 #include "exec/runtime_compat/runtime_state_helper.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/InternalService_types.h"
@@ -160,6 +167,78 @@ TEST(FragmentExecutorFinalSinkTest, connector_backed_sink_types_are_final_sinks)
 
     // Exchange sinks hand off to a downstream fragment and must NOT be classified as final.
     EXPECT_FALSE(FragmentExecutor::is_final_sink_type(TDataSinkType::DATA_STREAM_SINK));
+}
+
+namespace {
+// Minimal concrete ScanOperatorFactory: apply_refreshed_cloud_configurations only reads
+// plan_node_id() and scan_node(), so the create/prepare hooks are never exercised.
+class StubScanOperatorFactory final : public pipeline::ScanOperatorFactory {
+public:
+    StubScanOperatorFactory(int32_t id, ScanNode* scan_node) : pipeline::ScanOperatorFactory(id, scan_node) {}
+    Status do_prepare(RuntimeState*) override { return Status::OK(); }
+    void do_close(RuntimeState*) override {}
+    pipeline::OperatorPtr do_create(int32_t, int32_t) override { return nullptr; }
+};
+} // namespace
+
+// A refreshed cloud configuration keyed by scan-node id reaches the matching connector scan
+// provider through the pipeline -> scan factory -> ConnectorScanNode -> provider chain.
+TEST_F(FragmentExecutorPartitionTest, AppliesRefreshedCloudConfigurationToConnectorProvider) {
+    constexpr int32_t kPlanNodeId = 7;
+
+    TUniqueId fragment_id;
+    TQueryOptions query_options;
+    TQueryGlobals query_globals;
+    auto runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+    TUniqueId mem_id;
+    runtime_state->init_mem_trackers(mem_id);
+
+    TDescriptorTable thrift_tbl;
+    DescriptorTbl* descs = nullptr;
+    ASSERT_OK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), thrift_tbl, &descs,
+                                    config::vector_chunk_size));
+
+    TPlanNode tnode;
+    tnode.__set_node_id(kPlanNodeId);
+    tnode.__set_node_type(TPlanNodeType::HDFS_SCAN_NODE);
+    tnode.__set_row_tuples(std::vector<TTupleId>{});
+    tnode.__set_limit(-1);
+    TConnectorScanNode connector_scan_node;
+    connector_scan_node.connector_name = connector::Connector::HIVE;
+    tnode.__set_connector_scan_node(connector_scan_node);
+
+    auto scan_node = std::make_shared<ConnectorScanNode>(runtime_state->obj_pool(), tnode, *descs);
+    // Install a HiveDataSourceProvider directly rather than via the connector registry, which may
+    // not be force-loaded in this test binary. -fno-access-control lets the test set the member.
+    THdfsScanNode hdfs_scan_node;
+    auto hive_provider = std::make_unique<connector::HiveDataSourceProvider>(kPlanNodeId, hdfs_scan_node);
+    auto* hive_provider_raw = hive_provider.get();
+    scan_node->_data_source_provider = std::move(hive_provider);
+
+    auto scan_factory = std::make_shared<StubScanOperatorFactory>(0, scan_node.get());
+
+    // iterate_pipeline() walks the execution groups, not the raw pipeline list, so the pipeline
+    // must be registered in a non-empty group (set_pipelines drops empty groups).
+    auto fragment_ctx = std::make_shared<pipeline::FragmentContext>();
+    auto pipe = std::make_shared<pipeline::Pipeline>(0, pipeline::OpFactories{scan_factory}, nullptr);
+    pipeline::Pipelines pipelines;
+    pipelines.emplace_back(pipe);
+    auto exec_group = pipeline::ExecutionGroupBuilder::create_normal_exec_group();
+    exec_group->add_pipeline(pipe.get());
+    pipeline::ExecutionGroups exec_groups;
+    exec_groups.emplace_back(std::move(exec_group));
+    fragment_ctx->set_pipelines(std::move(exec_groups), std::move(pipelines));
+
+    TCloudConfiguration refreshed;
+    refreshed.__set_cloud_properties({{"fs.gs.temporary.access.token", "fresh"}});
+    std::map<TPlanNodeId, TCloudConfiguration> node_to_cc{{kPlanNodeId, refreshed}};
+
+    FragmentExecutor::apply_refreshed_cloud_configurations(fragment_ctx.get(), node_to_cc);
+
+    TCloudConfiguration holder;
+    const TCloudConfiguration* effective = hive_provider_raw->effective_cloud_configuration(&holder);
+    ASSERT_EQ(effective, &holder);
+    EXPECT_EQ(effective->cloud_properties.at("fs.gs.temporary.access.token"), "fresh");
 }
 
 } // namespace starrocks::orchestration

--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -607,6 +607,16 @@ This topic introduces the following types of FE configurations:
 
 ## Data Lake
 
+### `vended_credential_refresh_window_sec`
+
+- Default: 3000
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: For connector scans that read data files with catalog-vended cloud credentials (for example, GCS access tokens vended by an Iceberg REST catalog), the coordinator re-vends the credential when it expires within this window and pushes the fresh credential to the BEs, so a scan that runs longer than the credential's lifetime does not fail with a null- or expired-token error. Because credential delivery to the BEs typically happens early in the query while the scan itself can run much longer, this window must cover the expected scan duration, not just clock skew.
+- Introduced in: -
+
+
 ### `files_enable_insert_push_down_column_type`
 
 - Default: true

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -608,6 +608,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ## データレイク
 
+### `vended_credential_refresh_window_sec`
+
+- デフォルト：3000
+- タイプ：Long
+- 単位：Seconds
+- 変更可能：Yes
+- 説明：Catalog が下発（vend）するクラウド認証情報を使用してデータファイルを読み取る Connector スキャン（例：Iceberg REST Catalog が下発する GCS アクセストークン）において、認証情報がこのウィンドウ内に期限切れになる場合、コーディネーターは認証情報を再取得して BE にプッシュします。これにより、認証情報の有効期間より長く実行されるスキャンがトークンの欠落や期限切れで失敗しなくなります。認証情報は通常クエリの早い段階で BE に配信され、スキャン自体はより長く実行される可能性があるため、このウィンドウはクロックスキューだけでなく、想定されるスキャン時間をカバーする必要があります。
+- 導入時期：-
+
+
 ### `files_enable_insert_push_down_column_type`
 
 - デフォルト：true

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -608,6 +608,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ## 数据湖
 
+### `vended_credential_refresh_window_sec`
+
+- 默认值：3000
+- 类型：Long
+- 单位：秒
+- 是否动态：是
+- 描述：对于使用 Catalog 下发（vended）云凭证读取数据文件的 Connector 扫描（例如 Iceberg REST Catalog 下发的 GCS Access Token），当凭证将在该窗口时间内过期时，协调者会重新获取凭证并推送给 BE，避免运行时间超过凭证有效期的扫描因 Token 为空或过期而失败。由于凭证通常在查询早期下发给 BE，而扫描本身可能运行更长时间，该窗口应覆盖预期的扫描时长，而不仅是时钟偏差。
+- 引入版本：-
+
+
 ### `files_enable_insert_push_down_column_type`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1923,6 +1923,15 @@ public class Config extends ConfigBase {
     public static int max_query_retry_time = 2;
 
     /**
+     * Re-vend a connector scan's cloud credential when it expires within this window, so a scan
+     * that outlives its vended token keeps opening files. Credentials reach the BE early in the
+     * query while the scan can run much longer, so cover the expected scan duration.
+     */
+    @ConfField(mutable = true, comment = "Re-vend a connector scan's cloud credential when it " +
+            "expires within this many seconds.")
+    public static long vended_credential_refresh_window_sec = 3000;
+
+    /**
      * In order not to wait too long for create table(index), set a max timeout.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -16,7 +16,9 @@ package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.ConnectorMetadataRequestContext;
@@ -35,11 +37,14 @@ import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.QueueIcebergRemoteFileInfoSource;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.THdfsScanNode;
 import com.starrocks.thrift.TPlanNode;
@@ -55,8 +60,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
@@ -67,7 +74,13 @@ public class IcebergScanNode extends ScanNode {
     protected final IcebergTable icebergTable;
     private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
     private ScalarOperator icebergJobPlanningPredicate = null;
-    private CloudConfiguration cloudConfiguration = null;
+    // Rewritten under the synchronized refresh method from both the timer and delivery threads,
+    // read unsynchronized elsewhere (coordinator gate, thrift build).
+    private final AtomicReference<CloudConfiguration> cloudConfiguration = new AtomicReference<>();
+    // ponytail: 30s cooldown keeps a hot delivery loop from hammering the REST catalog.
+    private static final long VENDED_REFRESH_ATTEMPT_COOLDOWN_MS = 30_000L;
+    // Guarded by the synchronized refresh method; stamped at attempt completion.
+    private long lastVendedRefreshAttemptMs = 0;
     private IcebergConnectorScanRangeSource scanRangeSource = null;
     private final IcebergTableMORParams tableFullMORParams;
     private final IcebergMORParams morParams;
@@ -250,11 +263,93 @@ public class IcebergScanNode extends ScanNode {
             return;
         }
 
-        cloudConfiguration = IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable);
+        cloudConfiguration.set(IcebergUtil.getVendedCloudConfiguration(catalogName, icebergTable));
     }
 
     public void setCloudConfiguration(CloudConfiguration cloudConfiguration) {
-        this.cloudConfiguration = cloudConfiguration;
+        this.cloudConfiguration.set(cloudConfiguration);
+    }
+
+    public CloudConfiguration getCloudConfiguration() {
+        return cloudConfiguration.get();
+    }
+
+    // The current credential as thrift, for re-pushing after a failed delivery; null when none.
+    public TCloudConfiguration currentVendedCloudConfiguration() {
+        CloudConfiguration current = cloudConfiguration.get();
+        if (current == null) {
+            return null;
+        }
+        TCloudConfiguration result = new TCloudConfiguration();
+        current.toThrift(result);
+        return result;
+    }
+
+    /**
+     * Re-vend the vended cloud credential once it is within {@code refreshWindowMs} of expiry and
+     * return it as thrift for delivery to the BE, or null when no refresh is needed or available.
+     * A table reload produces the fresh token in the native table's FileIO properties.
+     */
+    public synchronized TCloudConfiguration refreshVendedCloudConfigurationIfNearExpiry(long refreshWindowMs) {
+        CloudConfiguration currentConfig = cloudConfiguration.get();
+        if (currentConfig == null) {
+            return null;
+        }
+        TCloudConfiguration current = new TCloudConfiguration();
+        currentConfig.toThrift(current);
+        String expiration = current.getCloud_properties() == null ? null
+                : current.getCloud_properties().get(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY);
+        if (expiration == null) {
+            return null;
+        }
+        long expiryMs;
+        try {
+            expiryMs = Long.parseLong(expiration);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        long nowMs = System.currentTimeMillis();
+        if (nowMs + refreshWindowMs < expiryMs) {
+            return null;
+        }
+        // The catalog may re-serve the same token (e.g. Polaris), so rate-limit reload attempts
+        // and only ship a credential that actually changed.
+        if (nowMs - lastVendedRefreshAttemptMs < VENDED_REFRESH_ATTEMPT_COOLDOWN_MS) {
+            return null;
+        }
+        try {
+            MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+            metadataMgr.refreshTable(icebergTable.getCatalogName(), icebergTable.getCatalogDBName(),
+                    icebergTable, Lists.newArrayList(), false);
+            Table refreshed = metadataMgr.getTable(new ConnectContext(), icebergTable.getCatalogName(),
+                    icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName());
+            if (!(refreshed instanceof IcebergTable)) {
+                return null;
+            }
+            CloudConfiguration fresh =
+                    IcebergUtil.getVendedCloudConfiguration(icebergTable.getCatalogName(), (IcebergTable) refreshed);
+            this.cloudConfiguration.set(fresh);
+            TCloudConfiguration result = new TCloudConfiguration();
+            fresh.toThrift(result);
+            if (Objects.equals(current.getCloud_properties(), result.getCloud_properties())) {
+                // Same credential re-served: a no-op on the BE (its filesystem cache keys on the
+                // token value). Compare the whole map — a new token can carry the same expiry.
+                return null;
+            }
+            String newExpiration = result.getCloud_properties() == null ? null
+                    : result.getCloud_properties().get(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY);
+            LOG.info("re-vended cloud credential for table {}: expiry {} -> {}",
+                    icebergTable.getCatalogTableName(), expiration, newExpiration);
+            return result;
+        } catch (Exception e) {
+            // Best-effort: a failed re-vend just leaves the current token; the scan continues.
+            LOG.warn("failed to refresh vended cloud configuration for table {}",
+                    icebergTable.getCatalogTableName(), e);
+            return null;
+        } finally {
+            // Start the cooldown from completion so a slow reload doesn't immediately admit another.
+            lastVendedRefreshAttemptMs = System.currentTimeMillis();
+        }
     }
 
     public void setUsedForDelete(boolean usedForDelete) {
@@ -446,7 +541,7 @@ public class IcebergScanNode extends ScanNode {
         }
         msg.hdfs_scan_node.setTable_name(icebergTable.getName());
         HdfsScanNode.setScanOptimizeOptionToThrift(tHdfsScanNode, this);
-        HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
+        HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration.get());
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
         HdfsScanNode.setDataCacheOptionsToThrift(tHdfsScanNode, dataCacheOptions);
         if (columnAccessPaths != null && !columnAccessPaths.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -66,6 +66,7 @@ import com.starrocks.datacache.DataCacheSelectMetrics;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.planner.DescriptorTable;
+import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
@@ -73,6 +74,7 @@ import com.starrocks.planner.ResultSink;
 import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.StreamLoadPlanner;
+import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.qe.scheduler.Coordinator;
@@ -89,15 +91,19 @@ import com.starrocks.qe.scheduler.dag.PhasedExecutionSchedule;
 import com.starrocks.qe.scheduler.dag.SingleNodeSchedule;
 import com.starrocks.qe.scheduler.slot.DeployState;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
+import com.starrocks.rpc.BackendServiceClient;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.InternalServiceVersion;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TPlanFragmentExecParams;
 import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TReportAuditStatisticsParams;
@@ -113,6 +119,7 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -124,9 +131,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -531,6 +542,8 @@ public class DefaultCoordinator extends Coordinator {
         // if all the instance are in the same worker, we can send them all in once
         // but only after prepareExec() we can know the worker number
         maybeChangeScheduler();
+
+        maybeStartVendedCredentialRefreshTask();
     }
 
     @Override
@@ -543,6 +556,7 @@ public class DefaultCoordinator extends Coordinator {
 
     @Override
     public void onFinished() {
+        cancelVendedCredentialRefreshTask();
         onReleaseSlots();
         // for async profile, if Be doesn't report profile in time, we upload the most complete profile
         // into profile Manager here. IN other case, queryProfile.finishAllInstances just do nothing here
@@ -772,6 +786,7 @@ public class DefaultCoordinator extends Coordinator {
                 }
                 if (hasMoreScanRanges) {
                     coordinatorPreprocessor.assignIncrementalScanRangesToFragmentInstances(fragment);
+                    maybeRefreshVendedCredentials(fragment);
                     updatedPlanFragmentIds.add(fragmentId);
                 }
             }
@@ -798,6 +813,194 @@ public class DefaultCoordinator extends Coordinator {
             }
         }
         return updatedStates;
+    }
+
+    // ponytail: fixed 60s tick; the per-scan-node re-vend cooldown does the real rate limiting.
+    private static final long VENDED_REFRESH_TICK_SECONDS = 60;
+    // The scheduler only dispatches; tick work (catalog reload, RPC waits) runs on the elastic
+    // pool so one slow query cannot delay other queries' refreshes.
+    private static final ScheduledExecutorService VENDED_REFRESH_SCHEDULER =
+            ThreadPoolManager.newDaemonScheduledThreadPool(1, "vended-cred-refresh-timer", true);
+    // SynchronousQueue overload: thread-per-tick up to 32 (the bounded-queue overload has zero
+    // core threads and serves one task at a time until its queue fills). Overflow is discarded
+    // and logged; the skipped tick retries next minute.
+    private static final ExecutorService VENDED_REFRESH_EXECUTOR =
+            ThreadPoolManager.newDaemonCacheThreadPool(32, "vended-cred-refresh", false);
+    private final AtomicReference<ScheduledFuture<?>> vendedCredentialRefreshTask = new AtomicReference<>();
+    private volatile boolean vendedRefreshStopped = false;
+    private final AtomicBoolean vendedRefreshTickRunning = new AtomicBoolean(false);
+    // Set when a refresh push fails; the next tick re-pushes the current credential.
+    private volatile boolean vendedRefreshResendNeeded = false;
+
+    /**
+     * Incremental delivery ends early in the query while the scan can run much longer, so poll for
+     * the query's lifetime and push each genuinely new credential to every instance with a
+     * refresh-only request (no scan ranges).
+     */
+    private void maybeStartVendedCredentialRefreshTask() {
+        boolean hasVendedIcebergScan = executionDAG.getScanNodes().stream()
+                .anyMatch(scanNode -> scanNode instanceof IcebergScanNode
+                        && ((IcebergScanNode) scanNode).getCloudConfiguration() != null);
+        if (!hasVendedIcebergScan || !jobSpec.isEnablePipeline() || vendedRefreshStopped) {
+            return;
+        }
+        vendedCredentialRefreshTask.set(VENDED_REFRESH_SCHEDULER.scheduleWithFixedDelay(
+                this::submitVendedRefreshTick, VENDED_REFRESH_TICK_SECONDS, VENDED_REFRESH_TICK_SECONDS,
+                TimeUnit.SECONDS));
+    }
+
+    private void cancelVendedCredentialRefreshTask() {
+        vendedRefreshStopped = true;
+        ScheduledFuture<?> task = vendedCredentialRefreshTask.getAndSet(null);
+        if (task != null) {
+            task.cancel(false);
+        }
+    }
+
+    private void submitVendedRefreshTick() {
+        try {
+            // The in-flight CAS lives in the task, so a dropped submission can never strand it.
+            VENDED_REFRESH_EXECUTOR.execute(this::runVendedRefreshTick);
+        } catch (RejectedExecutionException e) {
+            LOG.warn("vended credential refresh rejected for query {}", DebugUtil.printId(jobSpec.getQueryId()), e);
+        }
+    }
+
+    // A tick that outlives its 60s slot is skipped, not stacked.
+    private void runVendedRefreshTick() {
+        if (!vendedRefreshTickRunning.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            refreshVendedCredentialsTick();
+        } finally {
+            vendedRefreshTickRunning.set(false);
+        }
+    }
+
+    private void refreshVendedCredentialsTick() {
+        if (vendedRefreshStopped || isDone()) {
+            // Backstop for lifecycle paths that miss cancel: stop the periodic task with the query.
+            cancelVendedCredentialRefreshTask();
+            return;
+        }
+        try {
+            boolean resend = vendedRefreshResendNeeded;
+            boolean anyFailure = false;
+            for (ExecutionFragment fragment : executionDAG.getFragmentsInPostorder()) {
+                if (vendedRefreshStopped) {
+                    return;
+                }
+                Map<Integer, TCloudConfiguration> refreshed = null;
+                for (ScanNode scanNode : fragment.getScanNodes()) {
+                    if (!(scanNode instanceof IcebergScanNode)) {
+                        continue;
+                    }
+                    IcebergScanNode icebergScanNode = (IcebergScanNode) scanNode;
+                    TCloudConfiguration cc = icebergScanNode.refreshVendedCloudConfigurationIfNearExpiry(
+                            Config.vended_credential_refresh_window_sec * 1000L);
+                    if (cc == null && resend) {
+                        // A previous push failed after the FE already swapped its credential, so the
+                        // near-expiry/unchanged gates would never resend it. Push the current one.
+                        cc = icebergScanNode.currentVendedCloudConfiguration();
+                    }
+                    if (cc != null) {
+                        if (refreshed == null) {
+                            refreshed = new HashMap<>();
+                        }
+                        refreshed.put(scanNode.getId().asInt(), cc);
+                    }
+                }
+                if (refreshed == null) {
+                    continue;
+                }
+                List<Future<PExecPlanFragmentResult>> pushes = new ArrayList<>();
+                for (FragmentInstance instance : fragment.getInstances()) {
+                    FragmentInstanceExecState execState = executionDAG.getExecution(instance.getIndexInJob());
+                    if (execState == null) {
+                        continue;
+                    }
+                    FragmentInstanceExecState.State state = execState.getState();
+                    if (state == FragmentInstanceExecState.State.CREATED
+                            || state == FragmentInstanceExecState.State.DEPLOYING) {
+                        // The BE hasn't registered the fragment yet and would drop the push as OK;
+                        // retry next tick.
+                        anyFailure = true;
+                        continue;
+                    }
+                    if (state != FragmentInstanceExecState.State.EXECUTING) {
+                        continue;
+                    }
+                    TExecPlanFragmentParams request = new TExecPlanFragmentParams();
+                    request.setProtocol_version(InternalServiceVersion.V1);
+                    request.setParams(new TPlanFragmentExecParams());
+                    request.params.setQuery_id(jobSpec.getQueryId());
+                    request.params.setFragment_instance_id(instance.getInstanceId());
+                    request.params.setPer_node_scan_ranges(new HashMap<>());
+                    request.params.setPer_exch_num_senders(new HashMap<>());
+                    request.params.setNode_to_cloud_configuration(refreshed);
+                    // Independent RPC: the deployer owns the exec state's requestToDeploy/deployFuture.
+                    try {
+                        pushes.add(BackendServiceClient.getInstance().execPlanFragmentAsync(
+                                execState.getWorker().getBrpcAddress(), request, jobSpec.getPlanProtocol()));
+                    } catch (TException | RpcException e) {
+                        anyFailure = true;
+                        LOG.warn("failed to push refreshed vended credential to instance {} of query {}",
+                                DebugUtil.printId(instance.getInstanceId()),
+                                DebugUtil.printId(jobSpec.getQueryId()), e);
+                    }
+                }
+                // Await the responses: a lost push must be retried on the next tick, because the FE
+                // already carries the new credential and would otherwise never resend it.
+                for (Future<PExecPlanFragmentResult> push : pushes) {
+                    try {
+                        PExecPlanFragmentResult result = push.get(10, TimeUnit.SECONDS);
+                        if (result.status.statusCode != TStatusCode.OK.getValue()) {
+                            anyFailure = true;
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        anyFailure = true;
+                    } catch (Exception e) {
+                        anyFailure = true;
+                    }
+                }
+                LOG.info("pushed refreshed vended credential to {} instances of fragment {} for query {}",
+                        fragment.getInstances().size(), fragment.getFragmentId(),
+                        DebugUtil.printId(jobSpec.getQueryId()));
+            }
+            vendedRefreshResendNeeded = anyFailure;
+        } catch (Throwable t) {
+            if (t instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            // Never let the worker thread die on one bad tick; retry the push next tick.
+            vendedRefreshResendNeeded = true;
+            LOG.warn("vended credential refresh tick failed for query {}",
+                    DebugUtil.printId(jobSpec.getQueryId()), t);
+        }
+    }
+
+    /**
+     * Re-vend near-expiry cloud credentials for a fragment still delivering scan ranges and stash
+     * them so the next incremental batch carries them to the BE.
+     */
+    private void maybeRefreshVendedCredentials(ExecutionFragment fragment) {
+        Map<Integer, TCloudConfiguration> refreshed = null;
+        for (ScanNode scanNode : fragment.getScanNodes()) {
+            if (!(scanNode instanceof IcebergScanNode)) {
+                continue;
+            }
+            TCloudConfiguration cc = ((IcebergScanNode) scanNode)
+                    .refreshVendedCloudConfigurationIfNearExpiry(Config.vended_credential_refresh_window_sec * 1000L);
+            if (cc != null) {
+                if (refreshed == null) {
+                    refreshed = new HashMap<>();
+                }
+                refreshed.put(scanNode.getId().asInt(), cc);
+            }
+        }
+        fragment.setRefreshedNodeCloudConfigs(refreshed);
     }
 
     private boolean isInternalCancelError(String errMsg) {
@@ -1111,6 +1314,7 @@ public class DefaultCoordinator extends Coordinator {
      */
     @Override
     public void cancel(PPlanFragmentCancelReason reason, String message) {
+        cancelVendedCredentialRefreshTask();
         lock();
         try {
             // All results have been obtained. The query has ended. Ignore this error.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -29,6 +29,7 @@ import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.thrift.InternalServiceVersion;
 import com.starrocks.thrift.TAdaptiveDopParam;
 import com.starrocks.thrift.TArrowFlightSQLVersion;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TFunctionVersion;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TFragmentInstanceFactory {
     private final ConnectContext context;
@@ -102,6 +104,12 @@ public class TFragmentInstanceFactory {
         result.params.setPer_node_scan_ranges(instance.getNode2ScanRanges());
         result.params.setNode_to_per_driver_seq_scan_ranges(instance.getNode2DriverSeqToScanRanges());
         result.params.setPer_exch_num_senders(new HashMap<>());
+        // Carry re-vended cloud credentials so a long connector scan can refresh its vended token.
+        Map<Integer, TCloudConfiguration> refreshedCloudConfigs =
+                instance.getExecFragment().getRefreshedNodeCloudConfigs();
+        if (refreshedCloudConfigs != null && !refreshedCloudConfigs.isEmpty()) {
+            result.params.setNode_to_cloud_configuration(refreshedCloudConfigs);
+        }
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -33,6 +33,7 @@ import com.starrocks.qe.ColocatedBackendSelector;
 import com.starrocks.qe.CoordinatorPreprocessor;
 import com.starrocks.qe.FragmentScanRangeAssignment;
 import com.starrocks.qe.scheduler.ExplainBuilder;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TEsScanRange;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TInternalScanRange;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.starrocks.qe.scheduler.dag.FragmentInstance.ABSENT_DRIVER_SEQUENCE;
@@ -74,6 +76,11 @@ public class ExecutionFragment {
 
     private final FragmentScanRangeAssignment scanRangeAssignment;
     private ColocatedBackendSelector.Assignment colocatedAssignment = null;
+
+    // Re-vended cloud credentials (scan-node-id -> config) computed per incremental deploy round;
+    // null when nothing needs refreshing.
+    private final AtomicReference<Map<Integer, TCloudConfiguration>> refreshedNodeCloudConfigs =
+            new AtomicReference<>();
 
     public static class BucketSeqAssignment {
         public List<Integer> bucketSeqToInstance;
@@ -130,6 +137,14 @@ public class ExecutionFragment {
 
     public PlanFragmentId getFragmentId() {
         return planFragment.getFragmentId();
+    }
+
+    public void setRefreshedNodeCloudConfigs(Map<Integer, TCloudConfiguration> refreshedNodeCloudConfigs) {
+        this.refreshedNodeCloudConfigs.set(refreshedNodeCloudConfigs);
+    }
+
+    public Map<Integer, TCloudConfiguration> getRefreshedNodeCloudConfigs() {
+        return refreshedNodeCloudConfigs.get();
     }
 
     public Collection<ScanNode> getScanNodes() {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeVendedRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeVendedRefreshTest.java
@@ -1,0 +1,238 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.gcp.GCPCloudConfiguration;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
+import com.starrocks.credential.gcp.GCPCloudCredential;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.thrift.TCloudConfiguration;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Pins the near-expiry re-vend contract of
+ * {@link IcebergScanNode#refreshVendedCloudConfigurationIfNearExpiry(long)}: re-vend only inside
+ * the window, rate-limit reloads, skip unchanged credentials, and keep the current token on error.
+ */
+public class IcebergScanNodeVendedRefreshTest {
+
+    private static final long HOUR_MS = 3600_000L;
+
+    private IcebergTable icebergTable;
+    private int reloadCalls;
+    private CloudConfiguration freshConfig;
+
+    private static CloudConfiguration vendedConfig(String token, long expiresAtMs) {
+        GCPCloudCredential credential = new GCPCloudCredential("", false, "", "", "", "",
+                token, String.valueOf(expiresAtMs));
+        return new GCPCloudConfiguration(credential);
+    }
+
+    private static Long expirationOf(TCloudConfiguration tCloudConfiguration) {
+        String v = tCloudConfiguration.getCloud_properties()
+                .get(GCPCloudConfigurationProvider.TOKEN_EXPIRATION_KEY);
+        return v == null ? null : Long.parseLong(v);
+    }
+
+    private IcebergScanNode newNode(String initialToken, long initialExpiryMs) {
+        // Constructed with a null catalog name so the constructor's credential setup is skipped;
+        // the catalog identity is mocked afterwards for the refresh path.
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getCatalogName() {
+                return null;
+            }
+        };
+        icebergTable = new IcebergTable();
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(icebergTable);
+        IcebergScanNode node = new IcebergScanNode(new PlanNodeId(0), desc, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, null);
+
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getCatalogName() {
+                return "cat";
+            }
+
+            @Mock
+            public String getCatalogDBName() {
+                return "db";
+            }
+
+            @Mock
+            public String getCatalogTableName() {
+                return "tbl";
+            }
+        };
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public void refreshTable(String catalogName, String srDbName, Table table,
+                                     List<String> partitionNames, boolean onlyCachedPartitions) {
+                reloadCalls++;
+            }
+
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                return icebergTable;
+            }
+        };
+        new MockUp<IcebergUtil>() {
+            @Mock
+            public CloudConfiguration getVendedCloudConfiguration(String catalogName, IcebergTable table) {
+                return freshConfig;
+            }
+        };
+        node.setCloudConfiguration(vendedConfig(initialToken, initialExpiryMs));
+        return node;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        reloadCalls = 0;
+    }
+
+    @Test
+    public void testNoVendedCredentialDoesNotReload() {
+        IcebergScanNode node = newNode("tok1", System.currentTimeMillis() + 60_000L);
+        node.setCloudConfiguration(null);
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(0, reloadCalls);
+    }
+
+    @Test
+    public void testMissingExpirationDoesNotReload() {
+        IcebergScanNode node = newNode("tok1", System.currentTimeMillis() + 60_000L);
+        // An empty access token serializes no expiration property.
+        node.setCloudConfiguration(vendedConfig("", 0));
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(0, reloadCalls);
+    }
+
+    @Test
+    public void testMalformedExpirationDoesNotReload() {
+        IcebergScanNode node = newNode("tok1", System.currentTimeMillis() + 60_000L);
+        GCPCloudCredential credential = new GCPCloudCredential("", false, "", "", "", "", "tok1", "soon");
+        node.setCloudConfiguration(new GCPCloudConfiguration(credential));
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(0, reloadCalls);
+    }
+
+    @Test
+    public void testReloadReturningNonIcebergTableKeepsCurrentToken() {
+        IcebergScanNode node = newNode("tok1", System.currentTimeMillis() + 60_000L);
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public void refreshTable(String catalogName, String srDbName, Table table,
+                                     List<String> partitionNames, boolean onlyCachedPartitions) {
+                // no-op: the reload only needs to be observed, not performed
+            }
+
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                return null;
+            }
+        };
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+    }
+
+    @Test
+    public void testFarFromExpiryDoesNotReload() {
+        long expiry = System.currentTimeMillis() + 10 * HOUR_MS;
+        IcebergScanNode node = newNode("tok1", expiry);
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(0, reloadCalls);
+    }
+
+    @Test
+    public void testNearExpiryRevendsFreshToken() {
+        long oldExpiry = System.currentTimeMillis() + 60_000L;
+        long newExpiry = System.currentTimeMillis() + HOUR_MS;
+        IcebergScanNode node = newNode("tok1", oldExpiry);
+        freshConfig = vendedConfig("tok2", newExpiry);
+
+        TCloudConfiguration refreshed = node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L);
+        Assertions.assertNotNull(refreshed);
+        Assertions.assertEquals(newExpiry, expirationOf(refreshed));
+        Assertions.assertEquals(1, reloadCalls);
+        // The node now carries the fresh credential for subsequent delivery rounds.
+        Assertions.assertSame(freshConfig, node.getCloudConfiguration());
+    }
+
+    @Test
+    public void testSameTokenReservedIsNotShipped() {
+        long expiry = System.currentTimeMillis() + 60_000L;
+        IcebergScanNode node = newNode("tok1", expiry);
+        // The catalog re-serves the same token until it is really about to die (observed with
+        // Polaris): shipping it would be a no-op on the BE, so it must be skipped.
+        freshConfig = vendedConfig("tok1", expiry);
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(1, reloadCalls);
+    }
+
+    @Test
+    public void testNewTokenWithSameExpiryIsShipped() {
+        long expiry = System.currentTimeMillis() + 60_000L;
+        IcebergScanNode node = newNode("tok1", expiry);
+        // Catalogs can vend a different token with the same (e.g. rounded) expiry; the BE
+        // filesystem-handle cache keys on the token value, so it must still be shipped.
+        freshConfig = vendedConfig("tok2", expiry);
+        TCloudConfiguration refreshed = node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L);
+        Assertions.assertNotNull(refreshed);
+        Assertions.assertEquals(expiry, expirationOf(refreshed));
+        Assertions.assertEquals(1, reloadCalls);
+    }
+
+    @Test
+    public void testReloadAttemptsAreRateLimited() {
+        long expiry = System.currentTimeMillis() + 60_000L;
+        IcebergScanNode node = newNode("tok1", expiry);
+        freshConfig = vendedConfig("tok2", System.currentTimeMillis() + HOUR_MS);
+
+        Assertions.assertNotNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        // Immediately asking again (e.g. the next delivery round, milliseconds later) must not
+        // reload the table again: the 30s cooldown does the rate limiting.
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+        Assertions.assertEquals(1, reloadCalls);
+    }
+
+    @Test
+    public void testReloadFailureKeepsCurrentToken() {
+        long expiry = System.currentTimeMillis() + 60_000L;
+        IcebergScanNode node = newNode("tok1", expiry);
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public void refreshTable(String catalogName, String srDbName, Table table,
+                                     List<String> partitionNames, boolean onlyCachedPartitions) {
+                throw new RuntimeException("catalog unreachable");
+            }
+        };
+        // Best-effort: a failed re-vend returns null and the scan continues on the current token.
+        Assertions.assertNull(node.refreshVendedCloudConfigurationIfNearExpiry(3000_000L));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/IncrementalDeployHiveTest.java
@@ -15,10 +15,14 @@
 package com.starrocks.qe.scheduler;
 
 import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
 import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.THdfsScanRange;
+import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPlanFragmentExecParams;
 import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TUniqueId;
@@ -52,6 +56,42 @@ public class IncrementalDeployHiveTest extends SchedulerConnectorTestBase {
             connectContext.getSessionVariable().setEnablePhasedScheduler(true);
             runSchedule();
         }
+    }
+
+
+    @Test
+    public void testIncrementalRequestCarriesRefreshedCloudConfiguration() throws Exception {
+        connectContext.getSessionVariable().setEnableConnectorIncrementalScanRanges(true);
+        connectContext.getSessionVariable().setConnectorIncrementalScanRangeNumber(20);
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+            }
+        };
+        DefaultCoordinator coordinator = startScheduling("select * from hive0.file_split_db.file_split_tbl");
+
+        ExecutionFragment scanFragment = coordinator.getExecutionDAG().getFragmentsInPostorder().stream()
+                .filter(fragment -> !fragment.getScanNodes().isEmpty())
+                .findFirst().orElseThrow();
+        FragmentInstance instance = scanFragment.getInstances().get(0);
+        int scanId = scanFragment.getScanNodes().iterator().next().getId().asInt();
+        TFragmentInstanceFactory factory = new TFragmentInstanceFactory(connectContext,
+                coordinator.getJobSpec(), coordinator.getExecutionDAG(), new TNetworkAddress("127.0.0.1", 9020));
+
+        // A freshly re-vended credential stashed on the fragment rides the incremental request,
+        // keyed by scan node id, so the BE can refresh its filesystem token mid-query.
+        TCloudConfiguration cc = new TCloudConfiguration();
+        cc.setCloud_properties(Map.of("fs.gs.temporary.access.token", "tok2"));
+        scanFragment.setRefreshedNodeCloudConfigs(Map.of(scanId, cc));
+        TExecPlanFragmentParams withRefresh = factory.createIncrementalScanRanges(instance);
+        Assertions.assertTrue(withRefresh.params.isSetNode_to_cloud_configuration());
+        Assertions.assertEquals("tok2", withRefresh.params.getNode_to_cloud_configuration()
+                .get(scanId).getCloud_properties().get("fs.gs.temporary.access.token"));
+
+        // Nothing stashed (the common case): the field stays unset so the wire cost is zero.
+        scanFragment.setRefreshedNodeCloudConfigs(null);
+        TExecPlanFragmentParams withoutRefresh = factory.createIncrementalScanRanges(instance);
+        Assertions.assertFalse(withoutRefresh.params.isSetNode_to_cloud_configuration());
     }
 
     public void runSchedule() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/VendedCredentialRefreshSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/VendedCredentialRefreshSchedulerTest.java
@@ -1,0 +1,283 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.connector.iceberg.IcebergTableMORParams;
+import com.starrocks.connector.iceberg.IcebergUtil;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.gcp.GCPCloudConfiguration;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
+import com.starrocks.credential.gcp.GCPCloudCredential;
+import com.starrocks.planner.IcebergScanNode;
+import com.starrocks.planner.PlanNodeId;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.planner.TupleId;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+import com.starrocks.qe.scheduler.slot.DeployState;
+import com.starrocks.rpc.BackendServiceClient;
+import com.starrocks.server.MetadataMgr;
+import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Covers the coordinator side of mid-query vended credential refresh: the refresh-only timer tick
+ * and the delivery-round attach path. The scheduler harness only mocks a hive catalog, so an
+ * IcebergScanNode carrying a near-expiry vended credential is injected into the scan fragment.
+ */
+public class VendedCredentialRefreshSchedulerTest extends SchedulerConnectorTestBase {
+
+    private IcebergTable icebergTable;
+    private CloudConfiguration freshConfig;
+
+    private static CloudConfiguration vendedConfig(String token, long expiresAtMs) {
+        GCPCloudCredential credential = new GCPCloudCredential("", false, "", "", "", "",
+                token, String.valueOf(expiresAtMs));
+        return new GCPCloudConfiguration(credential);
+    }
+
+    private IcebergScanNode newIcebergNode(int planNodeId, String token, long expiryMs) {
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getCatalogName() {
+                return null;
+            }
+        };
+        icebergTable = new IcebergTable();
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(planNodeId));
+        desc.setTable(icebergTable);
+        IcebergScanNode node = new IcebergScanNode(new PlanNodeId(planNodeId), desc, "IcebergScanNode",
+                IcebergTableMORParams.EMPTY, IcebergMORParams.EMPTY, null);
+
+        new MockUp<IcebergTable>() {
+            @Mock
+            public String getCatalogName() {
+                return "cat";
+            }
+
+            @Mock
+            public String getCatalogDBName() {
+                return "db";
+            }
+
+            @Mock
+            public String getCatalogTableName() {
+                return "tbl";
+            }
+        };
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public void refreshTable(String catalogName, String srDbName, Table table,
+                                     List<String> partitionNames, boolean onlyCachedPartitions) {
+                // no-op: the reload only needs to be observed, not performed
+            }
+
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                return icebergTable;
+            }
+        };
+        new MockUp<IcebergUtil>() {
+            @Mock
+            public CloudConfiguration getVendedCloudConfiguration(String catalogName, IcebergTable table) {
+                return freshConfig;
+            }
+        };
+        node.setCloudConfiguration(vendedConfig(token, expiryMs));
+        return node;
+    }
+
+    private ExecutionFragment scanFragmentWithInjectedIcebergNode(DefaultCoordinator coordinator,
+                                                                  IcebergScanNode node) {
+        ExecutionFragment scanFragment = coordinator.getExecutionDAG().getFragmentsInPostorder().stream()
+                .filter(fragment -> !fragment.getScanNodes().isEmpty())
+                .findFirst().orElseThrow();
+        Map<PlanNodeId, ScanNode> scanNodes = Deencapsulation.getField(scanFragment, "scanNodes");
+        scanNodes.put(node.getId(), node);
+        return scanFragment;
+    }
+
+    // Deploys are mocked, so exec states stay CREATED; the tick only pushes to EXECUTING instances.
+    private static void markExecuting(DefaultCoordinator coordinator) {
+        for (FragmentInstanceExecState execState : coordinator.getExecutionDAG().getExecutions()) {
+            Deencapsulation.setField(execState, "state", FragmentInstanceExecState.State.EXECUTING);
+        }
+    }
+
+    private static Future<PExecPlanFragmentResult> okPushResult() {
+        PExecPlanFragmentResult result = new PExecPlanFragmentResult();
+        StatusPB status = new StatusPB();
+        status.statusCode = TStatusCode.OK.getValue();
+        result.status = status;
+        return CompletableFuture.completedFuture(result);
+    }
+
+    @Test
+    public void testRefreshTickPushesRefreshOnlyRequests() throws Exception {
+        List<TExecPlanFragmentParams> pushed = new ArrayList<>();
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PExecPlanFragmentResult> execPlanFragmentAsync(
+                    TNetworkAddress address, TExecPlanFragmentParams tRequest, String protocol) {
+                pushed.add(tRequest);
+                return okPushResult();
+            }
+        };
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                // no-op: deploys are not exercised by these tests
+            }
+        };
+        DefaultCoordinator coordinator = startScheduling("select * from hive0.file_split_db.file_split_tbl");
+        IcebergScanNode node = newIcebergNode(1000, "tok1", System.currentTimeMillis() + 60_000L);
+        freshConfig = vendedConfig("tok2", System.currentTimeMillis() + 3600_000L);
+        ExecutionFragment scanFragment = scanFragmentWithInjectedIcebergNode(coordinator, node);
+
+        // Instances not yet EXECUTING are skipped and flagged for retry: the BE would drop the
+        // push as OK before its fragment context exists.
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+        Assertions.assertTrue(pushed.isEmpty());
+        markExecuting(coordinator);
+
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+
+        // One refresh-only request per instance: no scan ranges, credential keyed by scan node id.
+        Assertions.assertEquals(scanFragment.getInstances().size(), pushed.size());
+        TExecPlanFragmentParams request = pushed.get(0);
+        Assertions.assertFalse(request.isSetFragment());
+        Assertions.assertTrue(request.params.getPer_node_scan_ranges().isEmpty());
+        TCloudConfiguration cc = request.params.getNode_to_cloud_configuration().get(node.getId().asInt());
+        Assertions.assertEquals("tok2",
+                cc.getCloud_properties().get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
+
+        // A second tick inside the re-vend cooldown pushes nothing.
+        int pushedSoFar = pushed.size();
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+        Assertions.assertEquals(pushedSoFar, pushed.size());
+    }
+
+    @Test
+    public void testFailedPushIsResentNextTick() throws Exception {
+        AtomicBoolean failPush = new AtomicBoolean(true);
+        List<TExecPlanFragmentParams> pushed = new ArrayList<>();
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PExecPlanFragmentResult> execPlanFragmentAsync(
+                    TNetworkAddress address, TExecPlanFragmentParams tRequest, String protocol) throws TException {
+                if (failPush.get()) {
+                    throw new TException("injected push failure");
+                }
+                pushed.add(tRequest);
+                return okPushResult();
+            }
+        };
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                // no-op: deploys are not exercised by these tests
+            }
+        };
+        DefaultCoordinator coordinator = startScheduling("select * from hive0.file_split_db.file_split_tbl");
+        IcebergScanNode node = newIcebergNode(1000, "tok1", System.currentTimeMillis() + 60_000L);
+        freshConfig = vendedConfig("tok2", System.currentTimeMillis() + 3600_000L);
+        scanFragmentWithInjectedIcebergNode(coordinator, node);
+        markExecuting(coordinator);
+
+        // Tick 1: the FE re-vends (credential becomes tok2) but every push fails.
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+        Assertions.assertTrue(pushed.isEmpty());
+
+        // Tick 2: inside the re-vend cooldown and the catalog is unchanged, yet the current
+        // credential must still be re-pushed because the previous delivery was lost.
+        failPush.set(false);
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+        Assertions.assertFalse(pushed.isEmpty());
+        TCloudConfiguration cc = pushed.get(0).params.getNode_to_cloud_configuration().get(node.getId().asInt());
+        Assertions.assertEquals("tok2",
+                cc.getCloud_properties().get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
+
+        // Tick 3: the resend succeeded, so nothing further is pushed.
+        int pushedSoFar = pushed.size();
+        Deencapsulation.invoke(coordinator, "refreshVendedCredentialsTick");
+        Assertions.assertEquals(pushedSoFar, pushed.size());
+    }
+
+    @Test
+    public void testDeliveryRoundAttachesRefreshedCredentials() throws Exception {
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                // no-op: deploys are not exercised by these tests
+            }
+        };
+        DefaultCoordinator coordinator = startScheduling("select * from hive0.file_split_db.file_split_tbl");
+        IcebergScanNode node = newIcebergNode(1000, "tok1", System.currentTimeMillis() + 60_000L);
+        freshConfig = vendedConfig("tok2", System.currentTimeMillis() + 3600_000L);
+        ExecutionFragment scanFragment = scanFragmentWithInjectedIcebergNode(coordinator, node);
+
+        Deencapsulation.invoke(coordinator, "maybeRefreshVendedCredentials", scanFragment);
+
+        Map<Integer, TCloudConfiguration> refreshed = scanFragment.getRefreshedNodeCloudConfigs();
+        Assertions.assertNotNull(refreshed);
+        Assertions.assertEquals("tok2", refreshed.get(node.getId().asInt())
+                .getCloud_properties().get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
+    }
+
+    @Test
+    public void testSlowTickIsSkippedNotStacked() throws Exception {
+        new MockUp<Deployer>() {
+            @Mock
+            public void deployFragments(DeployState deployState) {
+                // no-op: deploys are not exercised by these tests
+            }
+        };
+        DefaultCoordinator coordinator = startScheduling("select * from hive0.file_split_db.file_split_tbl");
+        AtomicBoolean running = Deencapsulation.getField(coordinator, "vendedRefreshTickRunning");
+
+        // A tick arriving while the previous one is in flight is skipped, not stacked.
+        running.set(true);
+        Deencapsulation.invoke(coordinator, "runVendedRefreshTick");
+        Assertions.assertTrue(running.get());
+
+        // A normal run releases the flag on completion.
+        running.set(false);
+        Deencapsulation.invoke(coordinator, "runVendedRefreshTick");
+        Assertions.assertFalse(running.get());
+    }
+}

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -490,6 +490,10 @@ struct TPlanFragmentExecParams {
   // used for global lazy materialization
   75: optional map<Types.TPlanNodeId, i32> per_look_up_num_fetchers
   76: optional map<Types.TPlanNodeId, Descriptors.TNodesInfo> per_fetch_target_nodes
+
+  // Re-vended cloud credentials keyed by scan plan node id, so a long connector scan can refresh
+  // a vended token that would otherwise expire mid-query. Only set on incremental batches.
+  77: optional map<Types.TPlanNodeId, CloudConfiguration.TCloudConfiguration> node_to_cloud_configuration
 }
 
 // Global query parameters assigned by the coordinator.


### PR DESCRIPTION
## Why I'm doing:

A catalog-vended cloud credential (e.g. a GCS access token vended by an Iceberg REST catalog such as Apache Polaris) is delivered once in `THdfsScanNode.cloud_configuration` and frozen for the whole scan. A connector scan that outlives the token's TTL fails:

```
hdfsOpenFile failed ... root_cause=NullPointerException: AccessToken cannot be null!
```

`TemporaryGCPAccessTokenProvider` returns null on expiry, its `refresh()` cannot re-fetch, and there is no FE→BE channel to hand a fresh token to a running fragment. FE-side catalog session self-healing (#76457) extends survival but cannot help the already-dispatched BE scan.

## What I'm doing:

Add the missing channel and drive it for the query's whole lifetime:

- **thrift**: `TPlanFragmentExecParams.node_to_cloud_configuration` (optional map, scan-node-id → `TCloudConfiguration`), carried by incremental scan-range requests and by refresh-only requests (empty scan ranges) — both route to the existing `append_incremental_scan_ranges` handler.
- **FE**: `IcebergScanNode` re-vends via a table reload when the credential is within `vended_credential_refresh_window_sec` of expiry (new mutable config, default 3000s — credential delivery happens early in the query while the scan can run much longer), rate-limited with a 30s cooldown and skipping tokens the catalog re-served unchanged. The coordinator attaches refreshed credentials to delivery rounds, and a per-query 60s timer keeps pushing refresh-only requests after delivery drains, so tokens roll for as long as the query runs.
- **BE**: `append_incremental_scan_ranges` applies the refreshed configuration to the matching `HiveDataSourceProvider`; scanners consult it when opening files through a member-lifetime holder (file opens are lazy). Since `HdfsFsCache` keys its handle cache on the token value, a new token transparently yields a fresh filesystem connection — no cache or provider changes needed.

**Validation on a shared-data cluster reading Iceberg via a Polaris REST catalog with credential vending**: the same wide scan that failed at 3m40s (bare) and 13m42s (#76457 only) completes in 33–55 minutes with 16+ mid-query re-vend pushes logged — including runs with incremental delivery disabled, where the timer alone carried the refresh.

Fixes the `AccessToken cannot be null` failure mode on long connector scans.

Known limitation: expiry detection is GCP-only, so AWS/Azure vended credentials are not yet refreshed — see #76598.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5