### PR TITLE
[BugFix] Check L1/L2 key existence for primary-key inserts

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1901,8 +1901,7 @@ Status ShardByLengthMutableIndex::upsert(size_t n, const Slice* keys, const Inde
     return Status::OK();
 }
 
-Status ShardByLengthMutableIndex::insert(size_t n, const Slice* keys, const IndexValue* values,
-                                         std::set<size_t>& check_l1_key_sizes) {
+Status ShardByLengthMutableIndex::insert(size_t n, const Slice* keys, const IndexValue* values) {
     DCHECK(_fixed_key_size != -1);
     if (_fixed_key_size > 0) {
         const auto [shard_offset, shard_size] = _shard_info_by_key_size[_fixed_key_size];
@@ -1910,7 +1909,6 @@ Status ShardByLengthMutableIndex::insert(size_t n, const Slice* keys, const Inde
         for (size_t i = 0; i < shard_size; ++i) {
             RETURN_IF_ERROR(_shards[shard_offset + i]->insert(keys, values, idxes_by_shard[i]));
         }
-        check_l1_key_sizes.insert(shard_offset);
     } else {
         DCHECK(_fixed_key_size == 0);
         const auto* fkeys = reinterpret_cast<const Slice*>(keys);
@@ -3163,21 +3161,27 @@ Status ImmutableIndex::get(size_t n, const Slice* keys, KeysInfo& keys_info, Ind
     return Status::OK();
 }
 
-Status ImmutableIndex::check_not_exist(size_t n, const Slice* keys, size_t key_size) {
-    auto iter = _shard_info_by_length.find(key_size);
-    if (iter == _shard_info_by_length.end()) {
-        return Status::OK();
-    }
-    const auto [shard_off, nshard] = iter->second;
-    uint32_t shard_bits = log2(nshard);
-    std::vector<KeysInfo> keys_info_by_shard(nshard);
-    for (size_t i = 0; i < n; i++) {
-        IndexHash h(key_index_hash(keys[i].data, keys[i].size));
-        auto shard = h.shard(shard_bits);
-        keys_info_by_shard[shard].key_infos.emplace_back(i, h.hash);
-    }
-    for (size_t i = 0; i < nshard; i++) {
-        RETURN_IF_ERROR(_check_not_exist_in_shard(shard_off + i, n, keys, keys_info_by_shard[i]));
+Status ImmutableIndex::check_not_exist(size_t n, const Slice* keys) {
+    for (const auto& [key_size, shard_info] : _shard_info_by_length) {
+        const auto [shard_off, nshard] = shard_info;
+        uint32_t shard_bits = log2(nshard);
+        std::vector<KeysInfo> keys_info_by_shard(nshard);
+        for (size_t i = 0; i < n; i++) {
+            // A fixed-size shard (key_size != 0) stores keys of exactly |key_size| bytes and
+            // compares them with a raw memcmp of |key_size| bytes, so probing a key of a different
+            // length would read past the key buffer and could report a false "already exist"; skip
+            // those. The var-len shard (key_size == 0) verifies the full key length itself, so any
+            // key is safe to probe there.
+            if (key_size != 0 && keys[i].size != key_size) {
+                continue;
+            }
+            IndexHash h(key_index_hash(keys[i].data, keys[i].size));
+            auto shard = h.shard(shard_bits);
+            keys_info_by_shard[shard].key_infos.emplace_back(i, h.hash);
+        }
+        for (size_t i = 0; i < nshard; i++) {
+            RETURN_IF_ERROR(_check_not_exist_in_shard(shard_off + i, n, keys, keys_info_by_shard[i]));
+        }
     }
     return Status::OK();
 }
@@ -4125,25 +4129,18 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
 }
 
 Status PersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* values, bool check_l1) {
-    std::set<size_t> check_l1_l2_key_sizes;
-    RETURN_IF_ERROR(_l0->insert(n, keys, values, check_l1_l2_key_sizes));
+    RETURN_IF_ERROR(_l0->insert(n, keys, values));
     if (!_l1_vec.empty()) {
         int end_idx = _has_l1 ? 1 : 0;
         for (int i = _l1_vec.size() - 1; i >= end_idx; i--) {
-            for (const auto check_l1_l2_key_size : check_l1_l2_key_sizes) {
-                RETURN_IF_ERROR(_l1_vec[i]->check_not_exist(n, keys, check_l1_l2_key_size));
-            }
+            RETURN_IF_ERROR(_l1_vec[i]->check_not_exist(n, keys));
         }
     }
     if (_has_l1 && check_l1) {
-        for (const auto check_l1_l2_key_size : check_l1_l2_key_sizes) {
-            RETURN_IF_ERROR(_l1_vec[0]->check_not_exist(n, keys, check_l1_l2_key_size));
-        }
+        RETURN_IF_ERROR(_l1_vec[0]->check_not_exist(n, keys));
     }
     for (int i = _l2_vec.size() - 1; i >= 0; i--) {
-        for (const auto check_l1_l2_key_size : check_l1_l2_key_sizes) {
-            RETURN_IF_ERROR(_l2_vec[i]->check_not_exist(n, keys, check_l1_l2_key_size));
-        }
+        RETURN_IF_ERROR(_l2_vec[i]->check_not_exist(n, keys));
     }
     std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kFixedMaxKeySize + 1,
                                                                 std::pair<int64_t, int64_t>(0, 0));

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -352,8 +352,7 @@ public:
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
     // |values|: value array
-    // |check_l1_key_sizes|: a set of key size need to be checked in l1.
-    Status insert(size_t n, const Slice* keys, const IndexValue* values, std::set<size_t>& check_l1_key_sizes);
+    Status insert(size_t n, const Slice* keys, const IndexValue* values);
 
     // batch erase(delete)
     // |n|: size of key/value array
@@ -452,8 +451,9 @@ public:
     Status get(size_t n, const Slice* keys, KeysInfo& keys_info, IndexValue* values, KeysInfo* found_keys_info,
                size_t key_size, IOStat* stat = nullptr);
 
-    // batch check key existence
-    Status check_not_exist(size_t n, const Slice* keys, size_t key_size);
+    // batch check that none of |keys| already exist in this immutable index. Keys are grouped
+    // internally by the index's own shard layout (_shard_info_by_length)
+    Status check_not_exist(size_t n, const Slice* keys);
 
     // get Immutable index file size;
     uint64_t file_size() {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -656,6 +656,149 @@ TEST_P(PersistentIndexTest, test_fixlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
+// Regression test: PersistentIndex::insert(check_l1=true) must reject fixed-size keys that already
+// live in L1. This used to be silently skipped -- the L1/L2 existence check was driven off a wrong
+// (offset-based) key size that never matched the length-keyed immutable shard info, so it always
+// returned OK.
+TEST_P(PersistentIndexTest, test_insert_existing_key_in_l1) {
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_insert_existing_key_in_l1";
+    const std::string kIndexFile = kPersistentIndexDir + "/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    int64_t old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10240; // force an L0 -> L1 flush
+    DeferOp defer([&]() {
+        config::l0_max_mem_usage = old_val;
+        (void)fs::remove_all(kPersistentIndexDir);
+    });
+
+    using Key = uint64_t;
+    const int N = 10000;
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values(N);
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+        values[i] = i * 2;
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(Key));
+    }
+
+    { // create empty l0 index file
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    PersistentIndexMetaPB index_meta;
+    EditVersion version(0, 0);
+    index_meta.set_key_size(sizeof(Key));
+    index_meta.set_size(0);
+    version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+    l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_5);
+    version.to_pb(snapshot_meta->mutable_version());
+
+    PersistentIndex index(kPersistentIndexDir);
+    ASSERT_OK(index.load(index_meta));
+
+    // upsert all keys and flush them down into L1
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+    ASSERT_OK(index.prepare(EditVersion(1, 0), N));
+    ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
+    ASSERT_OK(index.commit(&index_meta));
+    ASSERT_OK(index.on_commited());
+
+    // The keys now live in L1 and L0 is empty. insert()-ing the same keys with
+    // check_l1=true must be rejected because they already exist in L1.
+    const int dup_n = 100;
+    ASSERT_OK(index.prepare(EditVersion(2, 0), dup_n));
+    auto st = index.insert(dup_n, key_slices.data(), values.data(), true);
+    // Correct behavior: AlreadyExist. With the bug this returns OK.
+    ASSERT_TRUE(st.is_already_exist()) << "insert() should reject keys already present in L1, but got: " << st;
+}
+
+// Regression test for the var-len side of the same bug: the L1/L2 existence check used to be skipped
+// entirely for var-len primary keys (_fixed_key_size == 0). The keys here span a range of lengths
+// (including > kSliceMaxFixLength) so both the fixlen and var-len immutable shards are exercised.
+TEST_P(PersistentIndexTest, test_insert_existing_varlen_key_in_l1) {
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_insert_existing_varlen_key_in_l1";
+    const std::string kIndexFile = kPersistentIndexDir + "/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    int64_t old_val = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10240; // force an L0 -> L1 flush
+    DeferOp defer([&]() {
+        config::l0_max_mem_usage = old_val;
+        (void)fs::remove_all(kPersistentIndexDir);
+    });
+
+    const int N = 10000;
+    // Mixed-length keys: (i % 100 + 1) filler chars plus a unique numeric suffix, so lengths span
+    // ~1..100 bytes and cross kSliceMaxFixLength (64). The numeric suffix keeps every key unique.
+    auto make_key = [](char filler, int i) { return std::string(i % 100 + 1, filler) + std::to_string(i); };
+
+    std::vector<std::string> keys(N);
+    std::vector<Slice> key_slices;
+    std::vector<IndexValue> values(N);
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = make_key('a', i);
+        values[i] = i * 2;
+        key_slices.emplace_back(keys[i].data(), keys[i].size());
+    }
+
+    { // create empty l0 index file
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    PersistentIndexMetaPB index_meta;
+    EditVersion version(0, 0);
+    index_meta.set_key_size(0); // var-len
+    index_meta.set_size(0);
+    version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+    l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_5);
+    version.to_pb(snapshot_meta->mutable_version());
+
+    PersistentIndex index(kPersistentIndexDir);
+    ASSERT_OK(index.load(index_meta));
+
+    // upsert all keys and flush them down into L1
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+    ASSERT_OK(index.prepare(EditVersion(1, 0), N));
+    ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
+    ASSERT_OK(index.commit(&index_meta));
+    ASSERT_OK(index.on_commited());
+
+    // Brand-new keys (different filler) of the same mixed lengths must be accepted -- they do not
+    // exist in L1. This also guards against probing a key against a wrong-length fixlen shard.
+    const int new_n = 1000;
+    std::vector<std::string> new_keys(new_n);
+    std::vector<Slice> new_key_slices;
+    std::vector<IndexValue> new_values(new_n);
+    new_key_slices.reserve(new_n);
+    for (int i = 0; i < new_n; i++) {
+        new_keys[i] = make_key('b', i);
+        new_values[i] = i;
+        new_key_slices.emplace_back(new_keys[i].data(), new_keys[i].size());
+    }
+    ASSERT_OK(index.prepare(EditVersion(2, 0), new_n));
+    ASSERT_OK(index.insert(new_n, new_key_slices.data(), new_values.data(), true));
+
+    // Re-inserting keys that already live in L1 with check_l1=true must be rejected.
+    const int dup_n = 100;
+    ASSERT_OK(index.prepare(EditVersion(3, 0), dup_n));
+    auto st = index.insert(dup_n, key_slices.data(), values.data(), true);
+    ASSERT_TRUE(st.is_already_exist()) << "insert() should reject var-len keys already present in L1, but got: " << st;
+}
+
 TEST_P(PersistentIndexTest, test_l0_max_file_size) {
     int64_t l0_max_file_size = config::l0_max_file_size;
     config::l0_max_file_size = 200000;
@@ -1354,7 +1497,7 @@ TEST_P(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     for (size_t i = 0; i < N; i++) {
         ASSERT_EQ(values[i], get_values[i]);
     }
-    ASSERT_TRUE(idx_loaded->check_not_exist(N, key_slices.data(), sizeof(Key)).is_already_exist());
+    ASSERT_TRUE(idx_loaded->check_not_exist(N, key_slices.data()).is_already_exist());
 
     vector<Key> check_not_exist_keys(10);
     vector<Slice> check_not_exist_key_slices(10);
@@ -1362,7 +1505,7 @@ TEST_P(PersistentIndexTest, test_flush_fixlen_to_immutable) {
         check_not_exist_keys[i] = N + i;
         check_not_exist_key_slices[i] = Slice((uint8_t*)(&check_not_exist_keys[i]), sizeof(Key));
     }
-    ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_key_slices.data(), sizeof(Key)).ok());
+    ASSERT_TRUE(idx_loaded->check_not_exist(10, check_not_exist_key_slices.data()).ok());
     ASSERT_TRUE(fs::remove_all("./index.l1.1.1").ok());
 }
 
@@ -1415,9 +1558,9 @@ TEST_P(PersistentIndexTest, test_flush_varlen_to_immutable) {
         ASSERT_EQ(values[i], get_values[i]);
     }
 
-    auto st_check = idx_loaded->check_not_exist(N, keys_slice.data(), 0);
+    auto st_check = idx_loaded->check_not_exist(N, keys_slice.data());
     LOG(WARNING) << "check status is " << st_check;
-    ASSERT_TRUE(idx_loaded->check_not_exist(N, keys_slice.data(), 0).is_already_exist());
+    ASSERT_TRUE(idx_loaded->check_not_exist(N, keys_slice.data()).is_already_exist());
 
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }


### PR DESCRIPTION
## Why I'm doing:

`PersistentIndex::insert(check_l1=true)` is supposed to reject keys that already
exist in L1/L2, but that check was silently skipped:

- `ShardByLengthMutableIndex::insert` recorded the shard **offset** (always `0`
  for fixed-size keys) into `check_l1_key_sizes` instead of the key length, and
  recorded **nothing at all** for var-len keys (`_fixed_key_size == 0`).
- `ImmutableIndex::check_not_exist` then looked the value up in
  `_shard_info_by_length`, which is keyed by key **length**. `find(0)` never
  matched a fixed-size index, and var-len keys were never checked, so the "key
  must not already exist" guard always returned OK.

## What I'm doing:

Make `ImmutableIndex::check_not_exist` self-contained: it iterates the index's
own `_shard_info_by_length` and probes each shard group with the matching keys,
instead of relying on a key size supplied by the caller.

- A fixed-size shard (`key_size != 0`) stores keys of exactly `key_size` bytes
  and compares them with a raw `memcmp` of `key_size` bytes, so only keys of that
  exact length are probed there — otherwise a shorter key would be read past its
  buffer and could report a false "already exist".
- The var-len shard (`key_size == 0`) verifies the full key length itself, so any
  key is safe to probe there.

This removes the redundant key-size plumbing from `insert()` / `check_not_exist()`
and makes the check correct for both fixed-size and var-len primary keys.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

> The L1/L2 existence check is now actually enforced, so an `insert(check_l1=true)`
> that previously slipped a duplicate key through will now correctly return
> `AlreadyExist`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
