### PR TITLE
[Enhancement] Support index filtering for monotonic runtime filter expressions

### DIFF
--- a/be/src/compute_env/query/scan_conjuncts_manager.cpp
+++ b/be/src/compute_env/query/scan_conjuncts_manager.cpp
@@ -893,8 +893,17 @@ Status ChunkPredicateBuilder<E, Type>::normalize_join_runtime_filter(const SlotD
             using ValueType = typename RunTimeTypeTraits<SlotType>::CppType;
             SlotId slot_id;
 
-            // probe expr is slot ref and slot id matches.
-            if (!desc->is_probe_slot_ref(&slot_id) || slot_id != slot.id()) continue;
+            if (!desc->is_probe_slot_ref(&slot_id)) {
+                Expr* probe_expr = desc->probe_expr_ctx()->root();
+                std::vector<SlotId> slot_ids;
+                if (probe_expr->is_monotonic() && probe_expr->get_slot_ids(&slot_ids) == 1 &&
+                    slot_ids[0] == slot.id()) {
+                    rt_ranger_params.add_unarrived_rf(desc, &slot, _opts.driver_sequence);
+                }
+                continue;
+            }
+
+            if (slot_id != slot.id()) continue;
 
             // runtime filter existed and does not have null.
             if (rf == nullptr || rf->get_in_filter() != nullptr) {

--- a/be/src/compute_env/runtime_range_pruner.hpp
+++ b/be/src/compute_env/runtime_range_pruner.hpp
@@ -56,6 +56,12 @@ struct RuntimeColumnPredicateBuilder {
             if (!probe_expr->is_slotref()) {
                 if (!probe_expr->is_monotonic()) return preds;
 
+                // Skip index filtering if the column referenced by the expr is dict encoded.
+                if (global_dictmaps != nullptr &&
+                    global_dictmaps->find(parser->column_id(*slot)) != global_dictmaps->end()) {
+                    return preds;
+                }
+
                 const auto* filter = down_cast<const MinMaxRuntimeFilter<mapping_type>*>(rf->get_min_max_filter());
                 if (filter == nullptr || filter->is_empty_range() || rf->has_null()) return preds;
 
@@ -338,9 +344,13 @@ inline auto RuntimeScanRangePruner::_get_predicates(const ColumnIdToGlobalDictMa
     // convert to olap filter
     auto slot_desc = _slot_descs[idx];
     auto* desc = _unarrived_runtime_filters[idx];
+    // Slot-ref probes dispatch on the slot type: a dict encoded column's probe expr is typed
+    // as dict code, while dict decoding lives in the string-type branch.
+    const LogicalType dispatch_type =
+            desc->probe_expr_ctx()->root()->is_slotref() ? slot_desc->type().type : desc->probe_expr_type();
     return type_dispatch_predicate<StatusOr<PredicatesRawPtrs>>(
-            desc->probe_expr_type(), false, detail::RuntimeColumnPredicateBuilder(), global_dictmaps, _parser, desc,
-            slot_desc, _driver_sequence, pool);
+            dispatch_type, false, detail::RuntimeColumnPredicateBuilder(), global_dictmaps, _parser, desc, slot_desc,
+            _driver_sequence, pool);
 }
 
 inline void RuntimeScanRangePruner::_init(const UnarrivedRuntimeFilterList& params) {

--- a/be/src/compute_env/runtime_range_pruner.hpp
+++ b/be/src/compute_env/runtime_range_pruner.hpp
@@ -21,6 +21,9 @@
 #include "column/global_dict/config.h"
 #include "compute_env/runtime_range_pruner.h"
 #include "exec_primitive/runtime_filter/runtime_filter_probe.h"
+#include "exprs/binary_predicate.h"
+#include "exprs/expr_context.h"
+#include "exprs/literal.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_in_filter.h"
 #include "storage_primitive/column_and_predicate.h"
@@ -39,18 +42,63 @@ struct RuntimeColumnPredicateBuilder {
                                                              const RuntimeFilterProbeDescriptor* desc,
                                                              const SlotDescriptor* slot, int32_t driver_sequence,
                                                              ObjectPool* pool) {
-        // keep consistent with ColumnRangeBuilder
+        // Unsupported probe expression types fall back to the original runtime filter.
         if constexpr (ltype == TYPE_TIME || ltype == TYPE_NULL || ltype == TYPE_JSON || ltype == TYPE_VARIANT ||
                       lt_is_float<ltype> || lt_is_binary<ltype>) {
-            DCHECK(false) << "unreachable path";
-            return Status::NotSupported("unreachable path");
+            return std::vector<const ColumnPredicate*>{};
         } else {
             std::vector<const ColumnPredicate*> preds;
+            constexpr LogicalType mapping_type = ltype == TYPE_CHAR ? TYPE_VARCHAR : ltype;
+            const RuntimeFilter* rf = desc->runtime_filter(driver_sequence);
+            ExprContext* probe_expr_ctx = desc->probe_expr_ctx();
+            Expr* probe_expr = probe_expr_ctx->root();
+
+            if (!probe_expr->is_slotref()) {
+                if (!probe_expr->is_monotonic()) return preds;
+
+                const auto* filter = down_cast<const MinMaxRuntimeFilter<mapping_type>*>(rf->get_min_max_filter());
+                if (filter == nullptr || filter->is_empty_range() || rf->has_null()) return preds;
+
+                using DecoderType = DummyDecoder<typename RunTimeTypeTraits<mapping_type>::CppType>;
+                DecoderType decoder(nullptr);
+                MinMaxParser<MinMaxRuntimeFilter<mapping_type>, DecoderType> minmax_parser(filter, &decoder);
+
+                RuntimeState* state = probe_expr_ctx->runtime_state();
+                const TypeDescriptor& probe_type = probe_expr->type();
+
+                auto add_predicate = [&](ColumnPtr bound, TExprOpcode::type opcode) -> Status {
+                    TExprNode node;
+                    node.node_type = TExprNodeType::BINARY_PRED;
+                    node.type = TypeDescriptor(TYPE_BOOLEAN).to_thrift();
+                    node.child_type = to_thrift(ltype);
+                    node.__set_opcode(opcode);
+
+                    Expr* root = pool->add(VectorizedBinaryPredicateFactory::from_thrift(node));
+                    root->add_child(Expr::copy(pool, probe_expr));
+                    root->add_child(pool->add(new VectorizedLiteral(std::move(bound), probe_type)));
+                    root->set_monotonic(true);
+
+                    auto* expr_ctx = pool->add(new ExprContext(root));
+                    RETURN_IF_ERROR(expr_ctx->prepare(state));
+                    RETURN_IF_ERROR(expr_ctx->open(state));
+                    ASSIGN_OR_RETURN(auto* predicate, parser->parse_expr_ctx(*slot, state, expr_ctx));
+                    if (predicate == nullptr) return Status::OK();
+
+                    predicate = pool->add(predicate);
+                    predicate->set_index_filter_only(true);
+                    preds.emplace_back(predicate);
+                    return Status::OK();
+                };
+
+                RETURN_IF_ERROR(add_predicate(minmax_parser.template min_const_column<ltype>(probe_type, pool),
+                                              filter->left_close_interval() ? TExprOpcode::GE : TExprOpcode::GT));
+                RETURN_IF_ERROR(add_predicate(minmax_parser.template max_const_column<ltype>(probe_type, pool),
+                                              filter->right_close_interval() ? TExprOpcode::LE : TExprOpcode::LT));
+                return preds;
+            }
 
             // Treat tinyint and boolean as int
             constexpr LogicalType limit_type = ltype == TYPE_TINYINT || ltype == TYPE_BOOLEAN ? TYPE_INT : ltype;
-            // Map TYPE_CHAR to TYPE_VARCHAR
-            constexpr LogicalType mapping_type = ltype == TYPE_CHAR ? TYPE_VARCHAR : ltype;
 
             using value_type = typename RunTimeTypeLimits<limit_type>::value_type;
             using RangeType = ColumnValueRange<value_type>;
@@ -65,8 +113,6 @@ struct RuntimeColumnPredicateBuilder {
 
             RangeType& range = full_range;
             range.set_index_filter_only(true);
-
-            const RuntimeFilter* rf = desc->runtime_filter(driver_sequence);
 
             // process agg in runtime-filter
             auto* in_filter = rf->get_in_filter();
@@ -291,9 +337,10 @@ inline auto RuntimeScanRangePruner::_get_predicates(const ColumnIdToGlobalDictMa
                                                     ObjectPool* pool) -> StatusOr<PredicatesRawPtrs> {
     // convert to olap filter
     auto slot_desc = _slot_descs[idx];
+    auto* desc = _unarrived_runtime_filters[idx];
     return type_dispatch_predicate<StatusOr<PredicatesRawPtrs>>(
-            slot_desc->type().type, false, detail::RuntimeColumnPredicateBuilder(), global_dictmaps, _parser,
-            _unarrived_runtime_filters[idx], slot_desc, _driver_sequence, pool);
+            desc->probe_expr_type(), false, detail::RuntimeColumnPredicateBuilder(), global_dictmaps, _parser, desc,
+            slot_desc, _driver_sequence, pool);
 }
 
 inline void RuntimeScanRangePruner::_init(const UnarrivedRuntimeFilterList& params) {

--- a/be/src/exec_primitive/runtime_filter/runtime_filter_probe.h
+++ b/be/src/exec_primitive/runtime_filter/runtime_filter_probe.h
@@ -62,7 +62,7 @@ public:
     bool skip_wait() const { return _skip_wait; }
     // RF is built by stream
     bool is_stream_build_filter() const { return _is_stream_build_filter; }
-    ExprContext* probe_expr_ctx() { return _probe_expr_ctx; }
+    ExprContext* probe_expr_ctx() const { return _probe_expr_ctx; }
     bool is_bound(const std::vector<TupleId>& tuple_ids) const { return _probe_expr_ctx->root()->is_bound(tuple_ids); }
     // Disable pushing down runtime filters when:
     //  - partition_by_exprs have multi columns;

--- a/be/test/compute_env/runtime_range_pruner_test.cpp
+++ b/be/test/compute_env/runtime_range_pruner_test.cpp
@@ -168,6 +168,102 @@ TEST_F(RuntimeRangePrunerTest, monotonic_expr_builds_two_column_expr_predicates)
     runtime_filter_desc->close(&_runtime_state);
 }
 
+// The predicates built for a dict encoded column must carry decoded strings, not dict codes.
+TEST_F(RuntimeRangePrunerTest, dict_encoded_slot_ref_decodes_codes) {
+    SlotDescriptor slot(0, "c0", TypeDescriptor::create_varchar_type(10));
+    std::vector<SlotDescriptor*> slot_descs{&slot};
+    ConnectorPredicateParser predicate_parser(&slot_descs);
+
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc,
+                          _gen_runtime_filter_desc(ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(0, true)));
+
+    MinMaxRuntimeFilter<TYPE_INT> rf;
+    rf.insert(100);
+    rf.insert(200);
+    runtime_filter_desc->set_runtime_filter(&rf);
+
+    GlobalDictMap dict{{Slice("apple"), 100}, {Slice("melon"), 200}};
+    ColumnIdToGlobalDictMap dict_maps;
+    dict_maps[0] = &dict;
+
+    UnarrivedRuntimeFilterList unarrived_runtime_filters;
+    unarrived_runtime_filters.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
+
+    std::vector<std::string> predicate_strings;
+    ASSERT_OK(pruner.update_range_if_arrived(
+            &dict_maps,
+            [&](auto, const PredicateList& predicates) {
+                for (const auto* predicate : predicates) {
+                    predicate_strings.emplace_back(predicate->debug_string());
+                }
+                return Status::OK();
+            },
+            false, 200000));
+    ASSERT_EQ(2, predicate_strings.size());
+    EXPECT_NE(predicate_strings[0].find("apple"), std::string::npos) << predicate_strings[0];
+    EXPECT_NE(predicate_strings[1].find("melon"), std::string::npos) << predicate_strings[1];
+}
+
+// No index filtering for a monotonic expr over a dict encoded column.
+TEST_F(RuntimeRangePrunerTest, monotonic_expr_on_dict_column_falls_back) {
+    SlotDescriptor slot(0, "c0", TypeDescriptor::create_varchar_type(10));
+    std::vector<SlotDescriptor*> slot_descs{&slot};
+    ConnectorPredicateParser predicate_parser(&slot_descs);
+
+    TExprNode add_node;
+    add_node.node_type = TExprNodeType::ARITHMETIC_EXPR;
+    add_node.num_children = 2;
+    add_node.type = TYPE_INT_DESC.to_thrift();
+    add_node.__set_opcode(TExprOpcode::ADD);
+    add_node.__set_child_type(TPrimitiveType::INT);
+    add_node.__set_is_nullable(true);
+    add_node.__set_is_monotonic(true);
+
+    TExpr slot_expr = ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(0, true);
+    TExprNode literal_node;
+    literal_node.node_type = TExprNodeType::INT_LITERAL;
+    literal_node.num_children = 0;
+    literal_node.type = TYPE_INT_DESC.to_thrift();
+    literal_node.__set_is_nullable(false);
+    TIntLiteral literal;
+    literal.value = 1;
+    literal_node.__set_int_literal(literal);
+
+    TExpr probe_expr;
+    probe_expr.nodes.emplace_back(add_node);
+    probe_expr.nodes.emplace_back(slot_expr.nodes[0]);
+    probe_expr.nodes.emplace_back(literal_node);
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc, _gen_runtime_filter_desc(probe_expr));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->prepare(&_runtime_state));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->open(&_runtime_state));
+
+    MinMaxRuntimeFilter<TYPE_INT> rf;
+    rf.insert(100);
+    rf.insert(200);
+    runtime_filter_desc->set_runtime_filter(&rf);
+
+    GlobalDictMap dict{{Slice("apple"), 100}, {Slice("melon"), 200}};
+    ColumnIdToGlobalDictMap dict_maps;
+    dict_maps[0] = &dict;
+
+    UnarrivedRuntimeFilterList unarrived_runtime_filters;
+    unarrived_runtime_filters.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
+
+    size_t updater_called = 0;
+    ASSERT_OK(pruner.update_range_if_arrived(
+            &dict_maps,
+            [&](auto, const PredicateList& predicates) {
+                updater_called += predicates.size();
+                return Status::OK();
+            },
+            false, 200000));
+    ASSERT_EQ(0, updater_called);
+
+    runtime_filter_desc->close(&_runtime_state);
+}
+
 TEST_F(RuntimeRangePrunerTest, update_1) {
     SlotDescriptor slot(0, "c0", TYPE_INT_DESC);
     std::vector<SlotDescriptor*> slot_descs{&slot};

--- a/be/test/compute_env/runtime_range_pruner_test.cpp
+++ b/be/test/compute_env/runtime_range_pruner_test.cpp
@@ -23,6 +23,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/runtime_filter.h"
 #include "runtime/runtime_state.h"
+#include "storage_primitive/column_expr_predicate.h"
 #include "storage_primitive/column_predicate_factory.h"
 #include "storage_primitive/predicate_parser.h"
 #include "testutil/exprs_test_helper.h"
@@ -33,6 +34,7 @@ namespace starrocks {
 class RuntimeRangePrunerTest : public ::testing::Test {
 protected:
     StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> _gen_runtime_filter_desc();
+    StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> _gen_runtime_filter_desc(const TExpr& probe_expr);
 
     using Int32Decoder = detail::RuntimeColumnPredicateBuilder::DummyDecoder<int32_t>;
     using Int32RuntimeFilter = ComposedRuntimeBloomFilter<TYPE_INT>;
@@ -46,6 +48,11 @@ protected:
 };
 
 StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> RuntimeRangePrunerTest::_gen_runtime_filter_desc() {
+    return _gen_runtime_filter_desc(ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(1, true));
+}
+
+StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> RuntimeRangePrunerTest::_gen_runtime_filter_desc(
+        const TExpr& probe_expr) {
     TRuntimeFilterDescription desc;
     desc.__set_filter_id(1);
     desc.__set_has_remote_targets(false);
@@ -53,9 +60,8 @@ StatusOr<std::shared_ptr<RuntimeFilterProbeDescriptor>> RuntimeRangePrunerTest::
     desc.__set_build_join_mode(TRuntimeFilterBuildJoinMode::BROADCAST);
     desc.__set_filter_type(TRuntimeFilterBuildType::TOPN_FILTER);
 
-    TExpr col_ref = ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(1, true);
     desc.__isset.plan_node_id_to_target_expr = true;
-    desc.plan_node_id_to_target_expr.emplace(_node_id, col_ref);
+    desc.plan_node_id_to_target_expr.emplace(_node_id, probe_expr);
 
     auto runtime_filter_desc = std::make_shared<RuntimeFilterProbeDescriptor>();
     RETURN_IF_ERROR(runtime_filter_desc->init(&_pool, desc, _node_id, &_runtime_state));
@@ -91,6 +97,75 @@ TEST_F(RuntimeRangePrunerTest, min_max_parser_for_decimal) {
     ColumnPtr max_column = parser.max_const_column<TYPE_DECIMAL32>(TYPE_DECIMAL32_DESC, &_pool);
     ASSERT_EQ(min_column->debug_string(), "CONST: 0.0010 Size : 1");
     ASSERT_EQ(max_column->debug_string(), "CONST: 0.0020 Size : 1");
+}
+
+TEST_F(RuntimeRangePrunerTest, monotonic_expr_builds_two_column_expr_predicates) {
+    SlotDescriptor slot(0, "c0", TYPE_INT_DESC);
+    std::vector<SlotDescriptor*> slot_descs{&slot};
+    ConnectorPredicateParser predicate_parser(&slot_descs);
+
+    TExprNode add_node;
+    add_node.node_type = TExprNodeType::ARITHMETIC_EXPR;
+    add_node.num_children = 2;
+    add_node.type = TYPE_INT_DESC.to_thrift();
+    add_node.__set_opcode(TExprOpcode::ADD);
+    add_node.__set_child_type(TPrimitiveType::INT);
+    add_node.__set_is_nullable(true);
+    add_node.__set_is_monotonic(true);
+
+    TExpr slot_expr = ExprsTestHelper::create_column_ref_t_expr<TYPE_INT>(0, true);
+    TExprNode literal_node;
+    literal_node.node_type = TExprNodeType::INT_LITERAL;
+    literal_node.num_children = 0;
+    literal_node.type = TYPE_INT_DESC.to_thrift();
+    literal_node.__set_is_nullable(false);
+    TIntLiteral literal;
+    literal.value = 1;
+    literal_node.__set_int_literal(literal);
+
+    TExpr probe_expr;
+    probe_expr.nodes.emplace_back(add_node);
+    probe_expr.nodes.emplace_back(slot_expr.nodes[0]);
+    probe_expr.nodes.emplace_back(literal_node);
+    ASSIGN_OR_ASSERT_FAIL(auto runtime_filter_desc, _gen_runtime_filter_desc(probe_expr));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->prepare(&_runtime_state));
+    ASSERT_OK(runtime_filter_desc->probe_expr_ctx()->open(&_runtime_state));
+
+    MinMaxRuntimeFilter<TYPE_INT> rf;
+    rf.insert(10);
+    rf.insert(20);
+    runtime_filter_desc->set_runtime_filter(&rf);
+
+    UnarrivedRuntimeFilterList unarrived_runtime_filters;
+    unarrived_runtime_filters.add_unarrived_rf(runtime_filter_desc.get(), &slot, 1);
+    RuntimeScanRangePruner pruner(&predicate_parser, unarrived_runtime_filters);
+
+    std::vector<PredicateType> predicate_types;
+    std::vector<TExprOpcode::type> predicate_opcodes;
+    std::vector<std::string> predicate_bounds;
+    ASSERT_OK(pruner.update_range_if_arrived(
+            nullptr,
+            [&](auto, const PredicateList& predicates) {
+                for (const auto* predicate : predicates) {
+                    predicate_types.emplace_back(predicate->type());
+                    const auto* expr_predicate = down_cast<const ColumnExprPredicate*>(predicate);
+                    Expr* root = expr_predicate->get_expr_ctxs()[0]->root();
+                    predicate_opcodes.emplace_back(root->op());
+                    const auto* literal = down_cast<const VectorizedLiteral*>(root->get_child(1));
+                    predicate_bounds.emplace_back(literal->value()->debug_string());
+                }
+                return Status::OK();
+            },
+            false, 200000));
+    ASSERT_EQ(2, predicate_types.size());
+    EXPECT_EQ(PredicateType::kExpr, predicate_types[0]);
+    EXPECT_EQ(PredicateType::kExpr, predicate_types[1]);
+    EXPECT_EQ(TExprOpcode::GE, predicate_opcodes[0]);
+    EXPECT_EQ(TExprOpcode::LE, predicate_opcodes[1]);
+    EXPECT_EQ("CONST: 10 Size : 1", predicate_bounds[0]);
+    EXPECT_EQ("CONST: 20 Size : 1", predicate_bounds[1]);
+
+    runtime_filter_desc->close(&_runtime_state);
 }
 
 TEST_F(RuntimeRangePrunerTest, update_1) {

--- a/test/sql/test_runtime_filter/R/test_runtime_filter_monotonic_expr
+++ b/test/sql/test_runtime_filter/R/test_runtime_filter_monotonic_expr
@@ -1,0 +1,117 @@
+-- name: test_runtime_filter_monotonic_expr
+create table rf_expr_probe_${uuid0} (
+    id int not null,
+    c_bigint bigint null,
+    c_date date null
+)
+duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num" = "1");
+-- result:
+-- !result
+create table rf_expr_build_${uuid0} (
+    id int not null,
+    k_slot bigint null,
+    k_subtract bigint null,
+    k_multiply bigint null,
+    k_divide bigint null,
+    k_nested bigint null,
+    k_negative bigint null,
+    k_year smallint null
+)
+duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into rf_expr_probe_${uuid0}
+select g,
+       cast(g as bigint),
+       date_add('2000-01-01', interval g year)
+from table(generate_series(1, 20)) t(g);
+-- result:
+-- !result
+insert into rf_expr_probe_${uuid0} values (21, null, null);
+-- result:
+-- !result
+insert into rf_expr_build_${uuid0} values
+    (1, 10, 9, 20, 5, 22, -10, 2010),
+    (2, 14, 13, 28, 7, 30, -14, 2014),
+    (3, null, null, null, null, null, null, null);
+-- result:
+-- !result
+select typeof(c_bigint - 1),
+       typeof(c_bigint * 2),
+       typeof(c_bigint div 2),
+       typeof((c_bigint + 1) * 2),
+       typeof(c_bigint * -1),
+       typeof(year(c_date))
+from rf_expr_probe_${uuid0}
+where id = 1;
+-- result:
+bigint	bigint	bigint	bigint	bigint	smallint
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint = b.k_slot
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint - 1 = b.k_subtract
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint * 2 = b.k_multiply
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint div 2 = b.k_divide
+order by p.id, b.id;
+-- result:
+10	1
+11	1
+14	2
+15	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on (p.c_bigint + 1) * 2 = b.k_nested
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint * -1 = b.k_negative
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on year(p.c_date) = b.k_year
+order by p.id, b.id;
+-- result:
+10	1
+14	2
+-- !result
+drop table rf_expr_probe_${uuid0};
+-- result:
+-- !result
+drop table rf_expr_build_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_filter_monotonic_expr
+++ b/test/sql/test_runtime_filter/T/test_runtime_filter_monotonic_expr
@@ -1,0 +1,91 @@
+-- name: test_runtime_filter_monotonic_expr
+
+create table rf_expr_probe_${uuid0} (
+    id int not null,
+    c_bigint bigint null,
+    c_date date null
+)
+duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num" = "1");
+
+create table rf_expr_build_${uuid0} (
+    id int not null,
+    k_slot bigint null,
+    k_subtract bigint null,
+    k_multiply bigint null,
+    k_divide bigint null,
+    k_nested bigint null,
+    k_negative bigint null,
+    k_year smallint null
+)
+duplicate key(id)
+distributed by hash(id) buckets 1
+properties("replication_num" = "1");
+
+insert into rf_expr_probe_${uuid0}
+select g,
+       cast(g as bigint),
+       date_add('2000-01-01', interval g year)
+from table(generate_series(1, 20)) t(g);
+
+-- Keep a NULL Probe row in every query. Ordinary equality must never match it.
+insert into rf_expr_probe_${uuid0} values (21, null, null);
+
+-- The two non-NULL Build rows produce narrow runtime-filter bounds.
+-- The NULL key is ignored by every ordinary-equality runtime filter below.
+insert into rf_expr_build_${uuid0} values
+    (1, 10, 9, 20, 5, 22, -10, 2010),
+    (2, 14, 13, 28, 7, 30, -14, 2014),
+    (3, null, null, null, null, null, null, null);
+
+-- Verify the result types used to decode runtime-filter bounds.
+select typeof(c_bigint - 1),
+       typeof(c_bigint * 2),
+       typeof(c_bigint div 2),
+       typeof((c_bigint + 1) * 2),
+       typeof(c_bigint * -1),
+       typeof(year(c_date))
+from rf_expr_probe_${uuid0}
+where id = 1;
+
+-- Existing SlotRef path as a control.
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint = b.k_slot
+order by p.id, b.id;
+
+-- Supported monotonic single-column arithmetic expressions.
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint - 1 = b.k_subtract
+order by p.id, b.id;
+
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint * 2 = b.k_multiply
+order by p.id, b.id;
+
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint div 2 = b.k_divide
+order by p.id, b.id;
+
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on (p.c_bigint + 1) * 2 = b.k_nested
+order by p.id, b.id;
+
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on p.c_bigint * -1 = b.k_negative
+order by p.id, b.id;
+
+-- year() is the function currently recognized as monotonic by the RF expression path.
+select p.id, b.id
+from rf_expr_probe_${uuid0} p join rf_expr_build_${uuid0} b
+on year(p.c_date) = b.k_year
+order by p.id, b.id;
+
+drop table rf_expr_probe_${uuid0};
+drop table rf_expr_build_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Runtime filters on monotonic probe expressions are currently applied only after data is read and cannot use ZoneMap indexes. This change enables page-level pruning for these expressions, reducing unnecessary data reads.

## What I'm doing:

Convert the min/max bounds of runtime filters on single-column monotonic probe expressions into `ColumnExprPredicate`s, allowing the storage engine to use ZoneMap indexes for page-level pruning. Unsupported expressions continue to use the existing runtime-filter path.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
