### PR TITLE
[BugFix] fix schema-change bad_variant_access converting an invalid string to a NOT NULL numeric column

### DIFF
--- a/be/src/column/type_converter.cpp
+++ b/be/src/column/type_converter.cpp
@@ -61,6 +61,17 @@ Status TypeConverter::convert_column(TypeInfo* src_type, const Column& src, Type
         Datum old_datum = src.get(i);
         Datum new_datum;
         RETURN_IF_ERROR(convert_datum(src_type, old_datum, dst_type, &new_datum, allocator));
+        // convert_datum() produces a null Datum for a value that cannot be represented in the
+        // target type (e.g. an unparseable or out-of-range string->number conversion). Appending
+        // a null Datum to a non-nullable column would read the wrong std::variant alternative and
+        // throw std::bad_variant_access, which the alter_tablet threadpool catches and retries
+        // forever (schema change stuck in RUNNING). Fail the conversion with a clear error instead.
+        if (new_datum.is_null() && !dst->is_nullable()) {
+            return Status::InternalError(strings::Substitute(
+                    "schema change failed: value at row $0 cannot be converted to the target type "
+                    "(unparseable or out of range) and would become NULL, but the target column is NOT NULL",
+                    i));
+        }
         dst->append_datum(new_datum);
     }
     return Status::OK();

--- a/be/test/column/type_converter_core_test.cpp
+++ b/be/test/column/type_converter_core_test.cpp
@@ -87,6 +87,39 @@ TEST(TypeConverterCoreTest, NullableVarcharToInt) {
     EXPECT_TRUE(dst->get(1).is_null());
 }
 
+// Regression test for the schema-change crash: converting an unparseable or out-of-range
+// string to a NON-NULLABLE integer column must return an error, not append a null Datum to
+// the non-nullable column. The latter previously threw std::bad_variant_access (std::get:
+// wrong index for variant), which the alter_tablet threadpool caught and retried forever,
+// leaving the schema change stuck in RUNNING.
+TEST(TypeConverterCoreTest, VarcharToNonNullableIntInvalidValueFails) {
+    TypeConverterTestAllocator allocator_holder;
+    TypeInfoAllocator allocator = allocator_holder.make_allocator();
+
+    auto src_type = get_type_info(TYPE_VARCHAR);
+    auto dst_type = get_type_info(TYPE_INT);
+    const TypeConverter* converter = get_type_converter(TYPE_VARCHAR, TYPE_INT);
+    ASSERT_NE(nullptr, converter);
+
+    // Unparseable value -> would convert to NULL; the non-nullable target must reject it.
+    {
+        auto src = BinaryColumn::create();
+        src->append(Slice("abc"));
+        auto dst = Int32Column::create(); // non-nullable
+        ASSERT_FALSE(dst->is_nullable());
+        auto status = converter->convert_column(src_type.get(), *src, dst_type.get(), dst.get(), &allocator);
+        EXPECT_FALSE(status.ok()) << "expected a clean error, not std::bad_variant_access";
+    }
+    // Out-of-range value -> would convert to NULL; same expectation.
+    {
+        auto src = BinaryColumn::create();
+        src->append(Slice("99999999999999"));
+        auto dst = Int32Column::create(); // non-nullable
+        auto status = converter->convert_column(src_type.get(), *src, dst_type.get(), dst.get(), &allocator);
+        EXPECT_FALSE(status.ok());
+    }
+}
+
 TEST(TypeConverterCoreTest, VarcharJsonRoundTrip) {
     TypeConverterTestAllocator allocator_holder;
     TypeInfoAllocator allocator = allocator_holder.make_allocator();

--- a/test/sql/test_alter_table/R/test_modify_string_to_notnull_numeric
+++ b/test/sql/test_alter_table/R/test_modify_string_to_notnull_numeric
@@ -1,0 +1,34 @@
+-- name: test_modify_string_to_notnull_numeric
+create database test_sc_notnull_${uuid0};
+-- result:
+-- !result
+use test_sc_notnull_${uuid0};
+-- result:
+-- !result
+create table t (k int NOT NULL, v varchar(32) NOT NULL) duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values (1, '100'), (2, 'abc'), (3, '99999999999999');
+-- result:
+-- !result
+alter table t modify column v int NOT NULL;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("test_sc_notnull_${uuid0}", "t", "CANCELLED")
+-- result:
+CANCELLED
+-- !result
+desc t;
+-- result:
+k	int	NO	true	None	
+v	varchar(32)	NO	false	None	
+-- !result
+select * from t order by k;
+-- result:
+1	100
+2	abc
+3	99999999999999
+-- !result
+drop database test_sc_notnull_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_alter_table/T/test_modify_string_to_notnull_numeric
+++ b/test/sql/test_alter_table/T/test_modify_string_to_notnull_numeric
@@ -1,0 +1,16 @@
+-- name: test_modify_string_to_notnull_numeric
+create database test_sc_notnull_${uuid0};
+use test_sc_notnull_${uuid0};
+-- Regression test for the schema-change crash (std::bad_variant_access): converting a NOT NULL
+-- VARCHAR column to a NOT NULL numeric type when the data contains unparseable or out-of-range
+-- values used to append a NULL Datum to a non-nullable column in TypeConverter::convert_column,
+-- throwing std::bad_variant_access. The alter_tablet threadpool caught it and retried forever,
+-- leaving the schema change stuck in RUNNING. The conversion must now fail cleanly (CANCELLED),
+-- leaving the column type and data unchanged.
+create table t (k int NOT NULL, v varchar(32) NOT NULL) duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num"="1");
+insert into t values (1, '100'), (2, 'abc'), (3, '99999999999999');
+alter table t modify column v int NOT NULL;
+function: wait_table_schema_change_finish("test_sc_notnull_${uuid0}", "t", "CANCELLED")
+desc t;
+select * from t order by k;
+drop database test_sc_notnull_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

A string->number schema change (ALTER MODIFY COLUMN) converts an unparseable or out-of-range value to a null Datum, matching query-time CAST semantics (#75538). When the target column is NOT NULL, TypeConverter::convert_column appended that null Datum to a non-nullable column, which reads the wrong std::variant alternative and throws std::bad_variant_access. The alter_tablet threadpool catches the exception and retries forever, leaving the schema change stuck in RUNNING.

Guard convert_column: if a converted value is null but the destination column is not nullable, return an error so the schema change fails cleanly (CANCELLED) instead of crashing/hanging.

Add a unit test (VarcharToNonNullableIntInvalidValueFails) for the unparseable and out-of-range cases.

## What I'm doing:

The bug introduced in #75538

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
