### PR TITLE
[BugFix] Project a wider gap range onto the segment sort key in PK tablet merge

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1508,6 +1508,12 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
                                                                       const TabletMetadataPB& new_metadata,
                                                                       const CanonicalContribMap& canonical_contribs) {
     std::vector<CanonicalGapSpec> result;
+    // The current tablet schema, used to project a gap range whose bound arity is wider than a canonical
+    // rowset's (archived) sort key. This path is primary-key-only and the metadata-only trailing sort-key
+    // add excludes primary-key tables, so a wider bound does not arise here today; passing current_schema
+    // keeps create_seek_range_from correct and consistent with the other call sites regardless.
+    const TabletSchemaCSPtr current_schema =
+            new_metadata.has_schema() ? TabletSchema::create(new_metadata.schema()) : nullptr;
     for (const auto& [canonical_index, contrib] : canonical_contribs) {
         if (canonical_index < 0 || canonical_index >= new_metadata.rowsets_size()) {
             return Status::InternalError(
@@ -1563,8 +1569,8 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
 
             Roaring gap_bits;
             for (const auto& gap_range : non_contributed) {
-                ASSIGN_OR_RETURN(auto seek_range,
-                                 TabletRangeHelper::create_seek_range_from(gap_range, schema, /*mem_pool=*/nullptr));
+                ASSIGN_OR_RETURN(auto seek_range, TabletRangeHelper::create_seek_range_from(
+                                                          gap_range, schema, /*mem_pool=*/nullptr, current_schema));
                 LakeIOOptions io_opts{.fill_data_cache = false};
                 ASSIGN_OR_RETURN(auto rowid_range_opt,
                                  segment_seek_range_to_rowid_range(base_segment, seek_range, io_opts));


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #76341. When the range-bound projection was added there, one of the three
`create_seek_range_from` call sites was left on the old exact-arity path:
`compute_synthesized_gap_specs` (the primary-key tablet-merge gap-range seek). A gap range takes its
arity from the tablet-level range (the current, possibly wider sort key), while its schema comes from
`resolve_rowset_schema_pb` (a canonical rowset's possibly-archived narrower schema). If the tablet range
were ever wider than that schema, the decode would fail with `Status::Corruption("current schema is
required to project a wider range bound")` instead of projecting.

This path is primary-key-only and the metadata-only trailing sort-key add excludes primary-key tables, so
a wider gap range does not arise today. The fix is defensive and keeps all three `create_seek_range_from`
call sites consistent.

## What I'm doing:

Thread the current tablet schema (from `new_metadata.schema()`) into `compute_synthesized_gap_specs` and
pass it as the `current_schema` argument of the gap-range `create_seek_range_from`, matching the scan
(`Rowset::get_seek_range`) and DCG-rebuild call sites.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
