### PR TITLE
[BugFix] Skip non-extended access paths when extending meta-scan tabl…

### DIFF
--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -86,6 +86,14 @@ Status OlapMetaScanner::_init_meta_reader_params() {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*_reader_params.tablet_schema);
         int field_number = starrocks::next_uniq_id(_parent->_meta_scan_node);
         for (auto& path : _parent->_column_access_paths) {
+            // Only JSONV2 extended paths become synthetic tablet columns here, and they are always
+            // linear (one subfield per path). Non-extended paths (e.g. cbo_prune_subfield's merged
+            // multi-child subfield tree) are consumed by the reader's leaf iterator, not the schema;
+            // linear_path() below assumes a single-child chain and crashes on a multi-child tree.
+            // Skip them, consistent with extend_schema_by_access_paths().
+            if (!path->is_extended()) {
+                continue;
+            }
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
 

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -62,6 +62,12 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*base_schema);
         int field_number = read_params.next_uniq_id;
         for (auto& path : *read_params.column_access_paths) {
+            // See olap_meta_scanner: only JSONV2 extended (linear) paths become synthetic tablet
+            // columns; skip non-extended cbo_prune_subfield multi-child trees, which linear_path()
+            // cannot handle and which the reader consumes via its leaf iterator instead.
+            if (!path->is_extended()) {
+                continue;
+            }
             int root_column_index = tmp_schema->field_index(path->path());
             RETURN_IF(root_column_index < 0, Status::RuntimeError("unknown access path: " + path->path()));
 

--- a/test/sql/test_json/R/test_meta_scan_json_multi_subfield
+++ b/test/sql/test_json/R/test_meta_scan_json_multi_subfield
@@ -1,0 +1,45 @@
+-- name: test_meta_scan_json_multi_subfield
+drop database if exists test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+create database test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+use test_meta_scan_json_multi_subfield;
+-- result:
+-- !result
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+set cbo_prune_subfield = true;
+-- result:
+-- !result
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b
+FROM t [_META_];
+-- result:
+None	None
+-- !result
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b,
+       length(dict_merge(get_json_string(fields, 'title'), 255)) c
+FROM t [_META_];
+-- result:
+None	None	None
+-- !result
+drop database test_meta_scan_json_multi_subfield;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_meta_scan_json_multi_subfield
+++ b/test/sql/test_json/T/test_meta_scan_json_multi_subfield
@@ -1,0 +1,39 @@
+-- name: test_meta_scan_json_multi_subfield
+-- Regression for the meta-scan multi-child access-path crash: a dict_merge([_META_]) meta scan
+-- over >=2 subfields of the SAME json column makes cbo_prune_subfield build one merged multi-child
+-- access path (json_col -> {a, b}). The meta scanner used to feed every access path through
+-- ColumnAccessPath::linear_path(), which assumes a single-child chain and aborted the BE
+-- (column_access_path.cpp: Check failed: iter->_children.size() <= 1) / silently produced a wrong
+-- path in release. The meta scanner must skip non-extended paths (consumed by the reader's leaf
+-- iterator, not the schema), matching extend_schema_by_access_paths(). This is independent of
+-- subfield-name case (json_v2 rewrite is off here), so it isolates the meta-scan fix.
+drop database if exists test_meta_scan_json_multi_subfield;
+create database test_meta_scan_json_multi_subfield;
+use test_meta_scan_json_multi_subfield;
+
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}'));
+
+set cbo_json_v2_rewrite = false;
+set cbo_prune_subfield = true;
+
+-- Two subfields of one json column through a meta scan: previously aborted the BE, must now complete.
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b
+FROM t [_META_];
+
+-- Three subfields (still a multi-child tree): must also complete.
+SELECT length(dict_merge(get_json_string(fields, 'Campaign'), 255)) a,
+       length(dict_merge(get_json_string(fields, 'campaign'), 255)) b,
+       length(dict_merge(get_json_string(fields, 'title'), 255)) c
+FROM t [_META_];
+
+drop database test_meta_scan_json_multi_subfield;


### PR DESCRIPTION
## Why I'm doing:

JSON object keys are case-sensitive, so get_json_string(c, 'Campaign') and get_json_string(c, 'campaign') address two distinct fields with distinct values. JsonPathRewriteRule (cbo_json_v2_rewrite, default on) materializes each subfield as an extended Column whose name is the subfield path. Those names, however, are keyed through Table.nameToColumn -- a case-insensitive map -- and through every downstream name-based lookup (global dict in DecodeCollector/AddDecodeNodeForDictStringRule, min/max stats in ApplyMinMaxStatisticRule). Two case-differing subfields of the same column therefore collapse onto one column: the scan emits a duplicate access path (e.g. /c/Campaign twice, /c/campaign dropped) and returns a chunk whose columns have mismatched row counts. On a release build this reaches BinaryColumnBase::append (chunk accumulation) or ::filter_range (predicate filter) and reads out of bounds -> CN SIGSEGV; global-dict aggregation instead fails with "Dict Decode failed, Dict can't take cover all key".

Fix: detect the case-collision in a side-effect-free pre-pass and skip the JSONV2 path rewrite for that scan, reading the JSON column whole (identical to running with cbo_json_v2_rewrite=false). Only the rare colliding query loses the subfield-pushdown optimization; non-colliding queries are unaffected. The check must run before any extended column is created, because a partially-applied rewrite leaves dangling column refs that break later statistics derivation.

Tests:
- JsonPathRewriteTest.testCaseCollidingJsonSubfieldsFallBack: a colliding query has no ExtendedColumnAccessPath and leaves get_json_string unrewritten, while a non-colliding query in the same shape is still pushed down.
- test/sql/test_json/test_json_subfield_case_collision: end-to-end regression over a JSON column with the Campaign/campaign case pair, asserting distinct values and no crash/dict failure under the default (rewrite + dict-opt) session.

## What I'm doing:

Fixes #issue


```
I20260720 06:16:21.839099 139898394305344 starrocks_main.cpp:201] file system provider registry init successfully
Built on a system without sched_getcpu() support. Performance may be impacted.F20260720 06:18:05.875302 139891042170560 column_access_path.cpp:177] Check failed: iter->_children. size() <= 1 
asan ASAN (build 35c68c6 distro ubuntu arch x86_64)
query_id:019f7e2c-b053-7f57-9143-c6557a984c38, fragment_instance:019f7e2c-b053-7f57-9143-c6557a984c3a, plan_node_id:-1
[1784528285.875][thread: 139891042170560] je_mallctl execute purge success
[1784528285.875][thread: 139891042170560] je_mallctl execute dontdump success
*** Aborted at 1784528285 (unix time) try "date -d @1784528285" if you are using GNU date ***
PC: @     0x7f3ca24deb2c pthread_kill
*** SIGABRT (@0x9fd15) received by PID 654613 (TID 0x7f3aebe036c0) LWP(655056) from PID 654613; stack trace: ***
    @         0x33b4d307 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f3ca24e1ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33b4cb06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f3ca2485330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f3ca24deb2c pthread_kill
    @     0x7f3ca248527e gsignal
    @     0x7f3ca24688ff abort
    @         0x1d830c86 starrocks::failure_function()
    @         0x33b40c1d google::LogMessage::Fail()
    @         0x33b41d04 google::LogMessageFatal::~LogMessageFatal()
    @         0x2e581a06 starrocks::ColumnAccessPath::linear_path[abi:cxx11]() const
    @         0x1facd6a7 starrocks::OlapMetaScanner::_init_meta_reader_params()
    @         0x1facc13e starrocks::OlapMetaScanner::init(starrocks::RuntimeState*, starrocks::MetaScannerParams const&)
    @         0x204bb01c starrocks::pipeline::OlapMetaScanPrepareOperator::_prepare_scan_context(starrocks::RuntimeState*)
    @         0x204b8fed starrocks::pipeline::MetaScanPrepareOperator::prepare(starrocks::RuntimeState*)
    @         0x2458511c starrocks::pipeline::PipelineDriver::prepare(starrocks::RuntimeState*)
    @         0x2456249a starrocks::pipeline::NormalExecutionGroup::prepare_drivers(starrocks::RuntimeState*)::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#1}::operator()(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&) const
    @         0x24562774 auto starrocks::pipeline::for_each_active_driver<starrocks::pipeline::NormalExecutionGroup::prepare_drivers(starrocks::RuntimeState*)::{lambda(std::shared_ptr<starrocks::pipeline::PipelineDriver> const&)#1}>(std::vector<starrocks::pipeline::Pipeline*, std:@
    @         0x245629a7 starrocks::pipeline::NormalExecutionGroup::prepare_drivers(starrocks::RuntimeState*)
    @         0x24609f8c starrocks::pipeline::FragmentContext::prepare_active_drivers()
    @         0x1dcc798e starrocks::orchestration::FragmentExecutor::execute(starrocks::ExecEnv*)
    @         0x1d85b576 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @         0x1d85aeb9 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*)
    @         0x1d850fa0 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @         0x1d85f182 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() @
    @         0x1d87573a void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*@
    @         0x1d8714b0 std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::@
    @         0x1d86a43e std::_Function_handler<void (), starrocks::PInternalServiceImplBase<starrocks::PInternalService>::exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closur@
    @         0x1d6811a2 std::function<void ()>::operator()() const
    @         0x1d67fb15 starrocks::PriorityThreadPool::work_thread(int)
    @         0x1d69a614 void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&)
    @         0x1d69a4cf std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityThread@
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
