### PR TITLE
[BugFix] Fix statistics cache load failure on empty min/max under ERROR_IF_OVERFLOW (backport #76684)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -64,10 +64,15 @@ public class StatisticSQLBuilder {
                     + " FROM " + StatsConstants.SAMPLE_STATISTICS_TABLE_NAME
                     + " WHERE $predicate";
 
+    // Collection jobs persist min/max as IFNULL(MAX(col), ''), so an all-NULL partition stores ''
+    // rather than NULL. The '' must be mapped back to NULL before the $type cast: the internal
+    // statistics session inherits the global sql_mode, and under ERROR_IF_OVERFLOW casting '' to a
+    // numeric/date type aborts the whole batched load instead of yielding NULL.
     private static final String QUERY_FULL_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
+                    + " cast(max(cast(nullif(max, '') as $type)) as string),"
+                    + " cast(min(cast(nullif(min, '') as $type)) as string),"
                     + " cast(avg(collection_size) as bigint)"
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
@@ -81,10 +86,13 @@ public class StatisticSQLBuilder {
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
 
+    // nullif(x, '') for the same reason as QUERY_FULL_STATISTIC_TEMPLATE: '' is the persisted
+    // representation of "no min/max" and must not reach the $type cast.
     private static final String QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE =
             "SELECT cast(" + STATISTIC_EXTERNAL_QUERY_V2_VERSION + " as INT), column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
+                    + " cast(max(cast(nullif(max, '') as $type)) as string),"
+                    + " cast(min(cast(nullif(min, '') as $type)) as string),"
                     + " max(update_time)"
                     + " FROM " + StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -524,8 +524,9 @@ public class AnalyzeStmtTest {
                         "db_id, table_id, column_name," +
                         " sum(row_count), " +
                         "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                        "cast(max(cast(max as bigint)) as string), " +
-                        "cast(min(cast(min as bigint)) as string), cast(avg(collection_size) as bigint) FROM column_statistics " +
+                        "cast(max(cast(nullif(max, '') as bigint)) as string), " +
+                        "cast(min(cast(nullif(min, '') as bigint)) as string), " +
+                        "cast(avg(collection_size) as bigint) FROM column_statistics " +
                         "WHERE table_id = %d and column_name in (\"v1\", \"v2\") " +
                         "GROUP BY db_id, table_id, column_name", table.getId()),
                 StatisticSQLBuilder.buildQueryFullStatisticsSQL(table.getId(),
@@ -677,13 +678,13 @@ public class AnalyzeStmtTest {
 
         String pattern = String.format("SELECT cast(10 as INT), now(), db_id, table_id, column_name, sum(row_count), " +
                 "cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string), " +
+                "cast(max(cast(nullif(max, '') as string)) as string), cast(min(cast(nullif(min, '') as string)) as string), " +
                 "cast(avg(collection_size) as bigint) " +
                 "FROM column_statistics WHERE table_id = %d and column_name in (\"kk2\") " +
                 "GROUP BY db_id, table_id, column_name " +
                 "UNION ALL SELECT cast(10 as INT), now(), db_id, table_id, column_name, " +
                 "sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  " +
-                "cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string), " +
+                "cast(max(cast(nullif(max, '') as bigint)) as string), cast(min(cast(nullif(min, '') as bigint)) as string), " +
                 "cast(avg(collection_size) as bigint) " +
                 "FROM column_statistics WHERE table_id = %d and column_name in (\"kk1\") " +
                 "GROUP BY db_id, table_id, column_name", table.getId(), table.getId());

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -148,13 +148,17 @@ public class StatisticsExecutorTest extends PlanTestBase {
             public List<TStatisticData> executeStatisticDQL(ConnectContext context, String sql) {
                 Assertions.assertEquals(
                         "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
-                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as string)) as string), " +
-                                "cast(min(cast(min as string)) as string), max(update_time) FROM external_column_statistics " +
+                                "hll_union_agg(ndv), sum(null_count),  " +
+                                "cast(max(cast(nullif(max, '') as string)) as string), " +
+                                "cast(min(cast(nullif(min, '') as string)) as string), " +
+                                "max(update_time) FROM external_column_statistics " +
                                 "WHERE table_uuid = \"hive0.partitioned_db.t1.0\" " +
                                 "and column_name in (\"c2\") GROUP BY table_uuid, column_name UNION ALL " +
                                 "SELECT cast(8 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
-                                "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as bigint)) as string), " +
-                                "cast(min(cast(min as bigint)) as string), max(update_time) " +
+                                "hll_union_agg(ndv), sum(null_count),  " +
+                                "cast(max(cast(nullif(max, '') as bigint)) as string), " +
+                                "cast(min(cast(nullif(min, '') as bigint)) as string), " +
+                                "max(update_time) " +
                                 "FROM external_column_statistics WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
                                 " and column_name in (\"c1\") GROUP BY table_uuid, column_name", sql);
                 return Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -432,7 +432,8 @@ public class StatisticsSQLTest extends PlanTestBase {
     public void testExternalTableCollectionStatsType() {
         String sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a", Lists.newArrayList("col1", "col2"),
                 Lists.newArrayList(Type.ARRAY_INT, new MapType(Type.INT, Type.STRING)));
-        assertContains(sql, "cast(max(cast(max as string)) as string), cast(min(cast(min as string)) as string)");
+        assertContains(sql, "cast(max(cast(nullif(max, '') as string)) as string)," +
+                " cast(min(cast(nullif(min, '') as string)) as string)");
     }
 
     @Test

--- a/test/sql/test_analyze_statistics/R/test_stats_all_null_column_error_if_overflow
+++ b/test/sql/test_analyze_statistics/R/test_stats_all_null_column_error_if_overflow
@@ -1,0 +1,49 @@
+-- name: test_stats_all_null_column_error_if_overflow @sequential
+[UC]ori_sql_mode=select @@GLOBAL.sql_mode;
+-- result:
+
+-- !result
+set global sql_mode = 'ERROR_IF_OVERFLOW';
+-- result:
+-- !result
+create database analyze_test_${uuid0};
+-- result:
+-- !result
+use analyze_test_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `all_null_decimal` (
+  `k1` int,
+  `c1` decimal(20,8)
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO all_null_decimal VALUES (1, null), (2, null), (3, null);
+-- result:
+-- !result
+analyze table all_null_decimal;
+-- result:
+[REGEX].*OK.*
+-- !result
+select column_name, length(`max`), length(`min`) from default_catalog._statistics_.column_statistics where table_name='analyze_test_${uuid0}.all_null_decimal' and column_name='c1';
+-- result:
+c1	0	0
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait column stats cache load under ERROR_IF_OVERFLOW"}
+  result=explain costs select c1 from all_null_decimal;
+  CHECK: re.search("c1-->.*ESTIMATE", ${result}) != None
+} END LOOP
+set global sql_mode = '${ori_sql_mode}';
+-- result:
+-- !result
+drop database analyze_test_${uuid0};
+-- result:
+-- !result
+CLEANUP {
+    set global sql_mode = '${ori_sql_mode}';
+    drop database if exists analyze_test_${uuid0};
+} END CLEANUP

--- a/test/sql/test_analyze_statistics/T/test_stats_all_null_column_error_if_overflow
+++ b/test/sql/test_analyze_statistics/T/test_stats_all_null_column_error_if_overflow
@@ -1,0 +1,30 @@
+-- name: test_stats_all_null_column_error_if_overflow @sequential
+ori_sql_mode=select @@GLOBAL.sql_mode;
+set global sql_mode = 'ERROR_IF_OVERFLOW';
+create database analyze_test_${uuid0};
+use analyze_test_${uuid0};
+CREATE TABLE `all_null_decimal` (
+  `k1` int,
+  `c1` decimal(20,8)
+)
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+INSERT INTO all_null_decimal VALUES (1, null), (2, null), (3, null);
+analyze table all_null_decimal;
+-- an all-NULL decimal column persists empty-string min/max into the stats table
+select column_name, length(`max`), length(`min`) from default_catalog._statistics_.column_statistics where table_name='analyze_test_${uuid0}.all_null_decimal' and column_name='c1';
+-- loading these stats back must not fail even when the internal statistics session
+-- inherits ERROR_IF_OVERFLOW from the global sql_mode (cast('' as decimal) would throw)
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait column stats cache load under ERROR_IF_OVERFLOW"}
+  result=explain costs select c1 from all_null_decimal;
+  CHECK: re.search("c1-->.*ESTIMATE", ${result}) != None
+} END LOOP
+set global sql_mode = '${ori_sql_mode}';
+drop database analyze_test_${uuid0};
+
+CLEANUP {
+    set global sql_mode = '${ori_sql_mode}';
+    drop database if exists analyze_test_${uuid0};
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

Statistics collection persists min/max as `IFNULL(MAX(col), '')`, so a column whose partitions are all NULL (e.g. a newly added DECIMAL column on historical partitions) stores an empty string `''` in `_statistics_.column_statistics`. The column-statistics cache loader reads it back with `cast(max(cast(max as $type)) as string)`, and the internal statistics session inherits the **global** sql_mode. Under `ERROR_IF_OVERFLOW`, `cast('' as decimal)` aborts the whole batched load:

```
ERROR (stats-cache-refresher-N) ColumnBasicStatsCacheLoader.lambda$asyncLoadAll$1():
com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Statistics query fail
| Error Message [Expr evaluate meet error: The type cast from string to decimal overflows: BE:xxx]
```

Because the query batches all columns of a table with UNION ALL, one all-NULL column keeps the statistics of **every** column of the table permanently UNKNOWN (failed futures are not cached, so every query replanning retriggers the failing load). Hit in production after a user enabled `sql_mode = ERROR_IF_OVERFLOW` globally and added nullable DECIMAL columns.

## What I'm doing:

Map the persisted `''` sentinel back to NULL before the type cast in the two loader query templates (internal `QUERY_FULL_STATISTIC_TEMPLATE` and external `QUERY_EXTERNAL_FULL_STATISTIC_V2_TEMPLATE`):

```sql
cast(max(cast(max as $type)) as string)
-> cast(max(cast(nullif(max, '') as $type)) as string)
```

`cast(NULL as decimal)` is legal even under `ERROR_IF_OVERFLOW`, and `MAX()/MIN()` ignore NULL inputs, so the result is identical to the previous non-strict behavior (where `cast('' as decimal)` silently yielded NULL): all-NULL partitions contribute no min/max, other columns load normally.

Verified end-to-end: the new SQL test fails on an unfixed build (column statistics stay UNKNOWN until the 120s loop times out; the loader SQL reproduces the exact production error) and passes on a fixed build (ESTIMATE on the first probe).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

