### PR TITLE
[BugFix] Fix dictionary refresh interval overflow and unintended auto refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Dictionary.java
@@ -160,6 +160,11 @@ public class Dictionary implements Writable {
     public void updateNextSchedulableTime(long refreshInterval) {
         if (refreshInterval > 0) {
             nextSchedulableTime.set(System.currentTimeMillis() + refreshInterval);
+        } else {
+            // Auto refresh is disabled. Pin to Long.MAX_VALUE so that the dictionary is never
+            // picked by the regular schedule. This also heals a stale nextSchedulableTime
+            // persisted by older versions, which used to re-arm the schedule on every refresh.
+            nextSchedulableTime.set(Long.MAX_VALUE);
         }
     }
 
@@ -232,12 +237,22 @@ public class Dictionary implements Writable {
     }
 
     private void buildRefreshInterval(String value) throws DdlException {
+        // refreshInterval is stored as int milliseconds, so a value whose millisecond form
+        // does not fit an int must be rejected explicitly instead of wrapping silently.
+        long intervalSeconds;
         try {
-            refreshInterval = Integer.parseInt(value) * 1000;
-        } catch (Exception e) {
+            intervalSeconds = Long.parseLong(value);
+        } catch (NumberFormatException e) {
             throw new DdlException("parse dictionary_refresh_interval failed" +
                                    ", given parameter: " + value);
         }
+        if (intervalSeconds > Integer.MAX_VALUE / 1000 || intervalSeconds < Integer.MIN_VALUE / 1000) {
+            throw new DdlException("dictionary_refresh_interval is out of range" +
+                                   ", should be within [" + Integer.MIN_VALUE / 1000 +
+                                   ", " + Integer.MAX_VALUE / 1000 + "] seconds" +
+                                   ", given parameter: " + value);
+        }
+        refreshInterval = (int) (intervalSeconds * 1000);
     }
 
     private void buildReadLatest(String value) throws DdlException {
@@ -327,7 +342,11 @@ public class Dictionary implements Writable {
         this.stateBeforeRefresh = this.state;
         this.state = DictionaryState.REFRESHING;
         this.lastSuccessRefreshTime = ts;
-        this.nextSchedulableTime.set(ts + refreshInterval);
+        // Do not touch nextSchedulableTime when auto refresh is disabled (refreshInterval <= 0),
+        // otherwise a manual refresh or warm up would re-enable the regular schedule.
+        if (refreshInterval > 0) {
+            this.nextSchedulableTime.set(ts + refreshInterval);
+        }
         this.setErrorMsg("");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/DictionaryMgrTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.proto.PProcessDictionaryCacheRequest;
@@ -313,5 +314,109 @@ public class DictionaryMgrTest {
         
         // Test that worker can be instantiated and has proper initialization
         Assertions.assertNotNull(worker);
+    }
+
+    @Test
+    public void testBuildRefreshInterval() throws Exception {
+        List<String> dictionaryKeys = Lists.newArrayList("key");
+        List<String> dictionaryValues = Lists.newArrayList("value");
+        Map<String, String> properties = new HashMap<>();
+
+        // the largest value whose millisecond form still fits an int
+        properties.put("dictionary_refresh_interval", "2147483");
+        Dictionary dictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        dictionary.buildDictionaryProperties();
+        Assertions.assertEquals(2147483000, dictionary.getRefreshInterval());
+
+        // zero disables auto refresh
+        properties.put("dictionary_refresh_interval", "0");
+        dictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        dictionary.buildDictionaryProperties();
+        Assertions.assertEquals(0, dictionary.getRefreshInterval());
+
+        // negative values are accepted and also disable auto refresh (<= 0 semantics)
+        properties.put("dictionary_refresh_interval", "-1");
+        dictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        dictionary.buildDictionaryProperties();
+        Assertions.assertEquals(-1000, dictionary.getRefreshInterval());
+
+        // non-numeric values are rejected
+        properties.put("dictionary_refresh_interval", "abc");
+        Dictionary nonNumericDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        Assertions.assertThrows(DdlException.class, nonNumericDictionary::buildDictionaryProperties);
+
+        // 30 days in seconds: the millisecond form does not fit an int, so it must be
+        // rejected with a clear error instead of wrapping silently
+        properties.put("dictionary_refresh_interval", "2592000");
+        Dictionary overflowDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        Assertions.assertThrows(DdlException.class, overflowDictionary::buildDictionaryProperties);
+
+        // far beyond the range
+        properties.put("dictionary_refresh_interval", "9223372036854775807");
+        Dictionary hugeDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        Assertions.assertThrows(DdlException.class, hugeDictionary::buildDictionaryProperties);
+    }
+
+    @Test
+    public void testSetRefreshingNextSchedulableTime() throws Exception {
+        List<String> dictionaryKeys = Lists.newArrayList("key");
+        List<String> dictionaryValues = Lists.newArrayList("value");
+
+        // refreshInterval <= 0: a manual refresh or warm up must not reset nextSchedulableTime,
+        // otherwise the regular schedule would be re-enabled unexpectedly.
+        Dictionary dictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, null);
+        dictionary.setRefreshing(System.currentTimeMillis());
+        Assertions.assertEquals(Long.MAX_VALUE, dictionary.getNextSchedulableTime());
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("dictionary_refresh_interval", "-1");
+        Dictionary negativeDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        negativeDictionary.buildDictionaryProperties();
+        negativeDictionary.setRefreshing(System.currentTimeMillis());
+        Assertions.assertEquals(Long.MAX_VALUE, negativeDictionary.getNextSchedulableTime());
+        // refreshInterval > 0: next schedulable time is based on the refresh start time
+        properties.put("dictionary_refresh_interval", "10"); // 10 seconds
+        Dictionary autoRefreshDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        autoRefreshDictionary.buildDictionaryProperties();
+        long ts = System.currentTimeMillis();
+        autoRefreshDictionary.setRefreshing(ts);
+        Assertions.assertEquals(ts + 10000L, autoRefreshDictionary.getNextSchedulableTime());
+    }
+
+    @Test
+    public void testResetStateHealsStaleNextSchedulableTime() throws Exception {
+        List<String> dictionaryKeys = Lists.newArrayList("key");
+        List<String> dictionaryValues = Lists.newArrayList("value");
+
+        // Simulate a dictionary loaded from an image written by an older version: auto refresh
+        // is disabled (refreshInterval <= 0) but nextSchedulableTime was persisted as a past
+        // timestamp, because setRefreshing() used to re-arm the schedule unconditionally.
+        // resetState() must heal it, otherwise the regular schedule keeps firing in a loop.
+        Dictionary dictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, null);
+        dictionary.setNextSchedulableTime(System.currentTimeMillis() - 1000);
+        dictionary.resetState();
+        Assertions.assertEquals(Long.MAX_VALUE, dictionary.getNextSchedulableTime());
+
+        // refreshInterval > 0: resetState recomputes the next schedule from now
+        Map<String, String> properties = new HashMap<>();
+        properties.put("dictionary_refresh_interval", "10"); // 10 seconds
+        Dictionary autoRefreshDictionary = new Dictionary(1, "dict", "t", "default_catalog", "testDb",
+                dictionaryKeys, dictionaryValues, properties);
+        autoRefreshDictionary.buildDictionaryProperties();
+        long before = System.currentTimeMillis();
+        autoRefreshDictionary.resetState();
+        long nextSchedulableTime = autoRefreshDictionary.getNextSchedulableTime();
+        Assertions.assertTrue(nextSchedulableTime >= before + 10000L);
+        Assertions.assertTrue(nextSchedulableTime <= System.currentTimeMillis() + 10000L);
     }
 }


### PR DESCRIPTION
## What I'm doing:
The dictionary refresh interval is stored as an int in milliseconds, so
dictionary_refresh_interval values larger than 2147483 seconds (~24.8 days)
overflowed during the seconds-to-milliseconds conversion and silently
wrapped to a negative or tiny positive interval. Reject such out-of-range
values with a clear error at create time instead of wrapping silently.
Keeping the field an int also keeps the persisted metadata fully readable
by older versions.

Besides, setRefreshing() unconditionally reset nextSchedulableTime, so a
manual refresh or warm up on a dictionary with auto refresh disabled
(refreshInterval <= 0) made it schedulable again and the regular scheduler
kept refreshing it in a loop. Only re-arm nextSchedulableTime when
refreshInterval > 0, and pin it to Long.MAX_VALUE in
updateNextSchedulableTime() otherwise, so that a stale nextSchedulableTime
persisted by older versions is also healed on image load or replay instead
of keeping the refresh loop running after upgrade.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
