### PR TITLE
[BugFix] Skip empty snapshot for Iceberg metadata delete matching no files

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -611,6 +611,13 @@ public class IcebergMetadata implements ConnectorMetadata {
         long startMs = System.currentTimeMillis();
         String deleteType = "metadata";
 
+        // executeMetadataDelete may run against a cached native table. Refresh it so the no-match probe below
+        // sees the latest snapshot: without this a stale cache could skip the commit while a concurrent writer
+        // has appended matching files, silently leaving them behind. DeleteFiles.commit() refreshes internally,
+        // so refreshing here keeps the "nothing matched -> skip commit" decision consistent with what a real
+        // commit would have seen.
+        nativeTbl.refresh();
+
         // Cast-on-string-partition conjuncts cannot be expressed as a sound Iceberg filter; evaluate them
         // StarRocks-side per partition and delete matching files individually. Anything else keeps the existing
         // row-filter delete. canDeleteUsingMetadata guarantees the whole predicate is partition level here.
@@ -620,6 +627,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         DeleteFiles deleteFiles = nativeTbl.newDelete();
         String deleteDesc;
+        boolean hasMatchedFiles;
         if (residual.hasResidual()) {
             if (icebergTable.hasPartitionTransformedEvolution()) {
                 // Defensive: canDeleteUsingMetadata should have returned false; never silently mis-delete.
@@ -643,6 +651,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 throw new StarRocksConnectorException("Cannot metadata-delete on %s.%s: pushable predicate is not " +
                         "convertible to an Iceberg expression", dbName, tableName);
             }
+            // Delete the individual files whose partition values satisfy the StarRocks-side residual.
             int matchedFiles = 0;
             try (CloseableIterable<FileScanTask> tasks = nativeTbl.newScan()
                     .filter(pushableExpr).caseSensitive(false).ignoreResiduals().planFiles()) {
@@ -660,14 +669,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                 throw new StarRocksConnectorException("Failed to plan files for metadata delete on %s.%s: %s",
                         dbName, tableName, e.getMessage());
             }
-            if (matchedFiles == 0) {
-                // No partition matched the residual -> nothing to delete; do not commit an empty snapshot.
-                ConnectorMetricsMgr.increaseDeleteTotalSuccess(ConnectorMetricsMgr.CONNECTOR_ICEBERG, deleteType);
-                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
-                        System.currentTimeMillis() - startMs, deleteType);
-                LOG.info("Metadata delete on {}.{} matched no partitions; nothing deleted", dbName, tableName);
-                return;
-            }
+            hasMatchedFiles = matchedFiles > 0;
             deleteDesc = "cast-on-string-partition residual, matchedFiles=" + matchedFiles;
         } else {
             // Convert ScalarOperator to Iceberg Expression
@@ -679,8 +681,32 @@ public class IcebergMetadata implements ConnectorMetadata {
                         System.currentTimeMillis() - startMs, deleteType);
                 throw new StarRocksConnectorException("Failed to convert predicate to Iceberg expression");
             }
+            // canDeleteUsingMetadata guarantees every candidate file is wholly matched, so a single row-filter
+            // delete is sound; only probe for existence to detect the no-match case handled below.
+            try (CloseableIterable<FileScanTask> tasks = nativeTbl.newScan()
+                    .filter(deleteExpr).caseSensitive(false).ignoreResiduals().planFiles();
+                    CloseableIterator<FileScanTask> iterator = tasks.iterator()) {
+                hasMatchedFiles = iterator.hasNext();
+            } catch (IOException e) {
+                ConnectorMetricsMgr.increaseDeleteTotalFail(ConnectorMetricsMgr.CONNECTOR_ICEBERG, e, deleteType);
+                ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                        System.currentTimeMillis() - startMs, deleteType);
+                throw new StarRocksConnectorException("Failed to plan files for metadata delete on %s.%s: %s",
+                        dbName, tableName, e.getMessage());
+            }
             deleteFiles.deleteFromRowFilter(deleteExpr);
             deleteDesc = deleteExpr.toString();
+        }
+
+        // DeleteFiles.commit() creates a new snapshot even when nothing matched (Iceberg has no no-op
+        // detection), so an idempotent cleanup DELETE hitting an absent partition, or any DELETE on an empty
+        // table, would pollute the snapshot log with empty `delete` snapshots. Skip the commit in that case.
+        if (!hasMatchedFiles) {
+            ConnectorMetricsMgr.increaseDeleteTotalSuccess(ConnectorMetricsMgr.CONNECTOR_ICEBERG, deleteType);
+            ConnectorMetricsMgr.increaseDeleteDurationMs(ConnectorMetricsMgr.CONNECTOR_ICEBERG,
+                    System.currentTimeMillis() - startMs, deleteType);
+            LOG.info("Metadata delete on {}.{} matched no files; nothing deleted", dbName, tableName);
+            return;
         }
 
         // Set engine info and user for audit

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -3904,6 +3904,91 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testExecuteMetadataDeleteNoMatchingFilesSkipsCommit() throws Exception {
+        // A metadata delete whose filter matches no files must not commit a new (empty) snapshot:
+        // Iceberg's DeleteFiles has no no-op detection, so an unconditional commit would inflate
+        // the snapshot log for idempotent cleanup DELETEs that match nothing.
+        mockedNativeTableB.newFastAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+        mockedNativeTableB.refresh();
+        long snapshotIdBeforeDelete = mockedNativeTableB.currentSnapshot().snapshotId();
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        // k2 = 999 is partition level (identity partition) but matches no existing partition
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(1, INT, "k2", true), ConstantOperator.createInt(999));
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        Assertions.assertTrue(metadata.canDeleteUsingMetadata(icebergTable, predicate),
+                "partition-level predicate should route to metadata delete");
+
+        metadata.executeMetadataDelete(icebergTable, predicate, connectContext);
+
+        mockedNativeTableB.refresh();
+        Assertions.assertEquals(snapshotIdBeforeDelete, mockedNativeTableB.currentSnapshot().snapshotId(),
+                "no-match metadata delete must not commit a new snapshot");
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTableB.newScan().planFiles());
+        Assertions.assertEquals(2, fileScanTasks.size(), "no files should be deleted");
+    }
+
+    @Test
+    public void testExecuteMetadataDeleteOnEmptyTableSkipsCommit() throws Exception {
+        // On an empty table canDeleteUsingMetadata is vacuously true for any convertible predicate
+        // (no candidate files to check), so even a non-partition predicate routes to metadata delete.
+        // Executing it must not create a snapshot on a table that has none.
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(0, INT, "k1", true), ConstantOperator.createInt(1));
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public Frontend getMySelf() {
+                return new Frontend(FrontendNodeType.LEADER, "test-fe", "127.0.0.1", 9010);
+            }
+        };
+
+        new MockUp<Frontend>() {
+            @Mock
+            public String getFeVersion() {
+                return "test-version";
+            }
+        };
+
+        Assertions.assertTrue(metadata.canDeleteUsingMetadata(icebergTable, predicate),
+                "any convertible predicate on an empty table routes to metadata delete");
+
+        metadata.executeMetadataDelete(icebergTable, predicate, connectContext);
+
+        mockedNativeTableB.refresh();
+        Assertions.assertNull(mockedNativeTableB.currentSnapshot(),
+                "delete on an empty table must not create a snapshot");
+    }
+
+    @Test
     public void testCanDeleteUsingMetadataStringDatePartitionCast() throws Exception {
         // A STRING date partition column compared with a temporal value coerces to CAST(k2 AS DATETIME) = <ts>.
         // The whole predicate is on the identity partition column, so metadata (whole-file) delete is eligible;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -157,6 +157,7 @@ import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
@@ -169,6 +170,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.TableScanUtil;
 import org.junit.jupiter.api.Assertions;
@@ -3986,6 +3988,43 @@ public class IcebergMetadataTest extends TableTestBase {
         mockedNativeTableB.refresh();
         Assertions.assertNull(mockedNativeTableB.currentSnapshot(),
                 "delete on an empty table must not create a snapshot");
+    }
+
+    @Test
+    public void testExecuteMetadataDeleteNoMatchProbeIOExceptionFails() {
+        // The no-match probe's scan iterable is closed via try-with-resources; an IOException from close()
+        // must surface as a StarRocksConnectorException instead of being swallowed or committing blindly.
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        ScalarOperator predicate = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(0, INT, "k1", true), ConstantOperator.createInt(1));
+
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), DEFAULT_CATALOG_PROPERTIES);
+
+        new MockUp<SnapshotScan>() {
+            @Mock
+            public CloseableIterable<FileScanTask> planFiles() {
+                return new CloseableIterable<FileScanTask>() {
+                    @Override
+                    public CloseableIterator<FileScanTask> iterator() {
+                        return CloseableIterator.empty();
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        throw new IOException("mocked planFiles close failure");
+                    }
+                };
+            }
+        };
+
+        StarRocksConnectorException e = Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.executeMetadataDelete(icebergTable, predicate, connectContext));
+        Assertions.assertTrue(e.getMessage().contains("Failed to plan files for metadata delete"),
+                "unexpected message: " + e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

An Iceberg `DELETE` that matches no rows still committed a new (empty) snapshot. In `IcebergMetadata.executeMetadataDelete`, the row-filter branch called `DeleteFiles.commit()` unconditionally, and Iceberg's `DeleteFiles` has no no-op detection (its `commit()` always applies a fresh snapshot; the only short-circuit covers rolling back to an already-current snapshot id). So an idempotent cleanup job deleting an absent partition, or any `DELETE` on an empty table, inflated the snapshot log with empty `delete` snapshots (`total-records=0`, `total-data-files=0`) for zero actual work — growing `metadata.json`, slowing snapshot-log processing, and adding pressure on `expire_snapshots`.

The cast-on-string-partition residual branch already guarded this (it skips the commit when `matchedFiles == 0`); the main row-filter branch and the empty-table case did not.

## What I'm doing:

At the start of `executeMetadataDelete`, refresh the native table, then probe for matching files before committing and skip the commit (recording success metrics + a log line) when nothing matches. The cast-on-string-partition residual branch still enumerates all candidate files because each matching file must be staged individually, while the row-filter branch uses a bounded existence probe and stops after the first matching file. An empty table is handled naturally because `planFiles()` returns no tasks.

The refresh is needed because StarRocks serves Iceberg tables from a cross-query cache (`enable_iceberg_metadata_cache=true`, `iceberg_meta_cache_ttl_sec` default 24h). Making the "no match -> skip" decision on that possibly-stale cache would bypass the refresh that `DeleteFiles.commit()` performs internally (`SnapshotProducer.apply()` -> `refresh()`) and could miss files appended by a concurrent external writer. When files do match, the commit path is unchanged and still refreshes + CAS-retries on `CommitFailedException`.

Note: the residual branch already had the same skip-without-refresh gap before this PR (narrow scope — only cast-on-string-partition predicates), so placing the refresh before both branches also hardens that pre-existing path.

Fixes: StarRocks/StarRocksTest#11590.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
