### PR TITLE
[BugFix] Handle bundled metadata format in lake-to-lake replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -536,12 +536,22 @@ StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::build_source_tablet_meta(
     auto src_metadata_file_name = tablet_metadata_filename(src_tablet_id, version);
     auto src_tablet_meta_path = join_path(meta_dir, src_metadata_file_name);
     auto src_tablet_meta_or = _tablet_manager->get_tablet_metadata(src_tablet_meta_path, false, 0, shared_src_fs);
-    if (!src_tablet_meta_or.ok()) {
-        VLOG(3) << "Lake replicate storage task, failed to build source tablet meta for version: " << version
-                << ", src_tablet_id: " << src_tablet_id << ", error: " << src_tablet_meta_or.status();
-        return src_tablet_meta_or;
+    if (src_tablet_meta_or.ok()) {
+        return src_tablet_meta_or.value();
     }
-    return src_tablet_meta_or.value();
+    if (src_tablet_meta_or.status().is_not_found()) {
+        auto bundle_file_name = tablet_metadata_filename(0, version);
+        auto bundle_file_path = join_path(meta_dir, bundle_file_name);
+        auto bundle_result =
+                _tablet_manager->get_tablet_metadata_from_bundle_file(bundle_file_path, src_tablet_id, shared_src_fs);
+        if (bundle_result.ok()) {
+            LOG(INFO) << "Lake replicate storage task, found source tablet meta from bundle: " << bundle_file_path;
+            return bundle_result;
+        }
+    }
+    VLOG(3) << "Lake replicate storage task, failed to build source tablet meta for version: " << version
+            << ", src_tablet_id: " << src_tablet_id << ", error: " << src_tablet_meta_or.status();
+    return src_tablet_meta_or;
 }
 
 StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::try_build_source_tablet_meta_with_fallback(

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -908,6 +908,70 @@ StatusOr<TabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadat
     return metadatas;
 }
 
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata_from_bundle_file(const std::string& bundle_file_path,
+                                                                                int64_t tablet_id,
+                                                                                const std::shared_ptr<FileSystem>& fs) {
+    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+    ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, bundle_file_path));
+    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+
+    auto file_size = serialized_string.size();
+    ASSIGN_OR_RETURN(auto bundle_metadata, parse_bundle_tablet_metadata(bundle_file_path, serialized_string));
+
+    auto meta_it = bundle_metadata->tablet_meta_pages().find(tablet_id);
+    if (meta_it == bundle_metadata->tablet_meta_pages().end()) {
+        return Status::NotFound(
+                strings::Substitute("can not find tablet $0 from bundle metadata $1", tablet_id, bundle_file_path));
+    }
+
+    const PagePointerPB& page_pointer = meta_it->second;
+    auto offset = page_pointer.offset();
+    auto size = page_pointer.size();
+
+    if (file_size < offset + size) {
+        return Status::Corruption(
+                strings::Substitute("deserialized bundle metadata($0) failed, file_size($1) too small($2/$3)",
+                                    bundle_file_path, file_size, offset, size));
+    }
+
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
+
+    auto crc_it = bundle_metadata->tablet_meta_page_checksum().find(tablet_id);
+    if (crc_it != bundle_metadata->tablet_meta_page_checksum().end() &&
+        olap_adler32(ADLER32_INIT, metadata_str.data(), size) != crc_it->second) {
+        return Status::Corruption(strings::Substitute("mismatched checksum of tablet $0 metadata in bundle metadata $1",
+                                                      tablet_id, bundle_file_path));
+    }
+
+    if (!metadata->ParseFromArray(metadata_str.data(), size)) {
+        return Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed from bundle $1",
+                                                      tablet_id, bundle_file_path));
+    }
+
+    normalize_tablet_metadata_after_load(metadata.get());
+
+    auto schema_id = bundle_metadata->tablet_to_schema().find(tablet_id);
+    if (schema_id != bundle_metadata->tablet_to_schema().end()) {
+        auto schema_it = bundle_metadata->schemas().find(schema_id->second);
+        if (schema_it != bundle_metadata->schemas().end()) {
+            metadata->mutable_schema()->CopyFrom(schema_it->second);
+            auto& item = (*metadata->mutable_historical_schemas())[schema_id->second];
+            item.CopyFrom(schema_it->second);
+        }
+    }
+
+    for (auto& [_, rowset_schema_id] : metadata->rowset_to_schema()) {
+        auto schema_it = bundle_metadata->schemas().find(rowset_schema_id);
+        if (schema_it != bundle_metadata->schemas().end()) {
+            auto& item = (*metadata->mutable_historical_schemas())[rowset_schema_id];
+            item.CopyFrom(schema_it->second);
+        }
+    }
+
+    return metadata;
+}
+
 StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                       bool fill_cache, int64_t expected_gtid,
                                                                       const std::shared_ptr<FileSystem>& fs) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -122,6 +122,10 @@ public:
                                                            const CacheOptions& cache_opts, int64_t expected_gtid = 0,
                                                            const std::shared_ptr<FileSystem>& fs = nullptr);
 
+    StatusOr<TabletMetadataPtr> get_tablet_metadata_from_bundle_file(const std::string& bundle_file_path,
+                                                                     int64_t tablet_id,
+                                                                     const std::shared_ptr<FileSystem>& fs);
+
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 


### PR DESCRIPTION
## Why I'm doing:

Lake-to-lake cross-cluster replication between shared-data clusters fails with 'shard does not exist'. The migration tool creates table structure on the target but no data is migrated. This feature is documented as supported from v4.1 onwards, but is completely broken in practice.

## What I'm doing:

`build_source_tablet_meta` constructs paths for individual per-tablet metadata files (tablet_id-specific filenames), but 4.x shared-data clusters store metadata in bundled format (tablet_id=0 filenames). When the individual file is not found, `get_single_tablet_metadata` falls through to `_location_provider` which resolves source tablet IDs as local shards on the target cluster.

Added `TabletManager::get_tablet_metadata_from_bundle_file` to read bundled metadata from a caller-provided path and filesystem, and try it as a fallback in `build_source_tablet_meta` when the individual file is not found.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
