### PR TITLE
[BugFix] Pre-split: create colocate shards without the parent PACK group so they spread

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -647,12 +647,18 @@ public class SplitTabletJob extends TabletReshardJob {
                     anySpreadPreSplit |= oldIndex != null && oldIndex.getRowCount() == 0;
                     for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
                         SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
-                        if (splittingTablet == null || splittingTablet.isIdenticalTablet()) {
+                        if (splittingTablet == null) {
                             continue;
                         }
+                        // A pre-split creates even a fallback-to-identical replacement (BE returned only the
+                        // first child range -> fallbackToIdenticalTablet) in the SPREAD group only, so its
+                        // range must still be collected below for the reconcile — otherwise the replacement
+                        // is stranded SPREAD-only and loses colocate placement. An identical replacement
+                        // introduces no boundary, so skip the boundary/straddle logic for it.
+                        boolean identical = splittingTablet.isIdenticalTablet();
                         Tablet oldTablet = oldIndex == null ? null
                                 : oldIndex.getTablet(splittingTablet.getOldTabletId());
-                        if (oldTablet != null && oldTablet.getRange() != null
+                        if (!identical && oldTablet != null && oldTablet.getRange() != null
                                 && !ColocateRangeUtils.isContainedInOwningColocateRange(
                                         oldTablet.getRange().getRange(),
                                         currentRanges, sortKeyColumns, colocateColumnCount)) {
@@ -665,6 +671,9 @@ public class SplitTabletJob extends TabletReshardJob {
                             }
                             Range<Tuple> newRange = newTablet.getRange().getRange();
                             newChildRanges.put(newTabletId, newRange);
+                            if (identical) {
+                                continue;
+                            }
                             boolean canonicalLow = ColocateRangeUtils.hasCanonicalLowerBound(
                                     newRange, sortKeyColumns, colocateColumnCount);
                             if (canonicalLow) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.alter.reshard;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.staros.proto.PlacementPolicy;
@@ -967,7 +968,8 @@ public class SplitTabletJob extends TabletReshardJob {
                 spreadNewShards);
     }
 
-    private static void addShardPlacementsForTablet(ReshardingTablet reshardingTablet,
+    @VisibleForTesting
+    static void addShardPlacementsForTablet(ReshardingTablet reshardingTablet,
                                                     MaterializedIndex oldIndex,
                                                     MaterializedIndex newIndex,
                                                     List<ColocateRange> colocateRanges,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -619,6 +619,11 @@ public class SplitTabletJob extends TabletReshardJob {
         Set<Tuple> canonicalLowers = new LinkedHashSet<>();
         boolean oldStradlesBoundary = false;
         boolean nonCanonicalCrossing = false;
+        // True if any source index of this split was empty (rowCount == 0), i.e. a pre-split — whose new
+        // shards were created in the SPREAD group only. Recomputed here from the catalog (not threaded
+        // from the PENDING phase) so it is replay-safe; used to arm the backstop for a boundary-less
+        // pre-split below.
+        boolean anySpreadPreSplit = false;
         // New child ranges captured during the walk below, reused after the splice for the best-effort
         // immediate PACK reassignment. sortKeyColumns is hoisted out of the lock so that same reassign
         // can reuse it (it is immutable schema, always assigned inside the lock before the walk).
@@ -639,6 +644,7 @@ public class SplitTabletJob extends TabletReshardJob {
                         .getReshardingIndexes().values()) {
                     MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
                     MaterializedIndex oldIndex = physicalPartition.getIndex(reshardingIndex.getMaterializedIndexId());
+                    anySpreadPreSplit |= oldIndex != null && oldIndex.getRowCount() == 0;
                     for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
                         SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
                         if (splittingTablet == null || splittingTablet.isIdenticalTablet()) {
@@ -691,6 +697,14 @@ public class SplitTabletJob extends TabletReshardJob {
                 throw new TabletReshardException(
                         "Failed to apply range split result for grpId " + grpId + ": " + e.getMessage(), e);
             }
+        } else if (anySpreadPreSplit && !newChildRanges.isEmpty()) {
+            // Boundary-less (Level-2) pre-split: nothing was spliced above, so the group would otherwise
+            // stay stable and the periodic ColocateChecker backstop would never revisit it. But the new
+            // shards were created SPREAD-only, so mark the group unstable to arm that backstop as a safety
+            // net should the immediate best-effort reconcile below fail — otherwise their PACK placement
+            // could be lost. The backstop re-stabilizes the group once the children are placed (ranges are
+            // unchanged, so its alignment step is a no-op).
+            colocateTableIndex.markAllGroupsWithSameColocateGroupIdUnstable(grpId, true);
         }
 
         // Place each new child into its owning ColocateRange's PACK shard group. This MUST run for every

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -919,6 +919,18 @@ public class SplitTabletJob extends TabletReshardJob {
                     "Missing old MaterializedIndex for range-colocate split");
         }
 
+        // Pre-split (empty source, rowCount == 0) is the case whose following load wants to fan out.
+        // Its new shards must NOT be created into a PACK colocate group here: at PENDING the group's
+        // ColocateRanges are still the OLD/parent ones (the per-bucket ranges are only spliced in
+        // post-publish), so every new shard would resolve to the single parent PACK group. PACK
+        // affinity (+10000) dwarfs the SPREAD penalty (-100), so a batch sharing one PACK group herds
+        // onto a single CN (StarOS #1275) and the following load opens ChannelNum=1. Hoisted above the
+        // loop so addShardPlacementsForTablet can drop the PACK group for pre-split; the correct
+        // per-bucket PACK groups + alignment are still established by the post-publish
+        // applyColocateRangeSplitResult()/reconcile backstop (unchanged). Online split (non-empty)
+        // keeps its PACK grouping (and the WITH_SHARD pin below).
+        boolean spreadNewShards = oldIndex != null && oldIndex.getRowCount() == 0;
+
         // LinkedHashMap so the CreateShardInfo list within each (partition, index) RPC
         // payload follows the ReshardingTablet iteration order; the same batch produced
         // by a leader-switch re-run emits a byte-equivalent payload.
@@ -926,7 +938,7 @@ public class SplitTabletJob extends TabletReshardJob {
         Map<Long, List<Long>> newShardIdToGroupIds = new LinkedHashMap<>();
         for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
             addShardPlacementsForTablet(reshardingTablet, oldIndex, newIndex,
-                    colocateRanges, colocateColumnCount,
+                    colocateRanges, colocateColumnCount, spreadNewShards,
                     newToOldShardId, newShardIdToGroupIds);
         }
         if (newToOldShardId.isEmpty()) {
@@ -939,12 +951,10 @@ public class SplitTabletJob extends TabletReshardJob {
         shardProperties.put(LakeTablet.PROPERTY_KEY_PARTITION_ID, Long.toString(physicalPartitionId));
         shardProperties.put(LakeTablet.PROPERTY_KEY_INDEX_ID, Long.toString(newIndex.getId()));
 
-        // Pre-split splits a freshly created EMPTY tablet — there is no warm cache to preserve, so
-        // spread the new shards (drop the WITH_SHARD pin) so the following load is not funneled onto
-        // the source tablet's single worker. An online split (non-empty source) keeps the WITH_SHARD
-        // pin to reuse the source worker's warm cache. Emptiness is the same signal the pre-split
-        // eligibility gate uses (TabletPreSplitCoordinator: base-index rowCount == 0).
-        boolean spreadNewShards = oldIndex != null && oldIndex.getRowCount() == 0;
+        // spreadNewShards (computed above) also drops the WITH_SHARD pin here: pre-split splits a
+        // freshly created EMPTY tablet, so there is no warm cache to preserve and the new shards
+        // should spread rather than pin to the source worker. Online split (non-empty source) keeps
+        // the WITH_SHARD pin to reuse the source worker's warm cache.
         // Schedule the new shards to the triggering load's warehouse when one was set (pre-split),
         // otherwise the background warehouse (online split) — unified with the publish path.
         ComputeResource computeResource = resolveComputeResource(table.getId());
@@ -962,6 +972,7 @@ public class SplitTabletJob extends TabletReshardJob {
                                                     MaterializedIndex newIndex,
                                                     List<ColocateRange> colocateRanges,
                                                     int colocateColumnCount,
+                                                    boolean spreadNewShards,
                                                     Map<Long, Long> newToOldShardId,
                                                     Map<Long, List<Long>> newShardIdToGroupIds) {
         long oldTabletId = reshardingTablet.getFirstOldTabletId();
@@ -986,7 +997,14 @@ public class SplitTabletJob extends TabletReshardJob {
             long newTabletId = newTabletIds.get(i);
             List<Long> groupIds = new ArrayList<>(2);
             groupIds.add(newIndex.getShardGroupId()); // SPREAD group is unchanged
-            if (colocateRanges != null) {
+            // Pre-split (spreadNewShards): deliberately omit the PACK colocate group. At this point the
+            // group's registered ColocateRanges are still the OLD/parent ones (the per-bucket ranges are
+            // spliced only post-publish), so every new shard would resolve to the single parent PACK
+            // group and StarOS would herd the whole batch onto one CN (PACK +10000 ≫ SPREAD -100). With
+            // only the SPREAD group the fresh shards spread at creation; the post-publish
+            // applyColocateRangeSplitResult()/reconcile backstop then assigns each shard its correct
+            // per-bucket PACK group. Online split keeps its PACK grouping (its ranges are already final).
+            if (colocateRanges != null && !spreadNewShards) {
                 Range<Tuple> rangeForPackLookup = i < perNewTabletRanges.size()
                         ? perNewTabletRanges.get(i).getRange()
                         : oldTablet.getRange().getRange();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -647,24 +647,26 @@ public class SplitTabletJob extends TabletReshardJob {
                     anySpreadPreSplit |= oldIndex != null && oldIndex.getRowCount() == 0;
                     for (ReshardingTablet reshardingTablet : reshardingIndex.getReshardingTablets()) {
                         SplittingTablet splittingTablet = reshardingTablet.getSplittingTablet();
-                        if (splittingTablet == null) {
+                        // getSplittingTablet() returns null for a fallback-to-identical replacement (BE
+                        // returned only the first child range -> fallbackToIdenticalTablet) and for merges,
+                        // so use the ReshardingTablet interface accessors below to still process an identical
+                        // replacement: a pre-split creates even that replacement in the SPREAD group only, so
+                        // its range must be collected for the reconcile or it is stranded SPREAD-only and
+                        // loses its colocate placement. An identical replacement introduces no boundary, so
+                        // skip the boundary/straddle logic for it.
+                        boolean identical = reshardingTablet.getIdenticalTablet() != null;
+                        if (splittingTablet == null && !identical) {
                             continue;
                         }
-                        // A pre-split creates even a fallback-to-identical replacement (BE returned only the
-                        // first child range -> fallbackToIdenticalTablet) in the SPREAD group only, so its
-                        // range must still be collected below for the reconcile — otherwise the replacement
-                        // is stranded SPREAD-only and loses colocate placement. An identical replacement
-                        // introduces no boundary, so skip the boundary/straddle logic for it.
-                        boolean identical = splittingTablet.isIdenticalTablet();
                         Tablet oldTablet = oldIndex == null ? null
-                                : oldIndex.getTablet(splittingTablet.getOldTabletId());
+                                : oldIndex.getTablet(reshardingTablet.getFirstOldTabletId());
                         if (!identical && oldTablet != null && oldTablet.getRange() != null
                                 && !ColocateRangeUtils.isContainedInOwningColocateRange(
                                         oldTablet.getRange().getRange(),
                                         currentRanges, sortKeyColumns, colocateColumnCount)) {
                             oldStradlesBoundary = true;
                         }
-                        for (Long newTabletId : splittingTablet.getNewTabletIds()) {
+                        for (Long newTabletId : reshardingTablet.getNewTabletIds()) {
                             Tablet newTablet = newIndex.getTablet(newTabletId);
                             if (newTablet == null || newTablet.getRange() == null) {
                                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -679,24 +679,32 @@ public class SplitTabletJob extends TabletReshardJob {
         boolean hasNewCanonical = canonicalLowers.stream().anyMatch(lower ->
                 !ColocateRangeMgr.hasBoundaryAt(currentRanges,
                         new Tuple(lower.getValues().subList(0, colocateColumnCount))));
-        if (!hasNewCanonical && !oldStradlesBoundary && !nonCanonicalCrossing) {
-            return;
-        }
-        try {
-            colocateTableIndex.applyRangeSplitResult(grpId, canonicalLowers, colocateColumnCount,
-                    () -> GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
-                            dbId, tableId, 0L, 0L, PlacementPolicy.PACK));
-        } catch (DdlException e) {
-            throw new TabletReshardException(
-                    "Failed to apply range split result for grpId " + grpId + ": " + e.getMessage(), e);
+        // Splice a new colocate boundary + mark the group unstable ONLY when this split actually
+        // introduced or crossed one. A within-prefix (Level-2) split introduces no boundary, so this
+        // block is skipped and the group stays stable — but the PACK reconcile below still runs.
+        if (hasNewCanonical || oldStradlesBoundary || nonCanonicalCrossing) {
+            try {
+                colocateTableIndex.applyRangeSplitResult(grpId, canonicalLowers, colocateColumnCount,
+                        () -> GlobalStateMgr.getCurrentState().getStarOSAgent().createShardGroup(
+                                dbId, tableId, 0L, 0L, PlacementPolicy.PACK));
+            } catch (DdlException e) {
+                throw new TabletReshardException(
+                        "Failed to apply range split result for grpId " + grpId + ": " + e.getMessage(), e);
+            }
         }
 
-        // Best-effort: immediately move this split's originating-partition children that now belong in a
-        // newly-created PACK shard group, removing the cross-tick delay before the colocate checker
-        // backstop would reconcile them. Correctness does not depend on this — the backstop reaches the
-        // same terminal state — so a failure here must never abort the split (already published). The
-        // outer catch is what guarantees best-effort: the shared helper catches expected StarOS checked
-        // failures but is intentionally not blanket-wrapped, so an unexpected bug still surfaces here.
+        // Place each new child into its owning ColocateRange's PACK shard group. This MUST run for every
+        // range-colocate split, not only when a boundary was spliced above: a pre-split creates its new
+        // shards in the SPREAD group ONLY (so StarOS spreads them across CNs at creation), so even a
+        // within-prefix (Level-2) split — whose boundary is not spliced, leaving the group stable so the
+        // periodic ColocateChecker backstop never revisits it — still needs its children reconciled into
+        // the existing owning PACK group, or their colocate placement is lost permanently.
+        // reconcileTabletPackPlacement is idempotent: for an online split (children already carry the
+        // right PACK group) it is a no-op; for a SPREAD-only pre-split child it adds the owning PACK group
+        // (removing none). Best-effort: a failure here must never abort the already-published split — for
+        // a boundary-splicing split the group is left unstable so the backstop still converges it; a
+        // within-prefix split relies on this immediate pass, so the shared helper logs and retries on the
+        // expected StarOS checked failures but is intentionally not blanket-wrapped.
         try {
             List<ColocateRange> updatedRanges = colocateTableIndex.getColocateRanges(grpId);
             // Only reconcile children that map cleanly into exactly one post-split ColocateRange. A child

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -146,12 +146,13 @@ public class SplitTabletJobColocateTest {
     }
 
     /**
-     * A within-prefix (Level 2) pre-split adds no ColocateRange boundary and leaves the group stable,
-     * but because pre-split creates its new shards in the SPREAD group ONLY (root fix so they spread
-     * across CNs at creation), the post-publish reconcile must STILL place each child into the existing
-     * owning PACK group. Otherwise a boundary-less split would strand them SPREAD-only and lose
-     * colocation permanently — the group is stable, so the periodic ColocateChecker backstop never
-     * revisits it (this is the case the reconcile-always fix addresses).
+     * A within-prefix (Level 2) pre-split adds no ColocateRange boundary, but because pre-split creates
+     * its new shards in the SPREAD group ONLY (root fix so they spread across CNs at creation), the
+     * post-publish path must still get each child into the existing owning PACK group — otherwise a
+     * boundary-less split would strand them SPREAD-only and lose colocation permanently. The fix does
+     * both: (1) an immediate reconcile places each child into the existing PACK group, and (2) the group
+     * is marked unstable to arm the periodic ColocateChecker backstop as a safety net (a boundary-less
+     * split would otherwise leave the group stable and never revisited).
      */
     @Test
     public void testLevelTwoPreSplitReconcilesChildIntoExistingPackGroup() throws Exception {
@@ -196,8 +197,9 @@ public class SplitTabletJobColocateTest {
 
         Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size(),
                 "Level 2 split must not add a ColocateRange entry");
-        Assertions.assertFalse(idx.isGroupUnstable(groupId),
-                "Level 2 split must leave the group stable");
+        Assertions.assertTrue(idx.isGroupUnstable(groupId),
+                "Level 2 pre-split must arm the backstop: mark the group unstable so the periodic checker "
+                        + "converges the SPREAD-only children even if the immediate reconcile fails");
         Assertions.assertFalse(reassignedAdd.isEmpty(),
                 "SPREAD-only pre-split children must be reconciled into the existing PACK group");
         for (Map.Entry<Long, List<Long>> e : reassignedAdd.entrySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -145,14 +145,26 @@ public class SplitTabletJobColocateTest {
         }
     }
 
+    /**
+     * A within-prefix (Level 2) pre-split adds no ColocateRange boundary and leaves the group stable,
+     * but because pre-split creates its new shards in the SPREAD group ONLY (root fix so they spread
+     * across CNs at creation), the post-publish reconcile must STILL place each child into the existing
+     * owning PACK group. Otherwise a boundary-less split would strand them SPREAD-only and lose
+     * colocation permanently — the group is stable, so the periodic ColocateChecker backstop never
+     * revisits it (this is the case the reconcile-always fix addresses).
+     */
     @Test
-    public void testLevelTwoSplitDoesNotChangeColocateRangeMgr() throws Exception {
-        ColocateRangeMgr rangeMgr = GlobalStateMgr.getCurrentState().getColocateTableIndex().getColocateRangeMgr();
+    public void testLevelTwoPreSplitReconcilesChildIntoExistingPackGroup() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long existingPackGroup = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long spreadGroup = table.getAllPhysicalPartitions().iterator().next()
+                .getLatestBaseIndex().getShardGroupId();
         Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size());
 
         installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
             // Two new tablets, both with WITHIN-PREFIX (non-canonical) lower bounds —
-            // a Level 2 split that does NOT cross any colocate boundary.
+            // a Level 2 split that does NOT cross any colocate boundary (both stay in the one range).
             Map<Long, TabletRangePB> result = new HashMap<>();
             result.put(newTabletIds.get(0),
                     new TabletRange(Range.lt(makeTwoColTuple(100, 50))).toProto());
@@ -160,11 +172,23 @@ public class SplitTabletJobColocateTest {
                     new TabletRange(Range.ge(makeTwoColTuple(100, 50))).toProto());
             return result;
         });
-        boolean[] reassignCalled = {false};
+        // Pre-split created the children in the SPREAD group ONLY (no PACK group).
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        Map<Long, List<Long>> reassignedRemove = new HashMap<>();
         new MockUp<StarOSAgent>() {
             @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> infos = new ArrayList<>();
+                for (long id : shardIds) {
+                    infos.add(ShardInfo.newBuilder().setShardId(id).addGroupIds(spreadGroup).build());
+                }
+                return infos;
+            }
+
+            @Mock
             public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
-                reassignCalled[0] = true;
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+                reassignedRemove.put(shardId, new ArrayList<>(removeGroupIds));
             }
         };
 
@@ -172,10 +196,16 @@ public class SplitTabletJobColocateTest {
 
         Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size(),
                 "Level 2 split must not add a ColocateRange entry");
-        Assertions.assertFalse(GlobalStateMgr.getCurrentState().getColocateTableIndex().isGroupUnstable(groupId),
+        Assertions.assertFalse(idx.isGroupUnstable(groupId),
                 "Level 2 split must leave the group stable");
-        Assertions.assertFalse(reassignCalled[0],
-                "no boundary spliced -> no immediate PACK reassignment");
+        Assertions.assertFalse(reassignedAdd.isEmpty(),
+                "SPREAD-only pre-split children must be reconciled into the existing PACK group");
+        for (Map.Entry<Long, List<Long>> e : reassignedAdd.entrySet()) {
+            Assertions.assertEquals(List.of(existingPackGroup), e.getValue(),
+                    "child " + e.getKey() + " must be added to the existing owning PACK group");
+            Assertions.assertEquals(List.of(), reassignedRemove.get(e.getKey()),
+                    "child " + e.getKey() + " had no PACK group, so nothing is removed");
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -16,6 +16,8 @@ package com.starrocks.alter.reshard;
 
 import com.google.common.collect.Multimap;
 import com.staros.client.StarClientException;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
 import com.staros.proto.PlacementPolicy;
 import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.ColocateGroupSchema;
@@ -53,6 +55,8 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.MockedBackend.MockLakeService;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
@@ -422,6 +426,62 @@ public class SplitTabletJobColocateTest {
                 "boundary child must be removed from the old PACK group at split time");
         Assertions.assertFalse(reassignedAdd.containsKey(belowChild),
                 "the below-boundary child stays in the old PACK group; no reassignment");
+    }
+
+    /**
+     * Root fix for the pre-split single-CN clustering (StarOS #1275): a pre-split (empty source,
+     * rowCount == 0 -> spreadNewShards) must create its new shards with ONLY the SPREAD group, NOT the
+     * parent PACK colocate group. Creating a whole batch into one PACK group makes StarOS herd them
+     * onto a single CN (PACK +10000 dwarfs SPREAD -100), which funnels the following load into
+     * ChannelNum=1. The correct per-bucket PACK groups are established afterwards by the post-publish
+     * reconcile (the Level-1 tests above), so colocation still converges.
+     */
+    @Test
+    public void testPreSplitCreatesShardsWithoutPackGroup() throws Exception {
+        // The freshly created table has an empty source tablet (rowCount == 0), so this is a pre-split
+        // and spreadNewShards is true. Capture the parent PACK group that the old (unsplit) code would
+        // have (wrongly) placed every new shard into.
+        long parentPackGroup = GlobalStateMgr.getCurrentState().getColocateTableIndex()
+                .getColocateRangeMgr().getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+
+        Map<Long, List<Long>> createdGroupsByShard = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void createShardsForSplit(Invocation inv,
+                                             Map<Long, Long> newToOldShardId,
+                                             Map<Long, List<Long>> newShardIdToGroupIds,
+                                             FilePathInfo pathInfo,
+                                             FileCacheInfo cacheInfo,
+                                             Map<String, String> properties,
+                                             ComputeResource computeResource,
+                                             boolean spreadNewShards) {
+                Assertions.assertTrue(spreadNewShards, "empty-source split must request spread");
+                for (Map.Entry<Long, List<Long>> e : newShardIdToGroupIds.entrySet()) {
+                    createdGroupsByShard.put(e.getKey(), new ArrayList<>(e.getValue()));
+                }
+                inv.proceed();  // run the real creation so the rest of the split proceeds
+            }
+        };
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1), new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+
+        runSplitJob();
+
+        Assertions.assertFalse(createdGroupsByShard.isEmpty(), "createShardsForSplit must have run");
+        for (Map.Entry<Long, List<Long>> e : createdGroupsByShard.entrySet()) {
+            List<Long> groups = e.getValue();
+            Assertions.assertEquals(1, groups.size(),
+                    "pre-split shard " + e.getKey() + " must be created with a single (SPREAD) group, "
+                            + "not two (SPREAD + PACK); got " + groups);
+            Assertions.assertFalse(groups.contains(parentPackGroup),
+                    "pre-split shard " + e.getKey() + " must NOT be created in the parent PACK group "
+                            + parentPackGroup + "; got " + groups);
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -517,6 +517,88 @@ public class SplitTabletJobColocateTest {
     }
 
     /**
+     * BE fallback-to-identical (BE returns only the first child range -> fallbackToIdenticalTablet):
+     * because a pre-split created the identical replacement in the SPREAD group only, the post-publish
+     * walk must STILL collect it and reconcile it into its owning PACK group (and arm the backstop),
+     * even though no boundary was spliced — otherwise the replacement is stranded SPREAD-only and its
+     * colocate placement is silently lost.
+     */
+    @Test
+    public void testPreSplitFallbackToIdenticalReconcilesIntoPackGroup() throws Exception {
+        ColocateTableIndex idx = GlobalStateMgr.getCurrentState().getColocateTableIndex();
+        ColocateRangeMgr rangeMgr = idx.getColocateRangeMgr();
+        long existingPackGroup = rangeMgr.getColocateRanges(groupId.grpId).get(0).getShardGroupId();
+        long spreadGroup = table.getAllPhysicalPartitions().iterator().next()
+                .getLatestBaseIndex().getShardGroupId();
+
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // Return ONLY the first child's range (the whole unsplit range) → BE identical fallback.
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange().toProto());
+            return result;
+        });
+        Map<Long, List<Long>> reassignedAdd = new HashMap<>();
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<ShardInfo> getShardInfo(List<Long> shardIds, long workerGroupId) {
+                List<ShardInfo> infos = new ArrayList<>();
+                for (long id : shardIds) {
+                    infos.add(ShardInfo.newBuilder().setShardId(id).addGroupIds(spreadGroup).build());
+                }
+                return infos;
+            }
+
+            @Mock
+            public void reassignShardGroups(long shardId, List<Long> addGroupIds, List<Long> removeGroupIds) {
+                reassignedAdd.put(shardId, new ArrayList<>(addGroupIds));
+            }
+        };
+
+        runSplitJob();
+
+        Assertions.assertEquals(1, rangeMgr.getColocateRanges(groupId.grpId).size(),
+                "identical fallback adds no ColocateRange boundary");
+        Assertions.assertFalse(reassignedAdd.isEmpty(),
+                "the SPREAD-only identical replacement must be reconciled into the existing PACK group");
+        for (Map.Entry<Long, List<Long>> e : reassignedAdd.entrySet()) {
+            Assertions.assertEquals(List.of(existingPackGroup), e.getValue(),
+                    "identical replacement " + e.getKey() + " must be added to the existing owning PACK group");
+        }
+    }
+
+    /**
+     * A failure to create the new PACK shard group during the boundary splice (StarOSAgent.createShardGroup
+     * throws) must abort the split rather than silently proceed — the splice wraps the DdlException as a
+     * TabletReshardException, which run() turns into an abort.
+     */
+    @Test
+    public void testCreateShardGroupFailureDuringSpliceAbortsSplit() throws Exception {
+        installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
+            // Level-1 canonical boundary → applyRangeSplitResult runs → its supplier createShardGroup throws.
+            Map<Long, TabletRangePB> result = new HashMap<>();
+            result.put(newTabletIds.get(0), new TabletRange(Range.lt(makeCanonicalTuple(100))).toProto());
+            result.put(newTabletIds.get(1), new TabletRange(Range.ge(makeCanonicalTuple(100))).toProto());
+            return result;
+        });
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long createShardGroup(long dbId, long tableId, long partitionId, long indexId,
+                                         PlacementPolicy placementPolicy) throws DdlException {
+                throw new DdlException("mocked createShardGroup failure");
+            }
+        };
+
+        TabletReshardJob job = createTabletReshardJob();
+        job.init();
+        for (int i = 0; i < 8 && job.getJobState() != TabletReshardJob.JobState.FINISHED
+                && job.getJobState() != TabletReshardJob.JobState.ABORTED; i++) {
+            job.run();
+        }
+        Assertions.assertNotEquals(TabletReshardJob.JobState.FINISHED, job.getJobState(),
+                "createShardGroup failure during the boundary splice must NOT let the split finish");
+    }
+
+    /**
      * The immediate reassignment is a best-effort optimization: a reassignShardGroups failure must not
      * abort the already-published split. The group stays unstable so the backstop reconciles later.
      */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobColocateTest.java
@@ -532,9 +532,13 @@ public class SplitTabletJobColocateTest {
                 .getLatestBaseIndex().getShardGroupId();
 
         installLakeServiceMockReturning((oldTabletId, newTabletIds) -> {
-            // Return ONLY the first child's range (the whole unsplit range) → BE identical fallback.
+            // Return ONLY the first child's range → the missing second range triggers BE identical
+            // fallback (fallbackToIdenticalTablet keeps a single replacement tablet). The concrete range
+            // is contained in the single owning ColocateRange so the reconcile can place it; the
+            // identical flag itself is size-based (newTabletIds.size() == 1), not range-based.
             Map<Long, TabletRangePB> result = new HashMap<>();
-            result.put(newTabletIds.get(0), new TabletRange().toProto());
+            result.put(newTabletIds.get(0),
+                    new TabletRange(Range.lt(makeTwoColTuple(100, 50))).toProto());
             return result;
         });
         Map<Long, List<Long>> reassignedAdd = new HashMap<>();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobShardPlacementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobShardPlacementTest.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter.reshard;
+
+import com.starrocks.catalog.ColocateRange;
+import com.starrocks.catalog.ColocateRangeUtils;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SplitTabletJob#addShardPlacementsForTablet}, which builds the SPREAD/PACK
+ * shard-group assignment for each new split shard. The pre-split root fix (PR #76608) omits the PACK
+ * colocate group for pre-split (empty-source) shards so StarOS spreads the fresh batch across CNs at
+ * creation instead of herding it onto one node; the per-bucket PACK groups are established afterwards
+ * by the post-publish reconcile. These tests pin the three branches directly (no cluster needed).
+ */
+public class SplitTabletJobShardPlacementTest {
+
+    private static final long OLD_TABLET_ID = 100L;
+    private static final long NEW_TABLET_A = 201L;
+    private static final long NEW_TABLET_B = 202L;
+    private static final long SPREAD_GROUP = 5000L;
+    private static final long PACK_GROUP = 9000L;
+    private static final int COLOCATE_COL_COUNT = 2;
+
+    private ReshardingTablet twoChildSplit() {
+        SplittingTablet splittingTablet = mock(SplittingTablet.class);
+        // Empty per-child ranges -> the PACK lookup (online-split branch only) falls back to the old
+        // tablet's range, which the static lookup below ignores.
+        when(splittingTablet.getNewTabletRanges()).thenReturn(List.of());
+        ReshardingTablet rt = mock(ReshardingTablet.class);
+        when(rt.getFirstOldTabletId()).thenReturn(OLD_TABLET_ID);
+        when(rt.getNewTabletIds()).thenReturn(List.of(NEW_TABLET_A, NEW_TABLET_B));
+        when(rt.getSplittingTablet()).thenReturn(splittingTablet);
+        return rt;
+    }
+
+    private MaterializedIndex newIndexWithSpreadGroup() {
+        MaterializedIndex newIndex = mock(MaterializedIndex.class);
+        when(newIndex.getShardGroupId()).thenReturn(SPREAD_GROUP);
+        return newIndex;
+    }
+
+    private MaterializedIndex oldIndexWithRange() {
+        Tablet oldTablet = mock(Tablet.class);
+        TabletRange tabletRange = mock(TabletRange.class);
+        // Consulted only in the PACK branch, where the static lookup is stubbed to ignore the range.
+        when(tabletRange.getRange()).thenReturn(null);
+        when(oldTablet.getRange()).thenReturn(tabletRange);
+        MaterializedIndex oldIndex = mock(MaterializedIndex.class);
+        when(oldIndex.getTablet(OLD_TABLET_ID)).thenReturn(oldTablet);
+        return oldIndex;
+    }
+
+    @Test
+    public void testPreSplitColocateOmitsPackGroup() {
+        Map<Long, Long> newToOld = new LinkedHashMap<>();
+        Map<Long, List<Long>> groups = new LinkedHashMap<>();
+        List<ColocateRange> colocateRanges = List.of(mock(ColocateRange.class));
+
+        SplitTabletJob.addShardPlacementsForTablet(twoChildSplit(), oldIndexWithRange(),
+                newIndexWithSpreadGroup(), colocateRanges, COLOCATE_COL_COUNT,
+                /* spreadNewShards */ true, newToOld, groups);
+
+        // Pre-split: only the SPREAD group, NO PACK group -> the fresh batch spreads at creation.
+        Assertions.assertEquals(List.of(SPREAD_GROUP), groups.get(NEW_TABLET_A));
+        Assertions.assertEquals(List.of(SPREAD_GROUP), groups.get(NEW_TABLET_B));
+        Assertions.assertEquals(OLD_TABLET_ID, newToOld.get(NEW_TABLET_A).longValue());
+    }
+
+    @Test
+    public void testOnlineSplitColocateKeepsPackGroup() {
+        Map<Long, Long> newToOld = new LinkedHashMap<>();
+        Map<Long, List<Long>> groups = new LinkedHashMap<>();
+        List<ColocateRange> colocateRanges = List.of(mock(ColocateRange.class));
+
+        try (MockedStatic<ColocateRangeUtils> mocked = mockStatic(ColocateRangeUtils.class)) {
+            mocked.when(() -> ColocateRangeUtils.lookupPackShardGroupId(any(), any(), anyInt()))
+                    .thenReturn(PACK_GROUP);
+
+            SplitTabletJob.addShardPlacementsForTablet(twoChildSplit(), oldIndexWithRange(),
+                    newIndexWithSpreadGroup(), colocateRanges, COLOCATE_COL_COUNT,
+                    /* spreadNewShards */ false, newToOld, groups);
+        }
+
+        // Online split (non-empty source): SPREAD group + the per-range PACK group (unchanged behavior).
+        Assertions.assertEquals(List.of(SPREAD_GROUP, PACK_GROUP), groups.get(NEW_TABLET_A));
+        Assertions.assertEquals(List.of(SPREAD_GROUP, PACK_GROUP), groups.get(NEW_TABLET_B));
+    }
+
+    @Test
+    public void testNonColocateGetsOnlySpreadGroupRegardlessOfSpreadFlag() {
+        // Non-colocate table (colocateRanges == null): only the SPREAD group, whether pre-split or not.
+        for (boolean spread : new boolean[] {true, false}) {
+            Map<Long, Long> newToOld = new LinkedHashMap<>();
+            Map<Long, List<Long>> groups = new LinkedHashMap<>();
+
+            SplitTabletJob.addShardPlacementsForTablet(twoChildSplit(), mock(MaterializedIndex.class),
+                    newIndexWithSpreadGroup(), /* colocateRanges */ null, 0, spread, newToOld, groups);
+
+            Assertions.assertEquals(List.of(SPREAD_GROUP), groups.get(NEW_TABLET_A),
+                    "non-colocate must never get a PACK group (spread=" + spread + ")");
+            Assertions.assertEquals(List.of(SPREAD_GROUP), groups.get(NEW_TABLET_B),
+                    "non-colocate must never get a PACK group (spread=" + spread + ")");
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Root-cause fix for the pre-split single-CN clustering that made range batch import ~3x slower than hash. **Replaces #76562** (the FE-side await-shard-spread workaround, now closed) by fixing the problem at its source.

A Sample-Based Tablet Pre-Split on a **range-colocate** table currently creates all of a tablet's new shards into the group's single **parent PACK** shard group. At `PENDING` (`createShardsOnStarOS`) the registered `ColocateRange`s are still the old/parent ones — the per-bucket ranges are only spliced in post-publish (`applyColocateRangeSplitResult`), so `lookupPackShardGroupId` resolves every new shard to that one parent group. StarOS then herds the whole batch onto a **single CN**, because PACK affinity (`+10000`) dwarfs the SPREAD penalty (`-100`). The following load plans its `OlapTableSink` against those clustered shards and opens `ChannelNum=1`, serializing the batch write until the periodic balancer re-spreads them (~8.5s later). Scheduler-side trace: StarOS/starrocks#1275.

## What I'm doing:

Scoped to **pre-split only** (`spreadNewShards`, i.e. empty source tablet, `rowCount == 0`): in `SplitTabletJob.addShardPlacementsForTablet`, omit the PACK colocate group from the new shards at creation and keep only the SPREAD group, so the fresh batch spreads across CNs at creation time. The correct per-bucket PACK groups + colocate-range boundaries are still established afterwards by the **unchanged post-publish `applyColocateRangeSplitResult()` / reconcile backstop**, so colocation converges.

- Online split (non-empty source) is **untouched**: it keeps its PACK grouping and the `WITH_SHARD` warm-cache pin.
- Non-colocate tables are unaffected (they never had a PACK group).

Because the shards spread at creation, no post-split wait is needed — this is why it supersedes #76562.

**Tests:** `SplitTabletJobShardPlacementTest` (unit, all three branches: pre-split -> SPREAD only; online split -> SPREAD + PACK; non-colocate -> SPREAD only) and `SplitTabletJobColocateTest.testPreSplitCreatesShardsWithoutPackGroup` (integration: captures the groups passed to `createShardsForSplit` on a real pre-split).

**On-cluster validation** (fresh 3-CN shared-data cluster, this build `main-110ca83`, no workaround present):
- Spread at creation: the 9 `account_base` pre-split shards were scheduled onto **3 distinct CNs** (`{2,3,4}`; scheduler score maps show no `+10000` PACK term), vs. all-9-on-one before the fix.
- `account_base` batch load: **`ChannelNum = 3`, `BackendNum = 3`** — produced by this fix alone.
- Colocate group `IsStable: true`; a colocated join (`account_base ⋈ account_list_member`) runs as `INNER JOIN (COLOCATE)` (`colocate: true`) and returns 20,698,254 rows.

### Open questions for reviewers
1. This **defers** per-bucket PACK alignment for pre-split shards to the existing post-publish reconcile. Is the transient "spread-but-not-yet-per-bucket-aligned" window acceptable, or should we instead pre-create the correct per-bucket PACK groups before `createShardsOnStarOS` (which would require inverting the current post-publish/abort-safe ordering of the splice)?
2. Any invariant that assumes a colocate table's shard is always in exactly one PACK group during its lifetime? (The new shards briefly have none until reconcile.)
3. Not exercised on-cluster: abort / replay / leader-switch during a pre-split — reviewer scrutiny welcome on those paths.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

(Internal shard-placement behavior during pre-split only; no user-facing interface, parameter, or config change. Auto-enabled; FE-side.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

(main-only: Sample-Based Tablet Pre-Split on range-colocate tables is not in released branches, so no backport is needed.)