### PR TITLE
[BugFix] Fix column-subset ADD ROLLUP online rewrite on shared-data range-distribution tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -348,7 +348,7 @@ public class MaterializedViewHandler extends AlterHandler {
      * (The caller is {@code processBatchAddRollup}, so this is always a plain rollup, never a
      * synchronous materialized view, which carries a query statement.)
      */
-    static boolean isRangeRollupRoutable(OlapTable olapTable) {
+    public static boolean isRangeRollupRoutable(OlapTable olapTable) {
         // A cloud-native, non-colocate, non-auto-increment, non-primary-key range-distribution table
         // admits an additive rollup. A table that already carries one or more rollups is still routable:
         // each additive job is serialized by the table's OlapTableState (a new ADD ROLLUP requires the

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -123,9 +123,11 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -361,12 +363,32 @@ public class InsertPlanner {
 
             List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
             long tableId = targetTable.getId();
+            // A shadow-rewrite INSERT (the internal online rewrite that materializes a range rollup or a
+            // schema-change shadow index) writes ONLY the target write index. Base columns outside that
+            // index's column set are carried in the tuple solely to satisfy the sink's base
+            // distribution/partition plumbing (BE validates their presence); they are never persisted nor
+            // used for range routing (per-index distribution exprs route by the target index's key). Relax
+            // their slot nullability so an omitted NOT-NULL base column that is default-filled with NULL is
+            // not rejected by the BE non-nullable data validation.
+            boolean shadowRewriteSubsetWrite =
+                    insertStmt.isShadowRewrite() && insertStmt.getTargetWriteIndexId() != null;
+            Set<String> shadowRewriteTargetIndexColumns = Collections.emptySet();
+            if (shadowRewriteSubsetWrite) {
+                MaterializedIndexMeta targetIndexMeta =
+                        ((OlapTable) targetTable).getIndexMetaByMetaId(insertStmt.getTargetWriteIndexId());
+                Preconditions.checkState(targetIndexMeta != null && !targetIndexMeta.getSchema().isEmpty(),
+                        "shadow-rewrite target write index %s not found", insertStmt.getTargetWriteIndexId());
+                shadowRewriteTargetIndexColumns = targetIndexMeta.getSchema().stream()
+                        .map(c -> c.getName().toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+            }
             for (Column column : outputFullSchema) {
                 SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(tupleDesc);
                 slotDescriptor.setIsMaterialized(true);
                 slotDescriptor.setType(column.getType());
                 slotDescriptor.setColumn(column);
-                slotDescriptor.setIsNullable(column.isAllowNull());
+                boolean nullable = column.isAllowNull() || (shadowRewriteSubsetWrite
+                        && !shadowRewriteTargetIndexColumns.contains(column.getName().toLowerCase(Locale.ROOT)));
+                slotDescriptor.setIsNullable(nullable);
                 if (column.getType().isVarchar() &&
                         IDictManager.getInstance().hasGlobalDict(tableId, column.getColumnId())) {
                     Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getColumnId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnBuilder;
@@ -1278,6 +1279,45 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 }
             }
         }
+        // For a shared-data range-distribution rollup, the online rewrite writes only the rollup's own
+        // columns and cannot supply a value for base columns the rollup omits. Reject the two shapes it
+        // cannot build correctly, mirroring the DROP-key-column guards (a partition column cannot be
+        // dropped; a generated column's dependency cannot be dropped -- see visitDropColumnClause):
+        //   (a) a rollup omitting a partition column (for an automatic/expression partition column, the
+        //       expression's source columns, from which the hidden partition column is recomputed);
+        //   (b) a rollup generated column whose referenced columns are not all included -- else it would be
+        //       recomputed from unavailable (NULL) inputs and silently persist a wrong value.
+        if (table instanceof OlapTable && MaterializedViewHandler.isRangeRollupRoutable((OlapTable) table)) {
+            OlapTable olapTable = (OlapTable) table;
+            Set<String> rollupColumnNames = columnNames.stream()
+                    .map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+            for (Column partitionColumn : olapTable.getPartitionColumns()) {
+                if (partitionColumn.isGeneratedColumn()) {
+                    for (SlotRef ref : partitionColumn.getGeneratedColumnRef(olapTable.getIdToColumn())) {
+                        if (!rollupColumnNames.contains(ref.getColumnName().toLowerCase(Locale.ROOT))) {
+                            throw new SemanticException("Range-distribution rollup must contain partition column "
+                                    + "source '" + ref.getColumnName() + "'");
+                        }
+                    }
+                } else if (!rollupColumnNames.contains(partitionColumn.getName().toLowerCase(Locale.ROOT))) {
+                    throw new SemanticException("Range-distribution rollup must contain partition column '"
+                            + partitionColumn.getName() + "'");
+                }
+            }
+            for (String columnName : columnNames) {
+                Column column = olapTable.getColumn(columnName);
+                if (column != null && column.isGeneratedColumn()) {
+                    for (SlotRef ref : column.getGeneratedColumnRef(olapTable.getIdToColumn())) {
+                        if (!rollupColumnNames.contains(ref.getColumnName().toLowerCase(Locale.ROOT))) {
+                            throw new SemanticException("Range-distribution rollup generated column '"
+                                    + column.getName() + "' references '" + ref.getColumnName()
+                                    + "' which must also be in the rollup");
+                        }
+                    }
+                }
+            }
+        }
+
         clause.setBaseRollupName(Strings.emptyToNull(clause.getBaseRollupName()));
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeKeyColumnRoutingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeKeyColumnRoutingTest.java
@@ -384,6 +384,172 @@ public class RangeKeyColumnRoutingTest {
         Assertions.assertFalse(SchemaChangeHandler.needsRangeRewriteSchemaChange(dup, unrelatedModify));
     }
 
+    // ---- ADD ROLLUP guard tests (issue #76521) ----------------------------------
+    // A column-subset range rollup writes only its own columns in the online rewrite, which cannot
+    // supply a value for base columns the rollup omits. Two shapes are therefore rejected up front
+    // (mirroring the DROP-key-column guards): a rollup that omits a partition column, and a rollup whose
+    // generated column references a base column not included in the rollup.
+
+    /** Fetches the just-built (not yet run) range-rollup job and clears the handler. Build-not-run. */
+    private static AlterJobV2 fetchAndClearRollupJob() {
+        MaterializedViewHandler handler = GlobalStateMgr.getCurrentState().getRollupHandler();
+        List<AlterJobV2> jobs = new java.util.ArrayList<>(handler.getAlterJobsV2().values());
+        handler.clearJobs();
+        return jobs.isEmpty() ? null : jobs.get(jobs.size() - 1);
+    }
+
+    /** Creates a range DUP table carrying a generated value column {@code g = v1 + 1}. */
+    private static OlapTable buildLakeRangeTableWithGeneratedColumn(String tableName) throws Exception {
+        starRocksAssert.withTable("create table " + tableName
+                + " (k1 int NOT NULL, v1 int, g bigint AS (v1 + 1))\n"
+                + "duplicate key(k1)\n"
+                + "order by(k1)\n"
+                + "properties('replication_num' = '1');");
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", tableName);
+    }
+
+    @Test
+    public void testAddRollupOmittingPartitionColumnRejected() throws Exception {
+        // Range table partitioned on k1; a rollup r(k2, v1) omits the partition column k1. BE routes each
+        // row by its partition value, so the rollup must retain it.
+        OlapTable partitioned = buildLakeRangePartitionedTable(KeysType.DUP_KEYS,
+                /*sortKey*/ List.of("k1", "k2"), /*partitionCol*/ "k1");
+        assertThrowsDdl("must contain partition column",
+                () -> alter(partitioned, "ADD ROLLUP r_no_part(k2, v1) ORDER BY (k2)"));
+        GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
+    }
+
+    @Test
+    public void testAddRollupOmittingPartitionColumnStillAcceptedWhenIncluded() throws Exception {
+        // The same partitioned table accepts a rollup that keeps the partition column k1.
+        OlapTable partitioned = buildLakeRangePartitionedTable(KeysType.DUP_KEYS,
+                List.of("k1", "k2"), "k1");
+        alter(partitioned, "ADD ROLLUP r_with_part(k1, k2, v1) ORDER BY (k2, k1)");
+        AlterJobV2 job = fetchAndClearRollupJob();
+        Assertions.assertTrue(job instanceof LakeRangeRollupJob, "Expected a LakeRangeRollupJob, got: " + job);
+    }
+
+    @Test
+    public void testAddRollupGeneratedColumnMissingDependencyRejected() throws Exception {
+        // r(k1, g) omits g's referenced column v1: the rewrite would recompute g from a NULL-filled v1
+        // and silently persist a wrong value. Rejected.
+        OlapTable t = buildLakeRangeTableWithGeneratedColumn("t_rangekey_gencol_" + TABLE_SEQ.incrementAndGet());
+        assertThrowsDdl("must also be in the rollup",
+                () -> alter(t, "ADD ROLLUP r_gen(k1, g) ORDER BY (k1)"));
+        GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
+    }
+
+    @Test
+    public void testAddRollupGeneratedColumnWithDependencyAccepted() throws Exception {
+        // r(k1, g, v1) includes g's dependency v1, so g can be recomputed correctly. Accepted.
+        OlapTable t = buildLakeRangeTableWithGeneratedColumn("t_rangekey_gencol_" + TABLE_SEQ.incrementAndGet());
+        alter(t, "ADD ROLLUP r_gen_ok(k1, g, v1) ORDER BY (k1)");
+        AlterJobV2 job = fetchAndClearRollupJob();
+        Assertions.assertTrue(job instanceof LakeRangeRollupJob, "Expected a LakeRangeRollupJob, got: " + job);
+    }
+
+    @Test
+    public void testAddReducedKeyRollupUnpartitionedAccepted() throws Exception {
+        // Regression: the common reduced-key column-subset rollup on an unpartitioned table with no
+        // generated columns must NOT be rejected by the new guards.
+        OlapTable dup = buildLakeRangeTable(KeysType.DUP_KEYS, List.of("k1", "k2"));
+        alter(dup, "ADD ROLLUP r_reduced(k2, v1) ORDER BY (k2)");
+        AlterJobV2 job = fetchAndClearRollupJob();
+        Assertions.assertTrue(job instanceof LakeRangeRollupJob, "Expected a LakeRangeRollupJob, got: " + job);
+    }
+
+    /**
+     * Creates a shared-data range-distribution table with automatic EXPRESSION range partitioning
+     * ({@code date_trunc('day', dt)}). The partition column is the ordinary column {@code dt} (a single
+     * date/time expression partition exposes its underlying column, not a hidden generated one), so
+     * {@link OlapTable#getPartitionColumns()} returns {@code dt}.
+     *
+     * <p>Note on the generated-partition-column branch of the guard: a hidden
+     * {@code __generated_partition_column_*} is only synthesized by the MULTI-expression partition path
+     * ({@code CreateTableAnalyzer}); that branch reuses the exact same
+     * {@code getGeneratedColumnRef(...)} source-expansion that the rollup generated-column guard uses,
+     * which is covered by {@link #testAddRollupGeneratedColumnMissingDependencyRejected()}.
+     */
+    private static OlapTable buildLakeRangeExprPartitionedTable(String tableName) throws Exception {
+        starRocksAssert.withTable("create table " + tableName
+                + " (dt datetime NOT NULL, k1 int NOT NULL, v1 int)\n"
+                + "duplicate key(dt, k1)\n"
+                + "partition by date_trunc('day', dt)(\n"
+                + "    START (\"2023-03-27\") END (\"2023-03-30\") EVERY (INTERVAL 1 day)\n"
+                + ")\n"
+                + "order by(dt, k1)\n"
+                + "properties('replication_num' = '1');");
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", tableName);
+    }
+
+    @Test
+    public void testAddRollupOnExprPartitionRejectedWhenPartitionColumnOmitted() throws Exception {
+        // An expression-partitioned range table still routes each row by its partition column dt, so a
+        // column-subset rollup r(k1, v1) that omits dt is rejected (the rewrite has no value for dt).
+        OlapTable t = buildLakeRangeExprPartitionedTable("t_rangekey_exprpart_" + TABLE_SEQ.incrementAndGet());
+        List<Column> partitionColumns = t.getPartitionColumns();
+        Assertions.assertEquals(1, partitionColumns.size());
+        Assertions.assertEquals("dt", partitionColumns.get(0).getName());
+        assertThrowsDdl("must contain partition column",
+                () -> alter(t, "ADD ROLLUP r_expr_no(k1, v1) ORDER BY (k1)"));
+        GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
+    }
+
+    @Test
+    public void testAddRollupOnExprPartitionAcceptedWhenPartitionColumnIncluded() throws Exception {
+        // The same table accepts a column-subset rollup that keeps the partition column dt (omitting the
+        // other base key k1).
+        OlapTable t = buildLakeRangeExprPartitionedTable("t_rangekey_exprpart_" + TABLE_SEQ.incrementAndGet());
+        alter(t, "ADD ROLLUP r_expr_ok(dt, v1) ORDER BY (dt)");
+        AlterJobV2 job = fetchAndClearRollupJob();
+        Assertions.assertTrue(job instanceof LakeRangeRollupJob, "Expected a LakeRangeRollupJob, got: " + job);
+    }
+
+    /**
+     * Creates a shared-data range-distribution table with MULTI-expression automatic partitioning
+     * ({@code PARTITION BY site_id, date_trunc('day', event_day)}). The {@code date_trunc(...)} term
+     * synthesizes a hidden generated partition column ({@code __generated_partition_column_*}) over
+     * {@code event_day}, so {@link OlapTable#getPartitionColumns()} returns the ordinary {@code site_id}
+     * plus a generated column whose real source is {@code event_day}. This exercises the guard's
+     * generated-partition-column source-expansion branch.
+     */
+    private static OlapTable buildLakeRangeMultiExprPartitionedTable(String tableName) throws Exception {
+        starRocksAssert.withTable("create table " + tableName
+                + " (site_id int NOT NULL, event_day datetime NOT NULL, v1 int)\n"
+                + "duplicate key(site_id, event_day)\n"
+                + "partition by site_id, date_trunc('day', event_day)\n"
+                + "order by(site_id, event_day)\n"
+                + "properties('replication_num' = '1');");
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", tableName);
+    }
+
+    @Test
+    public void testAddRollupOnMultiExprPartitionRejectsWhenGeneratedSourceOmitted() throws Exception {
+        // The generated partition column over event_day means the rollup must retain event_day (its
+        // source), not the hidden column. r(site_id, v1) keeps the ordinary partition column but omits
+        // event_day -> rejected, naming the source event_day.
+        OlapTable t = buildLakeRangeMultiExprPartitionedTable(
+                "t_rangekey_multiexpr_" + TABLE_SEQ.incrementAndGet());
+        List<Column> partitionColumns = t.getPartitionColumns();
+        Assertions.assertTrue(partitionColumns.stream().anyMatch(Column::isGeneratedColumn),
+                "expected a hidden generated partition column, got: "
+                        + partitionColumns.stream().map(Column::getName).collect(Collectors.toList()));
+        assertThrowsDdl("partition column source",
+                () -> alter(t, "ADD ROLLUP r_mexpr_no(site_id, v1) ORDER BY (site_id)"));
+        GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
+    }
+
+    @Test
+    public void testAddRollupOnMultiExprPartitionAcceptedWhenGeneratedSourceIncluded() throws Exception {
+        // Including both partition inputs (ordinary site_id + generated-column source event_day) is
+        // accepted, even though the hidden generated partition column itself is never named.
+        OlapTable t = buildLakeRangeMultiExprPartitionedTable(
+                "t_rangekey_multiexpr_" + TABLE_SEQ.incrementAndGet());
+        alter(t, "ADD ROLLUP r_mexpr_ok(site_id, event_day, v1) ORDER BY (event_day, site_id)");
+        AlterJobV2 job = fetchAndClearRollupJob();
+        Assertions.assertTrue(job instanceof LakeRangeRollupJob, "Expected a LakeRangeRollupJob, got: " + job);
+    }
+
     /** Runs the ALTER via analyzeAndCreateJob and returns the constructed (not run) job. */
     private static AlterJobV2 alterAndReturnJob(OlapTable table, String clauseSql) throws Exception {
         com.starrocks.sql.ast.AlterTableStmt stmt = (com.starrocks.sql.ast.AlterTableStmt)

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupOrderByAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AddRollupOrderByAnalyzerTest.java
@@ -50,6 +50,13 @@ public class AddRollupOrderByAnalyzerTest {
             public boolean isCloudNativeTable() {
                 return true;
             }
+
+            // The column-subset guard in visitAddRollupClause introspects the partition columns; an
+            // unpartitioned range table has none, so the guard is a no-op for these ORDER BY cases.
+            @Mock
+            public java.util.List<Column> getPartitionColumns() {
+                return Lists.newArrayList();
+            }
         };
         return new OlapTable();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerShadowRewriteSubsetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/InsertPlannerShadowRewriteSubsetTest.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.TupleDescriptor;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.thrift.TStorageType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Part 1 of the issue #76521 fix: the internal shadow-rewrite INSERT that materializes a column-subset
+ * range rollup writes ONLY the target rollup index. Base columns the target index omits are carried in
+ * the sink tuple solely to satisfy the sink's base distribution/partition plumbing (BE validates their
+ * presence); they are never persisted nor used for routing. {@link InsertPlanner} must therefore relax
+ * the nullability of those omitted-slot columns, so an omitted NOT-NULL base column that gets
+ * default-filled with NULL is not rejected by the BE non-nullable data validation.
+ *
+ * <p>The relaxation is distribution-agnostic (it keys off the shadow-rewrite flags + the target write
+ * index's column set), so this planner test uses a plain hash-distributed DUP table with a real subset
+ * rollup index registered in every physical partition; the range-distribution runtime is validated
+ * end-to-end on a cluster.
+ */
+public class InsertPlannerShadowRewriteSubsetTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        PlanTestBase.afterClass();
+    }
+
+    /** Registers a NORMAL rollup index carrying {@code schema} in every physical partition of {@code table}. */
+    private static long registerSubsetRollupIndex(OlapTable table, String name, List<Column> schema) {
+        long metaId = GlobalStateMgr.getCurrentState().getNextId();
+        table.setIndexMeta(metaId, name, schema, 0, 0, (short) 1,
+                TStorageType.COLUMN, KeysType.DUP_KEYS, null, List.of(0));
+        for (PhysicalPartition pp : table.getPhysicalPartitions()) {
+            long physId = GlobalStateMgr.getCurrentState().getNextId();
+            pp.createRollupIndex(new MaterializedIndex(physId, metaId,
+                    MaterializedIndex.IndexState.NORMAL, PhysicalPartition.INVALID_SHARD_GROUP_ID));
+        }
+        return metaId;
+    }
+
+    /** Finds the sink (output) tuple: the one carrying a slot for the omitted base column {@code k1}. */
+    private static TupleDescriptor findSinkTuple(ExecPlan plan, String omittedColumn) {
+        for (TupleDescriptor tuple : plan.getDescTbl().getTupleDescs()) {
+            for (SlotDescriptor slot : tuple.getSlots()) {
+                if (slot.getColumn() != null && omittedColumn.equalsIgnoreCase(slot.getColumn().getName())) {
+                    return tuple;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static SlotDescriptor slotOf(TupleDescriptor tuple, String columnName) {
+        for (SlotDescriptor slot : tuple.getSlots()) {
+            if (slot.getColumn() != null && columnName.equalsIgnoreCase(slot.getColumn().getName())) {
+                return slot;
+            }
+        }
+        return null;
+    }
+
+    private static ExecPlan planShadowRewriteSubsetInsert(OlapTable table, String sql, long targetWriteIndexId)
+            throws Exception {
+        List<StatementBase> stmts = SqlParser.parse(sql, new SessionVariable());
+        InsertStmt insertStmt = (InsertStmt) stmts.get(0);
+        // The rewrite job sets these BEFORE analysis; InsertAnalyzer's shadow-rewrite relaxation depends on them.
+        insertStmt.setShadowRewrite(true);
+        insertStmt.setTargetWriteIndexId(targetWriteIndexId);
+        Analyzer.analyze(insertStmt, starRocksAssert.getCtx());
+        AnalyzerUtils.collectAllDatabase(starRocksAssert.getCtx(), insertStmt);
+
+        PlannerMetaLocker locker = new PlannerMetaLocker(starRocksAssert.getCtx(), insertStmt);
+        StatementPlanner.lock(locker);
+        try {
+            return new InsertPlanner(locker, true).plan(insertStmt, starRocksAssert.getCtx());
+        } finally {
+            StatementPlanner.unLock(locker);
+        }
+    }
+
+    @Test
+    public void testShadowRewriteSubsetRelaxesOmittedSlotNullability() throws Exception {
+        starRocksAssert.withTable("create table d_shadow_subset (k1 int not null, k2 int not null, v int)\n"
+                + "duplicate key(k1) distributed by hash(k1) buckets 1\n"
+                + "properties('replication_num' = '1')");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable("test", "d_shadow_subset");
+        List<Column> base = table.getSchemaByIndexMetaId(table.getBaseIndexMetaId());
+        // Subset rollup index = [k2, v] (omits the NOT-NULL base key k1).
+        List<Column> subset = List.of(base.get(1), base.get(2));
+        long shadowMetaId = registerSubsetRollupIndex(table, "r_sub", subset);
+
+        ExecPlan plan = planShadowRewriteSubsetInsert(table,
+                "insert into d_shadow_subset (k2, v) select k2, v from d_shadow_subset", shadowMetaId);
+
+        TupleDescriptor sinkTuple = findSinkTuple(plan, "k1");
+        Assertions.assertNotNull(sinkTuple, "omitted base column k1 must still be present in the sink tuple");
+
+        SlotDescriptor k1Slot = slotOf(sinkTuple, "k1");
+        SlotDescriptor k2Slot = slotOf(sinkTuple, "k2");
+        SlotDescriptor vSlot = slotOf(sinkTuple, "v");
+        Assertions.assertNotNull(k1Slot);
+        Assertions.assertNotNull(k2Slot);
+        Assertions.assertNotNull(vSlot);
+
+        // k1 is omitted from the target index -> its slot nullability is relaxed so its NULL fill passes
+        // the BE non-nullable validation, even though the base column is declared NOT NULL.
+        Assertions.assertTrue(k1Slot.getIsNullable(),
+                "omitted NOT-NULL base column k1 must have its slot relaxed to nullable");
+        // k2 is in the target index and declared NOT NULL -> keeps its declared (non-null) nullability.
+        Assertions.assertFalse(k2Slot.getIsNullable(),
+                "target-index NOT-NULL column k2 must keep its NOT-NULL slot");
+        // v is in the target index and nullable -> nullable.
+        Assertions.assertTrue(vSlot.getIsNullable(), "nullable target-index column v stays nullable");
+
+        // k1 is genuinely absent from the target write index's persisted column set.
+        List<String> targetIndexColumns = table.getIndexMetaByMetaId(shadowMetaId).getSchema()
+                .stream().map(Column::getName).toList();
+        Assertions.assertFalse(targetIndexColumns.contains("k1"), "k1 must not be in the target rollup index");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

On a shared-data (存算分离) range-distribution table, an `ADD ROLLUP` whose column set omits a
**non-nullable base column** is accepted by the analyzer but its online rewrite is **CANCELLED** with
`Insert has filtered data / NULL value in non-nullable column`. This blocks the common and valuable case —
a reduced-key AGG/UNIQUE rollup, or any column-subset rollup — leaving only full-column rollups (different
sort order) buildable. Pre-existing since the range-rollup feature (#75618); reproduces with a **single**
rollup on a fresh table (independent of #76473).

Minimal repro:

```sql
ADMIN SET FRONTEND CONFIG ('enable_range_distribution' = 'true');
CREATE TABLE d (k1 INT NOT NULL, k2 INT NOT NULL, v INT)
DUPLICATE KEY(k1) ORDER BY(k1) PROPERTIES ('replication_num' = '1');
INSERT INTO d SELECT generate_series % 100, generate_series % 50, generate_series
  FROM TABLE(generate_series(1, 20000));
ALTER TABLE d ADD ROLLUP r_sub (k2, v) ORDER BY (k2);   -- was CANCELLED
```

## What I'm doing:

The range online rewrite materializes a rollup with an internal
`INSERT INTO t (rollupCols) SELECT rollupCols FROM t` that writes **only** the shadow rollup index
(`setTargetWriteIndexId`). `InsertPlanner`, however, built the tuple from the full base schema and
default-filled the omitted base columns; a non-nullable base column without a default became `NULL` in a
`is_nullable=false` slot, which the BE data validation (`_validate_data`) then filtered — cancelling the
rewrite.

**Part 1 (`InsertPlanner`)** — for a shadow-rewrite subset write, relax the slot nullability of base
columns that the **target write index does not persist** (derived from the target index metadata). These
columns are kept in the tuple only to satisfy the sink's base distribution/partition plumbing (BE
validates their presence); they are never persisted (only the target index is written) nor used for range
routing (per-index distribution exprs route by the target index's key). So the omitted non-nullable
column's `NULL` fill now passes validation, and the rollup builds. This also fixes the same latent case on
the schema-change `DROP` key-column rewrite.

**Part 2 (`MaterializedViewHandler`)** — reject up front the two range-rollup shapes the rewrite cannot
materialize correctly, mirroring the existing `DROP`-key-column guards
(`checkPartitionColumnChange` / `visitDropColumnClause`):
- a rollup that omits a **partition column** (for an expression partition column, its source columns) —
  BE routes each row by its partition value, so it cannot be dropped from the rollup;
- a rollup whose **generated column** references a base column not included in the rollup — otherwise it
  would be recomputed from unavailable inputs and silently persist a wrong value.

These shapes were previously accepted but always failed (CANCEL) or risked a wrong generated value; they
now fail fast with a clear DDL error.

Fixes #76521

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The primary effect is a bug fix: a previously-CANCELLED column-subset rollup now builds correctly. The two
new analysis-time rejections (Part 2) only turn shapes that were **already unbuildable** (silent CANCEL,
or a latent wrong generated-column value) into a clear DDL error — no previously-working DDL changes its
result. (Happy to reclassify as Yes + Miscellaneous if a maintainer prefers to surface the new rejection.)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

The shared-data range-distribution rollup feature is main-only (landed in v4.2 via #75618); this fix is
**main-only**, no backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
