### PR TITLE
[Doc] Document LIKE clause in SHOW CATALOGS

### DIFF
--- a/docs/en/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
+++ b/docs/en/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
@@ -14,8 +14,14 @@ SHOW CATALOGS queries all catalogs in the current StarRocks cluster, including t
 ## Syntax
 
 ```SQL
-SHOW CATALOGS
+SHOW CATALOGS [LIKE '<pattern>']
 ```
+
+## Parameters
+
+| **Parameter** | **Description**                                              |
+| ------------- | ------------------------------------------------------------ |
+| pattern       | Optional. The pattern used to match catalog names by using the `LIKE` clause. `%` matches any number of characters and `_` matches a single character. Only the catalogs whose names match the pattern are returned. |
 
 ## Output
 
@@ -48,6 +54,16 @@ Catalog: hudi_catalog
    Type: Hudi
 Comment: NULL
 *************************** 3. row ***************************
+Catalog: iceberg_catalog
+   Type: Iceberg
+Comment: NULL
+```
+
+Query the catalogs whose names match a specific pattern.
+
+```SQL
+SHOW CATALOGS LIKE 'iceberg%'\G
+*************************** 1. row ***************************
 Catalog: iceberg_catalog
    Type: Iceberg
 Comment: NULL

--- a/docs/ja/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
+++ b/docs/ja/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
@@ -16,8 +16,14 @@ description: "SHOW CATALOGS queries all catalogs in the current StarRocks cluste
 ## 構文
 
 ```SQL
-SHOW CATALOGS
+SHOW CATALOGS [LIKE '<pattern>']
 ```
+
+## パラメータ
+
+| **パラメータ** | **説明**                                              |
+| ------------- | ------------------------------------------------------------ |
+| pattern       | 任意。`LIKE` 句を使用して catalog 名を照合するためのパターン。`%` は任意の数の文字に一致し、`_` は 1 文字に一致します。名前がパターンに一致する catalog のみが返されます。 |
 
 ## 出力
 
@@ -50,6 +56,16 @@ Catalog: hudi_catalog
    Type: Hudi
 Comment: NULL
 *************************** 3. row ***************************
+Catalog: iceberg_catalog
+   Type: Iceberg
+Comment: NULL
+```
+
+名前が特定のパターンに一致する catalog をクエリします。
+
+```SQL
+SHOW CATALOGS LIKE 'iceberg%'\G
+*************************** 1. row ***************************
 Catalog: iceberg_catalog
    Type: Iceberg
 Comment: NULL

--- a/docs/zh/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
+++ b/docs/zh/sql-reference/sql-statements/Catalog/SHOW_CATALOGS.md
@@ -16,8 +16,14 @@ description: "SHOW CATALOGS queries all catalogs in the current StarRocks cluste
 ## 语法
 
 ```SQL
-SHOW CATALOGS
+SHOW CATALOGS [LIKE '<pattern>']
 ```
+
+## 参数说明
+
+| **参数** | **说明**                                                     |
+| -------- | ------------------------------------------------------------ |
+| pattern  | 可选。通过 `LIKE` 子句匹配 Catalog 名称的模式。`%` 匹配任意数量的字符，`_` 匹配单个字符。仅返回名称与该模式匹配的 Catalog。 |
 
 ## 返回结果说明
 
@@ -50,6 +56,16 @@ Catalog: hudi_catalog
    Type: Hudi
 Comment: NULL
 *************************** 3. row ***************************
+Catalog: iceberg_catalog
+   Type: Iceberg
+Comment: NULL
+```
+
+查看名称匹配特定模式的 catalog。
+
+```SQL
+SHOW CATALOGS LIKE 'iceberg%'\G
+*************************** 1. row ***************************
 Catalog: iceberg_catalog
    Type: Iceberg
 Comment: NULL


### PR DESCRIPTION
## Why I'm doing:

`SHOW CATALOGS` has supported an optional `LIKE` clause since 3.5.0 (#53698), but the SQL reference page only documented `SHOW CATALOGS` without the pattern-matching syntax. Users had no way to discover the feature from the docs.

## What I'm doing:

Update the `SHOW CATALOGS` SQL reference for all three languages (en/zh/ja):
- Add the `LIKE '<pattern>'` clause to the **Syntax** section.
- Add a **Parameters** section describing the `pattern` argument (`%` / `_` semantics).
- Add an example: `SHOW CATALOGS LIKE 'iceberg%'`.

Docs-only change; no code changes.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)