### PR TITLE
[BugFix] Handle bundled metadata format in lake-to-lake replication

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -519,12 +519,27 @@ StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::build_source_tablet_meta(
     auto src_metadata_file_name = tablet_metadata_filename(src_tablet_id, version);
     auto src_tablet_meta_path = join_path(meta_dir, src_metadata_file_name);
     auto src_tablet_meta_or = _tablet_manager->get_tablet_metadata(src_tablet_meta_path, false, 0, shared_src_fs);
-    if (!src_tablet_meta_or.ok()) {
-        VLOG(3) << "Lake replicate storage task, failed to build source tablet meta for version: " << version
-                << ", src_tablet_id: " << src_tablet_id << ", error: " << src_tablet_meta_or.status();
-        return src_tablet_meta_or;
+    if (src_tablet_meta_or.ok()) {
+        return src_tablet_meta_or.value();
     }
-    return src_tablet_meta_or.value();
+    if (src_tablet_meta_or.status().is_not_found()) {
+        auto bundle_file_name = tablet_metadata_filename(0, version);
+        auto bundle_file_path = join_path(meta_dir, bundle_file_name);
+        auto bundle_result =
+                _tablet_manager->get_tablet_metadata_from_bundle_file(bundle_file_path, src_tablet_id, shared_src_fs);
+        if (bundle_result.ok()) {
+            LOG(INFO) << "Lake replicate storage task, found source tablet meta from bundle: " << bundle_file_path;
+            return bundle_result;
+        }
+        if (!bundle_result.status().is_not_found()) {
+            LOG(WARNING) << "Lake replicate storage task, bundle file exists but failed to read: " << bundle_file_path
+                         << ", error: " << bundle_result.status();
+            return bundle_result.status();
+        }
+    }
+    VLOG(3) << "Lake replicate storage task, failed to build source tablet meta for version: " << version
+            << ", src_tablet_id: " << src_tablet_id << ", error: " << src_tablet_meta_or.status();
+    return src_tablet_meta_or;
 }
 
 StatusOr<TabletMetadataPtr> LakeReplicationTxnManager::try_build_source_tablet_meta_with_fallback(

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -980,6 +980,78 @@ StatusOr<TabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadat
     return metadatas;
 }
 
+StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata_from_bundle_file(const std::string& bundle_file_path,
+                                                                                int64_t tablet_id,
+                                                                                const std::shared_ptr<FileSystem>& fs) {
+    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+    ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, bundle_file_path));
+    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+
+    auto file_size = serialized_string.size();
+    ASSIGN_OR_RETURN(auto bundle_metadata, parse_bundle_tablet_metadata(bundle_file_path, serialized_string));
+
+    auto meta_it = bundle_metadata->tablet_meta_pages().find(tablet_id);
+    if (meta_it == bundle_metadata->tablet_meta_pages().end()) {
+        return Status::NotFound(
+                strings::Substitute("can not find tablet $0 from bundle metadata $1", tablet_id, bundle_file_path));
+    }
+
+    const PagePointerPB& page_pointer = meta_it->second;
+    auto offset = page_pointer.offset();
+    auto size = page_pointer.size();
+
+    if (file_size < offset + size) {
+        return Status::Corruption(
+                strings::Substitute("deserialized bundle metadata($0) failed, file_size($1) too small($2/$3)",
+                                    bundle_file_path, file_size, offset, size));
+    }
+
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
+
+    auto crc_it = bundle_metadata->tablet_meta_page_checksum().find(tablet_id);
+    if (crc_it != bundle_metadata->tablet_meta_page_checksum().end() &&
+        olap_adler32(ADLER32_INIT, metadata_str.data(), size) != crc_it->second) {
+        return Status::Corruption(strings::Substitute("mismatched checksum of tablet $0 metadata in bundle metadata $1",
+                                                      tablet_id, bundle_file_path));
+    }
+
+    if (!metadata->ParseFromArray(metadata_str.data(), size)) {
+        return Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed from bundle $1",
+                                                      tablet_id, bundle_file_path));
+    }
+
+    // The page is keyed by tablet id, so a page whose payload belongs to another tablet means the
+    // bundle is inconsistent. Replication copies data files based on this metadata, so returning it
+    // would silently replicate the wrong tablet instead of failing.
+    if (metadata->id() != tablet_id) {
+        return Status::Corruption(strings::Substitute("tablet id mismatch in bundle $0, expect $1, real $2",
+                                                      bundle_file_path, tablet_id, metadata->id()));
+    }
+
+    normalize_tablet_metadata_after_load(metadata.get());
+
+    auto schema_id = bundle_metadata->tablet_to_schema().find(tablet_id);
+    if (schema_id != bundle_metadata->tablet_to_schema().end()) {
+        auto schema_it = bundle_metadata->schemas().find(schema_id->second);
+        if (schema_it != bundle_metadata->schemas().end()) {
+            metadata->mutable_schema()->CopyFrom(schema_it->second);
+            auto& item = (*metadata->mutable_historical_schemas())[schema_id->second];
+            item.CopyFrom(schema_it->second);
+        }
+    }
+
+    for (auto& [_, rowset_schema_id] : metadata->rowset_to_schema()) {
+        auto schema_it = bundle_metadata->schemas().find(rowset_schema_id);
+        if (schema_it != bundle_metadata->schemas().end()) {
+            auto& item = (*metadata->mutable_historical_schemas())[rowset_schema_id];
+            item.CopyFrom(schema_it->second);
+        }
+    }
+
+    return metadata;
+}
+
 StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                       bool fill_cache, int64_t expected_gtid,
                                                                       const std::shared_ptr<FileSystem>& fs) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -148,6 +148,10 @@ public:
                                                            const CacheOptions& cache_opts, int64_t expected_gtid = 0,
                                                            const std::shared_ptr<FileSystem>& fs = nullptr);
 
+    StatusOr<TabletMetadataPtr> get_tablet_metadata_from_bundle_file(const std::string& bundle_file_path,
+                                                                     int64_t tablet_id,
+                                                                     const std::shared_ptr<FileSystem>& fs);
+
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -669,6 +669,35 @@ protected:
         return file.save(*_tablet_metadata);
     }
 
+    // Stage a bundle metadata file under `target_meta_dir`.
+    //
+    // `put_bundle_tablet_metadata` can only write to the location provider's metadata root, but the
+    // replication path receives a `meta_dir` that points at the *source* cluster and is unrelated to
+    // the local provider. Relocating the bundle reproduces that: the local provider resolves nothing,
+    // so `build_source_tablet_meta` has to reach the bundle through the fallback under test.
+    Status stage_bundle_at(std::map<int64_t, TabletMetadataPB>& metas, const std::string& target_meta_dir,
+                           int64_t version) {
+        auto provider_meta_dir = _location_provider->metadata_root_location(_src_tablet_id);
+        RETURN_IF_ERROR(fs::create_directories(provider_meta_dir));
+        RETURN_IF_ERROR(_tablet_mgr->put_bundle_tablet_metadata(metas));
+
+        auto bundle_name = lake::tablet_metadata_filename(0, version);
+        auto src_path = lake::join_path(provider_meta_dir, bundle_name);
+        ASSIGN_OR_RETURN(auto in, fs::new_random_access_file(src_path));
+        ASSIGN_OR_RETURN(auto content, in->read_all());
+
+        RETURN_IF_ERROR(fs::create_directories(target_meta_dir));
+        ASSIGN_OR_RETURN(auto out, fs::new_writable_file(lake::join_path(target_meta_dir, bundle_name)));
+        RETURN_IF_ERROR(out->append(Slice(content)));
+        RETURN_IF_ERROR(out->close());
+
+        // Drop the local copy and the cached "this partition is bundled" hint so the local provider
+        // cannot satisfy the lookup.
+        RETURN_IF_ERROR(fs::delete_file(src_path));
+        _tablet_mgr->prune_metacache();
+        return Status::OK();
+    }
+
     // Build path formats for testing
     // Current format: {base}/db{db_id}/{table_id}/{partition_id}/meta
     std::string build_current_format_meta_dir() {
@@ -755,6 +784,68 @@ TEST_F(TryBuildSourceTabletMetaWithFallbackTest, test_all_attempts_fail_not_foun
     // Verify failure with NotFound error
     ASSERT_FALSE(result.ok());
     EXPECT_TRUE(result.status().is_not_found()) << result.status();
+}
+
+TEST_F(TryBuildSourceTabletMetaWithFallbackTest, test_bundle_fallback_success) {
+    // Source partition holds only bundled metadata, which is what 4.x shared-data clusters write.
+    std::map<int64_t, TabletMetadataPB> metas;
+    metas.emplace(_src_tablet_id, *_tablet_metadata);
+    auto meta_dir = build_current_format_meta_dir();
+    ASSERT_OK(stage_bundle_at(metas, meta_dir, _version));
+
+    auto result = _replication_txn_manager->build_source_tablet_meta(_src_tablet_id, _version, meta_dir, _shared_fs);
+
+    // The per-tablet file does not exist, so the tablet must be recovered from the bundle.
+    ASSERT_TRUE(result.ok()) << result.status();
+    EXPECT_EQ(_src_tablet_id, result.value()->id());
+    EXPECT_EQ(_version, result.value()->version());
+    // put_bundle_tablet_metadata strips the schema into the bundle header; it must be restored.
+    ASSERT_TRUE(result.value()->has_schema());
+    ASSERT_EQ(1, result.value()->schema().column_size());
+    EXPECT_EQ("c0", result.value()->schema().column(0).name());
+}
+
+TEST_F(TryBuildSourceTabletMetaWithFallbackTest, test_bundle_tablet_not_in_bundle) {
+    // Write a bundle that contains a DIFFERENT tablet, not our _src_tablet_id
+    auto other_metadata = std::make_shared<TabletMetadata>();
+    other_metadata->set_id(next_id());
+    other_metadata->set_version(_version);
+    auto other_schema = other_metadata->mutable_schema();
+    other_schema->set_keys_type(DUP_KEYS);
+    other_schema->set_id(next_id());
+    auto c0 = other_schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    std::map<int64_t, TabletMetadataPB> metas;
+    metas.emplace(other_metadata->id(), *other_metadata);
+    auto meta_dir = build_current_format_meta_dir();
+    ASSERT_OK(stage_bundle_at(metas, meta_dir, _version));
+
+    auto result = _replication_txn_manager->build_source_tablet_meta(_src_tablet_id, _version, meta_dir, _shared_fs);
+
+    // Should fail: individual file not found, bundle exists but doesn't contain our tablet
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_not_found()) << result.status();
+}
+
+TEST_F(TryBuildSourceTabletMetaWithFallbackTest, test_bundle_corruption_propagates) {
+    // Write a corrupt bundle file (write individual metadata format as if it were a bundle)
+    auto meta_dir = build_current_format_meta_dir();
+    auto filename = lake::tablet_metadata_filename(0, _version);
+    auto filepath = lake::join_path(meta_dir, filename);
+    ASSERT_OK(fs::create_directories(meta_dir));
+    ProtobufFile file(filepath);
+    ASSERT_OK(file.save(*_tablet_metadata)); // This is individual metadata, NOT a valid bundle
+
+    auto result = _replication_txn_manager->build_source_tablet_meta(_src_tablet_id, _version, meta_dir, _shared_fs);
+
+    // Should fail with Corruption, NOT NotFound (error propagation)
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
 }
 
 #ifdef USE_STAROS


### PR DESCRIPTION
## Why I'm doing:

Lake-to-lake cross-cluster replication between shared-data clusters fails with 'shard does not exist'. The migration tool creates table structure on the target but no data is migrated. This feature is documented as supported from v4.1 onwards.

## What I'm doing:

`build_source_tablet_meta` constructs paths for individual per-tablet metadata files (tablet_id-specific filenames), but 4.x shared-data clusters store metadata in bundled format (tablet_id=0 filenames). When the individual file is not found, `get_single_tablet_metadata` falls through to `_location_provider` which resolves source tablet IDs as local shards on the target cluster.

Added `TabletManager::get_tablet_metadata_from_bundle_file` to read bundled metadata from a caller-provided path and filesystem, and try it as a fallback in `build_source_tablet_meta` when the individual file is not found. Only NotFound from the bundle probe is ignored; other errors (corruption, checksum mismatch) are propagated to the caller.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4