### PR TITLE
[BugFix] Skip write-triggered auto-refresh for MVs that will not self-heal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobMVListener.java
@@ -24,6 +24,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.DmlType;
 import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.transaction.InsertOverwriteJobStats;
 import com.starrocks.transaction.PartitionCommitInfo;
@@ -166,6 +167,11 @@ public class LoadJobMVListener implements LoadJobListener {
             }
             // It's fine to no lock here, since it's not a critical operation and can be retried.
             if (materializedView.shouldTriggeredRefreshBy(db.getFullName(), table.getName())) {
+                if (!materializedView.isActive()
+                        && MVActiveChecker.isNonAutoActivatableReason(materializedView.getInactiveReason())) {
+                    // Won't self-heal via retry; skip instead of resubmitting a doomed refresh on every write.
+                    continue;
+                }
                 LOG.info("Trigger auto materialized view refresh because of base table {} has changed, " +
                                 "db:{}, mv:{}", table.getName(), mvDb.getFullName(),
                         materializedView.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -129,17 +129,22 @@ public class MVActiveChecker extends LeaderDaemon {
     }
 
     /**
+     * Whether this inactive reason never self-heals via retry (manual inactivation, or one of the
+     * automatic reasons above); callers that would otherwise keep retrying should skip instead.
+     */
+    public static boolean isNonAutoActivatableReason(String reason) {
+        String r = Optional.ofNullable(reason).orElse("");
+        return AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(r)
+                || MV_NO_AUTOMATIC_ACTIVE_REASONS.stream().anyMatch(r::contains);
+    }
+
+    /**
      * @param mv
      * @param checkGracePeriod whether check the grace period, usually background active would check it, but foreground
      *                         job doesn't
      */
     public static void tryToActivate(MaterializedView mv, boolean checkGracePeriod) {
-        // if the mv is set to inactive manually, we don't activate it
-        String reason = Optional.ofNullable(mv.getInactiveReason()).orElse("");
-        if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {
-            return;
-        }
-        if (MV_NO_AUTOMATIC_ACTIVE_REASONS.stream().anyMatch(reason::contains)) {
+        if (mv.isActive() || isNonAutoActivatableReason(mv.getInactiveReason())) {
             return;
         }
 
@@ -160,7 +165,8 @@ public class MVActiveChecker extends LeaderDaemon {
         String mvFullName =
                 new TableName(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME, dbName.get(), mv.getName()).toString();
         String sql = String.format("ALTER MATERIALIZED VIEW %s active", mvFullName);
-        LOG.info("[MVActiveChecker] Start to activate MV {} because of its inactive reason: {}", mvFullName, reason);
+        LOG.info("[MVActiveChecker] Start to activate MV {} because of its inactive reason: {}",
+                mvFullName, mv.getInactiveReason());
         try {
             ConnectContext connect = StatisticUtils.buildConnectContext();
             connect.setStatisticsContext(false);

--- a/fe/fe-core/src/test/java/com/starrocks/listener/LoadJobMVListenerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/listener/LoadJobMVListenerTest.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.listener;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.sql.ast.PartitionRangeDesc;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.util.EitherOr;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LoadJobMVListenerTest extends MVTestBase {
+
+    private static Database getDb() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+    }
+
+    private static Table getBaseTable(String tableName) {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(DB_NAME, tableName);
+    }
+
+    private AtomicInteger mockRefreshCallCount() {
+        AtomicInteger callCount = new AtomicInteger(0);
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public String refreshMaterializedView(String dbName, String mvName, boolean force,
+                                                   EitherOr<PartitionRangeDesc, Set<PListCell>> partitionDesc,
+                                                   int priority, boolean mergeRedundant, boolean isManual) {
+                callCount.incrementAndGet();
+                return null;
+            }
+        };
+        return callCount;
+    }
+
+    @Test
+    public void testSkipsAutoTriggerWhenMvSuspendedByConsecutiveFailures() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE lt_base_t1 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW lt_mv1\n" +
+                "REFRESH ASYNC\n" +
+                "AS select sum(k1), k2, k3 from lt_base_t1 group by k2, k3;");
+        MaterializedView mv = getMv("lt_mv1");
+        mv.setInactiveAndReason(MaterializedViewExceptions.inactiveReasonForConsecutiveFailures(mv.getName()));
+
+        AtomicInteger callCount = mockRefreshCallCount();
+        LoadJobMVListener.INSTANCE.onTableDataChange(getDb(), getBaseTable("lt_base_t1"));
+
+        Assertions.assertEquals(0, callCount.get(),
+                "auto-trigger must not resubmit a refresh for an MV suspended by consecutive failures");
+    }
+
+    @Test
+    public void testStillTriggersForTransientlyInactiveMv() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE lt_base_t2 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW lt_mv2\n" +
+                "REFRESH ASYNC\n" +
+                "AS select sum(k1), k2, k3 from lt_base_t2 group by k2, k3;");
+        MaterializedView mv = getMv("lt_mv2");
+        // A reason that is NOT in MVActiveChecker's non-auto-activatable set -- retry should still
+        // be attempted so a transient breakage keeps self-healing on the next write.
+        mv.setInactiveAndReason("some transient error unrelated to the blocked reasons");
+
+        AtomicInteger callCount = mockRefreshCallCount();
+        LoadJobMVListener.INSTANCE.onTableDataChange(getDb(), getBaseTable("lt_base_t2"));
+
+        Assertions.assertEquals(1, callCount.get(),
+                "auto-trigger must still retry an MV that is inactive for a self-healing reason");
+    }
+
+    @Test
+    public void testStillTriggersForActiveMv() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE lt_base_t3 (\n" +
+                "   k1 int,\n" +
+                "   k2 date,\n" +
+                "   k3 string\n" +
+                ")\n" +
+                "DUPLICATE KEY(k1);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW lt_mv3\n" +
+                "REFRESH ASYNC\n" +
+                "AS select sum(k1), k2, k3 from lt_base_t3 group by k2, k3;");
+
+        AtomicInteger callCount = mockRefreshCallCount();
+        LoadJobMVListener.INSTANCE.onTableDataChange(getDb(), getBaseTable("lt_base_t3"));
+
+        Assertions.assertEquals(1, callCount.get(), "a healthy, active MV must still auto-refresh on write");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`LoadJobMVListener` resubmits a refresh on every write to a base table for any load-triggered (`REFRESH ASYNC`, no interval) MV, with no check on whether the MV's Task has already been suspended or the MV is inactive for a reason that never auto-reactivates (consecutive-failure suspension, a non-append-only base change, base-table optimization, backup/restore, or manual inactivation). Once such an MV is stuck, every subsequent write keeps resubmitting a doomed refresh with no backoff until a human runs `ALTER MATERIALIZED VIEW ... ACTIVE`.

Confirmed live on a cluster: after the underlying cause was fixed, writes kept generating new `FAILED` TaskRuns indefinitely, because the suspended Task's state was never consulted by the auto-trigger path.

## What I'm doing:

Extract the "will this ever self-heal" check that `MVActiveChecker.tryToActivate()` already makes into a reusable `isNonAutoActivatableReason()`, and consult it in `LoadJobMVListener` before resubmitting. This only skips MVs currently inactive for one of the known non-recoverable reasons; MVs inactive for other, transient reasons keep retrying and self-healing as before, and other trigger paths (manual `REFRESH`, periodic scheduling) are unaffected.

Verified live on a cluster:
- an MV suspended by consecutive failures stops regenerating `FAILED` TaskRuns on writes once the root cause is fixed (every write previously produced a new failed run)
- a healthy sibling MV on the same base table is unaffected
- an MV inactive for a non-blocked reason still self-heals on the very next write without ever accumulating 10 failures
- manual `ALTER ... ACTIVE` still recovers a suspended MV as before

Fixes #issue: N/A — found via internal IVM testing, no tracked community issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5