### PR TITLE
[BugFix] Skip JSON subfield pushdown when subfield keys collide case-insensitively

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -55,9 +55,12 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -267,6 +270,14 @@ public class JsonPathRewriteRule extends TransformationRule {
         private OptExpression rewriteMetaScan(OptExpression optExpr, Void v) {
             LogicalProjectOperator project = (LogicalProjectOperator) optExpr.getOp();
             LogicalMetaScanOperator metaScan = (LogicalMetaScanOperator) optExpr.inputAt(0).getOp();
+
+            // Skip the JSON-path pushdown when two subfields of the same JSON column collide
+            // case-insensitively (e.g. 'Campaign' vs 'campaign'); see hasCaseCollidingJsonSubfields.
+            if (hasCaseCollidingJsonSubfields(new ArrayList<>(project.getColumnRefMap().values()), columnRefFactory,
+                    null)) {
+                return optExpr;
+            }
+
             LogicalMetaScanOperator.Builder scanBuilder =
                     LogicalMetaScanOperator.builder().withOperator(metaScan);
 
@@ -327,6 +338,20 @@ public class JsonPathRewriteRule extends TransformationRule {
 
         private OptExpression rewriteLogicalScan(OptExpression optExpr, Void v) {
             LogicalScanOperator scanOperator = (LogicalScanOperator) optExpr.getOp();
+
+            // Skip the JSON-path pushdown when two subfields of the same JSON column collide
+            // case-insensitively (e.g. 'Campaign' vs 'campaign'); see hasCaseCollidingJsonSubfields.
+            List<ScalarOperator> jsonRoots = new ArrayList<>();
+            if (scanOperator.getPredicate() != null) {
+                jsonRoots.add(scanOperator.getPredicate());
+            }
+            if (scanOperator.getProjection() != null) {
+                jsonRoots.addAll(scanOperator.getProjection().getColumnRefMap().values());
+            }
+            if (hasCaseCollidingJsonSubfields(jsonRoots, columnRefFactory, scanOperator.getTable())) {
+                return optExpr;
+            }
+
             LogicalScanOperator.Builder builder =
                     (LogicalScanOperator.Builder) OperatorBuilderFactory.build(scanOperator)
                             .withOperator(scanOperator);
@@ -393,6 +418,85 @@ public class JsonPathRewriteRule extends TransformationRule {
             Operator newOp = builder.build();
             return OptExpression.builder().with(optExpr).setOp(newOp).build();
         }
+    }
+
+    /**
+     * Returns true if any JSON column referenced by {@code roots} has two subfields whose access
+     * paths differ only by case, e.g. {@code get_json_string(c,'Campaign')} and
+     * {@code get_json_string(c,'campaign')}.
+     *
+     * <p>JSON object keys are case-sensitive, so these are two distinct fields with distinct values.
+     * The pushdown, however, materializes each as an extended {@link Column} whose name is the
+     * subfield path; those names collide in {@code Table.nameToColumn} (a case-insensitive map) and
+     * in every downstream name-keyed lookup (global-dict, min/max statistics). The result is a scan
+     * chunk with mismatched column row counts (BE crash) or a wrong global-dict mapping ("Dict Decode
+     * failed"). When such a collision is present we skip the rewrite for that scan entirely and let
+     * the query read the JSON column whole (identical to running with cbo_json_v2_rewrite=false),
+     * which is correct — only the (rare) colliding query loses the subfield-pushdown optimization.
+     *
+     * <p>This is a side-effect-free pre-pass: it must run before any extended column is created,
+     * because a partially-applied rewrite leaves dangling column refs that break later stages.
+     */
+    private static boolean hasCaseCollidingJsonSubfields(List<ScalarOperator> roots, ColumnRefFactory factory,
+                                                         Table scanTable) {
+        // key: case-folded extended-column name -> the actual (case-sensitive) name that first claimed it.
+        // Used for collisions WITHIN this scan; cross-scan collisions are caught against the table below.
+        Map<String, String> claimed = Maps.newHashMap();
+        Deque<ScalarOperator> stack = new ArrayDeque<>();
+        for (ScalarOperator root : roots) {
+            if (root != null) {
+                stack.push(root);
+            }
+        }
+        while (!stack.isEmpty()) {
+            ScalarOperator op = stack.pop();
+            for (ScalarOperator child : op.getChildren()) {
+                stack.push(child);
+            }
+            if (!(op instanceof CallOperator call)) {
+                continue;
+            }
+            if (!SUPPORTED_JSON_FUNCTIONS.contains(call.getFnName())
+                    || call.getArguments().size() != 2
+                    || !call.getChild(0).getType().equals(JsonType.JSON)) {
+                continue;
+            }
+            ScalarOperator jsonColumn = call.getArguments().get(0);
+            ScalarOperator pathArg = call.getArguments().get(1);
+            if (!(pathArg instanceof ConstantOperator) || !(jsonColumn instanceof ColumnRefOperator jsonColumnRef)) {
+                continue;
+            }
+            Pair<Table, Column> tableAndColumn = factory.getTableAndColumn(jsonColumnRef);
+            if (tableAndColumn == null) {
+                continue;
+            }
+            List<String> fields = JsonPathExpressionRewriter.parseJsonPath(((ConstantOperator) pathArg).getVarchar());
+            if (fields == null || !JsonPathExpressionRewriter.isValidJsonPath(fields)) {
+                continue;
+            }
+            // The extended column name is the linear path columnId.field1.field2...; build it exactly as
+            // createColumnAccessExpression()/createExtendedColumn() do, so it matches what gets stored.
+            List<String> fullPath = Lists.newArrayList();
+            fullPath.add(tableAndColumn.second.getColumnId().getId());
+            fullPath.addAll(fields);
+            String name = ColumnAccessPath.createLinearPath(fullPath, call.getType()).getLinearPath();
+
+            // (a) collision within this scan: two subfields whose extended-column names differ only by case.
+            String prior = claimed.putIfAbsent(name.toLowerCase(Locale.ROOT), name);
+            if (prior != null && !prior.equals(name)) {
+                return true;
+            }
+            // (b) cross-scan collision: aliases of the same table share one analyzer table copy
+            // (AnalyzerUtils.copyTable), so another scan may already have added a case-differing extended
+            // column (e.g. t1 read j->'Campaign', t2 reads j->'campaign'). createExtendedColumn() would then
+            // reuse that column case-insensitively and emit the wrong path for this scan.
+            Table targetTable = scanTable != null ? scanTable : tableAndColumn.first;
+            Column existing = targetTable.getColumn(name);
+            if (existing != null && !existing.getName().equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static ScalarOperator rewriteScalar(ScalarOperator scalar,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -410,5 +410,50 @@ public class JsonPathRewriteTest extends PlanTestBase {
         }
     }
 
+    /**
+     * JSON object keys are case-sensitive, so get_json_string(j,'Campaign') and
+     * get_json_string(j,'campaign') address two distinct fields. But an extended column's name is the
+     * subfield path, and Table.nameToColumn (plus every downstream name-keyed lookup) is
+     * case-insensitive, so materializing both would collapse them -> a scan chunk with mismatched
+     * column row counts (BE crash) or a wrong global-dict mapping ("Dict Decode failed"). When such a
+     * case-collision is present, JsonPathRewriteRule must skip the pushdown for that scan and read the
+     * JSON column whole. A non-colliding query in the same shape must still be pushed down.
+     */
+    @Test
+    public void testCaseCollidingJsonSubfieldsFallBack() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+
+        starRocksAssert.withTable(
+                "create table json_case_collision (\n" +
+                        "  id int,\n" +
+                        "  j json\n" +
+                        ") properties('replication_num'='1')");
+        try {
+            // Colliding pair 'Campaign' vs 'campaign' -> fall back: no ExtendedColumnAccessPath and the
+            // get_json_string calls are left unrewritten (read the whole JSON column).
+            String collidingSql =
+                    "select get_json_string(j, 'Campaign') a, get_json_string(j, 'campaign') b from json_case_collision";
+            String collidingPlan = getVerboseExplain(collidingSql);
+            assertNotContains(collidingPlan, "ExtendedColumnAccessPath");
+            assertContains(collidingPlan, "get_json_string");
+
+            // Collision only among a subset still aborts the whole scan (a pushed-down subfield path
+            // would prune the JSON column and starve the un-rewritten sibling).
+            String mixedSql = "select get_json_string(j, 'Campaign') a, get_json_string(j, 'campaign') b, "
+                    + "get_json_string(j, 'title') c from json_case_collision";
+            assertNotContains(getVerboseExplain(mixedSql), "ExtendedColumnAccessPath");
+
+            // Control: a non-colliding query in the same shape is still pushed down.
+            String okSql =
+                    "select get_json_string(j, 'Campaign') a, get_json_string(j, 'title') b from json_case_collision";
+            String okPlan = getVerboseExplain(okSql);
+            assertContains(okPlan, "ExtendedColumnAccessPath: [/j(varchar)/Campaign(varchar), /j(varchar)/title(varchar)]");
+        } finally {
+            starRocksAssert.dropTable("json_case_collision");
+        }
+    }
+
 }
 

--- a/test/sql/test_json/R/test_json_subfield_case_collision
+++ b/test/sql/test_json/R/test_json_subfield_case_collision
@@ -1,0 +1,98 @@
+-- name: test_json_subfield_case_collision
+drop database if exists test_json_subfield_case_collision;
+-- result:
+-- !result
+CREATE DATABASE test_json_subfield_case_collision;
+-- result:
+-- !result
+USE test_json_subfield_case_collision;
+-- result:
+-- !result
+CREATE TABLE activity (
+  id bigint,
+  tenant_id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO activity VALUES
+ (1, 1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, 1, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}')),
+ (3, 1, parse_json('{"Campaign":"CapC","title":"t3"}')),
+ (4, 1, parse_json('{"campaign":"lowd"}')),
+ (5, 1, parse_json('{}'));
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+set cbo_json_v2_dict_opt = true;
+-- result:
+-- !result
+SELECT count(get_json_string(fields, 'Campaign')) AS caps_cnt,
+       count(get_json_string(fields, 'campaign')) AS low_cnt,
+       sum(CASE WHEN get_json_string(fields, 'Campaign') = get_json_string(fields, 'campaign')
+                THEN 1 ELSE 0 END) AS eq_cnt
+FROM activity;
+-- result:
+3072	3072	0
+-- !result
+SELECT min(get_json_string(fields, 'Campaign')) AS mn_caps,
+       max(get_json_string(fields, 'Campaign')) AS mx_caps,
+       min(get_json_string(fields, 'campaign')) AS mn_low,
+       max(get_json_string(fields, 'campaign')) AS mx_low
+FROM activity;
+-- result:
+CapA	CapC	lowa	lowd
+-- !result
+SELECT COALESCE(get_json_string(fields, 'Campaign'), get_json_string(fields, 'campaign')) AS c,
+       count(*) AS cnt
+FROM activity
+GROUP BY c
+ORDER BY c;
+-- result:
+None	1024
+CapA	1024
+CapB	1024
+CapC	1024
+lowd	1024
+-- !result
+SELECT count(get_json_string(fields, 'title')) AS t_cnt,
+       count(get_json_string(fields, 'Campaign')) AS caps_cnt,
+       count(get_json_string(fields, 'campaign')) AS low_cnt
+FROM activity;
+-- result:
+3072	3072	3072
+-- !result

--- a/test/sql/test_json/R/test_json_subfield_case_collision_self_join
+++ b/test/sql/test_json/R/test_json_subfield_case_collision_self_join
@@ -1,0 +1,38 @@
+-- name: test_json_subfield_case_collision_self_join
+drop database if exists test_json_subfield_case_collision_self_join;
+-- result:
+-- !result
+create database test_json_subfield_case_collision_self_join;
+-- result:
+-- !result
+use test_json_subfield_case_collision_self_join;
+-- result:
+-- !result
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CAP1","campaign":"low1"}')),
+ (2, parse_json('{"Campaign":"CAP2","campaign":"low2"}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+SELECT t1.id AS id,
+       get_json_string(t1.fields, 'Campaign') AS caps,
+       get_json_string(t2.fields, 'campaign') AS low
+FROM t t1 JOIN t t2 ON t1.id = t2.id
+ORDER BY t1.id;
+-- result:
+1	CAP1	low1
+2	CAP2	low2
+-- !result
+drop database test_json_subfield_case_collision_self_join;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_json_subfield_case_collision
+++ b/test/sql/test_json/T/test_json_subfield_case_collision
@@ -1,0 +1,67 @@
+-- name: test_json_subfield_case_collision
+-- Regression for the JSON subfield case-collision crash: get_json_string(j,'Campaign') and
+-- get_json_string(j,'campaign') address two distinct (case-sensitive) JSON fields. The JSONV2
+-- path-rewrite used to collapse them onto one extended column (case-insensitive Table column map),
+-- producing a scan chunk with mismatched column row counts (CN SIGSEGV) or a wrong global-dict
+-- mapping ("Dict Decode failed"). The rewrite must detect the collision and fall back to reading
+-- the JSON column whole, returning correct distinct values.
+drop database if exists test_json_subfield_case_collision;
+CREATE DATABASE test_json_subfield_case_collision;
+USE test_json_subfield_case_collision;
+
+CREATE TABLE activity (
+  id bigint,
+  tenant_id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO activity VALUES
+ (1, 1, parse_json('{"Campaign":"CapA","campaign":"lowa","title":"t1"}')),
+ (2, 1, parse_json('{"Campaign":"CapB","campaign":"lowb","title":"t2"}')),
+ (3, 1, parse_json('{"Campaign":"CapC","title":"t3"}')),
+ (4, 1, parse_json('{"campaign":"lowd"}')),
+ (5, 1, parse_json('{}'));
+
+-- Amplify past chunk_size (4096) so the buggy plan crosses the chunk append / filter paths.
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+INSERT INTO activity SELECT id, tenant_id, fields FROM activity;
+
+set cbo_json_v2_rewrite = true;
+set cbo_json_v2_dict_opt = true;
+
+-- Distinct values: 'Campaign' (Cap*) and 'campaign' (low*) must never be equal (eq_cnt = 0).
+SELECT count(get_json_string(fields, 'Campaign')) AS caps_cnt,
+       count(get_json_string(fields, 'campaign')) AS low_cnt,
+       sum(CASE WHEN get_json_string(fields, 'Campaign') = get_json_string(fields, 'campaign')
+                THEN 1 ELSE 0 END) AS eq_cnt
+FROM activity;
+
+-- min/max exercises the global-dict path over the colliding pair (previously "Dict Decode failed").
+SELECT min(get_json_string(fields, 'Campaign')) AS mn_caps,
+       max(get_json_string(fields, 'Campaign')) AS mx_caps,
+       min(get_json_string(fields, 'campaign')) AS mn_low,
+       max(get_json_string(fields, 'campaign')) AS mx_low
+FROM activity;
+
+-- GROUP BY on a coalesced subfield expression (dict-triggering aggregation, mirrors the crash query).
+SELECT COALESCE(get_json_string(fields, 'Campaign'), get_json_string(fields, 'campaign')) AS c,
+       count(*) AS cnt
+FROM activity
+GROUP BY c
+ORDER BY c;
+
+-- Five distinct subfields including the Campaign/campaign case pair (the original crash trigger).
+SELECT count(get_json_string(fields, 'title')) AS t_cnt,
+       count(get_json_string(fields, 'Campaign')) AS caps_cnt,
+       count(get_json_string(fields, 'campaign')) AS low_cnt
+FROM activity;

--- a/test/sql/test_json/T/test_json_subfield_case_collision_self_join
+++ b/test/sql/test_json/T/test_json_subfield_case_collision_self_join
@@ -1,0 +1,35 @@
+-- name: test_json_subfield_case_collision_self_join
+-- Cross-scan variant of the JSON subfield case-collision: when the same table is scanned twice in
+-- one query (self-join / same base index via aliases), the analyzer reuses ONE copied OlapTable for
+-- both aliases (AnalyzerUtils.copyTable). A per-scan collision check misses a case-differing pair
+-- split across the aliases -- t1 reads fields->'Campaign', t2 reads fields->'campaign'. The first
+-- rewrite adds an extended fields.Campaign column to the shared copy; the second scan then reused it
+-- case-insensitively for fields.campaign and emitted /fields/Campaign for both -> silently wrong
+-- values (Campaign extraction returns the campaign value, or vice versa). The rewrite must also
+-- detect collisions against the shared table's already-added extended columns and fall back.
+drop database if exists test_json_subfield_case_collision_self_join;
+create database test_json_subfield_case_collision_self_join;
+use test_json_subfield_case_collision_self_join;
+
+CREATE TABLE t (
+  id bigint,
+  fields json
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO t VALUES
+ (1, parse_json('{"Campaign":"CAP1","campaign":"low1"}')),
+ (2, parse_json('{"Campaign":"CAP2","campaign":"low2"}'));
+
+set cbo_json_v2_rewrite = true;
+
+-- 'Campaign' (via t1) and 'campaign' (via t2) address two distinct fields and must return their own
+-- values: caps = CAP1/CAP2, low = low1/low2. Before the cross-scan guard, caps came back as low1/low2.
+SELECT t1.id AS id,
+       get_json_string(t1.fields, 'Campaign') AS caps,
+       get_json_string(t2.fields, 'campaign') AS low
+FROM t t1 JOIN t t2 ON t1.id = t2.id
+ORDER BY t1.id;
+
+drop database test_json_subfield_case_collision_self_join;


### PR DESCRIPTION
## Why I'm doing:

JSON object keys are case-sensitive, so get_json_string(c, 'Campaign') and get_json_string(c, 'campaign') address two distinct fields with distinct values. JsonPathRewriteRule (cbo_json_v2_rewrite, default on) materializes each subfield as an extended Column whose name is the subfield path. Those names, however, are keyed through Table.nameToColumn -- a case-insensitive map -- and through every downstream name-based lookup (global dict in DecodeCollector/AddDecodeNodeForDictStringRule, min/max stats in ApplyMinMaxStatisticRule). Two case-differing subfields of the same column therefore collapse onto one column: the scan emits a duplicate access path (e.g. /c/Campaign twice, /c/campaign dropped) and returns a chunk whose columns have mismatched row counts. On a release build this reaches BinaryColumnBase::append (chunk accumulation) or ::filter_range (predicate filter) and reads out of bounds -> CN SIGSEGV; global-dict aggregation instead fails with "Dict Decode failed, Dict can't take cover all key".

Fix: detect the case-collision in a side-effect-free pre-pass and skip the JSONV2 path rewrite for that scan, reading the JSON column whole (identical to running with cbo_json_v2_rewrite=false). Only the rare colliding query loses the subfield-pushdown optimization; non-colliding queries are unaffected. The check must run before any extended column is created, because a partially-applied rewrite leaves dangling column refs that break later statistics derivation.


## What I'm doing:

```
F20260720 02:19:57.557758 140242326341312 chunk.cpp:437] Check failed: num_rows() == c->size() (2048 vs. 0) F20260720 02:19:57.558782 140242346424000 chunk.cpp:437] Check failed:
 num_rows() == c->size() (4096 vs. 0) 
PC: @     0x7f90594e6b2c pthread_kill
*** SIGABRT (@0x990dc) received by PID 626908 (TID 0x7f8cb87026c0) LWP(627749) from PID 626908; stack trace: ***
    @         0x33b4d307 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f90594e9ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33b4cb06 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f905948d330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f90594e6b2c pthread_kill
    @     0x7f905948d27e gsignal
    @     0x7f90594708ff abort
    @         0x1d830c86 starrocks::failure_function()
    @         0x33b40c1d google::LogMessage::Fail()
    @         0x33b41d04 google::LogMessageFatal::~LogMessageFatal()
    @         0x2e558ad8 starrocks::Chunk::check_or_die()
    @         0x1d9e5f4e starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x239a87bc starrocks::SegmentIteratorWrapper::do_get_next(starrocks::Chunk*)
    @         0x1d9e5f3b starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x24e6fcb4 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x1d9e5f3b starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x22f4b868 starrocks::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x1d9e5f3b starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x2045ee73 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
    @         0x2045d785 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x20418585 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x2042e204 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldCon
text>(starrocks::workgroup::YieldContext&) const
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
