### PR TITLE
[Enhancement] Relocate sort-key samples from tablet metadata to a segment page

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -354,9 +354,10 @@ CONF_String(storage_root_path, "${STARROCKS_HOME}/storage");
 // Row interval between consecutive sort-key samples recorded by the segment
 // writer. Samples are consumed by tablet split and range-split parallel
 // compaction to accurately estimate row distribution for overlapping segments.
-// Setting to 0 disables sampling. The per-segment value is persisted in
-// SegmentMetadataPB.sort_key_sample_row_interval so that a runtime change
-// does not break cross-version readers.
+// Setting to 0 disables sampling. The sampled tuples and their interval are
+// persisted in the segment's SORT_KEY_SAMPLE_PAGE (SortKeySampleDataPB), not
+// in tablet metadata, so that a runtime change does not break cross-version
+// readers.
 CONF_mInt64(segment_sort_key_sample_row_interval, "65536");
 CONF_Bool(enable_transparent_data_encryption, "false");
 // BE process will exit if the percentage of error disk reach this value.

--- a/be/src/common/config_rowset_fwd.h
+++ b/be/src/common/config_rowset_fwd.h
@@ -23,9 +23,10 @@ namespace starrocks::config {
 // Row interval between consecutive sort-key samples recorded by the segment
 // writer. Samples are consumed by tablet split and range-split parallel
 // compaction to accurately estimate row distribution for overlapping segments.
-// Setting to 0 disables sampling. The per-segment value is persisted in
-// SegmentMetadataPB.sort_key_sample_row_interval so that a runtime change
-// does not break cross-version readers.
+// Setting to 0 disables sampling. The sampled tuples and their interval are
+// persisted in the segment's SORT_KEY_SAMPLE_PAGE (SortKeySampleDataPB), not
+// in tablet metadata, so that a runtime change does not break cross-version
+// readers.
 CONF_mInt64(segment_sort_key_sample_row_interval, "65536");
 
 CONF_Bool(enable_transparent_data_encryption, "false");

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2419,13 +2419,15 @@ StatusOr<std::vector<SegmentSplitInfo>> TabletParallelCompactionManager::_collec
         const std::vector<RowsetPtr>& rowsets) {
     std::vector<SegmentSplitInfo> segments;
 
+    const LakeIOOptions lake_io_opts = sort_key_sample_read_options();
     for (const auto& rowset : rowsets) {
         const auto& rowset_meta = rowset->metadata();
         int32_t num_segments = rowset_meta.segment_metas_size();
         int64_t rowset_data_size = rowset->data_size();
         int64_t rowset_num_rows = rowset->num_rows();
 
-        for (const auto& segment_meta : rowset_meta.segment_metas()) {
+        for (int si = 0; si < rowset_meta.segment_metas_size(); ++si) {
+            const auto& segment_meta = rowset_meta.segment_metas(si);
             SegmentSplitInfo segment;
             RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
             RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
@@ -2435,7 +2437,14 @@ StatusOr<std::vector<SegmentSplitInfo>> TabletParallelCompactionManager::_collec
             } else if (num_segments > 0) {
                 segment.data_size = rowset_data_size / num_segments;
             }
-            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            if (segment_meta.deprecated_sort_key_samples_size() > 0) {
+                RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta)); // legacy metadata, no I/O
+            } else if (_tablet_mgr != nullptr) {
+                // Best-effort: a page-read failure degrades this segment to no-sample, never fails compaction.
+                WARN_IF_ERROR(read_segment_sort_key_samples(_tablet_mgr, rowset->tablet_id(), rowset->tablet_schema(),
+                                                            lake_io_opts, rowset_meta, si, &segment),
+                              "sort-key sample page read failed (degrading to no-sample range-split compaction)");
+            }
             segments.push_back(std::move(segment));
         }
     }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -383,7 +383,7 @@ private:
 
     // Collect sort key bounds from all segments across all rowsets.
     // Returns SegmentSplitInfo (defined in tablet_splitter.h) for each segment.
-    static StatusOr<std::vector<SegmentSplitInfo>> _collect_segment_key_bounds(const std::vector<RowsetPtr>& rowsets);
+    StatusOr<std::vector<SegmentSplitInfo>> _collect_segment_key_bounds(const std::vector<RowsetPtr>& rowsets);
 
     // Create SubtaskGroups using range split strategy.
     // Uses calculate_range_split_boundaries() from tablet_splitter to calculate boundaries.

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -23,11 +23,14 @@
 #include <vector>
 
 #include "common/logging.h"
+#include "fs/fs.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
 #include "storage/lake/update_manager.h"
+#include "storage/options.h"
+#include "storage/rowset/segment.h"
 #include "storage/tablet_range.h"
 #include "storage/tablet_schema.h"
 #include "storage/tablet_schema_map.h"
@@ -43,25 +46,70 @@ namespace starrocks::lake {
 
 using google::protobuf::RepeatedPtrField;
 
+// Overflow-safe validity of a sample set: samples.size() * row_interval < num_rows.
+static bool sample_count_consistent(int64_t num_samples, int64_t row_interval, int64_t num_rows) {
+    return row_interval > 0 && num_rows > 0 && num_samples <= (num_rows - 1) / row_interval;
+}
+
 Status SegmentSplitInfo::load_sort_key_samples(const SegmentMetadataPB& segment_meta) {
-    if (segment_meta.sort_key_samples_size() == 0 || !segment_meta.has_sort_key_sample_row_interval()) {
+    // Legacy fallback: read samples from the deprecated tablet-metadata fields, for segments written
+    // before samples were relocated to the segment's SORT_KEY_SAMPLE_PAGE. New segments have these empty.
+    if (segment_meta.deprecated_sort_key_samples_size() == 0 ||
+        !segment_meta.has_deprecated_sort_key_sample_row_interval()) {
         return Status::OK();
     }
-    const int64_t row_interval = segment_meta.sort_key_sample_row_interval();
-    const int64_t num_samples = segment_meta.sort_key_samples_size();
-    // Overflow-safe validity: sort_key_samples.size() * row_interval < num_rows.
-    if (!(row_interval > 0 && num_rows > 0 && num_samples <= (num_rows - 1) / row_interval)) {
+    const int64_t row_interval = segment_meta.deprecated_sort_key_sample_row_interval();
+    const int64_t num_samples = segment_meta.deprecated_sort_key_samples_size();
+    if (!sample_count_consistent(num_samples, row_interval, num_rows)) {
         return Status::OK(); // Invalid metadata -- fall through with empty samples.
     }
     sort_key_sample_row_interval = row_interval;
     sort_key_samples.reserve(num_samples);
-    for (const auto& sample_pb : segment_meta.sort_key_samples()) {
+    for (const auto& sample_pb : segment_meta.deprecated_sort_key_samples()) {
         VariantTuple sample;
         RETURN_IF_ERROR(sample.from_proto(sample_pb));
         DCHECK(sort_key_samples.empty() || sort_key_samples.back().compare(sample) <= 0);
         sort_key_samples.push_back(std::move(sample));
     }
     return Status::OK();
+}
+
+Status SegmentSplitInfo::load_sort_key_samples_from_segment(Segment* segment, const LakeIOOptions& lake_io_opts) {
+    std::vector<VariantTuple> samples;
+    int64_t row_interval = 0;
+    RETURN_IF_ERROR(segment->read_sort_key_samples(lake_io_opts, &samples, &row_interval));
+    const int64_t num_samples = static_cast<int64_t>(samples.size());
+    // Same overflow-safe validity check as load_sort_key_samples; an empty page (num_samples == 0)
+    // or an inconsistent one degrades to no-sample distribution.
+    if (num_samples == 0 || !sample_count_consistent(num_samples, row_interval, num_rows)) {
+        return Status::OK();
+    }
+    sort_key_sample_row_interval = row_interval;
+    sort_key_samples = std::move(samples);
+    return Status::OK();
+}
+
+LakeIOOptions sort_key_sample_read_options() {
+    LakeIOOptions opts;
+    opts.fill_data_cache = false; // one-shot read on a rare path; don't pollute the local data cache
+    opts.use_page_cache = true;   // sample page is small and immutable; caching it is harmless
+    opts.fill_metadata_cache = false;
+    return opts;
+}
+
+Status read_segment_sort_key_samples(TabletManager* tablet_manager, int64_t tablet_id,
+                                     const TabletSchemaPtr& tablet_schema, const LakeIOOptions& lake_io_opts,
+                                     const RowsetMetadataPB& rowset_meta, int segment_pos, SegmentSplitInfo* out) {
+    const auto& segment_meta = rowset_meta.segment_metas(segment_pos);
+    FileInfo seg_info{.path = tablet_manager->segment_location(tablet_id, segment_meta.filename())};
+    if (segment_meta.has_size()) seg_info.size = segment_meta.size();
+    if (segment_meta.has_bundle_file_offset()) seg_info.bundle_file_offset = segment_meta.bundle_file_offset();
+    if (segment_meta.has_encryption_meta()) seg_info.encryption_meta = segment_meta.encryption_meta();
+    const uint32_t segment_id = get_segment_idx(rowset_meta, segment_pos);
+    size_t footer_size_hint = 16 * 1024;
+    ASSIGN_OR_RETURN(auto segment, tablet_manager->load_segment(seg_info, segment_id, &footer_size_hint, lake_io_opts,
+                                                                /*fill_meta_cache=*/false, tablet_schema));
+    return out->load_sort_key_samples_from_segment(segment.get(), lake_io_opts);
 }
 
 // ================================================================================
@@ -620,21 +668,69 @@ void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& ancho
     }
 }
 
+// Resolve the materialized TabletSchema that governs `rowset_id`, mirroring lake::Rowset's
+// rowset_to_schema -> historical_schemas -> top-level-schema resolution. Returns nullptr when the
+// resolved schema has no valid id (hand-crafted test / legacy metadata that never assigned one):
+// GlobalTabletSchemaMap::emplace DCHECK-aborts on an invalid id, so in that case the page-read path
+// is skipped and split/compaction degrades to no-sample, like any other page-read failure. Doing
+// the resolution here (instead of constructing a throwaway Rowset just to reach tablet_schema())
+// also avoids aborting when a rowset_to_schema mapping dangles into a missing historical schema.
+TabletSchemaPtr resolve_rowset_schema_or_null(const TabletMetadataPtr& tablet_metadata, uint32_t rowset_id) {
+    const auto& rowset_to_schema = tablet_metadata->rowset_to_schema();
+    if (auto it = rowset_to_schema.find(rowset_id); it != rowset_to_schema.end()) {
+        auto hs_it = tablet_metadata->historical_schemas().find(it->second);
+        if (hs_it != tablet_metadata->historical_schemas().end()) {
+            if (hs_it->second.id() == TabletSchema::invalid_id()) return nullptr;
+            return GlobalTabletSchemaMap::Instance()->emplace(hs_it->second).first;
+        }
+        // Mapping present but the referenced historical schema is missing (corrupt metadata):
+        // fall through to the top-level schema rather than aborting.
+    }
+    if (tablet_metadata->schema().id() == TabletSchema::invalid_id()) return nullptr;
+    return GlobalTabletSchemaMap::Instance()->emplace(tablet_metadata->schema()).first;
+}
+
 // Build SegmentSplitInfo[] from a tablet's rowsets. Does NOT enforce "segments
 // non-empty" — the data-driven and external-boundaries callers have different
 // semantics on empty (one errors, the other treats it as a no-op fast path) and
 // own that check.
-Status build_segments_from_rowsets(const RepeatedPtrField<RowsetMetadataPB>& rowsets,
-                                   std::vector<SegmentSplitInfo>* segments) {
-    for (const auto& rowset : rowsets) {
-        for (const auto& segment_meta : rowset.segment_metas()) {
+//
+// Sort-key samples: prefer legacy metadata samples (no I/O) when present; otherwise, if
+// `tablet_manager` is non-null, open the segment and read them from its SORT_KEY_SAMPLE_PAGE
+// (non-fatal -- degrades to no-sample on any open/read failure). `tablet_manager` may be
+// nullptr in unit tests, in which case the page path is skipped entirely.
+Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
+                                   const LakeIOOptions& lake_io_opts, std::vector<SegmentSplitInfo>* segments) {
+    for (int ri = 0; ri < tablet_metadata->rowsets_size(); ++ri) {
+        const auto& rowset = tablet_metadata->rowsets(ri);
+        // Per-rowset schema for the page-read path, resolved lazily on the first segment that
+        // needs it (nullptr => unresolvable => skip the page path, degrade to no-sample).
+        TabletSchemaPtr rowset_schema;
+        bool rowset_schema_resolved = false;
+        for (int si = 0; si < rowset.segment_metas_size(); ++si) {
+            const auto& segment_meta = rowset.segment_metas(si);
             SegmentSplitInfo segment;
             segment.source_id = rowset.id();
             RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
             RETURN_IF_ERROR(segment.max_key.from_proto(segment_meta.sort_key_max()));
             segment.num_rows = segment_meta.num_rows();
             segment.data_size = segment_meta.size();
-            RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta));
+            if (segment_meta.deprecated_sort_key_samples_size() > 0) {
+                RETURN_IF_ERROR(segment.load_sort_key_samples(segment_meta)); // legacy metadata, no I/O
+            } else if (tablet_manager != nullptr) {
+                if (!rowset_schema_resolved) {
+                    rowset_schema = resolve_rowset_schema_or_null(tablet_metadata, rowset.id());
+                    rowset_schema_resolved = true;
+                }
+                if (rowset_schema != nullptr) {
+                    // Best-effort: a page-read failure degrades this segment to no-sample, never fails the split.
+                    WARN_IF_ERROR(read_segment_sort_key_samples(tablet_manager, tablet_metadata->id(), rowset_schema,
+                                                                lake_io_opts, rowset, si, &segment),
+                                  fmt::format("sort-key sample page read failed (degrading to no-sample split), "
+                                              "tablet={} rowset={} seg_pos={}",
+                                              tablet_metadata->id(), rowset.id(), si));
+                }
+            }
             segments->push_back(std::move(segment));
         }
     }
@@ -684,7 +780,8 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     }
 
     std::vector<SegmentSplitInfo> segments;
-    RETURN_IF_ERROR(build_segments_from_rowsets(tablet_metadata->rowsets(), &segments));
+    RETURN_IF_ERROR(
+            build_segments_from_rowsets(tablet_manager, tablet_metadata, sort_key_sample_read_options(), &segments));
     if (segments.empty()) {
         return Status::InvalidArgument("No segments found in tablet metadata");
     }
@@ -973,7 +1070,8 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
     //    here is corruption (we already short-circuited the empty-rowsets case
     //    at step 4); external boundaries uses a distinct error message vs the data-driven path.
     std::vector<SegmentSplitInfo> segments;
-    RETURN_IF_ERROR(build_segments_from_rowsets(old_tablet_metadata->rowsets(), &segments));
+    RETURN_IF_ERROR(build_segments_from_rowsets(tablet_manager, old_tablet_metadata, sort_key_sample_read_options(),
+                                                &segments));
     if (segments.empty()) {
         return Status::InvalidArgument("rowsets present but no segments derived (possibly corrupt metadata)");
     }

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -20,10 +20,12 @@
 #include "common/statusor.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/lake/tablet_metadata.h"
+#include "storage/lake/types_fwd.h"
 #include "storage/variant_tuple.h"
 
 namespace starrocks {
 class TabletRange;
+struct LakeIOOptions;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -55,6 +57,11 @@ struct SegmentSplitInfo {
     // sort_key_sample_row_interval at their defaults (empty/zero).
     // Requires num_rows to be set before calling.
     Status load_sort_key_samples(const SegmentMetadataPB& segment_meta);
+
+    // Populate sort_key_samples / sort_key_sample_row_interval from the segment's sample page.
+    // Applies the same validity check as load_sort_key_samples; on failure leaves samples empty.
+    // `num_rows` must be set first.
+    Status load_sort_key_samples_from_segment(Segment* segment, const LakeIOOptions& lake_io_opts);
 };
 
 // Per-range estimated statistics keyed by source_id.
@@ -145,6 +152,20 @@ Status compute_split_ranges_from_external_boundaries(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
         const google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges,
         std::vector<TabletRangeInfo>* split_ranges);
+
+// Cache/I/O options for reading sort-key sample pages at split / range-split-compaction time:
+// one-shot read on a rare path, so don't fill the local data cache or the metadata cache; the
+// small immutable sample page is left eligible for the shared page cache (harmless to cache).
+LakeIOOptions sort_key_sample_read_options();
+
+// Open segment `segment_pos` of `rowset_meta` and populate `out`'s samples from its SORT_KEY_SAMPLE_PAGE.
+// BEST-EFFORT: sort-key samples only refine split-boundary accuracy, NEVER data correctness. A page
+// open/read failure (transient object-store error, corrupt page, or a legacy dummy-file test fixture)
+// must degrade the split/compaction to min/max-only distribution, NOT abort the reshard/compaction.
+// Therefore callers MUST invoke this via WARN_IF_ERROR and MUST NOT RETURN_IF_ERROR it.
+Status read_segment_sort_key_samples(TabletManager* tablet_manager, int64_t tablet_id,
+                                     const TabletSchemaPtr& tablet_schema, const LakeIOOptions& lake_io_opts,
+                                     const RowsetMetadataPB& rowset_meta, int segment_pos, SegmentSplitInfo* out);
 
 // -----------------------------------------------------------------------------
 // Phase-1 per-segment shared optimization. The helpers below are exposed for

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -114,6 +114,9 @@ Status PageIO::write_page(WritableFile* wfile, const std::vector<Slice>& body, c
     case SHORT_KEY_PAGE:
         CHECK(footer.has_short_key_page_footer());
         break;
+    case SORT_KEY_SAMPLE_PAGE:
+        // No sub-footer: samples + row_interval live in the body (SortKeySampleDataPB).
+        break;
     default:
         CHECK(false) << "Invalid page footer type: " << footer.type();
         break;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -283,6 +283,10 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
     RETURN_IF_ERROR(_create_column_readers(&footer));
     _num_rows = footer.num_rows();
     _short_key_index_page = PagePointer(footer.short_key_index_page());
+    _has_sort_key_sample_page = footer.has_sort_key_sample_page();
+    if (_has_sort_key_sample_page) {
+        _sort_key_sample_page = PagePointer(footer.sort_key_sample_page());
+    }
     _skip_vector_index =
             footer.has_vector_index_storage_type() && footer.vector_index_storage_type() == VECTOR_INDEX_STORAGE_NONE;
     return Status::OK();
@@ -436,6 +440,53 @@ Status Segment::_load_index(const LakeIOOptions& lake_io_opts) {
 
     _sk_index_decoder = std::make_unique<ShortKeyIndexDecoder>();
     return _sk_index_decoder->parse(body, footer.short_key_page_footer());
+}
+
+Status Segment::read_sort_key_samples(const LakeIOOptions& lake_io_opts, std::vector<VariantTuple>* out_samples,
+                                      int64_t* out_row_interval) {
+    out_samples->clear();
+    *out_row_interval = 0;
+    if (!_has_sort_key_sample_page) {
+        return Status::OK();
+    }
+    RandomAccessFileOptions file_opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache,
+                                      .buffer_size = lake_io_opts.buffer_size};
+    if (_encryption_info) {
+        file_opts.encryption_info = *_encryption_info;
+    } else if (!_segment_file_info.encryption_meta.empty()) {
+        ASSIGN_OR_RETURN(auto info, KeyCache::instance().unwrap_encryption_meta(_segment_file_info.encryption_meta));
+        file_opts.encryption_info = std::move(info);
+        _encryption_info = std::make_unique<FileEncryptionInfo>(file_opts.encryption_info);
+    }
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file_with_bundling(file_opts, _segment_file_info));
+
+    PageReadOptions opts;
+    opts.use_page_cache = lake_io_opts.use_page_cache;
+    opts.read_file = read_file.get();
+    opts.page_pointer = _sort_key_sample_page;
+    opts.codec = nullptr; // NO_COMPRESSION
+    OlapReaderStatistics tmp_stats;
+    opts.stats = &tmp_stats;
+
+    PageHandle handle;
+    Slice body;
+    PageFooterPB footer;
+    RETURN_IF_ERROR(PageIO::read_and_decompress_page(opts, &handle, &body, &footer));
+    if (footer.type() != SORT_KEY_SAMPLE_PAGE) {
+        return Status::Corruption("unexpected page type for sort key sample page");
+    }
+    SortKeySampleDataPB data;
+    if (!data.ParseFromArray(body.data, static_cast<int>(body.size))) {
+        return Status::Corruption("failed to parse sort key sample page");
+    }
+    out_samples->reserve(data.samples_size());
+    for (const auto& sample_pb : data.samples()) {
+        VariantTuple vt;
+        RETURN_IF_ERROR(vt.from_proto(sample_pb));
+        out_samples->push_back(std::move(vt));
+    }
+    *out_row_interval = data.row_interval();
+    return Status::OK();
 }
 
 void Segment::_reset() {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -51,6 +51,7 @@
 #include "storage/options.h"
 #include "storage/rowset/page_pointer.h"
 #include "storage/tablet_schema.h"
+#include "storage/variant_tuple.h"
 
 namespace starrocks {
 
@@ -209,6 +210,12 @@ public:
     Status load_index(const LakeIOOptions& lake_io_opts = {});
     bool has_loaded_index() const;
 
+    // Lazily read the sort-key sample page (if present). On OK, |out_samples| is filled
+    // with the segment's samples (empty if the segment has no sample page) and
+    // |out_row_interval| with the interval used to produce them (0 if empty).
+    Status read_sort_key_samples(const LakeIOOptions& lake_io_opts, std::vector<VariantTuple>* out_samples,
+                                 int64_t* out_row_interval);
+
     Status new_inverted_index_iterator(uint32_t cid, InvertedIndexIterator** iter, const SegmentReadOptions& opts,
                                        const IndexReadOptions& index_opt);
 
@@ -321,6 +328,8 @@ private:
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;
     PagePointer _short_key_index_page;
+    PagePointer _sort_key_sample_page;
+    bool _has_sort_key_sample_page = false;
     bool _skip_vector_index = false;
 
     // ColumnReader for each column in TabletSchema. If ColumnReader is nullptr,

--- a/be/src/storage/rowset/segment_file_info.cpp
+++ b/be/src/storage/rowset/segment_file_info.cpp
@@ -43,12 +43,6 @@ void SegmentFileInfo::to_proto(uint32_t segment_idx, SegmentMetadataPB* segment_
     // Sort-key fields.
     sort_key_min.to_proto(segment_meta->mutable_sort_key_min());
     sort_key_max.to_proto(segment_meta->mutable_sort_key_max());
-    for (const auto& sample : sort_key_samples) {
-        sample.to_proto(segment_meta->add_sort_key_samples());
-    }
-    if (!sort_key_samples.empty() && sort_key_sample_row_interval > 0) {
-        segment_meta->set_sort_key_sample_row_interval(sort_key_sample_row_interval);
-    }
     // Other per-segment metadata.
     segment_meta->set_num_rows(num_rows);
     segment_meta->set_segment_idx(segment_idx);

--- a/be/src/storage/rowset/segment_file_info.h
+++ b/be/src/storage/rowset/segment_file_info.h
@@ -33,12 +33,6 @@ void to_file_meta_pb(const FileInfo& file, FileMetaPB* file_meta);
 struct SegmentFileInfo : public FileInfo {
     VariantTuple sort_key_min;
     VariantTuple sort_key_max;
-    // Equal-row-interval samples of the sort key (NON-DECREASING) collected by
-    // SegmentWriter. May be empty for small segments (num_rows <= interval) or
-    // segments where sampling was not armed. Always paired with
-    // sort_key_sample_row_interval: samples.empty() <=> sort_key_sample_row_interval == 0.
-    std::vector<VariantTuple> sort_key_samples;
-    int64_t sort_key_sample_row_interval = 0;
     int64_t num_rows = 0;
     // IDs of vector indexes whose .vi file belongs to this segment (one .vi file per id).
     std::vector<int64_t> vector_index_ids;

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -138,6 +138,9 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         if (footer->has_short_key_index_page()) {
             *_footer.mutable_short_key_index_page() = footer->short_key_index_page();
         }
+        if (footer->has_sort_key_sample_page()) {
+            *_footer.mutable_sort_key_sample_page() = footer->sort_key_sample_page();
+        }
         _verify_footer();
         // in partial update, key columns have been written in partial segment
         // set _num_rows as _num_rows in partial segment
@@ -327,8 +330,6 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
 void SegmentWriter::write_sort_key_fields_to(SegmentFileInfo& file_info) {
     file_info.sort_key_min = _sort_key_min;
     file_info.sort_key_max = _sort_key_max;
-    file_info.sort_key_samples = std::move(_sort_key_samples);
-    file_info.sort_key_sample_row_interval = file_info.sort_key_samples.empty() ? 0 : _sort_key_sample_row_interval;
 }
 
 // TODO(lingbin): Currently this function does not include the size of various indexes,
@@ -419,6 +420,7 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
     if (_has_key) {
         uint64_t index_offset = _wfile->size();
         RETURN_IF_ERROR(_write_short_key_index());
+        RETURN_IF_ERROR(_write_sort_key_sample_page());
         *index_size += _wfile->size() - index_offset;
         _index_builder.reset();
     }
@@ -442,6 +444,29 @@ Status SegmentWriter::_write_short_key_index() {
     // short key index page is not compressed right now
     RETURN_IF_ERROR(PageIO::write_page(_wfile.get(), body, footer, &pp));
     pp.to_proto(_footer.mutable_short_key_index_page());
+    return Status::OK();
+}
+
+Status SegmentWriter::_write_sort_key_sample_page() {
+    if (_sort_key_samples.empty()) {
+        return Status::OK();
+    }
+    SortKeySampleDataPB data;
+    for (const auto& sample : _sort_key_samples) {
+        sample.to_proto(data.add_samples());
+    }
+    data.set_row_interval(_sort_key_sample_row_interval);
+    std::string buf;
+    if (!data.SerializeToString(&buf)) {
+        return Status::InternalError("failed to serialize sort key sample page");
+    }
+    std::vector<Slice> body{Slice(buf)};
+    PageFooterPB footer;
+    footer.set_type(SORT_KEY_SAMPLE_PAGE);
+    footer.set_uncompressed_size(static_cast<uint32_t>(buf.size()));
+    PagePointer pp;
+    RETURN_IF_ERROR(PageIO::write_page(_wfile.get(), body, footer, &pp)); // NO_COMPRESSION
+    pp.to_proto(_footer.mutable_sort_key_sample_page());
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -179,10 +179,10 @@ public:
     const VariantTuple& get_sort_key_min() { return _sort_key_min; }
     const VariantTuple& get_sort_key_max() { return _sort_key_max; }
 
-    // Transfer sort-key min, max, samples, and interval into a SegmentFileInfo.
-    // Moves _sort_key_samples out; preserves the carrier invariant
-    // (samples.empty() <=> interval == 0). Callers serialize the resulting
-    // SegmentFileInfo to a SegmentMetadataPB via SegmentFileInfo::to_proto().
+    // Transfer sort-key min/max into a SegmentFileInfo. Samples are no longer routed
+    // through SegmentFileInfo; they are written directly to a SORT_KEY_SAMPLE_PAGE by
+    // _write_sort_key_sample_page during finalize_columns. Callers serialize the
+    // resulting SegmentFileInfo to a SegmentMetadataPB via SegmentFileInfo::to_proto().
     void write_sort_key_fields_to(SegmentFileInfo& file_info);
 
     // Accessors for sort-key samples (used in unit tests).
@@ -191,6 +191,7 @@ public:
 
 private:
     Status _write_short_key_index();
+    Status _write_sort_key_sample_page();
     Status _write_footer();
     Status _write_raw_data(const std::vector<Slice>& slices);
     void _init_column_meta(ColumnMetaPB* meta, uint32_t column_id, const TabletColumn& column);

--- a/be/src/storage/rowset/storage_page_decoder.cpp
+++ b/be/src/storage/rowset/storage_page_decoder.cpp
@@ -162,7 +162,8 @@ Status StoragePageDecoder::decode_page(PageFooterPB* footer, uint32_t footer_siz
     DCHECK(footer->has_type()) << "type must be set";
     switch (footer->type()) {
     case INDEX_PAGE:
-    case SHORT_KEY_PAGE: {
+    case SHORT_KEY_PAGE:
+    case SORT_KEY_SAMPLE_PAGE: {
         return Status::OK();
     }
     case DICTIONARY_PAGE:

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -22,11 +22,16 @@
 #include "base/failpoint/fail_point.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/utility/defer_op.h"
+#include "column/chunk.h"
+#include "column/fixed_length_column.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_primary_key_fwd.h"
+#include "common/config_rowset_fwd.h"
 #include "common/thread/threadpool.h"
 #include "fs/fs_factory.h"
 #include "gen_cpp/lake_service.pb.h"
+#include "storage/chunk_helper.h"
 #include "storage/datum_variant.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/compaction_task_context.h"
@@ -34,6 +39,8 @@
 #include "storage/lake/test_util.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/rows_mapper.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet_schema.h"
 #include "storage/types.h"
 #include "storage/variant_tuple.h"
 #include "types/type_descriptor.h"
@@ -4689,7 +4696,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_collect_segment_key_bounds) {
             rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), meta, i, 0));
         }
 
-        auto result = TabletParallelCompactionManager::_collect_segment_key_bounds(rowsets);
+        auto result = _manager->_collect_segment_key_bounds(rowsets);
         ASSERT_TRUE(result.ok());
         ASSERT_EQ(3, result.value().size());
         EXPECT_EQ(200, result.value()[0].num_rows);
@@ -4725,7 +4732,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_collect_segment_key_bounds) {
             rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), meta, i, 0));
         }
 
-        auto result = TabletParallelCompactionManager::_collect_segment_key_bounds(rowsets);
+        auto result = _manager->_collect_segment_key_bounds(rowsets);
         ASSERT_TRUE(result.ok());
         ASSERT_EQ(3, result.value().size());
         for (const auto& bound : result.value()) {
@@ -4764,11 +4771,95 @@ TEST_F(TabletParallelCompactionManagerTest, test_collect_segment_key_bounds) {
             rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), meta, i, 0));
         }
 
-        auto result = TabletParallelCompactionManager::_collect_segment_key_bounds(rowsets);
+        auto result = _manager->_collect_segment_key_bounds(rowsets);
         ASSERT_TRUE(result.ok());
         ASSERT_EQ(2, result.value().size());
         EXPECT_EQ(1000, result.value()[0].data_size); // 100/400 * 4000
         EXPECT_EQ(3000, result.value()[1].data_size); // 300/400 * 4000
+    }
+}
+
+// _collect_segment_key_bounds reads sort-key samples from each segment's
+// SORT_KEY_SAMPLE_PAGE when SegmentMetadataPB carries none. Uses a REAL
+// TabletManager-backed rowset with a genuine compaction_segment_limit (a real
+// partial-compaction Rowset, not just next_compaction_offset metadata): the
+// consumer iterates rowset->metadata().segment_metas() and opens each segment
+// by position, so it must still read ALL segments' samples even though the
+// limited Rowset's own segments() accessor would trim to fewer.
+TEST_F(TabletParallelCompactionManagerTest, test_collect_segment_key_bounds_reads_page_samples_partial_compaction) {
+    auto old_interval = config::segment_sort_key_sample_row_interval;
+    DeferOp guard([old_interval]() { config::segment_sort_key_sample_row_interval = old_interval; });
+    config::segment_sort_key_sample_row_interval = 5;
+
+    const int64_t tablet_id = 20301;
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    metadata->set_id(tablet_id);
+    metadata->set_version(2);
+
+    auto tablet_schema = TabletSchema::create(metadata->schema());
+
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(0);
+    rowset->set_overlapped(true);
+
+    const int num_segments = 3;
+    const int rows_per_segment = 21; // interval=5 -> (21-1)/5 = 4 samples per segment.
+    int64_t total_rows = 0;
+    for (int s = 0; s < num_segments; ++s) {
+        std::string segment_name = fmt::format("page_seg_{}.dat", s);
+        std::string path = _lp->segment_location(tablet_id, segment_name);
+        std::string dir = std::filesystem::path(path).parent_path().string();
+        CHECK_OK(fs::create_directories(dir));
+
+        WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wfile, fs::new_writable_file(fopts, path));
+        SegmentWriterOptions wopts;
+        SegmentWriter writer(std::move(wfile), 0, tablet_schema, wopts);
+        CHECK_OK(writer.init());
+
+        const int base = s * 100;
+        auto col0 = Int32Column::create();
+        auto col1 = Int32Column::create();
+        std::vector<int> v0(rows_per_segment), v1(rows_per_segment, 0);
+        for (int i = 0; i < rows_per_segment; ++i) v0[i] = base + i;
+        col0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        col1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        auto chunk_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+        auto chunk = std::make_shared<Chunk>(Columns{std::move(col0), std::move(col1)}, chunk_schema);
+        CHECK_OK(writer.append_chunk(*chunk));
+
+        uint64_t seg_size = 0, index_size = 0, footer_position = 0;
+        CHECK_OK(writer.finalize(&seg_size, &index_size, &footer_position));
+
+        auto* segment_meta = rowset->add_segment_metas();
+        segment_meta->set_filename(segment_name);
+        segment_meta->set_size(static_cast<int64_t>(seg_size));
+        segment_meta->set_num_rows(rows_per_segment);
+        segment_meta->mutable_sort_key_min()->CopyFrom(make_int_tuple(base));
+        segment_meta->mutable_sort_key_max()->CopyFrom(make_int_tuple(base + rows_per_segment - 1));
+        total_rows += rows_per_segment;
+    }
+    rowset->set_num_rows(total_rows);
+    rowset->set_data_size(total_rows * 8);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(tablet_id, 2));
+    auto meta = tablet.metadata();
+
+    // A REAL limited/partial-compaction Rowset: compaction_segment_limit=1 (< num_segments).
+    std::vector<RowsetPtr> rowsets;
+    rowsets.push_back(std::make_shared<Rowset>(_tablet_mgr.get(), meta, /*rowset_index=*/0,
+                                               /*compaction_segment_limit=*/1));
+
+    auto result = _manager->_collect_segment_key_bounds(rowsets);
+    ASSERT_TRUE(result.ok());
+    ASSERT_EQ(num_segments, result.value().size());
+    for (const auto& seg : result.value()) {
+        EXPECT_EQ(4U, seg.sort_key_samples.size());
+        EXPECT_EQ(5, seg.sort_key_sample_row_interval);
+        for (size_t i = 1; i < seg.sort_key_samples.size(); ++i) {
+            EXPECT_LE(seg.sort_key_samples[i - 1].compare(seg.sort_key_samples[i]), 0);
+        }
     }
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -29,6 +29,7 @@
 #include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/column_helper.h"
+#include "common/config_rowset_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "fs/fs.h"
 #include "fs/fs_factory.h"
@@ -46,6 +47,7 @@
 #include "storage/lake/tablet_merger_split_family.h"
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reshard_helper.h"
+#include "storage/lake/tablet_splitter.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/rowset/segment.h"
@@ -827,6 +829,138 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
     EXPECT_EQ(0, tablet_ranges.size());
 }
 
+// Data-driven split reads sort-key samples from the segment's SORT_KEY_SAMPLE_PAGE (new
+// writer, no metadata samples) rather than SegmentMetadataPB.sort_key_samples. Proven by
+// parity: the page-backed metadata (real TabletManager, segments carry samples only in
+// their page) must produce byte-identical split ranges to an equivalent legacy metadata
+// (tablet_manager=nullptr, samples set directly on SegmentMetadataPB) -- if the page were
+// not opened/read, the page-backed run would degrade to no-sample distribution and diverge.
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_reads_sort_key_samples_from_segment_page) {
+    auto old_interval = config::segment_sort_key_sample_row_interval;
+    DeferOp guard([old_interval]() { config::segment_sort_key_sample_row_interval = old_interval; });
+    config::segment_sort_key_sample_row_interval = 10;
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_id(9101);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto* c0 = schema_pb.add_column();
+    c0->set_unique_id(1);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+    auto* c1 = schema_pb.add_column();
+    c1->set_unique_id(2);
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(false);
+    c1->set_is_nullable(false);
+    c1->set_aggregation("REPLACE");
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+
+    // 101 rows with keys 0..100 (monotonic, dense) -> min=0, max=100. With
+    // row_interval=10, samples fire at 0-indexed rows 10,20,...,100 (10 samples).
+    const int num_rows = 101;
+    auto write_monotonic_segment = [&](const std::string& seg_name) -> uint64_t {
+        auto segment_path = _tablet_manager->segment_location(tablet_id, seg_name);
+        WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wfile_or = fs::new_writable_file(fopts, segment_path);
+        CHECK_OK(wfile_or.status());
+        SegmentWriterOptions opts;
+        SegmentWriter writer(std::move(wfile_or.value()), 0, tablet_schema, opts);
+        CHECK_OK(writer.init());
+        auto col0 = Int32Column::create();
+        auto col1 = Int32Column::create();
+        std::vector<int> v0(num_rows), v1(num_rows);
+        for (int i = 0; i < num_rows; ++i) {
+            v0[i] = i;
+            v1[i] = i;
+        }
+        col0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        col1->append_numbers(v1.data(), v1.size() * sizeof(int));
+        auto chunk_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+        auto chunk = std::make_shared<Chunk>(Columns{std::move(col0), std::move(col1)}, chunk_schema);
+        CHECK_OK(writer.append_chunk(*chunk));
+        uint64_t segment_file_size = 0, index_size = 0, footer_position = 0;
+        CHECK_OK(writer.finalize(&segment_file_size, &index_size, &footer_position));
+        return segment_file_size;
+    };
+
+    const uint64_t seg0_size = write_monotonic_segment("seg_0.dat");
+    const uint64_t seg1_size = write_monotonic_segment("seg_1.dat");
+
+    std::vector<int64_t> expected_samples;
+    for (int64_t v = 10; v <= 100; v += 10) expected_samples.push_back(v);
+    ASSERT_EQ(10U, expected_samples.size());
+
+    auto build_metadata = [&](bool with_legacy_samples) {
+        auto m = std::make_shared<TabletMetadataPB>();
+        m->set_id(tablet_id);
+        m->set_version(1);
+        *m->mutable_schema() = schema_pb;
+        auto* rowset = m->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_overlapped(true);
+        rowset->set_num_rows(2 * num_rows);
+        rowset->set_data_size(static_cast<int64_t>(seg0_size + seg1_size));
+        for (int s = 0; s < 2; ++s) {
+            auto* sm = rowset->add_segment_metas();
+            sm->set_filename(s == 0 ? "seg_0.dat" : "seg_1.dat");
+            sm->set_size(static_cast<int64_t>(s == 0 ? seg0_size : seg1_size));
+            sm->set_num_rows(num_rows);
+            *sm->mutable_sort_key_min() = generate_sort_key(0);
+            *sm->mutable_sort_key_max() = generate_sort_key(100);
+            if (with_legacy_samples) {
+                for (int64_t v : expected_samples) {
+                    *sm->add_deprecated_sort_key_samples() = generate_sort_key(static_cast<int>(v));
+                }
+                sm->set_deprecated_sort_key_sample_row_interval(10);
+            }
+        }
+        return m;
+    };
+
+    // A) page-backed: real tablet_manager, no legacy metadata samples. Must open the real
+    //    segment files and read their SORT_KEY_SAMPLE_PAGE.
+    auto meta_page = build_metadata(/*with_legacy_samples=*/false);
+    std::vector<lake::TabletRangeInfo> ranges_page;
+    ASSERT_OK(lake::get_tablet_split_ranges(_tablet_manager.get(), meta_page, /*split_count=*/2, &ranges_page));
+
+    // B) legacy metadata-backed parity reference: identical sample content, no I/O needed
+    //    (tablet_manager=nullptr proves this path never touches the segment files).
+    auto meta_legacy = build_metadata(/*with_legacy_samples=*/true);
+    std::vector<lake::TabletRangeInfo> ranges_legacy;
+    ASSERT_OK(
+            lake::get_tablet_split_ranges(/*tablet_manager=*/nullptr, meta_legacy, /*split_count=*/2, &ranges_legacy));
+
+    ASSERT_EQ(2U, ranges_page.size());
+    ASSERT_EQ(ranges_legacy.size(), ranges_page.size());
+    for (size_t i = 0; i < ranges_page.size(); ++i) {
+        EXPECT_EQ(ranges_legacy[i].range.SerializeAsString(), ranges_page[i].range.SerializeAsString())
+                << "range " << i;
+        ASSERT_EQ(ranges_legacy[i].rowset_stats.size(), ranges_page[i].rowset_stats.size());
+        for (const auto& [rowset_id, stat] : ranges_page[i].rowset_stats) {
+            auto it = ranges_legacy[i].rowset_stats.find(rowset_id);
+            ASSERT_NE(ranges_legacy[i].rowset_stats.end(), it);
+            EXPECT_EQ(it->second.num_rows, stat.num_rows);
+            EXPECT_EQ(it->second.data_size, stat.data_size);
+            EXPECT_EQ(it->second.num_dels, stat.num_dels);
+        }
+    }
+
+    // Row conservation across both children.
+    int64_t total_rows = 0;
+    for (const auto& r : ranges_page) {
+        for (const auto& [rowset_id, stat] : r.rowset_stats) total_rows += stat.num_rows;
+    }
+    EXPECT_EQ(2 * num_rows, total_rows);
+}
+
 // A flush_pk_memtable failure during an identical-tablet reshard must propagate out of
 // publish_resharding_tablet rather than copying stale, unflushed metadata onto the new tablet.
 TEST_F(LakeTabletReshardTest, test_identical_tablet_flush_failure_propagates) {
@@ -1421,9 +1555,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_fewer_ranges_than_requested_
         sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
         sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(300));
         sm->set_num_rows(300);
-        sm->set_sort_key_sample_row_interval(100);
-        sm->add_sort_key_samples()->CopyFrom(generate_sort_key(100));
-        sm->add_sort_key_samples()->CopyFrom(generate_sort_key(200));
+        sm->set_deprecated_sort_key_sample_row_interval(100);
+        sm->add_deprecated_sort_key_samples()->CopyFrom(generate_sort_key(100));
+        sm->add_deprecated_sort_key_samples()->CopyFrom(generate_sort_key(200));
     }
     rowset_meta_pb->set_num_rows(300);
     rowset_meta_pb->set_data_size(1024);
@@ -2089,9 +2223,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_three_level_chain_
         sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(min_v));
         sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(max_v));
         sm->set_num_rows(num_rows);
-        sm->set_sort_key_sample_row_interval(interval);
+        sm->set_deprecated_sort_key_sample_row_interval(interval);
         for (int v = min_v + interval; v < max_v; v += interval) {
-            sm->add_sort_key_samples()->CopyFrom(generate_sort_key(v));
+            sm->add_deprecated_sort_key_samples()->CopyFrom(generate_sort_key(v));
         }
     };
 

--- a/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
+++ b/be/test/storage/rowset/segment_writer_sort_key_sampling_test.cpp
@@ -22,9 +22,14 @@
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
+#include "common/config_rowset_fwd.h"
 #include "fs/fs_memory.h"
+#include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/substitute.h"
 #include "storage/chunk_helper.h"
+#include "storage/options.h"
+#include "storage/rowset/page_pointer.h"
+#include "storage/rowset/segment.h"
 #include "storage/rowset/segment_file_info.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
@@ -252,25 +257,154 @@ TEST_F(SegmentWriterSortKeySamplingTest, vertical_writer_reinit_preserves_sample
 }
 
 // ---------------------------------------------------------------------------
-// write_sort_key_fields_to(SegmentFileInfo&) transfers min, max, samples, and
-// interval into a SegmentFileInfo. Preserves the carrier invariant
-// (samples.empty() <=> 0).
+// write_sort_key_fields_to(SegmentFileInfo&) copies only sort-key min/max.
+// Samples are no longer routed through SegmentFileInfo -- they stay in the
+// writer and are consumed by _write_sort_key_sample_page during finalize.
 // ---------------------------------------------------------------------------
-TEST_F(SegmentWriterSortKeySamplingTest, write_sort_key_fields_to_transfers_ownership) {
+TEST_F(SegmentWriterSortKeySamplingTest, write_sort_key_fields_to_copies_min_max_only) {
+    const int64_t num_rows = 2 * kInterval + 3;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+    SegmentFileInfo file_info;
+    w->write_sort_key_fields_to(file_info);
+    EXPECT_FALSE(file_info.sort_key_min.empty());
+    EXPECT_FALSE(file_info.sort_key_max.empty());
+    // Samples stay in the writer (consumed by _write_sort_key_sample_page during finalize),
+    // no longer moved into SegmentFileInfo.
+    EXPECT_EQ(2U, w->get_sort_key_samples().size());
+    EXPECT_EQ(kInterval, w->get_sort_key_sample_row_interval());
+}
+
+// ---------------------------------------------------------------------------
+// Sort-key samples are written to a SORT_KEY_SAMPLE_PAGE in the segment file
+// and are no longer present in SegmentMetadataPB (built from SegmentFileInfo).
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, samples_written_to_page_not_metadata) {
     const int64_t num_rows = 2 * kInterval + 3;
     auto w = new_writer(0);
     ASSERT_OK(w->init(true));
     auto chunk = make_increasing_chunk(num_rows, 0);
     ASSERT_OK(w->append_chunk(*chunk));
 
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(w->finalize(&file_size, &index_size, &footer_position));
+
     SegmentFileInfo file_info;
     w->write_sort_key_fields_to(file_info);
-    EXPECT_EQ(2U, file_info.sort_key_samples.size());
-    EXPECT_EQ(kInterval, file_info.sort_key_sample_row_interval);
-    EXPECT_FALSE(file_info.sort_key_min.empty());
-    EXPECT_FALSE(file_info.sort_key_max.empty());
-    // After fill, writer's samples should be moved out.
-    EXPECT_TRUE(w->get_sort_key_samples().empty());
+    SegmentMetadataPB segment_meta;
+    file_info.to_proto(/*segment_idx=*/0, &segment_meta);
+    EXPECT_EQ(0, segment_meta.deprecated_sort_key_samples_size());
+    EXPECT_FALSE(segment_meta.has_deprecated_sort_key_sample_row_interval());
+
+    // The on-disk footer carries the page pointer instead.
+    ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(w->segment_path()));
+    SegmentFooterPB footer;
+    // Pass nullptr for the footer-length hint so parse reads the default tail window from EOF
+    // (a zero-valued hint would read 0 bytes and fail the magic check).
+    ASSERT_OK(Segment::parse_segment_footer(read_file.get(), &footer, nullptr, nullptr).status());
+    ASSERT_TRUE(footer.has_sort_key_sample_page());
+    EXPECT_GT(footer.sort_key_sample_page().size(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Partial-update rewrite: init(cols, has_key=false, &partial_footer) merges
+// the supplied footer's sort_key_sample_page pointer into the new writer's
+// footer, and it survives finalize (verified via the on-disk footer, since
+// this writer itself never re-arms sampling with has_key=false).
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, sort_key_sample_page_preserved_on_partial_update_rewrite) {
+    SegmentFooterPB partial_footer;
+    PagePointer pp(/*offset=*/123, /*size=*/456);
+    pp.to_proto(partial_footer.mutable_sort_key_sample_page());
+    partial_footer.set_num_rows(1);
+
+    auto w = new_writer(0);
+    std::vector<uint32_t> value_cols{1};
+    ASSERT_OK(w->init(value_cols, /*has_key=*/false, &partial_footer));
+
+    auto s = ChunkHelper::convert_schema(_schema, value_cols);
+    auto chunk = ChunkFactory::new_chunk(s, 1);
+    chunk->columns()[0]->as_mutable_ptr()->append_datum(Datum(static_cast<int32_t>(0)));
+    ASSERT_OK(w->append_chunk(*chunk));
+
+    uint64_t index_size = 0;
+    uint64_t file_size = 0;
+    ASSERT_OK(w->finalize_columns(&index_size));
+    ASSERT_OK(w->finalize_footer(&file_size));
+
+    ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(w->segment_path()));
+    SegmentFooterPB footer;
+    // Pass nullptr for the footer-length hint so parse reads the default tail window from EOF
+    // (a zero-valued hint would read 0 bytes and fail the magic check).
+    ASSERT_OK(Segment::parse_segment_footer(read_file.get(), &footer, nullptr, nullptr).status());
+    ASSERT_TRUE(footer.has_sort_key_sample_page());
+    EXPECT_EQ(123, footer.sort_key_sample_page().offset());
+    EXPECT_EQ(456, footer.sort_key_sample_page().size());
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: Segment::read_sort_key_samples() reads back exactly the samples
+// the writer produced, in order.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, read_sort_key_samples_round_trip) {
+    const int64_t num_rows = 2 * kInterval + 3;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+    const auto expected_samples = w->get_sort_key_samples();
+
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(w->finalize(&file_size, &index_size, &footer_position));
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{w->segment_path()}, 0, _schema));
+
+    std::vector<VariantTuple> samples;
+    int64_t interval = 0;
+    LakeIOOptions io_opts; // defaults
+    ASSERT_OK(segment->read_sort_key_samples(io_opts, &samples, &interval));
+    EXPECT_EQ((num_rows - 1) / config::segment_sort_key_sample_row_interval, (int64_t)samples.size());
+    EXPECT_EQ(config::segment_sort_key_sample_row_interval, interval);
+    ASSERT_EQ(expected_samples.size(), samples.size());
+    for (size_t i = 0; i < samples.size(); ++i) {
+        EXPECT_EQ(0, expected_samples[i].compare(samples[i]));
+    }
+    for (size_t i = 1; i < samples.size(); ++i) {
+        EXPECT_LE(samples[i - 1].compare(samples[i]), 0);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small segment (num_rows <= interval): no sample page is written; reading
+// back yields an empty sample set and interval == 0.
+// ---------------------------------------------------------------------------
+TEST_F(SegmentWriterSortKeySamplingTest, read_sort_key_samples_small_segment_is_empty) {
+    const int64_t num_rows = kInterval - 1;
+    auto w = new_writer(0);
+    ASSERT_OK(w->init(true));
+    auto chunk = make_increasing_chunk(num_rows, 0);
+    ASSERT_OK(w->append_chunk(*chunk));
+    ASSERT_TRUE(w->get_sort_key_samples().empty());
+
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+    uint64_t footer_position = 0;
+    ASSERT_OK(w->finalize(&file_size, &index_size, &footer_position));
+
+    ASSIGN_OR_ABORT(auto segment, Segment::open(_fs, FileInfo{w->segment_path()}, 0, _schema));
+
+    std::vector<VariantTuple> samples;
+    int64_t interval = 0;
+    LakeIOOptions io_opts;
+    ASSERT_OK(segment->read_sort_key_samples(io_opts, &samples, &interval));
+    EXPECT_TRUE(samples.empty());
+    EXPECT_EQ(0, interval);
 }
 
 } // namespace starrocks

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -214,22 +214,21 @@ message SegmentMetadataPB {
     // IDs of vector indexes that need .vi files for this segment.
     // Only populated when the segment meets the build threshold.
     repeated int64 vector_index_ids = 5;
-    // Equal-row-interval samples of the sort key, NON-DECREASING.
-    // sort_key_samples[i] is the sort key at 0-indexed row (i+1) * interval,
-    // where interval == sort_key_sample_row_interval. Always paired with
-    // a positive sort_key_sample_row_interval. May be empty when num_rows
-    // is not greater than interval (small segments produce no samples
-    // because the first sample row is at index `interval`, which only
-    // exists for num_rows > interval). Consumed by tablet split and
-    // range-split parallel compaction to accurately estimate row
-    // distribution for overlapping segments.
-    repeated TuplePB sort_key_samples = 6;
-    // Row interval used to produce sort_key_samples. Set if and only if
-    // sort_key_samples_size() > 0; in that case the value is > 0 and
-    // sort_key_samples.size() * sort_key_sample_row_interval < num_rows.
-    // Persisted per-segment so a future change to the producer's interval
-    // constant cannot break cross-version readers.
-    optional int64 sort_key_sample_row_interval = 7;
+    // DEPRECATED (renamed with deprecated_ prefix to prevent new use): the canonical home for
+    // sort-key samples is now the segment's SORT_KEY_SAMPLE_PAGE (SegmentFooterPB.sort_key_sample_page,
+    // body SortKeySampleDataPB), which keeps tablet metadata from growing with row count. Current
+    // writers do NOT populate these fields; tablet split / range-split compaction read them ONLY as a
+    // fallback for segments written before the relocation. Field numbers 6/7 are reserved forever and
+    // MUST NOT be renumbered or reused. A later version may drop the read-fallback and add
+    // [deprecated = true] once no live segment stores samples only in metadata.
+    //
+    // Equal-row-interval samples of the sort key, NON-DECREASING: element i is the sort key at
+    // 0-indexed row (i+1) * deprecated_sort_key_sample_row_interval. json_name preserves the original
+    // field name so JSON dump/tooling output is unchanged by the rename (matches deprecated_segments etc.).
+    repeated TuplePB deprecated_sort_key_samples = 6 [json_name = "sort_key_samples"];
+    // Row interval that produced deprecated_sort_key_samples (see above). Set iff
+    // deprecated_sort_key_samples is non-empty; then > 0 and size() * interval < num_rows.
+    optional int64 deprecated_sort_key_sample_row_interval = 7 [json_name = "sort_key_sample_row_interval"];
     // File attributes of the segment. These are the canonical home for the
     // per-segment file info that historically lived in the parallel arrays on
     // RowsetMetadataPB (deprecated_segments / deprecated_segment_size /

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -68,6 +68,7 @@ enum PageTypePB {
     INDEX_PAGE = 2;
     DICTIONARY_PAGE = 3;
     SHORT_KEY_PAGE = 4;
+    SORT_KEY_SAMPLE_PAGE = 5;
 }
 
 enum NullEncodingPB {
@@ -131,6 +132,14 @@ message ShortKeyFooterPB {
     optional uint32 num_rows_per_block = 5;
     // How many rows in this segment
     optional uint32 num_segment_rows = 6;
+}
+
+// Body of a SORT_KEY_SAMPLE_PAGE. Equal-row-interval samples of the sort key,
+// NON-DECREASING; samples[i] is the sort key at 0-indexed row (i+1) * row_interval.
+// Relocated here from SegmentMetadataPB.sort_key_samples so tablet metadata stays small.
+message SortKeySampleDataPB {
+    repeated TuplePB samples = 1;
+    optional int64 row_interval = 2;
 }
 
 message PageFooterPB {
@@ -226,6 +235,11 @@ message SegmentFooterPB {
     optional PagePointerPB short_key_index_page = 9;
     // vector index storage type
     optional VectorIndexStorageTypePB vector_index_storage_type = 10;
+    // Page pointer to the sort-key sample page (body: serialized SortKeySampleDataPB).
+    // Written by new segment writers; read lazily only at tablet split / range-split
+    // compaction. Absent for segments written before this change (their samples, if any,
+    // live in the deprecated-for-write SegmentMetadataPB.sort_key_samples).
+    optional PagePointerPB sort_key_sample_page = 11;
 }
 
 message BTreeMetaPB {


### PR DESCRIPTION
## Why I'm doing:

To make tablet-split points accurate in shared-data range-distributed tables, the segment writer records one sort-key sample tuple every `segment_sort_key_sample_row_interval` (default 65536) rows. These samples were stored in tablet metadata (`SegmentMetadataPB.sort_key_samples`), which is read and parsed on every hot-path metadata access (publish, planner, compaction pick, vacuum, `get_tablet_stats`). Because the sample count grows with the segment's row count, for large tablets the samples dominate tablet-metadata size and slow down every metadata read/parse.

## What I'm doing:

The samples are consumed only at tablet split and range-split parallel compaction (both rare, reshard-triggered). This PR relocates them out of the hot tablet metadata into a dedicated, lazily-read `SORT_KEY_SAMPLE_PAGE` inside the segment file, referenced by a `PagePointerPB` in `SegmentFooterPB` — mirroring the existing `short_key_index_page`. Normal segment open and scans are unaffected because the page is read only at split time.

- `segment.proto`: add `PageTypePB::SORT_KEY_SAMPLE_PAGE`, message `SortKeySampleDataPB`, and `SegmentFooterPB.sort_key_sample_page`.
- Page I/O: accept the new footer-less page type in `PageIO::write_page` and as a no-op in `StoragePageDecoder::decode_page`.
- `SegmentWriter`: write the samples as a page during `finalize`; stop routing them through `SegmentFileInfo` into tablet metadata; preserve the page pointer across partial-update segment rewrite.
- `Segment`: add `read_sort_key_samples()` that lazily reads the page.
- Tablet split (data-driven and external-boundaries paths) and range-split parallel compaction: read samples from the segment page, falling back to the legacy metadata fields for segments written before this change. The read is best-effort/non-fatal — a page-read failure is logged (`WARN_IF_ERROR`) and degrades to a coarser (no-sample) split rather than failing the reshard, since samples only affect split-point balance, never data correctness.

The now-legacy tablet-metadata fields are renamed with a `deprecated_` prefix — `deprecated_sort_key_samples` / `deprecated_sort_key_sample_row_interval` (field numbers 6/7 unchanged, with `json_name` preserving the original JSON names, matching the sibling `deprecated_segments` convention) — to prevent new use. They are read only as a fallback for pre-relocation segments and are no longer written; a later version can add `[deprecated = true]` and drop the fallback once no live segment stores samples only in metadata. Note: the sampler lives in the shared `SegmentWriter`, so shared-nothing segments also persist this (small) page even though only the shared-data split/compaction paths read it.

Verification: new BE unit tests cover the writer→page→reader round-trip (and assert no samples remain in tablet metadata), partial-update footer-pointer preservation, and — end-to-end — that split produces byte-identical ranges whether samples are read from the page or from legacy metadata (parity), plus a range-split parallel-compaction case over a real partial-compaction rowset. Focused `starrocks_dw_test` suites: 320/320 pass.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

