### PR TITLE
[BugFix] Fix COUNT(DISTINCT) over-count on Iceberg bucket tables under bucket-aware execution

### DIFF
--- a/be/src/exec/pipeline/pipeline_builder_operators.cpp
+++ b/be/src/exec/pipeline/pipeline_builder_operators.cpp
@@ -263,9 +263,32 @@ OpFactories maybe_interpolate_local_shuffle_exchange(PipelineBuilderContext* con
                                                            source_op->get_bucket_properties());
     }
 
-    return do_maybe_interpolate_local_shuffle_exchange(context, state, plan_node_id, pred_operators,
-                                                       self_partition_exprs_generator(), source_op->partition_type(),
-                                                       source_op->get_bucket_properties());
+    // Self-keys branch: the source declared no stable partition_exprs, so we partition on this
+    // operator's own keys (e.g. the join equi-keys or the group-by keys).
+    //
+    // The source may still carry bucket_properties (a lake bucket(K, N) scan reports its bucket
+    // transform there instead of in partition_exprs). We may reuse them ONLY when the self keys line
+    // up 1:1 with the bucket columns -- i.e. same count. That is the genuine bucket-shuffle case
+    // (e.g. a [BUCKET] join or a GROUP BY exactly on the bucket columns): hashing each self key by
+    // its murmur3 bucket transform keeps the local exchange aligned with the physical bucket layout.
+    //
+    // When the self keys are a strict SUPERSET of the bucket columns (e.g. COUNT(DISTINCT K) over
+    // GROUP BY K, other), reusing bucket_properties is wrong on two counts: (1) the murmur3 path in
+    // ShufflePartitioner indexes bucket_properties by the partition-column count, which is now larger
+    // than the bucket-column count -> out-of-bounds; and (2) it stamps could_local_shuffle=false on
+    // the output (see do_maybe_interpolate_local_shuffle_exchange), falsely telling a downstream
+    // DISTINCT(K) that the data is already partitioned by K when the superset [K, other] has actually
+    // scattered K across drivers -> the DISTINCT skips its own local exchange and over-counts.
+    // Drop bucket_properties in that case; the rows are then hashed by the self keys via the
+    // partition type's normal shuffle hash (CRC32 for BUCKET_SHUFFLE_HASH_PARTITIONED, fnv/xxh3 for
+    // HASH_PARTITIONED -- see ShufflePartitioner::shuffle_channel_ids), matching the native OLAP path
+    // whose source has empty bucket_properties.
+    const auto self_partition_exprs = self_partition_exprs_generator();
+    const auto& bucket_properties = source_op->get_bucket_properties();
+    const bool self_keys_match_buckets = self_partition_exprs.size() == bucket_properties.size();
+    return do_maybe_interpolate_local_shuffle_exchange(
+            context, state, plan_node_id, pred_operators, self_partition_exprs, source_op->partition_type(),
+            self_keys_match_buckets ? bucket_properties : std::vector<TBucketProperty>{});
 }
 
 OpFactories maybe_interpolate_local_bucket_shuffle_exchange(PipelineBuilderContext* context, RuntimeState* state,

--- a/test/sql/test_iceberg/R/test_iceberg_bucket_aware_count_distinct
+++ b/test/sql/test_iceberg/R/test_iceberg_bucket_aware_count_distinct
@@ -1,0 +1,53 @@
+-- name: test_iceberg_bucket_aware_count_distinct
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table t1 (
+  id int,
+  grp int
+)
+partition by bucket(id, 8)
+properties ("file_format"="parquet");
+-- result:
+-- !result
+insert into t1
+select a.generate_series, b.generate_series
+from table(generate_series(1, 1000)) a, table(generate_series(1, 200)) b;
+-- result:
+-- !result
+set pipeline_dop = 8;
+-- result:
+-- !result
+set enable_bucket_aware_execution_on_lake = true;
+-- result:
+-- !result
+select count(distinct id) from (select id, grp, count(*) c from t1 group by id, grp) t;
+-- result:
+1000
+-- !result
+set enable_bucket_aware_execution_on_lake = false;
+-- result:
+-- !result
+select count(distinct id) from (select id, grp, count(*) c from t1 group by id, grp) t;
+-- result:
+1000
+-- !result
+set pipeline_dop = 0;
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_bucket_aware_count_distinct
+++ b/test/sql/test_iceberg/T/test_iceberg_bucket_aware_count_distinct
@@ -1,0 +1,72 @@
+-- name: test_iceberg_bucket_aware_count_distinct
+
+-- Regression for the bucket-aware-execution-on-lake COUNT(DISTINCT) over-count bug.
+--
+-- Plan background (FE), same as the native OLAP path: for an Iceberg table partitioned by
+-- bucket(K, N), the scan output is reported as LOCAL hash-distributed on K
+-- (OutputPropertyDeriver.visitPhysicalIcebergScan). For COUNT(DISTINCT K) over a GROUP BY that is
+-- a *superset* of K (K plus other columns), the optimizer keeps the property as LOCAL(K) through
+-- the inner group-by and drops the reshuffle before the outer DISTINCT(K) (no HASH_PARTITIONED(K)
+-- exchange). This is legitimate on its own -- the native OLAP path produces the same plan.
+--
+-- Root cause (BE): at execution the inner group-by parallelizes with a local shuffle keyed on the
+-- FULL group-by columns (K, grp), which physically SCATTERS K across the pipeline drivers (whenever
+-- a K value has more than one distinct combination of the other group-by columns). On the lake path
+-- the group-by's local exchange carried the scan's bucket_properties, which wrongly marked its
+-- output could_local_shuffle=false, so the outer DISTINCT(K) skipped its own local exchange and
+-- counted each K once per driver it landed on -> COUNT(DISTINCT K) over-counts by roughly the
+-- parallelism. (The native OLAP path is correct only because its scan has empty bucket_properties,
+-- so could_local_shuffle stays true and the DISTINCT interpolates its local exchange on K.)
+--
+-- Fix (BE): in the self-keys local-shuffle branch, pipeline_builder_operators.cpp only reuses the
+-- source's bucket_properties when the self keys line up 1:1 with the bucket columns (the genuine
+-- bucket-shuffle case, e.g. a [BUCKET] join or GROUP BY exactly on the bucket columns). When the
+-- self keys are a strict SUPERSET of the bucket columns (this case: (K, grp) vs bucket column K) it
+-- drops them, so the DISTINCT interpolates a local exchange on K (as the native OLAP path does) and
+-- each K is regrouped onto one driver. The fix is not visible in EXPLAIN (no network exchange
+-- added), so this is a result assertion.
+--
+-- This reproduces on conforming data on a single BE: below, each id has 200 distinct grp
+-- values, true COUNT(DISTINCT id) = 1000, but before the fix bucket-aware ON returns ~pipeline_dop * 1000.
+-- (An earlier version of this case used grp = id % 5, a hidden functional dependency that
+-- collapsed (id,grp) back to id and masked the bug -- keep grp INDEPENDENT of id.)
+
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+create table t1 (
+  id int,
+  grp int
+)
+partition by bucket(id, 8)
+properties ("file_format"="parquet");
+
+-- cartesian product: each id gets 200 distinct grp values (grp independent of id),
+-- so the inner group-by(id,grp) scatters each id across many drivers. true distinct id = 1000.
+insert into t1
+select a.generate_series, b.generate_series
+from table(generate_series(1, 1000)) a, table(generate_series(1, 200)) b;
+
+set pipeline_dop = 8;
+
+-- ############### bucket-aware ON: must return the correct distinct count (1000), not dop*1000 ###############
+set enable_bucket_aware_execution_on_lake = true;
+
+-- end-to-end result: over-counts to ~pipeline_dop*1000 before the fix, 1000 after.
+-- The fix is a BE-side local exchange interpolated before the DISTINCT (not visible in EXPLAIN),
+-- so this is a result assertion rather than a plan assertion.
+select count(distinct id) from (select id, grp, count(*) c from t1 group by id, grp) t;
+
+-- ############### bucket-aware OFF: ground-truth reference ###############
+set enable_bucket_aware_execution_on_lake = false;
+select count(distinct id) from (select id, grp, count(*) c from t1 group by id, grp) t;
+
+-- restore session state so it does not leak into subsequent statements/tests.
+set pipeline_dop = 0;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.t1 force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

On an Iceberg table partitioned by `bucket(K, N)`, enabling
`enable_bucket_aware_execution_on_lake` makes `COUNT(DISTINCT K)` over a
`GROUP BY` that is a *superset* of `K` (i.e. `K` plus other columns) return an
over-count — roughly `true_distinct * pipeline_dop`. A production query on an
8-BE cluster returned 2508 instead of the correct 164.

Root cause is in the BE local-shuffle interpolation:

1. The bucket scan reports a `LOCAL` hash distribution on `K`, so the optimizer
   drops the reshuffle before the outer `DISTINCT(K)` (single fragment, no
   `HASH_PARTITIONED` exchange — the same plan the native OLAP path produces).
2. At execution the inner group-by parallelizes with a local shuffle keyed on
   the full group-by columns `(K, other)`, a strict superset of the bucket
   column, which physically **scatters `K` across pipeline drivers**.
3. On the lake path that local exchange reused the scan's `bucket_properties`,
   which wrongly stamped `could_local_shuffle = false` on its output. The
   downstream `DISTINCT(K)` trusted that it was already partitioned by `K` and
   **skipped its own local exchange**, counting each `K` once per driver it
   landed on.

The native OLAP path is correct only because its scan has empty
`bucket_properties`, so `could_local_shuffle` stays `true` and the `DISTINCT`
interpolates its local exchange on `K`.

## What I'm doing:

In the self-keys branch of `maybe_interpolate_local_shuffle_exchange`
(`pipeline_builder_operators.cpp`), reuse the source's `bucket_properties` only
when the self keys line up 1:1 with the bucket columns — i.e. the same count.
That is the genuine bucket-shuffle case (a `[BUCKET]` join, or a `GROUP BY`
exactly on the bucket columns), where hashing each self key by its murmur3
bucket transform keeps the local exchange aligned with the physical bucket
layout, so those paths keep working unchanged.

When the self keys are a strict **superset** of the bucket columns (e.g.
`COUNT(DISTINCT K)` over `GROUP BY K, other`), drop `bucket_properties`. The rows
are then hashed by the self keys via the partition type's normal shuffle hash
(CRC32 for the `BUCKET_SHUFFLE_HASH_PARTITIONED` scan sources here, fnv/xxh3 for
`HASH_PARTITIONED`), and `could_local_shuffle` stays `true`, so the `DISTINCT`
interpolates its local exchange on `K` and each `K` is regrouped onto one driver
— matching the native OLAP path. This also removes a latent out-of-bounds access
that indexed `bucket_properties` (sized to the bucket columns) by the larger
partition-column count.

Added an Iceberg SQL regression test that reproduces the over-count on
conforming data on a single BE.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
