### PR TITLE
[Tool] Opt in allow-unsafe-pr-checkout for clang-format auto-fix

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -38,6 +38,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.PAT }}
+          # actions/checkout now refuses fork PR checkout under pull_request_target
+          # by default (v7 GA 2026-06-18, backported to all majors 2026-07-16).
+          # This workflow intentionally checks out fork code with a write token
+          # solely to run clang-format and push the fix back, so opt back in.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up base branch reference
         env:


### PR DESCRIPTION
## Why I'm doing:

The `CI - Clang Format Auto Fix` workflow (`.github/workflows/ci-clang-format.yml`) started failing at the `Checkout PR head branch` step for **every fork PR** with:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow … set 'allow-unsafe-pr-checkout: true'.

Root cause is an official GitHub change, not our config: `actions/checkout` now refuses to check out fork PR code under `pull_request_target` by default (v7 GA on 2026-06-18, backported to all supported major versions on 2026-07-16). Our workflow is pinned to `actions/checkout@v4`, so the backport is what broke it.

## What I'm doing:

Add `allow-unsafe-pr-checkout: true` to the checkout step — the official opt-out. This workflow already intentionally checks out fork code with a write-capable token, and its only subsequent steps run `clang-format-10` + `git` (it does not execute fork-controlled scripts), so re-enabling fork checkout restores the prior, intended behavior.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5