### PR TITLE
[Enhancement] reclaim unscheduled timer tasks

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1021,6 +1021,14 @@ CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");
 CONF_Int64(brpc_max_body_size, "2147483648");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED.
 CONF_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
+// brpc TimerThread reclaims unscheduled tasks from its internal min-heap once the
+// heap grows to at least this many tasks (apache/brpc#3384). Larger values keep the
+// sweep rarer at the cost of more transient memory; 0 keeps brpc's built-in default.
+CONF_Int32(brpc_timer_heap_sweep_min_size, "4096");
+// brpc TimerThread wakes up at least this often (in milliseconds) to drain its buckets
+// and sweep unscheduled tasks even when every pending task is far in the future.
+// 0 (default) disables the periodic wakeup and keeps the legacy sleep-until-run_time.
+CONF_Int32(brpc_timer_max_wakeup_interval_ms, "0");
 // brpc connection types, "single", "pooled", "short".
 CONF_String_enum(brpc_connection_type, "single", "single,pooled,short");
 // If the amount of data to be sent by a single channel of brpc exceeds brpc_socket_max_unwritten_bytes

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -77,6 +77,15 @@ DECLARE_bool(socket_keepalive);
 
 } // namespace brpc
 
+namespace bthread {
+
+// Defined in the bundled brpc's timer_thread.cpp (patched in via
+// thirdparty/patches/brpc-1.9.0-timer-reclaim.patch, apache/brpc#3384).
+DECLARE_uint32(brpc_timer_heap_sweep_min_size);
+DECLARE_uint32(brpc_timer_max_wakeup_interval_ms);
+
+} // namespace bthread
+
 namespace starrocks {
 
 StorageEngine* init_storage_engine(RuntimeEnv* runtime_env, std::vector<StorePath> paths, bool as_cn,
@@ -320,6 +329,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     brpc::FLAGS_socket_keepalive = config::brpc_socket_keepalive;
 
     brpc::FLAGS_socket_max_unwritten_bytes = config::brpc_socket_max_unwritten_bytes;
+
+    // Bound the memory held by brpc's TimerThread for unscheduled tasks.
+    bthread::FLAGS_brpc_timer_heap_sweep_min_size = config::brpc_timer_heap_sweep_min_size;
+    bthread::FLAGS_brpc_timer_max_wakeup_interval_ms = config::brpc_timer_max_wakeup_interval_ms;
     auto brpc_server = std::make_unique<brpc::Server>();
 
     auto* load_channel_mgr = data_workflows_env->load_channel_mgr();

--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -303,6 +303,24 @@ This topic introduces the following types of BE configurations:
 - Description: The expire time of bRPC stub cache. The default value is 60 minutes.
 - Introduced in: -
 
+
+### brpc_timer_heap_sweep_min_size
+
+- Default: 4096
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: The bRPC `TimerThread` recycles a timer task's pooled slot only when the task is popped at its run time, so a task unscheduled after being pulled into the thread's internal min-heap lingers there until then. Once the heap holds at least this many tasks, the timer thread sweeps unscheduled tasks out of it to bound the memory they occupy (which otherwise grows to roughly QPS x timeout). Heaps smaller than this never pay the sweep cost. (apache/brpc#3384)
+- Introduced in: -
+
+### brpc_timer_max_wakeup_interval_ms
+
+- Default: 0
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: No
+- Description: The maximum interval at which the bRPC `TimerThread` wakes up to drain its buckets and sweep unscheduled tasks, even when every pending task has a far-future run time. `0` (default) disables the periodic wakeup and keeps the legacy behavior of sleeping until the nearest task's run time. Set a positive value to bound reclaim latency when timers may have far-future deadlines. (apache/brpc#3384)
+- Introduced in: -
 ### compress_rowbatches
 
 - Default: true

--- a/docs/zh/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/BE_parameters/log_server_meta.md
@@ -287,6 +287,24 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：BRPC stub 缓存的过期时间，默认 60 minutes。
 - 引入版本：-
 
+
+### brpc_timer_heap_sweep_min_size
+
+- 默认值：4096
+- 类型：Int
+- 单位：-
+- 是否动态：否
+- 描述：bRPC `TimerThread` 仅在定时任务到达运行时间被弹出时才回收其对象池槽位，因此被拉入内部最小堆后又被取消调度的任务会一直驻留到运行时间。当堆中任务数达到该值后，定时线程会清扫堆中已取消调度的任务，以限制其占用的内存（否则内存约增长到 QPS × 超时时间）。小于该值的堆不会承担清扫开销。（apache/brpc#3384）
+- 引入版本：-
+
+### brpc_timer_max_wakeup_interval_ms
+
+- 默认值：0
+- 类型：Int
+- 单位：毫秒
+- 是否动态：否
+- 描述：bRPC `TimerThread` 至少以该间隔唤醒一次以消费桶并清扫已取消调度的任务，即使所有待处理任务的运行时间都在很久之后。`0`（默认）禁用周期性唤醒，保持睡眠至最近任务运行时间的旧有行为。当定时器可能存在很久之后才到期的任务时，可设置正值以限制回收延迟。（apache/brpc#3384）
+- 引入版本：-
 ### compress_rowbatches
 
 - 默认值：true

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -508,6 +508,8 @@ if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "brpc-1.3.0" ]; then
 fi
 if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "brpc-1.9.0" ]; then
     patch < $TP_PATCH_DIR/brpc-1.9.0.patch
+    # PR apache/brpc#3384: reclaim unscheduled timer tasks (heap sweep + capped wakeup)
+    patch -p1 < $TP_PATCH_DIR/brpc-1.9.0-timer-reclaim.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/brpc-1.9.0-timer-reclaim.patch
+++ b/thirdparty/patches/brpc-1.9.0-timer-reclaim.patch
@@ -1,0 +1,288 @@
+diff --git a/src/bthread/timer_thread.cpp b/src/bthread/timer_thread.cpp
+index 3b2f8a7..b8309d3 100644
+--- a/src/bthread/timer_thread.cpp
++++ b/src/bthread/timer_thread.cpp
+@@ -19,6 +19,7 @@
+ 
+ 
+ #include <queue>                           // heap functions
++#include <gflags/gflags.h>
+ #include "butil/scoped_lock.h"
+ #include "butil/logging.h"
+ #include "butil/third_party/murmurhash3/murmurhash3.h"   // fmix64
+@@ -31,6 +32,31 @@
+ 
+ namespace bthread {
+ 
++// Tasks unscheduled after being pulled into the timer thread's min-heap are
++// only recycled when popped at their run_time, which can be far in the future
++// for large timeouts. To bound the memory they occupy (~ qps * timeout), the
++// timer thread periodically sweeps the heap and drops unscheduled tasks. The
++// sweep only kicks in once the heap grows beyond this size, so that small
++// heaps (where the retained memory is negligible) never pay the O(N) cost.
++DEFINE_uint32(brpc_timer_heap_sweep_min_size, 4096,
++              "The timer thread sweeps unscheduled tasks out of its internal "
++              "heap only when the heap has at least this many tasks");
++
++// The timer thread only consumes buckets and reclaims unscheduled tasks when
++// it wakes up, which normally happens at the nearest task's run_time. If every
++// pending task has a far-future run_time (e.g. minutes away), the thread would
++// sleep that whole time while newly scheduled-then-unscheduled tasks pile up
++// in the buckets, occupying pooled slots for the entire duration. Capping the
++// sleep makes the thread wake up periodically to drain the buckets and sweep
++// the heap, bounding that latency regardless of the timeout distribution.
++// 0 (the default) disables the cap: sleep until the nearest run_time, the
++// legacy behavior. Set it to a positive value to bound reclaim latency when
++// tasks may have far-future run_times.
++DEFINE_uint32(brpc_timer_max_wakeup_interval_ms, 0,
++              "The timer thread wakes up at least this often (in milliseconds) "
++              "to reclaim unscheduled tasks even when all pending tasks are far "
++              "in the future; 0 means no periodic wakeup");
++
+ // Defined in task_control.cpp
+ void run_worker_startfn();
+ 
+@@ -129,6 +155,7 @@ TimerThread::TimerThread()
+     , _buckets(NULL)
+     , _nearest_run_time(std::numeric_limits<int64_t>::max())
+     , _nsignals(0)
++    , _npending(0)
+     , _thread(0) {
+ }
+ 
+@@ -324,6 +351,11 @@ void TimerThread::run() {
+     // min heap of tasks (ordered by run_time)
+     std::vector<Task*> tasks;
+     tasks.reserve(4096);
++    // Heap size at the last sweep. Used to trigger the next sweep only after
++    // the heap has roughly doubled, keeping the amortized cost of sweeping at
++    // O(1) per task. It also follows the heap down when tasks are run, so a
++    // regrowth (e.g. filled with newly-unscheduled tasks) triggers a sweep.
++    size_t last_sweep_size = 0;
+ 
+     // vars
+     size_t nscheduled = 0;
+@@ -366,6 +398,29 @@ void TimerThread::run() {
+             }
+         }
+ 
++        // A task is only checked by try_delete() once, right when it is pulled
++        // out of its bucket. If it gets unscheduled afterwards, it lingers in
++        // the heap (occupying a pooled Task slot) until it is popped at its
++        // run_time. For large timeouts this keeps a lot of dead tasks around.
++        // Sweep them out here. The sweep is gated on the heap having grown to
++        // twice its post-sweep size (and past a minimum), so the O(N) pass is
++        // amortized O(1) per task and small heaps never pay for it.
++        if (tasks.size() >= FLAGS_brpc_timer_heap_sweep_min_size &&
++            tasks.size() >= last_sweep_size * 2) {
++            size_t j = 0;
++            for (size_t i = 0; i < tasks.size(); ++i) {
++                Task* task = tasks[i];
++                if (!task->try_delete()) {  // still scheduled, keep it
++                    tasks[j++] = task;
++                }
++            }
++            if (j != tasks.size()) {
++                tasks.resize(j);
++                std::make_heap(tasks.begin(), tasks.end(), task_greater);
++            }
++            last_sweep_size = tasks.size();
++        }
++
+         bool pull_again = false;
+         while (!tasks.empty()) {
+             Task* task1 = tasks[0];  // the about-to-run task
+@@ -396,10 +451,18 @@ void TimerThread::run() {
+                 ++ntriggered;
+             }
+         }
++        // Publish the heap size before possibly looping back on pull_again,
++        // so the observability counter doesn't go stale during the retry spin.
++        _npending.store((int64_t)tasks.size(), butil::memory_order_relaxed);
+         if (pull_again) {
+             BT_VLOG << "pull again, tasks=" << tasks.size();
+             continue;
+         }
++        // Let the sweep baseline follow the heap down as tasks are run, so
++        // that a heap refilled with (soon unscheduled) tasks is swept again.
++        if (tasks.size() < last_sweep_size) {
++            last_sweep_size = tasks.size();
++        }
+ 
+         // The realtime to wait for.
+         int64_t next_run_time = std::numeric_limits<int64_t>::max();
+@@ -426,7 +489,18 @@ void TimerThread::run() {
+         timespec next_timeout = { 0, 0 };
+         const int64_t now = butil::gettimeofday_us();
+         if (next_run_time != std::numeric_limits<int64_t>::max()) {
+-            next_timeout = butil::microseconds_to_timespec(next_run_time - now);
++            int64_t wait_us = next_run_time - now;
++            // Cap the sleep so we periodically wake up to drain buckets and
++            // sweep the heap even when the nearest task is far in the future.
++            // Note: an empty heap keeps ptimeout NULL (sleep until woken by a
++            // schedule()), which is safe because the first task after the heap
++            // empties is always earlier than _nearest_run_time and wakes us.
++            const int64_t max_wakeup_us =
++                (int64_t)FLAGS_brpc_timer_max_wakeup_interval_ms * 1000;
++            if (max_wakeup_us > 0 && wait_us > max_wakeup_us) {
++                wait_us = max_wakeup_us;
++            }
++            next_timeout = butil::microseconds_to_timespec(wait_us);
+             ptimeout = &next_timeout;
+         }
+         busy_seconds += (now - last_sleep_time) / 1000000.0;
+diff --git a/src/bthread/timer_thread.h b/src/bthread/timer_thread.h
+index 139c2e9..5b7871b 100644
+--- a/src/bthread/timer_thread.h
++++ b/src/bthread/timer_thread.h
+@@ -100,6 +100,10 @@ private:
+     // the futex for wake up timer thread. can't use _nearest_run_time because
+     // it's 64-bit.
+     int _nsignals;
++    // Number of tasks buffered in the internal min-heap, published by the
++    // timer thread each iteration. Not part of the public API; read by unit
++    // tests through the -fno-access-control build flag.
++    butil::atomic<int64_t> _npending;
+     pthread_t _thread;       // all scheduled task will be run on this thread
+ };
+ 
+diff --git a/test/bthread_timer_thread_unittest.cpp b/test/bthread_timer_thread_unittest.cpp
+index 9351fe4..c8d70ce 100644
+--- a/test/bthread_timer_thread_unittest.cpp
++++ b/test/bthread_timer_thread_unittest.cpp
+@@ -17,6 +17,9 @@
+ 
+ #include <gtest/gtest.h>
+ #include <gflags/gflags.h>
++#include <algorithm>
++#include <string>
++#include <vector>
+ #include "bthread/sys_futex.h"
+ #include "bthread/timer_thread.h"
+ #include "bthread/bthread.h"
+@@ -254,4 +257,125 @@ TEST(TimerThreadTest, schedule_and_unschedule_in_task) {
+     keeper5.expect_first_run();
+ }
+ 
++static void noop_routine(void*) {}
++
++// RAII helper: set a gflag for the duration of a test and restore its previous
++// value on scope exit, so tests don't leak configuration into later tests and
++// cause order-dependent failures. Also asserts the flag exists and was set.
++class ScopedFlag {
++public:
++    ScopedFlag(const char* name, const char* value) : _name(name) {
++        EXPECT_TRUE(GFLAGS_NAMESPACE::GetCommandLineOption(name, &_old_value))
++            << "unknown gflag " << name;
++        EXPECT_FALSE(
++            GFLAGS_NAMESPACE::SetCommandLineOption(name, value).empty())
++            << "failed to set gflag " << name << "=" << value;
++    }
++    ~ScopedFlag() {
++        GFLAGS_NAMESPACE::SetCommandLineOption(_name.c_str(), _old_value.c_str());
++    }
++private:
++    std::string _name;
++    std::string _old_value;
++};
++
++// Tasks that are unscheduled after being pulled into the timer thread's
++// internal heap must not stay there (occupying a pooled Task slot) until
++// their run_time. With large timeouts that would let memory grow ~ qps *
++// timeout. The timer thread should sweep them out and keep the heap bounded.
++TEST(TimerThreadTest, sweep_unscheduled_tasks_in_heap) {
++    // Lower the sweep threshold so the test doesn't need a huge heap.
++    ScopedFlag sweep_flag("brpc_timer_heap_sweep_min_size", "512");
++
++    bthread::TimerThread timer_thread;
++    ASSERT_EQ(0, timer_thread.start(NULL));
++
++    // Run far enough in the future that these tasks never fire on their own.
++    const timespec far = butil::seconds_from_now(100000);
++    const size_t kBatch = 2000;
++    const size_t kRounds = 20;
++
++    int64_t max_pending = 0;
++    for (size_t r = 0; r < kRounds; ++r) {
++        std::vector<bthread::TimerThread::TaskId> ids;
++        ids.reserve(kBatch);
++        for (size_t i = 0; i < kBatch; ++i) {
++            ids.push_back(timer_thread.schedule(noop_routine, NULL, far));
++        }
++        // A near-term task forces the timer thread to wake up and consume the
++        // buckets, so the far tasks above land in the heap (alive).
++        timer_thread.schedule(noop_routine, NULL,
++                              butil::milliseconds_from_now(1));
++        usleep(20000);  // let the timer thread consume the buckets
++
++        // Now unschedule the far tasks: they become dead-in-heap, exactly the
++        // case that used to linger until run_time.
++        for (size_t i = 0; i < ids.size(); ++i) {
++            timer_thread.unschedule(ids[i]);
++        }
++        // Another near-term task wakes the timer thread again, triggering the
++        // sweep that reclaims the dead tasks.
++        timer_thread.schedule(noop_routine, NULL,
++                              butil::milliseconds_from_now(1));
++        usleep(20000);
++
++        // Read the internal heap size directly (brpc tests are built with
++        // -fno-access-control, so no public accessor is needed).
++        const int64_t pending =
++            timer_thread._npending.load(butil::memory_order_relaxed);
++        LOG(INFO) << "round=" << r << " pending=" << pending;
++        max_pending = std::max(max_pending, pending);
++    }
++
++    // Without the sweep, pending would grow to ~ kBatch * kRounds (40000).
++    // With it, the heap is bounded by roughly a couple of sweep thresholds.
++    EXPECT_LT(max_pending, (int64_t)(kBatch * kRounds) / 4)
++        << "dead tasks are not being reclaimed from the heap";
++
++    timer_thread.stop_and_join();
++}
++
++// When every pending task is far in the future, the nearest run_time never
++// arrives, so the timer thread used to sleep for the whole duration and never
++// consume the buckets. Tasks scheduled meanwhile (and the slots they occupy)
++// would then be stranded in the buckets until that far deadline. The capped
++// wakeup makes the timer thread wake up periodically to drain the buckets so
++// their tasks are consumed (and, if unscheduled, reclaimed) within the cap
++// rather than after the timeout.
++TEST(TimerThreadTest, periodic_wakeup_drains_buckets) {
++    ScopedFlag wakeup_flag("brpc_timer_max_wakeup_interval_ms", "50");
++
++    bthread::TimerThread timer_thread;
++    ASSERT_EQ(0, timer_thread.start(NULL));
++
++    // Anchor task an hour out: it becomes the nearest task, so the tasks below
++    // (with even later run_times) are never the "earliest" and thus never wake
++    // the timer via schedule() -- only the periodic wakeup can drain them.
++    timer_thread.schedule(noop_routine, NULL, butil::seconds_from_now(3600));
++    usleep(100000);  // let the anchor be consumed into the heap
++    // Only the anchor is in the heap so far.
++    ASSERT_EQ(1, timer_thread._npending.load(butil::memory_order_relaxed));
++
++    // Pile far tasks with strictly-increasing run_times into the buckets. None
++    // of these wake the timer.
++    const int kN = 2000;
++    for (int i = 0; i < kN; ++i) {
++        timer_thread.schedule(noop_routine, NULL,
++                              butil::seconds_from_now(3600 + 1 + i));
++    }
++
++    // Without the periodic wakeup the timer would stay asleep (nearest task is
++    // an hour away) and these would sit in the buckets, unconsumed. With it,
++    // they are pulled into the heap within a few wakeup intervals.
++    usleep(300000);  // several 50ms intervals
++    const int64_t pending =
++        timer_thread._npending.load(butil::memory_order_relaxed);
++    LOG(INFO) << "pending after bucket fill = " << pending << " (scheduled "
++              << kN << " + 1 anchor)";
++    EXPECT_GE(pending, (int64_t)kN)
++        << "buckets were not drained by the periodic wakeup";
++
++    timer_thread.stop_and_join();
++}
++
+ } // end namespace


### PR DESCRIPTION
## Why I'm doing:

Backport apache/brpc#3384 onto the bundled brpc 1.9.0. The brpc TimerThread only recycles a task's pooled slot when the task is popped at its run_time, so tasks unscheduled after being pulled into the internal heap (or piled into the buckets while the thread sleeps on a far-future deadline) keep their slots until run_time. With large timeouts the live Task count grows to ~ qps * timeout.

The patch adds two bounded reclamation paths, both off by default except the heap-sweep size gate:
- Heap sweep past brpc_timer_heap_sweep_min_size (default 4096) once the heap roughly doubles since the last sweep; amortized O(1) per task, unschedule() hot path unchanged.
- Optional periodic wakeup capped at brpc_timer_max_wakeup_interval_ms (default 0 = disabled, legacy behavior) to drain buckets and sweep the heap even when every pending task is far in the future.

The PR was generated against brpc master and does not apply to 1.9.0 (master diverged), so it is rebased to 1.9.0 as thirdparty/patches/brpc-1.9.0-timer-reclaim.patch and applied in download-thirdparty.sh after the existing brpc-1.9.0.patch.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5