### PR TITLE
[Enhancement] Add statistics for RTRIM binary

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -1031,6 +1031,8 @@ public class ExpressionStatisticCalculator {
                     return calculateDateTruncStats(callOperator, right);
                 case FunctionSet.LTRIM:
                 case FunctionSet.LTRIM_STRING:
+                case FunctionSet.RTRIM:
+                case FunctionSet.RTRIM_STRING:
                     minValue = Double.NEGATIVE_INFINITY;
                     maxValue = Double.POSITIVE_INFINITY;
                     averageRowSize = left.getAverageRowSize();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticsCalculatorTest.java
@@ -669,6 +669,18 @@ public class ExpressionStatisticsCalculatorTest {
         Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
         Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
         Assertions.assertEquals(100, columnStatistic.getDistinctValuesCount(), 0.001);
+        // test rtrim function
+        callOperator = new CallOperator(FunctionSet.RTRIM, VarcharType.VARCHAR, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(100, columnStatistic.getDistinctValuesCount(), 0.001);
+        // test rtrim_string function
+        callOperator = new CallOperator(FunctionSet.RTRIM_STRING, VarcharType.VARCHAR, Lists.newArrayList(left, right));
+        columnStatistic = ExpressionStatisticCalculator.calculate(callOperator, builder.build());
+        Assertions.assertEquals(Double.NEGATIVE_INFINITY, columnStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(Double.POSITIVE_INFINITY, columnStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(100, columnStatistic.getDistinctValuesCount(), 0.001);
 
 
         callOperator = new CallOperator(FunctionSet.MULTIPLY, IntegerType.BIGINT, Lists.newArrayList(left, right));


### PR DESCRIPTION
## Why I'm doing:

#76605 added binary expression statistics estimation for `LTRIM` / `LTRIM_STRING`, but the symmetric right-trim functions `RTRIM` / `RTRIM_STRING` were left unhandled and fall through to `ColumnStatistic.unknown()`. This causes the optimizer to lose column statistics for expressions involving binary `RTRIM`, degrading cardinality/cost estimation.

## What I'm doing:

Extend the binary branch of `ExpressionStatisticCalculator` to handle `RTRIM` and `RTRIM_STRING`, reusing the exact same estimation as `LTRIM` / `LTRIM_STRING`. Both only strip content (leading vs. trailing), so the estimation is identical:

- `averageRowSize` = input's average row size (trimming never grows a value)
- `distinctValues` = `min(rowCount, input NDV)` (trimming is many-to-one, so NDV cannot increase)

The single-argument `RTRIM` already shares the unary code path with `LTRIM`; this change only covers the two-argument (binary) form.

Added unit tests for binary `RTRIM` and `RTRIM_STRING` in `ExpressionStatisticsCalculatorTest`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
