### PR TITLE
[Doc] Fix FE configuration drift against Config.java

### DIFF
--- a/docs/en/administration/management/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/FE_parameters/log_server_meta.md
@@ -1311,7 +1311,7 @@ This topic introduces the following types of FE configurations:
 
 ### `enable_background_refresh_connector_metadata`
 
-- Default: true in v3.0 and later and false in v2.5
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes

--- a/docs/en/administration/management/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/FE_parameters/shared_lake_other.md
@@ -939,7 +939,7 @@ This topic introduces the following types of FE configurations:
 
 ### `hive_meta_cache_refresh_interval_s`
 
-- Default: 3600 * 2
+- Default: 60
 - Type: Long
 - Unit: Seconds
 - Is mutable: No
@@ -1092,7 +1092,7 @@ This topic introduces the following types of FE configurations:
 
 ### `jwt_principal_field`
 
-- Default: Empty string
+- Default: sub
 - Type: String
 - Unit: -
 - Is mutable: No
@@ -1218,7 +1218,7 @@ This topic introduces the following types of FE configurations:
 
 ### `mv_plan_cache_thread_pool_size`
 
-- Default: 3
+- Default: 8
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -1290,7 +1290,7 @@ This topic introduces the following types of FE configurations:
 
 ### `oauth2_principal_field`
 
-- Default: Empty string
+- Default: sub
 - Type: String
 - Unit: -
 - Is mutable: No

--- a/docs/en/administration/management/FE_parameters/stats_storage.md
+++ b/docs/en/administration/management/FE_parameters/stats_storage.md
@@ -558,7 +558,7 @@ This topic introduces the following types of FE configurations:
 - Default: 300
 - Type: Int
 - Unit: Seconds
-- Is mutable: No
+- Is mutable: Yes
 - Description: The time interval at which the FE retrieves tablet statistics from each BE.
 - Introduced in: -
 

--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -229,7 +229,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### `enable_active_materialized_view_schema_strict_check`
 
-- Default: true
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
@@ -678,18 +678,18 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### `max_scalar_operator_flat_children`
 
-- Default：10000
-- Type：Int
-- Unit：-
+- Default: 10000
+- Type: Int
+- Unit: -
 - Is mutable: Yes
-- Description：The maximum number of flat children for ScalarOperator. You can set this limit to prevent the optimizer from using too much memory.
+- Description: The maximum number of flat children for ScalarOperator. You can set this limit to prevent the optimizer from using too much memory.
 - Introduced in: -
 
 ### `max_scalar_operator_optimize_depth`
 
-- Default：256
-- Type：Int
-- Unit：-
+- Default: 256
+- Type: Int
+- Unit: -
 - Is mutable: Yes
 - Description: The maximum depth that ScalarOperator optimization can be applied.
 - Introduced in: -
@@ -781,7 +781,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### `slow_query_analyze_threshold`
 
-- Default: 5
+- Default: 5000
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
@@ -862,7 +862,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### `statistic_collect_interval_sec`
 
-- Default: 5 * 60
+- Default: 10 * 60
 - Type: Long
 - Unit: Seconds
 - Is mutable: Yes


### PR DESCRIPTION
## Fix FE configuration doc drift against `Config.java`

Corrects documented FE config **defaults** and **mutability** that contradict the
`@ConfField` source of truth in `fe/fe-core/src/main/java/com/starrocks/common/Config.java`,
found by an automated doc↔code drift audit. Every change below was verified
against the raw `Config.java` declaration on `main`.

### Default value corrections

| Parameter | Docs said | Code (main) |
|---|---|---|
| `slow_query_analyze_threshold` | `5` | `5000` |
| `hive_meta_cache_refresh_interval_s` | `3600 * 2` (7200) | `60` |
| `statistic_collect_interval_sec` | `5 * 60` (300) | `10 * 60` (600) |
| `mv_plan_cache_thread_pool_size` | `3` | `8` |
| `jwt_principal_field` | Empty string | `sub` |
| `oauth2_principal_field` | Empty string | `sub` |
| `enable_active_materialized_view_schema_strict_check` | `true` | `false` |
| `enable_background_refresh_connector_metadata` | version-conditional prose | `true` |

### Mutability correction

- `tablet_stat_update_interval_second`: **Is mutable** No → Yes (declared `@ConfField(mutable = true)`)

### Formatting

- `max_scalar_operator_flat_children`, `max_scalar_operator_optimize_depth`: replaced
  full-width colons (`：`) with ASCII colons so the fields render/parse correctly
  (values were already correct).

### Flagged for the FE team (intentionally NOT changed here)

- `spark_dpp_version`: the code default is build-substituted (`"main"` on main,
  `"4.1"` on branch-4.1), not a literal value — needs an FE-side decision, not a
  doc edit.
- Candidate stale removals (documented but no longer in `Config.java`):
  `dump_log_dir`, `tablet_reshard_history_job_max_keep_ms` — left in place pending
  confirmation these were removed vs. renamed.

Targets `main`; please **backport to `branch-4.1`** (docs.starrocks.io serves 4.1 as current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)