### PR TITLE
[Refactor] Extract reusable position-delete row reader from IcebergDeleteBuilder

### DIFF
--- a/be/src/formats/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/formats/iceberg/iceberg_delete_builder.cpp
@@ -23,6 +23,7 @@
 #include "formats/orc/orc_input_stream.h"
 #include "formats/parquet/file_reader.h"
 #include "formats/scan_context.h"
+#include "formats/utils.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/chunk_helper.h"
 #include "runtime/descriptors.h"
@@ -42,6 +43,137 @@ static const IcebergColumnMeta k_delete_file_path{
 
 static const IcebergColumnMeta k_delete_file_pos{
         .id = INT32_MAX - 102, .col_name = "pos", .type = TPrimitiveType::BIGINT};
+
+namespace {
+
+Status visit_position_delete_rows(const ChunkPtr& chunk, const IcebergPositionDeleteReader::RowCallback& cb) {
+    const ColumnPtr& file_path = chunk->get_column_by_slot_id(k_delete_file_path.id);
+    const ColumnPtr& pos = chunk->get_column_by_slot_id(k_delete_file_pos.id);
+    if (file_path == nullptr || pos == nullptr) {
+        return Status::InternalError("position-delete chunk is missing file_path/pos columns");
+    }
+    for (int i = 0; i < chunk->num_rows(); i++) {
+        cb(file_path->get(i).get_slice(), pos->get(i).get_int64());
+    }
+    return Status::OK();
+}
+
+Status read_parquet_rows(RandomAccessFile* file, int64_t length, int32_t chunk_size, const std::string& timezone,
+                         const FormatScannerOptions& options, FormatScannerStats* stats,
+                         const IcebergPositionDeleteReader::RowCallback& cb) {
+    std::unique_ptr<parquet::FileReader> reader;
+    try {
+        reader = std::make_unique<parquet::FileReader>(chunk_size, file, length);
+    } catch (std::exception& e) {
+        const auto s = strings::Substitute(
+                "IcebergPositionDeleteReader: create parquet::FileReader failed. reason = $0", e.what());
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+
+    std::vector slot_descriptors{&(IcebergDeleteFileMeta::get_delete_file_path_slot()),
+                                 &(IcebergDeleteFileMeta::get_delete_file_pos_slot())};
+
+    std::vector<FormatColumnInfo> columns;
+    for (size_t i = 0; i < slot_descriptors.size(); i++) {
+        FormatColumnInfo column;
+        column.slot_desc = slot_descriptors[i];
+        column.idx_in_chunk = i;
+        column.decode_needed = true;
+        columns.emplace_back(column);
+    }
+
+    std::vector<TIcebergSchemaField> schema_fields;
+    for (const auto* slot : slot_descriptors) {
+        TIcebergSchemaField field;
+        field.__set_field_id(slot->id());
+        field.__set_name(std::string(slot->col_name()));
+        schema_fields.push_back(field);
+    }
+    TIcebergSchema iceberg_schema;
+    iceberg_schema.__set_fields(schema_fields);
+
+    std::atomic<int32_t> lazy_column_coalesce_counter = 0;
+    // TODO: Remove this empty placeholder once FileReader supports a null predicate tree for predicate-free scans.
+    PredicateTree predicate_tree;
+    FormatScanContext format_scan_context;
+    format_scan_context.timezone = timezone;
+    format_scan_context.materialized_columns = std::move(columns);
+    format_scan_context.stats = stats;
+    format_scan_context.options = options;
+    format_scan_context.options.enable_split_tasks = false;
+    format_scan_context.lake_schema = &iceberg_schema;
+    format_scan_context.scan_range_offset = 0;
+    format_scan_context.scan_range_length = length;
+    format_scan_context.lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
+    format_scan_context.predicate_tree = &predicate_tree;
+    RETURN_IF_ERROR(reader->init(&format_scan_context));
+
+    while (true) {
+        ASSIGN_OR_RETURN(ChunkPtr chunk, RuntimeChunkHelper::new_chunk_checked(slot_descriptors, chunk_size));
+        Status status = reader->get_next(&chunk);
+        if (status.is_end_of_file()) {
+            break;
+        }
+        RETURN_IF_ERROR(status);
+        RETURN_IF_ERROR(visit_position_delete_rows(chunk, cb));
+    }
+    return Status::OK();
+}
+
+Status read_orc_rows(RandomAccessFile* file, const std::string& path, int64_t length, int32_t chunk_size,
+                     const std::string& timezone, const IcebergPositionDeleteReader::RowCallback& cb) {
+    std::vector slot_descriptors{&(IcebergDeleteFileMeta::get_delete_file_path_slot()),
+                                 &(IcebergDeleteFileMeta::get_delete_file_pos_slot())};
+
+    auto input_stream = std::make_unique<ORCHdfsFileStream>(file, length, nullptr);
+    std::unique_ptr<orc::Reader> reader;
+    try {
+        orc::ReaderOptions options;
+        reader = createReader(std::move(input_stream), options);
+    } catch (std::exception& e) {
+        auto s = strings::Substitute("IcebergPositionDeleteReader: create orc::Reader failed. reason = $0", e.what());
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+
+    auto orc_reader = std::make_unique<OrcChunkReader>(chunk_size, slot_descriptors);
+    orc_reader->disable_broker_load_mode();
+    orc_reader->set_current_file_name(path);
+    RETURN_IF_ERROR(orc_reader->set_timezone(timezone));
+    RETURN_IF_ERROR(orc_reader->init(std::move(reader)));
+
+    orc::RowReader::ReadPosition position;
+    while (true) {
+        Status s = orc_reader->read_next(&position);
+        if (s.is_end_of_file()) {
+            break;
+        }
+        RETURN_IF_ERROR(s);
+        ASSIGN_OR_RETURN(ChunkPtr chunk, orc_reader->get_chunk());
+        RETURN_IF_ERROR(visit_position_delete_rows(chunk, cb));
+    }
+    return Status::OK();
+}
+
+} // namespace
+
+Status IcebergPositionDeleteReader::read_rows(RandomAccessFile* file, const std::string& path, int64_t length,
+                                              const std::string& format, int32_t chunk_size,
+                                              const std::string& timezone, const FormatScannerOptions& options,
+                                              FormatScannerStats* stats, const RowCallback& cb) {
+    FormatScannerStats local_stats;
+    if (stats == nullptr) {
+        stats = &local_stats;
+    }
+    if (format == PARQUET) {
+        return read_parquet_rows(file, length, chunk_size, timezone, options, stats, cb);
+    }
+    if (format == ORC) {
+        return read_orc_rows(file, path, length, chunk_size, timezone, cb);
+    }
+    return Status::NotSupported(strings::Substitute("unsupported iceberg position-delete file format: $0", format));
+}
 
 StatusOr<std::unique_ptr<RandomAccessFile>> IcebergDeleteBuilder::open_random_access_file(
         const TIcebergDeleteFile& delete_file, FormatScannerStats& fs_stats, FormatScannerStats& app_stats,
@@ -67,101 +199,7 @@ StatusOr<std::unique_ptr<RandomAccessFile>> IcebergDeleteBuilder::open_random_ac
     return file;
 }
 
-Status IcebergDeleteBuilder::fill_skip_rowids(const ChunkPtr& chunk) const {
-    const ColumnPtr& file_path = chunk->get_column_by_slot_id(k_delete_file_path.id);
-    const ColumnPtr& pos = chunk->get_column_by_slot_id(k_delete_file_pos.id);
-    for (int i = 0; i < chunk->num_rows(); i++) {
-        if (file_path->get(i).get_slice() == _ctx.data_file_path) {
-            _deletion_bitmap->add_value(pos->get(i).get_int64());
-        }
-    }
-    return Status::OK();
-}
-
-Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file) const {
-    FormatScannerStats app_stats;
-    FormatScannerStats fs_stats;
-    std::shared_ptr<SharedBufferedInputStream> shared_buffered_input_stream = nullptr;
-    std::shared_ptr<CacheInputStream> cache_input_stream = nullptr;
-
-    ASSIGN_OR_RETURN(auto file, open_random_access_file(delete_file, fs_stats, app_stats, shared_buffered_input_stream,
-                                                        cache_input_stream));
-
-    std::unique_ptr<parquet::FileReader> reader;
-    try {
-        reader = std::make_unique<parquet::FileReader>(_ctx.chunk_size, file.get(), file->get_size().value());
-    } catch (std::exception& e) {
-        const auto s = strings::Substitute(
-                "IcebergDeleteBuilder::build_parquet create parquet::FileReader failed. reason = $0", e.what());
-        LOG(WARNING) << s;
-        return Status::InternalError(s);
-    }
-
-    std::vector<FormatColumnInfo> columns;
-    std::vector slot_descriptors{&(IcebergDeleteFileMeta::get_delete_file_path_slot()),
-                                 &(IcebergDeleteFileMeta::get_delete_file_pos_slot())};
-    for (size_t i = 0; i < slot_descriptors.size(); i++) {
-        auto* slot = slot_descriptors[i];
-        FormatColumnInfo column;
-        column.slot_desc = slot;
-        column.idx_in_chunk = i;
-        column.decode_needed = true;
-        columns.emplace_back(column);
-    }
-
-    std::vector<TIcebergSchemaField> schema_fields;
-
-    // build file path field
-    TIcebergSchemaField file_path_field;
-    file_path_field.__set_field_id(k_delete_file_path.id);
-    file_path_field.__set_name(k_delete_file_path.col_name);
-    schema_fields.push_back(file_path_field);
-
-    // build position field
-    TIcebergSchemaField pos_field;
-    pos_field.__set_field_id(k_delete_file_pos.id);
-    pos_field.__set_name(k_delete_file_pos.col_name);
-    schema_fields.push_back(pos_field);
-
-    TIcebergSchema iceberg_schema = TIcebergSchema();
-    iceberg_schema.__set_fields(schema_fields);
-
-    std::atomic<int32_t> lazy_column_coalesce_counter = 0;
-    // TODO: Remove this empty placeholder once FileReader supports a null predicate tree for predicate-free scans.
-    PredicateTree predicate_tree;
-    FormatScanContext format_scan_context;
-    format_scan_context.timezone = _ctx.scan_context->timezone;
-    format_scan_context.materialized_columns = std::move(columns);
-    format_scan_context.stats = &app_stats;
-    format_scan_context.options = _ctx.scan_context->options;
-    format_scan_context.options.enable_split_tasks = false;
-    format_scan_context.lake_schema = &iceberg_schema;
-    format_scan_context.scan_range_offset = 0;
-    format_scan_context.scan_range_length = delete_file.length;
-    format_scan_context.lazy_column_coalesce_counter = &lazy_column_coalesce_counter;
-    format_scan_context.predicate_tree = &predicate_tree;
-    RETURN_IF_ERROR(reader->init(&format_scan_context));
-
-    while (true) {
-        ASSIGN_OR_RETURN(ChunkPtr chunk, RuntimeChunkHelper::new_chunk_checked(slot_descriptors, _ctx.chunk_size));
-
-        Status status = reader->get_next(&chunk);
-        if (status.is_end_of_file()) {
-            break;
-        }
-
-        RETURN_IF_ERROR(status);
-        RETURN_IF_ERROR(fill_skip_rowids(chunk));
-    }
-    update_delete_file_io_counter(_ctx.runtime_profile, app_stats, fs_stats, cache_input_stream,
-                                  shared_buffered_input_stream);
-    return Status::OK();
-}
-
-Status IcebergDeleteBuilder::build_orc(const TIcebergDeleteFile& delete_file) const {
-    std::vector slot_descriptors{&(IcebergDeleteFileMeta::get_delete_file_path_slot()),
-                                 &(IcebergDeleteFileMeta::get_delete_file_pos_slot())};
-
+Status IcebergDeleteBuilder::build(const TIcebergDeleteFile& delete_file, const std::string& format) const {
     FormatScannerStats app_stats;
     FormatScannerStats fs_stats;
     std::shared_ptr<SharedBufferedInputStream> shared_buffered_input_stream;
@@ -170,44 +208,24 @@ Status IcebergDeleteBuilder::build_orc(const TIcebergDeleteFile& delete_file) co
     ASSIGN_OR_RETURN(auto file, open_random_access_file(delete_file, fs_stats, app_stats, shared_buffered_input_stream,
                                                         cache_input_stream));
 
-    auto input_stream = std::make_unique<ORCHdfsFileStream>(file.get(), delete_file.length, nullptr);
-    std::unique_ptr<orc::Reader> reader;
-    try {
-        orc::ReaderOptions options;
-        reader = createReader(std::move(input_stream), options);
-    } catch (std::exception& e) {
-        auto s =
-                strings::Substitute("ORCPositionDeleteBuilder::build create orc::Reader failed. reason = $0", e.what());
-        LOG(WARNING) << s;
-        return Status::InternalError(s);
-    }
-
-    auto orc_reader = std::make_unique<OrcChunkReader>(_ctx.chunk_size, slot_descriptors);
-    orc_reader->disable_broker_load_mode();
-    orc_reader->set_current_file_name(delete_file.full_path);
-    RETURN_IF_ERROR(orc_reader->set_timezone(_ctx.scan_context->timezone));
-    RETURN_IF_ERROR(orc_reader->init(std::move(reader)));
-
-    orc::RowReader::ReadPosition position;
-    Status s;
-
-    while (true) {
-        s = orc_reader->read_next(&position);
-        if (s.is_end_of_file()) {
-            break;
-        }
-
-        RETURN_IF_ERROR(s);
-
-        auto ret = orc_reader->get_chunk();
-        if (!ret.ok()) {
-            return ret.status();
-        }
-        RETURN_IF_ERROR(fill_skip_rowids(ret.value()));
-    }
+    RETURN_IF_ERROR(IcebergPositionDeleteReader::read_rows(
+            file.get(), delete_file.full_path, delete_file.length, format, _ctx.chunk_size, _ctx.scan_context->timezone,
+            _ctx.scan_context->options, &app_stats, [this](const Slice& file_path, int64_t pos) {
+                if (file_path == _ctx.data_file_path) {
+                    _deletion_bitmap->add_value(pos);
+                }
+            }));
     update_delete_file_io_counter(_ctx.runtime_profile, app_stats, fs_stats, cache_input_stream,
                                   shared_buffered_input_stream);
     return Status::OK();
+}
+
+Status IcebergDeleteBuilder::build_parquet(const TIcebergDeleteFile& delete_file) const {
+    return build(delete_file, PARQUET);
+}
+
+Status IcebergDeleteBuilder::build_orc(const TIcebergDeleteFile& delete_file) const {
+    return build(delete_file, ORC);
 }
 
 SlotDescriptor IcebergDeleteFileMeta::gen_slot_helper(const IcebergColumnMeta& meta) {

--- a/be/src/formats/iceberg/iceberg_delete_builder.h
+++ b/be/src/formats/iceberg/iceberg_delete_builder.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -45,6 +46,21 @@ struct IcebergDeleteBuilderContext {
 
 struct IcebergColumnMeta;
 
+// Reads an Iceberg position-delete file (the 2-column file_path/pos layout, parquet or orc) row
+// by row. Opening the file is the caller's concern: the scan side reads through its IO stack
+// (data cache, coalesced IO), other callers may use a plain FileSystem open.
+class IcebergPositionDeleteReader {
+public:
+    using RowCallback = std::function<void(const Slice& file_path, int64_t pos)>;
+
+    // Invokes cb once per row. `path` is used for error reporting only; `length` is the file
+    // size in bytes. `stats` may be null when the caller does not collect scanner stats.
+    static Status read_rows(RandomAccessFile* file, const std::string& path, int64_t length,
+                            const std::string& format, // "parquet" | "orc"
+                            int32_t chunk_size, const std::string& timezone, const FormatScannerOptions& options,
+                            FormatScannerStats* stats, const RowCallback& cb);
+};
+
 class IcebergDeleteBuilder {
 public:
     explicit IcebergDeleteBuilder(IcebergDeleteBuilderContext ctx)
@@ -59,6 +75,8 @@ public:
     DeletionBitmapPtr deletion_bitmap() const { return _deletion_bitmap; }
 
 private:
+    Status build(const TIcebergDeleteFile& delete_file, const std::string& format) const;
+
     StatusOr<std::unique_ptr<RandomAccessFile>> open_random_access_file(
             const TIcebergDeleteFile& delete_file, FormatScannerStats& fs_stats, FormatScannerStats& app_stats,
             std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream,
@@ -68,7 +86,6 @@ private:
             RuntimeProfile* parent_profile, const FormatScannerStats& app_stats, const FormatScannerStats& fs_stats,
             const std::shared_ptr<CacheInputStream>& cache_input_stream,
             const std::shared_ptr<SharedBufferedInputStream>& shared_buffered_input_stream);
-    Status fill_skip_rowids(const ChunkPtr& chunk) const;
 
     IcebergDeleteBuilderContext _ctx;
     DeletionBitmapPtr _deletion_bitmap;

--- a/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
+++ b/be/test/formats/iceberg/iceberg_delete_builder_test.cpp
@@ -16,14 +16,21 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "base/testutil/assert.h"
 #include "column/chunk.h"
 #include "formats/column_evaluator.h"
+#include "formats/io/async_flush_output_stream.h"
+#include "formats/orc/orc_file_writer.h"
 #include "formats/parquet/file_writer.h"
 #include "formats/parquet/parquet_file_writer.h"
 #include "fs/fs.h"
 #include "fs/fs_memory.h"
 #include "runtime/current_thread.h"
+#include "runtime/runtime_state.h"
 #include "testutil/column_test_helper.h"
 
 namespace starrocks::formats {
@@ -49,43 +56,90 @@ protected:
         CurrentThread::set_mem_tracker_source(iceberg_delete_builder_test_env_initialized,
                                               iceberg_delete_builder_test_mem_tracker);
         tls_mem_tracker = nullptr;
+
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = 4096;
+        TQueryGlobals query_globals;
+        _runtime_state = std::make_shared<RuntimeState>(fragment_id, query_options, query_globals, nullptr);
+        _runtime_state->init_instance_mem_tracker();
+
+        (void)FileSystem::Default()->delete_dir_recursive(_tmp_dir);
+        ASSERT_OK(FileSystem::Default()->create_dir_recursive(_tmp_dir));
     }
 
     void TearDown() override {
+        (void)FileSystem::Default()->delete_dir_recursive(_tmp_dir);
         tls_thread_status.set_mem_tracker(nullptr);
         CurrentThread::set_mem_tracker_source(nullptr, nullptr);
         g_iceberg_delete_builder_test_mem_tracker = nullptr;
+    }
+
+    static ChunkPtr make_delete_rows_chunk(const std::vector<std::pair<std::string, int64_t>>& rows) {
+        std::vector<Slice> file_paths;
+        std::vector<int64_t> positions;
+        file_paths.reserve(rows.size());
+        positions.reserve(rows.size());
+        for (const auto& [file_path, pos] : rows) {
+            file_paths.emplace_back(file_path);
+            positions.push_back(pos);
+        }
+        auto chunk = std::make_shared<Chunk>();
+        chunk->append_column(ColumnTestHelper::build_column<Slice>(file_paths), 0);
+        chunk->append_column(ColumnTestHelper::build_column<int64_t>(positions), 1);
+        return chunk;
+    }
+
+    // Writes a 2-column (file_path, pos) parquet position-delete file into `fs`.
+    void write_parquet_delete_file(MemoryFileSystem& fs, const std::string& path,
+                                   const std::vector<std::pair<std::string, int64_t>>& rows) {
+        std::vector type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+                               TypeDescriptor::from_logical_type(TYPE_BIGINT)};
+        auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+        auto writer_options = std::make_shared<ParquetWriterOptions>();
+        writer_options->column_ids = {FileColumnId{IcebergDeleteFileMeta::get_delete_file_path_slot().id(), {}},
+                                      FileColumnId{IcebergDeleteFileMeta::get_delete_file_pos_slot().id(), {}}};
+        ASSIGN_OR_ABORT(auto writable_file, fs.new_writable_file(path));
+        auto output_stream = std::make_shared<parquet::ParquetOutputStream>(std::move(writable_file));
+        ParquetFileWriter writer(path, std::move(output_stream), {"file_path", "pos"}, type_descs,
+                                 std::move(column_evaluators), TCompressionType::NO_COMPRESSION,
+                                 std::move(writer_options), [] {}, {false, false});
+        ASSERT_OK(writer.init());
+        auto chunk = make_delete_rows_chunk(rows);
+        ASSERT_OK(writer.write(chunk.get()));
+        ASSERT_OK(writer.close().io_status);
+    }
+
+    // Writes a 2-column (file_path, pos) orc position-delete file under _tmp_dir (default fs).
+    void write_orc_delete_file(const std::string& path, const std::vector<std::pair<std::string, int64_t>>& rows) {
+        std::vector type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR),
+                               TypeDescriptor::from_logical_type(TYPE_BIGINT)};
+        auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
+        ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(path));
+        auto stream = std::make_unique<AsyncFlushOutputStream>(std::move(writable_file), nullptr, _runtime_state.get());
+        auto orc_stream = std::make_shared<AsyncOrcOutputStream>(stream.get());
+        ORCFileWriter writer(path, std::move(orc_stream), {"file_path", "pos"}, type_descs,
+                             std::move(column_evaluators), TCompressionType::NO_COMPRESSION,
+                             std::make_shared<ORCWriterOptions>(), [] {});
+        ASSERT_OK(writer.init());
+        auto chunk = make_delete_rows_chunk(rows);
+        ASSERT_OK(writer.write(chunk.get()));
+        ASSERT_OK(writer.close().io_status);
     }
 
     const std::string _parquet_delete_path = "/iceberg_position_delete.parquet";
     const std::string _parquet_data_path = "parquet_data_file.parquet";
     MemoryFileSystem _fs;
     MemTracker _mem_tracker{-1, "iceberg_delete_builder_test"};
+    std::shared_ptr<RuntimeState> _runtime_state;
+    const std::string _tmp_dir = "./ut_dir/iceberg_delete_builder_test";
 };
 
 TEST_F(IcebergDeleteBuilderTest, TestParquetBuilder) {
     RuntimeProfile runtime_profile("IcebergDeleteBuilderTest");
 
-    std::vector type_descs{TypeDescriptor::from_logical_type(TYPE_VARCHAR),
-                           TypeDescriptor::from_logical_type(TYPE_BIGINT)};
-    auto column_evaluators = ColumnSlotIdEvaluator::from_types(type_descs);
-    auto writer_options = std::make_shared<ParquetWriterOptions>();
-    writer_options->column_ids = {FileColumnId{IcebergDeleteFileMeta::get_delete_file_path_slot().id(), {}},
-                                  FileColumnId{IcebergDeleteFileMeta::get_delete_file_pos_slot().id(), {}}};
-    ASSIGN_OR_ABORT(auto writable_file, _fs.new_writable_file(_parquet_delete_path));
-    auto output_stream = std::make_shared<parquet::ParquetOutputStream>(std::move(writable_file));
-    ParquetFileWriter writer(_parquet_delete_path, std::move(output_stream), {"file_path", "pos"}, type_descs,
-                             std::move(column_evaluators), TCompressionType::NO_COMPRESSION, std::move(writer_options),
-                             [] {}, {false, false});
-    ASSERT_OK(writer.init());
-
-    auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(ColumnTestHelper::build_column<Slice>(
-                                 {_parquet_data_path, "another_data_file.parquet", _parquet_data_path}),
-                         0);
-    chunk->append_column(ColumnTestHelper::build_column<int64_t>({7, 9, 11}), 1);
-    ASSERT_OK(writer.write(chunk.get()));
-    ASSERT_OK(writer.close().io_status);
+    write_parquet_delete_file(_fs, _parquet_delete_path,
+                              {{_parquet_data_path, 7}, {"another_data_file.parquet", 9}, {_parquet_data_path, 11}});
 
     FormatScanContext scan_context;
     scan_context.timezone = "UTC";
@@ -110,6 +164,65 @@ TEST_F(IcebergDeleteBuilderTest, TestParquetBuilder) {
     std::vector<uint64_t> deleted_rowids(deletion_bitmap->get_cardinality());
     deletion_bitmap->to_array(deleted_rowids);
     EXPECT_EQ((std::vector<uint64_t>{7, 11}), deleted_rowids);
+}
+
+TEST_F(IcebergDeleteBuilderTest, TestOrcBuilder) {
+    RuntimeProfile runtime_profile("IcebergDeleteBuilderTest");
+
+    const std::string data_path = "orc_data_file.parquet";
+    const std::string delete_path = _tmp_dir + "/iceberg_position_delete.orc";
+    write_orc_delete_file(delete_path, {{data_path, 7}, {"another_data_file.parquet", 9}, {data_path, 11}});
+
+    FormatScanContext scan_context;
+    scan_context.timezone = "UTC";
+
+    ASSIGN_OR_ABORT(const int64_t delete_file_size, FileSystem::Default()->get_file_size(delete_path));
+    TIcebergDeleteFile delete_file;
+    delete_file.__set_full_path(delete_path);
+    delete_file.__set_length(delete_file_size);
+
+    IcebergDeleteBuilder builder(IcebergDeleteBuilderContext{
+            .scan_context = &scan_context,
+            .fs = FileSystem::Default(),
+            .data_file_path = data_path,
+            .runtime_profile = &runtime_profile,
+            .chunk_size = 4096,
+    });
+
+    ASSERT_OK(builder.build_orc(delete_file));
+    auto deletion_bitmap = builder.deletion_bitmap();
+    ASSERT_NE(nullptr, deletion_bitmap);
+    EXPECT_EQ(2, deletion_bitmap->get_cardinality());
+    std::vector<uint64_t> deleted_rowids(deletion_bitmap->get_cardinality());
+    deletion_bitmap->to_array(deleted_rowids);
+    EXPECT_EQ((std::vector<uint64_t>{7, 11}), deleted_rowids);
+}
+
+TEST_F(IcebergDeleteBuilderTest, TestReadRowsVisitsAllRows) {
+    write_parquet_delete_file(_fs, _parquet_delete_path, {{"dataA", 1}, {"dataB", 2}, {"dataA", 3}});
+
+    ASSIGN_OR_ABORT(const int64_t delete_file_size, _fs.get_file_size(_parquet_delete_path));
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_parquet_delete_path));
+
+    std::vector<std::pair<std::string, int64_t>> rows;
+    ASSERT_OK(IcebergPositionDeleteReader::read_rows(
+            file.get(), _parquet_delete_path, delete_file_size, "parquet", 4096, "UTC", FormatScannerOptions{}, nullptr,
+            [&](const Slice& file_path, int64_t pos) { rows.emplace_back(file_path.to_string(), pos); }));
+
+    const std::vector<std::pair<std::string, int64_t>> expected{{"dataA", 1}, {"dataB", 2}, {"dataA", 3}};
+    EXPECT_EQ(expected, rows);
+}
+
+TEST_F(IcebergDeleteBuilderTest, TestReadRowsRejectsUnknownFormat) {
+    write_parquet_delete_file(_fs, _parquet_delete_path, {{"dataA", 1}});
+
+    ASSIGN_OR_ABORT(const int64_t delete_file_size, _fs.get_file_size(_parquet_delete_path));
+    ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_parquet_delete_path));
+
+    auto status = IcebergPositionDeleteReader::read_rows(file.get(), _parquet_delete_path, delete_file_size, "avro",
+                                                         4096, "UTC", FormatScannerOptions{}, nullptr,
+                                                         [](const Slice&, int64_t) {});
+    EXPECT_FALSE(status.ok());
 }
 
 } // namespace starrocks::formats


### PR DESCRIPTION
## Why I'm doing:

`IcebergDeleteBuilder` mixes the parquet/orc position-delete read loops with scanner-specific concerns: opening the file through the scanner IO stack (data cache, coalesced IO), MOR profile counters, and filtering rows into the scan-side skip bitmap. The read loops themselves are generic "read the 2-column file_path/pos layout" logic, and keeping them fused to the scanner context means any other consumer of position-delete files has to duplicate them.

## What I'm doing:

- Extract the per-format read loops into `IcebergPositionDeleteReader::read_rows(file, path, length, format, chunk_size, timezone, options, stats, cb)`: it reads an already-opened position-delete file and invokes a callback per row, so file opening (scanner IO stack vs plain `FileSystem` open) and row consumption stay with the caller.
- `build_parquet`/`build_orc` keep their signatures and behavior: they still open through the scanner IO stack, filter rows to the scanned data file into the deletion bitmap, and update the MOR counters. Both now share one private `build(delete_file, format)`.
- Use the existing `formats::PARQUET`/`formats::ORC` constants for format dispatch.
- Tests: keep the existing parquet builder case, add orc builder coverage (previously untested), plus `read_rows` cases (full-row visitation with a plain FS open, unknown-format rejection).

Two benign differences from the old code, called out for review:
- The parquet `FileReader` is now constructed with `delete_file.length` (same source as the `scan_range_length` it already used) instead of `file->get_size().value()`.
- The two reader-creation error messages are prefixed `IcebergPositionDeleteReader:` (this also fixes the stale `ORCPositionDeleteBuilder` name in the orc branch).

No behavior change on the scan path: same rows visited, same bitmap produced, same counters updated.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5