### PR TITLE
[Enhancement] Cover the remaining untraced lake publish-version steps

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -523,7 +523,12 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                         res.status().to_protobuf(response->mutable_status());
                     }
                     TRACE("finished");
-                    g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
+                    auto tablet_publish_cost = butil::gettimeofday_us() - run_ts;
+                    // Emit the per-tablet total into the child trace so the sub-latencies can be
+                    // reconciled against the whole: total - sum(sub-counters) is the still-untraced
+                    // residual, which makes an uncovered slow step obvious at a glance.
+                    TRACE_COUNTER_INCREMENT("publish_tablet_total_us", tablet_publish_cost);
+                    g_publish_tablet_version_latency << tablet_publish_cost;
                 },
                 [&, tablet_info] {
                     g_publish_version_failed_tasks << 1;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1112,7 +1112,10 @@ Status MetaFileBuilder::finalize(int64_t txn_id, bool skip_write_tablet_metadata
     auto version = _tablet_meta->version();
 
     // Finalize delete vectors by updating their metadata and writing them to disk
-    RETURN_IF_ERROR(_finalize_delvec(version, txn_id));
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("finalize_delvec_write_us");
+        RETURN_IF_ERROR(_finalize_delvec(version, txn_id));
+    }
 
     // Clean up SSTable metadata after an alter operation that changes the persistent index type
     _sstable_meta_clean_after_alter_type();
@@ -1122,6 +1125,7 @@ Status MetaFileBuilder::finalize(int64_t txn_id, bool skip_write_tablet_metadata
         (void)_tablet.tablet_mgr()->cache_tablet_metadata(_tablet_meta);
     } else {
         // Persist the updated tablet metadata
+        TRACE_COUNTER_SCOPE_LATENCY_US("put_tablet_metadata_us");
         RETURN_IF_ERROR(_tablet.put_metadata(_tablet_meta));
     }
 

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -556,6 +556,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
             auto tablet_id_in_txn_log = tablet_ids_in_txn_logs[j];
             auto& txn_logs = txn_logs_vector[j];
             for (auto& txn_log : txn_logs) {
+                TRACE_COUNTER_SCOPE_LATENCY_US("convert_txn_log_us");
                 ASSIGN_OR_RETURN(auto converted_txn_log, convert_txn_log(txn_log, base_metadata, tablet_info));
                 txn_log = std::move(converted_txn_log);
             }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -2074,10 +2074,13 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
     auto resolver = std::make_unique<LakePrimaryKeyCompactionConflictResolver>(
             metadata.get(), &output_rowset, _tablet_mgr, builder, &index, base_version, op_compaction.lcrm_file(),
             &segment_id_to_add_dels, &delvecs);
-    if (op_compaction.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
-        RETURN_IF_ERROR(resolver->execute_without_update_index());
-    } else {
-        RETURN_IF_ERROR(resolver->execute());
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("compaction_conflict_resolve_us");
+        if (op_compaction.ssts_size() > 0 && use_cloud_native_pk_index(*metadata)) {
+            RETURN_IF_ERROR(resolver->execute_without_update_index());
+        } else {
+            RETURN_IF_ERROR(resolver->execute());
+        }
     }
     // A lost output segment (experimental_lake_ignore_lost_segment) has no data and its SST must not be
     // ingested, otherwise the PK index would reference an rssid that scans skip. The resolver reports
@@ -2105,10 +2108,14 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
                                          delvec_page_pb, delvecs[i].second));
     }
     _index_cache.update_object_size(index_entry, index.memory_usage());
-    // 5. update TabletMeta
+    // 5. update TabletMeta (in-memory metadata edit; not traced -- covered by the per-tablet total)
     RETURN_IF_ERROR(builder->apply_opcompaction(op_compaction, max_rowset_id, tablet_schema->id()));
     RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
-    RETURN_IF_ERROR(index.apply_opcompaction(metadata, op_compaction));
+    {
+        // index.apply_opcompaction opens the output index sstable(s) (footer + bloom filter), so it can do I/O.
+        TRACE_COUNTER_SCOPE_LATENCY_US("index_apply_opcompaction_us");
+        RETURN_IF_ERROR(index.apply_opcompaction(metadata, op_compaction));
+    }
 
     TRACE_COUNTER_INCREMENT("output_rowsets_size", output_rowset.num_segments());
     TRACE_COUNTER_INCREMENT("max_rowsetid", max_rowset_id);

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <random>
 
+#include "base/debug/trace.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
 #include "base/utility/defer_op.h"
@@ -2766,6 +2767,61 @@ TEST_P(LakePrimaryKeyPublishTest, test_compaction_publish_tolerates_lost_output_
     // The tablet stays readable afterwards (a lost segment's rows are simply gone).
     ASSIGN_OR_ABORT(auto chunk, read(tablet_id, version));
     (void)chunk;
+}
+
+// Verify the publish path emits the trace counters added to attribute a slow lake publish. The test
+// harness publishes via lake::publish_version (bypassing the LakeServiceImpl RPC layer), so it covers
+// the counters on that path -- finalize (delvec write + metadata put) and the compaction internals --
+// but not publish_tablet_total_us, which is emitted in the RPC handler.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_emits_trace_counters) {
+    auto tablet_id = _tablet_metadata->id();
+    int64_t version = 1;
+    for (int i = 0; i < 3; i++) {
+        auto [chunk, indexes] = gen_data_and_index(kChunkSize, /*shift=*/i, /*random_shuffle=*/false,
+                                                   /*upsert=*/true);
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto dw, DeltaWriterBuilder()
+                                         .set_tablet_manager(_tablet_mgr.get())
+                                         .set_tablet_id(tablet_id)
+                                         .set_txn_id(txn_id)
+                                         .set_partition_id(_partition_id)
+                                         .set_mem_tracker(_mem_tracker.get())
+                                         .set_schema_id(_tablet_schema->id())
+                                         .set_slot_descriptors(&_slot_pointers)
+                                         .set_profile(&_dummy_runtime_profile)
+                                         .build());
+        CHECK_OK(dw->open());
+        CHECK_OK(dw->write(*chunk, indexes.data(), indexes.size()));
+        CHECK_OK(dw->finish_with_txnlog());
+        dw->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    int64_t txn_id = next_id();
+    auto old_min = config::lake_pk_compaction_min_input_segments;
+    config::lake_pk_compaction_min_input_segments = 1;
+    DeferOp reset_min([&] { config::lake_pk_compaction_min_input_segments = old_min; });
+    auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(ctx.get()));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    // Publish the compaction txn under an adopted trace; the publish runs synchronously on this thread,
+    // so the counters land on `trace`.
+    scoped_refptr<Trace> trace(new Trace);
+    {
+        ADOPT_TRACE(trace.get());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+    }
+    version++;
+
+    const std::string metrics = trace->MetricsAsJSON();
+    // finalize() always writes the delvec file and persists the tablet metadata.
+    EXPECT_NE(metrics.find("finalize_delvec_write_us"), std::string::npos) << metrics;
+    EXPECT_NE(metrics.find("put_tablet_metadata_us"), std::string::npos) << metrics;
+    // A compaction publish runs the conflict resolver and applies the compaction to the PK index.
+    EXPECT_NE(metrics.find("compaction_conflict_resolve_us"), std::string::npos) << metrics;
+    EXPECT_NE(metrics.find("index_apply_opcompaction_us"), std::string::npos) << metrics;
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #75901, which traced the common load publish-version orchestration
(base-metadata read, txn-log load, apply-finish, primary-index lock wait). Several
steps on the publish hot path were still uncovered, so a slow publish could not be
attributed from the child trace alone (the sub-latencies did not add up to the RPC
cost, with no way to tell where the residual went).

## What I'm doing:

Add the missing `TRACE_COUNTER`s so the publish trace is self-reconciling:

- `publish_tablet_total_us`: the per-tablet total wall time, emitted into the child
  trace (previously only in the `g_publish_tablet_version_latency` bvar). This is the
  reconciliation anchor — `total - sum(sub-counters)` is the still-untraced residual,
  making an uncovered slow step obvious at a glance.
- Compaction publish internals (`light_publish_primary_compaction`):
  - `compaction_conflict_resolve_us`: the conflict resolver
    (`execute()` / `execute_without_update_index()`).
  - `index_apply_opcompaction_us`: applying the compaction to the PK index
    (opens the output index sstable(s), so it can do I/O).

  (`builder->apply_opcompaction` is pure in-memory metadata editing — not
  separately traced; the per-tablet total covers it if it ever surprises.)
- `finalize()` breakdown (previously only the coarse `apply_finish_latency_us`):
  - `finalize_delvec_write_us`: writing delvec files.
  - `put_tablet_metadata_us`: persisting the tablet metadata to object storage.
- `convert_txn_log_us`: per-txn-log conversion on the apply path.

All additions are pure instrumentation; no behavior change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
