### PR TITLE
[Tool] Pass github.token to FE/BE-UT review clone

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -92,6 +92,11 @@ jobs:
     env:
       BRANCH:      ${{ needs.prepare.outputs.BRANCH }}
       COMMIT_SHA:  ${{ needs.prepare.outputs.COMMIT_SHA }}
+      # elastic-ut-review.sh clones the repo inside the ECI via
+      # https://$GITHUB_ACCESS_TOKEN@github.com/... . On forks/CelerData the
+      # [ubuntu, ai] runner's init.sh does not inject GITHUB_ACCESS_TOKEN, so
+      # pass the run token here (no-op for the public StarRocks/starrocks clone).
+      GITHUB_ACCESS_TOKEN: ${{ github.token }}
     outputs:
       oss_path: ${{ steps.run_ut.outputs.oss_path }}
     steps:
@@ -128,6 +133,9 @@ jobs:
     env:
       BRANCH:      ${{ needs.prepare.outputs.BRANCH }}
       COMMIT_SHA:  ${{ needs.prepare.outputs.COMMIT_SHA }}
+      # See FE-UT REVIEW: pass the run token so the in-ECI git clone in
+      # elastic-ut-review.sh has credentials on the [ubuntu, ai] runner.
+      GITHUB_ACCESS_TOKEN: ${{ github.token }}
     outputs:
       oss_path: ${{ steps.run_ut.outputs.oss_path }}
     steps:


### PR DESCRIPTION
## Why I'm doing:

`UNSTABLE CASE REVIEW`'s FE-UT / BE-UT jobs run on `[self-hosted, ubuntu, ai]`, whose `lib/init.sh` does not inject `GITHUB_ACCESS_TOKEN`. `bin/elastic-ut-review.sh` builds the in-ECI clone URL as `https://${GITHUB_ACCESS_TOKEN}@github.com/...`; with an empty token it becomes `https://@github.com/...` → anonymous clone. On forks / CelerData (private repo) that fails with `fatal: could not read Password` → 0 cases → the trailing `tar ... run*/` exits 2. On CelerData this workflow has failed on every run since 2026-07-13. (SQL-Tester review is unaffected — it uses `actions/checkout` + `deploy-cluster.sh`, not the in-ECI token clone.)

## What I'm doing:

Pass the workflow run token as `GITHUB_ACCESS_TOKEN: ${{ github.token }}` in the `fe-ut-review` and `be-ut-review` job env, so the in-ECI clone has valid credentials without depending on the runner's `init.sh`. No-op for the public `StarRocks/starrocks` clone (that path uses an empty token by design).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: fixes the FE/BE-UT unstable-case review clone (CI tooling only)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4