### PR TITLE
[UT] Fix PreSplitFlowTest compile error from Prepared record arity change

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -570,7 +570,7 @@ public class PreSplitFlowTest {
     private static PreSplitFlow.Prepared preparedWithPartitionInSortKey(ScanContext scanContext) {
         Column sortCol = bigintColumn("sort_col");
         return new PreSplitFlow.Prepared(scanContext, List.of(sortCol), List.of(sortCol),
-                /*estimatedBytes*/ 4096L, mock(ComputeResource.class));
+                /*estimatedBytes*/ 4096L, mock(ComputeResource.class), List.of());
     }
 
     /** Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target for {@code table}. */


### PR DESCRIPTION
## Why I'm doing:

`main` is currently red. Commit d358178126d (#76546) added a sixth component — `List<SecondaryIndexSpec> secondaryIndexSpecs` — to the `PreSplitFlow.Prepared` record and updated `preparedFor()` to pass `List.of()`, but the sibling helper `preparedWithPartitionInSortKey()` was left calling the constructor with only five arguments:

```
constructor Prepared in record com.starrocks.alter.reshard.presplit.PreSplitFlow.Prepared cannot be applied to given types;
  required: ScanContext, List<Column>, List<Column>, long, ComputeResource, List<SecondaryIndexSpec>
  found:    ScanContext, List<Column>, List<Column>, long, ComputeResource
  reason: actual and formal argument lists differ in length
```

`fe-core` test compilation fails, so **FE UT is red on main and on every open PR** (the whole test module fails to compile before any test runs).

## What I'm doing:

Pass an empty `secondaryIndexSpecs` list (`List.of()`) to the constructor in `preparedWithPartitionInSortKey()`, matching what `preparedFor()` already does. One-line, test-only fix.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5