### PR TITLE
[BugFix] Fix PreSplitFlowTest Prepared constructor arity to restore fe-core test compilation

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -570,7 +570,7 @@ public class PreSplitFlowTest {
     private static PreSplitFlow.Prepared preparedWithPartitionInSortKey(ScanContext scanContext) {
         Column sortCol = bigintColumn("sort_col");
         return new PreSplitFlow.Prepared(scanContext, List.of(sortCol), List.of(sortCol),
-                /*estimatedBytes*/ 4096L, mock(ComputeResource.class));
+                /*estimatedBytes*/ 4096L, mock(ComputeResource.class), List.of());
     }
 
     /** Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target for {@code table}. */


### PR DESCRIPTION
## Why I'm doing:

`fe-core` test compilation is currently broken on `main`, so **FE UT fails for every open PR**:

```
PreSplitFlowTest.java:[572,16] constructor Prepared in record
com.starrocks.alter.reshard.presplit.PreSplitFlow.Prepared cannot be applied to given types;
  reason: actual and formal argument lists differ in length
```

`PreSplitFlow.Prepared` gained a sixth component, `secondaryIndexSpecs` (`List<SecondaryIndexSpec>`), from the rollup pre-split work (#76233 / #76392). The multi-partition meta-tier test helper `preparedWithPartitionInSortKey`, added by #76546, still constructs `Prepared` with only **five** arguments. No textual merge conflict flagged this semantic clash, so it landed when #76546 merged and broke the build.

## What I'm doing:

Pass an empty `secondaryIndexSpecs` (`List.of()`) at the one broken call site, matching the sibling `Prepared(...)` call in the same test. Test-only, one line, restores `fe-core` test compilation.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

### Test plan

Compile-only fix. `mvn -pl fe-core test-compile` (equivalently `./run-fe-ut.sh`) now compiles the `com.starrocks.alter.reshard.presplit` test sources that failed on `main`. The breakage is main-only (the `secondaryIndexSpecs` component and the `preparedWithPartitionInSortKey` helper are both new on `main`), so no backport is needed.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
