### PR TITLE
[BugFix] Stop the auto-split job loop on un-splittable range-distribution tablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TableAlignmentLatch.java
@@ -20,10 +20,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Edge-triggered, per-table latch that stops {@link ColocateChecker}'s self-sustaining alignment-job
- * storm. Split/merge is deterministic, so re-issuing identical alignment work on an unchanged table
- * layout makes no progress — it just churns tablets. This latch remembers the last alignment attempt
- * per table and suppresses that re-issue until the table's layout/data changes.
+ * Edge-triggered, per-table latch that suppresses re-issuing a deterministic reshard split on an
+ * unchanged table layout, which makes no progress and just churns tablets. Used by
+ * {@link ColocateChecker} to stop its self-sustaining alignment-job storm and by
+ * {@link TabletReshardJobMgr} to stop the size-based auto-split trigger from re-firing on an
+ * un-splittable (single-key) tablet. Each consumer holds its own instance and supplies its own
+ * convergence signature; this class only remembers the last attempt per table and decides whether to
+ * re-fire.
  *
  * <p>The latch is keyed per TABLE (not per colocate group) because alignment jobs are per-table:
  * keying by group would let one table's attempt suppress a peer that had never been attempted, or miss

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -17,6 +17,7 @@ package com.starrocks.alter.reshard;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import com.google.common.hash.Hashing;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -61,6 +62,18 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
     // ({@code tablet_reshard_job_scheduler_interval_ms}) and self-gates on shared-data-mode,
     // leader status, and empty unstable-groups before doing any real work.
     private final ColocateChecker colocateChecker = new ColocateChecker();
+
+    // Per-table edge-triggered latch that stops the size-based auto-split trigger from re-issuing a
+    // deterministic split that made no progress: a tablet dominated by a single distribution-key value
+    // is un-splittable, so BE returns the identical-tablet fallback and the tablet stays over threshold.
+    // Reuses the generic mechanism the colocate checker uses for its alignment-job storm; keyed on the
+    // table's convergence signature (tablet ranges + dataVersion + a split-plan fingerprint of
+    // target_size / max_split_count / computed count), so a successful split, a load, or a reshard-config
+    // change re-arms it while the no-progress fallback (only visibleVersion moves; size/config unchanged)
+    // does not. Touched only from
+    // the single reshard scheduler tick (triggerTabletReshard), never from the concurrent
+    // addReshardCandidate producers, so no synchronization is needed; cleared on leader demotion.
+    private final TableAlignmentLatch sizeSplitLatch = new TableAlignmentLatch();
 
     // Coalescible reshard candidate for one table, marked by both the publish path and the periodic
     // TabletStatMgr scan: the largest tablet (split) and the smallest adjacent fresh-pair sum (merge).
@@ -120,10 +133,11 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         return reshardingTabletInfo.getReshardingTablet();
     }
 
-    public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+    public TabletReshardJob createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
             throws StarRocksException {
         TabletReshardJob job = new SplitTabletJobFactory(db, table, splitTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
+        return job;
     }
 
     public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause mergeTabletClause)
@@ -134,6 +148,20 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         }
         TabletReshardJob job = new MergeTabletJobFactory(db, table, mergeTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
+    }
+
+    // 64-bit fingerprint of the requested split plan: the raw reshard-config knobs plus the max
+    // tablet's computed split count. Folding the raw configs guarantees any admin config change
+    // re-arms the size-split latch even when calcSplitCount is capped at max_split_count; the computed
+    // count also captures a max-tablet size-band crossing. murmur3 (matching ColocateChecker) avoids
+    // the 32-bit Objects.hash collision that could hide a config change.
+    @VisibleForTesting
+    static long splitPlanSignature(long maxTabletSize) {
+        return Hashing.murmur3_128().newHasher()
+                .putLong(Config.tablet_reshard_target_size)
+                .putInt(Config.tablet_reshard_max_split_count)
+                .putInt(TabletReshardUtils.calcSplitCount(maxTabletSize, Config.tablet_reshard_target_size))
+                .hash().asLong();
     }
 
     /**
@@ -156,11 +184,23 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         }
         try {
             if (TabletReshardUtils.needSplit(maxTabletSize)) {
-                createTabletReshardJob(db, table, new SplitTabletClause());
-                LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
-                        db.getFullName(), table.getName(), maxTabletSize);
+                long signature = ColocateChecker.tableConvergenceSignature(db, table,
+                        splitPlanSignature(maxTabletSize));
+                TableAlignmentLatch.AlignmentDecision decision = sizeSplitLatch.evaluate(table.getId(), signature);
+                if (decision.fire()) {
+                    TabletReshardJob job = createTabletReshardJob(db, table, new SplitTabletClause());
+                    sizeSplitLatch.recordFired(table.getId(), signature, job.getJobId(), decision.nextAbortRetries());
+                    LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
+                            db.getFullName(), table.getName(), maxTabletSize);
+                } else if (sizeSplitLatch.claimSuppressionLog(table.getId())) {
+                    LOG.warn("Auto split for table {}.{} made no progress on an unchanged layout "
+                                    + "(tablet not splittable); suppressing further split jobs until its data changes",
+                            db.getFullName(), table.getName());
+                }
                 return;
             }
+            // Below the split threshold: drop any stale suppression so future growth re-arms, and bound the map.
+            sizeSplitLatch.forgetTable(table.getId());
             if (TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
                 createTabletReshardJob(db, table, new MergeTabletClause());
                 LOG.info("Auto triggered merge tablet job for table {}.{}, minAdjacentTabletPairSize {}",
@@ -261,6 +301,7 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         // path, so a demoted node must not run them.
         if (!isLeaderAdmissionOpen()) {
             reshardCandidates.clear();
+            sizeSplitLatch.clear();
             return;
         }
         colocateChecker.runOneCycle();
@@ -278,6 +319,16 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
         return reshardCandidates.size();
     }
 
+    @VisibleForTesting
+    boolean hasSizeSplitLatch(long tableId) {
+        return sizeSplitLatch.hasRecordedAttempt(tableId);
+    }
+
+    @VisibleForTesting
+    void clearSizeSplitLatchForTest() {
+        sizeSplitLatch.clear();
+    }
+
     private void drainReshardCandidates() {
         if (reshardCandidates.isEmpty()) {
             return;
@@ -292,11 +343,13 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
             // is simply skipped this cycle.
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(candidate.dbId());
             if (db == null) {
+                sizeSplitLatch.forgetTable(tableId);
                 continue;
             }
             Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(candidate.dbId(), candidate.tableId());
             if (!(table instanceof OlapTable)) {
+                sizeSplitLatch.forgetTable(tableId);
                 continue;
             }
             triggerTabletReshard(db, (OlapTable) table,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -183,16 +183,17 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
             return;
         }
         try {
+            long tableId = table.getId();
             if (TabletReshardUtils.needSplit(maxTabletSize)) {
                 long signature = ColocateChecker.tableConvergenceSignature(db, table,
                         splitPlanSignature(maxTabletSize));
-                TableAlignmentLatch.AlignmentDecision decision = sizeSplitLatch.evaluate(table.getId(), signature);
+                TableAlignmentLatch.AlignmentDecision decision = sizeSplitLatch.evaluate(tableId, signature);
                 if (decision.fire()) {
                     TabletReshardJob job = createTabletReshardJob(db, table, new SplitTabletClause());
-                    sizeSplitLatch.recordFired(table.getId(), signature, job.getJobId(), decision.nextAbortRetries());
+                    sizeSplitLatch.recordFired(tableId, signature, job.getJobId(), decision.nextAbortRetries());
                     LOG.info("Auto triggered split tablet job for table {}.{}, maxTabletSize {}",
                             db.getFullName(), table.getName(), maxTabletSize);
-                } else if (sizeSplitLatch.claimSuppressionLog(table.getId())) {
+                } else if (sizeSplitLatch.claimSuppressionLog(tableId)) {
                     LOG.warn("Auto split for table {}.{} made no progress on an unchanged layout "
                                     + "(tablet not splittable); suppressing further split jobs until its data changes",
                             db.getFullName(), table.getName());
@@ -200,7 +201,7 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
                 return;
             }
             // Below the split threshold: drop any stale suppression so future growth re-arms, and bound the map.
-            sizeSplitLatch.forgetTable(table.getId());
+            sizeSplitLatch.forgetTable(tableId);
             if (TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
                 createTabletReshardJob(db, table, new MergeTabletClause());
                 LOG.info("Auto triggered merge tablet job for table {}.{}, minAdjacentTabletPairSize {}",
@@ -339,14 +340,11 @@ public class TabletReshardJobMgr extends FrontendDaemon implements GsonPostProce
             if (candidate == null) {
                 continue;
             }
-            // db and table lookups are not atomic; the null guards are conservative — a dropped db/table
-            // is simply skipped this cycle.
+            // db and table lookups are not atomic; the guard is conservative — a dropped db/table is
+            // simply skipped this cycle, and its stale size-split latch entry is reclaimed so a
+            // re-created table re-arms cleanly.
             Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(candidate.dbId());
-            if (db == null) {
-                sizeSplitLatch.forgetTable(tableId);
-                continue;
-            }
-            Table table = GlobalStateMgr.getCurrentState().getLocalMetastore()
+            Table table = db == null ? null : GlobalStateMgr.getCurrentState().getLocalMetastore()
                     .getTable(candidate.dbId(), candidate.tableId());
             if (!(table instanceof OlapTable)) {
                 sizeSplitLatch.forgetTable(tableId);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/AutomaticTabletReshardTest.java
@@ -71,13 +71,14 @@ public class AutomaticTabletReshardTest {
                 return true;
             }
         };
+        GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().clearSizeSplitLatchForTest();
     }
 
     @Test
     void testTriggerTabletReshardFailed() {
         new MockUp<TabletReshardJobMgr>() {
             @Mock
-            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
                     throws StarRocksException {
                 throw new StarRocksException("Create tablet reshard job failed");
             }
@@ -92,9 +93,12 @@ public class AutomaticTabletReshardTest {
     void testTriggerTabletReshardSuccess() {
         new MockUp<TabletReshardJobMgr>() {
             @Mock
-            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
                     throws StarRocksException {
-                return;
+                TabletReshardJobMgrTest.TestNormalTabletReshardJob job =
+                        new TabletReshardJobMgrTest.TestNormalTabletReshardJob(1L, TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
             }
         };
 
@@ -150,9 +154,10 @@ public class AutomaticTabletReshardTest {
         boolean[] splitCalled = {false};
         new MockUp<TabletReshardJobMgr>() {
             @Mock
-            public void createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table, SplitTabletClause splitTabletClause)
                     throws StarRocksException {
                 splitCalled[0] = true;
+                return new TabletReshardJobMgrTest.TestNormalTabletReshardJob(2L, TabletReshardJob.JobType.SPLIT_TABLET);
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -514,7 +514,7 @@ public class TabletReshardJobMgrTest {
 
         mockLeaderAdmissionOpen();
         oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
-        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        TabletReshardJobMgr mgr = new TabletReshardJobMgr();
 
         // Round 1: first over-threshold observation -> one split job fired, table latched.
         mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
@@ -547,7 +547,7 @@ public class TabletReshardJobMgrTest {
 
         mockLeaderAdmissionOpen();
         oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
-        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        TabletReshardJobMgr mgr = new TabletReshardJobMgr();
 
         mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
                 Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
@@ -585,7 +585,7 @@ public class TabletReshardJobMgrTest {
         mockLeaderAdmissionOpen();
         long originalTarget = Config.tablet_reshard_target_size;
         try {
-            TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+            TabletReshardJobMgr mgr = new TabletReshardJobMgr();
             long big = originalTarget * 8; // calcSplitCount ~ 8
             oversizedTablet.setDataSize(big);
             mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), big, Long.MAX_VALUE);
@@ -622,7 +622,7 @@ public class TabletReshardJobMgrTest {
         long originalTarget = Config.tablet_reshard_target_size;
         int originalMax = Config.tablet_reshard_max_split_count;
         try {
-            TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+            TabletReshardJobMgr mgr = new TabletReshardJobMgr();
             // Cap the count at 2; huge tablet so calcSplitCount is pinned at the cap regardless of target.
             Config.tablet_reshard_max_split_count = 2;
             long huge = originalTarget * 100;
@@ -700,7 +700,7 @@ public class TabletReshardJobMgrTest {
 
         mockLeaderAdmissionOpen();
         oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
-        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        TabletReshardJobMgr mgr = new TabletReshardJobMgr();
 
         mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
                 Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
@@ -729,7 +729,7 @@ public class TabletReshardJobMgrTest {
         };
         mockLeaderAdmissionOpen();
         oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
-        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        TabletReshardJobMgr mgr = new TabletReshardJobMgr();
 
         mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
                 Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
@@ -754,7 +754,7 @@ public class TabletReshardJobMgrTest {
             }
         };
         oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
-        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        TabletReshardJobMgr mgr = new TabletReshardJobMgr();
 
         mockLeaderAdmissionOpen();
         mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -529,4 +529,243 @@ public class TabletReshardJobMgrTest {
         mgr.runAfterCatalogReadyForTest();
         Assertions.assertEquals(1, splitCalls[0], "an unchanged split request must not re-fire (loop broken)");
     }
+
+    @Test
+    public void testAutoSplitReArmsOnDataChange() throws Exception {
+        int[] splitCalls = {0};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                splitCalls[0]++;
+                TestNormalTabletReshardJob job =
+                        new TestNormalTabletReshardJob(2000L + splitCalls[0], TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+        };
+
+        mockLeaderAdmissionOpen();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertEquals(1, splitCalls[0], "suppressed while nothing changed");
+
+        // Simulate a load: advance dataVersion -> signature changes -> latch re-arms.
+        com.starrocks.catalog.PhysicalPartition pp = reshardTable.getPartitions().iterator().next()
+                .getDefaultPhysicalPartition();
+        pp.setDataVersion(pp.getDataVersion() + 1);
+
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertEquals(2, splitCalls[0], "a data change (dataVersion bump) must re-arm the split");
+    }
+
+    @Test
+    public void testAutoSplitReArmsOnSplitCountChange() throws Exception {
+        int[] splitCalls = {0};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                splitCalls[0]++;
+                TestNormalTabletReshardJob job =
+                        new TestNormalTabletReshardJob(2500L + splitCalls[0], TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+        };
+        mockLeaderAdmissionOpen();
+        long originalTarget = Config.tablet_reshard_target_size;
+        try {
+            TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+            long big = originalTarget * 8; // calcSplitCount ~ 8
+            oversizedTablet.setDataSize(big);
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), big, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), big, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            Assertions.assertEquals(1, splitCalls[0], "suppressed at unchanged split count");
+
+            // Raise the target so calcSplitCount(big, target) drops -> requested split count changes -> re-arm.
+            Config.tablet_reshard_target_size = big / 2; // calcSplitCount ~ 2, different from ~8
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), big, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            Assertions.assertEquals(2, splitCalls[0], "a changed requested split count must re-arm the split");
+        } finally {
+            Config.tablet_reshard_target_size = originalTarget;
+        }
+    }
+
+    @Test
+    public void testAutoSplitReArmsOnConfigChangeWhenCountCapped() throws Exception {
+        int[] splitCalls = {0};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                splitCalls[0]++;
+                TestNormalTabletReshardJob job =
+                        new TestNormalTabletReshardJob(2700L + splitCalls[0], TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+        };
+        mockLeaderAdmissionOpen();
+        long originalTarget = Config.tablet_reshard_target_size;
+        int originalMax = Config.tablet_reshard_max_split_count;
+        try {
+            TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+            // Cap the count at 2; huge tablet so calcSplitCount is pinned at the cap regardless of target.
+            Config.tablet_reshard_max_split_count = 2;
+            long huge = originalTarget * 100;
+            oversizedTablet.setDataSize(huge);
+            // sanity: count is capped at 2 for both target values used below
+            Assertions.assertEquals(2, TabletReshardUtils.calcSplitCount(huge, originalTarget));
+            Assertions.assertEquals(2, TabletReshardUtils.calcSplitCount(huge, originalTarget * 3));
+
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), huge, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), huge, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            Assertions.assertEquals(1, splitCalls[0], "suppressed while config + layout unchanged (count capped)");
+
+            // Change target: the max count stays capped at 2, but the raw target config in the fingerprint changes.
+            Config.tablet_reshard_target_size = originalTarget * 3;
+            mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), huge, Long.MAX_VALUE);
+            mgr.runAfterCatalogReadyForTest();
+            Assertions.assertEquals(2, splitCalls[0],
+                    "a config change must re-arm even when the max tablet's computed count is capped/unchanged");
+        } finally {
+            Config.tablet_reshard_target_size = originalTarget;
+            Config.tablet_reshard_max_split_count = originalMax;
+        }
+    }
+
+    @Test
+    public void testSplitPlanSignatureAvoids32BitCollision() {
+        long originalTarget = Config.tablet_reshard_target_size;
+        int originalMax = Config.tablet_reshard_max_split_count;
+        try {
+            Config.tablet_reshard_max_split_count = 2; // pin computed count at the cap for a huge tablet
+            long huge = 1024L * 1024 * 1024 * 1024; // 1 TiB, far over any target's split threshold
+
+            // Two DISTINCT targets that collide under Long.hashCode (hence under Objects.hash):
+            //   Long.hashCode(10737418240L) == Long.hashCode(2147483650L) == -2147483646
+            long targetA = 10737418240L; // 10 GiB
+            long targetB = 2147483650L;  // ~2 GiB
+            Assertions.assertEquals(Long.hashCode(targetA), Long.hashCode(targetB),
+                    "precondition: targets collide under Long.hashCode");
+            Assertions.assertEquals(2, TabletReshardUtils.calcSplitCount(huge, targetA));
+            Assertions.assertEquals(2, TabletReshardUtils.calcSplitCount(huge, targetB));
+            Assertions.assertEquals(java.util.Objects.hash(targetA, 2, 2), java.util.Objects.hash(targetB, 2, 2),
+                    "the old 32-bit Objects.hash fingerprint would have collided on these inputs");
+
+            Config.tablet_reshard_target_size = targetA;
+            long sigA = TabletReshardJobMgr.splitPlanSignature(huge);
+            Config.tablet_reshard_target_size = targetB;
+            long sigB = TabletReshardJobMgr.splitPlanSignature(huge);
+            Assertions.assertNotEquals(sigA, sigB,
+                    "the 64-bit murmur3 fingerprint must distinguish targets that collide under Objects.hash");
+        } finally {
+            Config.tablet_reshard_target_size = originalTarget;
+            Config.tablet_reshard_max_split_count = originalMax;
+        }
+    }
+
+    @Test
+    public void testAutoSplitLatchForgottenBelowThreshold() throws Exception {
+        boolean[] splitFired = {false};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                splitFired[0] = true;
+                TestNormalTabletReshardJob job = new TestNormalTabletReshardJob(3000L, TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+            @Mock
+            public void createTabletReshardJob(Database db, OlapTable table, MergeTabletClause clause) {
+                // no-op: keep the table state unchanged so the drain reaches triggerTabletReshard
+            }
+        };
+
+        mockLeaderAdmissionOpen();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertTrue(splitFired[0], "initial split must fire");
+        Assertions.assertTrue(mgr.hasSizeSplitLatch(reshardTable.getId()), "latched after firing");
+
+        // A drain where needSplit is false (only a merge signal) must forget the size-split latch entry.
+        long mergePairBelowThreshold = TabletReshardUtils.mergePairThreshold(Config.tablet_reshard_target_size) - 1;
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(), 0L, mergePairBelowThreshold);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertFalse(mgr.hasSizeSplitLatch(reshardTable.getId()),
+                "dropping below the split threshold must forget the latch so future growth re-arms");
+    }
+
+    @Test
+    public void testAutoSplitCreationFailureRetries() throws Exception {
+        int[] attempts = {0};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) throws StarRocksException {
+                attempts[0]++;
+                throw new StarRocksException("transient create failure");
+            }
+        };
+        mockLeaderAdmissionOpen();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+
+        Assertions.assertEquals(2, attempts[0], "a creation failure records nothing and must retry, not suppress");
+        Assertions.assertFalse(mgr.hasSizeSplitLatch(reshardTable.getId()), "no latch entry on a failed creation");
+    }
+
+    @Test
+    public void testAdmissionClosedClearsSizeSplitLatch() throws Exception {
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                TestNormalTabletReshardJob job = new TestNormalTabletReshardJob(3500L, TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+        };
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+
+        mockLeaderAdmissionOpen();
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertTrue(mgr.hasSizeSplitLatch(reshardTable.getId()), "latched after firing");
+
+        // Demotion: the admission-closed tick must clear the latch (bounding it to a leader tenure).
+        mockLeaderAdmissionClosed();
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertFalse(mgr.hasSizeSplitLatch(reshardTable.getId()),
+                "leader demotion must clear the size-split latch");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -186,6 +186,7 @@ public class TabletReshardJobMgrTest {
         // Tests that use the singleton TabletReshardJobMgr share its state. Clear it before each
         // test so a job created in one test does not block table-reservation checks in the next.
         GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().tabletReshardJobs.clear();
+        GlobalStateMgr.getCurrentState().getTabletReshardJobMgr().clearSizeSplitLatchForTest();
         // Reset the table state: a split job created by a previous test transitions the table to
         // TABLET_RESHARD via init(), and triggerTabletReshard short-circuits on non-NORMAL.
         if (reshardTable != null) {
@@ -494,5 +495,38 @@ public class TabletReshardJobMgrTest {
         mgr.runAfterCatalogReadyForTest();
         Assertions.assertTrue(mergeCalled[0],
                 "drain must route a sub-threshold merge candidate to a merge job");
+    }
+
+    @Test
+    public void testAutoSplitSuppressedAfterNoProgress() throws Exception {
+        int[] splitCalls = {0};
+        new MockUp<TabletReshardJobMgr>() {
+            @Mock
+            public TabletReshardJob createTabletReshardJob(Database db, OlapTable table,
+                    com.starrocks.sql.ast.SplitTabletClause clause) {
+                splitCalls[0]++;
+                TestNormalTabletReshardJob job =
+                        new TestNormalTabletReshardJob(1000L + splitCalls[0], TabletReshardJob.JobType.SPLIT_TABLET);
+                job.setTableId(table.getId());
+                return job;
+            }
+        };
+
+        mockLeaderAdmissionOpen();
+        oversizedTablet.setDataSize(Config.tablet_reshard_target_size * 2);
+        TabletReshardJobMgr mgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+
+        // Round 1: first over-threshold observation -> one split job fired, table latched.
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertEquals(1, splitCalls[0], "first over-threshold scan must fire exactly one split");
+        Assertions.assertTrue(mgr.hasSizeSplitLatch(reshardTable.getId()), "table must be latched after firing");
+
+        // Round 2: same size -> same signature (identical fallback leaves layout + requested count unchanged) -> suppressed.
+        mgr.addReshardCandidate(reshardDb.getId(), reshardTable.getId(),
+                Config.tablet_reshard_target_size * 2, Long.MAX_VALUE);
+        mgr.runAfterCatalogReadyForTest();
+        Assertions.assertEquals(1, splitCalls[0], "an unchanged split request must not re-fire (loop broken)");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, FE's size-based auto-split re-fires a split job on **every** `TabletStatMgr` scan for a range-distribution tablet the BE cannot split, forever.

When a tablet is dominated by a single distribution-key value there is no interior key boundary, so on CN `get_tablet_split_ranges` deterministically fails (`Not enough split ranges available`) and `split_tablet` falls back to producing **one identical tablet** at a new version — same data files, unchanged size. Because the trigger (`TabletReshardJobMgr.triggerTabletReshard`, fed by the periodic `TabletStatMgr` scan and the publish path) is purely size-based and **stateless**, the still-over-threshold tablet is re-selected on the next scan: a fresh split job plus a no-op `visibleVersion` bump, indefinitely. Symptom: FE logs `Auto triggered split tablet job ...` every cycle; CN logs `Failed to get tablet split ranges, will not split this tablet ...` every cycle, on the same tablet, version climbing by +1 each round.

## What I'm doing:

Guard the size-based auto-split trigger with a per-table, edge-triggered **convergence latch**, reusing the already-shipped range-colocate alignment-storm mechanism (`TableAlignmentLatch` + `ColocateChecker.tableConvergenceSignature`, from PR #75930).

The latch re-fires a split only when the table's convergence signature changes: the visible-index tablet **ranges** + each physical partition's **`dataVersion`** + a 64-bit murmur3 fingerprint of the requested **split plan** (`tablet_reshard_target_size` + `tablet_reshard_max_split_count` + `calcSplitCount`). The identical-tablet fallback preserves ranges and advances only `visibleVersion` (not `dataVersion`), so its signature is unchanged and the latch suppresses the re-fire; a genuine load (advances `dataVersion`), a successful split (changes ranges), or a reshard-config change re-arms it. The latch is in-memory / per-leader (cleared on leader demotion), is touched only from the single reshard scheduler tick, and is a **separate instance** from the colocate checker's (they share the class + signature, not state).

No change to the BE splitter, to the identical-tablet fallback (an intended safety net), or to the colocate alignment path (`ColocateChecker` is untouched — the reuse is a same-package static call).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5