### PR TITLE
[BugFix] Stop pass-through exchange from appending after the receiver is cancelled

### DIFF
--- a/be/src/compute_env/data_stream/data_stream_recvr.cpp
+++ b/be/src/compute_env/data_stream/data_stream_recvr.cpp
@@ -272,6 +272,8 @@ void DataStreamRecvr::remove_sender(int sender_id, int be_number) {
 }
 
 void DataStreamRecvr::cancel_stream() {
+    // Stop the peer sink from appending into the shared pass-through buffer.
+    _pass_through_context.set_cancelled();
     auto notify = this->defer_notify();
     for (auto& _sender_queue : _sender_queues) {
         _sender_queue->cancel();
@@ -283,6 +285,8 @@ void DataStreamRecvr::close() {
     if (_closed) {
         return;
     }
+    // Stop the peer sink from appending into the shared pass-through buffer.
+    _pass_through_context.set_cancelled();
     for (auto& _sender_queue : _sender_queues) {
         _sender_queue->close();
     }

--- a/be/src/compute_env/data_stream/local_pass_through_buffer.cpp
+++ b/be/src/compute_env/data_stream/local_pass_through_buffer.cpp
@@ -59,6 +59,22 @@ public:
         _total_bytes -= _physical_bytes;
         _physical_bytes = 0;
     }
+    // Drop everything buffered without handing it to a consumer. Used when the receiver is
+    // cancelled/closed: nobody will ever pull these chunks, so free them now instead of
+    // holding the memory until query teardown. The accounting mirrors the destructor:
+    // pre-charge the physical bytes to the current MemTracker so the immediate _buffer.clear()
+    // frees net-zero on it, and release them from the global passthrough tracker.
+    void clear() {
+        std::unique_lock lock(_mutex);
+        if (_physical_bytes > 0) {
+            CurrentThread::current().mem_consume(_physical_bytes);
+            RuntimeEnv::GetInstance()->passthrough_mem_tracker()->release(_physical_bytes);
+            _total_bytes -= _physical_bytes;
+            _physical_bytes = 0;
+        }
+        _buffer.clear();
+        _bytes.clear();
+    }
 
 private:
     std::mutex _mutex; // lock-step to push/pull chunks
@@ -91,10 +107,24 @@ public:
 
     int64_t get_total_bytes() const { return _total_bytes; }
 
+    // Marked once the receiver (DataStreamRecvr) is cancelled or closed. The sink and
+    // receiver share the same PassThroughChannel, so this is how the append side learns
+    // that the peer is gone and it should stop buffering chunks. It also drops whatever is
+    // already buffered, since the cancelled receiver will never pull it.
+    void set_cancelled() {
+        _cancelled.store(true, std::memory_order_release);
+        std::unique_lock lock(_mutex);
+        for (auto& [_, sender_channel] : _sender_id_to_channel) {
+            sender_channel->clear();
+        }
+    }
+    bool is_cancelled() const { return _cancelled.load(std::memory_order_acquire); }
+
 private:
     std::mutex _mutex;
     std::unordered_map<int, PassThroughSenderChannel*> _sender_id_to_channel;
     std::atomic_int64_t _total_bytes = 0;
+    std::atomic<bool> _cancelled{false};
 };
 
 PassThroughChunkBuffer::PassThroughChunkBuffer(const TUniqueId& query_id) : _mutex(), _query_id(query_id) {}
@@ -127,6 +157,13 @@ void PassThroughContext::init() {
 }
 
 void PassThroughContext::append_chunk(int sender_id, const Chunk* chunk, size_t chunk_size, int32_t driver_sequence) {
+    // The receiver has been cancelled/closed; drop the chunk instead of buffering it forever.
+    // This mirrors the RPC path, where PipelineSenderQueue::add_chunks returns early once the
+    // receiver queue is cancelled. Without this, the sink keeps cloning chunks into the shared
+    // pass-through buffer that nobody will ever pull, holding the memory until query teardown.
+    if (_channel->is_cancelled()) {
+        return;
+    }
     PassThroughSenderChannel* sender_channel = _channel->get_or_create_sender_channel(sender_id);
     sender_channel->append_chunk(chunk, chunk_size, driver_sequence);
 }
@@ -137,6 +174,14 @@ void PassThroughContext::pull_chunks(int sender_id, ChunkUniquePtrVector* chunks
 
 int64_t PassThroughContext::total_bytes() const {
     return _channel->get_total_bytes();
+}
+
+void PassThroughContext::set_cancelled() {
+    _channel->set_cancelled();
+}
+
+bool PassThroughContext::is_cancelled() const {
+    return _channel->is_cancelled();
 }
 
 void PassThroughChunkBufferManager::open_fragment_instance(const TUniqueId& query_id) {

--- a/be/src/compute_env/data_stream/local_pass_through_buffer.h
+++ b/be/src/compute_env/data_stream/local_pass_through_buffer.h
@@ -66,6 +66,9 @@ public:
     void append_chunk(int sender_id, const Chunk* chunk, size_t chunk_size, int32_t driver_sequence);
     void pull_chunks(int sender_id, ChunkUniquePtrVector* chunks, std::vector<size_t>* bytes);
     int64_t total_bytes() const;
+    // Mark the shared channel cancelled so the sink stops appending; called by the receiver.
+    void set_cancelled();
+    bool is_cancelled() const;
 
 private:
     // hold this chunk buffer to avoid early deallocation.

--- a/test/sql/test_pass_through_exchange/R/test_pass_through_cancel
+++ b/test/sql/test_pass_through_exchange/R/test_pass_through_cancel
@@ -1,0 +1,46 @@
+-- name: test_pass_through_cancel
+create table src (k int, v int) duplicate key(k)
+distributed by hash(k) buckets 8 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into src select generate_series % 1000, generate_series from TABLE(generate_series(1, 200000));
+-- result:
+-- !result
+create table dst (k int, cnt bigint, s bigint) duplicate key(k)
+distributed by hash(k) buckets 8 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into dst select k, count(*), sum(v) from src group by k;
+-- result:
+-- !result
+select count(*) as nkeys, sum(cnt) as nrows, sum(s) as sumv from dst;
+-- result:
+1000	200000	20000100000
+-- !result
+truncate table dst;
+-- result:
+-- !result
+insert into dst
+select a.k, count(*), sum(a.v)
+from src a join [shuffle] (select k, count(v) v from src group by k having count(v) > 999999999) b
+  on a.k = b.k
+group by a.k;
+-- result:
+-- !result
+select count(*) as dst_rows from dst;
+-- result:
+0
+-- !result
+insert into dst select k, count(*), sum(v) from src group by k;
+-- result:
+-- !result
+select count(*) as nkeys, sum(cnt) as nrows, sum(s) as sumv from dst;
+-- result:
+1000	200000	20000100000
+-- !result
+drop table dst;
+-- result:
+-- !result
+drop table src;
+-- result:
+-- !result

--- a/test/sql/test_pass_through_exchange/T/test_pass_through_cancel
+++ b/test/sql/test_pass_through_exchange/T/test_pass_through_cancel
@@ -1,0 +1,35 @@
+-- name: test_pass_through_cancel
+-- Functional smoke test for the local (same-process) pass-through exchange when the
+-- receiver is cancelled. An INSERT ... SELECT over a shuffle join whose build (right)
+-- side is empty ONLY at runtime makes the hash join short-circuit the probe, which
+-- cancels/closes the probe-side pass-through receiver while the sink may still be
+-- feeding. The query must complete cleanly and return the correct (empty) result.
+create table src (k int, v int) duplicate key(k)
+distributed by hash(k) buckets 8 properties("replication_num" = "1");
+
+insert into src select generate_series % 1000, generate_series from TABLE(generate_series(1, 200000));
+
+create table dst (k int, cnt bigint, s bigint) duplicate key(k)
+distributed by hash(k) buckets 8 properties("replication_num" = "1");
+
+-- Shuffle GROUP BY insert flows through the local pass-through exchange; result must be exact.
+insert into dst select k, count(*), sum(v) from src group by k;
+select count(*) as nkeys, sum(cnt) as nrows, sum(s) as sumv from dst;
+
+-- Empty-at-runtime right side (HAVING can never be satisfied). The optimizer keeps a real
+-- partitioned shuffle join (not EMPTYSET / broadcast), so the probe streams through
+-- pass-through until the empty build short-circuits it -> receiver cancel/close.
+truncate table dst;
+insert into dst
+select a.k, count(*), sum(a.v)
+from src a join [shuffle] (select k, count(v) v from src group by k having count(v) > 999999999) b
+  on a.k = b.k
+group by a.k;
+select count(*) as dst_rows from dst;
+
+-- Pass-through path still correct after the short-circuit cancel.
+insert into dst select k, count(*), sum(v) from src group by k;
+select count(*) as nkeys, sum(cnt) as nrows, sum(s) as sumv from dst;
+
+drop table dst;
+drop table src;


### PR DESCRIPTION
## Why I'm doing:

The local (same-process) pass-through exchange had no cancelled/closed state on the append side. Receiver cancellation only set _is_cancelled inside the receiver's SenderQueue, which the sink's append path never consulted. So after the receiver was cancelled or closed, the sink kept cloning chunks into the shared PassThroughSenderChannel buffer that nobody would ever pull, holding the memory until query teardown (unlike the RPC path, which drops dropped-receiver data immediately).

Add a cancelled flag on the shared PassThroughChannel (set by DataStreamRecvr::cancel_stream() and close()), guard PassThroughContext::append_chunk against it, and drop the already-buffered chunks on cancel via PassThroughSenderChannel::clear(), whose memory accounting mirrors the destructor.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
