### PR TITLE
[Feature] Record per-partition last update time and last query access time

### DIFF
--- a/be/src/schema_scanner/schema_partitions_meta_scanner.cpp
+++ b/be/src/schema_scanner/schema_partitions_meta_scanner.cpp
@@ -59,6 +59,8 @@ SchemaScanner::ColumnDesc SchemaPartitionsMetaScanner::_s_columns[] = {
         {"METADATA_SWITCH_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"MIN_VI_BUILT_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
         {"MAX_VI_BUILT_VERSION", TypeDescriptor::from_logical_type(TYPE_BIGINT), sizeof(int64_t), false},
+        {"LAST_UPDATE_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"LAST_ACCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
 };
 
 SchemaPartitionsMetaScanner::SchemaPartitionsMetaScanner()
@@ -324,6 +326,28 @@ Status SchemaPartitionsMetaScanner::fill_chunk(ChunkPtr* chunk) {
         case 33: {
             // MAX_VI_BUILT_VERSION
             fill_column_with_slot<TYPE_BIGINT>(column, (void*)&info.max_vi_built_version);
+            break;
+        }
+        case 34: {
+            // LAST_UPDATE_TIME
+            if (info.last_update_time > 0) {
+                DateTimeValue ts;
+                ts.from_unixtime(info.last_update_time, _ctz);
+                fill_column_with_slot<TYPE_DATETIME>(column, (void*)&ts);
+            } else {
+                fill_data_column_with_null(column);
+            }
+            break;
+        }
+        case 35: {
+            // LAST_ACCESS_TIME
+            if (info.last_access_time > 0) {
+                DateTimeValue ts;
+                ts.from_unixtime(info.last_access_time, _ctz);
+                fill_column_with_slot<TYPE_DATETIME>(column, (void*)&ts);
+            } else {
+                fill_data_column_with_null(column);
+            }
             break;
         }
 

--- a/be/test/schema_scanner/schema_partitions_meta_scanner_test.cpp
+++ b/be/test/schema_scanner/schema_partitions_meta_scanner_test.cpp
@@ -95,4 +95,43 @@ TEST_F(SchemaPartitionsMetaScannerTest, fill_data_size_column) {
     EXPECT_EQ(1536, chunk->get_column_by_slot_id(22)->get(0).get_int64());
 }
 
+// LAST_UPDATE_TIME (slot 34) / LAST_ACCESS_TIME (slot 35) are unix-seconds surfaced as DATETIME,
+// and NULL when the value is 0. Exercise both the non-null and the null branch of each case.
+TEST_F(SchemaPartitionsMetaScannerTest, fill_last_update_and_access_time_columns) {
+    SchemaPartitionsMetaScanner scanner;
+    SchemaScannerParam params;
+    std::string ip = "127.0.0.1";
+    params.ip = &ip;
+    params.port = 9020;
+    ObjectPool pool;
+    ASSERT_OK(scanner.init(&params, &pool));
+
+    ChunkPtr chunk = std::make_shared<Chunk>();
+    for (auto* slot : scanner.get_slot_descs()) {
+        if (slot->id() == 34 || slot->id() == 35) {
+            chunk->append_column(ColumnHelper::create_column(slot->type(), slot->is_nullable()), slot->id());
+        }
+    }
+    ASSERT_EQ(2, chunk->num_columns());
+
+    // Row 0: both set (> 0) -> non-null datetime.
+    TPartitionMetaInfo withValues;
+    withValues.__set_last_update_time(1000);
+    withValues.__set_last_access_time(2000);
+    set_rows(scanner, {withValues});
+    ASSERT_OK(fill_chunk(scanner, &chunk));
+
+    // Row 1: both 0 -> null.
+    TPartitionMetaInfo zero;
+    zero.__set_last_update_time(0);
+    zero.__set_last_access_time(0);
+    set_rows(scanner, {zero});
+    ASSERT_OK(fill_chunk(scanner, &chunk));
+
+    EXPECT_FALSE(chunk->get_column_by_slot_id(34)->is_null(0));
+    EXPECT_FALSE(chunk->get_column_by_slot_id(35)->is_null(0));
+    EXPECT_TRUE(chunk->get_column_by_slot_id(34)->is_null(1));
+    EXPECT_TRUE(chunk->get_column_by_slot_id(35)->is_null(1));
+}
+
 } // namespace starrocks

--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -1372,6 +1372,15 @@ This topic introduces the following types of FE configurations:
 - Description: Whether to enable the Legacy Compatibility for Replication. StarRocks may behave differently between the old and new versions, causing problems during cross-cluster data migration. Therefore, you must enable Legacy Compatibility for the target cluster before data migration and disable it after data migration is completed. `true` indicates enabling this mode.
 - Introduced in: v3.1.10, v3.2.6
 
+### `enable_collect_partition_access_time`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to collect and expose the per-partition `LAST_ACCESS_TIME` (the last time a partition was scanned by a user query) in `SHOW PARTITIONS` and `information_schema.partitions_meta`. When disabled, the access time is neither recorded nor aggregated across FEs, and the `LAST_ACCESS_TIME` column shows `NULL`. This does not affect `LAST_UPDATE_TIME`.
+- Introduced in: v4.2.0
+
 ### `enable_show_materialized_views_include_all_task_runs`
 
 - Default: true

--- a/docs/en/sql-reference/information_schema/partitions_meta.md
+++ b/docs/en/sql-reference/information_schema/partitions_meta.md
@@ -42,3 +42,5 @@ The following fields are provided in `partitions_meta`:
 | STORAGE_SIZE                  | Storage size of the partition.                               |
 | METADATA_SWITCH_VERSION       | Metadata switch version of the partition.                    |
 | TABLET_BALANCED               | Whether the tablet distribution is balanced in the partition. |
+| LAST_UPDATE_TIME              | The last time the partition was modified by a user write (load / INSERT / DELETE / UPDATE). |
+| LAST_ACCESS_TIME              | The last time the partition was read by a user statement: a query, `INSERT ... SELECT`, `INSERT OVERWRITE`, CTAS, primary-key `UPDATE`/`DELETE`, materialized view refresh, or `EXPORT`. Reads issued by internal statistics collection are excluded. Currently kept in FE memory only (not persisted); aggregated across FEs at query time. |

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
@@ -62,6 +62,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
 | DataVersion              | The version number of loading transactions. Compaction operations are not included. |
 | VersionEpoch             | The epoch of partition. The system assigns the version epoch when the partition was created, and changes it when the partition was swapped. |
 | VersionTxnType           | The type of the transaction that generates the current data version. Valid values: `NORMAL` (normal transaction) and `REPLICATION` (data replication). |
+| LastUpdateTime           | The last time the partition was modified by a user write (load / INSERT / DELETE / UPDATE). |
+| LastAccessTime           | The last time the partition was read by a user statement: a query, `INSERT ... SELECT`, `INSERT OVERWRITE`, CTAS, primary-key `UPDATE`/`DELETE`, materialized view refresh, or `EXPORT`. Reads issued by internal statistics collection are excluded. Currently kept in FE memory only (not persisted); aggregated across FEs at query time. |
 
 ## Examples
 
@@ -87,6 +89,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
                     DataSize:  4KB   
                 IsInMemory: false
                     RowCount: 3 
+            LastUpdateTime: 2023-08-08 15:45:13
+            LastAccessTime: 2023-08-09 10:00:00
     1 row in set (0.00 sec)
     ```
 

--- a/docs/ja/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/management/FE_parameters/log_server_meta.md
@@ -1363,6 +1363,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：レプリケーションのレガシー互換性を有効にするかどうか。StarRocks は、以前のバージョンと新しいバージョンで異なる動作をする可能性があり、クロスクラスターデータ移行中に問題を引き起こすことがあります。したがって、データ移行前にターゲットクラスターでレガシー互換性を有効にし、データ移行完了後に無効にする必要があります。`true` はこのモードを有効にすることを示します。
 - 導入時期：v3.1.10, v3.2.6
 
+### `enable_collect_partition_access_time`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：`SHOW PARTITIONS` および `information_schema.partitions_meta` で、パーティションごとの `LAST_ACCESS_TIME`（パーティションがユーザークエリによって最後にスキャンされた時刻）を収集して公開するかどうかを制御します。無効にすると、アクセス時刻は記録されず、FE 間で集約もされず、`LAST_ACCESS_TIME` 列は `NULL` を表示します。この項目は `LAST_UPDATE_TIME` には影響しません。
+- 導入時期：v4.2.0
+
 ### `enable_show_materialized_views_include_all_task_runs`
 
 - デフォルト：true

--- a/docs/ja/sql-reference/information_schema/partitions_meta.md
+++ b/docs/ja/sql-reference/information_schema/partitions_meta.md
@@ -42,3 +42,5 @@ description: "partitions_metaはテーブルのパーティションに関する
 | STORAGE_SIZE                  | パーティションのストレージサイズ。               |
 | METADATA_SWITCH_VERSION       | パーティションのメタデータスイッチバージョン。   |
 | TABLET_BALANCED               | Tablet の配置がパーティション内で均等に分散されているかどうか。 |
+| LAST_UPDATE_TIME              | パーティションが最後にユーザー書き込み（ロード / INSERT / DELETE / UPDATE）で変更された時刻。 |
+| LAST_ACCESS_TIME              | パーティションが最後にユーザーステートメント（クエリ、`INSERT ... SELECT`、`INSERT OVERWRITE`、CTAS、主キーテーブルの `UPDATE`/`DELETE`、マテリアライズドビューのリフレッシュ、`EXPORT`）で読み取られた時刻。内部の統計情報収集による読み取りは除外されます。現在は FE メモリのみに保持され（永続化されない）、クエリ時に FE 間で集約されます。 |

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
@@ -62,6 +62,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
 | DataVersion              | ロードトランザクションのバージョン番号。Compaction 操作は含まれない。 |
 | VersionEpoch             | パーティションのエポック。システムはパーティションが作成されたときにバージョンエポックを割り当て、パーティションがスワップされたときに変更します。 |
 | VersionTxnType           | 現在のデータバージョンを生成するトランザクションのタイプ。有効な値：`NORMAL` （通常のトランザクション）と `REPLICATION` （データ複製）。 |
+| LastUpdateTime           | パーティションが最後にユーザー書き込み（ロード / INSERT / DELETE / UPDATE）で変更された時刻。 |
+| LastAccessTime           | パーティションが最後にユーザーステートメント（クエリ、`INSERT ... SELECT`、`INSERT OVERWRITE`、CTAS、主キーテーブルの `UPDATE`/`DELETE`、マテリアライズドビューのリフレッシュ、`EXPORT`）で読み取られた時刻。内部の統計情報収集による読み取りは除外されます。現在は FE メモリのみに保持され（永続化されない）、クエリ時に FE 間で集約されます。 |
 
 ## 例
 
@@ -87,6 +89,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
                     DataSize:  4KB   
                 IsInMemory: false
                     RowCount: 3 
+            LastUpdateTime: 2023-08-08 15:45:13
+            LastAccessTime: 2023-08-09 10:00:00
     1 row in set (0.00 sec)
     ```
 

--- a/docs/zh/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/management/FE_parameters/log_server_meta.md
@@ -1371,6 +1371,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 是否启用 Legacy 复制兼容性。StarRocks 在新旧版本之间可能表现不同，导致跨集群数据迁移时出现问题。因此，在数据迁移之前，您必须为目标集群启用 Legacy 兼容性，并在数据迁移完成后禁用它。`true` 表示启用此模式。
 - 引入版本: v3.1.10, v3.2.6
 
+### `enable_collect_partition_access_time`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 是否采集并展示每个分区的 `LAST_ACCESS_TIME`（分区最近一次被用户查询扫描的时间），展示在 `SHOW PARTITIONS` 和 `information_schema.partitions_meta` 中。禁用后，访问时间既不会被记录，也不会跨 FE 聚合，`LAST_ACCESS_TIME` 列显示为 `NULL`。此项不影响 `LAST_UPDATE_TIME`。
+- 引入版本: v4.2.0
+
 ### `enable_show_materialized_views_include_all_task_runs`
 
 - 默认值: true

--- a/docs/zh/sql-reference/information_schema/partitions_meta.md
+++ b/docs/zh/sql-reference/information_schema/partitions_meta.md
@@ -9,36 +9,38 @@ description: "partitions_meta 提供表分区的信息。"
 
 `partitions_meta` 提供以下字段：
 
-| **字段**                      | **描述**                                         |
-| ----------------------------- | ------------------------------------------------ |
-| DB_NAME                       | 分区所属数据库的名称。                           |
-| TABLE_NAME                    | 分区所属表的名称。                               |
-| PARTITION_NAME                | 分区的名称。                                     |
-| PARTITION_ID                  | 分区的 ID。                                      |
-| COMPACT_VERSION               | 分区的 Compact 版本。                            |
-| VISIBLE_VERSION               | 分区的可见版本。                                 |
-| VISIBLE_VERSION_TIME          | 分区的可见版本时间。                             |
-| NEXT_VERSION                  | 分区的下一个版本。                               |
-| DATA_VERSION                  | 分区的数据版本。                                 |
-| VERSION_EPOCH                 | 分区的版本 Epoch。                               |
-| VERSION_TXN_TYPE              | 分区的版本事务类型。                             |
-| PARTITION_KEY                 | 分区的分区键。                                   |
-| PARTITION_VALUE               | 分区的值（例如，`Range` 或 `List`）。            |
-| DISTRIBUTION_KEY              | 分区的分布键。                                   |
-| BUCKETS                       | 分区中的 Bucket 数量。                           |
-| REPLICATION_NUM               | 分区的副本数量。                                 |
-| STORAGE_MEDIUM                | 分区的存储介质。                                 |
-| COOLDOWN_TIME                 | 分区的冷却时间。                                 |
-| LAST_CONSISTENCY_CHECK_TIME   | 分区上次一致性检查时间。                         |
-| IS_IN_MEMORY                  | 指示分区是否在内存中（`true`）或不在（`false`）。 |
-| IS_TEMP                       | 指示分区是否为临时分区（`true`）或不是（`false`）。 |
-| DATA_SIZE                     | 分区的数据大小。                                 |
-| ROW_COUNT                     | 分区中的行数。                                   |
-| ENABLE_DATACACHE              | 指示分区是否启用数据缓存（`true`）或不启用（`false`）。 |
-| AVG_CS                        | 分区的平均 Compaction Score。                    |
-| P50_CS                        | 分区的 50 百分位 Compaction Score。              |
-| MAX_CS                        | 分区的最大 Compaction Score。                    |
-| STORAGE_PATH                  | 分区的存储路径。                                 |
-| STORAGE_SIZE                  | 分区的存储大小。                                 |
-| METADATA_SWITCH_VERSION       | 分区的元数据切换版本。                           |
-| TABLET_BALANCED               | 分区的 Tablet 分布是否均衡。                     |
+| **字段**                      | **描述**                                                                                                   |
+| ----------------------------- |----------------------------------------------------------------------------------------------------------|
+| DB_NAME                       | 分区所属数据库的名称。                                                                                              |
+| TABLE_NAME                    | 分区所属表的名称。                                                                                                |
+| PARTITION_NAME                | 分区的名称。                                                                                                   |
+| PARTITION_ID                  | 分区的 ID。                                                                                                  |
+| COMPACT_VERSION               | 分区的 Compact 版本。                                                                                          |
+| VISIBLE_VERSION               | 分区的可见版本。                                                                                                 |
+| VISIBLE_VERSION_TIME          | 分区的可见版本时间。                                                                                               |
+| NEXT_VERSION                  | 分区的下一个版本。                                                                                                |
+| DATA_VERSION                  | 分区的数据版本。                                                                                                 |
+| VERSION_EPOCH                 | 分区的版本 Epoch。                                                                                             |
+| VERSION_TXN_TYPE              | 分区的版本事务类型。                                                                                               |
+| PARTITION_KEY                 | 分区的分区键。                                                                                                  |
+| PARTITION_VALUE               | 分区的值（例如，`Range` 或 `List`）。                                                                               |
+| DISTRIBUTION_KEY              | 分区的分布键。                                                                                                  |
+| BUCKETS                       | 分区中的 Bucket 数量。                                                                                          |
+| REPLICATION_NUM               | 分区的副本数量。                                                                                                 |
+| STORAGE_MEDIUM                | 分区的存储介质。                                                                                                 |
+| COOLDOWN_TIME                 | 分区的冷却时间。                                                                                                 |
+| LAST_CONSISTENCY_CHECK_TIME   | 分区上次一致性检查时间。                                                                                             |
+| IS_IN_MEMORY                  | 指示分区是否在内存中（`true`）或不在（`false`）。                                                                          |
+| IS_TEMP                       | 指示分区是否为临时分区（`true`）或不是（`false`）。                                                                         |
+| DATA_SIZE                     | 分区的数据大小。                                                                                                 |
+| ROW_COUNT                     | 分区中的行数。                                                                                                  |
+| ENABLE_DATACACHE              | 指示分区是否启用数据缓存（`true`）或不启用（`false`）。                                                                       |
+| AVG_CS                        | 分区的平均 Compaction Score。                                                                                  |
+| P50_CS                        | 分区的 50 百分位 Compaction Score。                                                                             |
+| MAX_CS                        | 分区的最大 Compaction Score。                                                                                  |
+| STORAGE_PATH                  | 分区的存储路径。                                                                                                 |
+| STORAGE_SIZE                  | 分区的存储大小。                                                                                                 |
+| METADATA_SWITCH_VERSION       | 分区的元数据切换版本。                                                                                              |
+| TABLET_BALANCED               | 分区的 Tablet 分布是否均衡。                                                                                       |
+| LAST_UPDATE_TIME              | 分区最近一次被**用户写入**（导入 / INSERT / DELETE / UPDATE）修改的时间。                                                     |
+| LAST_ACCESS_TIME              | 分区最近一次被用户语句读取的时间，包括查询、`INSERT ... SELECT`、`INSERT OVERWRITE`、CTAS、主键表的 `UPDATE`/`DELETE`、物化视图刷新以及 `EXPORT`；内部统计信息采集发起的读取不计入。当前仅保存在 FE 内存中（不持久化），查询时跨 FE 聚合结果。 |

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_PARTITIONS.md
@@ -64,6 +64,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
 | DataVersion              | 导入事务的版本号。不包括 Compaction 操作。 |
 | VersionEpoch             | 分区的纪元号。系统会在创建分区时赋值纪元，并在每次分区被 SWAP 时更改版本纪元。 |
 | VersionTxnType           | 生成当前数据版本的事务类型。有效值：`NORMAL`（正常事务）和 `REPLICATION`（数据复制）。 |
+| LastUpdateTime           | 分区最近一次被用户写入（导入 / INSERT / DELETE / UPDATE）修改的时间。 |
+| LastAccessTime           | 分区最近一次被用户语句读取的时间，包括查询、`INSERT ... SELECT`、`INSERT OVERWRITE`、CTAS、主键表的 `UPDATE`/`DELETE`、物化视图刷新以及 `EXPORT`；内部统计信息采集发起的读取不计入。当前仅保存在 FE 内存中（不持久化），查询时跨 FE 聚合结果。 |
 
 ## 示例
 
@@ -89,6 +91,8 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
                     DataSize:  4KB   
                 IsInMemory: false
                     RowCount: 3 
+            LastUpdateTime: 2023-08-08 15:45:13
+            LastAccessTime: 2023-08-09 10:00:00
     1 row in set (0.00 sec)
     ```
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -197,6 +197,15 @@ public class Partition extends MetaObject implements GsonPostProcessable {
         return idToSubPartition.get(id);
     }
 
+    // Most recent user-write time (ms epoch) across sub-partitions.
+    public long getLastUpdateTime() {
+        long maxTime = 0;
+        for (PhysicalPartition subPartition : getSubPartitions()) {
+            maxTime = Math.max(maxTime, subPartition.getLastUpdateTime());
+        }
+        return maxTime;
+    }
+
     public PhysicalPartition getLatestPhysicalPartition() {
         return getSubPartitions()
                 .stream()

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionAccessTimeMgr.java
@@ -1,0 +1,184 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.Pair;
+import com.starrocks.rpc.ThriftConnectionPool;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Frontend;
+import com.starrocks.thrift.TGetPartitionAccessTimesRequest;
+import com.starrocks.thrift.TGetPartitionAccessTimesResponse;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TPartitionAccessTimeTableRef;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks the last time each partition was scanned by a user query (lastAccessTime).
+ * <p>
+ * Pure in-memory: the timestamps live in {@link #partitionAccessTimes} on this FE and are NOT persisted
+ * (no {@code @SerializedName}, no edit log), so they reset on FE restart/failover. Keyed by
+ * {@code dbId -> tableId -> (logicalPartitionId -> ms)}; all three ids are globally unique. The query hot path
+ * records with a single lock-free, catalog-free {@code merge} (monotonic max) via {@link #recordAccess},
+ * and reads are lock-free too: the read path just snapshots the relevant tables' inner maps without
+ * touching the catalog or walking the partition structure.
+ * <p>
+ * A cluster-consistent value is assembled entirely inside {@link #getAccessTimes}: each FE only records the
+ * queries it coordinates, so it folds this FE's own records together with the other FEs' (a best-effort
+ * cross-FE RPC that lands in each peer's {@link #getLocalAccessTimes}), all keyed by logical partition id,
+ * and raises {@link ErrorCode#ERR_GET_PARTITION_ACCESS_TIME} when there is nothing to show and every peer
+ * failed. The read paths (SHOW PARTITIONS and information_schema.partitions_meta) just call it and map each
+ * logical timestamp onto its physical sub-partition rows using the logical parent already in scope during
+ * their {@code for (logical) for (physical)} row-building loop -- no reverse lookup, and no lock is needed
+ * for the access-time column.
+ */
+public class PartitionAccessTimeMgr {
+    private static final Logger LOG = LogManager.getLogger(PartitionAccessTimeMgr.class);
+
+    // dbId -> (tableId -> (logicalPartitionId -> last query access time ms epoch)).
+    private final ConcurrentHashMap<Long, ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>>> partitionAccessTimes =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Record that the given logical partitions of {@code (dbId, tableId)} were accessed now.
+     */
+    public void recordAccess(long dbId, long tableId, Collection<Long> logicalPartitionIds) {
+        if (logicalPartitionIds == null || logicalPartitionIds.isEmpty()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        ConcurrentHashMap<Long, Long> perTable = partitionAccessTimes
+                .computeIfAbsent(dbId, k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(tableId, k -> new ConcurrentHashMap<>());
+        for (Long partitionId : logicalPartitionIds) {
+            if (partitionId != null) {
+                perTable.merge(partitionId, now, Math::max);
+            }
+        }
+    }
+
+    /**
+     * Cluster-aggregated access times for a single table (SHOW PARTITIONS).
+     */
+    public Map<Long, Long> getAccessTimes(long dbId, long tableId) {
+        TPartitionAccessTimeTableRef ref = new TPartitionAccessTimeTableRef();
+        ref.setDb_id(dbId);
+        ref.setTable_id(tableId);
+        return getAccessTimes(Collections.singletonList(ref));
+    }
+
+    /**
+     * Cluster-aggregated access times for a batch of tables (logicalPartitionId -&gt; ms), keyed by logical
+     * partition id across all tables (ids are globally unique).
+     * <p>
+     * When the merged result is empty AND every peer we actually contacted failed, an empty result would be
+     * indistinguishable from "genuinely never accessed", so this raises {@link ErrorCode#ERR_GET_PARTITION_ACCESS_TIME}
+     * instead of returning a misleading NULL. A single-FE cluster (or one where every peer is down and thus
+     * skipped) contacts no peer, so nothing "failed" and the empty result is honored as "never accessed".
+     */
+    public Map<Long, Long> getAccessTimes(List<TPartitionAccessTimeTableRef> tables) {
+        // Seed with this FE's own records, then fold in the other FEs' (best-effort).
+        Map<Long, Long> merged = getLocalAccessTimes(tables);
+        if (tables == null || tables.isEmpty()) {
+            return merged;
+        }
+        GlobalStateMgr state = GlobalStateMgr.getCurrentState();
+        Pair<String, Integer> self = state.getNodeMgr().getSelfNode();
+        if (self == null) {
+            // Node topology not initialized yet (self is unknown): treat as "no peers to contact" rather
+            // than a total failure, so a transient startup window does not fail metadata reads.
+            return merged;
+        }
+        String selfHost = self.first;
+        List<Frontend> frontends = state.getNodeMgr().getFrontends(null);
+        boolean anyRemoteSucceeded = false;
+        List<String> failures = new ArrayList<>();
+        for (Frontend fe : frontends) {
+            if (fe.getHost().equals(selfHost) || !fe.isAlive()) {
+                continue;
+            }
+            try {
+                TNetworkAddress addr = new TNetworkAddress(fe.getHost(), fe.getRpcPort());
+                TGetPartitionAccessTimesRequest req = new TGetPartitionAccessTimesRequest();
+                req.setTables(tables);
+                TGetPartitionAccessTimesResponse resp = ThriftRPCRequestExecutor.call(
+                        ThriftConnectionPool.frontendPool, addr, Config.thrift_rpc_timeout_ms,
+                        client -> client.getPartitionAccessTimes(req));
+                anyRemoteSucceeded = true;
+                if (resp != null && resp.getPartition_id_to_access_time_ms() != null) {
+                    resp.getPartition_id_to_access_time_ms().forEach((pid, ts) -> merged.merge(pid, ts, Math::max));
+                }
+            } catch (Exception e) {
+                LOG.debug("skip FE {} while collecting partition access times: {}", fe.getHost(), e.getMessage());
+                failures.add(fe.getHost() + " (" + e.getMessage() + ")");
+            }
+        }
+        // No record anywhere AND every peer we contacted failed (a single-FE cluster / all-peers-down contacts
+        // nobody, so `failures` is empty and this does not fire): surface it rather than a misleading NULL.
+        if (merged.isEmpty() && !anyRemoteSucceeded && !failures.isEmpty()) {
+            throw ErrorReportException.report(ErrorCode.ERR_GET_PARTITION_ACCESS_TIME, String.join(", ", failures));
+        }
+        return merged;
+    }
+
+    /**
+     * This FE's local access times for a batch of tables (logicalPartitionId -&gt; ms).
+     */
+    public Map<Long, Long> getLocalAccessTimes(List<TPartitionAccessTimeTableRef> tables) {
+        Map<Long, Long> merged = new HashMap<>();
+        if (tables == null) {
+            return merged;
+        }
+        for (TPartitionAccessTimeTableRef ref : tables) {
+            getLocalTableAccessTimes(ref.getDb_id(), ref.getTable_id())
+                    .forEach((pid, ts) -> merged.merge(pid, ts, Math::max));
+        }
+        return merged;
+    }
+
+    // This FE's local access times for (dbId, tableId) (logicalPartitionId -> ms).
+    private Map<Long, Long> getLocalTableAccessTimes(long dbId, long tableId) {
+        ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>> perDb = partitionAccessTimes.get(dbId);
+        if (perDb == null) {
+            return new HashMap<>();
+        }
+        ConcurrentHashMap<Long, Long> perTable = perDb.get(tableId);
+        return perTable == null ? new HashMap<>() : new HashMap<>(perTable);
+    }
+
+    // The recorded access time (ms) for a (dbId, tableId, logicalPartitionId), 0 if none.
+    @VisibleForTesting
+    public long getLastAccessTime(long dbId, long tableId, long logicalPartitionId) {
+        ConcurrentHashMap<Long, ConcurrentHashMap<Long, Long>> perDb = partitionAccessTimes.get(dbId);
+        if (perDb == null) {
+            return 0L;
+        }
+        ConcurrentHashMap<Long, Long> perTable = perDb.get(tableId);
+        return perTable == null ? 0L : perTable.getOrDefault(logicalPartitionId, 0L);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -116,6 +116,10 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
     @SerializedName(value = "nextVersion")
     private long nextVersion;
 
+    // Last time this physical partition was modified by a USER write (load/DML)0 = unknown.
+    @SerializedName(value = "lastUpdateTime")
+    private volatile long lastUpdateTime = 0;
+
     @SerializedName(value = "dataVersion")
     private long dataVersion;
     @SerializedName(value = "nextDataVersion")
@@ -350,6 +354,16 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public long getVisibleVersionTime() {
         return visibleVersionTime;
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void updateLastUpdateTime(long newTime) {
+        if (newTime > lastUpdateTime) {
+            lastUpdateTime = newTime;
+        }
     }
 
     public void setVisibleVersion(long visibleVersion, long visibleVersionTime) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -68,6 +68,8 @@ public class PartitionsMetaSystemTable {
                         .column("METADATA_SWITCH_VERSION", IntegerType.BIGINT)
                         .column("MIN_VI_BUILT_VERSION", IntegerType.BIGINT)
                         .column("MAX_VI_BUILT_VERSION", IntegerType.BIGINT)
+                        .column("LAST_UPDATE_TIME", DateType.DATETIME)
+                        .column("LAST_ACCESS_TIME", DateType.DATETIME)
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4593,6 +4593,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int max_get_partitions_meta_result_count = 100000;
 
+    @ConfField(mutable = true, comment = "Whether to collect and expose the per-partition LAST_ACCESS_TIME " +
+            "(the last time a partition was scanned by a user query) in SHOW PARTITIONS and " +
+            "information_schema.partitions_meta. When disabled, the access time is neither recorded nor aggregated " +
+            "across FEs and the LAST_ACCESS_TIME column shows NULL.")
+    public static boolean enable_collect_partition_access_time = true;
+
     @ConfField(mutable = false)
     public static int max_spm_cache_baseline_size = 1000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -55,6 +55,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.TimeUtils;
@@ -80,6 +81,7 @@ import com.starrocks.type.DateType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -132,7 +134,9 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("DataVersion")
                     .add("VersionEpoch")
                     .add("VersionTxnType")
-                    .add("MetaSwitchVersion");
+                    .add("MetaSwitchVersion")
+                    .add("LastUpdateTime")
+                    .add("LastAccessTime");
             this.titleNames = builder.build();
         } else {
             ImmutableList.Builder<String> builder = new ImmutableList.Builder<String>()
@@ -157,7 +161,9 @@ public class PartitionsProcDir implements ProcDirInterface {
                     .add("DataVersion")
                     .add("VersionEpoch")
                     .add("VersionTxnType")
-                    .add("TabletBalanced");
+                    .add("TabletBalanced")
+                    .add("LastUpdateTime")
+                    .add("LastAccessTime");
             this.titleNames = builder.build();
         }
     }
@@ -291,6 +297,11 @@ public class PartitionsProcDir implements ProcDirInterface {
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();
         Locker locker = new Locker();
         long tableId = table.getId();
+        // Access times keyed by logical partition id, aggregated across all FEs (this FE's own records plus
+        // the others' via a best-effort cross-FE RPC).
+        Map<Long, Long> accessTimes = Config.enable_collect_partition_access_time
+                ? GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr().getAccessTimes(db.getId(), tableId)
+                : new HashMap<>();
         locker.lockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         try {
             List<Long> partitionIds;
@@ -316,16 +327,18 @@ public class PartitionsProcDir implements ProcDirInterface {
                             !partitionName.startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
                         if (table.isOlapTableOrMaterializedView()) {
                             partitionInfos.add(
-                                    getOlapPartitionInfo(tblPartitionInfo, partition, physicalPartition));
+                                    getOlapPartitionInfo(tblPartitionInfo, partition, physicalPartition, accessTimes));
                         } else {
-                            partitionInfos.add(getLakePartitionInfo(tblPartitionInfo, partition, physicalPartition));
+                            partitionInfos.add(
+                                    getLakePartitionInfo(tblPartitionInfo, partition, physicalPartition, accessTimes));
                         }
                     } else if (Config.enable_display_shadow_partitions) {
                         if (table.isOlapTableOrMaterializedView()) {
                             partitionInfos.add(
-                                    getOlapPartitionInfo(tblPartitionInfo, partition, physicalPartition));
+                                    getOlapPartitionInfo(tblPartitionInfo, partition, physicalPartition, accessTimes));
                         } else {
-                            partitionInfos.add(getLakePartitionInfo(tblPartitionInfo, partition, physicalPartition));
+                            partitionInfos.add(
+                                    getLakePartitionInfo(tblPartitionInfo, partition, physicalPartition, accessTimes));
                         }
                     }
                 }
@@ -352,7 +365,8 @@ public class PartitionsProcDir implements ProcDirInterface {
     }
 
     private List<Comparable> getOlapPartitionInfo(PartitionInfo tblPartitionInfo,
-                                                  Partition partition, PhysicalPartition physicalPartition) {
+                                                  Partition partition, PhysicalPartition physicalPartition,
+                                                  Map<Long, Long> accessTimes) {
         List<Comparable> partitionInfo = new ArrayList<Comparable>();
         partitionInfo.add(physicalPartition.getId()); // PartitionId
         partitionInfo.add(partition.getName()); // PartitionName
@@ -390,11 +404,17 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
 
         partitionInfo.add(physicalPartition.isTabletBalanced());
+        partitionInfo.add(physicalPartition.getLastUpdateTime() == 0 ? FeConstants.NULL_STRING
+                : TimeUtils.longToTimeString(physicalPartition.getLastUpdateTime())); // LastUpdateTime
+        long lastAccessTime = accessTimes.getOrDefault(partition.getId(), 0L);
+        partitionInfo.add(lastAccessTime == 0 ? FeConstants.NULL_STRING
+                : TimeUtils.longToTimeString(lastAccessTime)); // LastAccessTime
         return partitionInfo;
     }
 
     private List<Comparable> getLakePartitionInfo(PartitionInfo tblPartitionInfo, Partition partition,
-                                                  PhysicalPartition physicalPartition) {
+                                                  PhysicalPartition physicalPartition,
+                                                  Map<Long, Long> accessTimes) {
         PartitionIdentifier identifier = new PartitionIdentifier(db.getId(), table.getId(), physicalPartition.getId());
         PartitionStatistics statistics = GlobalStateMgr.getCurrentState().getCompactionMgr().getStatistics(identifier);
         Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
@@ -427,6 +447,11 @@ public class PartitionsProcDir implements ProcDirInterface {
         partitionInfo.add(physicalPartition.getVersionEpoch()); // VersionEpoch
         partitionInfo.add(physicalPartition.getVersionTxnType()); // VersionTxnType
         partitionInfo.add(physicalPartition.getMetadataSwitchVersion()); // MetaSwitchVersion
+        partitionInfo.add(physicalPartition.getLastUpdateTime() == 0 ? FeConstants.NULL_STRING
+                : TimeUtils.longToTimeString(physicalPartition.getLastUpdateTime())); // LastUpdateTime
+        long lastAccessTime = accessTimes.getOrDefault(partition.getId(), 0L);
+        partitionInfo.add(lastAccessTime == 0 ? FeConstants.NULL_STRING
+                : TimeUtils.longToTimeString(lastAccessTime)); // LastAccessTime
         return partitionInfo;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -419,6 +419,12 @@ public class ExportJob implements Writable, GsonPostProcessable {
                 ((OlapScanNode) scanNode).setIsPreAggregation(false, "This an export operation");
                 ((OlapScanNode) scanNode).setCanTurnOnPreAggr(false);
                 ((OlapScanNode) scanNode).computePartitionInfo();
+                // Record the export scan as a user access, mirroring the query path. computePartitionInfo()
+                // has resolved the data-bearing logical partitions.
+                if (Config.enable_collect_partition_access_time) {
+                    GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr()
+                            .recordAccess(dbId, exportTable.getId(), ((OlapScanNode) scanNode).getSelectedPartitionIds());
+                }
                 break;
             case MYSQL:
                 scanNode = new MysqlScanNode(new PlanNodeId(0), exportTupleDesc, (MysqlTable) this.exportTable);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -55,6 +55,7 @@ import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PartitionAccessTimeMgr;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.catalog.Table;
@@ -1992,6 +1993,12 @@ public class StmtExecutor {
         List<String> colNames = execPlan.getColNames();
         List<Expr> outputExprs = execPlan.getOutputExprs();
 
+        // Skip scheduler-only explains: they build the schedule via execWithoutDeploy() below and
+        // return without scanning any data, so they must not advance LAST_ACCESS_TIME.
+        if (!isSchedulerExplain) {
+            recordPartitionAccessTime(execPlan);
+        }
+
         if (executeInFe) {
             coord = new FeExecuteCoordinator(context, execPlan);
         } else {
@@ -2094,6 +2101,41 @@ public class StmtExecutor {
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);
         GlobalStateMgr.getCurrentState().getQueryHistoryMgr().addQueryHistory(context, execPlan);
+    }
+
+    /**
+     * Record that the OLAP partitions scanned by {@code execPlan} were accessed by a user statement
+     * now, feeding the per-partition last query access time exposed via
+     * information_schema.partitions_meta and SHOW PARTITIONS. Covers every user path that carries a
+     * scan plan: SELECT, INSERT ... SELECT / INSERT OVERWRITE, CTAS, primary-key UPDATE / DELETE, and
+     * materialized-view refresh (which runs as an internal INSERT). System-driven reads (statistics
+     * collection, internal metadata queries) are skipped by {@link #isInternalAccess} so the signal
+     * reflects user access only, consistent with LAST_UPDATE_TIME excluding system transactions.
+     * Best-effort: recording must never fail the statement.
+     */
+    private void recordPartitionAccessTime(ExecPlan execPlan) {
+        if (execPlan == null || isInternalAccess() || !Config.enable_collect_partition_access_time) {
+            return;
+        }
+        PartitionAccessTimeMgr accessTimeMgr = GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+        for (ScanNode scanNode : execPlan.getScanNodes()) {
+            if (scanNode instanceof OlapScanNode) {
+                OlapScanNode olapScanNode = (OlapScanNode) scanNode;
+                OlapTable olapTable = olapScanNode.getOlapTable();
+                accessTimeMgr.recordAccess(MetaUtils.lookupDbIdByTable(olapTable), olapTable.getId(),
+                        olapScanNode.getSelectedPartitionIds());
+            }
+        }
+    }
+
+    /**
+     * Whether the current statement is a system-driven read that must not update the partition access
+     * time: statistics collection (analyze jobs and the statistics connection) and internal metadata
+     * queries. Materialized-view refresh and user DML run on non-statistics contexts and are recorded.
+     */
+    private boolean isInternalAccess() {
+        return context != null
+                && (context.isStatisticsJob() || context.isStatisticsConnection() || context.isMetadataContext());
     }
 
     private void responseRowBatch(RawScopedTimer timer, RowBatch batch, MysqlChannel channel) throws IOException {
@@ -3372,6 +3414,12 @@ public class StmtExecutor {
                 !(targetTable.isIcebergTable() || targetTable.isHiveTable())) {
             handleInsertOverwrite((InsertStmt) parsedStmt);
             return;
+        }
+
+        // Record the source-side scan as a user access. Skip scheduler-only explains, which build the
+        // schedule via execWithoutDeploy() without scanning any data.
+        if (!isSchedulerExplain) {
+            recordPartitionAccessTime(execPlan);
         }
 
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -68,6 +68,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.GlobalFunctionMgr;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MetaReplayState;
+import com.starrocks.catalog.PartitionAccessTimeMgr;
 import com.starrocks.catalog.RefreshDictionaryCacheTaskDaemon;
 import com.starrocks.catalog.ResourceGroupMgr;
 import com.starrocks.catalog.ResourceMgr;
@@ -405,6 +406,8 @@ public class GlobalStateMgr {
     private final GlobalTransactionMgr globalTransactionMgr;
 
     private final TabletStatMgr tabletStatMgr;
+
+    private final PartitionAccessTimeMgr partitionAccessTimeMgr;
 
     private AuthenticationMgr authenticationMgr;
     private AuthorizationMgr authorizationMgr;
@@ -752,6 +755,7 @@ public class GlobalStateMgr {
 
         this.globalTransactionMgr = new GlobalTransactionMgr(this);
         this.tabletStatMgr = new TabletStatMgr();
+        this.partitionAccessTimeMgr = new PartitionAccessTimeMgr();
         this.authenticationMgr = new AuthenticationMgr();
         this.domainResolver = new DomainResolver(authenticationMgr);
         this.authorizationMgr = new AuthorizationMgr(new DefaultAuthorizationProvider());
@@ -1052,6 +1056,10 @@ public class GlobalStateMgr {
 
     public TabletStatMgr getTabletStatMgr() {
         return tabletStatMgr;
+    }
+
+    public PartitionAccessTimeMgr getPartitionAccessTimeMgr() {
+        return partitionAccessTimeMgr;
     }
 
     // Only used in UT

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -64,6 +64,7 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionAccessTimeMgr;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PhysicalPartition;
@@ -269,6 +270,8 @@ import com.starrocks.thrift.TGetLoadTxnStatusRequest;
 import com.starrocks.thrift.TGetLoadTxnStatusResult;
 import com.starrocks.thrift.TGetLoadsParams;
 import com.starrocks.thrift.TGetLoadsResult;
+import com.starrocks.thrift.TGetPartitionAccessTimesRequest;
+import com.starrocks.thrift.TGetPartitionAccessTimesResponse;
 import com.starrocks.thrift.TGetPartitionsMetaRequest;
 import com.starrocks.thrift.TGetPartitionsMetaResponse;
 import com.starrocks.thrift.TGetProfileRequest;
@@ -354,6 +357,7 @@ import com.starrocks.thrift.TOlapTableIndexTablets;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
 import com.starrocks.thrift.TOlapTableTablet;
+import com.starrocks.thrift.TPartitionAccessTimeTableRef;
 import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPartitionMetaRequest;
 import com.starrocks.thrift.TPartitionMetaResponse;
@@ -3169,6 +3173,23 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TGetPartitionsMetaResponse getPartitionsMeta(TGetPartitionsMetaRequest request) throws TException {
         return InformationSchemaDataSource.generatePartitionsMetaResponse(request);
+    }
+
+    @Override
+    public TGetPartitionAccessTimesResponse getPartitionAccessTimes(TGetPartitionAccessTimesRequest request)
+            throws TException {
+        TGetPartitionAccessTimesResponse response = new TGetPartitionAccessTimesResponse();
+        PartitionAccessTimeMgr accessTimeMgr = GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+        Map<Long, Long> result = new HashMap<>();
+        List<TPartitionAccessTimeTableRef> tables = request.getTables();
+        // When access-time collection is disabled this FE contributes nothing; return an empty (OK) response
+        // so a peer's aggregation still sees a successful reply.
+        if (tables != null && Config.enable_collect_partition_access_time) {
+            result.putAll(accessTimeMgr.getLocalAccessTimes(tables));
+        }
+        response.setPartition_id_to_access_time_ms(result);
+        response.setStatus(new TStatus(TStatusCode.OK));
+        return response;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -73,6 +73,7 @@ import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TGetTemporaryTablesInfoRequest;
 import com.starrocks.thrift.TGetTemporaryTablesInfoResponse;
 import com.starrocks.thrift.TKeywordInfo;
+import com.starrocks.thrift.TPartitionAccessTimeTableRef;
 import com.starrocks.thrift.TPartitionMetaInfo;
 import com.starrocks.thrift.TTableConfigInfo;
 import com.starrocks.thrift.TTableInfo;
@@ -411,6 +412,13 @@ public class InformationSchemaDataSource {
             }
         }
 
+        // Cross-FE aggregated (best-effort) access times, scoped to exactly the tables returned in THIS
+        // page: accumulate this FE's local values during the walk, then after the page is built fetch the
+        // other FEs' values for the page's tables in a single batch RPC (outside any lock) and backfill
+        // the rows. Scoping to the page keeps a paged scan from re-sending every remaining table id.
+        List<TPartitionAccessTimeTableRef> pageTableRefs = new ArrayList<>();
+        List<Long> pageLogicalIds = new ArrayList<>();
+
         for (Element ele : sortedElements) {
             Table table = ele.table;
             if (!table.isNativeTableOrMaterializedView()) {
@@ -439,6 +447,13 @@ public class InformationSchemaDataSource {
                 }
                 OlapTable olapTable = (OlapTable) table;
                 PartitionInfo tblPartitionInfo = olapTable.getPartitionInfo();
+                // Record this table for the post-loop access-time backfill. Nothing access-time related
+                // runs under this table lock anymore: the whole cluster-aggregated collection happens after
+                // the page is built, via a single getAccessTimes call outside every lock.
+                TPartitionAccessTimeTableRef pageRef = new TPartitionAccessTimeTableRef();
+                pageRef.setDb_id(ele.dbId);
+                pageRef.setTable_id(olapTable.getId());
+                pageTableRefs.add(pageRef);
                 // normal partition
                 for (Partition partition : olapTable.getPartitions()) {
                     for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
@@ -448,6 +463,7 @@ public class InformationSchemaDataSource {
                         genPartitionMetaInfo(ele.dbId, olapTable, tblPartitionInfo, partition, physicalPartition,
                                 partitionMetaInfo, false /* isTemp */);
                         pList.add(partitionMetaInfo);
+                        pageLogicalIds.add(partition.getId());
                     }
                 }
                 // temp partition
@@ -459,6 +475,7 @@ public class InformationSchemaDataSource {
                         genPartitionMetaInfo(ele.dbId, olapTable, tblPartitionInfo, partition, physicalPartition,
                                 partitionMetaInfo, true /* isTemp */);
                         pList.add(partitionMetaInfo);
+                        pageLogicalIds.add(partition.getId());
                     }
                 }
                 if (pList.size() >= Config.max_get_partitions_meta_result_count) {
@@ -467,6 +484,17 @@ public class InformationSchemaDataSource {
                 }
             } finally {
                 locker.unLockTableWithIntensiveDbLock(ele.dbId, table.getId(), LockType.READ);
+            }
+        }
+        // The page's table set is now known. Collect access times outside any lock.
+        if (Config.enable_collect_partition_access_time) {
+            Map<Long, Long> accessTimes =
+                    GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr().getAccessTimes(pageTableRefs);
+            for (int i = 0; i < pList.size(); i++) {
+                long accessMs = accessTimes.getOrDefault(pageLogicalIds.get(i), 0L);
+                if (accessMs > 0) {
+                    pList.get(i).setLast_access_time(accessMs / 1000);
+                }
             }
         }
         resp.partitions_meta_infos = pList;
@@ -558,6 +586,11 @@ public class InformationSchemaDataSource {
         partitionMetaInfo.setStorage_size(physicalPartition.storageDataSize() + physicalPartition.getExtraFileSize());
         // TABLET_BALANCED
         partitionMetaInfo.setTablet_balanced(physicalPartition.isTabletBalanced());
+        // LAST_UPDATE_TIME (last user write, excluding compaction; persisted, cross-FE consistent)
+        long lastUpdateTimeMs = physicalPartition.getLastUpdateTime();
+        if (lastUpdateTimeMs > 0) {
+            partitionMetaInfo.setLast_update_time(lastUpdateTimeMs / 1000);
+        }
     }
 
     // tables

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -105,6 +105,9 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                     || version == partition.getVisibleVersion() + 1);
 
             partition.updateVisibleVersion(version, versionTime);
+            if (txnState.isUserWriteSource()) {
+                partition.updateLastUpdateTime(versionTime);
+            }
             if (txnState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
                 partition.setDataVersion(partitionCommitInfo.getDataVersion());
                 if (partitionCommitInfo.getVersionEpoch() > 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 public class OlapTableTxnLogApplier implements TransactionLogApplier {
     private static final Logger LOG = LogManager.getLogger(OlapTableTxnLogApplier.class);
+
     // olap table or olap materialized view
     private final OlapTable table;
 
@@ -204,6 +205,9 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             }
             if (!partitionCommitInfo.getDictCollectedVersions().isEmpty()) {
                 dictCollectedVersions = partitionCommitInfo.getDictCollectedVersions();
+            }
+            if (txnState.isUserWriteSource()) {
+                partition.updateLastUpdateTime(versionTime);
             }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -102,6 +103,9 @@ public class TransactionState implements Writable, GsonPreProcessable {
     public enum LoadJobSourceType {
         // The second argument marks whether the source type is a loading transaction, which is used to decide
         // combined txn log support. When adding a new type, set it explicitly so the classification is not missed.
+        // NOTE: if a new type is a *system/internal* txn (not a user data write), also add it to
+        // TransactionState.NON_USER_WRITE_SOURCE_TYPES (see isUserWriteSource()) so it does not advance
+        // a partition's lastUpdateTime.
         FRONTEND(1, false),                    // old dpp load, mini load, insert stmt(not streaming type) use this type
         BACKEND_STREAMING(2, true),            // streaming load use this type
         INSERT_STREAMING(3, true),             // insert stmt (streaming type) use this type
@@ -213,6 +217,11 @@ public class TransactionState implements Writable, GsonPreProcessable {
             return sourceType.toString() + ": " + ip;
         }
     }
+
+    // Transaction source types that are NOT a user data write (compaction / replication / shadow-rewrite):
+    // they bump the visible version but must NOT advance a partition's lastUpdateTime. See isUserWriteSource().
+    private static final EnumSet<LoadJobSourceType> NON_USER_WRITE_SOURCE_TYPES =
+            EnumSet.of(LoadJobSourceType.LAKE_COMPACTION, LoadJobSourceType.REPLICATION, LoadJobSourceType.SHADOW_REWRITE);
 
     @SerializedName("dd")
     private long dbId;
@@ -1179,6 +1188,10 @@ public class TransactionState implements Writable, GsonPreProcessable {
 
     public LoadJobSourceType getSourceType() {
         return sourceType;
+    }
+
+    public boolean isUserWriteSource() {
+        return !NON_USER_WRITE_SOURCE_TYPES.contains(sourceType);
     }
 
     public boolean isFromLakeCompaction() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PartitionAccessTimeMgrTest.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.thrift.TPartitionAccessTimeTableRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class PartitionAccessTimeMgrTest {
+
+    private static final long DB_ID = 10L;
+    private static final long TABLE_ID = 1000L;
+
+    private static List<TPartitionAccessTimeTableRef> refs(long dbId, long tableId) {
+        TPartitionAccessTimeTableRef ref = new TPartitionAccessTimeTableRef();
+        ref.setDb_id(dbId);
+        ref.setTable_id(tableId);
+        return Collections.singletonList(ref);
+    }
+
+    @Test
+    public void testRecordAccessStampsGivenLogicalIds() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+
+        long before = System.currentTimeMillis();
+        mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList(100L, 300L));
+
+        Assertions.assertTrue(mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L) >= before, "accessed id must be stamped");
+        Assertions.assertTrue(mgr.getLastAccessTime(DB_ID, TABLE_ID, 300L) >= before, "accessed id must be stamped");
+        Assertions.assertEquals(0L, mgr.getLastAccessTime(DB_ID, TABLE_ID, 200L), "un-accessed id must stay 0");
+    }
+
+    @Test
+    public void testRecordAccessIsMonotonic() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList(100L));
+        long first = mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L);
+        Assertions.assertTrue(first > 0);
+
+        // A subsequent record never moves the timestamp backwards (max-merge).
+        mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList(100L));
+        Assertions.assertTrue(mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L) >= first);
+    }
+
+    @Test
+    public void testTablesAreIsolated() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList(100L));
+
+        // A different table sharing the same logical id is tracked separately.
+        Assertions.assertTrue(mgr.getLastAccessTime(DB_ID, TABLE_ID, 100L) > 0);
+        Assertions.assertEquals(0L, mgr.getLastAccessTime(DB_ID, 2000L, 100L));
+        // A different db is also isolated, even with the same table/logical id.
+        Assertions.assertEquals(0L, mgr.getLastAccessTime(20L, TABLE_ID, 100L));
+
+        // getLocalAccessTimes returns exactly the requested table's logicalPartitionId -> ts snapshot.
+        Map<Long, Long> local = mgr.getLocalAccessTimes(refs(DB_ID, TABLE_ID));
+        Assertions.assertEquals(1, local.size());
+        Assertions.assertTrue(local.containsKey(100L));
+        Assertions.assertTrue(mgr.getLocalAccessTimes(refs(DB_ID, 2000L)).isEmpty(), "unknown table -> empty");
+        Assertions.assertTrue(mgr.getLocalAccessTimes(refs(20L, TABLE_ID)).isEmpty(), "unknown db -> empty");
+    }
+
+    @Test
+    public void testNullOrEmptyArgumentsAreNoOps() {
+        PartitionAccessTimeMgr mgr = new PartitionAccessTimeMgr();
+        // Must not throw on a null / empty id collection, and must not create an entry.
+        mgr.recordAccess(DB_ID, TABLE_ID, null);
+        mgr.recordAccess(DB_ID, TABLE_ID, Lists.newArrayList());
+        Assertions.assertTrue(mgr.getLocalAccessTimes(refs(DB_ID, TABLE_ID)).isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionLastUpdateTimeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionLastUpdateTimeTest.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PhysicalPartitionLastUpdateTimeTest {
+
+    @Test
+    public void testUpdateTimeIsMonotonicAndAggregates() {
+        MaterializedIndex index = new MaterializedIndex(1L, MaterializedIndex.IndexState.NORMAL);
+        PhysicalPartition pp = new PhysicalPartition(10L, 1L, index);
+        Assertions.assertEquals(0L, pp.getLastUpdateTime());
+
+        pp.updateLastUpdateTime(1000L);
+        pp.updateLastUpdateTime(500L);   // older must NOT overwrite
+        Assertions.assertEquals(1000L, pp.getLastUpdateTime());
+        pp.updateLastUpdateTime(2000L);
+        Assertions.assertEquals(2000L, pp.getLastUpdateTime());
+
+        Partition partition = new Partition(100L, 101L, "p1", index, null);
+        for (PhysicalPartition sub : partition.getSubPartitions()) {
+            sub.updateLastUpdateTime(7000L);
+        }
+        Assertions.assertEquals(7000L, partition.getLastUpdateTime());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/PartitionsProcDirTest.java
@@ -23,15 +23,22 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionAccessTimeMgr;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.clone.BalanceStat;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.type.VarcharType;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +117,80 @@ public class PartitionsProcDirTest {
                 () -> dir.lookup("no_such_partition"));
         Assertions.assertTrue(ex.getMessage().contains("no_such_partition"),
                 "Expected message to mention the missing partition name, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testGetPartitionInfosThrowsWhenAllRemotesFailedAndNoLocalRecord() {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        olapTable.getIndexNameToMetaId().put("index1", index.getMetaId());
+        olapTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
+        db.registerTableUnlocked(olapTable);
+
+        // This FE holds no record for the table and every other FE failed to return a result, so
+        // getAccessTimes raises ERR_GET_PARTITION_ACCESS_TIME rather than returning an empty map that would
+        // look like "never accessed". The read must let that error surface instead of a misleading NULL.
+        new MockUp<PartitionAccessTimeMgr>() {
+            @Mock
+            public Map<Long, Long> getAccessTimes(long dbId, long tableId) {
+                throw ErrorReportException.report(
+                        ErrorCode.ERR_GET_PARTITION_ACCESS_TIME, "127.0.0.2:9020 (Connection refused)");
+            }
+        };
+
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            PartitionsProcDir dir = new PartitionsProcDir(db, olapTable, false);
+            ErrorReportException ex = Assertions.assertThrows(ErrorReportException.class, dir::getPartitionInfos);
+            Assertions.assertTrue(ex.getMessage().contains("127.0.0.2"),
+                    "Expected the error to name the unreachable FE, got: " + ex.getMessage());
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
+    }
+
+    @Test
+    public void testGetPartitionInfosReturnsNullAccessTimeWhenSomeRemoteResponded() throws AnalysisException {
+        Database db = new Database(10000L, "PartitionsProcDirTestDB");
+
+        List<Column> col = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartition = new ListPartitionInfo(PartitionType.LIST, col);
+        long partitionId = 1025;
+        listPartition.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        listPartition.setReplicationNum(partitionId, (short) 1);
+        OlapTable olapTable = new OlapTable(1024L, "olap_table", col, null, listPartition, null);
+        MaterializedIndex index = new MaterializedIndex(1000L, IndexState.NORMAL);
+        olapTable.getIndexNameToMetaId().put("index1", index.getMetaId());
+        olapTable.addPartition(new Partition(partitionId, 1035, "p1", index, new RandomDistributionInfo(10)));
+        db.registerTableUnlocked(olapTable);
+
+        // getAccessTimes returns an empty map without raising (a trustworthy "never accessed": at least one
+        // FE answered, or there was no peer to fail), so LastAccessTime renders as NULL rather than throwing.
+        new MockUp<PartitionAccessTimeMgr>() {
+            @Mock
+            public Map<Long, Long> getAccessTimes(long dbId, long tableId) {
+                return new HashMap<>();
+            }
+        };
+
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = true;
+        try {
+            List<List<Comparable>> rows = new PartitionsProcDir(db, olapTable, false).getPartitionInfos();
+            // LastAccessTime is the last column; with no record it must render as the NULL placeholder.
+            List<Comparable> row = rows.get(0);
+            Assertions.assertEquals(FeConstants.NULL_STRING, row.get(row.size() - 1));
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -17,6 +17,7 @@ package com.starrocks.load;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionAccessTimeMgr;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.catalog.Table;
@@ -50,6 +51,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -233,6 +235,75 @@ public class ExportJobTest {
         Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
         Assertions.assertEquals(5, fragments.size());
         Assertions.assertEquals(5, scanNodes.size());
+    }
+
+    @Test
+    public void testGenScanNodeRecordsPartitionAccess(@Mocked GlobalStateMgr globalStateMgr,
+                                                       @Mocked Table table,
+                                                       @Mocked OlapScanNode scanNode) {
+        long dbId = 777L;
+        long tableId = 555L;
+        PartitionAccessTimeMgr accessTimeMgr = new PartitionAccessTimeMgr();
+        new Expectations() {
+            {
+                table.getType();
+                result = Table.TableType.OLAP;
+                table.getId();
+                result = tableId;
+                GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr();
+                result = accessTimeMgr;
+                // computePartitionInfo() has resolved these data-bearing logical partition ids.
+                scanNode.getSelectedPartitionIds();
+                result = Lists.newArrayList(100L, 200L);
+            }
+        };
+
+        ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
+        Deencapsulation.setField(job, "exportTable", table);
+        Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
+        Deencapsulation.setField(job, "dbId", dbId);
+
+        long before = System.currentTimeMillis();
+        Deencapsulation.invoke(job, "genScanNode");
+
+        // genScanNode records the export scan as a user access for exactly the selected partitions.
+        Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 100L) >= before);
+        Assertions.assertTrue(accessTimeMgr.getLastAccessTime(dbId, tableId, 200L) >= before);
+        Assertions.assertEquals(0L, accessTimeMgr.getLastAccessTime(dbId, tableId, 300L));
+    }
+
+    @Test
+    public void testGenScanNodeSkipsAccessRecordingWhenDisabled(@Mocked GlobalStateMgr globalStateMgr,
+                                                                @Mocked Table table,
+                                                                @Mocked OlapScanNode scanNode) {
+        boolean saved = Config.enable_collect_partition_access_time;
+        Config.enable_collect_partition_access_time = false;
+        try {
+            new Expectations() {
+                {
+                    table.getType();
+                    result = Table.TableType.OLAP;
+                }
+            };
+
+            ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
+            Deencapsulation.setField(job, "exportTable", table);
+            Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
+            Deencapsulation.setField(job, "dbId", 777L);
+
+            Deencapsulation.invoke(job, "genScanNode");
+
+            // With the feature disabled, genScanNode must not reach the access-time collection at all
+            // (the whole block, starting at GlobalStateMgr.getCurrentState(), is skipped).
+            new Verifications() {
+                {
+                    GlobalStateMgr.getCurrentState();
+                    times = 0;
+                }
+            };
+        } finally {
+            Config.enable_collect_partition_access_time = saved;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -77,6 +77,8 @@ import com.starrocks.thrift.TGetDictQueryParamRequest;
 import com.starrocks.thrift.TGetDictQueryParamResponse;
 import com.starrocks.thrift.TGetLoadTxnStatusRequest;
 import com.starrocks.thrift.TGetLoadTxnStatusResult;
+import com.starrocks.thrift.TGetPartitionAccessTimesRequest;
+import com.starrocks.thrift.TGetPartitionAccessTimesResponse;
 import com.starrocks.thrift.TGetProfileRequest;
 import com.starrocks.thrift.TGetProfileResponse;
 import com.starrocks.thrift.TGetTableSchemaRequest;
@@ -106,6 +108,7 @@ import com.starrocks.thrift.TManualLoadTxnCommitAttachment;
 import com.starrocks.thrift.TMergeCommitRequest;
 import com.starrocks.thrift.TMergeCommitResult;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TPartitionAccessTimeTableRef;
 import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPartitionMetaRequest;
 import com.starrocks.thrift.TPartitionMetaResponse;
@@ -2411,5 +2414,46 @@ public class FrontendServiceImplTest {
         Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code());
         // partitions should be empty since the created partition was "dropped" by TTL
         Assertions.assertTrue(result.getPartitions() == null || result.getPartitions().isEmpty());
+    }
+
+    @Test
+    public void testGetPartitionAccessTimes() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "site_access_auto");
+
+        // Record a query access on every (logical) partition of the table on this (local) FE.
+        List<Long> partitionIds = table.getPartitions().stream()
+                .map(Partition::getId).collect(Collectors.toList());
+        GlobalStateMgr.getCurrentState().getPartitionAccessTimeMgr()
+                .recordAccess(db.getId(), table.getId(), partitionIds);
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+
+        // Batch request carrying this table; the handler is lock-free and returns logicalPartitionId -> ms.
+        TGetPartitionAccessTimesRequest request = new TGetPartitionAccessTimesRequest();
+        TPartitionAccessTimeTableRef ref = new TPartitionAccessTimeTableRef();
+        ref.setDb_id(db.getId());
+        ref.setTable_id(table.getId());
+        request.setTables(Lists.newArrayList(ref));
+
+        TGetPartitionAccessTimesResponse response = impl.getPartitionAccessTimes(request);
+        Assertions.assertEquals(TStatusCode.OK, response.getStatus().getStatus_code());
+        Map<Long, Long> accessTimes = response.getPartition_id_to_access_time_ms();
+        Assertions.assertNotNull(accessTimes);
+        Assertions.assertEquals(partitionIds.size(), accessTimes.size());
+        for (Long pid : partitionIds) {
+            Assertions.assertTrue(accessTimes.getOrDefault(pid, 0L) > 0);
+        }
+
+        // A table absent on this FE (bogus id) must not fail: the lock-free snapshot returns empty.
+        TGetPartitionAccessTimesRequest missingReq = new TGetPartitionAccessTimesRequest();
+        TPartitionAccessTimeTableRef missingRef = new TPartitionAccessTimeTableRef();
+        missingRef.setDb_id(db.getId());
+        missingRef.setTable_id(-1L);
+        missingReq.setTables(Lists.newArrayList(missingRef));
+        TGetPartitionAccessTimesResponse missingResp = impl.getPartitionAccessTimes(missingReq);
+        Assertions.assertEquals(TStatusCode.OK, missingResp.getStatus().getStatus_code());
+        Assertions.assertTrue(missingResp.getPartition_id_to_access_time_ms().isEmpty());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnLogApplierTest.java
@@ -267,4 +267,42 @@ public class LakeTableTxnLogApplierTest extends LakeTableTestHelper {
         Assertions.assertEquals(1, table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion());
         Assertions.assertEquals(2, table.getPartition(partitionId).getDefaultPhysicalPartition().getNextVersion());
     }
+
+    @Test
+    public void testApplyVisibleLogRecordsLastUpdateTimeForUserWrite() {
+        LakeTable table = buildLakeTable();
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        // A routine-load (user write) visible txn must advance lastUpdateTime on the shared-data path.
+        TransactionState state = newTransactionState();
+        state.setTransactionStatus(TransactionStatus.VISIBLE);
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(physicalPartitionId, 2, 0);
+        long versionTime = System.currentTimeMillis();
+        partitionCommitInfo.setVersionTime(versionTime);
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+
+        applier.applyVisibleLog(state, tableCommitInfo, /*unused*/null);
+        Assertions.assertEquals(versionTime,
+                table.getPartition(partitionId).getDefaultPhysicalPartition().getLastUpdateTime());
+    }
+
+    @Test
+    public void testApplyVisibleLogSkipsLastUpdateTimeForCompaction() {
+        LakeTable table = buildLakeTable();
+        LakeTableTxnLogApplier applier = new LakeTableTxnLogApplier(table);
+        // Compaction is not a user write: it advances the visible version but must NOT touch
+        // lastUpdateTime, which must stay 0 (its initial value).
+        TransactionState state = newCompactionTransactionState();
+        state.setTxnCommitAttachment(new CompactionTxnCommitAttachment(true));
+        state.setTransactionStatus(TransactionStatus.VISIBLE);
+        PartitionCommitInfo partitionCommitInfo = new PartitionCommitInfo(physicalPartitionId, 2, 0);
+        partitionCommitInfo.setVersionTime(System.currentTimeMillis());
+        TableCommitInfo tableCommitInfo = new TableCommitInfo(tableId);
+        tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
+
+        applier.applyVisibleLog(state, tableCommitInfo, /*unused*/null);
+        Assertions.assertEquals(2, table.getPartition(partitionId).getDefaultPhysicalPartition().getVisibleVersion());
+        Assertions.assertEquals(0L,
+                table.getPartition(partitionId).getDefaultPhysicalPartition().getLastUpdateTime());
+    }
 }

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -373,6 +373,9 @@ public enum ErrorCode {
     ERR_MULTI_PARTITION_STEP_LQ_ZERO(5703, new byte[] {'4', '2', '0', '0', '0'},
             "The interval of the Multi-Range Partition must be greater than 0"),
 
+    ERR_GET_PARTITION_ACCESS_TIME(5704, new byte[] {'H', 'Y', '0', '0', '0'},
+            "Failed to get partition access time: %s"),
+
     /**
      * 5800 - 5899: Pipe
      */

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1660,6 +1660,31 @@ struct TPartitionMetaInfo {
     // tablets. Only meaningful for tables with an async vector index (shared-data).
     33: optional i64 min_vi_built_version
     34: optional i64 max_vi_built_version
+    // Last time this partition was scanned by a query (unix seconds). In-memory only on FE
+    // (not persisted); 0/absent = never accessed, or the value was lost on FE restart/failover.
+    35: optional i64 last_access_time
+    // Last time this partition was modified by a user write (load/DML, excluding compaction),
+    // in unix seconds. 0/absent = unknown.
+    36: optional i64 last_update_time
+}
+
+// Ask one FE for its local in-memory partition query-access times of a table, so the querying FE
+// can aggregate (max) across all FEs. Best-effort: callers tolerate a missing/slow FE.
+struct TPartitionAccessTimeTableRef {
+    1: optional i64 db_id
+    2: optional i64 table_id
+}
+
+struct TGetPartitionAccessTimesRequest {
+    // One entry per requested table. SHOW PARTITIONS sends a single element; partitions_meta sends the
+    // whole page so a single RPC per FE covers many tables (O(FEs) round-trips, not O(tables * FEs)).
+    // Logical partition ids are globally unique, so the response merges into one logicalPartitionId -> ms map.
+    1: optional list<TPartitionAccessTimeTableRef> tables
+}
+
+struct TGetPartitionAccessTimesResponse {
+    1: optional Status.TStatus status
+    2: optional map<i64, i64> partition_id_to_access_time_ms // logicalPartitionId -> lastAccessTime(ms)
 }
 
 struct TGetPartitionsMetaResponse {
@@ -2573,6 +2598,8 @@ service FrontendService {
     TTableReplicationResponse startTableReplication(1: TTableReplicationRequest request)
 
     TGetPartitionsMetaResponse getPartitionsMeta(1: TGetPartitionsMetaRequest request)
+
+    TGetPartitionAccessTimesResponse getPartitionAccessTimes(1: optional TGetPartitionAccessTimesRequest request)
 
     TReportLakeCompactionResponse reportLakeCompaction(1: TReportLakeCompactionRequest request)
 


### PR DESCRIPTION
## Why I'm doing:

Operators need to know, per partition, when it was last **written by a user** and when it was last **scanned by a query**, to drive cold/hot data tiering and statistics/cache-warmup decisions. Today `visibleVersionTime` is not a faithful "last update" signal (in shared-data mode compaction also advances it), and there is no per-partition "last query access" signal at all.

## What I'm doing:

Add two per-partition timestamps, exposed via `information_schema.partitions_meta` (`LAST_UPDATE_TIME`, `LAST_ACCESS_TIME`) and `SHOW PARTITIONS` (`LastUpdateTime`, `LastAccessTime`).

- **LAST_UPDATE_TIME** — last user write (load / INSERT / DELETE / UPDATE). Recorded in the transaction apply path (`OlapTableTxnLogApplier` / `LakeTableTxnLogApplier`), **excluding** system/internal txns (`LAKE_COMPACTION`, `REPLICATION`, `SHADOW_REWRITE`). Because it rides the transaction journal, it is consistent across FEs (replay) and persisted with the FE image (`@SerializedName`), with no extra write path or RPC.
- **LAST_ACCESS_TIME** — last time a user statement scanned the partition. Covers every user-driven read that carries a scan plan — `SELECT`, `INSERT ... SELECT` / `INSERT OVERWRITE`, CTAS, primary-key `UPDATE` / `DELETE`, materialized-view refresh (internal INSERT) — plus `EXPORT`. Recorded in memory on the coordinating FE (`StmtExecutor.recordPartitionAccessTime` from `handleQueryStmt` / `handleDMLStmt`, and `ExportJob.genScanNode`); statistics collection and internal metadata queries are excluded, and `EXPLAIN SCHEDULER` is skipped (no scan actually runs). **In-memory only** (not persisted; resets on FE restart/failover), held in `PartitionAccessTimeMgr` keyed `dbId -> tableId -> logicalPartitionId -> ms` with lock-free record and read. Reads aggregate (max) across all FEs at query time via a best-effort `getPartitionAccessTimes` RPC (one call per FE per page), so the exposed value is cluster-consistent.

**Feature switch** — `enable_collect_partition_access_time` (FE config, mutable, default `true`) gates `LAST_ACCESS_TIME` only: when disabled, the access time is neither recorded nor aggregated across FEs and the column shows `NULL`. It does not affect `LAST_UPDATE_TIME`.

**Cross-FE failure handling** — the aggregation is best-effort and normally tolerates a slow/unreachable FE (skipped, not fatal). The one exception: if the coordinating FE holds no record for the requested table(s) **and** every other FE failed to return a result, the read raises `ERR_GET_PARTITION_ACCESS_TIME` (`SHOW PARTITIONS`) / a thrift error (`partitions_meta`) instead of returning an empty result that would be indistinguishable from "never accessed". If at least one FE answers (even with nothing), an empty result is a genuine "never accessed" and renders as `NULL`.

Design intentionally keeps the read path behind `PartitionAccessTimeMgr` (`getLocalTableAccessTimes` / `getRemoteAccessTimes`) and retains the db/table dimensions in the map, so a future v2 (periodic flush to an internal system table, à la `_statistics_.loads_history`, plus eviction of dropped-partition entries) can be added without touching the exposure layer.

Fixes #76680

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5