### PR TITLE
[BugFix] fix use-after-free on multi-char CSV delimiter straddling a buffer expansion

### DIFF
--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -58,6 +58,9 @@ inline bool CSVReader::is_column_delimiter(bool expandBuffer) {
                 if (_buff.limit_offset() - p < 1) {
                     return false;
                 }
+                // readMore() may have expanded (reallocated) the buffer via _storage.resize(),
+                // freeing the storage base_ptr was taken from. Refresh it before the next read.
+                base_ptr = _buff.base_ptr();
             }
         }
         if (i == _column_delimiter_length) {
@@ -90,6 +93,9 @@ inline bool CSVReader::is_row_delimiter(bool expandBuffer) {
                 if (_buff.limit_offset() - p < 1) {
                     return false;
                 }
+                // readMore() may have expanded (reallocated) the buffer via _storage.resize(),
+                // freeing the storage base_ptr was taken from. Refresh it before the next read.
+                base_ptr = _buff.base_ptr();
             }
         }
         if (i == _row_delimiter_length) {

--- a/be/test/formats/csv/csv_reader_test.cpp
+++ b/be/test/formats/csv/csv_reader_test.cpp
@@ -42,8 +42,9 @@ protected:
 // CSVScanner::ScannerCSVReader::_fill_buffer for the state-machine parser.
 class StringCSVReader : public starrocks::CSVReader {
 public:
-    StringCSVReader(const starrocks::CSVParseOptions& parse_options, std::string data, size_t max_chunk = SIZE_MAX)
-            : CSVReader(parse_options), _data(std::move(data)), _max_chunk(max_chunk) {}
+    StringCSVReader(const starrocks::CSVParseOptions& parse_options, std::string data, size_t max_chunk = SIZE_MAX,
+                    size_t buffer_size = 128 * 1024)
+            : CSVReader(parse_options, buffer_size), _data(std::move(data)), _max_chunk(max_chunk) {}
 
     // Collects each row's fields as copied strings so tests don't have to
     // worry about the underlying buffer being reused.
@@ -416,6 +417,28 @@ TEST_F(CSVReaderTest, test_split_record_trim_space_empty_field) {
     reader.split_record(record3, &fields3);
     EXPECT_EQ(1, fields3.size());
     EXPECT_EQ("", fields3[0].to_string());
+}
+
+// Regression test for the multi-char column-delimiter buffer-expansion use-after-free:
+// is_column_delimiter() caches base_ptr = _buff.base_ptr(), then mid-match calls readMore(),
+// which can expand the buffer via _storage.resize() (reallocation frees the old storage). The
+// subsequent read *(base_ptr + p) then dereferences the freed old buffer. Feed a field that fills
+// the buffer so a two-char column delimiter straddles the boundary, forcing expansion during the
+// match. (is_row_delimiter has the same pattern and the same fix.)
+TEST_F(CSVReaderTest, test_multichar_delimiter_expand_boundary_uaf) {
+    starrocks::CSVParseOptions options("\n", "||", 0, false, 0, 0);
+    const size_t buf = 16;
+    std::string data(buf - 1, 'a'); // first '|' lands at the last buffer byte -> 2nd '|' forces expand
+    data += "||b\n";
+    StringCSVReader reader(options, data, SIZE_MAX, buf);
+
+    std::vector<std::vector<std::string>> rows;
+    auto st = reader.read_all_rows(&rows);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(1u, rows.size());
+    ASSERT_EQ(2u, rows[0].size());
+    EXPECT_EQ(std::string(buf - 1, 'a'), rows[0][0]);
+    EXPECT_EQ("b", rows[0][1]);
 }
 
 } // namespace starrocks::csv


### PR DESCRIPTION
## Why I'm doing:

CSVReader::is_column_delimiter() and is_row_delimiter() cache base_ptr = _buff.base_ptr() and then, while matching a multi-byte delimiter, may call readMore(). When the buffer is full, readMore() -> _expand_buffer_loosely() does _storage.resize(), which reallocates and frees the storage base_ptr points into. The next loop iteration reads *(base_ptr + p) from the freed buffer (heap-use-after-free). This is reachable via the FILES() TVF / broker load / Hive text connector scanner (v2 state machine, used when enclose or escape is set) with a multi-character column/row separator and a record that straddles the read buffer's expansion boundary.

Refresh base_ptr = _buff.base_ptr() after readMore() in both functions.

Add a BE unit test (CSVReaderTest.test_multichar_delimiter_expand_boundary_uaf, with a small buffer so a two-char delimiter straddles the boundary) that reads the freed buffer under AddressSanitizer before the fix and passes after.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
