### PR TITLE
[Tool] Dedup backport-conflict notification (labeled event only)

### DIFF
--- a/.github/workflows/ci-backport-checker.yml
+++ b/.github/workflows/ci-backport-checker.yml
@@ -7,7 +7,6 @@ on:
       - 'branch-[0-9].[0-9]'
       - 'branch-[0-9].[0-9].[0-9]'
     types:
-      - closed
       - labeled
 
 env:
@@ -26,14 +25,8 @@ jobs:
     if: >
       contains(github.event.pull_request.title, 'backport') &&
       startsWith(github.head_ref, 'mergify/bp') &&
-      (
-        (github.event.action == 'labeled' &&
-         (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')) ||
-        (github.event.action == 'closed' &&
-         github.event.pull_request.merged != true &&
-         (contains(github.event.pull_request.labels.*.name, 'conflicts') ||
-          contains(github.event.pull_request.labels.*.name, 'conflict')))
-      )
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'conflicts' || github.event.label.name == 'conflict')
     env:
       STATUS: CONFLICT
 


### PR DESCRIPTION
## Why I'm doing:

The `BACKPORT NOTIFICATION` workflow (`ci-backport-checker.yml`) sends its Feishu/Slack "BACKPORT FAILURE — CONFLICT" message **twice** for every conflicting backport PR. Mergify both adds the `conflicts` label (a `labeled` event) and then auto-closes the same PR ~1 minute later (a `closed` event); the `backport-close` job's `if` accepted both, so the original author gets two identical DMs per branch.

Observed on the backports of #76684 (branch-4.0 #76705, branch-3.5 #76706): each was labeled `conflicts` by `mergify[bot]`, then closed by `mergify[bot]`, producing two notifications each.

## What I'm doing:

Keep only the `labeled` / `conflicts` trigger and drop the `closed` branch:
- The `labeled` event fires earlier (at label time, before the auto-close) and always fires when Mergify applies the label.
- It still covers the case where Mergify leaves the conflicting PR open instead of closing it.
- Removing `closed` from `on.types` also stops a self-hosted runner from spinning up on every closed backport PR just to evaluate the `if` and skip.

No linked issue.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5