### PR TITLE
[BugFix] Ignore recycled missing shard groups in meta sync

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -594,7 +594,18 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                     if (redundantGroupToShards.get(groupId) != null) {
                         starmgrShardIdsSet = redundantGroupToShards.get(groupId);
                     } else {
-                        List<Long> starmgrShardIds = starOSAgent.listShard(groupId);
+                        List<Long> starmgrShardIds;
+                        try {
+                            starmgrShardIds = starOSAgent.listShard(groupId);
+                        } catch (DdlException e) {
+                            if (isShardGroupNotExist(e) && table.getPhysicalPartition(physicalPartition.getId()) == null) {
+                                LOG.info("skip syncing removed partition {} shard group {}, because it has been removed " +
+                                                "from StarMgr",
+                                        physicalPartition.getParentId(), groupId);
+                                continue;
+                            }
+                            throw e;
+                        }
                         starmgrShardIdsSet = new HashSet<>(starmgrShardIds);
                     }
 
@@ -647,6 +658,11 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             SHARD_DELETE_COUNTER.increase((long) shardToDelete.size());
         }
         return !shardToDelete.isEmpty();
+    }
+
+    private boolean isShardGroupNotExist(DdlException e) {
+        String message = e.getMessage();
+        return message != null && (message.contains("NOT_EXIST") || message.contains("not exist"));
     }
 
     private void syncTableColocationInfo(Database db, OlapTable table) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -18,8 +18,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.staros.client.StarClientException;
 import com.staros.proto.ShardGroupInfo;
 import com.staros.proto.ShardInfo;
+import com.staros.proto.StatusCode;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -674,8 +676,8 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
     }
 
     private boolean isShardGroupNotExist(DdlException e) {
-        String message = e.getMessage();
-        return message != null && (message.contains("NOT_EXIST") || message.contains("not exist"));
+        return e.getCause() instanceof StarClientException
+                && ((StarClientException) e.getCause()).getCode() == StatusCode.NOT_EXIST;
     }
 
     private void syncTableColocationInfo(Database db, OlapTable table) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -613,7 +613,7 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
                             starmgrShardIds = starOSAgent.listShard(groupId);
                         } catch (DdlException e) {
                             if (isShardGroupNotExist(e) && table.getPhysicalPartition(physicalPartition.getId()) == null) {
-                                LOG.info("skip syncing removed partition {} shard group {}, because it has been removed " +
+                                LOG.debug("skip syncing removed partition {} shard group {}, because it has been removed " +
                                                 "from StarMgr",
                                         physicalPartition.getParentId(), groupId);
                                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -606,7 +606,18 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
                     if (redundantGroupToShards.get(groupId) != null) {
                         starmgrShardIdsSet = redundantGroupToShards.get(groupId);
                     } else {
-                        List<Long> starmgrShardIds = starOSAgent.listShard(groupId);
+                        List<Long> starmgrShardIds;
+                        try {
+                            starmgrShardIds = starOSAgent.listShard(groupId);
+                        } catch (DdlException e) {
+                            if (isShardGroupNotExist(e) && table.getPhysicalPartition(physicalPartition.getId()) == null) {
+                                LOG.info("skip syncing removed partition {} shard group {}, because it has been removed " +
+                                                "from StarMgr",
+                                        physicalPartition.getParentId(), groupId);
+                                continue;
+                            }
+                            throw e;
+                        }
                         starmgrShardIdsSet = new HashSet<>(starmgrShardIds);
                     }
 
@@ -660,6 +671,11 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
             SHARD_DELETE_COUNTER.increase((long) shardToDelete.size());
         }
         return !shardToDelete.isEmpty();
+    }
+
+    private boolean isShardGroupNotExist(DdlException e) {
+        String message = e.getMessage();
+        return message != null && (message.contains("NOT_EXIST") || message.contains("not exist"));
     }
 
     private void syncTableColocationInfo(Database db, OlapTable table) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -817,7 +817,8 @@ public class StarOSAgent {
             shardInfo = client.listShard(serviceId, Arrays.asList(groupId), DEFAULT_WORKER_GROUP_ID,
                                          true /* withoutReplicaInfo */);
         } catch (StarClientException e) {
-            throw new DdlException(String.format("Failed to list shards in group %d. error:%s", groupId, e.getMessage()));
+            throw new DdlException(
+                    String.format("Failed to list shards in group %d. error:%s", groupId, e.getMessage()), e);
         }
         return shardInfo.get(0).stream().map(ShardInfo::getShardId).collect(Collectors.toList());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -419,6 +419,66 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
+    public void testSyncTableMetaIgnoresMissingShardGroupForRecycleBinPartition() throws Exception {
+        long dbId = 100;
+        long tableId = 1000;
+        long liveShardGroupId = 10000;
+        long recycledShardGroupId = 10001;
+
+        List<Column> baseSchema = new ArrayList<>();
+        KeysType keysType = KeysType.AGG_KEYS;
+        PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+        DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+        OlapTable table = new LakeTable(tableId, "lake_table", baseSchema, keysType, partitionInfo, defaultDistributionInfo);
+
+        MaterializedIndex liveIndex = new MaterializedIndex();
+        liveIndex.setShardGroupId(liveShardGroupId);
+        liveIndex.getTablets().add(new LakeTablet(10));
+        Partition livePartition = new Partition(101, 201, "p_live", liveIndex, defaultDistributionInfo);
+        table.addPartition(livePartition);
+
+        MaterializedIndex recycledIndex = new MaterializedIndex();
+        recycledIndex.setShardGroupId(recycledShardGroupId);
+        recycledIndex.getTablets().add(new LakeTablet(20));
+        Partition recycledPartition = new Partition(102, 202, "p_recycled", recycledIndex, defaultDistributionInfo);
+
+        Database db = new Database(dbId, "db");
+        Set<Long> deletedShardIds = new HashSet<>();
+
+        new Expectations(localMetastore) {
+            {
+                localMetastore.getTable(dbId, tableId);
+                result = table;
+
+                localMetastore.getAllPartitionsIncludeRecycleBin(table);
+                result = Lists.newArrayList(livePartition, recycledPartition);
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> listShard(long groupId) throws DdlException {
+                if (groupId == liveShardGroupId) {
+                    return Lists.newArrayList(10L, 11L);
+                }
+                if (groupId == recycledShardGroupId) {
+                    throw new DdlException("Failed to list shards in group " + recycledShardGroupId +
+                            ". error:NOT_EXIST:shard group " + recycledShardGroupId + " not exist.");
+                }
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public void deleteShards(Set<Long> shardIds) {
+                deletedShardIds.addAll(shardIds);
+            }
+        };
+
+        Assertions.assertTrue(starMgrMetaSyncer.syncTableMetaInternal(db, table, false));
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(11L)), deletedShardIds);
+    }
+
+    @Test
     @Disabled
     public void testSyncTableMeta() throws Exception {
         long dbId = 100;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -472,8 +472,8 @@ public class StarMgrMetaSyncerTest {
                     return Lists.newArrayList(10L, 11L);
                 }
                 if (groupId == recycledShardGroupId) {
-                    throw new DdlException("Failed to list shards in group " + recycledShardGroupId +
-                            ". error:NOT_EXIST:shard group " + recycledShardGroupId + " not exist.");
+                    throw new DdlException("arbitrary message",
+                            new StarClientException(StatusCode.NOT_EXIST, "arbitrary cause message"));
                 }
                 return Lists.newArrayList();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -429,6 +429,66 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
+    public void testSyncTableMetaIgnoresMissingShardGroupForRecycleBinPartition() throws Exception {
+        long dbId = 100;
+        long tableId = 1000;
+        long liveShardGroupId = 10000;
+        long recycledShardGroupId = 10001;
+
+        List<Column> baseSchema = new ArrayList<>();
+        KeysType keysType = KeysType.AGG_KEYS;
+        PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+        DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+        OlapTable table = new LakeTable(tableId, "lake_table", baseSchema, keysType, partitionInfo, defaultDistributionInfo);
+
+        MaterializedIndex liveIndex = new MaterializedIndex();
+        liveIndex.setShardGroupId(liveShardGroupId);
+        liveIndex.getTablets().add(new LakeTablet(10));
+        Partition livePartition = new Partition(101, 201, "p_live", liveIndex, defaultDistributionInfo);
+        table.addPartition(livePartition);
+
+        MaterializedIndex recycledIndex = new MaterializedIndex();
+        recycledIndex.setShardGroupId(recycledShardGroupId);
+        recycledIndex.getTablets().add(new LakeTablet(20));
+        Partition recycledPartition = new Partition(102, 202, "p_recycled", recycledIndex, defaultDistributionInfo);
+
+        Database db = new Database(dbId, "db");
+        Set<Long> deletedShardIds = new HashSet<>();
+
+        new Expectations(localMetastore) {
+            {
+                localMetastore.getTable(dbId, tableId);
+                result = table;
+
+                localMetastore.getAllPartitionsIncludeRecycleBin(table);
+                result = Lists.newArrayList(livePartition, recycledPartition);
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> listShard(long groupId) throws DdlException {
+                if (groupId == liveShardGroupId) {
+                    return Lists.newArrayList(10L, 11L);
+                }
+                if (groupId == recycledShardGroupId) {
+                    throw new DdlException("Failed to list shards in group " + recycledShardGroupId +
+                            ". error:NOT_EXIST:shard group " + recycledShardGroupId + " not exist.");
+                }
+                return Lists.newArrayList();
+            }
+
+            @Mock
+            public void deleteShards(Set<Long> shardIds) {
+                deletedShardIds.addAll(shardIds);
+            }
+        };
+
+        Assertions.assertTrue(starMgrMetaSyncer.syncTableMetaInternal(db, table, false));
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(11L)), deletedShardIds);
+    }
+
+    @Test
     @Disabled
     public void testSyncTableMeta() throws Exception {
         long dbId = 100;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -1001,6 +1001,21 @@ public class StarOSAgentTest {
     }
 
     @Test
+    public void testListShardPreservesClientException() throws StarClientException {
+        StarClientException expectedException = new StarClientException(StatusCode.NOT_EXIST, "arbitrary message");
+        new Expectations(client) {
+            {
+                client.listShard("1", Lists.newArrayList(999L), StarOSAgent.DEFAULT_WORKER_GROUP_ID, true);
+                result = expectedException;
+            }
+        };
+        Deencapsulation.setField(starosAgent, "serviceId", "1");
+
+        DdlException exception = Assertions.assertThrows(DdlException.class, () -> starosAgent.listShard(999L));
+        Assertions.assertSame(expectedException, exception.getCause());
+    }
+
+    @Test
     public void testUpdateWorkerGroupExcepted() throws StarClientException {
         long workerGroupId = 10086;
         Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, `TRUNCATE TABLE` replaces old lake partitions and puts the old partitions into the recycle bin as unrecoverable metadata. The recycle-bin erase path can remove the old partition's StarMgr shard group before the old partition stops being visible to all FE-side recycle-bin scans.

`StarMgrMetaSyncer.syncTableMetaInternal()` scans `getAllPartitionsIncludeRecycleBin(table)`. During this window, it may still see an old/recycled physical partition whose StarMgr shard group has already been deleted, then `listShard(groupId)` fails with `NOT_EXIST: shard group <id> not exist`. That aborts table meta sync and can leave colocate metadata stale until a later successful round.

## What I'm doing:

Only when `listShard(groupId)` throws a shard-group-not-exist error, re-check whether the physical partition is still in the live table metadata.

- If the physical partition is no longer in the live table, treat the shard group as already cleaned and skip it.
- If the physical partition is still live, keep throwing the exception so real live metadata corruption is still surfaced.
- Add a unit test covering a live partition plus a removed/recycled partition whose shard group has already been removed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
