### PR TITLE
[BugFix] Skip non-extended access paths when extending meta-scan tablet schema

### DIFF
--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -86,6 +86,14 @@ Status OlapMetaScanner::_init_meta_reader_params() {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*_reader_params.tablet_schema);
         int field_number = starrocks::next_uniq_id(_parent->_meta_scan_node);
         for (auto& path : _parent->_column_access_paths) {
+            // Only JSONV2 extended paths become synthetic tablet columns here, and they are always
+            // linear (one subfield per path). Non-extended paths (e.g. cbo_prune_subfield's merged
+            // multi-child subfield tree) are consumed by the reader's leaf iterator, not the schema;
+            // linear_path() below assumes a single-child chain and crashes on a multi-child tree.
+            // Skip them, consistent with extend_schema_by_access_paths().
+            if (!path->is_extended()) {
+                continue;
+            }
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
 

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -62,6 +62,12 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*base_schema);
         int field_number = read_params.next_uniq_id;
         for (auto& path : *read_params.column_access_paths) {
+            // See olap_meta_scanner: only JSONV2 extended (linear) paths become synthetic tablet
+            // columns; skip non-extended cbo_prune_subfield multi-child trees, which linear_path()
+            // cannot handle and which the reader consumes via its leaf iterator instead.
+            if (!path->is_extended()) {
+                continue;
+            }
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
 

--- a/test/sql/test_json/R/test_meta_scan_json_multi_subfield
+++ b/test/sql/test_json/R/test_meta_scan_json_multi_subfield
@@ -1,0 +1,45 @@
+-- name: test_meta_scan_json_multi_subfield
+drop database if exists test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+create database test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+use test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+set cbo_prune_subfield = true;
+-- result:
+-- !result
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b
+FROM t [_META_];
+-- result:
+None	None
+-- !result
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b,
+       length(dict_merge(get_json_string(fields, 'title'), 255)) c
+FROM t [_META_];
+-- result:
+None	None	None
+-- !result
+drop database test_meta_scan_json_multi_subfield;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_meta_scan_json_multi_subfield
+++ b/test/sql/test_json/T/test_meta_scan_json_multi_subfield
@@ -1,0 +1,39 @@
+-- name: test_meta_scan_json_multi_subfield
+-- Regression for the meta-scan multi-child access-path crash: a dict_merge([_META_]) meta scan
+-- over >=2 subfields of the SAME json column makes cbo_prune_subfield build one merged multi-child
+-- access path (json_col -> {a, b}). The meta scanner used to feed every access path through
+-- ColumnAccessPath::linear_path(), which assumes a single-child chain and aborted the BE
+-- (column_access_path.cpp: Check failed: iter->_children.size() <= 1) / silently produced a wrong
+-- path in release. The meta scanner must skip non-extended paths (consumed by the reader's leaf
+-- iterator, not the schema), matching extend_schema_by_access_paths(). This is independent of
+-- subfield-name case (json_v2 rewrite is off here), so it isolates the meta-scan fix.
+drop database if exists test_meta_scan_json_multi_subfield;
+create database test_meta_scan_json_multi_subfield;
+use test_meta_scan_json_multi_subfield;
+
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}'));
+
+set cbo_json_v2_rewrite = false;
+set cbo_prune_subfield = true;
+
+-- Two subfields of one json column through a meta scan: previously aborted the BE, must now complete.
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b
+FROM t [_META_];
+
+-- Three subfields (still a multi-child tree): must also complete.
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b,
+       length(dict_merge(get_json_string(fields, 'title'), 255)) c
+FROM t [_META_];
+
+drop database test_meta_scan_json_multi_subfield;


### PR DESCRIPTION
## Why I'm doing:

The meta scanners (OlapMetaScanner and LakeMetaReader) build synthetic "extended" tablet columns from the scan's column access paths, naming each column via ColumnAccessPath::linear_path(). linear_path() assumes a linear (single-child) chain and DCHECKs iter->_children.size() <= 1.

However, _column_access_paths can also carry NON-extended paths produced by cbo_prune_subfield, which merges multiple subfields of one JSON column into a single multi-child tree (e.g. fields -> {Campaign, campaign}). Iterating those through linear_path() aborts the BE (column_access_path.cpp: Check failed: iter->_children.size() <= 1) in debug, and silently produces a wrong path (only the first child) in release. Reachable via dict_merge([_META_]) / meta-scan dict collection over a JSON column with >=2 requested subfields; independent of subfield-name case.

The data-scan path already avoids this: extend_schema_by_access_paths() only extends for is_extended() paths and skips the rest (they are consumed by the reader's leaf iterator, not the schema). Apply the same guard in the two meta scanners: skip non-extended paths before calling linear_path().

Test: test/sql/test_json/test_meta_scan_json_multi_subfield runs dict_merge([_META_]) over 2 and 3 subfields of one JSON column with cbo_prune_subfield on; before the fix this aborted the BE, now it completes.

Verified on an ASan build: previously-crashing dict_merge([_META_]) queries now complete without aborting; a non-colliding pushdown meta scan still works.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
