### PR TITLE
[BugFix] Guard spillable join build set_finishing against cancel-time UAF

### DIFF
--- a/be/src/compute_env/spill/input_stream.cpp
+++ b/be/src/compute_env/spill/input_stream.cpp
@@ -199,9 +199,15 @@ StatusOr<ChunkUniquePtr> BufferedInputStream::get_next(workgroup::YieldContext& 
     if (has_chunk()) {
         return read_from_buffer();
     }
-    // if prefetch failed, return empty chunk
-    DCHECK(false);
-    return std::make_unique<Chunk>();
+    // Buffer is empty and the stream is not at EOF: the restore/prefetch task finished without
+    // producing a chunk -- either a real I/O/deserialize error, or the query was cancelled while a
+    // restore task was in flight. Surface that as an error instead of asserting (debug: DCHECK
+    // abort) or returning an empty chunk (release: would be mistaken for valid data and silently
+    // drop restored rows). The underlying failure is recorded on the spiller's task status.
+    if (Status st = _spiller->task_status(); !st.ok()) {
+        return st;
+    }
+    return Status::InternalError("spill BufferedInputStream: no buffered chunk and stream is not at EOF");
 }
 
 Status BufferedInputStream::prefetch(workgroup::YieldContext& yield_ctx, SerdeContext& ctx) {

--- a/be/src/compute_env/spill/spill_components.cpp
+++ b/be/src/compute_env/spill/spill_components.cpp
@@ -175,7 +175,11 @@ Status RawSpillerWriter::_compact_mem_table(workgroup::YieldContext& yield_ctx) 
     RETURN_IF_YIELD(yield_ctx.need_yield);
     RETURN_IF_ERROR(flush_ctx->output->flush());
     flush_ctx->output.reset();
-    DCHECK_EQ(flush_ctx->compact_input_num_rows, flush_ctx->block_group->num_rows());
+    // On cancellation the transfer stops early, so the compacted block group holds fewer rows than
+    // its input; only assert full compaction while the query is still running. Query cancel sets
+    // the runtime state (which the transfer honors) but not necessarily the spiller flag.
+    DCHECK(_runtime_state->is_cancelled() || _spiller->is_cancel() ||
+           flush_ctx->compact_input_num_rows == flush_ctx->block_group->num_rows());
     this->add_block_group(std::move(flush_ctx->block_group));
 
     return Status::OK();
@@ -789,6 +793,18 @@ Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield
                 SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
                 RETURN_IF_ERROR(reader->trigger_restore<SyncTaskExecutor>(_runtime_state, EmptyMemGuard{}));
                 if (!reader->has_output_data()) {
+                    // A restore IO-task error is recorded in the spiller task status rather than
+                    // returned from trigger_restore; surface it instead of concluding a clean EOF,
+                    // otherwise a short read (corrupt/partial spill block, deserialize error) is
+                    // silently treated as end-of-partition and the split proceeds on partial data.
+                    RETURN_IF_ERROR(_spiller->task_status());
+                    // On cancellation the restore stops early with a partial read. Bail out instead
+                    // of continuing the split with an incomplete partition, which downstream assumes
+                    // was fully read. Query cancel sets the runtime state (which restore honors) but
+                    // not necessarily the spiller flag.
+                    if (_runtime_state->is_cancelled() || _spiller->is_cancel()) {
+                        return Status::Cancelled("query is cancelled during partition split");
+                    }
                     DCHECK_EQ(reader->read_rows(), partition->num_rows);
                     break;
                 }

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -612,12 +612,11 @@ void JoinHashTable::_init_join_keys() {
 }
 
 int64_t JoinHashTable::mem_usage() const {
-    // Theoretically, `_table_items` may be a nullptr after a cancel, even though in practice we haven’t observed any
-    // cases where `_table_items` was unexpectedly cleared or left uninitialized.
-    // To prevent potential null pointer exceptions, we add a defensive check here.
+    // `_table_items` is legitimately null after a cancel: the build hash table can be reset/torn down
+    // while a memory-tracking query (ht_mem_usage from estimated_memory_reserved / revocable-bytes /
+    // close metrics) races in. Return 0 defensively; do NOT DCHECK(false) here -- that is a real,
+    // expected state on cancel and would abort debug/ASan builds (release already returns 0).
     if (_table_items == nullptr) {
-        LOG(WARNING) << "table_items is nullptr in mem_usage, stack:" << get_stack_trace();
-        DCHECK(false);
         return 0;
     }
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -101,8 +101,10 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
 
 void SpillableAggregateBlockingSinkOperator::close(RuntimeState* state) {
     AggregateBlockingSinkOperator::close(state);
-    DCHECK(is_finished());
-    DCHECK(!need_input());
+    // On cancellation the operator is closed without having finished; only assert the
+    // normal-completion invariants when the query is still running.
+    DCHECK(state->is_cancelled() || is_finished());
+    DCHECK(state->is_cancelled() || !need_input());
 }
 
 Status SpillableAggregateBlockingSinkOperator::prepare(RuntimeState* state) {
@@ -354,6 +356,8 @@ OperatorPtr SpillableAggregateBlockingSinkOperatorFactory::create(int32_t degree
     auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);
 
     spill_channel->set_spiller(spiller);
+    // Anchor the spill channel to the aggregator's lifetime (see SpillProcessOperator prepare/close).
+    spill_channel->set_guarded_context(aggregator.get());
     aggregator->set_spiller(spiller);
     aggregator->set_spill_channel(std::move(spill_channel));
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -32,8 +32,10 @@ Status SpillableAggregateBlockingSourceOperator::prepare(RuntimeState* state) {
 void SpillableAggregateBlockingSourceOperator::close(RuntimeState* state) {
     AggregateBlockingSourceOperator::close(state);
     _stream_aggregator->close(state);
-    DCHECK(is_finished());
-    DCHECK(!has_output());
+    // On cancellation the operator is closed without having finished; only assert the
+    // normal-completion invariants when the query is still running.
+    DCHECK(state->is_cancelled() || is_finished());
+    DCHECK(state->is_cancelled() || !has_output());
 }
 
 bool SpillableAggregateBlockingSourceOperator::has_output() const {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -177,6 +177,8 @@ OperatorPtr SpillableAggregateDistinctBlockingSinkOperatorFactory::create(int32_
     auto spill_channel = _spill_channel_factory->get_or_create(driver_sequence);
 
     spill_channel->set_spiller(spiller);
+    // Anchor the spill channel to the aggregator's lifetime (see SpillProcessOperator prepare/close).
+    spill_channel->set_guarded_context(aggregator.get());
     aggregator->set_spiller(spiller);
     aggregator->set_spill_channel(std::move(spill_channel));
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/pipeline/hashjoin/spillable_hash_join_build_operator.h"
 
+#include <unistd.h>
+
 #include <atomic>
 #include <memory>
 
@@ -43,6 +45,11 @@
 namespace starrocks::pipeline {
 
 DEFINE_FAIL_POINT(spill_flush_set_invalid_status);
+// Test-only hook: widen the window of the set_finishing spill-start path (which flushes buffered
+// chunks into build_chunk) so a query cancelled while the build is spilling reliably interleaves
+// with the cancel handling. A sleep can never itself crash the BE, so it introduces no false
+// failures; with the early cancel guard in place this only runs on the non-cancelled finish path.
+DEFINE_FAIL_POINT(spill_hash_join_build_set_finishing_sleep);
 
 Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(HashJoinBuildOperator::prepare(state));
@@ -59,8 +66,10 @@ Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
 
 void SpillableHashJoinBuildOperator::close(RuntimeState* state) {
     HashJoinBuildOperator::close(state);
-    DCHECK(is_finished());
-    DCHECK(!need_input());
+    // On cancellation the operator is closed without having finished; only assert the
+    // normal-completion invariants when the query is still running.
+    DCHECK(state->is_cancelled() || is_finished());
+    DCHECK(state->is_cancelled() || !need_input());
 }
 
 size_t SpillableHashJoinBuildOperator::estimated_memory_reserved(const ChunkPtr& chunk) {
@@ -81,6 +90,27 @@ bool SpillableHashJoinBuildOperator::need_input() const {
 Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() { _join_builder->spill_channel()->set_finishing(); });
+
+    // On cancellation the query is tearing down: an in-flight spill task may be running the build
+    // hash map iterator (which calls hash_join_builder()->reset(), freeing build_chunk) on a spill
+    // executor thread. Running the spill-start path here (prepare_for_spill_start flushes buffered
+    // chunks into build_chunk, then _convert_hash_map_to_chunk / append_spill_task) would append
+    // into that same build_chunk concurrently, causing a heap-use-after-free during the column
+    // resize. Bail out early like HashJoinBuildOperator::set_finishing does; just cancel the spiller.
+    if (state->is_cancelled()) {
+        if (_join_builder->spiller() != nullptr) {
+            _join_builder->spiller()->cancel();
+        }
+        // Mark finished on the early-cancel return, matching HashJoinBuildOperator::set_finishing
+        // (which sets it via a DeferOp even on cancel) so is_finished() holds when PipelineDriver
+        // later closes this cancelled operator.
+        _is_finished = true;
+        return Status::Cancelled("runtime state is cancelled");
+    }
+
+    // Test hook (see failpoint definition): sleep to widen the spill-start window so a concurrent
+    // cancel reliably interleaves. Reached only on the non-cancelled finish path thanks to the guard.
+    FAIL_POINT_TRIGGER_EXECUTE(spill_hash_join_build_set_finishing_sleep, { sleep(3); });
 
     if (spill_strategy() == spill::SpillStrategy::NO_SPILL ||
         (!_join_builder->spiller()->spilled() && _join_builder->hash_join_builder()->hash_table_row_count() == 0)) {
@@ -249,25 +279,37 @@ spill::SpillStrategy SpillableHashJoinBuildOperator::spill_strategy() const {
 }
 
 StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_convert_hash_map_to_chunk() {
-    _hash_tables.clear();
+    _build_chunks.clear();
     _hash_table_iterate_idx = 0;
 
-    _join_builder->hash_join_builder()->visitHt([this](JoinHashTable* ht) { _hash_tables.push_back(ht); });
+    // Snapshot the build chunks up front as shared_ptr, so iteration below never touches the
+    // JoinHashTables again (which the join builder may free on cancel/close while this iterator runs
+    // asynchronously on the spill executor).
+    _join_builder->hash_join_builder()->visitHt(
+            [this](JoinHashTable* ht) { _build_chunks.push_back(ht->get_build_chunk()); });
 
-    for (auto* ht : _hash_tables) {
-        auto build_chunk = ht->get_build_chunk();
+    for (auto& build_chunk : _build_chunks) {
         DCHECK_GT(build_chunk->num_rows(), 0);
         RETURN_IF_ERROR(build_chunk->upgrade_if_overflow());
     }
 
-    _hash_table_build_chunk_slice.reset(_hash_tables[_hash_table_iterate_idx]->get_build_chunk());
+    // The build chunks are now snapshotted as shared_ptr, so neither the async spill iterator below
+    // nor any later push_chunk needs the JoinHashTables anymore. Reset the builder HERE --
+    // synchronously, on the driver thread (this runs inside set_finishing / push_chunk) -- instead of
+    // at the async iterator's EOF. This frees the hash-table memory sooner, and, crucially, means the
+    // reset (which frees & recreates the per-partition builders) can never run concurrently with the
+    // operator's close() on cancel, so close()'s ht_mem_usage() read can never see a freed builder.
+    // The snapshot keeps the build_chunk data alive across the reset via shared_ptr refcount.
+    _join_builder->hash_join_builder()->reset(_join_builder->hash_table_param());
+
+    _hash_table_build_chunk_slice.reset(_build_chunks[_hash_table_iterate_idx]);
     _hash_table_build_chunk_slice.skip(kHashJoinKeyColumnOffset);
 
     return [this]() -> StatusOr<ChunkPtr> {
         if (_hash_table_build_chunk_slice.empty()) {
             _hash_table_iterate_idx++;
-            for (; _hash_table_iterate_idx < _hash_tables.size(); _hash_table_iterate_idx++) {
-                auto build_chunk = _hash_tables[_hash_table_iterate_idx]->get_build_chunk();
+            for (; _hash_table_iterate_idx < _build_chunks.size(); _hash_table_iterate_idx++) {
+                const auto& build_chunk = _build_chunks[_hash_table_iterate_idx];
                 // Every build chunk has a dummy row at index 0. Skip partitions that have no real build rows.
                 if (build_chunk->num_rows() > kHashJoinKeyColumnOffset) {
                     _hash_table_build_chunk_slice.reset(build_chunk);
@@ -276,7 +318,9 @@ StatusOr<std::function<StatusOr<ChunkPtr>()>> SpillableHashJoinBuildOperator::_c
                 }
             }
             if (_hash_table_build_chunk_slice.empty()) {
-                _join_builder->hash_join_builder()->reset(_join_builder->hash_table_param());
+                // Done spilling: drop our snapshot so the chunks can be reclaimed. The builder was
+                // already reset synchronously in the prologue above (see _convert_hash_map_to_chunk).
+                _build_chunks.clear();
                 return Status::EndOfFile("eos");
             }
         }
@@ -335,6 +379,8 @@ OperatorPtr SpillableHashJoinBuildOperatorFactory::create(int32_t degree_of_para
 
     auto joiner = _hash_joiner_factory->create_builder(degree_of_parallelism, driver_sequence);
 
+    // Anchor the spill channel to the joiner's lifetime (see SpillProcessOperator prepare/close).
+    spill_channel->set_guarded_context(joiner.get());
     joiner->set_spill_channel(spill_channel);
     joiner->set_spiller(spiller);
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -66,7 +66,10 @@ private:
     Status init_spiller_partitions(RuntimeState* state, HashJoinBuilder* builder);
 
     size_t _hash_table_iterate_idx = 0;
-    std::vector<JoinHashTable*> _hash_tables;
+    // Own (shared_ptr) the build chunks being spilled instead of borrowing the JoinHashTables by raw
+    // pointer, so the async spill iterator never dereferences hash-table state that the join builder
+    // may free on cancel/close. See _convert_hash_map_to_chunk.
+    std::vector<ChunkPtr> _build_chunks;
     ChunkSharedSlice _hash_table_build_chunk_slice;
     std::function<StatusOr<ChunkPtr>()> _hash_table_slice_iterator;
     bool _is_first_time_spill = true;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -68,8 +68,10 @@ void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
         _reset_load_partitions();
     }
     HashJoinProbeOperator::close(state);
-    DCHECK(!has_output());
-    DCHECK(is_finished());
+    // On cancellation the operator is closed without having finished; only assert the
+    // normal-completion invariants when the query is still running.
+    DCHECK(state->is_cancelled() || !has_output());
+    DCHECK(state->is_cancelled() || is_finished());
 }
 
 bool SpillableHashJoinProbeOperator::has_output() const {
@@ -291,6 +293,15 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
             }
 
             RETURN_IF_ERROR(reader->trigger_restore<SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker)));
+            // Cancellation (or a restore-task I/O error) can land *during* trigger_restore's IO
+            // task -- after the is_cancelled() check above -- leaving the stream with neither a
+            // buffered chunk nor EOF. Re-check both here so we bail cleanly instead of consuming
+            // an empty/not-eof stream (which would otherwise hit BufferedInputStream::get_next's
+            // no-data path).
+            if (state->is_cancelled()) {
+                return Status::Cancelled("cancelled");
+            }
+            RETURN_IF_ERROR(_join_builder->spiller()->task_status());
             auto chunk_st = reader->restore<SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker));
 
             FAIL_POINT_TRIGGER_EXECUTE(spill_hash_join_throw_bad_alloc, { throw std::bad_alloc(); });

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -57,6 +57,18 @@ bool SpillableNLJoinBuildOperator::is_finished() const {
 Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
     auto spiller = _spill_channel->spiller();
 
+    // On cancellation, do not run spiller->flush() during teardown. The not-spilled branch below
+    // already delegates to NLJoinBuildOperator::set_finishing, which early-returns when cancelled;
+    // guard the spilled branch the same way to avoid touching spill state while the query is being
+    // torn down.
+    if (state->is_cancelled()) {
+        if (spiller != nullptr) {
+            spiller->cancel();
+        }
+        _spill_channel->set_finishing();
+        return NLJoinBuildOperator::set_finishing(state);
+    }
+
     if (!spiller->spilled()) {
         _spill_channel->set_finishing();
         RETURN_IF_ERROR(NLJoinBuildOperator::set_finishing(state));

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -40,6 +40,9 @@ class SpillProcessTasksBuilder;
 namespace spill {
 class Spiller;
 }
+namespace pipeline {
+class ContextWithDependency;
+}
 
 class SpillProcessTask {
 public:
@@ -152,6 +155,12 @@ public:
     void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
     const std::shared_ptr<spill::Spiller>& spiller() { return _spiller; }
 
+    // Lifetime anchor: the spilling context (hash joiner / aggregator, a ContextWithDependency) that
+    // owns the state referenced by the spill tasks. SpillProcessOperator refs it on prepare and
+    // unrefs it on close, so the context cannot close() (free that state) while spill tasks run.
+    void set_guarded_context(pipeline::ContextWithDependency* context) { _guarded_context = context; }
+    pipeline::ContextWithDependency* guarded_context() const { return _guarded_context; }
+
     Status execute(SpillProcessTasksBuilder& task_builder);
 
     void close();
@@ -167,6 +176,7 @@ private:
     std::atomic_bool _is_finishing = false;
     std::atomic_bool _is_working = false;
     bool _is_closed = false;
+    pipeline::ContextWithDependency* _guarded_context = nullptr;
     std::shared_ptr<spill::Spiller> _spiller;
     UnboundedBlockingQueue<SpillProcessTask> _spill_tasks;
     SpillProcessTask _current_task;

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -18,6 +18,7 @@
 
 #include "compute_env/spill/mem_tracker_guard.h"
 #include "compute_env/spill/spiller.hpp"
+#include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/spill_process_channel.h"
 #include "runtime/runtime_state.h"
 
@@ -31,6 +32,12 @@ Status SpillProcessOperator::prepare(RuntimeState* state) {
     // for poller mode is inside subscribe_source.
     if (_channel->spiller() != nullptr) {
         _channel->spiller()->observable().subscribe_source(state, observer());
+    }
+    // Lifetime anchor: hold a ref on the spilling context (hash joiner / aggregator) for the whole
+    // spill-processing lifetime, so async spill tasks (which reference context-owned state such as the
+    // build chunks / hash map) never dereference it after the owning operators free it on cancel/close.
+    if (auto* context = _channel->guarded_context(); context != nullptr) {
+        context->ref();
     }
     return Status::OK();
 }
@@ -76,6 +83,11 @@ Status SpillProcessOperator::set_finished(RuntimeState* state) {
 
 void SpillProcessOperator::close(RuntimeState* state) {
     _channel->close();
+    // Release the lifetime-anchor ref taken in prepare(); the channel is drained by now, so no spill
+    // task will dereference the context after this (which may be the last unref -> context close()).
+    if (auto* context = _channel->guarded_context(); context != nullptr) {
+        context->unref(state);
+    }
     SourceOperator::close(state);
 }
 

--- a/test/sql/test_spill/R/test_spill_hash_join_build_cancelled
+++ b/test/sql/test_spill/R/test_spill_hash_join_build_cancelled
@@ -1,0 +1,50 @@
+-- name: test_spill_hash_join_build_cancelled @sequential
+CREATE TABLE `t0` (
+  `c0` largeint(40) NULL COMMENT "",
+  `c1` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 4096000));
+-- result:
+-- !result
+admin enable failpoint 'spill_hash_join_build_set_finishing_sleep';
+-- result:
+-- !result
+[UC]submit task etl_${uuid0}
+PROPERTIES (
+    "session.pipeline_dop"= "1",
+    "session.enable_spill"="true",
+    "session.spill_mode"="force",
+    "session.spill_operator_min_bytes"="1024",
+    "session.spill_mem_table_size"="1024"
+)
+as CREATE table tmp as select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+-- result:
+etl_${uuid0}	SUBMITTED
+-- !result
+shell: sleep 1
+-- result:
+0
+
+-- !result
+drop task etl_${uuid0};
+-- result:
+-- !result
+function: wait_util_no_queries()
+-- result:
+
+-- !result
+admin disable failpoint 'spill_hash_join_build_set_finishing_sleep';
+-- result:
+-- !result
+select "cluster still alive" as status;
+-- result:
+cluster still alive
+-- !result

--- a/test/sql/test_spill/R/test_spill_hash_join_restore_error
+++ b/test/sql/test_spill/R/test_spill_hash_join_restore_error
@@ -1,0 +1,45 @@
+-- name: test_spill_hash_join_restore_error @sequential
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+set spill_operator_min_bytes=1024;
+-- result:
+-- !result
+set spill_mem_table_size=1024;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `c0` largeint(40) NULL COMMENT "",
+  `c1` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 300000));
+-- result:
+-- !result
+admin enable failpoint 'spill_restore_error';
+-- result:
+-- !result
+[UC] select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+admin disable failpoint 'spill_restore_error';
+-- result:
+-- !result
+select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+-- result:
+45000150000	45000150000
+-- !result
+CLEANUP {
+  admin disable failpoint 'spill_restore_error';
+} END CLEANUP

--- a/test/sql/test_spill/T/test_spill_hash_join_build_cancelled
+++ b/test/sql/test_spill/T/test_spill_hash_join_build_cancelled
@@ -1,0 +1,40 @@
+-- name: test_spill_hash_join_build_cancelled @sequential
+
+CREATE TABLE `t0` (
+  `c0` largeint(40) NULL COMMENT "",
+  `c1` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 4096000));
+
+admin enable failpoint 'spill_hash_join_build_set_finishing_sleep';
+
+[UC]submit task etl_${uuid0}
+PROPERTIES (
+    "session.pipeline_dop"= "1",
+    "session.enable_spill"="true",
+    "session.spill_mode"="force",
+    "session.spill_operator_min_bytes"="1024",
+    "session.spill_mem_table_size"="1024"
+)
+as CREATE table tmp as select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+
+shell: sleep 1
+
+drop task etl_${uuid0};
+
+function: wait_util_no_queries()
+
+admin disable failpoint 'spill_hash_join_build_set_finishing_sleep';
+
+select "cluster still alive" as status;
+
+CLEANUP {
+  admin disable failpoint 'spill_hash_join_build_set_finishing_sleep';
+} END CLEANUP

--- a/test/sql/test_spill/T/test_spill_hash_join_restore_error
+++ b/test/sql/test_spill/T/test_spill_hash_join_restore_error
@@ -1,0 +1,43 @@
+-- name: test_spill_hash_join_restore_error @sequential
+
+-- A non-EOF error from a spill restore IO task (e.g. ColumnarSerde::deserialize hitting
+-- a short/corrupt block, injected here via spill_restore_error) reaches the spillable
+-- hash-join probe while it loads spilled build-side partitions
+-- (SpillableHashJoinProbeOperator::_load_partition_build_side -> SpillerReader::restore).
+-- It used to leave BufferedInputStream::get_next with an empty, non-eof buffer and hit
+-- DCHECK(false) (debug/ASan abort) / return an empty chunk (release: silently dropped
+-- build rows and swallowed the error). With the fix get_next surfaces the error, so the
+-- query fails fast and the BE stays up.
+
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop=1;
+set spill_operator_min_bytes=1024;
+set spill_mem_table_size=1024;
+
+CREATE TABLE `t0` (
+  `c0` largeint(40) NULL COMMENT "",
+  `c1` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 300000));
+
+admin enable failpoint 'spill_restore_error';
+
+-- Spilling hash join: the build side is spilled then restored during the probe phase;
+-- the injected restore error must fail the query gracefully instead of crashing the BE.
+[UC] select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+
+admin disable failpoint 'spill_restore_error';
+
+-- Sanity: with the failpoint off the same spilling join succeeds, proving the BE survived.
+select sum(l.c0), sum(r.c1) from t0 l join t0 r on l.c0 = r.c0;
+
+CLEANUP {
+  admin disable failpoint 'spill_restore_error';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

SpillableHashJoinBuildOperator::set_finishing runs the spill-start path (prepare_for_spill_start -> _flush_buffer_chunks appends buffered chunks into the build hash table's build_chunk, then _convert_hash_map_to_chunk / append_spill_task) even when the runtime state is already cancelled. Its only cancel check is after that work, unlike the base HashJoinBuildOperator which early-returns on cancel.

On cancellation an in-flight spill task may concurrently run the build hash-map iterator on a spill-executor thread; at EOF it calls hash_join_builder()->reset() (SingleHashJoinBuilder::reset = close()+create()), which frees build_chunk. The cancel-path flush then appends into that same build_chunk, so the column's std::vector<__int128> reallocation frees a buffer being freed/used by the other thread -> heap-use-after-free (observed in production as a jemalloc invalid free in FixedLengthColumnBase<__int128>::append -> vector::resize).

Add an early is_cancelled() guard (cancel the spiller and return Cancelled), matching the contract already used by HashJoinBuildOperator and the aggregate / sort spill sinks. Apply the same guard to SpillableNLJoinBuildOperator:: set_finishing, whose spilled() branch had no cancel guard either.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
