### PR TITLE
[Enhancement] Widen an integer sort-key column on shared-data range-distribution tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJob.java
@@ -391,6 +391,16 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
         if (sourceColumnNames.contains(column.getName())) {
             return backquoted;
         }
+        // A MODIFY-prefixed sort-key column -- e.g. an integer key widen -- has no source column under
+        // its prefixed name, but its unprefixed origin is still present in the base. Sample the ACTUAL
+        // source values cast to the new (wider) type, NOT a constant default: sampling the default would
+        // make this column non-distinguishing and collapse the boundaries.
+        String originName = Column.removeNamePrefix(column.getName());
+        if (sourceColumnNames.contains(originName)) {
+            return "CAST(" + ParseUtil.backquote(originName) + " AS " + column.getType().toSql()
+                    + ") AS " + backquoted;
+        }
+        // A genuinely-added key column: no source value, so materialize its constant default.
         // Backslash must be escaped before the double quote, or a trailing backslash in the
         // default would swallow the closing quote and a mid-string backslash would be silently
         // reinterpreted by the StarRocks string-literal lexer.
@@ -423,8 +433,11 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
      */
     @Override
     protected List<String> rewriteSelectColumnNames(@NotNull OlapTable table) {
+        // Select each surviving column by its UNPREFIXED name: an unchanged column selects itself; a
+        // MODIFY-prefixed type change (e.g. a key widen) selects its unprefixed origin, which
+        // InsertPlanner.fillShadowColumns then casts to the (wider) shadow-column type.
         return survivingColumns(table).stream()
-                .map(column -> ParseUtil.backquote(column.getName()))
+                .map(column -> ParseUtil.backquote(Column.removeNamePrefix(column.getName())))
                 .collect(Collectors.toList());
     }
 
@@ -448,7 +461,12 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
     }
 
     /**
-     * The non-generated newSchema columns present in the base (origin) index schema, in newSchema order.
+     * The non-generated newSchema columns whose value comes from the base (origin) index schema, in
+     * newSchema order. A column qualifies when its name -- with any {@code __starrocks_shadow_} prefix
+     * removed -- is present in the base schema: an unchanged column (no prefix), or a MODIFY-prefixed
+     * type change (e.g. an integer key widen) whose unprefixed origin still exists in the base and whose
+     * value is a cast of that origin. A genuinely-added ({@code __starrocks_shadow_}-prefixed) column has
+     * no unprefixed origin in the base and is excluded (it is default-materialized, not selected).
      */
     private List<Column> survivingColumns(@NotNull OlapTable table) {
         Set<String> baseNames = table.getSchemaByIndexMetaId(originIndexMetaId).stream()
@@ -456,7 +474,7 @@ public class LakeRangeRewriteSchemaChangeJob extends LakeOnlineRewriteJobBase {
                 .collect(Collectors.toCollection(() -> Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER)));
         return newSchema.stream()
                 .filter(column -> !column.isGeneratedColumn())
-                .filter(column -> baseNames.contains(column.getName()))
+                .filter(column -> baseNames.contains(Column.removeNamePrefix(column.getName())))
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2613,6 +2613,12 @@ public class SchemaChangeHandler extends AlterHandler {
         // available; the dispatch tail then classifies it as either a metadata-only trailing sort-key
         // add (async schema-evolution job) or the rewrite fallback.
         boolean rangeKeyAddPending = false;
+        // Set when a MODIFY COLUMN that widens an integer range sort-key column on a shared-data range
+        // table is routed (needsRangeRewriteSchemaChange + modifyColumnWidensRangeSortKeyIntType). Like
+        // rangeKeyAddPending, clause processing continues through finalAnalyze (preserving its
+        // compatibility / partition-column / short-key validation); the dispatch tail then builds the
+        // K-tablet rewrite job with the widened schema and the preserved sort key.
+        boolean rangeKeyWidenPending = false;
         // NOTE: be very careful with the order of processing alter clauses and early return!!!
         // It is in a for-loop!
         for (AlterClause alterClause : alterClauses) {
@@ -2793,7 +2799,16 @@ public class SchemaChangeHandler extends AlterHandler {
                                                            alterIndexMetaIdToIncrVarcharLenColNames);
                 AlterMetricRegistry.getInstance().updateAlterOperation(AlterMetricRegistry.AlterOperationType.MODIFY_COLUMN);
                 List<Column> postFlipBaseSchema = indexMetaIdToSchema.get(olapTable.getBaseIndexMetaId());
-                if (needsRangeRewriteSchemaChange(olapTable, modifyColumnClause)
+                boolean routedRangeRewrite = needsRangeRewriteSchemaChange(olapTable, modifyColumnClause);
+                if (routedRangeRewrite && modifyColumnWidensRangeSortKeyIntType(olapTable, modifyColumnClause)) {
+                    // An in-scope integer widen of a range sort-key column on a shared-data range table:
+                    // route to the K-tablet data rewrite (data is recast to the wider type, boundaries
+                    // re-sampled). Do NOT early-return -- continue through finalAnalyze (compatibility /
+                    // partition-column / short-key validation), then build the job in the dispatch tail.
+                    rangeKeyWidenPending = true;
+                }
+                if (routedRangeRewrite
+                        && modifyColumnShiftsRangeSortKey(olapTable, modifyColumnClause)
                         && rangeRewriteKeySchemaIsValid(postFlipBaseSchema)) {
                     // A keyness flip on a shared-data range table whose flip shifts the range sort key:
                     // re-route/re-sort/re-aggregate all data into a freshly sampled K-tablet shadow
@@ -2919,6 +2934,21 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
             return buildRoutedAddKeyColumnJob(db, olapTable, indexMetaIdToSchema, alterClauses);
+        }
+
+        if (rangeKeyWidenPending) {
+            // A routed in-scope integer widen of a range sort-key column on a shared-data range table:
+            // rewrite all data into the wider type via a freshly sampled K-tablet shadow index, keeping
+            // the existing sort key. Single-clause only (mirrors the keyness-flip / ADD routing): a batch
+            // must not ship another clause's change under the rewritten schema.
+            if (alterClauses.size() > 1) {
+                throw new DdlException("MODIFY COLUMN that widens a range sort-key column on a "
+                        + "range-distribution table can not be combined with other alter operations");
+            }
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
+                    MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()));
+            return createRangeRewriteJobForKeyWiden(db, olapTable,
+                    indexMetaIdToSchema.get(olapTable.getBaseIndexMetaId()));
         }
 
         if (!fastSchemaEvolution) {
@@ -4864,7 +4894,9 @@ public class SchemaChangeHandler extends AlterHandler {
             return ((ReorderColumnsClause) clause).getColumnsByPos().size() != table.getBaseSchema().size();
         }
         if (clause instanceof ModifyColumnClause) {
-            return modifyColumnShiftsRangeSortKey(table, (ModifyColumnClause) clause);
+            ModifyColumnClause modifyClause = (ModifyColumnClause) clause;
+            return modifyColumnShiftsRangeSortKey(table, modifyClause)
+                    || modifyColumnWidensRangeSortKeyIntType(table, modifyClause);
         }
         if (clause instanceof DropColumnClause) {
             String dropCol = ((DropColumnClause) clause).getColName();
@@ -4948,6 +4980,123 @@ public class SchemaChangeHandler extends AlterHandler {
                         keynessOverride).stream()
                 .map(Column::getName).collect(Collectors.toList());
         return !currentSortKeyNames.equals(candidateSortKeyNames);
+    }
+
+    /**
+     * Whether a MODIFY COLUMN widens an integer column that is in the base index's range sort key, with
+     * everything else about the column unchanged -- an order-preserving type widen that keeps every key
+     * value logically identical. Such a change is routed to {@link LakeRangeRewriteSchemaChangeJob},
+     * which rewrites the data into the wider type (the on-disk short-key index / segment metadata / range
+     * boundaries are re-derived at the wide type, so there is no mixed-width state to reconcile).
+     *
+     * <p>Eligible iff ALL of: the clause has no position move ({@code getColPos() == null}) and no rollup
+     * target -- the rewrite builder preserves the existing positional {@code sortKeyIdxes}, so a move
+     * would mis-map the sort key, and a {@link Column} comparison cannot observe position; the table is
+     * not PRIMARY_KEYS; the modified column is in the range sort key; and the resolved modified column
+     * differs from the original ONLY in the type ({@link Column#differsOnlyInType}, so keyness /
+     * nullability / default / aggregation / generated status are all unchanged, and generated columns are
+     * excluded on both sides), where the type change is an in-scope integer widen
+     * ({@link #isInScopeIntegerWiden}). A bundled nullability relaxation or default change, a generated
+     * column, or a position move therefore is NOT a pure widen and keeps its current (reject) behavior --
+     * finalAnalyze does not reject those on its own.
+     */
+    private static boolean modifyColumnWidensRangeSortKeyIntType(OlapTable table, ModifyColumnClause clause) {
+        // A position move, rollup target, or column properties are real changes beyond a pure type widen;
+        // the rewrite builder consumes only the resolved schema + preserved sort key, so reject them here
+        // (a Column comparison cannot observe them). Mirrors the guards in isCommentOnlyModification.
+        if (clause.getColPos() != null || clause.getRollupName() != null
+                || (clause.getProperties() != null && !clause.getProperties().isEmpty())) {
+            return false;
+        }
+        if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
+            return false;
+        }
+        long baseIndexMetaId = table.getBaseIndexMetaId();
+        MaterializedIndexMeta indexMeta = table.getIndexMetaByMetaId(baseIndexMetaId);
+        if (indexMeta == null) {
+            return false;
+        }
+        String columnName = clause.getColumnDef().getName();
+        Column oriColumn = null;
+        for (Column column : indexMeta.getSchema()) {
+            if (column.getName().equalsIgnoreCase(columnName)) {
+                oriColumn = column;
+                break;
+            }
+        }
+        if (oriColumn == null) {
+            return false;
+        }
+        boolean inRangeSortKey = MetaUtils.getRangeDistributionColumns(table, baseIndexMetaId).stream()
+                .anyMatch(c -> c.getName().equalsIgnoreCase(columnName));
+        if (!inRangeSortKey) {
+            return false;
+        }
+        Column modColumn = buildColumnInternal(clause.getColumnDef(), table);
+        if (oriColumn.isGeneratedColumn() || modColumn.isGeneratedColumn()) {
+            return false;
+        }
+        // Resolve the modified column's keyness exactly as processModifyColumn does before comparing:
+        // AGG_KEYS promotes a no-aggregation column to KEY, so `MODIFY COLUMN k BIGINT` (no KEY spelled)
+        // on an AGG table is still a pure key-type widen. Without this, the raw ColumnDef keyness would
+        // make differsOnlyInType spuriously reject it.
+        modColumn.setIsKey(resolveModifyColumnKeyness(table, clause.getColumnDef(), oriColumn));
+        return oriColumn.differsOnlyInType(modColumn)
+                && isInScopeIntegerWiden(oriColumn.getPrimitiveType(), modColumn.getPrimitiveType());
+    }
+
+    /**
+     * Whether {@code mod} is a strictly wider integer type than {@code ori}, within the in-scope integer
+     * family TINYINT &lt; SMALLINT &lt; INT &lt; BIGINT. LARGEINT is intentionally excluded (it crosses the
+     * FE {@code IntVariant} -&gt; {@code LargeIntVariant} boundary), as are all non-integer types.
+     */
+    private static boolean isInScopeIntegerWiden(PrimitiveType ori, PrimitiveType mod) {
+        int a = integerWidenRank(ori);
+        int b = integerWidenRank(mod);
+        return a > 0 && b > 0 && b > a;
+    }
+
+    private static int integerWidenRank(PrimitiveType type) {
+        if (type == null) {
+            return -1;
+        }
+        switch (type) {
+            case TINYINT:
+                return 1;
+            case SMALLINT:
+                return 2;
+            case INT:
+                return 3;
+            case BIGINT:
+                return 4;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Build a {@link LakeRangeRewriteSchemaChangeJob} for an in-scope integer widen of a range sort-key
+     * column (see {@link #modifyColumnWidensRangeSortKeyIntType}). Unlike the keyness-flip builder
+     * {@link #createRangeRewriteJob(Database, OlapTable, List)}, this does NOT strip the shadow name
+     * prefix (the widened column stays {@code __starrocks_shadow_}-prefixed so InsertPlanner materializes
+     * it as {@code CAST(origin AS widetype)}) and does NOT re-derive the sort key from key columns:
+     * a widen changes no key membership/order, so the table's EXISTING base-index sort key
+     * ({@code sortKeyIdxes}/{@code sortKeyUniqueIds}) is preserved verbatim (unique-ids/positions survive
+     * a MODIFY), including a divergent explicit {@code ORDER BY}. The short-key count is recomputed for
+     * the widened schema (a wider trailing key can shrink the short-key budget).
+     */
+    private AlterJobV2 createRangeRewriteJobForKeyWiden(Database db, OlapTable olapTable, List<Column> newSchema)
+            throws StarRocksException {
+        Preconditions.checkState(newSchema != null, "range-rewrite widen: missing new schema for base index");
+        long baseIndexMetaId = olapTable.getBaseIndexMetaId();
+        MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByMetaId(baseIndexMetaId);
+        List<Integer> sortKeyIdxes = indexMeta.getSortKeyIdxes();
+        List<Integer> sortKeyUniqueIds = indexMeta.getSortKeyUniqueIds();
+        short shortKeyColumnCount = (sortKeyIdxes != null)
+                ? GlobalStateMgr.calcShortKeyColumnCount(newSchema, null, sortKeyIdxes)
+                : GlobalStateMgr.calcShortKeyColumnCount(newSchema, null);
+        return buildRangeRewriteJob(db, olapTable, baseIndexMetaId, newSchema, olapTable.getKeysType(),
+                sortKeyIdxes, sortKeyUniqueIds, shortKeyColumnCount);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -1004,6 +1004,55 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.isHidden == other.isHidden();
     }
 
+    /**
+     * Whether {@code other} differs from this column in {@link #getType()} ONLY -- i.e. a pure type
+     * change. Every other column attribute {@link #equals(Object)} considers must be identical,
+     * including {@link #isKey()} (keyness unchanged), except the comment (ignored, as in
+     * {@link #differsOnlyInKeyness}). The type is intentionally NOT compared here; the caller decides
+     * whether the type change is an allowed conversion (e.g. an order-preserving integer widen).
+     *
+     * <p>Maintenance: like {@link #differsOnlyInKeyness}, this attribute list must stay in sync with
+     * the column's compatibility checks (the fields {@link #equals(Object)} considers). If a new
+     * attribute is added there but not here, a MODIFY COLUMN that changes only that new attribute
+     * would be misclassified as a pure type change.
+     */
+    public boolean differsOnlyInType(Column other) {
+        if (other == null) {
+            return false;
+        }
+        if (!this.name.equalsIgnoreCase(other.getName())) {
+            return false;
+        }
+        if (this.isKey != other.isKey) {
+            return false;
+        }
+        if (!(this.aggregationType == other.aggregationType ||
+                (AggregateType.isNullOrNone(this.aggregationType) &&
+                        AggregateType.isNullOrNone(other.getAggregationType())))) {
+            return false;
+        }
+        if (this.aggStateDesc != null && !this.aggStateDesc.equals(other.aggStateDesc)) {
+            return false;
+        }
+        if (this.isAllowNull != other.isAllowNull) {
+            return false;
+        }
+        if (!this.isSameDefaultValue(other)) {
+            return false;
+        }
+        if (this.isGeneratedColumn() != other.isGeneratedColumn()) {
+            return false;
+        }
+        if (this.isGeneratedColumn() &&
+                !this.generatedColumnExpr.equals(other.generatedColumnExpr)) {
+            return false;
+        }
+        if (this.isAutoIncrement != other.isAutoIncrement) {
+            return false;
+        }
+        return this.isHidden == other.isHidden();
+    }
+
     public boolean isSchemaCompatible(Column other) {
         if (!this.name.equalsIgnoreCase(other.getName())) {
             return false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RangeDistributionGuardTest.java
@@ -338,6 +338,183 @@ public class RangeDistributionGuardTest {
                 "Expected a LakeRangeRewriteSchemaChangeJob, got: " + job);
     }
 
+    // ---- Integer sort-key widen -> data-rewrite route ----
+
+    // A range table with NOT NULL integer keys, so `MODIFY COLUMN k BIGINT KEY NOT NULL` is a PURE type
+    // widen (keyness + nullability unchanged). `keys`/`orderBy` let a test diverge the sort key from the
+    // key columns.
+    private static String intKeyRangeTableDdl(String name, String colDefs, String keys, String orderBy) {
+        return "create table " + name + " (" + colDefs + ")\n" + keys + "\norder by(" + orderBy + ")\n"
+                + "properties('replication_num' = '1');";
+    }
+
+    private AlterJobV2 buildJobFor(String tableName, String alterSql) throws Exception {
+        com.starrocks.sql.ast.AlterTableStmt stmt = (com.starrocks.sql.ast.AlterTableStmt)
+                UtFrameUtils.parseStmtWithNewParser(alterSql, connectContext);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getTable("test", tableName);
+        return GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .analyzeAndCreateJob(stmt.getAlterClauseList(),
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test"), table);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenRoutedToRangeRewrite() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_dup",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        AlterJobV2 job = buildJobFor("t_widen_dup", "alter table t_widen_dup modify column k1 bigint key not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "Expected a LakeRangeRewriteSchemaChangeJob, got: " + job);
+        // The rewrite carries the WIDENED column type (shadow-prefixed until flip).
+        LakeRangeRewriteSchemaChangeJob rewrite = (LakeRangeRewriteSchemaChangeJob) job;
+        Column widened = rewrite.getNewSchema().stream()
+                .filter(c -> Column.removeNamePrefix(c.getName()).equalsIgnoreCase("k1"))
+                .findFirst().orElseThrow();
+        assertEquals(PrimitiveType.BIGINT, widened.getPrimitiveType(),
+                "widened key must carry the new BIGINT type in the rewrite schema");
+        // The boundary sampler projects the widened key as CAST(origin AS wide) -- the real values, not a
+        // constant default (which would collapse the boundaries).
+        List<String> projection = rewrite.buildSampleProjectionForTest(
+                new java.util.TreeSet<>(java.util.List.of("k1", "k2", "v1")));
+        assertTrue(projection.stream().anyMatch(p -> p.toLowerCase(Locale.ROOT).contains("cast(`k1`")
+                        && p.toLowerCase(Locale.ROOT).contains("bigint")),
+                "sample projection must CAST the origin k1 to bigint, got: " + projection);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenPreservesExplicitSortKey() throws Exception {
+        // Sort key (k2, k1) diverges from the key column order (k1, k2). A widen of k1 must PRESERVE the
+        // explicit sort key, not re-derive it from the key columns.
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_orderby",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k2, k1"));
+        AlterJobV2 job = buildJobFor("t_widen_orderby",
+                "alter table t_widen_orderby modify column k1 bigint key not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob);
+        List<Integer> sortKeyIdxes = Deencapsulation.getField(job, "newSortKeyIdxes");
+        assertEquals(List.of(1, 0), sortKeyIdxes,
+                "explicit ORDER BY (k2, k1) must be preserved across the widen, not re-derived to (k1, k2)");
+    }
+
+    @Test
+    public void testModifyIntKeyWidenTinyintToIntRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_tiny",
+                "k1 tinyint NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        AlterJobV2 job = buildJobFor("t_widen_tiny", "alter table t_widen_tiny modify column k1 int key not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenAggRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_agg",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int SUM", "AGGREGATE KEY(k1, k2)", "k1, k2"));
+        AlterJobV2 job = buildJobFor("t_widen_agg", "alter table t_widen_agg modify column k1 bigint key not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenUniqueRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_uniq",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "UNIQUE KEY(k1, k2)", "k1, k2"));
+        AlterJobV2 job = buildJobFor("t_widen_uniq", "alter table t_widen_uniq modify column k1 bigint key not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob);
+    }
+
+    @Test
+    public void testModifyDupValueColumnInSortKeyWidenRouted() throws Exception {
+        // A DUP table can sort by a value column: ORDER BY (k1, v1) makes v1 a range sort-key column.
+        // Widening v1 (staying a value column) is still a pure widen of a range sort-key column and routes.
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_dupval",
+                "k1 int NOT NULL, k2 int, v1 int NOT NULL", "DUPLICATE KEY(k1)", "k1, v1"));
+        AlterJobV2 job = buildJobFor("t_widen_dupval", "alter table t_widen_dupval modify column v1 bigint not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "a DUP value column in the range sort key must route when widened, got: " + job);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenAggWithoutKeyKeywordRouted() throws Exception {
+        // On an AGG table a column with no aggregation method is a key column, so `MODIFY COLUMN k1
+        // BIGINT NOT NULL` (KEY omitted) still preserves keyness -- it is a pure widen and must route.
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_agg_nokw",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int SUM", "AGGREGATE KEY(k1, k2)", "k1, k2"));
+        AlterJobV2 job = buildJobFor("t_widen_agg_nokw", "alter table t_widen_agg_nokw modify column k1 bigint not null");
+        assertTrue(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "an AGG key widen without the KEY keyword must still route, got: " + job);
+    }
+
+    @Test
+    public void testModifyKeyBigintToLargeintNotRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_large",
+                "k1 bigint NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        // BIGINT -> LARGEINT crosses the IntVariant/LargeIntVariant boundary: not an in-scope widen.
+        assertAlterRejectedWithRangeDistribution("alter table t_widen_large modify column k1 largeint key not null");
+    }
+
+    @Test
+    public void testModifyKeyNarrowingNotRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_narrow",
+                "k1 bigint NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        assertAlterRejectedWithRangeDistribution("alter table t_widen_narrow modify column k1 int key not null");
+    }
+
+    @Test
+    public void testModifyKeyNonIntegerNotRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_nonint",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        assertAlterRejectedWithRangeDistribution("alter table t_widen_nonint modify column k1 varchar(30) key not null");
+    }
+
+    @Test
+    public void testModifyIntKeyWidenWithPositionMoveNotRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_pos",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        // A position move would break the preserved positional sort key -> not routed as a pure widen.
+        assertAlterRejectedWithRangeDistribution(
+                "alter table t_widen_pos modify column k1 bigint key not null first");
+    }
+
+    @Test
+    public void testModifyIntKeyBareDropKeyNotRouted() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_bare",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        // Bare MODIFY (no KEY) on a DUP key drops keyness -> a keyness change bundled with a type change,
+        // neither a pure widen nor a pure keyness flip -> rejected.
+        assertAlterRejectedWithRangeDistribution("alter table t_widen_bare modify column k1 bigint");
+    }
+
+    @Test
+    public void testHashTableIntKeyWidenNotRoutedToRangeRewrite() throws Exception {
+        // Distribute by k2 so k1 (the widened key) is not the distribution column (modifying a
+        // distribution column is independently rejected, which would mask the routing check).
+        starRocksAssert.withTable("create table t_widen_hash (k1 int NOT NULL, k2 int NOT NULL, v1 int)\n"
+                + "DUPLICATE KEY(k1, k2)\nDISTRIBUTED BY HASH(k2) BUCKETS 3\n"
+                + "properties('replication_num' = '1');");
+        // The universal wrapper (needsRangeRewriteSchemaChange requires isRangeDistribution) must keep a
+        // HASH-distributed table off the rewrite route.
+        AlterJobV2 job = buildJobFor("t_widen_hash", "alter table t_widen_hash modify column k1 bigint key not null");
+        assertFalse(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "a HASH-distributed table must NOT route to the range rewrite, got: " + job);
+    }
+
+    @Test
+    public void testModifyIntKeyWidenMultiClauseRejected() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_multi",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        DdlException e = assertThrowsDdlException(() -> buildJobFor("t_widen_multi",
+                "alter table t_widen_multi modify column k1 bigint key not null, add column v2 int"));
+        assertTrue(e.getMessage().toLowerCase(Locale.ROOT).contains("combined"),
+                "expected a multi-clause rejection, got: " + e.getMessage());
+    }
+
+    @Test
+    public void testModifyValueColumnWidenNotRoutedToRangeRewrite() throws Exception {
+        starRocksAssert.withTable(intKeyRangeTableDdl("t_widen_value",
+                "k1 int NOT NULL, k2 int NOT NULL, v1 int", "DUPLICATE KEY(k1, k2)", "k1, k2"));
+        // v1 is NOT in the sort key: a value-column widen is an ordinary schema change, not the range rewrite.
+        AlterJobV2 job = buildJobFor("t_widen_value", "alter table t_widen_value modify column v1 bigint");
+        assertFalse(job instanceof LakeRangeRewriteSchemaChangeJob,
+                "a non-sort-key value column widen must NOT route to the range rewrite, got: " + job);
+    }
+
     @Test
     public void testOptimizeRejectedOnRangeDistribution() throws Exception {
         starRocksAssert.withTable(rangeTableDdl("t_guard_optimize"));
@@ -517,15 +694,19 @@ public class RangeDistributionGuardTest {
                 "alter table t_guard_shrink modify column k1 varchar(5) KEY NOT NULL");
     }
 
+    // An integer sort-key widen (INT -> BIGINT) is now ROUTED to the data-rewrite job (see
+    // testModifyIntKeyWidenRoutedToRangeRewrite). A type change that is NOT an in-scope integer widen --
+    // e.g. INT -> DECIMAL, which changes the FE Variant subclass -- stays rejected by the range-sort-key
+    // guard.
     @Test
-    public void testNonVarcharTypeChangeSortKeyColumnRejectedOnRangeDistribution() throws Exception {
+    public void testNonIntegerTypeChangeSortKeyColumnRejectedOnRangeDistribution() throws Exception {
         starRocksAssert.withTable(
                 "create table t_guard_int (k1 int NOT NULL, k2 int NOT NULL, v1 int)\n" +
                 "DUPLICATE KEY(k1, k2)\n" +
                 "order by(k1, k2)\n" +
                 "properties('replication_num' = '1');");
         assertAlterRejectedWithRangeDistribution(
-                "alter table t_guard_int modify column k1 bigint KEY NOT NULL");
+                "alter table t_guard_int modify column k1 decimal(20, 0) KEY NOT NULL");
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

An integer column in the range sort key of a shared-data (cloud-native) range-distribution table could not be widened at all. `ALTER TABLE ... MODIFY COLUMN <intkey> BIGINT` on such a sort-key column was rejected outright by the range-distribution sort-key guard, even though widening (e.g. to mitigate overflow) is a common ask and the storage engine can hold the wider type. This closes that capability gap.

## What I'm doing:

Route an order-preserving integer widen (TINYINT → SMALLINT → INT → BIGINT) of a range sort-key column to the existing K-tablet shadow-index data rewrite (`LakeRangeRewriteSchemaChangeJob`), which recasts every row to the wider type and re-samples the per-tablet boundaries. The result is a uniformly wide table with no mixed-width state, so it is byte/value-equivalent to a drop-and-recreate at the wider type.

Details:
- Eligibility is fail-closed. The change must be a **pure** type widen — keyness, nullability, default, aggregation and generated status all unchanged (`Column.differsOnlyInType`), generated columns excluded, no position move / rollup target / column properties, and DUP/AGG/UNIQUE only (not `PRIMARY_KEYS`). It is gated by the existing range-distribution routing wrapper (`needsRangeRewriteSchemaChange`: cloud-native, range distribution, single index, not colocate, not `AUTO_INCREMENT`). `BIGINT → LARGEINT` (crosses the FE `IntVariant`/`LargeIntVariant` boundary), narrowing, and non-integer changes keep their current behavior.
- The keyness of the modified column is resolved exactly as normal `MODIFY COLUMN` does (AGG promotes a no-aggregation column to key), so `MODIFY COLUMN k BIGINT NOT NULL` on an AGG table is recognized as a key widen without spelling `KEY`.
- The widened column stays `__starrocks_shadow_`-prefixed so the rewrite `INSERT` casts it from its origin, and the table's existing sort key (including a divergent explicit `ORDER BY`) is preserved rather than re-derived from the key columns; the short-key count is recomputed for the wider schema.

FE-only; no BE, gensrc, or protocol change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A `MODIFY COLUMN` that previously failed (an integer sort-key widen on a range-distribution table) now succeeds. No new SQL syntax is introduced. Happy to reclassify to Miscellaneous if preferred.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Compatibility

Main-only. The routed data rewrite produces a uniformly wide table (segments, per-tablet ranges, and short-key indexes are all re-derived at the wider type), so there is no mixed-width on-disk state and no downgrade/read-compat concern. `LakeRangeRewriteSchemaChangeJob` is itself main-only, so this is not backported.

## Testing

FE unit tests (`RangeDistributionGuardTest`, 79 tests, all green; `mvn`, JDK 17) cover: routing of an in-scope widen on DUP/AGG/UNIQUE range tables (incl. TINYINT→INT, AGG without the `KEY` keyword, and a DUP value column used by an explicit `ORDER BY`); preservation of a divergent explicit `ORDER BY` across the widen; and the fail-closed matrix — `BIGINT→LARGEINT`, narrowing, non-integer, position move, bare-drop-key, multi-clause batch, HASH-distributed, and a non-sort-key value column all NOT routed. Checkstyle (main + test) clean.
