### PR TITLE
[UT] Fix PreSplitFlowTest compile error on the Prepared constructor

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/presplit/PreSplitFlowTest.java
@@ -570,7 +570,7 @@ public class PreSplitFlowTest {
     private static PreSplitFlow.Prepared preparedWithPartitionInSortKey(ScanContext scanContext) {
         Column sortCol = bigintColumn("sort_col");
         return new PreSplitFlow.Prepared(scanContext, List.of(sortCol), List.of(sortCol),
-                /*estimatedBytes*/ 4096L, mock(ComputeResource.class));
+                /*estimatedBytes*/ 4096L, mock(ComputeResource.class), List.of());
     }
 
     /** Stub PreSplitTargets.findEligibleTarget to resolve a single-partition target for {@code table}. */


### PR DESCRIPTION
## Why I'm doing:

`fe-core` test compilation is currently broken on `main`. The meta-tier multi-partition tests (commit d358178126d, #76546) added the helper `preparedWithPartitionInSortKey`, which constructs `PreSplitFlow.Prepared` with **five** arguments. The `Prepared` record had already grown a **sixth** component — `secondaryIndexSpecs` (`List<SecondaryIndexSpec>`, added in #76233) — so the five-argument call no longer matches the canonical constructor:

```
PreSplitFlowTest.java:[572,16] constructor Prepared in record ...PreSplitFlow.Prepared cannot be applied to given types;
  required: ScanContext, List<Column>, List<Column>, long, ComputeResource, List<SecondaryIndexSpec>
  found:    ScanContext, List<Column>, List<Column>, long, ComputeResource
  reason: actual and formal argument lists differ in length
```

## What I'm doing:

Pass an empty `secondaryIndexSpecs` list (`List.of()`) as the sixth argument in `preparedWithPartitionInSortKey`, mirroring the sibling `preparedFor` helper. These meta-tier tests exercise no rollup index, so the empty list matches the documented single-index semantics.

Verified: `mvn test-compile -pl fe-core` is clean and `PreSplitFlowTest` passes (Tests run: 20, Failures: 0, Errors: 0).


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
