### PR TITLE
[Enhancement] Collect external-table statistics for multiple columns in a single scan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -204,9 +204,13 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         LOG.info("[ExternalStats] scan budget | jobId={} catalog={} db={} table={} bytesCap={} filesCap={} rowsCap={}",
                 jobId, catalogName, db.getOriginName(), table.getName(), scanBytesCap, scanFilesCap, scanRowsCap);
 
-        // Each per-partition query wraps the read in a CTE (base_cte_table) shared by every column's aggregate
-        // branch. Force CTE reuse (ratio 0 = reuse regardless of estimated cost) so the optimizer materializes
-        // a single scan per partition instead of inlining the CTE back into one scan per column.
+        // Each query wraps the read in a CTE (base_cte_table) shared by every column's aggregate branch. Force
+        // CTE reuse (ratio 0 = reuse regardless of estimated cost) so the optimizer materializes a single scan
+        // instead of inlining the CTE back into one scan per column.
+        // NOTE: buildConnectContext() already forces this, but collectStatistics(resetWarehouse=true) - used by
+        // the query-trigger and CREATE ANALYZE paths - calls setCurrentWarehouse() right before collect(),
+        // which re-clones the session variable from defaults (ratio back to 1.15) and only re-applies
+        // enable_profile. So re-force it here, the last write before the collection SQL runs. Do not remove.
         sessionVariable.setCboCteReuse(true);
         sessionVariable.setCboCTERuseRatio(0);
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -80,7 +80,18 @@ import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TA
 public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     private static final Logger LOG = LogManager.getLogger(ExternalFullStatisticsCollectJob.class);
 
-    private static final String BATCH_FULL_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
+    // Per-partition CTE wrapper: the partition is read exactly once into base_cte_table and every per-column
+    // aggregate branch reads from it, so a partition is scanned once instead of once per column. Requires CTE
+    // reuse to be forced on in the collection session (see collect()); otherwise the optimizer may inline the
+    // CTE and fall back to one scan per column.
+    private static final String BATCH_FULL_STATISTIC_CTE_TEMPLATE =
+            "WITH base_cte_table AS (SELECT $projection " +
+            "FROM `$catalogName`.`$dbName`.`$tableName` WHERE $partitionPredicate) $unionSelects";
+
+    // One statistics row per column, reading from the shared CTE instead of re-scanning the physical table.
+    // The output schema is identical to the previous per-(partition, column) query, so result parsing is
+    // unchanged.
+    private static final String BATCH_FULL_STATISTIC_SELECT_TEMPLATE = "SELECT cast($version as INT)" +
             ", '$partitionNameStr'" + // VARCHAR
             ", '$columnNameStr'" + // VARCHAR
             ", cast(COUNT(1) as BIGINT)" + // BIGINT
@@ -89,7 +100,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
-            " FROM `$catalogName`.`$dbName`.`$tableName` where $partitionPredicate";
+            " FROM base_cte_table";
 
     private final String catalogName;
     protected List<String> partitionNames;
@@ -150,6 +161,9 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         long savedScanBytesCap = sessionVariable.getExternalStatsScanBytesCap();
         long savedScanFilesCap = sessionVariable.getExternalStatsScanFilesCap();
         long savedScanRowsCap = sessionVariable.getExternalStatsScanRowsCap();
+        // Saved so the forced CTE-reuse settings (set below, restored in finally) do not leak to a reused context.
+        boolean savedCboCteReuse = sessionVariable.isCboCteReuse();
+        double savedCboCteReuseRatio = sessionVariable.getCboCTERuseRatio();
         long scanBytesCap = resolveScanCap(StatsConstants.EXTERNAL_ANALYZE_SCAN_BYTES_CAP,
                 Config.connector_table_analyze_scan_bytes_cap, jobId);
         long scanFilesCap = resolveScanCap(StatsConstants.EXTERNAL_ANALYZE_SCAN_FILES_CAP,
@@ -190,6 +204,12 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         LOG.info("[ExternalStats] scan budget | jobId={} catalog={} db={} table={} bytesCap={} filesCap={} rowsCap={}",
                 jobId, catalogName, db.getOriginName(), table.getName(), scanBytesCap, scanFilesCap, scanRowsCap);
 
+        // Each per-partition query wraps the read in a CTE (base_cte_table) shared by every column's aggregate
+        // branch. Force CTE reuse (ratio 0 = reuse regardless of estimated cost) so the optimizer materializes
+        // a single scan per partition instead of inlining the CTE back into one scan per column.
+        sessionVariable.setCboCteReuse(true);
+        sessionVariable.setCboCTERuseRatio(0);
+
         String status = "SUCCESS";
         String failureReason = "";
         try {
@@ -198,13 +218,10 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
             long totalCollectSQL = collectSQLList.size();
 
-            // First, the collection task is divided into several small tasks according to the column name and partition,
-            // and then the multiple small tasks are aggregated into several tasks
-            // that will actually be run according to the configured parallelism, and are connected by union all
-            // Because each union will run independently, if the number of unions is greater than the degree of parallelism,
-            // dop will be set to 1 to meet the requirements of the degree of parallelism.
-            // If the number of unions is less than the degree of parallelism,
-            // dop should be adjusted appropriately to use enough cpu cores
+            // Each element is one self-contained CTE query for a (partition, column-group): all columns in the
+            // group share a single partition scan. They cannot be merged (only one WITH per statement), so
+            // each runs on its own. The collect parallelism now drives per-query pipeline dop: a single-element
+            // group is given dop = parallelism to use enough cpu cores.
             for (List<String> sqlUnion : collectSQLList) {
                 if (sqlUnion.size() < parallelism) {
                     context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
@@ -230,6 +247,8 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             sessionVariable.setExternalStatsScanBytesCap(savedScanBytesCap);
             sessionVariable.setExternalStatsScanFilesCap(savedScanFilesCap);
             sessionVariable.setExternalStatsScanRowsCap(savedScanRowsCap);
+            sessionVariable.setCboCteReuse(savedCboCteReuse);
+            sessionVariable.setCboCTERuseRatio(savedCboCteReuseRatio);
             LOG.info("[ExternalStats] collect end | jobId={} catalog={} db={} table={} status={} " +
                             "durationMs={} partitions={} columns={} reason={}",
                     jobId, catalogName, db.getOriginName(), table.getName(),
@@ -343,48 +362,74 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     }
 
     protected List<List<String>> buildCollectSQLList(int parallelism) {
+        // Collect a partition in a single scan by wrapping the read in a CTE (base_cte_table) shared by every
+        // column's aggregate branch. Columns are split into groups so a wide table does not build one CTE
+        // multicast to hundreds of consumers (inflating query/plan size and the memory held for the
+        // materialized partition); each group scans the partition once, so total scans are
+        // partitions x ceil(columns / columnsPerScan). The group size mirrors the internal sample path
+        // (ColumnSampleManager.splitPrimitiveTypeStats): max(2, statistic_collect_parallelism), i.e. at least
+        // two columns share a scan. Each group is a self-contained CTE query and two CTE queries cannot be
+        // UNION ALL'd (one WITH per statement), so the outer group size is fixed to 1; parallelism only sets
+        // per-query pipeline dop in the execute loop.
+        int columnsPerScan = Math.max(2, parallelism);
         List<String> totalQuerySQL = new ArrayList<>();
         for (String partitionName : partitionNames) {
-            for (int i = 0; i < columnNames.size(); i++) {
-                if (DO_NOT_COLLECT_PARTITIONS.contains(partitionName)) {
-                    LOG.info("Skip collect full statistics for partition: {} in table: {}",
-                            partitionName, table.getName());
-                    continue;
-                }
-                totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, partitionName, columnNames.get(i),
-                        columnTypes.get(i)));
+            if (DO_NOT_COLLECT_PARTITIONS.contains(partitionName)) {
+                LOG.info("Skip collect full statistics for partition: {} in table: {}",
+                        partitionName, table.getName());
+                continue;
+            }
+            for (int start = 0; start < columnNames.size(); start += columnsPerScan) {
+                int end = Math.min(columnNames.size(), start + columnsPerScan);
+                totalQuerySQL.add(buildPartitionCTESQL(table, partitionName, start, end));
             }
         }
 
-        return Lists.partition(totalQuerySQL, parallelism);
+        return Lists.partition(totalQuerySQL, 1);
     }
 
-    private String buildBatchCollectFullStatisticSQL(Table table, String partitionName, String columnName,
-                                                     Type columnType) {
-        StringBuilder builder = new StringBuilder();
+    // Builds one CTE query that collects columns [startCol, endCol) of a single partition in a shared scan.
+    private String buildPartitionCTESQL(Table table, String partitionName, int startCol, int endCol) {
+        Collection<String> nullValues = resolveNullValues(table);
+        String partitionPredicate = table.isUnPartitioned() ? "1=1" :
+                Joiner.on(" AND ").join(generatePartitionPredicates(table, partitionName, nullValues));
+
+        // CTE projection: only the columns in this group actually read by an aggregate (statable,
+        // non-collection). Non-statable columns emit constant sketches and need nothing beyond COUNT(1).
+        List<String> projection = new ArrayList<>();
+        List<String> unionSelects = new ArrayList<>();
+        for (int i = startCol; i < endCol; i++) {
+            Type columnType = columnTypes.get(i);
+            if (columnType.canStatistic() && !columnType.isCollectionType()) {
+                projection.add(StatisticUtils.quoting(table, columnNames.get(i)));
+            }
+            unionSelects.add(buildColumnSelectFromCTE(table, partitionName, columnNames.get(i), columnType));
+        }
+
+        VelocityContext context = new VelocityContext();
+        context.put("catalogName", this.catalogName);
+        context.put("dbName", db.getOriginName());
+        context.put("tableName", table.getName());
+        context.put("projection", projection.isEmpty() ? "1" : Joiner.on(", ").join(projection));
+        context.put("partitionPredicate", partitionPredicate);
+        context.put("unionSelects", Joiner.on(" UNION ALL ").join(unionSelects));
+        return build(context, BATCH_FULL_STATISTIC_CTE_TEMPLATE);
+    }
+
+    // Builds one statistics row (COUNT/dataSize/HLL/null-count/max/min) for a single column, reading from the
+    // shared base_cte_table. The output columns match the legacy per-(partition, column) query verbatim.
+    private String buildColumnSelectFromCTE(Table table, String partitionName, String columnName, Type columnType) {
         VelocityContext context = new VelocityContext();
 
         String columnNameStr = StringEscapeUtils.escapeSql(columnName);
         String quoteColumnName = StatisticUtils.quoting(table, columnName);
-
-        Collection<String> nullValues;
-        if (table.isIcebergTable()) {
-            nullValues = Collections.singleton(IcebergApiConverter.PARTITION_NULL_VALUE);
-        } else if (table.isPaimonTable()) {
-            nullValues = PaimonMetadata.PARTITION_NULL_VALUES;
-        } else {
-            nullValues = Collections.singleton(HiveMetaClient.PARTITION_NULL_VALUE);
-        }
+        Collection<String> nullValues = resolveNullValues(table);
 
         context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
-        // all table now, partition later
         context.put("partitionNameStr", table.isIcebergTable() ? partitionName :
                 PartitionUtil.normalizePartitionName(partitionName, table.getPartitionColumnNames(), nullValues));
         context.put("columnNameStr", columnNameStr);
         context.put("dataSize", fullAnalyzeGetDataSize(quoteColumnName, columnType));
-        context.put("dbName", db.getOriginName());
-        context.put("tableName", table.getName());
-        context.put("catalogName", this.catalogName);
 
         if (!columnType.canStatistic() || columnType.isCollectionType()) {
             context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
@@ -398,15 +443,17 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             context.put("minFunction", getMinMaxFunction(columnType, quoteColumnName, false));
         }
 
-        if (table.isUnPartitioned()) {
-            context.put("partitionPredicate", "1=1");
-        } else {
-            List<String> partitionPredicate = generatePartitionPredicates(table, partitionName, nullValues);
-            context.put("partitionPredicate", Joiner.on(" AND ").join(partitionPredicate));
-        }
+        return build(context, BATCH_FULL_STATISTIC_SELECT_TEMPLATE);
+    }
 
-        builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));
-        return builder.toString();
+    private Collection<String> resolveNullValues(Table table) {
+        if (table.isIcebergTable()) {
+            return Collections.singleton(IcebergApiConverter.PARTITION_NULL_VALUE);
+        } else if (table.isPaimonTable()) {
+            return PaimonMetadata.PARTITION_NULL_VALUES;
+        } else {
+            return Collections.singleton(HiveMetaClient.PARTITION_NULL_VALUE);
+        }
     }
 
     private List<String> generatePartitionPredicates(Table table, String partitionName, Collection<String> nullValues) {

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1544,8 +1544,10 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // Columns split into groups of max(2, parallelism) per partition: 3 cols / 2-per-scan = 2 groups
+        // x 10 partitions = 20 queries.
         List<List<String>> lists = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(30, lists.size());
+        Assertions.assertEquals(20, lists.size());
 
         //test partition is null
         collectJob = (ExternalFullStatisticsCollectJob)
@@ -1556,8 +1558,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // Single partition, 3 cols / 2-per-scan = 2 groups.
         lists = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(3, lists.size());
+        Assertions.assertEquals(2, lists.size());
 
         //test unpartitioned table
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "paimon0", "pmn_db1",
@@ -1571,8 +1574,9 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // Unpartitioned, 2 cols / 2-per-scan = 1 group.
         lists = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(2, lists.size());
+        Assertions.assertEquals(1, lists.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -1199,16 +1199,22 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // Columns are split into groups of max(2, parallelism), each group a self-contained single-scan CTE
+        // query, per partition. 4 columns / 2-per-scan = 2 groups x 3 partitions = 6 queries.
         List<List<String>> collectSqlList = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(12, collectSqlList.size());
-
-        collectSqlList = collectJob.buildCollectSQLList(128);
-        Assertions.assertEquals(1, collectSqlList.size());
-        assertContains(collectSqlList.get(0).toString(), "c1", "c2", "c3", "par_col");
-        assertContains(collectSqlList.get(0).toString(), "`par_col` = '0'", "`par_col` = '1'", "`par_col` = '2'");
-
-        collectSqlList = collectJob.buildCollectSQLList(3);
-        Assertions.assertEquals(4, collectSqlList.size());
+        Assertions.assertEquals(6, collectSqlList.size());
+        // A large parallelism puts all 4 columns in one scan -> 1 group x 3 partitions = 3 queries.
+        Assertions.assertEquals(3, collectJob.buildCollectSQLList(128).size());
+        // parallelism 3 -> ceil(4/3)=2 groups x 3 partitions = 6 queries.
+        Assertions.assertEquals(6, collectJob.buildCollectSQLList(3).size());
+        for (List<String> group : collectSqlList) {
+            Assertions.assertEquals(1, group.size());
+            assertContains(group.get(0), "WITH base_cte_table AS");
+            assertContains(group.get(0), "FROM base_cte_table");
+        }
+        // All columns and all three partition predicates appear across the query list.
+        assertContains(collectSqlList.toString(), "c1", "c2", "c3", "par_col");
+        assertContains(collectSqlList.toString(), "`par_col` = '0'", "`par_col` = '1'", "`par_col` = '2'");
 
         database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "tpch");
         table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable(connectContext, "hive0", "tpch", "region");
@@ -1220,13 +1226,14 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // Unpartitioned table (1=1 predicate): 3 columns / 2-per-scan = 2 CTE queries.
         collectSqlList = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(3, collectSqlList.size());
-
-        collectSqlList = collectJob.buildCollectSQLList(128);
-        Assertions.assertEquals(1, collectSqlList.size());
-        assertContains(collectSqlList.get(0).toString(), "r_regionkey", "r_name", "r_comment");
-        assertContains(collectSqlList.get(0).toString(), "1=1");
+        Assertions.assertEquals(2, collectSqlList.size());
+        // All 3 columns in one scan with a large parallelism.
+        Assertions.assertEquals(1, collectJob.buildCollectSQLList(128).size());
+        assertContains(collectSqlList.toString(), "r_regionkey", "r_name", "r_comment");
+        assertContains(collectSqlList.toString(), "1=1");
+        assertContains(collectSqlList.toString(), "WITH base_cte_table AS");
 
         database = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "hive0", "partitioned_db");
         table = connectContext.getGlobalStateMgr().getMetadataMgr()
@@ -1239,14 +1246,14 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         StatsConstants.AnalyzeType.FULL,
                         StatsConstants.ScheduleType.ONCE,
                         Maps.newHashMap());
+        // 5 columns / 2-per-scan = ceil(5/2)=3 groups x 6 partitions = 18 queries; all columns in one scan -> 6.
         collectSqlList = collectJob.buildCollectSQLList(1);
-        Assertions.assertEquals(30, collectSqlList.size());
-        collectSqlList = collectJob.buildCollectSQLList(128);
-        Assertions.assertEquals(1, collectSqlList.size());
-        assertContains(collectSqlList.get(0).toString(), "par_col=1/par_date=NULL");
-        assertContains(collectSqlList.get(0).toString(), "`par_col` = '1' AND `par_date` IS NULL");
-        assertContains(collectSqlList.get(0).toString(), "par_col=NULL/par_date=2020-01-03");
-        assertContains(collectSqlList.get(0).toString(), "`par_col` IS NULL AND `par_date` = '2020-01-03'");
+        Assertions.assertEquals(18, collectSqlList.size());
+        Assertions.assertEquals(6, collectJob.buildCollectSQLList(128).size());
+        assertContains(collectSqlList.toString(), "par_col=1/par_date=NULL");
+        assertContains(collectSqlList.toString(), "`par_col` = '1' AND `par_date` IS NULL");
+        assertContains(collectSqlList.toString(), "par_col=NULL/par_date=2020-01-03");
+        assertContains(collectSqlList.toString(), "`par_col` IS NULL AND `par_date` = '2020-01-03'");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

External-table (Iceberg/Hive/Paimon) full statistics collection issued one statistics query per (partition, column). Because each query scanned the physical table on its own, a partition was re-read once for every column: for a table with C columns and P partitions the collection scanned the data P x C times. On wide tables and large lake datasets this dominates collection time and I/O, and is a big part of why triggered collection lags behind query planning.

The internal-table sample path already solves the same problem by grouping columns and sharing a single scan via a CTE. External collection did not, so it was both slower and inconsistent with the internal behavior.

## What I'm doing:

Rewrite the external statistics collection SQL so that a group of columns of a partition is collected in a single shared scan, instead of one scan per column.

Each generated query now wraps the partition read in a CTE that every per-column aggregate branch reads from:

```
Before (per column, P x C scans)          After (per column-group, P x ceil(C/N) scans)

SELECT ...col1... FROM t WHERE part=p      WITH base AS (SELECT col1..colN FROM t WHERE part=p)  <- scanned once
SELECT ...col2... FROM t WHERE part=p      SELECT ...col1... FROM base
SELECT ...col3... FROM t WHERE part=p      SELECT ...col2... FROM base
   (each line = its own table scan)        SELECT ...colN... FROM base
```

Key points:

- Columns are split into groups of `max(2, statistic_collect_parallelism)`, mirroring the internal sample path (`ColumnSampleManager.splitPrimitiveTypeStats`). No new configuration is introduced; the existing knob now also controls how many columns share one scan. Total scans drop from `P x C` to `P x ceil(C / group_size)`.
- CTE reuse is a cost-based decision, so the collection session forces it on (`cbo_cte_reuse=true`, `cbo_cte_reuse_rate=0`) and restores the previous values afterwards. Without forcing, the optimizer may inline the CTE and fall back to one scan per column.
- The output row schema of each query is unchanged, so result parsing, sample extrapolation, and statistics metadata handling are untouched — this is purely a change to how the collection SQL is shaped.

---------

Before this PR, the sql is like

```sql
SELECT
    CAST(5 AS INT),
    'ws_sold_date_sk=2452615',
    'ws_net_profit',
    CAST(COUNT(1) AS BIGINT),
    CAST(COUNT(1) * 4 AS BIGINT),
    HEX(
        HLL_SERIALIZE(
            IFNULL(HLL_RAW(`ws_net_profit`), HLL_EMPTY())
        )
    ),
    CAST(COUNT(1) - COUNT(`ws_net_profit`) AS BIGINT),
    IFNULL(MAX(`ws_net_profit`), ''),
    IFNULL(MIN(`ws_net_profit`), '')
FROM `iceberg`.`zz_iceberg_tpcds_sf1000_iceberg_parquet_lz4`.`web_sales`
WHERE `ws_sold_date_sk` = '2452615'

UNION ALL

SELECT
    CAST(5 AS INT),
    'ws_sold_date_sk=2452615',
    'ws_ext_ship_cost',
    CAST(COUNT(1) AS BIGINT),
    CAST(COUNT(1) * 4 AS BIGINT),
    HEX(
        HLL_SERIALIZE(
            IFNULL(HLL_RAW(`ws_ext_ship_cost`), HLL_EMPTY())
        )
    ),
    CAST(COUNT(1) - COUNT(`ws_ext_ship_cost`) AS BIGINT),
    IFNULL(MAX(`ws_ext_ship_cost`), ''),
    IFNULL(MIN(`ws_ext_ship_cost`), '')
FROM `iceberg`.`zz_iceberg_tpcds_sf1000_iceberg_parquet_lz4`.`web_sales`
WHERE `ws_sold_date_sk` = '2452615';

```

And after this PR, sql is like

```sql

WITH base_cte_table AS (
    SELECT
        `ws_net_profit`,
        `ws_ext_ship_cost`
    FROM `iceberg`.`zz_iceberg_tpcds_sf1000_iceberg_parquet_lz4`.`web_sales`
    WHERE `ws_sold_date_sk` = '2452572'
)

SELECT
    CAST(5 AS INT),
    'ws_sold_date_sk=2452572',
    'ws_net_profit',
    CAST(COUNT(1) AS BIGINT),
    CAST(COUNT(1) * 4 AS BIGINT),
    HEX(
        HLL_SERIALIZE(
            IFNULL(HLL_RAW(`ws_net_profit`), HLL_EMPTY())
        )
    ),
    CAST(COUNT(1) - COUNT(`ws_net_profit`) AS BIGINT),
    IFNULL(MAX(`ws_net_profit`), ''),
    IFNULL(MIN(`ws_net_profit`), '')
FROM base_cte_table

UNION ALL

SELECT
    CAST(5 AS INT),
    'ws_sold_date_sk=2452572',
    'ws_ext_ship_cost',
    CAST(COUNT(1) AS BIGINT),
    CAST(COUNT(1) * 4 AS BIGINT),
    HEX(
        HLL_SERIALIZE(
            IFNULL(HLL_RAW(`ws_ext_ship_cost`), HLL_EMPTY())
        )
    ),
    CAST(COUNT(1) - COUNT(`ws_ext_ship_cost`) AS BIGINT),
    IFNULL(MAX(`ws_ext_ship_cost`), ''),
    IFNULL(MIN(`ws_ext_ship_cost`), '')
FROM base_cte_table;
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
