### PR TITLE
[Enhancement] Add placeholders for tags occupied by downstream distributions (EncryptionKeyTypePB 21-23, TabletMetadataPB 50-51, BuiltinInvertedIndexPB 2-4)

### DIFF
--- a/be/src/platform/key_cache.cpp
+++ b/be/src/platform/key_cache.cpp
@@ -36,6 +36,10 @@ EncryptionKey::EncryptionKey() = default;
 EncryptionKey::EncryptionKey(EncryptionKeyPB pb) : _pb(std::move(pb)) {}
 EncryptionKey::~EncryptionKey() = default;
 
+static bool is_downstream_placeholder_type(EncryptionKeyTypePB type) {
+    return type == PLACEHOLDER_21 || type == PLACEHOLDER_22 || type == PLACEHOLDER_23;
+}
+
 static const std::string& get_identifier_from_pb(const EncryptionKeyPB& pb) {
     switch (pb.type()) {
     case NORMAL_KEY:
@@ -160,6 +164,15 @@ Status KeyCache::_resolve_encryption_meta(const EncryptionMetaPB& metaPb, std::v
                                           std::vector<std::unique_ptr<EncryptionKey>>& owned_keys,
                                           bool cache_last_key) {
     int nkey = metaPb.key_hierarchy_size();
+    // Downstream-occupied placeholder key types may appear in metadata written by
+    // downstream distributions; reject them up front instead of crashing later in
+    // the identifier/cache path.
+    for (int k = 0; k < nkey; k++) {
+        if (is_downstream_placeholder_type(metaPb.key_hierarchy(k).type())) {
+            return Status::NotSupported(
+                    fmt::format("encryption key type not supported:{}", metaPb.key_hierarchy(k).type()));
+        }
+    }
     int i = nkey - 1;
     for (; i >= 0; i--) {
         bool use_cache = (i != nkey - 1) || cache_last_key;

--- a/be/src/platform/key_cache.cpp
+++ b/be/src/platform/key_cache.cpp
@@ -40,6 +40,11 @@ static const std::string& get_identifier_from_pb(const EncryptionKeyPB& pb) {
     switch (pb.type()) {
     case NORMAL_KEY:
         return pb.has_plain_key() ? pb.plain_key() : pb.encrypted_key();
+    case PLACEHOLDER_21:
+    case PLACEHOLDER_22:
+    case PLACEHOLDER_23:
+        // downstream-occupied placeholder values, never produced by upstream
+        break;
     }
     CHECK(false) << fmt::format("get_identifier_from_pb not supported for type:{}", pb.type());
 }
@@ -121,6 +126,11 @@ StatusOr<std::unique_ptr<EncryptionKey>> EncryptionKey::create_from_pb(Encryptio
     switch (pb.type()) {
     case EncryptionKeyTypePB::NORMAL_KEY:
         return std::make_unique<NormalKey>(std::move(pb));
+    case EncryptionKeyTypePB::PLACEHOLDER_21:
+    case EncryptionKeyTypePB::PLACEHOLDER_22:
+    case EncryptionKeyTypePB::PLACEHOLDER_23:
+        // downstream-occupied placeholder values, never produced by upstream
+        break;
     }
     return Status::NotSupported(fmt::format("key type not supported:{}", pb.type()));
 }

--- a/be/test/platform/key_cache_test.cpp
+++ b/be/test/platform/key_cache_test.cpp
@@ -133,6 +133,30 @@ TEST_F(KeyCacheTest, WrapEncryptionMeta) {
     }
 }
 
+TEST_F(KeyCacheTest, RejectDownstreamPlaceholderKeyType) {
+    EncryptionKeyPB master;
+    master.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    master.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    master.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    master.set_plain_key("0000000000000000");
+
+    EncryptionKeyPB placeholder;
+    placeholder.set_id(2);
+    placeholder.set_type(EncryptionKeyTypePB::PLACEHOLDER_21);
+
+    EncryptionMetaPB metaPb;
+    *metaPb.add_key_hierarchy() = master;
+    *metaPb.add_key_hierarchy() = placeholder;
+    std::string encryption_meta;
+    ASSERT_TRUE(metaPb.SerializeToString(&encryption_meta));
+
+    KeyCache cache;
+    auto st = cache.create_encryption_meta_pair(encryption_meta);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.status().is_not_supported()) << st.status();
+    ASSERT_EQ(0, cache.size());
+}
+
 TEST_F(KeyCacheTest, RefreshKeys) {
     EncryptionKeyPB pb;
     pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);

--- a/gensrc/proto/encryption.proto
+++ b/gensrc/proto/encryption.proto
@@ -18,6 +18,12 @@ option java_package = "com.starrocks.proto";
 
 enum EncryptionKeyTypePB {
     NORMAL_KEY = 0; // store just algorithm and raw key bytes, mainly used internally for low level KEK and DEK
+    // Values 21-23 are occupied by downstream distributions and already persisted
+    // in downstream metadata. Placeholders are declared here (unused by upstream)
+    // so that no upstream value is ever allocated on these numbers.
+    PLACEHOLDER_21 = 21;
+    PLACEHOLDER_22 = 22;
+    PLACEHOLDER_23 = 23;
 }
 
 enum EncryptionAlgorithmPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -354,6 +354,12 @@ message TabletMetadataPB {
     // Per-segment index delta groups produced by ADD INDEX schema change
     // (lake-only). Allows adding indexes without rewriting segment data.
     optional IndexDeltaGroupMetadataPB idg_meta = 24;
+
+    // Tags 50, 51 are occupied by downstream distributions and already persisted
+    // in downstream tablet metadata. Placeholders are declared here (unused by
+    // upstream) so that no upstream field is ever allocated on these tags.
+    repeated int64 placeholder_50 = 50;
+    optional bytes placeholder_51 = 51;
 }
 
 message MetadataUpdateInfoPB {

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -352,4 +352,10 @@ message BloomFilterIndexPB {
 
 message BuiltinInvertedIndexPB {
     optional BitmapIndexPB bitmap_index = 1;
+    // Tags 2-4 are occupied by downstream distributions and already persisted
+    // in downstream segment metadata. Placeholders are declared here (unused by
+    // upstream) so that no upstream field is ever allocated on these tags.
+    optional int32 placeholder_2 = 2;
+    optional bytes placeholder_3 = 3;
+    optional bytes placeholder_4 = 4;
 }


### PR DESCRIPTION
## Why I'm doing:

Downstream distributions have shipped fields/enum values on tags that upstream StarRocks has not yet allocated, and those tags are already persisted in on-disk metadata. If upstream later allocates the same tags, the same persisted bytes would decode to a different meaning on shared metadata / mixed-version reads. Occupying the tags upstream fences them off so this can never happen.

## What I'm doing:

Declare unused placeholders on two number ranges. No behavior change; the placeholders are never read or written by upstream code.

- `EncryptionKeyTypePB`: `PLACEHOLDER_21/22/23 = 21/22/23`
- `TabletMetadataPB`: `placeholder_50 = 50`, `placeholder_51 = 51`
- `BuiltinInvertedIndexPB`: `placeholder_2/3/4 = 2/3/4`

Plain placeholder declarations are used instead of `reserved` statements because the FE proto codegen (jprotobuf) cannot parse `reserved`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Only declares unused placeholder enum values / fields; no runtime behavior change.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
