### PR TITLE
[Doc] Fix BE configuration drift against config.h

### DIFF
--- a/docs/en/administration/management/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/management/BE_parameters/log_server_meta.md
@@ -142,7 +142,7 @@ This topic introduces the following types of BE configurations:
 
 ### sys_log_verbose_modules
 
-- Default: 
+- Default: Empty string
 - Type: Strings
 - Unit: -
 - Is mutable: No
@@ -593,7 +593,7 @@ This topic introduces the following types of BE configurations:
 
 ### ssl_certificate_path
 
-- Default: 
+- Default: Empty string
 - Type: String
 - Unit: -
 - Is mutable: No

--- a/docs/en/administration/management/BE_parameters/query_loading.md
+++ b/docs/en/administration/management/BE_parameters/query_loading.md
@@ -109,7 +109,7 @@ This topic introduces the following types of BE configurations:
 
 ### enable_json_flat
 
-- Default: false
+- Default: true
 - Type: Boolean
 - Unit:
 - Is mutable: Yes
@@ -319,7 +319,7 @@ This topic introduces the following types of BE configurations:
 - Default: 10
 - Type: Int
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: Integer ratio in range [0-1000] that controls the use of late materialization in the SegmentIterator (vector query engine). A value of `0` (or &le; 0) disables late materialization; `1000` (or &ge; 1000) forces late materialization for all reads. Values `> 0` and `< 1000` enable a conditional strategy where both late and early materialization contexts are prepared and the iterator selects behavior based on predicate filter ratios (higher values favor late materialization). When a segment contains complex metric types, StarRocks uses `metric_late_materialization_ratio` instead. If `lake_io_opts.cache_file_only` is set, late materialization is disabled.
 - Introduced in: v3.2.0
 
@@ -409,7 +409,7 @@ This topic introduces the following types of BE configurations:
 - Default: -1
 - Type: Int
 - Unit: Milliseconds
-- Is mutable: No
+- Is mutable: Yes
 - Description: Timeout duration to establish HTTP connections with object storage. `-1` indicates to use the default timeout duration of the SDK configurations.
 - Introduced in: v3.0.9
 
@@ -418,7 +418,7 @@ This topic introduces the following types of BE configurations:
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: A boolean value to control whether to enable the late materialization of Parquet reader to improve performance. `true` indicates enabling late materialization, and `false` indicates disabling it.
 - Introduced in: -
 

--- a/docs/en/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/BE_parameters/shared_lake_other.md
@@ -274,7 +274,7 @@ This topic introduces the following types of BE configurations:
 
 ### starlet_use_star_cache
 
-- Default: false in v3.1 and true from v3.2.3
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
@@ -330,7 +330,7 @@ This topic introduces the following types of BE configurations:
 
 ### datacache_disk_size
 
-- Default: 0
+- Default: 100%
 - Type: String
 - Unit: -
 - Is mutable: Yes
@@ -360,13 +360,13 @@ This topic introduces the following types of BE configurations:
 - Default: 130172
 - Type: Int
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: The maximum number of inline cache items in Data Cache. For some particularly small cache blocks, Data Cache stores them in `inline` mode, which caches the block data and metadata together in memory.
 - Introduced in: v3.4.0
 
 ### datacache_mem_size
 
-- Default: 0
+- Default: 20%
 - Type: String
 - Unit: -
 - Is mutable: Yes
@@ -587,7 +587,7 @@ This topic introduces the following types of BE configurations:
 - Default: 0
 - Type: Int
 - Unit: -
-- Is mutable: Yes
+- Is mutable: No
 - Description: The maximum concurrency (per BE node) of the materialized view refresh tasks in the resource group `default_mv_wg`. The default value `0` indicates no limits.
 - Introduced in: v3.1
 
@@ -596,7 +596,7 @@ This topic introduces the following types of BE configurations:
 - Default: 1
 - Type: Int
 - Unit: -
-- Is mutable: Yes
+- Is mutable: No
 - Description: The maximum number of CPU cores (per BE node) that can be used by the materialized view refresh tasks in the resource group `default_mv_wg`.
 - Introduced in: v3.1
 
@@ -605,7 +605,7 @@ This topic introduces the following types of BE configurations:
 - Default: 0.8
 - Type: Double
 - Unit:
-- Is mutable: Yes
+- Is mutable: No
 - Description: The maximum memory proportion (per BE node) that can be used by the materialized view refresh tasks in the resource group `default_mv_wg`. The default value indicates 80% of the memory.
 - Introduced in: v3.1
 
@@ -614,7 +614,7 @@ This topic introduces the following types of BE configurations:
 - Default: 0.8
 - Type: Double
 - Unit: -
-- Is mutable: Yes
+- Is mutable: No
 - Description: The memory usage threshold before a materialized view refresh task in the resource group `default_mv_wg` triggers intermediate result spilling. The default value indicates 80% of the memory.
 - Introduced in: v3.1
 
@@ -679,7 +679,7 @@ This topic introduces the following types of BE configurations:
 - Default: 1000000
 - Type: Int
 - Unit: Bytes
-- Is mutable: No
+- Is mutable: Yes
 - Description: The maximum length of input values for bitmap functions.
 - Introduced in: -
 
@@ -688,7 +688,7 @@ This topic introduces the following types of BE configurations:
 - Default: 200000
 - Type: Int
 - Unit: Bytes
-- Is mutable: No
+- Is mutable: Yes
 - Description: The maximum length of input values for the to_base64() function.
 - Introduced in: -
 

--- a/docs/en/administration/management/BE_parameters/stats_storage.md
+++ b/docs/en/administration/management/BE_parameters/stats_storage.md
@@ -204,7 +204,7 @@ This topic introduces the following types of BE configurations:
 - Default: 1
 - Type: Int
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: The number of threads used for checking the consistency of tablets.
 - Introduced in: -
 
@@ -465,7 +465,7 @@ This topic introduces the following types of BE configurations:
 - Default: true
 - Type: Boolean
 - Unit: -
-- Is mutable: No
+- Is mutable: Yes
 - Description: Whether to enable the Size-tiered Compaction policy for Primary Key tables. `true` indicates the Size-tiered Compaction strategy is enabled, and `false` indicates it is disabled.
 - Introduced in: This item takes effect for shared-data clusters from v3.2.4 and v3.1.10 onwards, and for shared-nothing clusters from v3.2.5 and v3.1.10 onwards.
 
@@ -633,7 +633,7 @@ This topic introduces the following types of BE configurations:
 
 ### max_cumulative_compaction_num_singleton_deltas
 
-- Default: 1000
+- Default: 500
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -696,7 +696,7 @@ This topic introduces the following types of BE configurations:
 
 ### max_update_compaction_num_singleton_deltas
 
-- Default: 1000
+- Default: 500
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -858,7 +858,7 @@ This topic introduces the following types of BE configurations:
 
 ### pk_index_memtable_flush_threadpool_size
 
-- Default: 1048576
+- Default: 2048
 - Type: Int
 - Unit: -
 - Is mutable: Yes


### PR DESCRIPTION
## Fix BE configuration doc drift against `config.h`

Corrects documented BE config **defaults** and **mutability** that contradict the
`CONF_*` source of truth in `be/src/common/config.h`, found by an automated
doc↔code drift audit. `CONF_m*` macros denote runtime-mutable params. Every
change was verified against the raw declaration on `main`.

### Default value corrections

| Parameter | Docs said | Code (main) |
|---|---|---|
| `datacache_disk_size` | `0` | `100%` |
| `datacache_mem_size` | `0` | `20%` |
| `enable_json_flat` | `false` | `true` |
| `max_cumulative_compaction_num_singleton_deltas` | `1000` | `500` |
| `max_update_compaction_num_singleton_deltas` | `1000` | `500` |
| `pk_index_memtable_flush_threadpool_size` | `1048576` | `2048` |
| `starlet_use_star_cache` | version-conditional prose | `true` |

### Mutability corrections (docs contradicted the `CONF_m` / `CONF_` prefix)

- **Now mutable (Yes):** `check_consistency_worker_count`,
  `datacache_inline_item_count_limit`, `enable_pk_size_tiered_compaction_strategy`,
  `late_materialization_ratio`, `max_length_for_bitmap_function`,
  `max_length_for_to_base64`, `object_storage_request_timeout_ms`,
  `parquet_late_materialization_enable`
- **Now immutable (No):** `default_mv_resource_group_concurrency_limit`,
  `default_mv_resource_group_cpu_limit`, `default_mv_resource_group_memory_limit`,
  `default_mv_resource_group_spill_mem_limit_threshold`

### Missing defaults filled (code default is an empty string)

- `ssl_certificate_path`, `sys_log_verbose_modules`

### Flagged for the BE team (intentionally NOT changed here)

- Candidate stale removal (documented but no longer in `config.h`):
  `pk_index_parallel_get_threadpool_size` — left in place pending confirmation it
  was removed vs. renamed.

Targets `main`; please **backport to `branch-4.1`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)