### PR TITLE
[Enhancement] Optimize query queue V2 cost estimators

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -718,11 +718,11 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### `query_queue_slots_estimator_strategy`
 
-- Default: MAX
+- Default: PBE
 - Type: String
 - Unit: -
 - Is mutable: Yes
-- Description: Selects the slot estimation strategy used for queue-based queries when `enable_query_queue_v2` is true. Valid values: MBE (memory-based), PBE (parallelism-based), MAX (take max of MBE and PBE) and MIN (take min of MBE and PBE). MBE estimates slots from predicted memory or plan costs divided by the per-slot memory target and is capped by `totalSlots`. PBE derives slots from fragment parallelism (scan range counts or cardinality / rows-per-slot) and a CPU-cost based calculation (using CPU costs per slot), then bounds the result within [numSlots/2, numSlots]. MAX and MIN combine MBE and PBE by taking their maximum or minimum respectively. If the configured value is invalid, the default (`MAX`) is used.
+- Description: Selects the slot estimation strategy used for queue-based queries when `enable_query_queue_v2` is true. Valid values: `PBE` (parallelism-based, the default), `MBE` (memory-cost-based), and `CBE` (CPU-cost-based). PBE estimates a query's slots from scan parallelism, capped by the worker count: for OLAP tables it uses the number of scan ranges left after pruning, so only very small queries fall below the worker count; a connector/external scan is treated as a full-parallelism scan (the worker count) rather than a single-slot query. MBE estimates slots from the query's memory cost divided by `query_queue_v2_mem_bytes_per_slot`. CBE estimates slots from the plan CPU cost divided by `query_queue_v2_cpu_costs_per_slot`. MBE and CBE per-query slots are additionally capped by `number_of_workers * max(1, pipeline_dop / 2)`. The legacy values `MAX` and `MIN` are still accepted for forward compatibility and are treated as the default estimator; any other value is rejected by configuration validation.
 - Introduced in: v3.5.0
 
 ### `query_queue_v2_concurrency_level`
@@ -731,7 +731,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Controls how many logical concurrency "layers" are used when computing the system's total query slots. In shared-nothing mode the total slots = `query_queue_v2_concurrency_level` * number_of_BEs * cores_per_BE (derived from BackendResourceStat). In multi-warehouse mode the effective concurrency is scaled down to max(1, `query_queue_v2_concurrency_level` / 4). If the configured value is non-positive it is treated as `4`. Changing this value increases or decreases totalSlots (and therefore concurrent query capacity) and affects per-slot resources: memBytesPerSlot is derived by dividing per-worker memory by (cores_per_worker * concurrency), and CPU accounting uses `query_queue_v2_cpu_costs_per_slot`. Set it proportional to cluster size; very large values may reduce per-slot memory and cause resource fragmentation. 
+- Description: Interpreted as a capacity level relative to the default level `4`. For the default (PBE) and CPU-cost-based (CBE) estimators, the system's total query slots are computed as `number_of_workers * cores_per_worker * (query_queue_v2_concurrency_level / 4)` (derived from BackendResourceStat). For the memory-cost-based estimator (MBE), the total slots are instead derived from the warehouse memory budget. If the configured value is non-positive it is treated as `4`. total_slots is clamped to at least `number_of_workers`. Increasing this value raises totalSlots (and therefore concurrent query capacity); at the default `4` the total capacity equals `number_of_workers * cores_per_worker`. Set it proportional to the concurrency you want for the cluster.
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_cpu_costs_per_slot`
@@ -740,8 +740,17 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Long
 - Unit: planner CPU cost units
 - Is mutable: Yes
-- Description: Per-slot CPU cost threshold used to estimate how many slots a query needs from its planner CPU cost. The scheduler computes slots as integer(`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`) and then clamps the result to the range [1, totalSlots] (totalSlots is derived from the query queue V2 `V2` parameters). The V2 code normalizes non-positive settings to 1 (Math.max(1, value)), so a non-positive value effectively becomes `1`. Increasing this value reduces slots allocated per query (favoring fewer, larger-slot queries); decreasing it increases slots per query. Tune together with `query_queue_v2_num_rows_per_slot` and concurrency settings to control parallelism vs. resource granularity.
+- Description: Per-slot CPU cost threshold used by the CPU-cost-based estimator (CBE) to estimate how many slots a query needs from its plan CPU cost. The scheduler computes slots as `ceil(plan_cpu_costs / query_queue_v2_cpu_costs_per_slot)` and clamps the result to the range `[1, min(totalSlots, number_of_workers * max(1, pipeline_dop / 2))]`. A non-positive value is normalized to `1`. Increasing this value reduces slots allocated per query (favoring fewer, larger-slot queries); decreasing it increases slots per query.
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
+
+### `query_queue_v2_mem_bytes_per_slot`
+
+- Default: 0
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: Per-slot memory target used by the memory-cost-based estimator (MBE). When `query_queue_slots_estimator_strategy` is `MBE`, the total slots are derived from the warehouse memory budget, and a query's slots are estimated from its total memory cost divided by this value, capped by `number_of_workers * max(1, pipeline_dop / 2)`. If it is non-positive, Query Queue V2 uses the average worker memory per core.
+- Introduced in: -
 
 ### `query_queue_v2_num_rows_per_slot`
 
@@ -749,7 +758,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Rows
 - Is mutable: Yes
-- Description: The target number of source-row records assigned to a single scheduling slot when estimating per-query slot count. StarRocks computes `estimated_slots` = (cardinality of the Source Node) / `query_queue_v2_num_rows_per_slot`, then clamps the result to the range [1, totalSlots] and enforces a minimum of 1 if the computed value is non-positive. totalSlots is derived from available resources (roughly DOP * `query_queue_v2_concurrency_level` * number_of_workers/BE) and therefore depends on cluster/core counts. Increase this value to reduce slot count (each slot handles more rows) and lower scheduling overhead; decrease it to increase parallelism (more, smaller slots), up to the resource limit.
+- Description: Retained for backward compatibility with existing Query Queue V2 serialized and debug output. It is no longer used by the PBE, MBE, or CBE slot estimators.
 - Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_schedule_strategy`

--- a/docs/ja/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/ja/administration/management/FE_parameters/user_query_loading.md
@@ -699,11 +699,11 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `query_queue_slots_estimator_strategy`
 
-- デフォルト：MAX
+- デフォルト：PBE
 - タイプ：String
 - 単位：-
 - 変更可能：Yes
-- 説明：`enable_query_queue_v2` が true の場合に、キューベースクエリに使用されるスロット推定戦略を選択します。有効な値は、MBE (メモリベース)、PBE (並行性ベース)、MAX (MBE と PBE の最大値を取る)、MIN (MBE と PBE の最小値を取る) です。MBE は、予測されたメモリまたは計画コストをスロットあたりのメモリターゲットで割ってスロットを推定し、`totalSlots` で上限が設定されます。PBE は、フラグメントの並行性 (スキャン範囲のカウントまたはカーディナリティ / スロットあたりの行数) と CPU コストベースの計算 (スロットあたりの CPU コストを使用) からスロットを導出し、結果を [numSlots/2, numSlots] の範囲内に制限します。MAX と MIN は、MBE と PBE の最大値または最小値を取ることによってそれらを結合します。設定された値が無効な場合、デフォルト (`MAX`) が使用されます。
+- 説明：`enable_query_queue_v2` が true の場合に、キューベースクエリに使用されるスロット推定戦略を選択します。有効な値は `PBE` (並行性ベース、デフォルト)、`MBE` (メモリコストベース)、`CBE` (CPU コストベース) です。PBE はスキャン並行性(ワーカー数を上限)からクエリのスロットを推定します。OLAP テーブルでは剪定後に残ったスキャン範囲数を使うため、非常に小さいクエリのみワーカー数を下回ります。connector/外部スキャンは単一スロットではなくフルパラレルスキャン(ワーカー数)として扱われます。MBE はクエリのメモリコストを `query_queue_v2_mem_bytes_per_slot` で割ってスロットを推定します。CBE は計画 CPU コストを `query_queue_v2_cpu_costs_per_slot` で割ってスロットを推定します。MBE と CBE のクエリごとのスロットは、さらに `number_of_workers * max(1, pipeline_dop / 2)` で上限が設定されます。後方互換性のため、レガシー値 `MAX` と `MIN` は引き続き受け入れられ、デフォルトの推定器として扱われます。それ以外の値は構成検証で拒否されます。
 - 導入時期：v3.5.0
 
 ### `query_queue_v2_concurrency_level`
@@ -712,7 +712,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - タイプ：Int
 - 単位：-
 - 変更可能：Yes
-- 説明：システムの総クエリスロットを計算する際に使用される論理的な並行性「レイヤー」の数を制御します。Shared-nothing モードでは、総スロット = `query_queue_v2_concurrency_level` * BE の数 * BE ごとのコア数 (BackendResourceStat から派生)。マルチウェアハウスモードでは、実効並行性は max(1, `query_queue_v2_concurrency_level` / 4) にスケーリングされます。設定値が非正の場合、`4` として扱われます。この値を変更すると、totalSlots (したがって同時クエリ容量) が増減し、スロットごとのリソースに影響します。memBytesPerSlot はワーカーごとのメモリを (ワーカーごとのコア数 * 並行性) で割って導出され、CPU アカウンティングは `query_queue_v2_cpu_costs_per_slot` を使用します。クラスターサイズに比例して設定してください。非常に大きな値はスロットごとのメモリを減らし、リソースの断片化を引き起こす可能性があります。
+- 説明：デフォルトレベル `4` を基準とした容量レベルとして解釈されます。デフォルト (PBE) および CPU コストベース (CBE) の推定器では、システムの総クエリスロットは `number_of_workers * cores_per_worker * (query_queue_v2_concurrency_level / 4)` (BackendResourceStat から派生) として計算されます。メモリコストベース (MBE) の推定器では、総スロットは代わりにウェアハウスのメモリ予算から導出されます。設定値が非正の場合、`4` として扱われます。totalSlots は少なくとも `number_of_workers` になるようにクランプされます。この値を増やすと totalSlots (したがって同時クエリ容量) が増加します。デフォルト `4` では、総容量は `number_of_workers * cores_per_worker` に等しくなります。クラスターに必要な並行性に比例して設定してください。
 - 導入時期：v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_cpu_costs_per_slot`
@@ -721,8 +721,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - タイプ：Long
 - 単位：planner CPU cost units
 - 変更可能：Yes
-- 説明：プランナー CPU コストからクエリが必要とするスロット数を推定するために使用されるスロットごとの CPU コストしきい値。スケジューラーは、スロットを整数 (`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`) として計算し、結果を [1, totalSlots] の範囲にクランプします (totalSlots はクエリキュー V2 `V2` パラメーターから派生)。V2 コードは非正の設定を 1 に正規化するため (Math.max(1, value))、非正の値は事実上 `1` になります。この値を増やすと、クエリごとに割り当てられるスロットが減少し (より少ない、より大きなスロットのクエリを優先)、減らすとクエリごとのスロットが増加します。並行性対リソースの粒度を制御するために、`query_queue_v2_num_rows_per_slot` および並行性設定と合わせて調整してください。
+- 説明：CPU コストベースの推定器 (CBE) が計画 CPU コストからクエリの必要スロット数を推定するために使用するスロットごとの CPU コストしきい値。スケジューラーはスロットを `ceil(plan_cpu_costs / query_queue_v2_cpu_costs_per_slot)` として計算し、結果を `[1, min(totalSlots, number_of_workers * max(1, pipeline_dop / 2))]` の範囲にクランプします。非正の値は `1` に正規化されます。この値を増やすと、クエリごとに割り当てられるスロットが減少し (より少ない、より大きなスロットのクエリを優先)、減らすとクエリごとのスロットが増加します。
 - 導入時期：v3.3.4, v3.4.0, v3.5.0
+
+### `query_queue_v2_mem_bytes_per_slot`
+
+- デフォルト：0
+- タイプ：Long
+- 単位：バイト
+- 変更可能：Yes
+- 説明：メモリコストベースの推定器 (MBE) が使用するスロットごとのメモリターゲット。`query_queue_slots_estimator_strategy` が `MBE` の場合、総スロットはウェアハウスのメモリ予算から導出され、クエリのスロットはその総メモリコストをこの値で割って推定され、`number_of_workers * max(1, pipeline_dop / 2)` で上限が設定されます。非正の場合、Query Queue V2 はコアあたりの平均ワーカーメモリを使用します。
+- 導入時期：-
 
 ### `query_queue_v2_num_rows_per_slot`
 
@@ -730,7 +739,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - タイプ：Int
 - 単位：Rows
 - 変更可能：Yes
-- 説明：クエリごとのスロット数を推定する際に、単一のスケジューリングスロットに割り当てられるターゲットのソース行レコード数。StarRocks は、`estimated_slots` = (ソースノードのカーディナリティ) / `query_queue_v2_num_rows_per_slot` を計算し、その結果を [1, totalSlots] の範囲にクランプし、計算された値が非正の場合は最低 1 を強制します。totalSlots は利用可能なリソース (おおよそ DOP * `query_queue_v2_concurrency_level` * ワーカー/BE の数) から導出され、したがってクラスター/コア数に依存します。この値を増やすと、スロット数が減少し (各スロットがより多くの行を処理)、スケジューリングオーバーヘッドが減少します。減らすと、並行性が増加し (より多くの、より小さいスロット)、リソース制限まで増加します。
+- 説明：Query Queue V2 の既存のシリアライズ / デバッグ出力との後方互換性のために保持されています。PBE、MBE、CBE のスロット推定器では使用されなくなりました。
 - 導入時期：v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_schedule_strategy`

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -717,11 +717,11 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### `query_queue_slots_estimator_strategy`
 
-- 默认值: MAX
+- 默认值: PBE
 - 类型: String
 - 单位: -
 - 是否可变: Yes
-- 描述: 当 `enable_query_queue_v2` 为 true 时，选择用于基于队列的查询的槽位估算策略。有效值：MBE（基于内存）、PBE（基于并行度）、MAX（取 MBE 和 PBE 的最大值）和 MIN（取 MBE 和 PBE 的最小值）。MBE 根据预测内存或计划成本除以每个槽位内存目标来估算槽位，并受 `totalSlots` 限制。PBE 根据片段并行度（扫描范围计数或基数/每槽位行数）和基于 CPU 成本的计算（使用每槽位 CPU 成本）推导出槽位，然后将结果限制在 [numSlots/2, numSlots] 范围内。MAX 和 MIN 通过取其最大值或最小值来组合 MBE 和 PBE。如果配置值无效，则使用默认值 (`MAX`)。
+- 描述: 当 `enable_query_queue_v2` 为 true 时，选择用于基于队列的查询的槽位估算策略。有效值：`PBE`（基于并行度，默认值）、`MBE`（基于内存成本）和 `CBE`（基于 CPU 成本）。PBE 根据扫描并行度估算查询槽位（受 worker 数量上限）：OLAP 表使用剪枝后剩余的扫描范围数，因此只有极小的查询才会低于 worker 数；connector/外表扫描按满并行度（worker 数）处理，而不是当作单槽位查询。MBE 根据查询的内存成本除以 `query_queue_v2_mem_bytes_per_slot` 估算槽位。CBE 根据计划 CPU 成本除以 `query_queue_v2_cpu_costs_per_slot` 估算槽位。MBE 和 CBE 的单查询槽位还会被 `number_of_workers * max(1, pipeline_dop / 2)` 上限约束。为向后兼容，旧值 `MAX` 和 `MIN` 仍被接受，并按默认估算器处理；其他值会被配置校验拒绝。
 - 引入版本: v3.5.0
 
 ### `query_queue_v2_concurrency_level`
@@ -730,7 +730,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Int
 - 单位: -
 - 是否可变: Yes
-- 描述: 控制计算系统总查询槽位时使用的逻辑并发“层数”。在 shared-nothing 模式下，总槽位 = `query_queue_v2_concurrency_level` * BE 数量 * 每个 BE 的核心数（来自 BackendResourceStat）。在多仓库模式下，有效并发会缩减为 max(1, `query_queue_v2_concurrency_level` / 4)。如果配置值为非正数，则视为 `4`。更改此值会增加或减少 totalSlots（以及因此的并发查询容量），并影响每个槽位的资源：memBytesPerSlot 通过将每个 worker 内存除以（每个 worker 的核心数 * 并发）得出，并且 CPU 记账使用 `query_queue_v2_cpu_costs_per_slot`。将其设置为与集群大小成比例；非常大的值可能会减少每个槽位的内存并导致资源碎片。
+- 描述: 作为相对于默认层级 `4` 的容量层级来解释。对于默认（PBE）和基于 CPU 成本（CBE）的估算器，系统总查询槽位计算为 `number_of_workers * cores_per_worker * (query_queue_v2_concurrency_level / 4)`（来自 BackendResourceStat）。对于基于内存成本（MBE）的估算器，总槽位改为根据仓库内存预算推导。如果配置值为非正数，则视为 `4`。totalSlots 会被下限约束为至少 `number_of_workers`。增大此值会提高 totalSlots（以及并发查询容量）；在默认值 `4` 时，总容量等于 `number_of_workers * cores_per_worker`。请按集群所需并发度成比例设置。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_cpu_costs_per_slot`
@@ -739,8 +739,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Long
 - 单位: 规划器 CPU 成本单位
 - 是否可变: Yes
-- 描述: 每个槽位的 CPU 成本阈值，用于根据查询的规划器 CPU 成本估算查询所需的槽位数量。调度器计算槽位为整数（`plan_cpu_costs` / `query_queue_v2_cpu_costs_per_slot`），然后将结果限制在 [1, totalSlots] 范围内（totalSlots 来自查询队列 V2 `V2` 参数）。V2 代码将非正值规范化为 1 (Math.max(1, value))，因此非正值实际上变为 `1`。增加此值会减少每个查询分配的槽位（有利于更少、更大槽位的查询）；减少此值会增加每个查询的槽位。与 `query_queue_v2_num_rows_per_slot` 和并发设置一起调整，以控制并行度与资源粒度。
+- 描述: 基于 CPU 成本的估算器（CBE）使用的每槽位 CPU 成本阈值，用于根据查询的计划 CPU 成本估算所需槽位数量。调度器计算槽位为 `ceil(plan_cpu_costs / query_queue_v2_cpu_costs_per_slot)`，然后将结果限制在 `[1, min(totalSlots, number_of_workers * max(1, pipeline_dop / 2))]` 范围内。非正值会被规范化为 `1`。增大此值会减少每个查询分配的槽位（有利于更少、更大槽位的查询）；减小此值会增加每个查询的槽位。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
+
+### `query_queue_v2_mem_bytes_per_slot`
+
+- 默认值: 0
+- 类型: Long
+- 单位: 字节
+- 是否可变: Yes
+- 描述: 基于内存成本的估算器（MBE）使用的每槽位内存目标。当 `query_queue_slots_estimator_strategy` 为 `MBE` 时，总槽位根据仓库内存预算推导，单个查询的槽位根据其总内存成本除以该值估算，并被 `number_of_workers * max(1, pipeline_dop / 2)` 上限约束。如果为非正数，Query Queue V2 使用每核平均 worker 内存。
+- 引入版本: -
 
 ### `query_queue_v2_num_rows_per_slot`
 
@@ -748,7 +757,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Int
 - 单位: 行
 - 是否可变: Yes
-- 描述: 当估算每个查询的槽位计数时，分配给单个调度槽位的目标源行记录数。StarRocks 计算 `estimated_slots` = (源节点的基数) / `query_queue_v2_num_rows_per_slot`，然后将结果限制在 [1, totalSlots] 范围内，如果计算值为非正数，则强制最小值为 1。totalSlots 来自可用资源（大致为 DOP * `query_queue_v2_concurrency_level` * worker/BE 数量），因此取决于集群/核心计数。增加此值以减少槽位计数（每个槽位处理更多行）并降低调度开销；减少此值以增加并行度（更多、更小的槽位），直至达到资源限制。
+- 描述: 为向后兼容 Query Queue V2 现有的序列化 / 调试输出而保留。PBE、MBE、CBE 槽位估算器均不再使用它。
 - 引入版本: v3.3.4, v3.4.0, v3.5.0
 
 ### `query_queue_v2_schedule_strategy`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -951,9 +951,10 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_query_queue_v2 = true;
     /**
-     * Used to calculate the total number of slots the system has,
-     * which is equal to the configuration value * BE number * BE cores.
-     * It will be set to `4` if it is non-positive.
+     * Used to calculate the total number of slots the system has.
+     * If it is non-positive, Query Queue V2 uses 4 as the effective level.
+     * The effective level is interpreted as a level against the default level 4:
+     * total_slots = workers * cores_per_worker * (effective_level / 4).
      */
     @ConfField(mutable = true)
     public static int query_queue_v2_concurrency_level = 4;
@@ -961,22 +962,29 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Schedule strategy of pending queries: SWRR/SJF")
     public static String query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.createDefault().name();
 
-    @ConfField(mutable = true, comment = "Slot estimator strategy of queue based queries: MBE/PBE/MAX/MIN")
+    @ConfField(mutable = true, comment = "Slot estimator strategy of queue based queries: PBE/MBE/CBE")
     public static String query_queue_slots_estimator_strategy = SlotEstimatorFactory.EstimatorPolicy.createDefault().name();
 
     @ConfField(mutable = true, comment = "The max number of history allocated slots for a query queue")
     public static int max_query_queue_history_slots_number = 0;
 
     /**
-     * Used to estimate the number of slots of a query based on the cardinality of the Source Node. It is equal to the
-     * cardinality of the Source Node divided by the configuration value and is limited to between [1, DOP*numBEs].
-     * It will be set to `1` if it is non-positive.
+     * Used by MBE to estimate query slots from memory cost.
+     * If it is non-positive, Query Queue V2 uses average worker memory per core.
+     */
+    @ConfField(mutable = true)
+    public static long query_queue_v2_mem_bytes_per_slot = 0;
+
+    /**
+     * Retained for compatibility with existing Query Queue V2 serialized/debug output.
+     * It is not used by PBE, MBE, or CBE slot estimation.
      */
     @ConfField(mutable = true)
     public static int query_queue_v2_num_rows_per_slot = 4096;
     /**
-     * Used to estimate the number of slots of a query based on the plan cpu costs.
-     * It is equal to the plan cpu costs divided by the configuration value and is limited to between [1, totalSlots].
+     * Used by CBE to estimate the number of slots of a query based on the plan cpu costs.
+     * It is equal to the plan cpu costs divided by the configuration value and is limited to between
+     * [1, min(totalSlots, number_of_workers * max(1, pipeline_dop / 2))].
      * It will be set to `1` if it is non-positive.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ConfigBase.java
@@ -283,6 +283,16 @@ public class ConfigBase {
                                     + confVal);
                 }
                 break;
+            case "query_queue_slots_estimator_strategy":
+                if (!confVal.equalsIgnoreCase("PBE")
+                        && !confVal.equalsIgnoreCase("MBE")
+                        && !confVal.equalsIgnoreCase("CBE")
+                        && !confVal.equalsIgnoreCase("MAX")
+                        && !confVal.equalsIgnoreCase("MIN")) {
+                    throw new InvalidConfException("'query_queue_slots_estimator_strategy' must be one of PBE, "
+                            + "MBE, CBE, MAX, or MIN. Current value: " + confVal);
+                }
+                break;
             case "http_request_security_level":
                 int securityLevel = Integer.parseInt(confVal);
                 if (securityLevel < 1 || securityLevel > 4) {
@@ -333,10 +343,19 @@ public class ConfigBase {
         }
     }
 
-    public static void setConfigField(Field f, String confVal) throws Exception {
+    private static class ParsedConfigValue {
+        private final String confVal;
+        private final Object parsedValue;
+
+        private ParsedConfigValue(String confVal, Object parsedValue) {
+            this.confVal = confVal;
+            this.parsedValue = parsedValue;
+        }
+    }
+
+    private static ParsedConfigValue parseAndValidateConfigField(Field f, String confVal) throws Exception {
         confVal = confVal.trim();
         boolean isEmpty = confVal.isEmpty();
-
         String[] sa = confVal.split(",");
         for (int i = 0; i < sa.length; i++) {
             sa[i] = sa[i].trim();
@@ -344,71 +363,89 @@ public class ConfigBase {
 
         validateConfValue(f, sa, confVal);
 
-        // set config field
+        Object parsedValue;
         switch (f.getType().getSimpleName()) {
             case "short":
-                f.setShort(null, Short.parseShort(confVal));
+                parsedValue = Short.parseShort(confVal);
                 break;
             case "int":
-                f.setInt(null, Integer.parseInt(confVal));
+                parsedValue = Integer.parseInt(confVal);
                 break;
             case "long":
-                f.setLong(null, Long.parseLong(confVal));
+                parsedValue = Long.parseLong(confVal);
                 break;
             case "double":
-                f.setDouble(null, Double.parseDouble(confVal));
+                parsedValue = Double.parseDouble(confVal);
                 break;
             case "boolean":
-                f.setBoolean(null, Boolean.parseBoolean(confVal));
+                parsedValue = Boolean.parseBoolean(confVal);
                 break;
             case "String":
-                f.set(null, confVal);
+                parsedValue = confVal;
                 break;
             case "short[]":
                 short[] sha = isEmpty ? new short[0] : new short[sa.length];
                 for (int i = 0; i < sha.length; i++) {
                     sha[i] = Short.parseShort(sa[i]);
                 }
-                f.set(null, sha);
+                parsedValue = sha;
                 break;
             case "int[]":
                 int[] ia = isEmpty ? new int[0] : new int[sa.length];
                 for (int i = 0; i < ia.length; i++) {
                     ia[i] = Integer.parseInt(sa[i]);
                 }
-                f.set(null, ia);
+                parsedValue = ia;
                 break;
             case "long[]":
                 long[] la = isEmpty ? new long[0] : new long[sa.length];
                 for (int i = 0; i < la.length; i++) {
                     la[i] = Long.parseLong(sa[i]);
                 }
-                f.set(null, la);
+                parsedValue = la;
                 break;
             case "double[]":
                 double[] da = isEmpty ? new double[0] : new double[sa.length];
                 for (int i = 0; i < da.length; i++) {
                     da[i] = Double.parseDouble(sa[i]);
                 }
-                f.set(null, da);
+                parsedValue = da;
                 break;
             case "boolean[]":
                 boolean[] ba = isEmpty ? new boolean[0] : new boolean[sa.length];
                 for (int i = 0; i < ba.length; i++) {
                     ba[i] = Boolean.parseBoolean(sa[i]);
                 }
-                f.set(null, ba);
+                parsedValue = ba;
                 break;
             case "String[]":
-                f.set(null, isEmpty ? new String[0] : sa);
+                parsedValue = isEmpty ? new String[0] : sa;
                 break;
             default:
                 throw new InvalidConfException("unknown type: " + f.getType().getSimpleName());
         }
+        return new ParsedConfigValue(confVal, parsedValue);
+    }
+
+    public static void setConfigField(Field f, String confVal) throws Exception {
+        ParsedConfigValue parsedConfigValue = parseAndValidateConfigField(f, confVal);
+        f.set(null, parsedConfigValue.parsedValue);
     }
 
     public static synchronized void setMutableConfig(String key, String value,
                                                      boolean isPersisted, String userIdentity) throws InvalidConfException {
+        Field field = allMutableConfigs.get(key);
+        if (field == null) {
+            throw new InvalidConfException(ErrorCode.ERROR_CONFIG_NOT_EXIST, key);
+        }
+
+        ParsedConfigValue parsedConfigValue;
+        try {
+            parsedConfigValue = parseAndValidateConfigField(field, value);
+        } catch (Exception e) {
+            throw new InvalidConfException("Failed to set config '" + key + "'. err: " + e.getMessage());
+        }
+
         if (isPersisted) {
             if (!ConfigBase.isIsPersisted()) {
                 String errMsg = "set persisted config failed, because current running mode is not persisted";
@@ -417,19 +454,14 @@ public class ConfigBase {
             }
 
             try {
-                appendPersistedProperties(key, value, userIdentity);
+                appendPersistedProperties(key, parsedConfigValue.confVal, userIdentity);
             } catch (IOException e) {
                 throw new InvalidConfException("Failed to set config '" + key + "'. err: " + e.getMessage());
             }
         }
 
-        Field field = allMutableConfigs.get(key);
-        if (field == null) {
-            throw new InvalidConfException(ErrorCode.ERROR_CONFIG_NOT_EXIST, key);
-        }
-
         try {
-            ConfigBase.setConfigField(field, value);
+            field.set(null, parsedConfigValue.parsedValue);
         } catch (Exception e) {
             throw new InvalidConfException("Failed to set config '" + key + "'. err: " + e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueOptions.java
@@ -19,13 +19,11 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Config;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.RunMode;
 import com.starrocks.system.BackendResourceStat;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 public class QueryQueueOptions {
@@ -54,18 +52,15 @@ public class QueryQueueOptions {
             policy = SchedulePolicy.createDefault();
         }
 
-        int concurrencyLevel = Config.query_queue_v2_concurrency_level;
-        if (!RunMode.isSharedNothingMode()) {
-            // To avoid warehouse's cpu/mem usage too low, we can use concurrency level to scale up
-            // the total slots, the behavior is not changed by default.
-            concurrencyLevel = Math.max(1, Config.query_queue_v2_concurrency_level / 4);
-        }
-        final V2 v2 = new V2(concurrencyLevel,
+        SlotEstimatorFactory.EstimatorPolicy estimatorPolicy = SlotEstimatorFactory.getEstimatorPolicy();
+        final V2 v2 = new V2(Config.query_queue_v2_concurrency_level,
                 BackendResourceStat.getInstance().getNumBes(warehouseId),
                 BackendResourceStat.getInstance().getAvgNumCoresOfBe(warehouseId),
                 BackendResourceStat.getInstance().getAvgMemLimitBytes(warehouseId),
+                Config.query_queue_v2_mem_bytes_per_slot,
                 Config.query_queue_v2_num_rows_per_slot,
-                Config.query_queue_v2_cpu_costs_per_slot);
+                Config.query_queue_v2_cpu_costs_per_slot,
+                estimatorPolicy);
 
         return new QueryQueueOptions(true, v2, policy);
     }
@@ -125,6 +120,7 @@ public class QueryQueueOptions {
     }
 
     public static class V2 {
+        private static final int DEFAULT_CONCURRENCY_LEVEL = 4;
         public static final V2 DEFAULT = new V2();
 
         @SerializedName("NumWorkers")
@@ -143,29 +139,89 @@ public class QueryQueueOptions {
 
         @VisibleForTesting
         V2() {
-            this(1, 1, 1, 1, 1, 1);
+            this(1, 1, 1, 1, 0, 1, 1);
         }
 
         @VisibleForTesting
         V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker, int numRowsPerSlot,
                 long cpuCostsPerSlot) {
-            if (concurrencyLevel <= 0) {
-                concurrencyLevel = 4;
-            }
+            this(concurrencyLevel, numWorkers, numCoresPerWorker, memLimitBytesPerWorker, 0,
+                    numRowsPerSlot, cpuCostsPerSlot);
+        }
+
+        @VisibleForTesting
+        V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker,
+                long memBytesPerSlot, int numRowsPerSlot, long cpuCostsPerSlot) {
+            this(concurrencyLevel, numWorkers, numCoresPerWorker, memLimitBytesPerWorker, memBytesPerSlot,
+                    numRowsPerSlot, cpuCostsPerSlot, SlotEstimatorFactory.EstimatorPolicy.createDefault());
+        }
+
+        @VisibleForTesting
+        V2(int concurrencyLevel, int numWorkers, int numCoresPerWorker, long memLimitBytesPerWorker,
+                long memBytesPerSlot, int numRowsPerSlot, long cpuCostsPerSlot,
+                SlotEstimatorFactory.EstimatorPolicy estimatorPolicy) {
             int normNumWorkers = Math.max(1, numWorkers);
             int normNumCoresPerWorker = Math.max(1, numCoresPerWorker);
             int normNumRowsPerSlot = Math.max(1, numRowsPerSlot);
             long normCpuCostsPerSlot = Math.max(1, cpuCostsPerSlot);
+            int effectiveConcurrencyLevel = concurrencyLevel <= 0 ? DEFAULT_CONCURRENCY_LEVEL : concurrencyLevel;
+            double capacityRatio = (double) effectiveConcurrencyLevel / DEFAULT_CONCURRENCY_LEVEL;
+            long normMemBytesPerSlot = normalizeMemBytesPerSlot(memBytesPerSlot, memLimitBytesPerWorker,
+                    numCoresPerWorker);
 
             this.numWorkers = normNumWorkers;
             this.numRowsPerSlot = normNumRowsPerSlot;
 
-            this.totalSlots = normNumCoresPerWorker * concurrencyLevel * normNumWorkers;
-            int totalSlotsPerWorker = normNumCoresPerWorker * concurrencyLevel;
-            this.totalSmallSlots = normNumCoresPerWorker;
-            this.memBytesPerSlot = isAnyZero(memLimitBytesPerWorker, numCoresPerWorker) ? Long.MAX_VALUE :
-                    memLimitBytesPerWorker / totalSlotsPerWorker;
+            // SlotSelectionStrategyV2.WeightedRoundRobinQueue computes Utils.log2(totalSlots / numWorkers) and
+            // relies on totalSlots >= numWorkers. A below-default capacity level on a low-core warehouse can
+            // otherwise drive totalSlots under numWorkers (e.g. 3 one-core workers at level 1 => 1), making
+            // numSlotsPerWorker == 0 => log2(0) == -1 => negative/overflowed sub-queue bounds. Clamp to numWorkers.
+            this.totalSlots = Math.max(normNumWorkers, normalizeTotalSlots(estimatorPolicy, normNumWorkers,
+                    normNumCoresPerWorker, memLimitBytesPerWorker, normMemBytesPerSlot, capacityRatio));
+            this.totalSmallSlots = 0;
+            this.memBytesPerSlot = normMemBytesPerSlot;
             this.cpuCostsPerSlot = normCpuCostsPerSlot;
+        }
+
+        private static int normalizeTotalSlots(SlotEstimatorFactory.EstimatorPolicy estimatorPolicy, int numWorkers,
+                                               int numCoresPerWorker, long memLimitBytesPerWorker,
+                                               long memBytesPerSlot, double capacityRatio) {
+            if (estimatorPolicy == SlotEstimatorFactory.EstimatorPolicy.MBE) {
+                return normalizeMemoryTotalSlots(numWorkers, memLimitBytesPerWorker, memBytesPerSlot, capacityRatio);
+            }
+            return normalizeCoreTotalSlots(numWorkers, numCoresPerWorker, capacityRatio);
+        }
+
+        private static int normalizeCoreTotalSlots(int numWorkers, int numCoresPerWorker, double capacityRatio) {
+            double rawTotalSlots = numWorkers * (double) numCoresPerWorker * capacityRatio;
+            if (rawTotalSlots >= Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            return Math.max(1, (int) Math.round(rawTotalSlots));
+        }
+
+        private static int normalizeMemoryTotalSlots(int numWorkers, long memLimitBytesPerWorker,
+                                                     long memBytesPerSlot, double capacityRatio) {
+            if (memLimitBytesPerWorker <= 0 || memBytesPerSlot <= 0 || Double.isNaN(capacityRatio)
+                    || capacityRatio <= 0) {
+                return 1;
+            }
+            double rawTotalSlots = numWorkers * (double) memLimitBytesPerWorker * capacityRatio / memBytesPerSlot;
+            if (rawTotalSlots >= Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            return Math.max(1, (int) Math.floor(rawTotalSlots));
+        }
+
+        private static long normalizeMemBytesPerSlot(long memBytesPerSlot, long memLimitBytesPerWorker,
+                                                     int numCoresPerWorker) {
+            if (memBytesPerSlot > 0) {
+                return memBytesPerSlot;
+            }
+            if (memLimitBytesPerWorker <= 0 || numCoresPerWorker <= 0) {
+                return Long.MAX_VALUE;
+            }
+            return Math.max(1, memLimitBytesPerWorker / numCoresPerWorker);
         }
 
         public int getNumWorkers() {
@@ -236,10 +292,6 @@ public class QueryQueueOptions {
         public static SchedulePolicy create(String value) {
             return EnumUtils.getEnumIgnoreCase(SchedulePolicy.class, value);
         }
-    }
-
-    private static boolean isAnyZero(long... values) {
-        return Arrays.stream(values).anyMatch(val -> val == 0);
     }
 
     public static int correctSlotNum(int slotNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotEstimatorFactory.java
@@ -24,48 +24,44 @@ import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.sql.optimizer.cost.feature.CostPredictor;
 import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.starrocks.sql.optimizer.Utils.computeMinGEPower2;
 
 public class SlotEstimatorFactory {
     private static final Logger LOG = LogManager.getLogger(SlotEstimatorFactory.class);
 
     public enum EstimatorPolicy {
-        MBE, // memory-based slots estimator
-        PBE, // parallel-based slots estimator
-        MAX, // max of memory and parallel based slots estimator
-        MIN; // min of memory and parallel based slots estimator
+        PBE, // parallelism-based slots estimator
+        MBE, // memory-cost based slots estimator
+        CBE; // CPU-cost based slots estimator
 
         public static EstimatorPolicy createDefault() {
-            return MAX;
+            return PBE;
         }
 
         public static EstimatorPolicy create(String value) {
+            if ("MAX".equalsIgnoreCase(value) || "MIN".equalsIgnoreCase(value)) {
+                return createDefault();
+            }
             return EnumUtils.getEnumIgnoreCase(EstimatorPolicy.class, value);
         }
 
         public SlotEstimator createEstimator() {
             switch (this) {
-                case MBE:
-                    return new MemoryBasedSlotsEstimator();
                 case PBE:
                     return new ParallelismBasedSlotsEstimator();
-                case MAX:
-                    return new MaxSlotsEstimator(new MemoryBasedSlotsEstimator(), new ParallelismBasedSlotsEstimator());
-                case MIN:
-                    return new MinSlotsEstimator(new MemoryBasedSlotsEstimator(), new ParallelismBasedSlotsEstimator());
+                case MBE:
+                    return new MemoryBasedSlotsEstimator();
+                case CBE:
+                    return new CpuCostBasedSlotsEstimator();
                 default:
                     throw new IllegalArgumentException("Unknown EstimatorPolicy: " + this);
             }
@@ -77,172 +73,170 @@ public class SlotEstimatorFactory {
             return new DefaultSlotEstimator();
         }
 
-        EstimatorPolicy policy = EstimatorPolicy.create(Config.query_queue_slots_estimator_strategy);
-        if (policy == null) {
-            policy = EstimatorPolicy.createDefault();
-        }
+        EstimatorPolicy policy = getEstimatorPolicy();
         return policy.createEstimator();
     }
 
     /**
      * Estimate slots for EXPLAIN output when we only have ExecPlan (not DefaultCoordinator).
-     * This is used for query queue information in EXPLAIN.
+     * PBE uses fragments from ExecPlan; MBE and CBE use plan costs recorded in the audit event.
      */
     public static int estimateSlotsForExplain(QueryQueueOptions opts, ConnectContext context, ExecPlan execPlan) {
         if (!opts.isEnableQueryQueueV2()) {
             return 1;
         }
 
+        EstimatorPolicy policy = getEstimatorPolicy();
+        return estimateSlotsFromExecPlan(opts, context, execPlan, policy);
+    }
+
+    static EstimatorPolicy getEstimatorPolicy() {
         EstimatorPolicy policy = EstimatorPolicy.create(Config.query_queue_slots_estimator_strategy);
         if (policy == null) {
+            LOG.warn("unknown query_queue_slots_estimator_strategy: {}, fallback to default policy",
+                    Config.query_queue_slots_estimator_strategy);
             policy = EstimatorPolicy.createDefault();
         }
-
-        // For explain, we use a simplified estimation based on ExecPlan
-        // Memory-based estimation uses audit event costs (fallback path)
-        // Parallelism-based estimation uses fragments from ExecPlan
-        return estimateSlotsFromExecPlan(opts, context, execPlan, policy);
+        return policy;
     }
 
     private static int estimateSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context, ExecPlan execPlan,
                                                   EstimatorPolicy policy) {
-        int memBasedSlots = estimateMemoryBasedSlotsFromExecPlan(opts, context);
-        int parallelBasedSlots = estimateParallelismBasedSlotsFromExecPlan(opts, context, execPlan);
-
         switch (policy) {
-            case MBE:
-                return memBasedSlots;
             case PBE:
-                return parallelBasedSlots;
-            case MIN:
-                return Math.min(memBasedSlots, parallelBasedSlots);
-            case MAX:
+                return estimateParallelismBasedSlotsFromExecPlan(opts, execPlan);
+            case MBE:
+                return estimateMemoryBasedSlotsFromExecPlan(opts, context, execPlan);
+            case CBE:
+                return estimateCpuCostBasedSlots(opts, context, execPlan);
             default:
-                return Math.max(memBasedSlots, parallelBasedSlots);
+                return estimateParallelismBasedSlotsFromExecPlan(opts, execPlan);
         }
     }
 
-    private static int estimateMemoryBasedSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context) {
-        // Use audit event costs as fallback (same as MemoryBasedSlotsEstimator without predicted cost)
-        long memCost = (long) Math.max(context.getAuditEventBuilder().build().planMemCosts,
-                context.getAuditEventBuilder().build().planCpuCosts);
-        long numSlotsPerWorker = memCost / opts.v2().getMemBytesPerSlot();
-        numSlotsPerWorker = Math.max(numSlotsPerWorker, 0);
-        numSlotsPerWorker = computeMinGEPower2((int) numSlotsPerWorker);
-
-        long numSlots = numSlotsPerWorker * opts.v2().getNumWorkers();
-        numSlots = Math.max(numSlots, 1);
-        numSlots = Math.min(numSlots, opts.v2().getTotalSlots());
-
-        return (int) numSlots;
+    private static int estimateParallelismBasedSlotsFromExecPlan(QueryQueueOptions opts, ExecPlan execPlan) {
+        if (execPlan == null || execPlan.getFragments() == null || execPlan.getFragments().isEmpty()) {
+            return 1;
+        }
+        return estimateParallelismBasedSlotsFromRootFragment(opts, execPlan.getFragments().get(0));
     }
 
-    private static int estimateParallelismBasedSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context,
-                                                                  ExecPlan execPlan) {
-        List<PlanFragment> fragments = execPlan.getFragments();
-        if (fragments == null || fragments.isEmpty()) {
+    private static int estimateParallelismBasedSlotsFromRootFragment(QueryQueueOptions opts, PlanFragment rootFragment) {
+        if (rootFragment == null || rootFragment.getPlanRoot() == null) {
             return 1;
         }
 
-        PlanFragment rootFragment = fragments.get(0);
-        PlanNode rootNode = rootFragment.getPlanRoot();
         Map<PlanFragmentId, FragmentContext> contexts = Maps.newHashMap();
-        collectFragmentSourceNodes(rootNode, contexts);
-        calculateFragmentWorkers(opts, rootFragment, contexts);
-
-        int numSlots = contexts.values().stream()
-                .mapToInt(fragmentContext -> estimateFragmentSlots(opts, fragmentContext))
-                .max().orElse(1);
-
-        // Apply CPU-cost clamp like ParallelismBasedSlotsEstimator does
-        final int numWorkers = contexts.values().stream()
-                .mapToInt(fragmentContext -> fragmentContext.numWorkers)
-                .max().orElse(1);
-        final long planCpuCosts = (long) context.getAuditEventBuilder().build().planCpuCosts;
-        int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getCpuCostsPerSlot());
-        numSlotsByCpuCosts = Math.max(1, numSlotsByCpuCosts / numWorkers) * numWorkers;
-
-        // Restrict numSlotsByCpuCosts to be within [numSlots / 2, numSlots].
-        return Math.min(Math.max(numSlots / 2, numSlotsByCpuCosts), numSlots);
+        collectFragmentSourceNodes(rootFragment.getPlanRoot(), contexts);
+        int workUnits = contexts.values().stream()
+                .flatMap(fragmentContext -> fragmentContext.sourceNodes.stream())
+                .mapToInt(sourceNode -> estimateScanWorkUnits(opts, sourceNode))
+                .max()
+                .orElse(1);
+        return normalizeParallelismBasedSlots(opts, workUnits);
     }
 
-    private static int estimateFragmentSlots(QueryQueueOptions opts, FragmentContext context) {
-        int numSlots = 1;
-        for (PlanNode sourceNode : context.sourceNodes) {
-            int curNumSlots = estimateNumSlotsBySourceNode(opts, sourceNode);
-
-            curNumSlots /= context.numWorkers;
-            curNumSlots = Math.max(curNumSlots, 1);
-            curNumSlots = Math.min(curNumSlots, context.fragment.getPipelineDop());
-
-            curNumSlots *= context.numWorkers;
-            curNumSlots = Math.min(curNumSlots, opts.v2().getTotalSlots());
-
-            numSlots = Math.max(numSlots, curNumSlots);
-        }
-        return numSlots;
-    }
-
-    private static int estimateNumSlotsBySourceNode(QueryQueueOptions opts, PlanNode sourceNode) {
+    private static int estimateScanWorkUnits(QueryQueueOptions opts, PlanNode sourceNode) {
         if (sourceNode instanceof OlapScanNode) {
-            OlapScanNode olapScanNode = (OlapScanNode) sourceNode;
-            List<TScanRangeLocations> locations = olapScanNode.getScanRangeLocations(0);
-            if (locations != null) {
+            List<TScanRangeLocations> locations = ((OlapScanNode) sourceNode).getScanRangeLocations(0);
+            if (locations != null && !locations.isEmpty()) {
                 return locations.size();
             }
+            return 1;
         }
+        // PBE targets a parallelism of number_of_workers; only a very small query (pruned down to a few scan
+        // ranges) drops below the worker count. A connector/external scan does not expose its split/file count
+        // at estimation time (that listing is deferred to scheduling), so it is treated as a full-parallelism
+        // scan (number_of_workers work units) rather than collapsing to a single slot. This intentionally does
+        // not use the deprecated query_queue_v2_num_rows_per_slot or the (relative) optimizer cardinality.
+        if (sourceNode instanceof ScanNode && ((ScanNode) sourceNode).isConnectorScanNode()) {
+            return opts.v2().getNumWorkers();
+        }
+        // Other non-OLAP source nodes (e.g. exchange nodes) do not carry scan work; the leaf scans they are fed
+        // from are collected separately, so they contribute 1.
+        return 1;
+    }
 
-        return (int) (sourceNode.getCardinality() / opts.v2().getNumRowsPerSlot());
+    private static int normalizeParallelismBasedSlots(QueryQueueOptions opts, int workUnits) {
+        int numSlots = Math.min(opts.v2().getNumWorkers(), Math.max(1, workUnits));
+        return Math.max(1, Math.min(numSlots, opts.v2().getTotalSlots()));
+    }
+
+    private static int normalizeCostBasedSlots(QueryQueueOptions opts, double cost, long costPerSlot,
+                                               int maxSlotsByPipelineDop) {
+        int maxSlots = Math.max(1, Math.min(opts.v2().getTotalSlots(), maxSlotsByPipelineDop));
+        if (Double.isNaN(cost) || cost <= 0 || costPerSlot <= 0) {
+            return 1;
+        }
+        if (Double.isInfinite(cost)) {
+            return maxSlots;
+        }
+        double numSlots = Math.ceil(cost / costPerSlot);
+        if (numSlots >= maxSlots) {
+            return maxSlots;
+        }
+        return Math.max(1, (int) numSlots);
+    }
+
+    private static int normalizeCostBasedMaxSlots(QueryQueueOptions opts, int pipelineDop) {
+        int perWorkerMaxSlots = Math.max(1, pipelineDop / 2);
+        double rawMaxSlots = opts.v2().getNumWorkers() * (double) perWorkerMaxSlots;
+        int maxSlots = rawMaxSlots >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) rawMaxSlots;
+        return Math.max(1, Math.min(opts.v2().getTotalSlots(), maxSlots));
+    }
+
+    private static int getMaxPipelineDop(DefaultCoordinator coord) {
+        if (coord == null || coord.getExecutionDAG() == null) {
+            return 1;
+        }
+        return coord.getExecutionDAG().getFragmentsInCreatedOrder().stream()
+                .map(ExecutionFragment::getPlanFragment)
+                .mapToInt(PlanFragment::getPipelineDop)
+                .max()
+                .orElse(1);
+    }
+
+    private static int getMaxPipelineDop(ExecPlan execPlan) {
+        if (execPlan == null || execPlan.getFragments() == null || execPlan.getFragments().isEmpty()) {
+            return 1;
+        }
+        return execPlan.getFragments().stream()
+                .mapToInt(PlanFragment::getPipelineDop)
+                .max()
+                .orElse(1);
+    }
+
+    private static double getPlanMemCost(ConnectContext context) {
+        return context.getAuditEventBuilder().build().planMemCosts;
+    }
+
+    private static double getPlanCpuCost(ConnectContext context) {
+        return context.getAuditEventBuilder().build().planCpuCosts;
+    }
+
+    private static int estimateMemoryBasedSlotsFromExecPlan(QueryQueueOptions opts, ConnectContext context,
+                                                            ExecPlan execPlan) {
+        return normalizeCostBasedSlots(opts, getPlanMemCost(context), opts.v2().getMemBytesPerSlot(),
+                normalizeCostBasedMaxSlots(opts, getMaxPipelineDop(execPlan)));
+    }
+
+    private static int estimateCpuCostBasedSlots(QueryQueueOptions opts, ConnectContext context, ExecPlan execPlan) {
+        return normalizeCostBasedSlots(opts, getPlanCpuCost(context), opts.v2().getCpuCostsPerSlot(),
+                normalizeCostBasedMaxSlots(opts, getMaxPipelineDop(execPlan)));
     }
 
     private static void collectFragmentSourceNodes(PlanNode node, Map<PlanFragmentId, FragmentContext> contexts) {
         PlanFragmentId fragmentId = node.getFragmentId();
         if (node.getChildren().isEmpty() || !fragmentId.equals(node.getChildren().get(0).getFragmentId())) {
-            contexts.computeIfAbsent(fragmentId, k -> new FragmentContext(node.getFragment()))
+            contexts.computeIfAbsent(fragmentId, k -> new FragmentContext())
                     .sourceNodes.add(node);
         }
 
         node.getChildren().forEach(child -> collectFragmentSourceNodes(child, contexts));
     }
 
-    private static void calculateFragmentWorkers(QueryQueueOptions opts, PlanFragment fragment,
-                                                 Map<PlanFragmentId, FragmentContext> contexts) {
-        fragment.getChildren().forEach(child -> calculateFragmentWorkers(opts, child, contexts));
-
-        FragmentContext context = contexts.get(fragment.getFragmentId());
-        if (context == null) {
-            return;
-        }
-
-        PlanNode leftMostNode = fragment.getLeftMostNode();
-        if (leftMostNode instanceof OlapScanNode) {
-            OlapScanNode scanNode = (OlapScanNode) leftMostNode;
-            context.numWorkers = scanNode.getScanRangeLocations(0).stream()
-                    .flatMap(locations -> locations.getLocations().stream())
-                    .map(TScanRangeLocation::getBackend_id)
-                    .collect(Collectors.toSet())
-                    .size();
-        } else if (leftMostNode instanceof ScanNode && ((ScanNode) leftMostNode).isConnectorScanNode()) {
-            // TODO: get the actual number of files for connector scan nodes.
-            int numWorkers = (int) leftMostNode.getCardinality() / opts.v2().getNumRowsPerSlot();
-            context.numWorkers = Math.max(1, Math.min(numWorkers, opts.v2().getNumWorkers()));
-        } else if (fragment.isGatherFragment()) {
-            context.numWorkers = 1;
-        } else {
-            context.numWorkers = fragment.getChildren().stream()
-                    .mapToInt(child -> contexts.get(child.getFragmentId()).numWorkers)
-                    .max().orElse(1);
-        }
-    }
-
     private static class FragmentContext {
-        private final PlanFragment fragment;
         private final List<PlanNode> sourceNodes = Lists.newArrayList();
-        private int numWorkers = 1;
-
-        public FragmentContext(PlanFragment fragment) {
-            this.fragment = fragment;
-        }
     }
 
     public static class DefaultSlotEstimator implements SlotEstimator {
@@ -252,176 +246,35 @@ public class SlotEstimatorFactory {
         }
     }
 
-    public static class MemoryBasedSlotsEstimator implements SlotEstimator {
-        @Override
-        public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
-            long memCost;
-            boolean isCostPredictorAvailable = CostPredictor.getServiceBasedCostPredictor().isAvailable();
-            if (isCostPredictorAvailable && coord.getPredictedCost() > 0) {
-                memCost = coord.getPredictedCost();
-            } else {
-                if (isCostPredictorAvailable) {
-                    LOG.warn("Cost predictor is available, but predicted cost is not set. " +
-                            "Using planCpuCosts as the fallback.");
-                }
-                // The estimate of planMemCosts is typically an underestimation, often several orders of magnitude smaller than
-                // the actual memory usage, whereas planCpuCosts tends to be relatively larger.
-                // Therefore, the maximum value between the two is used as the estimate for memory.
-                memCost = (long) Math.max(context.getAuditEventBuilder().build().planMemCosts,
-                        context.getAuditEventBuilder().build().planCpuCosts);
-            }
-            long numSlotsPerWorker = memCost / opts.v2().getMemBytesPerSlot();
-            numSlotsPerWorker = Math.max(numSlotsPerWorker, 0);
-            numSlotsPerWorker = computeMinGEPower2((int) numSlotsPerWorker);
-
-            long numSlots = numSlotsPerWorker * opts.v2().getNumWorkers();
-            numSlots = Math.max(numSlots, 1);
-            numSlots = Math.min(numSlots, opts.v2().getTotalSlots());
-
-            return (int) numSlots;
-        }
-    }
-
     public static class ParallelismBasedSlotsEstimator implements SlotEstimator {
         @Override
         public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
-            Map<PlanFragmentId, FragmentContext> fragmentContexts = collectFragmentContexts(opts, coord);
-            int numSlots = fragmentContexts.values().stream()
-                    .mapToInt(fragmentContext -> estimateFragmentSlots(opts, fragmentContext))
-                    .max().orElse(1);
-
-            final int numWorkers = fragmentContexts.values().stream()
-                    .mapToInt(fragmentContext -> fragmentContext.numWorkers)
-                    .max().orElse(1);
-            final long planCpuCosts = (long) context.getAuditEventBuilder().build().planCpuCosts;
-            int numSlotsByCpuCosts = (int) (planCpuCosts / opts.v2().getCpuCostsPerSlot());
-            numSlotsByCpuCosts = Math.max(1, numSlotsByCpuCosts / numWorkers) * numWorkers;
-
-            // Restrict numSlotsByCpuCosts to be within [numSlots / 2, numSlots].
-            return Math.min(Math.max(numSlots / 2, numSlotsByCpuCosts), numSlots);
-        }
-
-        private static int estimateFragmentSlots(QueryQueueOptions opts, FragmentContext context) {
-            int numSlots = 1;
-            for (PlanNode sourceNode : context.sourceNodes) {
-                int curNumSlots = estimateNumSlotsBySourceNode(opts, sourceNode);
-
-                curNumSlots /= context.numWorkers;
-                curNumSlots = Math.max(curNumSlots, 1);
-                curNumSlots = Math.min(curNumSlots, context.fragment.getPipelineDop());
-
-                curNumSlots *= context.numWorkers;
-                curNumSlots = Math.min(curNumSlots, opts.v2().getTotalSlots());
-
-                numSlots = Math.max(numSlots, curNumSlots);
+            if (coord == null || coord.getExecutionDAG() == null || coord.getExecutionDAG().getRootFragment() == null) {
+                return 1;
             }
-            return numSlots;
-        }
-
-        private static int estimateNumSlotsBySourceNode(QueryQueueOptions opts, PlanNode sourceNode) {
-            if (sourceNode instanceof OlapScanNode) {
-                OlapScanNode olapScanNode = (OlapScanNode) sourceNode;
-                List<TScanRangeLocations> locations = olapScanNode.getScanRangeLocations(0);
-                if (locations != null) {
-                    return locations.size();
-                }
-            }
-
-            return (int) (sourceNode.getCardinality() / opts.v2().getNumRowsPerSlot());
-        }
-
-        private static Map<PlanFragmentId, FragmentContext> collectFragmentContexts(QueryQueueOptions opts,
-                                                                                    DefaultCoordinator coord) {
             PlanFragment rootFragment = coord.getExecutionDAG().getRootFragment().getPlanFragment();
-            PlanNode rootNode = rootFragment.getPlanRoot();
-
-            Map<PlanFragmentId, FragmentContext> contexts = Maps.newHashMap();
-            collectFragmentSourceNodes(rootNode, contexts);
-            calculateFragmentWorkers(opts, rootFragment, contexts);
-
-            return contexts;
-        }
-
-        private static void collectFragmentSourceNodes(PlanNode node, Map<PlanFragmentId, FragmentContext> contexts) {
-            PlanFragmentId fragmentId = node.getFragmentId();
-            if (node.getChildren().isEmpty() || !fragmentId.equals(node.getChildren().get(0).getFragmentId())) {
-                contexts.computeIfAbsent(fragmentId, k -> new FragmentContext(node.getFragment()))
-                        .sourceNodes.add(node);
-            }
-
-            node.getChildren().forEach(child -> collectFragmentSourceNodes(child, contexts));
-        }
-
-        private static void calculateFragmentWorkers(QueryQueueOptions opts, PlanFragment fragment,
-                                                     Map<PlanFragmentId, FragmentContext> contexts) {
-            fragment.getChildren().forEach(child -> calculateFragmentWorkers(opts, child, contexts));
-
-            FragmentContext context = contexts.get(fragment.getFragmentId());
-            if (context == null) {
-                return;
-            }
-
-            PlanNode leftMostNode = fragment.getLeftMostNode();
-            if (leftMostNode instanceof OlapScanNode) {
-                OlapScanNode scanNode = (OlapScanNode) leftMostNode;
-                context.numWorkers = scanNode.getScanRangeLocations(0).stream()
-                        .flatMap(locations -> locations.getLocations().stream())
-                        .map(TScanRangeLocation::getBackend_id)
-                        .collect(Collectors.toSet())
-                        .size();
-            } else if (leftMostNode instanceof ScanNode && ((ScanNode) leftMostNode).isConnectorScanNode()) {
-                // TODO: get the actual number of files for connector scan nodes.
-                int numWorkers = (int) leftMostNode.getCardinality() / opts.v2().getNumRowsPerSlot();
-                context.numWorkers = Math.max(1, Math.min(numWorkers, opts.v2().getNumWorkers()));
-            } else if (fragment.isGatherFragment()) {
-                context.numWorkers = 1;
-            } else {
-                context.numWorkers = fragment.getChildren().stream()
-                        .mapToInt(child -> contexts.get(child.getFragmentId()).numWorkers)
-                        .max().orElse(1);
-            }
-        }
-
-        private static class FragmentContext {
-            private final PlanFragment fragment;
-            private final List<PlanNode> sourceNodes = Lists.newArrayList();
-            private int numWorkers = 1;
-
-            public FragmentContext(PlanFragment fragment) {
-                this.fragment = fragment;
-            }
+            return estimateParallelismBasedSlotsFromRootFragment(opts, rootFragment);
         }
     }
 
-    public static class MaxSlotsEstimator implements SlotEstimator {
-        private final SlotEstimator[] estimators;
-
-        public MaxSlotsEstimator(SlotEstimator... estimators) {
-            this.estimators = estimators;
-        }
-
+    public static class MemoryBasedSlotsEstimator implements SlotEstimator {
         @Override
         public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
-            return Arrays.stream(estimators)
-                    .mapToInt(estimator -> estimator.estimateSlots(opts, context, coord))
-                    .max()
-                    .orElse(1);
+            double memCost = getPlanMemCost(context);
+            boolean isCostPredictorAvailable = CostPredictor.getServiceBasedCostPredictor().isAvailable();
+            if (isCostPredictorAvailable && coord != null && coord.getPredictedCost() > 0) {
+                memCost = coord.getPredictedCost();
+            }
+            return normalizeCostBasedSlots(opts, memCost, opts.v2().getMemBytesPerSlot(),
+                    normalizeCostBasedMaxSlots(opts, getMaxPipelineDop(coord)));
         }
     }
 
-    public static class MinSlotsEstimator implements SlotEstimator {
-        private final SlotEstimator[] estimators;
-
-        public MinSlotsEstimator(SlotEstimator... estimators) {
-            this.estimators = estimators;
-        }
-
+    public static class CpuCostBasedSlotsEstimator implements SlotEstimator {
         @Override
         public int estimateSlots(QueryQueueOptions opts, ConnectContext context, DefaultCoordinator coord) {
-            return Arrays.stream(estimators)
-                    .mapToInt(estimator -> estimator.estimateSlots(opts, context, coord))
-                    .min()
-                    .orElse(1);
+            return normalizeCostBasedSlots(opts, getPlanCpuCost(context), opts.v2().getCpuCostsPerSlot(),
+                    normalizeCostBasedMaxSlots(opts, getMaxPipelineDop(coord)));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/QueryQueueOptionsTest.java
@@ -31,16 +31,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class QueryQueueOptionsTest extends SchedulerTestBase {
     private boolean prevEnableQueryQueueV2 = false;
     private boolean prevEnableQueryQueueSelect = false;
+    private int prevQueryQueueV2ConcurrencyLevel = 0;
+    private long prevQueryQueueV2MemBytesPerSlot = 0;
+    private String prevQueryQueueSlotsEstimatorStrategy;
 
     @BeforeEach
     public void before() {
         prevEnableQueryQueueV2 = Config.enable_query_queue_v2;
         prevEnableQueryQueueSelect = GlobalVariable.isEnableQueryQueueSelect();
+        prevQueryQueueV2ConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        prevQueryQueueV2MemBytesPerSlot = Config.query_queue_v2_mem_bytes_per_slot;
+        prevQueryQueueSlotsEstimatorStrategy = Config.query_queue_slots_estimator_strategy;
+        Config.query_queue_v2_concurrency_level = 4;
+        Config.query_queue_v2_mem_bytes_per_slot = 0;
+        Config.query_queue_slots_estimator_strategy = SlotEstimatorFactory.EstimatorPolicy.createDefault().name();
     }
 
     @AfterEach
     public void after() {
         Config.enable_query_queue_v2 = prevEnableQueryQueueV2;
+        Config.query_queue_v2_concurrency_level = prevQueryQueueV2ConcurrencyLevel;
+        Config.query_queue_v2_mem_bytes_per_slot = prevQueryQueueV2MemBytesPerSlot;
+        Config.query_queue_slots_estimator_strategy = prevQueryQueueSlotsEstimatorStrategy;
         GlobalVariable.setEnableQueryQueueSelect(prevEnableQueryQueueSelect);
 
         BackendResourceStat.getInstance().reset();
@@ -48,19 +60,64 @@ public class QueryQueueOptionsTest extends SchedulerTestBase {
 
     @Test
     public void testZeroConcurrencyLevel() {
-        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(0, 0, 0, 0, 0, 0);
-        assertThat(opts.getTotalSlots()).isEqualTo(4);
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(0, 0, 0, 0, 0, 0, 0);
+        assertThat(opts.getTotalSlots()).isOne();
     }
 
     @Test
     public void testZeroOthers() {
-        QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(2, 0, 0, 0, 0, 0));
+        QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(2, 0, 0, 0, 0, 0, 0));
         assertThat(opts.v2().getNumWorkers()).isOne();
         assertThat(opts.v2().getNumRowsPerSlot()).isOne();
-        assertThat(opts.v2().getTotalSlots()).isEqualTo(2);
-        assertThat(opts.v2().getTotalSmallSlots()).isOne();
+        assertThat(opts.v2().getTotalSlots()).isOne();
+        assertThat(opts.v2().getTotalSmallSlots()).isZero();
         assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(Long.MAX_VALUE);
         assertThat(opts.v2().getCpuCostsPerSlot()).isOne();
+    }
+
+    @Test
+    public void testTotalSlotsSaturatesWhenCapacityOverflowsInteger() {
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(Integer.MAX_VALUE, Integer.MAX_VALUE, 1,
+                1024L, 0, 4096, 100);
+        assertThat(opts.getTotalSlots()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testCoreTotalSlotsClampedToNumWorkers() {
+        // A below-default capacity level on a low-core warehouse can drive core-based total slots under the
+        // worker count (3 one-core workers at level 1 => round(3 * 1 * 1/4) = 1). SlotSelectionStrategyV2's
+        // WeightedRoundRobinQueue then computes numSlotsPerWorker = totalSlots / numWorkers = 0 and
+        // Utils.log2(0) = -1, corrupting the sub-queue bounds. Total slots must stay >= numWorkers.
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(1, 3, 1, 0, 0, 4096, 100);
+        assertThat(opts.getNumWorkers()).isEqualTo(3);
+        assertThat(opts.getTotalSlots()).isGreaterThanOrEqualTo(opts.getNumWorkers());
+    }
+
+    @Test
+    public void testMemoryTotalSlotsClampedToNumWorkers() {
+        // Same invariant for the memory-based estimator: a tight memory budget can yield
+        // floor(3 * 64GB * 1/4 / 32GB) = 1 < numWorkers, which would corrupt the WRR queue as well.
+        final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+        final long memBytesPerSlot = 32L * 1024 * 1024 * 1024;
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(1, 3, 16, memLimitBytes, memBytesPerSlot, 4096, 100,
+                SlotEstimatorFactory.EstimatorPolicy.MBE);
+        assertThat(opts.getNumWorkers()).isEqualTo(3);
+        assertThat(opts.getTotalSlots()).isGreaterThanOrEqualTo(opts.getNumWorkers());
+    }
+
+    @Test
+    public void testAutoMemBytesPerSlotUsesMemPerCore() {
+        final int numCores = 16;
+        final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+
+        QueryQueueOptions.V2 opts = new QueryQueueOptions.V2(8, 1, numCores, memLimitBytes, 0, 4096, 100);
+        assertThat(opts.getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+
+        QueryQueueOptions.V2 legacyOpts = new QueryQueueOptions.V2(8, 1, numCores, memLimitBytes, 4096, 100);
+        assertThat(legacyOpts.getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+
+        QueryQueueOptions.V2 invalidCoresOpts = new QueryQueueOptions.V2(2, 1, 0, 1024L, 0, 4096, 100);
+        assertThat(invalidCoresOpts.getMemBytesPerSlot()).isEqualTo(Long.MAX_VALUE);
     }
 
     @Test
@@ -84,13 +141,139 @@ public class QueryQueueOptionsTest extends SchedulerTestBase {
             BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 2, memLimitBytes);
             Config.enable_query_queue_v2 = true;
             QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            int effectiveConcurrencyLevel = concurrencyLevel <= 0 ? 4 : concurrencyLevel;
+            double capacityRatio = (double) effectiveConcurrencyLevel / 4;
 
             assertThat(opts.isEnableQueryQueueV2()).isTrue();
             assertThat(opts.v2().getNumWorkers()).isEqualTo(numBEs);
             assertThat(opts.v2().getNumRowsPerSlot()).isEqualTo(Config.query_queue_v2_num_rows_per_slot);
-            assertThat(opts.v2().getTotalSlots()).isEqualTo(concurrencyLevel * numBEs * numCores);
-            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / concurrencyLevel / numCores);
-            assertThat(opts.v2().getTotalSmallSlots()).isEqualTo(numCores);
+            assertThat(opts.v2().getTotalSlots()).isEqualTo((int) Math.round(numBEs * numCores * capacityRatio));
+            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+            assertThat(opts.v2().getTotalSmallSlots()).isZero();
+        }
+    }
+
+    @Test
+    public void testCreateFromEnvUsesDefaultCapacityLevelWhenConcurrencyLevelIsZero() {
+        int prevConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        try {
+            final int numCores = 16;
+            final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+            final int numBEs = 2;
+
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 1, memLimitBytes);
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 2, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 2, memLimitBytes);
+            Config.enable_query_queue_v2 = true;
+            Config.query_queue_v2_concurrency_level = 0;
+
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            int effectiveConcurrencyLevel = 4;
+            double capacityRatio = (double) effectiveConcurrencyLevel / 4;
+
+            assertThat(opts.isEnableQueryQueueV2()).isTrue();
+            assertThat(opts.v2().getNumWorkers()).isEqualTo(numBEs);
+            assertThat(opts.v2().getTotalSlots()).isEqualTo((int) (numBEs * numCores * capacityRatio));
+            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+            assertThat(opts.v2().getTotalSmallSlots()).isZero();
+        } finally {
+            Config.query_queue_v2_concurrency_level = prevConcurrencyLevel;
+        }
+    }
+
+    @Test
+    public void testCreateFromEnvUsesConcurrencyLevelAsCapacityLevel() {
+        int prevConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        try {
+            final int numCores = 16;
+            final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+            final int numBEs = 2;
+            final int concurrencyLevel = 8;
+
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 1, memLimitBytes);
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 2, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 2, memLimitBytes);
+            Config.enable_query_queue_v2 = true;
+            Config.query_queue_v2_concurrency_level = concurrencyLevel;
+
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            double capacityRatio = (double) concurrencyLevel / 4;
+
+            assertThat(opts.isEnableQueryQueueV2()).isTrue();
+            assertThat(opts.v2().getNumWorkers()).isEqualTo(numBEs);
+            assertThat(opts.v2().getTotalSlots()).isEqualTo((int) (numBEs * numCores * capacityRatio));
+            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+            assertThat(opts.v2().getTotalSmallSlots()).isZero();
+        } finally {
+            Config.query_queue_v2_concurrency_level = prevConcurrencyLevel;
+        }
+    }
+
+    @Test
+    public void testCreateFromEnvUsesConfiguredMemBytesPerSlot() {
+        final int numCores = 16;
+        final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+        final long configuredMemBytesPerSlot = 2L * 1024 * 1024 * 1024;
+
+        BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, numCores);
+        BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 1, memLimitBytes);
+        Config.enable_query_queue_v2 = true;
+        Config.query_queue_v2_concurrency_level = 8;
+        Config.query_queue_v2_mem_bytes_per_slot = configuredMemBytesPerSlot;
+
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+        assertThat(opts.v2().getTotalSlots()).isEqualTo(32);
+        assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(configuredMemBytesPerSlot);
+    }
+
+    @Test
+    public void testCreateFromEnvUsesMemoryBudgetTotalSlotsForMemoryBasedEstimator() {
+        final int numCores = 16;
+        final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+        final int numBEs = 3;
+        final int concurrencyLevel = 8;
+        final long configuredMemBytesPerSlot = 8L * 1024 * 1024 * 1024;
+
+        for (int backendId = 1; backendId <= numBEs; backendId++) {
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, backendId, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, backendId, memLimitBytes);
+        }
+        Config.enable_query_queue_v2 = true;
+        Config.query_queue_slots_estimator_strategy = "MBE";
+        Config.query_queue_v2_concurrency_level = concurrencyLevel;
+        Config.query_queue_v2_mem_bytes_per_slot = configuredMemBytesPerSlot;
+
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        double capacityRatio = (double) concurrencyLevel / 4;
+        int expectedTotalSlots = (int) Math.floor(numBEs * (double) memLimitBytes * capacityRatio
+                / configuredMemBytesPerSlot);
+
+        assertThat(opts.v2().getTotalSlots()).isEqualTo(expectedTotalSlots);
+        assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(configuredMemBytesPerSlot);
+    }
+
+    @Test
+    public void testCreateFromEnvUsesMemPerCoreWhenMemBytesPerSlotIsAuto() {
+        int prevConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        try {
+            final int numCores = 16;
+            final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, numCores);
+            BackendResourceStat.getInstance().setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 1, memLimitBytes);
+            Config.enable_query_queue_v2 = true;
+            Config.query_queue_v2_concurrency_level = 8;
+            Config.query_queue_v2_mem_bytes_per_slot = 0;
+
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+
+            assertThat(opts.v2().getTotalSlots()).isEqualTo(32);
+            assertThat(opts.v2().getMemBytesPerSlot()).isEqualTo(memLimitBytes / numCores);
+        } finally {
+            Config.query_queue_v2_concurrency_level = prevConcurrencyLevel;
         }
     }
 
@@ -155,8 +338,8 @@ public class QueryQueueOptionsTest extends SchedulerTestBase {
             QueryQueueOptions.V2 v2 = opts.v2();
             assertThat(v2.getNumWorkers()).isEqualTo(1);
             assertThat(v2.getNumRowsPerSlot()).isEqualTo(Config.query_queue_v2_num_rows_per_slot);
-            assertThat(v2.getTotalSlots()).isEqualTo(4);
-            assertThat(v2.getTotalSmallSlots()).isEqualTo(1);
+            assertThat(v2.getTotalSlots()).isOne();
+            assertThat(v2.getTotalSmallSlots()).isZero();
             assertThat(v2.getCpuCostsPerSlot()).isEqualTo(Config.query_queue_v2_cpu_costs_per_slot);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotEstimatorTest.java
@@ -15,25 +15,59 @@
 package com.starrocks.qe.scheduler.slot;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.ConfigBase;
+import com.starrocks.common.InvalidConfException;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.scheduler.SchedulerTestBase;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SlotEstimatorTest extends SchedulerTestBase {
+    private String oldQueryQueueSlotsEstimatorStrategy;
+    private int oldQueryQueueV2ConcurrencyLevel;
+    private long oldQueryQueueV2MemBytesPerSlot;
+
     @BeforeAll
     public static void beforeClass() throws Exception {
         SchedulerTestBase.beforeClass();
         ConnectorPlanTestBase.mockCatalog(connectContext, MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        oldQueryQueueSlotsEstimatorStrategy = Config.query_queue_slots_estimator_strategy;
+        oldQueryQueueV2ConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        oldQueryQueueV2MemBytesPerSlot = Config.query_queue_v2_mem_bytes_per_slot;
+        Config.query_queue_slots_estimator_strategy = SlotEstimatorFactory.EstimatorPolicy.createDefault().name();
+        Config.query_queue_v2_concurrency_level = 4;
+        Config.query_queue_v2_mem_bytes_per_slot = 0;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.query_queue_slots_estimator_strategy = oldQueryQueueSlotsEstimatorStrategy;
+        Config.query_queue_v2_concurrency_level = oldQueryQueueV2ConcurrencyLevel;
+        Config.query_queue_v2_mem_bytes_per_slot = oldQueryQueueV2MemBytesPerSlot;
+        BackendResourceStat.getInstance().reset();
     }
 
     @Test
@@ -44,172 +78,217 @@ public class SlotEstimatorTest extends SchedulerTestBase {
 
     @Test
     public void testMemoryBasedSlotsEstimator() throws Exception {
-        final int numWorkers = 3;
-        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
-        QueryQueueOptions opts =
-                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(16, 3, 16, 64L * 1024 * 1024 * 1024,
+                        1024, 4096, 100));
         SlotEstimatorFactory.MemoryBasedSlotsEstimator estimator = new SlotEstimatorFactory.MemoryBasedSlotsEstimator();
 
-        DefaultCoordinator coordinator = getScheduler("SELECT * FROM lineitem");
+        DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=8)*/ * FROM lineitem");
 
         connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
-        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(3);
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(1000000L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
 
-        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers);
-        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+        connectContext.getAuditEventBuilder().setPlanMemCosts(1024L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
 
-        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers - 10);
-        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+        connectContext.getAuditEventBuilder().setPlanMemCosts(1024.5);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(2);
 
-        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers + 10);
-        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+        connectContext.getAuditEventBuilder().setPlanMemCosts(1025L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(2);
 
-        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers * 100);
-        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
+        connectContext.getAuditEventBuilder().setPlanMemCosts(1024L * 1000);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(12);
     }
 
     @Test
-    public void testParallelismBasedSlotsEstimator() throws Exception {
-        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator = new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
-        final int numWorkers = 3;
-        final int numCoresPerWorker = 16;
-        final int numRowsPerWorker = 4096;
-        final int dop = numCoresPerWorker / 2;
+    public void testMemoryBasedSlotsEstimatorClampsTotalPlanMemCostsByMemoryBudget() throws Exception {
+        final int numCores = 16;
+        final long memLimitBytes = 64L * 1024 * 1024 * 1024;
+        final long memBytesPerSlot = 32L * 1024 * 1024 * 1024;
+
+        BackendResourceStat.getInstance().setNumCoresOfBe(WarehouseManager.DEFAULT_WAREHOUSE_ID, 1, numCores);
+        BackendResourceStat.getInstance().setMemLimitBytesOfBe(WarehouseManager.DEFAULT_WAREHOUSE_ID, 1, memLimitBytes);
+        Config.query_queue_slots_estimator_strategy = "MBE";
+        Config.query_queue_v2_concurrency_level = numCores;
+        Config.query_queue_v2_mem_bytes_per_slot = memBytesPerSlot;
+
+        QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+        SlotEstimatorFactory.MemoryBasedSlotsEstimator estimator = new SlotEstimatorFactory.MemoryBasedSlotsEstimator();
+        DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=16)*/ * FROM lineitem");
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(100 * (double) memBytesPerSlot);
+
+        assertThat(opts.v2().getTotalSlots()).isEqualTo(8);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(8);
+    }
+
+    @Test
+    public void testCpuCostBasedSlotsEstimator() throws Exception {
+        SlotEstimatorFactory.CpuCostBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.CpuCostBasedSlotsEstimator();
         QueryQueueOptions opts = new QueryQueueOptions(true,
-                new QueryQueueOptions.V2(4, numWorkers, numCoresPerWorker, 64L * 1024 * 1024 * 1024, numRowsPerWorker, 100));
+                new QueryQueueOptions.V2(16, 3, 16, 64L * 1024 * 1024 * 1024,
+                        0, 4096, 100));
 
-        {
-            DefaultCoordinator coordinator = getScheduler("SELECT * FROM lineitem");
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(20 / 3 * 3);
-        }
+        DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=8)*/ * FROM lineitem");
 
-        String sql = "SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
-                "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "  4:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 1: L_ORDERKEY = 18: L_ORDERKEY\n" +
-                "  |  \n" +
-                "  |----3:EXCHANGE\n" +
-                "  |    \n" +
-                "  1:EXCHANGE");
-        assertContains(plan, "  RESULT SINK\n" +
-                "\n" +
-                "  8:AGGREGATE (merge finalize)\n" +
-                "  |  output: count(35: count)\n" +
-                "  |  group by: \n" +
-                "  |  \n" +
-                "  7:EXCHANGE");
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, 10);
-            setNodeCardinality(coordinator, 3, 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(20 / 3 * 3);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * 7);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(7 * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=100)*/ " +
-                    "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey");
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * 100);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(opts.v2().getTotalSlots());
-        }
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(-1L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
 
-        {
-            DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=19)*/ " +
-                    "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey");
-            // The exchange source node of the sink node only on one BE.
-            setNodeCardinality(coordinator, 7, numRowsPerWorker * 19);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(19);
-        }
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(100L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
 
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100. * numWorkers * dop * 1 / 4);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop / 2 * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100. * numWorkers * dop * 3 / 4);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * 3 / 4 * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100. * numWorkers * dop * 5 / 4);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
-        }
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(100.5);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(2);
+
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(101L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(2);
+
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(100L * 1000);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(12);
+    }
+
+    @Test
+    public void testCpuCostBasedSlotsEstimatorClampsByPipelineDopPerWorker() throws Exception {
+        SlotEstimatorFactory.CpuCostBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.CpuCostBasedSlotsEstimator();
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(16, 3, 16, 64L * 1024 * 1024 * 1024,
+                        0, 4096, 100));
+
+        DefaultCoordinator coordinator = getScheduler("SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
+                "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey");
+        setNodeCardinality(coordinator, 1, 3 * 4096 * 100);
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(250L);
+
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(3);
+
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(100L * 1000);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(12);
+    }
+
+    @Test
+    public void testParallelismBasedSlotsEstimatorForSingleOlapScanRange() throws Exception {
+        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        DefaultCoordinator coordinator = getScheduler("SELECT * FROM nation");
+
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
+    }
+
+    @Test
+    public void testParallelismBasedSlotsEstimatorForOlapScanCappedByWorkers() throws Exception {
+        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        DefaultCoordinator coordinator = getScheduler("SELECT * FROM lineitem");
+
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(numWorkers);
     }
 
     @Test
     public void testParallelismBasedSlotsEstimatorForConnectorScan() throws Exception {
-        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator = new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
+        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
         final int numWorkers = 3;
-        final int numCoresPerWorker = 16;
-        final int numRowsPerWorker = 4096;
-        final int dop = numCoresPerWorker / 2;
         QueryQueueOptions opts = new QueryQueueOptions(true,
-                new QueryQueueOptions.V2(4, numWorkers, numCoresPerWorker, 64L * 1024 * 1024 * 1024, numRowsPerWorker, 100));
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
 
-        String sql = "SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
-                "count(1) FROM hive0.tpch.lineitem t1 join [shuffle] hive0.tpch.lineitem t2 on t1.l_orderkey = t2.l_orderkey";
+        DefaultCoordinator coordinator = getScheduler("SELECT * FROM hive0.tpch.lineitem");
 
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
-        }
-        {
-            DefaultCoordinator coordinator = getScheduler(sql);
-            setNodeCardinality(coordinator, 1, numWorkers * numRowsPerWorker * dop * 10);
-            connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-            assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(dop * numWorkers);
-        }
+        // PBE aims for parallelism == number_of_workers; a connector/external scan's split count is not
+        // available at estimation time, so it is treated as a full-parallelism scan (number_of_workers work
+        // units) instead of collapsing to a single slot. The estimate does not depend on cardinality or on
+        // the deprecated query_queue_v2_num_rows_per_slot.
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(numWorkers);
+
+        // Cardinality changes must not change the connector estimate.
+        setNodeCardinality(coordinator, 0, 1L);
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(numWorkers);
     }
 
     @Test
-    public void testMaxSlotsEstimator() {
-        SlotEstimator estimator1 = (opts, context, coord) -> 1;
-        SlotEstimator estimator2 = (opts, context, coord) -> 2;
-        SlotEstimator estimator3 = (opts, context, coord) -> 3;
+    public void testParallelismBasedSlotsEstimatorForNoScanQuery() throws Exception {
+        SlotEstimatorFactory.ParallelismBasedSlotsEstimator estimator =
+                new SlotEstimatorFactory.ParallelismBasedSlotsEstimator();
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, 3, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
 
-        {
-            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator1, estimator2);
-            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(2);
-        }
+        DefaultCoordinator coordinator = getScheduler("SELECT 1");
 
-        {
-            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator1, estimator3);
-            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(3);
-        }
+        assertThat(estimator.estimateSlots(opts, connectContext, coordinator)).isEqualTo(1);
+    }
 
-        {
-            SlotEstimatorFactory.MaxSlotsEstimator estimator = new SlotEstimatorFactory.MaxSlotsEstimator(estimator2, estimator3);
-            assertThat(estimator.estimateSlots(null, null, null)).isEqualTo(3);
+    @Test
+    public void testEstimatorPolicyConfigValidationAcceptsLegacyMaxMin() throws Exception {
+        Field field = Config.class.getField("query_queue_slots_estimator_strategy");
+
+        ConfigBase.setConfigField(field, "PBE");
+        assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("PBE");
+        assertThat(SlotEstimatorFactory.getEstimatorPolicy()).isEqualTo(SlotEstimatorFactory.EstimatorPolicy.PBE);
+
+        ConfigBase.setConfigField(field, "MBE");
+        assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("MBE");
+        assertThat(SlotEstimatorFactory.getEstimatorPolicy()).isEqualTo(SlotEstimatorFactory.EstimatorPolicy.MBE);
+
+        ConfigBase.setConfigField(field, "CBE");
+        assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("CBE");
+        assertThat(SlotEstimatorFactory.getEstimatorPolicy()).isEqualTo(SlotEstimatorFactory.EstimatorPolicy.CBE);
+
+        ConfigBase.setConfigField(field, "MAX");
+        assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("MAX");
+        assertThat(SlotEstimatorFactory.getEstimatorPolicy())
+                .isEqualTo(SlotEstimatorFactory.EstimatorPolicy.createDefault());
+
+        ConfigBase.setConfigField(field, "MIN");
+        assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("MIN");
+        assertThat(SlotEstimatorFactory.getEstimatorPolicy())
+                .isEqualTo(SlotEstimatorFactory.EstimatorPolicy.createDefault());
+
+        assertThatThrownBy(() -> ConfigBase.setConfigField(field, "BAD_SET"))
+                .isInstanceOf(InvalidConfException.class)
+                .hasMessageContaining("query_queue_slots_estimator_strategy");
+        assertThatThrownBy(() -> ConfigBase.setConfigField(field, "FBE"))
+                .isInstanceOf(InvalidConfException.class)
+                .hasMessageContaining("query_queue_slots_estimator_strategy");
+    }
+
+    @Test
+    public void testPersistedEstimatorPolicyValidationAcceptsLegacyMaxMin(@TempDir Path tempDir)
+            throws Exception {
+        Field configPathField = ConfigBase.class.getDeclaredField("configPath");
+        Field isPersistedField = ConfigBase.class.getDeclaredField("isPersisted");
+        configPathField.setAccessible(true);
+        isPersistedField.setAccessible(true);
+        String oldConfigPath = (String) configPathField.get(null);
+        boolean oldIsPersisted = isPersistedField.getBoolean(null);
+
+        String initialConfig = "query_queue_slots_estimator_strategy = PBE\n";
+        Path configPath = tempDir.resolve("fe.conf");
+        Files.writeString(configPath, initialConfig);
+
+        try {
+            configPathField.set(null, configPath.toString());
+            isPersistedField.setBoolean(null, true);
+
+            ConfigBase.setMutableConfig("query_queue_slots_estimator_strategy", "MAX", true, "root");
+            assertThat(Config.query_queue_slots_estimator_strategy).isEqualTo("MAX");
+            assertThat(SlotEstimatorFactory.getEstimatorPolicy())
+                    .isEqualTo(SlotEstimatorFactory.EstimatorPolicy.createDefault());
+
+            assertThat(Files.readString(configPath)).contains("query_queue_slots_estimator_strategy = MAX");
+        } finally {
+            configPathField.set(null, oldConfigPath);
+            isPersistedField.setBoolean(null, oldIsPersisted);
         }
     }
 
@@ -222,7 +301,8 @@ public class SlotEstimatorTest extends SchedulerTestBase {
         assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.DefaultSlotEstimator.class);
 
         opts = new QueryQueueOptions(true, new QueryQueueOptions.V2(1, 1, 1, 1, 1, 1));
-        assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MaxSlotsEstimator.class);
+        assertThat(SlotEstimatorFactory.create(opts))
+                .isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
     }
 
     private static void setNodeCardinality(DefaultCoordinator coordinator, int nodeId, long cardinality) {
@@ -251,29 +331,39 @@ public class SlotEstimatorTest extends SchedulerTestBase {
     @Test
     public void testCreateWithPolicy() {
         {
+            Config.query_queue_slots_estimator_strategy = "PBE";
+            QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
+            assertThat(SlotEstimatorFactory.create(opts))
+                    .isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
+        }
+        {
             Config.query_queue_slots_estimator_strategy = "MBE";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
             assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MemoryBasedSlotsEstimator.class);
         }
         {
-            Config.query_queue_slots_estimator_strategy = "PBE";
+            Config.query_queue_slots_estimator_strategy = "CBE";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
-            assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
+            assertThat(SlotEstimatorFactory.create(opts))
+                    .isInstanceOf(SlotEstimatorFactory.CpuCostBasedSlotsEstimator.class);
         }
         {
             Config.query_queue_slots_estimator_strategy = "MAX";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
-            assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MaxSlotsEstimator.class);
+            assertThat(SlotEstimatorFactory.create(opts))
+                    .isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
         }
         {
             Config.query_queue_slots_estimator_strategy = "MIN";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
-            assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MinSlotsEstimator.class);
+            assertThat(SlotEstimatorFactory.create(opts))
+                    .isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
         }
         {
             Config.query_queue_slots_estimator_strategy = "BAD_SET";
             QueryQueueOptions opts = new QueryQueueOptions(true, new QueryQueueOptions.V2());
-            assertThat(SlotEstimatorFactory.create(opts)).isInstanceOf(SlotEstimatorFactory.MaxSlotsEstimator.class);
+            assertThat(SlotEstimatorFactory.create(opts))
+                    .isInstanceOf(SlotEstimatorFactory.ParallelismBasedSlotsEstimator.class);
         }
     }
 
@@ -286,109 +376,92 @@ public class SlotEstimatorTest extends SchedulerTestBase {
     }
 
     @Test
-    public void testEstimateSlotsForExplainWithMemoryBasedPolicy() throws Exception {
-        Config.query_queue_slots_estimator_strategy = "MBE";
-        final int numWorkers = 3;
-        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
-        QueryQueueOptions opts =
-                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
-
-        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
-        ExecPlan execPlan = planPair.second;
-
-        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
-        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
-        assertThat(slots).isEqualTo(3);
-
-        connectContext.getAuditEventBuilder().setPlanMemCosts(memLimitBytesPerWorker * numWorkers);
-        slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
-        assertThat(slots).isEqualTo(opts.v2().getTotalSlots());
-    }
-
-    @Test
-    public void testEstimateSlotsForExplainWithParallelBasedPolicy() throws Exception {
-        Config.query_queue_slots_estimator_strategy = "PBE";
-        final int numWorkers = 3;
-        final int numCoresPerWorker = 16;
-        final int numRowsPerWorker = 4096;
-        final int dop = numCoresPerWorker / 2;
-        QueryQueueOptions opts = new QueryQueueOptions(true,
-                new QueryQueueOptions.V2(4, numWorkers, numCoresPerWorker, 64L * 1024 * 1024 * 1024, numRowsPerWorker, 100));
-
-        String sql = "SELECT /*+SET_VAR(pipeline_dop=8)*/ " +
-                "count(1) FROM lineitem t1 join [shuffle] lineitem t2 on t1.l_orderkey = t2.l_orderkey";
-        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-        ExecPlan execPlan = planPair.second;
-
-        // Set cardinality on scan nodes in the exec plan
-        setNodeCardinalityInExecPlan(execPlan, 1, numWorkers * numRowsPerWorker * dop);
-
-        // Set planCpuCosts high enough to not be clamped by the CPU-cost clamp
-        connectContext.getAuditEventBuilder().setPlanCpuCosts(100 * 10000);
-
-        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
-        assertThat(slots).isEqualTo(dop * numWorkers);
-    }
-
-    @Test
-    public void testEstimateSlotsForExplainWithMaxPolicy() throws Exception {
-        Config.query_queue_slots_estimator_strategy = "MAX";
-        final int numWorkers = 3;
-        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
-        QueryQueueOptions opts =
-                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
-
-        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
-        ExecPlan execPlan = planPair.second;
-
-        // Memory-based will return 3, parallelism-based will return different value
-        // MAX should return the larger of the two
-        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
-        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
-        assertThat(slots).isGreaterThanOrEqualTo(1);
-    }
-
-    @Test
-    public void testEstimateSlotsForExplainWithMinPolicy() throws Exception {
-        Config.query_queue_slots_estimator_strategy = "MIN";
-        final int numWorkers = 3;
-        final long memLimitBytesPerWorker = 64L * 1024 * 1024 * 1024;
-        QueryQueueOptions opts =
-                new QueryQueueOptions(true, new QueryQueueOptions.V2(4, numWorkers, 16, memLimitBytesPerWorker, 4096, 1));
-
-        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
-        ExecPlan execPlan = planPair.second;
-
-        // MIN should return the smaller of memory-based and parallelism-based
-        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
-        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
-        assertThat(slots).isGreaterThanOrEqualTo(1);
-    }
-
-    @Test
-    public void testEstimateSlotsForExplainWithEmptyFragments() {
-        // Test with empty fragments
+    public void testEstimateSlotsForExplainWithParallelismBasedPolicy() throws Exception {
         Config.query_queue_slots_estimator_strategy = "PBE";
         final int numWorkers = 3;
         QueryQueueOptions opts = new QueryQueueOptions(true,
                 new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
 
-        // Create an exec plan with no fragments
-        ExecPlan emptyExecPlan = new ExecPlan();
-        
-        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, emptyExecPlan);
-        assertThat(slots).isEqualTo(1);
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(numWorkers);
     }
 
-    private static void setNodeCardinalityInExecPlan(ExecPlan execPlan, int nodeId, long cardinality) {
-        if (execPlan.getFragments() == null || execPlan.getFragments().isEmpty()) {
-            return;
-        }
-        PlanNode rootNode = execPlan.getFragments().get(0).getPlanRoot();
-        PlanNode node = findPlanNodeById(rootNode, nodeId);
-        if (node != null) {
-            Statistics statistics = Statistics.builder().setOutputRowCount(cardinality).build();
-            node.computeStatistics(statistics);
-        }
+    @Test
+    public void testEstimateSlotsForExplainUsesParallelismBasedPolicyByDefault() throws Exception {
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(numWorkers);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithInvalidPolicyFallsBackToParallelismBasedPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "BAD_SET";
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(numWorkers);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithMemoryBasedPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "MBE";
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(16, 3, 16, 64L * 1024 * 1024 * 1024, 1024, 4096, 100));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(-1L);
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(1);
+
+        connectContext.getAuditEventBuilder().setPlanMemCosts(1025L);
+        slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(2);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithCpuCostBasedPolicy() throws Exception {
+        Config.query_queue_slots_estimator_strategy = "CBE";
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(16, 3, 16, 64L * 1024 * 1024 * 1024, 0, 4096, 100));
+
+        Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, "SELECT * FROM lineitem");
+        ExecPlan execPlan = planPair.second;
+
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(-1L);
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(1);
+
+        connectContext.getAuditEventBuilder().setPlanCpuCosts(250L);
+        slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, execPlan);
+        assertThat(slots).isEqualTo(3);
+    }
+
+    @Test
+    public void testEstimateSlotsForExplainWithParallelismBasedPolicyAndEmptyFragments() {
+        Config.query_queue_slots_estimator_strategy = "PBE";
+        final int numWorkers = 3;
+        QueryQueueOptions opts = new QueryQueueOptions(true,
+                new QueryQueueOptions.V2(4, numWorkers, 16, 64L * 1024 * 1024 * 1024, 4096, 100));
+
+        ExecPlan emptyExecPlan = new ExecPlan();
+
+        int slots = SlotEstimatorFactory.estimateSlotsForExplain(opts, connectContext, emptyExecPlan);
+        assertThat(slots).isEqualTo(1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2Test.java
@@ -40,6 +40,10 @@ public class SlotSelectionStrategyV2Test {
     private static final int NUM_CORES = 16;
 
     private boolean prevEnableQueryQueueV2 = false;
+    private int prevQueryQueueV2ConcurrencyLevel = 0;
+    private String prevQueryQueueV2ScheduleStrategy;
+    private int prevMaxQueryQueueHistorySlotsNumber = 0;
+    private int prevQueryQueueConcurrencyLimit = -1;
 
     private SlotManager slotManager;
 
@@ -51,7 +55,15 @@ public class SlotSelectionStrategyV2Test {
     @BeforeEach
     public void before() {
         prevEnableQueryQueueV2 = Config.enable_query_queue_v2;
+        prevQueryQueueV2ConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        prevQueryQueueV2ScheduleStrategy = Config.query_queue_v2_schedule_strategy;
+        prevMaxQueryQueueHistorySlotsNumber = Config.max_query_queue_history_slots_number;
+        prevQueryQueueConcurrencyLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
         Config.enable_query_queue_v2 = true;
+        Config.query_queue_v2_concurrency_level = 0;
+        Config.query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.SWRR.name();
+        Config.max_query_queue_history_slots_number = 0;
+        GlobalVariable.setQueryQueueConcurrencyLimit(-1);
 
         ResourceUsageMonitor resourceUsageMonitor = new ResourceUsageMonitor();
         slotManager = new SlotManager(resourceUsageMonitor);
@@ -62,8 +74,16 @@ public class SlotSelectionStrategyV2Test {
     @AfterEach
     public void after() {
         Config.enable_query_queue_v2 = prevEnableQueryQueueV2;
+        Config.query_queue_v2_concurrency_level = prevQueryQueueV2ConcurrencyLevel;
+        Config.query_queue_v2_schedule_strategy = prevQueryQueueV2ScheduleStrategy;
+        Config.max_query_queue_history_slots_number = prevMaxQueryQueueHistorySlotsNumber;
+        GlobalVariable.setQueryQueueConcurrencyLimit(prevQueryQueueConcurrencyLimit);
 
         BackendResourceStat.getInstance().reset();
+    }
+
+    private static void useWideFbeCapacityForSchedulingTests() {
+        Config.query_queue_v2_concurrency_level = NUM_CORES;
     }
 
     private SlotSelectionStrategyV2 createSlotSelectionStrategy() {
@@ -71,70 +91,67 @@ public class SlotSelectionStrategyV2Test {
     }
 
     @Test
-    public void testSmallSlot() {
+    public void testSmallSlotDoesNotUseExtraCapacityUnderFbe() {
         QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
 
-        LogicalSlot largeSlot = generateSlot(opts.v2().getTotalSlots() - 1);
-        List<LogicalSlot> smallSlots = IntStream.range(0, NUM_CORES + 2)
-                .mapToObj(i -> generateSlot(1))
-                .collect(Collectors.toList());
+        assertThat(opts.v2().getTotalSmallSlots()).isZero();
 
-        // 1. Require and allocate the large slot with `totalSlots - 1` slots.
+        LogicalSlot largeSlot = generateSlot(opts.v2().getTotalSlots() - 1);
+        LogicalSlot smallSlot1 = generateSlot(1);
+        LogicalSlot smallSlot2 = generateSlot(1);
+
         slotTracker.requireSlot(largeSlot);
-        List<LogicalSlot> peakSlots = strategy.peakSlotsToAllocate(slotTracker);
-        assertThat(peakSlots).containsExactly(largeSlot);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(largeSlot);
         slotTracker.allocateSlot(largeSlot);
 
-        // 2. Require `NUM_CORES + 2` small slots.
-        for (LogicalSlot smallSlot : smallSlots) {
-            slotTracker.requireSlot(smallSlot);
-        }
+        slotTracker.requireSlot(smallSlot1);
+        slotTracker.requireSlot(smallSlot2);
 
-        // 3. Could peak and allocate `NUM_CORES + 1` small slots:
-        // - `NUM_CORES` small slot are allocated as small slots.
-        // - 1 small slot is allocated as a non-small slot.
         List<LogicalSlot> peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
-        assertThat(peakSmallSlots).hasSize(NUM_CORES + 1);
-        for (LogicalSlot peakSmallSlot : peakSmallSlots) {
-            slotTracker.allocateSlot(peakSmallSlot);
-        }
+        assertThat(peakSmallSlots).containsExactly(smallSlot1);
+        slotTracker.allocateSlot(smallSlot1);
 
-        // 4. Release the large slot and then the rest one small slot could be peaked.
-        peakSlots = strategy.peakSlotsToAllocate(slotTracker);
-        assertThat(peakSlots).isEmpty();
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
 
         slotTracker.releaseSlot(largeSlot.getSlotId());
-        peakSlots = strategy.peakSlotsToAllocate(slotTracker);
-        assertThat(peakSlots).hasSize(1);
-        slotTracker.allocateSlot(peakSlots.get(0));
-        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(smallSlots.size());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(smallSlot2);
+    }
 
-        // 5. Require `10+numAvailableSlots` small slots.
-        final int numAvailableSlots = opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots() - smallSlots.size();
-        List<LogicalSlot> smallSlots2 =
-                IntStream.range(0, 10 + numAvailableSlots)
-                        .mapToObj(i -> generateSlot(1))
-                        .collect(Collectors.toList());
-        smallSlots2.forEach(slotTracker::requireSlot);
+    @Test
+    public void testPointQueriesAreCappedByFbeTotalSlots() {
+        int oldConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        try {
+            Config.query_queue_v2_concurrency_level = 2;
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 2, NUM_CORES);
+            BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 3, NUM_CORES);
 
-        // 6. Could peak and allocate `numAvailableSlots` small slots.
-        peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
-        peakSmallSlots.forEach(slotTracker::allocateSlot);
-        assertThat(peakSmallSlots).hasSize(numAvailableSlots);
-        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots());
+            QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
+            SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
 
-        // 7. Release 10 small slots and then the rest small slots could be peaked and allocated.
-        smallSlots.stream().limit(10).forEach(slot -> slotTracker.releaseSlot(slot.getSlotId()));
-        peakSmallSlots = strategy.peakSlotsToAllocate(slotTracker);
-        peakSmallSlots.forEach(slotTracker::allocateSlot);
-        assertThat(peakSmallSlots).hasSize(10);
-        assertThat(slotTracker.getNumAllocatedSlots()).isEqualTo(opts.v2().getTotalSlots() + opts.v2().getTotalSmallSlots());
+            assertThat(opts.v2().getNumWorkers()).isEqualTo(3);
+            assertThat(opts.v2().getTotalSlots()).isEqualTo(24);
+            assertThat(opts.v2().getTotalSmallSlots()).isZero();
+
+            List<LogicalSlot> pointSlots = IntStream.range(0, 25)
+                    .mapToObj(i -> generateSlot(1))
+                    .collect(Collectors.toList());
+            pointSlots.forEach(slotTracker::requireSlot);
+
+            List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+            assertThat(peaked).hasSize(24);
+            peaked.forEach(slotTracker::allocateSlot);
+            assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+        } finally {
+            Config.query_queue_v2_concurrency_level = oldConcurrencyLevel;
+        }
     }
 
     @Test
     public void testHeadLineBlocking1() {
+        useWideFbeCapacityForSchedulingTests();
         QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
@@ -182,6 +199,7 @@ public class SlotSelectionStrategyV2Test {
 
     @Test
     public void testHeadLineBlocking2() {
+        useWideFbeCapacityForSchedulingTests();
         QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
@@ -349,6 +367,7 @@ public class SlotSelectionStrategyV2Test {
 
     @Test
     public void testHistorySlotsQueue() {
+        useWideFbeCapacityForSchedulingTests();
         Config.max_query_queue_history_slots_number = 10;
         QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
@@ -414,6 +433,7 @@ public class SlotSelectionStrategyV2Test {
 
     @Test
     public void testConcurrencyLimit1() {
+        useWideFbeCapacityForSchedulingTests();
         QueryQueueOptions opts = QueryQueueOptions.createFromEnv(WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, WarehouseManager.DEFAULT_WAREHOUSE_ID);
         SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotTrackerTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SlotTrackerTest {
     private static SlotManager slotManager;
@@ -179,12 +178,11 @@ public class SlotTrackerTest {
                 1, 1, 1, 1
         );
         BaseSlotTracker.ExtraMessage extraMessage = new BaseSlotTracker.ExtraMessage(1, v2);
-        assertTrue(extraMessage.getConcurrency() == 1);
-        assertThat(extraMessage.getV2().equals(v2));
+        assertThat(extraMessage.getConcurrency()).isEqualTo(1);
+        assertThat(extraMessage.getV2()).isEqualTo(v2);
         String json = GsonUtils.GSON.toJson(extraMessage);
-        assertTrue(json.equals("{\"Concurrency\":1,\"QueryQueueOption\":{\"NumWorkers\":300,\"NumRowsPerSlot\":1," +
-                "\"TotalSlots\":307200,\"MemBytesPerSlot\":0," +
-                "\"CpuCostsPerSlot\":1,\"TotalSmallSlots\":1}}"));
+        assertThat(json).isEqualTo("{\"Concurrency\":1,\"QueryQueueOption\":"
+                + GsonUtils.GSON.toJson(v2) + "}");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/WarehouseQueryQueueOptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/WarehouseQueryQueueOptionsTest.java
@@ -69,9 +69,11 @@ public class WarehouseQueryQueueOptionsTest {
         GlobalStateMgr.getCurrentState().getWarehouseMgr().addWarehouse(new DefaultWarehouse(warehouseId, "wh10000"));
         connectContext.setCurrentWarehouseId(warehouseId);
 
-        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10003L, 16);
-        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10004L, 16);
-        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10005L, 16);
+        final int numWorkers = 3;
+        final int numCores = 16;
+        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10003L, numCores);
+        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10004L, numCores);
+        BackendResourceStat.getInstance().setNumCoresOfBe(warehouseId, 10005L, numCores);
 
         {
             Config.enable_query_queue_v2 = false;
@@ -93,10 +95,15 @@ public class WarehouseQueryQueueOptionsTest {
             assertThat(opts.isEnableQueryQueueV2()).isTrue();
             assertThat(opts.v2()).isNotEqualTo(new QueryQueueOptions.V2());
             QueryQueueOptions.V2 v2 = opts.v2();
-            assertThat(v2.getNumWorkers()).isEqualTo(3);
+            int effectiveConcurrencyLevel = Config.query_queue_v2_concurrency_level <= 0 ? 4 :
+                    Config.query_queue_v2_concurrency_level;
+            double capacityRatio = (double) effectiveConcurrencyLevel / 4;
+
+            assertThat(v2.getNumWorkers()).isEqualTo(numWorkers);
             assertThat(v2.getNumRowsPerSlot()).isEqualTo(Config.query_queue_v2_num_rows_per_slot);
-            assertThat(QueryQueueOptions.correctSlotNum(v2.getTotalSlots())).isEqualTo(48);
-            assertThat(v2.getTotalSmallSlots()).isEqualTo(16);
+            assertThat(QueryQueueOptions.correctSlotNum(v2.getTotalSlots()))
+                    .isEqualTo((int) Math.round(numWorkers * numCores * capacityRatio));
+            assertThat(v2.getTotalSmallSlots()).isZero();
             assertThat(v2.getCpuCostsPerSlot()).isEqualTo(Config.query_queue_v2_cpu_costs_per_slot);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryQueueMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/warehouse/WarehouseQueryQueueMetricsTest.java
@@ -48,6 +48,8 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WarehouseQueryQueueMetricsTest extends SchedulerTestBase {
+    private int prevConcurrencyLevel;
+
     @BeforeAll
     public static void beforeClass() throws Exception {
         SchedulerTestBase.beforeClass();
@@ -56,6 +58,14 @@ public class WarehouseQueryQueueMetricsTest extends SchedulerTestBase {
 
     @BeforeEach
     public void before() {
+        // Query Queue V2 derives total slots from the capacity level as
+        // number_of_workers * cores_per_worker * (query_queue_v2_concurrency_level / 4). On this
+        // single-core test cluster the default level yields only 1 total slot, fewer than the queries
+        // this test runs concurrently. Raise the level so the queue concurrency limit (not the slot
+        // budget) is the admission gate.
+        prevConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        Config.query_queue_v2_concurrency_level = 16;
+
         GlobalVariable.setEnableGroupLevelQueryQueue(true);
 
         GlobalVariable.setQueryQueuePendingTimeoutSecond(Config.max_load_timeout_second);
@@ -84,6 +94,7 @@ public class WarehouseQueryQueueMetricsTest extends SchedulerTestBase {
                 .until(() -> 0 == MetricRepo.COUNTER_QUERY_QUEUE_PENDING.getValue());
         Awaitility.await().atMost(5, TimeUnit.SECONDS)
                 .until(() -> GlobalStateMgr.getCurrentState().getSlotManager().getSlots().isEmpty());
+        Config.query_queue_v2_concurrency_level = prevConcurrencyLevel;
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Query Queue V2 needs clearer and more controllable slot-estimation semantics. The
previous model made total capacity and per-query cost hard to reason about,
especially for memory-bound and CPU-bound workloads, and connector/external scans
or lower-capacity settings behaved poorly. This reworks the estimators so total
capacity and per-query cost are computed by well-defined, independently
configurable paths.

## What I'm doing:

- Interpret `query_queue_v2_concurrency_level` as a capacity level relative to the
  default `4`: `total_slots = number_of_workers * cores_per_worker * (level / 4)`,
  and clamp `total_slots` to at least the worker count so the weighted-round-robin
  sub-queue math (`log2(total_slots / number_of_workers)`) stays well-defined on
  low-core warehouses.
- Provide three estimators — PBE (parallelism-based), MBE (memory-cost-based) and
  CBE (CPU-cost-based) — with PBE as the default. Keep the legacy `MAX`/`MIN`
  values as accepted aliases that fall back to the default estimator for forward
  compatibility.
- PBE approximates scan parallelism from OLAP scan ranges, and from the estimated
  output cardinality (capped by the worker count) for connector and other non-OLAP
  source nodes, so large external scans are no longer admitted as single-slot
  queries.
- MBE derives total slots from the warehouse memory budget and per-query slots
  from total memory cost; add `query_queue_v2_mem_bytes_per_slot` to configure it.
- Cap MBE/CBE per-query slots by `number_of_workers * max(1, pipeline_dop / 2)` to
  reduce the impact of cost-estimation errors.
- Update FE unit tests for the new Query Queue V2 behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5