### PR TITLE
[Tool] Fix FE/BE-UT review clone token format (x-access-token)

### DIFF
--- a/.github/workflows/unstable-case-review.yml
+++ b/.github/workflows/unstable-case-review.yml
@@ -94,9 +94,10 @@ jobs:
       COMMIT_SHA:  ${{ needs.prepare.outputs.COMMIT_SHA }}
       # elastic-ut-review.sh clones the repo inside the ECI via
       # https://$GITHUB_ACCESS_TOKEN@github.com/... . On forks/CelerData the
-      # [ubuntu, ai] runner's init.sh does not inject GITHUB_ACCESS_TOKEN, so
-      # pass the run token here (no-op for the public StarRocks/starrocks clone).
-      GITHUB_ACCESS_TOKEN: ${{ github.token }}
+      # [ubuntu, ai] runner's init.sh does not inject GITHUB_ACCESS_TOKEN. The
+      # run token must use the x-access-token: form (a bare GITHUB_TOKEN as the
+      # userinfo is rejected). No-op for the public StarRocks/starrocks clone.
+      GITHUB_ACCESS_TOKEN: "x-access-token:${{ github.token }}"
     outputs:
       oss_path: ${{ steps.run_ut.outputs.oss_path }}
     steps:
@@ -135,7 +136,7 @@ jobs:
       COMMIT_SHA:  ${{ needs.prepare.outputs.COMMIT_SHA }}
       # See FE-UT REVIEW: pass the run token so the in-ECI git clone in
       # elastic-ut-review.sh has credentials on the [ubuntu, ai] runner.
-      GITHUB_ACCESS_TOKEN: ${{ github.token }}
+      GITHUB_ACCESS_TOKEN: "x-access-token:${{ github.token }}"
     outputs:
       oss_path: ${{ steps.run_ut.outputs.oss_path }}
     steps:


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #76686. That PR passed `GITHUB_ACCESS_TOKEN: ${{ github.token }}`, but `bin/elastic-ut-review.sh` builds the clone URL as `https://${GITHUB_ACCESS_TOKEN}@github.com/...`. A bare `GITHUB_TOKEN` used as the URL userinfo is rejected by GitHub, so git falls back to a password prompt — `fatal: could not read Password` — and the FE/BE-UT unstable-case review clone still fails on `[self-hosted, ubuntu, ai]` (verified on CelerData run 29888616101).

## What I'm doing:

Use the canonical Actions-token clone form by setting `GITHUB_ACCESS_TOKEN: "x-access-token:${{ github.token }}"`, so the URL becomes `https://x-access-token:<token>@github.com/...`. No-op for the public `StarRocks/starrocks` clone (that path uses an empty token by design).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: fixes the FE/BE-UT unstable-case review clone auth (CI tooling only)

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4