### PR TITLE
[Enhancement] Skip opening output segment footers in compaction publish conflict resolution

### DIFF
--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -14,6 +14,9 @@
 
 #include "storage/lake/lake_primary_key_compaction_conflict_resolver.h"
 
+#include <algorithm>
+
+#include "common/config_lake_fwd.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/lake_delvec_loader.h"
@@ -88,10 +91,25 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
 Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
         const std::function<Status(const CompactConflictResolveParams&, const std::vector<SegmentPtr>&,
                                    const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>& handler) {
-    // load all segments
+    // This "without read data" path never touches segment data -- it only needs each output
+    // segment's row count, which execute_without_update_index otherwise reads from the tablet
+    // metadata via output_segment_num_rows(). Opening every output segment's footer just to fetch
+    // num_rows is pure overhead on a large compaction, so skip it on the default path and leave
+    // `segments` empty (the handler then derives all row counts from metadata).
+    //
+    // Fall back to loading the segments (the pre-optimization behavior) when either:
+    //   - experimental_lake_ignore_lost_segment is on -- a null slot is the sole signal that an output
+    //     segment is physically missing, which the handler must tolerate; or
+    //   - the metadata is missing num_rows for some output segment -- e.g. a compaction txn log written
+    //     by an older BE during a rolling upgrade; the segment footer then supplies the row count.
+    const auto output_num_rows = output_segment_num_rows();
+    const bool metadata_missing_num_rows = std::any_of(output_num_rows.begin(), output_num_rows.end(),
+                                                       [](uint32_t n) { return n == kUnknownSegmentNumRows; });
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(_rowset->load_segments(&segments, true /* file cache*/));
-    RETURN_ERROR_IF_FALSE(segments.size() == _rowset->num_segments());
+    if (config::experimental_lake_ignore_lost_segment || metadata_missing_num_rows) {
+        RETURN_IF_ERROR(_rowset->load_segments(&segments, true /* file cache*/));
+        RETURN_ERROR_IF_FALSE(segments.size() == _rowset->num_segments());
+    }
     // init delvec loader
     LakeIOOptions lake_io_opts{.fill_data_cache = true, .skip_disk_cache = false};
 

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -221,41 +221,50 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
     RETURN_IF_ERROR(segment_iterator(
             [&](const CompactConflictResolveParams& params, const std::vector<std::shared_ptr<Segment>>& segments,
                 const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
-                // Pre-declare every segment's row count so the iterator can fire
-                // up to K parallel per-segment reads (each on its own RAF) and
-                // pipeline our processing of segment N against the still-pending
-                // downloads for segments N+1..N+K-1.
-                // This path only needs each segment's row count (never its data), so a null slot -- a
-                // physically-lost segment tolerated by experimental_lake_ignore_lost_segment -- falls back
-                // to the metadata row count. That keeps the rows-mapper aligned and the delvec (built purely
-                // from the mapper values) is still generated correctly.
+                // Pre-declare every output segment's row count so the rows-mapper iterator can fire
+                // up to K parallel per-segment reads and pipeline processing against pending reads.
+                // This path never reads segment data -- only the row count -- so counts come from the
+                // tablet metadata (segment_metas) via output_segment_num_rows(). The backend only
+                // materialises `segments` when it needs to detect physically-lost output segments
+                // (lake + experimental_lake_ignore_lost_segment); a null slot is then the signal, and
+                // its count falls back to metadata to keep the rows-mapper aligned. On the default path
+                // `segments` is empty and every count is taken from metadata, so no footer is opened.
                 const auto seg_num_rows = output_segment_num_rows();
-                std::vector<size_t> per_segment_rows;
-                per_segment_rows.reserve(segments.size());
-                for (size_t i = 0; i < segments.size(); i++) {
-                    if (segments[i] != nullptr) {
-                        per_segment_rows.push_back(segments[i]->num_rows());
-                        continue;
+                const bool segments_loaded = !segments.empty();
+                const size_t num_segments = segments_loaded ? segments.size() : seg_num_rows.size();
+                // A segment's row count comes from the tablet metadata (segment_metas); used both on the
+                // fast path and as the fallback for a lost segment.
+                auto metadata_row_count = [&](size_t i) -> StatusOr<size_t> {
+                    if (i >= seg_num_rows.size() || seg_num_rows[i] == kUnknownSegmentNumRows) {
+                        return Status::InternalError(
+                                fmt::format("cannot determine row count for output segment (index {}) during "
+                                            "compaction conflict resolution",
+                                            i));
                     }
-                    // A null segment only comes from a physically-lost segment tolerated by the flag; with
-                    // the flag off it is an unexpected bug -- fail loudly.
-                    RETURN_ERROR_IF_FALSE(
-                            config::experimental_lake_ignore_lost_segment,
-                            fmt::format("unexpected null segment at position {} during compaction conflict resolution",
-                                        i));
-                    if (i < seg_num_rows.size() && seg_num_rows[i] != kUnknownSegmentNumRows) {
-                        per_segment_rows.push_back(seg_num_rows[i]);
+                    return static_cast<size_t>(seg_num_rows[i]);
+                };
+                std::vector<size_t> per_segment_rows;
+                per_segment_rows.reserve(num_segments);
+                for (size_t i = 0; i < num_segments; i++) {
+                    if (segments_loaded && segments[i] != nullptr) {
+                        per_segment_rows.push_back(segments[i]->num_rows());
                     } else {
-                        return Status::InternalError(fmt::format(
-                                "cannot determine row count for a lost segment (index {}) during compaction "
-                                "conflict resolution",
-                                i));
+                        // A loaded null slot is a physically-lost segment, tolerated only under
+                        // experimental_lake_ignore_lost_segment; with the flag off it is an unexpected bug.
+                        // The fast path (segments not loaded) also lands here. Either way the row count
+                        // comes from metadata, keeping the rows-mapper aligned.
+                        RETURN_ERROR_IF_FALSE(!segments_loaded || config::experimental_lake_ignore_lost_segment,
+                                              fmt::format("unexpected null segment at position {} during compaction "
+                                                          "conflict resolution",
+                                                          i));
+                        ASSIGN_OR_RETURN(auto num_rows, metadata_row_count(i));
+                        per_segment_rows.push_back(num_rows);
                     }
                 }
                 RETURN_IF_ERROR(mapper_iter.prepare_segments(per_segment_rows));
 
                 std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
-                for (size_t segment_id = 0; segment_id < segments.size(); segment_id++) {
+                for (size_t segment_id = 0; segment_id < num_segments; segment_id++) {
                     RETURN_IF_ERROR(breakpoint_check());
                     // 2. get input rssid & rowids, so we can generate delvec
                     vector<uint32_t> tmp_deletes;
@@ -266,7 +275,7 @@ Status PrimaryKeyCompactionConflictResolver::execute_without_update_index() {
                         mapper_read_us_accum += MonotonicMicros() - t0;
                     }
                     DCHECK(per_segment_rows[segment_id] == rssid_rowids.size());
-                    if (segments[segment_id] == nullptr) {
+                    if (segments_loaded && segments[segment_id] == nullptr) {
                         // Lost segment (experimental_lake_ignore_lost_segment). We already advanced the
                         // rows-mapper above so the following segments stay aligned. Record its position
                         // and emit an empty delvec placeholder (keeps delvecs 1:1 with ssts); the caller

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -63,6 +63,10 @@ public:
                                        const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>&)>&
                     handler) = 0;
     // This function won't read data from each segment files. Only need to get segment's row count.
+    // The handler's `segments` argument may be EMPTY: a backend that gets row counts from metadata
+    // (see output_segment_num_rows()) leaves it empty to avoid opening segment footers, and only
+    // materialises it when it must detect physically-lost segments (null slots). Callers must derive
+    // the segment count from output_segment_num_rows() when `segments` is empty.
     virtual Status segment_iterator(
             const std::function<
                     Status(const CompactConflictResolveParams&, const std::vector<std::shared_ptr<Segment>>&,

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -2824,6 +2824,161 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_emits_trace_counters) {
     EXPECT_NE(metrics.find("index_apply_opcompaction_us"), std::string::npos) << metrics;
 }
 
+// Regression for the compaction-publish optimization that skips loading output segment footers:
+// on the default path (experimental_lake_ignore_lost_segment=false) execute_without_update_index()
+// takes each output segment's row count from the tablet metadata (output_segment_num_rows()) instead
+// of Rowset::load_segments(). Verify a cloud-native compaction still processes every output segment
+// correctly (preserving all live rows) when no segment footer is loaded.
+TEST_P(LakePrimaryKeyPublishTest, test_light_compaction_publish_row_count_from_metadata) {
+    // Precondition: the fast path (no segment-footer load) is the default.
+    ASSERT_FALSE(config::experimental_lake_ignore_lost_segment);
+
+    // Build index SSTs during load (write_buffer_size forces multi-segment rowsets; the 1-byte eager
+    // threshold builds an index SST for each) so the compaction carries op_compaction.ssts and
+    // light_publish_primary_compaction dispatches to execute_without_update_index (the path under test)
+    // rather than resolver->execute(). This is the recipe proven deterministic by pk_tablet_sst_writer_test.
+    ConfigResetGuard<int64_t> g_write_buffer(&config::write_buffer_size, 512);
+    ConfigResetGuard<int64_t> g_eager_threshold(&config::pk_index_eager_build_threshold_bytes, 1);
+    ConfigResetGuard<int64_t> g_min_input_segments(&config::lake_pk_compaction_min_input_segments, 2);
+
+    auto tablet_id = _tablet_metadata->id();
+    // The fixture's default single-INT-key schema uses PK encoding V1, for which eager PK index SST build
+    // is unsupported (pk_index_eager_build_supported); switch to V2 so the load and compaction build the
+    // index SSTs that route publish through execute_without_update_index (the path under test).
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    // 3 chunks of 80 rows each (240 distinct keys, 0..239), re-upserted by every rowset so the compaction
+    // has real dedup work and builds an index SST. The resolver must generate a delvec for every output
+    // segment, so a wrong per-segment row count (mis-advancing the rows-mapper) would corrupt the result.
+    // All chunks are 80 rows, so one index vector serves all writes.
+    auto [chunk0, indexes] = gen_data_and_index(80, /*shift=*/0, /*random_shuffle=*/false, /*upsert=*/true);
+    auto chunk1 = gen_data(80, /*shift=*/1, /*random_shuffle=*/false, /*upsert=*/true);
+    auto chunk2 = gen_data(80, /*shift=*/2, /*random_shuffle=*/false, /*upsert=*/true);
+
+    int64_t version = 1;
+    for (int i = 0; i < 4; i++) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&_slot_pointers)
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        CHECK_OK(dw->open());
+        CHECK_OK(dw->write(*chunk0, indexes.data(), indexes.size()));
+        CHECK_OK(dw->write(*chunk1, indexes.data(), indexes.size()));
+        CHECK_OK(dw->write(*chunk2, indexes.data(), indexes.size()));
+        CHECK_OK(dw->finish_with_txnlog());
+        dw->close();
+        // The load eagerly built an index SST -- the precondition for the compaction below to carry
+        // op_compaction.ssts and thus dispatch to execute_without_update_index.
+        ASSIGN_OR_ABORT(auto wlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        ASSERT_GT(wlog->op_write().ssts_size(), 0);
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    EXPECT_EQ(240, read_rows(tablet_id, version));
+
+    // Compact the rowsets into one; the eager-built index ssts drive
+    // light_publish_primary_compaction -> execute_without_update_index.
+    int64_t txn_id = next_id();
+    auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    // Assert the compaction built an index SST so publish takes execute_without_update_index (the path
+    // under test), not resolver->execute() -- otherwise this test would silently exercise nothing.
+    ASSIGN_OR_ABORT(auto txnlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_GT(txnlog->op_compaction().ssts_size(), 0);
+
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    version++;
+
+    // The compaction preserves every live row. The publish goes through
+    // light_publish_primary_compaction -> execute_without_update_index (the path under test), where a
+    // wrong per-segment row count (from output_segment_num_rows()) would mis-advance the rows-mapper and
+    // drop or duplicate rows.
+    EXPECT_EQ(240, read_rows(tablet_id, version));
+}
+
+// Companion to the test above covering the experimental_lake_ignore_lost_segment=true branch, where
+// execute_without_update_index DOES load the output segments (so a physically-lost one can be detected
+// via a null slot). No segment is lost here, so the compaction must still publish correctly.
+TEST_P(LakePrimaryKeyPublishTest, test_light_compaction_publish_loads_segments_under_ignore_lost_flag) {
+    ConfigResetGuard<bool> g_ignore_lost(&config::experimental_lake_ignore_lost_segment, true);
+    // Same index-SST-during-load recipe as the companion test (proven by pk_tablet_sst_writer_test) so
+    // the compaction carries op_compaction.ssts and publish dispatches to execute_without_update_index,
+    // which -- with the flag on -- loads the output segments.
+    ConfigResetGuard<int64_t> g_write_buffer(&config::write_buffer_size, 512);
+    ConfigResetGuard<int64_t> g_eager_threshold(&config::pk_index_eager_build_threshold_bytes, 1);
+    ConfigResetGuard<int64_t> g_min_input_segments(&config::lake_pk_compaction_min_input_segments, 2);
+
+    auto tablet_id = _tablet_metadata->id();
+    // Switch to PK encoding V2 (see the companion test) so the load and compaction build index SSTs and
+    // publish reaches execute_without_update_index -- here, with the flag on, its load-segments branch.
+    _tablet_metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+
+    // 3 chunks of 80 rows each (240 distinct keys, 0..239), re-upserted by every rowset so the compaction
+    // has real dedup work and builds an index SST. All chunks are 80 rows, so one index vector serves all
+    // writes.
+    auto [chunk0, indexes] = gen_data_and_index(80, /*shift=*/0, /*random_shuffle=*/false, /*upsert=*/true);
+    auto chunk1 = gen_data(80, /*shift=*/1, /*random_shuffle=*/false, /*upsert=*/true);
+    auto chunk2 = gen_data(80, /*shift=*/2, /*random_shuffle=*/false, /*upsert=*/true);
+
+    int64_t version = 1;
+    for (int i = 0; i < 4; i++) {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&_slot_pointers)
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        CHECK_OK(dw->open());
+        CHECK_OK(dw->write(*chunk0, indexes.data(), indexes.size()));
+        CHECK_OK(dw->write(*chunk1, indexes.data(), indexes.size()));
+        CHECK_OK(dw->write(*chunk2, indexes.data(), indexes.size()));
+        CHECK_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSIGN_OR_ABORT(auto wlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+        ASSERT_GT(wlog->op_write().ssts_size(), 0);
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    EXPECT_EQ(240, read_rows(tablet_id, version));
+
+    int64_t txn_id = next_id();
+    auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    // The compaction eagerly built an index SST, so publish takes execute_without_update_index and --
+    // with the flag on -- the load-segments branch. Assert the precondition so the test fails loudly
+    // (rather than silently taking resolver->execute()) if that ever stops holding.
+    ASSIGN_OR_ABORT(auto txnlog, _tablet_mgr->get_txn_log(tablet_id, txn_id));
+    ASSERT_GT(txnlog->op_compaction().ssts_size(), 0);
+
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    version++;
+
+    // Segments were loaded (flag on) and none was lost, so every row survives the compaction.
+    EXPECT_EQ(240, read_rows(tablet_id, version));
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,
                          ::testing::Values(PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE},
                                            PrimaryKeyParam{true, PersistentIndexTypePB::CLOUD_NATIVE,


### PR DESCRIPTION
## Why I'm doing:

The cloud-native "without read data" compaction conflict resolver
(`execute_without_update_index`, taken whenever an lcrm rows-mapper exists) only
needs each output segment's **row count** to advance the rows-mapper — it never
reads segment data. Yet it called `Rowset::load_segments()`, opening every output
segment's footer purely to read `num_rows`. On a large compaction (hundreds of
output segments) this is a wasteful burst of object-storage footer reads on the
publish hot path.

## What I'm doing:

- `execute_without_update_index` now takes per-output-segment row counts from the
  tablet metadata via `output_segment_num_rows()` (`segment_metas[].num_rows`) and
  no longer calls `load_segments()` on the default path — the handler's `segments`
  argument is left empty, so no segment footer is opened.
- `load_segments()` is still performed when `experimental_lake_ignore_lost_segment`
  is enabled, because a null segment slot is the only signal that an output segment
  is physically missing, which the resolver must tolerate. That experimental path is
  unchanged.
- Documented the now-optional `segments` contract on the base `segment_iterator`
  overload.

Note: on the default path this drops the incidental existence check that
`load_segments()` performed on freshly-written output segments. The resolver never
consumed their data, and their row counts come from metadata written by the same
compaction.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
