### PR TITLE
[BugFix] fix potential out-of-bounds read in CSV trim() on empty field with trim_space

### DIFF
--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -27,13 +27,13 @@ static std::pair<const char*, size_t> trim(const char* value, size_t len) {
         ++begin;
     }
 
-    size_t end = len - 1;
+    size_t end = len;
 
-    while (end > begin && value[end] == ' ') {
+    while (end > begin && value[end - 1] == ' ') {
         --end;
     }
 
-    return std::make_pair(value + begin, end - begin + 1);
+    return std::make_pair(value + begin, end - begin);
 }
 
 inline bool CSVReader::is_column_delimiter(bool expandBuffer) {

--- a/be/test/formats/csv/csv_reader_test.cpp
+++ b/be/test/formats/csv/csv_reader_test.cpp
@@ -377,4 +377,45 @@ TEST_F(CSVReaderTest, test_more_rows_enclose_crlf_buffer_boundary) {
     EXPECT_EQ("{\"y\":2}", rows[1][1]);
 }
 
+// Regression test for the empty-field trim crash: an EMPTY field parsed with
+// trim_space enabled must not crash. split_record() calls trim(value, 0) for
+// an empty field, and the previous trim() computed `end = len - 1`, which
+// underflows to SIZE_MAX when len == 0 -- value[SIZE_MAX] is then read out of
+// bounds and the BE crashes. Under ASAN the unfixed code aborts here; the
+// fixed trim() returns an empty slice.
+TEST_F(CSVReaderTest, test_split_record_trim_space_empty_field) {
+    starrocks::CSVParseOptions options;
+    options.column_delimiter = ",";
+    options.row_delimiter = "\n";
+    options.trim_space = true;
+
+    MockCSVReader reader(options);
+
+    // Leading empty field, a value, and a trailing empty field.
+    starrocks::CSVReader::Record record1{",x,", 3};
+    starrocks::CSVReader::Fields fields1;
+    reader.split_record(record1, &fields1);
+
+    EXPECT_EQ(3, fields1.size());
+    EXPECT_EQ("", fields1[0].to_string());
+    EXPECT_EQ("x", fields1[1].to_string());
+    EXPECT_EQ("", fields1[2].to_string());
+
+    // All-empty record: every field goes through trim(_, 0).
+    starrocks::CSVReader::Record record2{",,", 2};
+    starrocks::CSVReader::Fields fields2;
+    reader.split_record(record2, &fields2);
+    EXPECT_EQ(3, fields2.size());
+    EXPECT_EQ("", fields2[0].to_string());
+    EXPECT_EQ("", fields2[1].to_string());
+    EXPECT_EQ("", fields2[2].to_string());
+
+    // All-spaces field must trim to empty (exercises the end == begin path).
+    starrocks::CSVReader::Record record3{"   ", 3};
+    starrocks::CSVReader::Fields fields3;
+    reader.split_record(record3, &fields3);
+    EXPECT_EQ(1, fields3.size());
+    EXPECT_EQ("", fields3[0].to_string());
+}
+
 } // namespace starrocks::csv


### PR DESCRIPTION
## Why I'm doing:

CSVReader::trim() computed `end = len - 1`, which underflows to SIZE_MAX for an empty field (len == 0), so `value[SIZE_MAX]` (i.e. value[-1]) is read out of bounds. This is a latent/undefined-behavior issue, not a guaranteed crash: for the common comma/tab separator, value[-1] is the preceding in-bounds delimiter, so trim() returns the correct empty result. It turns into a real crash or wrong result only when value[-1] is a space -- e.g. a column_separator that is or ends with a space -- because trim() then walks backwards and returns a corrupt ~2^64-length slice. The affected path is the FILES() TVF / broker load / Hive text connector scanner (CSVReader::split_record); classic stream load uses a different parser and is unaffected.

Rewrite trim() so `end` is an exclusive index starting at `len`, scan value[end-1], and return end - begin -- no size_t underflow for empty/all-space fields.

Add a BE unit test (deterministically caught under ASAN as a global-buffer-overflow) and a FILES() SQL functional test covering the connector-scanner trim path.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
