### PR TITLE
[BugFix] Skip Paimon predicate pushdown when literal cast fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -637,8 +637,10 @@ public class PaimonMetadata implements ConnectorMetadata {
             ReadBuilder readBuilder = paimonNativeTable.newReadBuilder();
             int[] projected =
                     params.getFieldNames().stream().mapToInt(name -> (paimonTable.getFieldNames().indexOf(name))).toArray();
-            List<Predicate> predicates = extractPredicates(paimonTable, params.getPredicate());
+            List<ScalarOperator> scalarOperators = Utils.extractConjuncts(params.getPredicate());
+            List<Predicate> predicates = extractPredicates(paimonTable, scalarOperators);
             boolean pruneManifestsByLimit = params.getLimit() != -1 && params.getLimit() < Integer.MAX_VALUE
+                    && predicates.size() == scalarOperators.size()
                     && onlyHasPartitionPredicate(table, params.getPredicate());
             readBuilder = readBuilder.withFilter(predicates).withProjection(projected);
 
@@ -846,8 +848,7 @@ public class PaimonMetadata implements ConnectorMetadata {
         return rowCount;
     }
 
-    private List<Predicate> extractPredicates(PaimonTable paimonTable, ScalarOperator predicate) {
-        List<ScalarOperator> scalarOperators = Utils.extractConjuncts(predicate);
+    private List<Predicate> extractPredicates(PaimonTable paimonTable, List<ScalarOperator> scalarOperators) {
         List<Predicate> predicates = new ArrayList<>(scalarOperators.size());
 
         PaimonPredicateConverter converter = new PaimonPredicateConverter(paimonTable.getNativeTable().rowType());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -340,7 +340,7 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, P
             } else if (dataType instanceof DecimalType) {
                 res = operator.castTo(com.starrocks.type.DecimalType.DEFAULT_DECIMAL128);
             }
-            return res.orElse(operator);
+            return res.orElse(null);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -614,6 +614,19 @@ public class PaimonMetadataTest {
         CallOperator createDateCoalesce = new CallOperator("coalesce", VarcharType.VARCHAR,
                 List.of(createDateColumn, ConstantOperator.createVarchar("unknown")), coalesce);
 
+        ScalarOperator unconvertedPartitionPredicate = new BinaryPredicateOperator(BinaryType.EQ, createDateColumn,
+                createDateCoalesce);
+
+        // unconverted partition predicate, limit 1
+        metadata = new PaimonMetadata("paimon", environment, catalog, properties);
+        params = GetRemoteFilesParams.newBuilder().setFieldNames(fieldNames).setPredicate(unconvertedPartitionPredicate)
+                .setLimit(1).setTableVersionRange(TvrTableSnapshot.of(Optional.of(1L))).build();
+        result = metadata.getRemoteFiles(metadata.getTable(connectContext, "test_db", "test_table"), params);
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getFiles().size());
+        assertEquals(6, ((PaimonRemoteFileDesc) result.get(0).getFiles().get(0))
+                .getPaimonSplitsInfo().getPaimonSplits().size());
+
         ScalarOperator createDateCoalescePredicate = new BinaryPredicateOperator(BinaryType.EQ, createDateCoalesce,
                 ConstantOperator.createVarchar(dateFormatter.format(now)));
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -52,6 +52,7 @@ import org.apache.paimon.types.DateType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
@@ -78,7 +79,8 @@ public class PaimonPredicateConverterTest {
                     new DataField(6, "f6", new BigIntType()),
                     new DataField(7, "f7", new DecimalType()),
                     new DataField(8, "f8", new SmallIntType()),
-                    new DataField(9, "f9", new TinyIntType()));
+                    new DataField(9, "f9", new TinyIntType()),
+                    new DataField(10, "f10", new LocalZonedTimestampType()));
     private static final ColumnRefOperator F0 = new ColumnRefOperator(0, IntegerType.INT, "f0", true, false);
     private static final ColumnRefOperator F1 = new ColumnRefOperator(1, VarcharType.VARCHAR, "f1", true, false);
     private static final ColumnRefOperator F2 = new ColumnRefOperator(2, com.starrocks.type.FloatType.FLOAT, "f2", true, false);
@@ -91,6 +93,8 @@ public class PaimonPredicateConverterTest {
             com.starrocks.type.DecimalType.DEFAULT_DECIMAL128, "f7", true, false);
     private static final ColumnRefOperator F8 = new ColumnRefOperator(8, IntegerType.SMALLINT, "f8", true, false);
     private static final ColumnRefOperator F9 = new ColumnRefOperator(9, IntegerType.TINYINT, "f9", true, false);
+    private static final ColumnRefOperator F10 = new ColumnRefOperator(10,
+            com.starrocks.type.DateType.DATETIME, "f10", true, false);
     private static final PaimonPredicateConverter CONVERTER = new PaimonPredicateConverter(new RowType(DATA_FIELDS));
 
     @Test
@@ -303,6 +307,37 @@ public class PaimonPredicateConverterTest {
         Assertions.assertTrue(result instanceof LeafPredicate);
         LeafPredicate leafPredicate = (LeafPredicate) result;
         Assertions.assertEquals(14.11, leafPredicate.literals().get(0));
+    }
+
+    @Test
+    public void testInvalidCastLiteralIsNotPushedDown() {
+        CastOperator decimalAsString = new CastOperator(VarcharType.VARCHAR, F7);
+        BinaryPredicateOperator invalidCast = new BinaryPredicateOperator(
+                BinaryType.NE, decimalAsString, ConstantOperator.createVarchar(""));
+
+        Assertions.assertNull(CONVERTER.convert(invalidCast));
+
+        BinaryPredicateOperator validPredicate = new BinaryPredicateOperator(
+                BinaryType.EQ, F0, ConstantOperator.createInt(1));
+        Predicate andResult = CONVERTER.convert(new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, invalidCast, validPredicate));
+        Assertions.assertTrue(andResult instanceof LeafPredicate);
+        Assertions.assertTrue(((LeafPredicate) andResult).function() instanceof Equal);
+        Assertions.assertEquals(1, ((LeafPredicate) andResult).literals().get(0));
+
+        Predicate orResult = CONVERTER.convert(new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR, invalidCast, validPredicate));
+        Assertions.assertNull(orResult);
+    }
+
+    @Test
+    public void testLocalZonedTimestampPredicateIsNotPushedDown() {
+        ConstantOperator timestamp = ConstantOperator.createDatetime(
+                LocalDate.parse("2026-01-01").atTime(0, 0));
+
+        Predicate result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, F10, timestamp));
+
+        Assertions.assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A Paimon query can fail during FE planning when a DECIMAL column is cast to STRING and compared with a literal that cannot be converted back to DECIMAL:

```sql
CAST(decimal_column AS STRING) != ''
```

`PaimonPredicateConverter` unwraps the CAST to locate the underlying Paimon column and attempts to convert the literal to the column type. When that conversion fails, it currently falls back to the original VARCHAR constant.

This produces an invalid Paimon predicate that compares a DECIMAL field with a `BinaryString` literal. Paimon later throws a `ClassCastException` while using the predicate for manifest statistics pruning.

## What I'm doing:

- Treat a failed literal conversion as an unsupported Paimon predicate.
- Skip pushing that predicate down to Paimon instead of using the original, type-incompatible literal.
- Keep the original predicate as a StarRocks scan conjunct so it is still evaluated as a residual predicate.
- Add a regression test for `CAST(DECIMAL AS STRING) != ''`.

Successful literal conversions are unchanged. The change is limited to Paimon predicates whose literals cannot be converted safely. Such queries may scan more splits because the predicate is no longer used for Paimon pruning, but query correctness is preserved.

Fixes #76644

## Testing:

- `PaimonPredicateConverterTest`: 18 tests passed.
- FE Checkstyle: 0 violations.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
