### PR TITLE
[Doc] Add config value-drift suggested edits to doc-needed issues

### DIFF
--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -49,6 +49,16 @@ jobs:
           # Checkout the merged commit so we can run the diff script
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
+      # The value-drift engine lives in its own repo (single source of truth,
+      # reused by commercial docs too). Pinned to main and run from this trusted
+      # same-org checkout — never from the merged PR head.
+      - name: Check out the drift engine
+        uses: actions/checkout@v4
+        with:
+          repository: StarRocks/doc-config-drift
+          ref: main
+          path: drift-engine
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -146,6 +156,28 @@ jobs:
             echo "AI enrichment did not produce valid JSON (exit $ec) — keeping original"
           fi
 
+      # Detect config VALUE drift (documented Default/mutability that now
+      # contradicts the code) using the engine repo — no logic duplicated here.
+      # Restricted to params this PR changed via --changed-since HEAD^1.
+      - name: Detect config value drift
+        run: |
+          python3 - << 'PYEOF'
+          import json, subprocess
+          result = {}
+          for comp in ("fe", "be"):
+              p = subprocess.run(
+                  ["python3", "drift-engine/drift_audit.py", "--component", comp,
+                   "--repo", ".", "--changed-since", "HEAD^1", "--format", "json"],
+                  capture_output=True, text=True,
+              )
+              try:
+                  result[comp] = json.loads(p.stdout)
+              except Exception:
+                  result[comp] = {}
+          with open("/tmp/value_drift.json", "w") as f:
+              json.dump(result, f)
+          PYEOF
+
       # Build the issue body from the collected data
       - name: Build issue body
         id: issuebody
@@ -208,6 +240,46 @@ jobs:
                           f"| `{p['name']}` | {p.get('code_type','')} | "
                           f"`{p.get('default','')}` | {mut} | {desc} | {doc_path} |"
                       )
+                  lines.append("")
+
+          # Value drift from the engine (docs/value_drift.json): params this PR
+          # changed whose documented Default / mutability now contradicts code.
+          try:
+              with open("/tmp/value_drift.json") as f:
+                  vdrift = json.load(f)
+          except Exception:
+              vdrift = {}
+
+          def _drift_rows(comp):
+              rows = []
+              for x in comp.get("default_mismatch", []):
+                  rows.append((x["name"], "default", x["doc"], x["code"], x.get("file", "")))
+              for x in comp.get("mutable_mismatch", []):
+                  rows.append((x["name"], "mutable", x["doc"], x["code"], x.get("file", "")))
+              return sorted(rows)
+
+          vd_groups = [
+              ("FE Configuration", vdrift.get("fe", {}), "docs/en/administration/management/FE_parameters/"),
+              ("BE Configuration", vdrift.get("be", {}), "docs/en/administration/management/BE_parameters/"),
+          ]
+          if any(_drift_rows(c) for _, c, _ in vd_groups):
+              lines.append("## Parameter values changed — docs may be outdated")
+              lines.append("")
+              lines.append(
+                  "This PR changed the code default or mutability of parameters "
+                  "whose documentation still shows the old value. Suggested edits:"
+              )
+              lines.append("")
+              for title, comp, base in vd_groups:
+                  rows = _drift_rows(comp)
+                  if not rows:
+                      continue
+                  lines.append(f"### {title}")
+                  lines.append("")
+                  lines.append("| Parameter | Field | Docs say | Code says | Doc page |")
+                  lines.append("|-----------|-------|----------|-----------|----------|")
+                  for name, field, doc, code, file in rows:
+                      lines.append(f"| `{name}` | {field} | `{doc}` | `{code}` | {base}{file} |")
                   lines.append("")
 
           lines += [

--- a/.github/workflows/ci-doc-needs-update.yml
+++ b/.github/workflows/ci-doc-needs-update.yml
@@ -50,13 +50,16 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       # The value-drift engine lives in its own repo (single source of truth,
-      # reused by commercial docs too). Pinned to main and run from this trusted
-      # same-org checkout — never from the merged PR head.
+      # reused by commercial docs too) and runs from this trusted checkout, never
+      # from the merged PR head. Pinned to an immutable commit SHA: this job runs
+      # under pull_request_target with issues: write, so an unpinned `main` would
+      # let an upstream change execute with elevated permissions. Bump this SHA
+      # intentionally when upgrading the engine.
       - name: Check out the drift engine
         uses: actions/checkout@v4
         with:
           repository: StarRocks/doc-config-drift
-          ref: main
+          ref: dfd6f7285de5fa069dc1cddfe35c6833b0ad6c34  # doc-config-drift main @ 2026-07-22
           path: drift-engine
 
       - uses: actions/setup-python@v5
@@ -162,7 +165,7 @@ jobs:
       - name: Detect config value drift
         run: |
           python3 - << 'PYEOF'
-          import json, subprocess
+          import json, subprocess, sys
           result = {}
           for comp in ("fe", "be"):
               p = subprocess.run(
@@ -170,10 +173,20 @@ jobs:
                    "--repo", ".", "--changed-since", "HEAD^1", "--format", "json"],
                   capture_output=True, text=True,
               )
+              # drift_audit exits 0 (no drift) or 1 (drift found) normally; any
+              # other code, or unparseable stdout, means the detector itself broke
+              # — log it so the section isn't silently omitted without a trace.
               try:
                   result[comp] = json.loads(p.stdout)
-              except Exception:
+              except Exception as exc:
                   result[comp] = {}
+                  print(f"::warning::value-drift detection failed for {comp} "
+                        f"(exit {p.returncode}, {exc}); stderr:\n{p.stderr}",
+                        file=sys.stderr)
+              else:
+                  if p.returncode not in (0, 1):
+                      print(f"::warning::drift_audit for {comp} exited {p.returncode}; "
+                            f"stderr:\n{p.stderr}", file=sys.stderr)
           with open("/tmp/value_drift.json", "w") as f:
               json.dump(result, f)
           PYEOF
@@ -242,7 +255,7 @@ jobs:
                       )
                   lines.append("")
 
-          # Value drift from the engine (docs/value_drift.json): params this PR
+          # Value drift from the engine (/tmp/value_drift.json): params this PR
           # changed whose documented Default / mutability now contradicts code.
           try:
               with open("/tmp/value_drift.json") as f:
@@ -255,7 +268,7 @@ jobs:
               for x in comp.get("default_mismatch", []):
                   rows.append((x["name"], "default", x["doc"], x["code"], x.get("file", "")))
               for x in comp.get("mutable_mismatch", []):
-                  rows.append((x["name"], "mutable", x["doc"], x["code"], x.get("file", "")))
+                  rows.append((x["name"], "mutability", x["doc"], x["code"], x.get("file", "")))
               return sorted(rows)
 
           vd_groups = [


### PR DESCRIPTION
## Add config value-drift suggested edits to "Docs needed:" issues

**Problem.** When a merged PR changes a config **default** or **mutability**, the
auto-opened "Docs needed:" issue had no actionable content — the existing
tooling (`build-support/extract_and_diff_params.py`) compares parameter **names**
only, so it catches *new undocumented* params but never notices when a documented
value now contradicts the code. That's the common "Parameter changes" case.

**Change.** `ci-doc-needs-update.yml` now adds a **"Parameter values changed —
docs may be outdated"** section to the issue, with concrete old→new suggested
edits and the doc page to update. Example:

> | Parameter | Field | Docs say | Code says | Doc page |
> |---|---|---|---|---|
> | `enable_json_flat` | default | `false` | `true` | docs/en/administration/management/BE_parameters/query_loading.md |

**No duplicated logic.** The drift detection lives solely in the
[`StarRocks/doc-config-drift`](https://github.com/StarRocks/doc-config-drift)
engine repo (also reused by downstream docs). This workflow:

1. checks out that engine at a **pinned commit SHA**
   (`dfd6f7285de5fa069dc1cddfe35c6833b0ad6c34`), not a moving ref, and runs it from
   the trusted same-org checkout — never from the PR head, preserving the
   `pull_request_target` security model;
2. runs `drift_audit.py --changed-since HEAD^1` to restrict findings to params
   **this PR touched** (no backlog noise);
3. merges its JSON output into the issue body.

`build-support/extract_and_diff_params.py` is **unchanged** — it keeps owning
new-undocumented-param detection and AI descriptions. Only the workflow changes
(+72 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

