### PR TITLE
[Enhancement] Implementing dictification for union all columns with all constant string inputs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalUnionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalUnionOperator.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -21,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
 
 import java.util.List;
 
@@ -30,12 +32,15 @@ public class PhysicalUnionOperator extends PhysicalSetOperation {
     // record if this union is derived from IcebergEqualityDeleteRewriteRule
     private final boolean fromIcebergEqualityDeleteRewrite;
 
+    private List<Pair<Integer, ColumnDict>> globalDicts;
+
+
     public PhysicalUnionOperator(List<ColumnRefOperator> columnRef, List<List<ColumnRefOperator>> childOutputColumns,
                                  boolean isUnionAll,
                                  long limit,
                                  ScalarOperator predicate,
                                  Projection projection) {
-        this(columnRef, childOutputColumns, isUnionAll, limit, predicate, projection, false);
+        this(columnRef, childOutputColumns, isUnionAll, limit, predicate, projection, false, List.of());
     }
 
     public PhysicalUnionOperator(List<ColumnRefOperator> columnRef, List<List<ColumnRefOperator>> childOutputColumns,
@@ -43,10 +48,12 @@ public class PhysicalUnionOperator extends PhysicalSetOperation {
                                  long limit,
                                  ScalarOperator predicate,
                                  Projection projection,
-                                 boolean fromIcebergEqualityDeleteRewrite) {
+                                 boolean fromIcebergEqualityDeleteRewrite,
+                                 List<Pair<Integer, ColumnDict>> globalDicts) {
         super(OperatorType.PHYSICAL_UNION, columnRef, childOutputColumns, limit, predicate, projection);
         this.isUnionAll = isUnionAll;
         this.fromIcebergEqualityDeleteRewrite = fromIcebergEqualityDeleteRewrite;
+        this.globalDicts = globalDicts;
     }
 
     public boolean isFromIcebergEqualityDeleteRewrite() {
@@ -55,6 +62,10 @@ public class PhysicalUnionOperator extends PhysicalSetOperation {
 
     public boolean isUnionAll() {
         return isUnionAll;
+    }
+
+    public List<Pair<Integer, ColumnDict>> getGlobalDicts() {
+        return globalDicts;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownNonGroupedAggregateBelowUnion.java
@@ -200,7 +200,7 @@ public class PushDownNonGroupedAggregateBelowUnion implements TreeRewriteRule {
             // 2. Build a new UNION ALL operator.
             PhysicalUnionOperator newUnion = new PhysicalUnionOperator(unionOutputColumns, newChildOutputColumns,
                     true, union.getLimit(), union.getPredicate(), null,
-                    union.isFromIcebergEqualityDeleteRewrite());
+                    union.isFromIcebergEqualityDeleteRewrite(), union.getGlobalDicts());
             OptExpression newUnionExpr = OptExpression.builder()
                     .with(ctx.unionExpr())
                     .setOp(newUnion)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -323,7 +323,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         Set<Integer> mergedUnionDictColumns = unionDictionaryManager.getMergedDictColumnIds();
         mergeJoinEqColumnDicts(mergedUnionDictColumns);
         fillDisableStringColumns();
-        unionDictionaryManager.finalizeColumnDictionaries();
+        unionDictionaryManager.finalizeColumnDictionaries(disableRewriteStringColumns);
         context.unionDictionaryManager = unionDictionaryManager;
 
         // choose the profitable string columns
@@ -356,6 +356,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 context.allStringColumns.add(cid);
             }
         }
+        context.allStringColumns.addAll(unionDictionaryManager.getGeneratedDictionaryIds());
         // resolve depend-on relation:
         // like: b = upper(a), c = lower(b), if we forbidden a, should forbidden b & c too
         stringRefToDefineExprMap.forEach((cid, defineExpr) ->  {
@@ -799,14 +800,19 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 boolean isCandidate = childColumns.stream().allMatch(
                         c -> context.outputStringColumns.contains(c) || unionDictionaryManager.isSupportedConstant(c));
                 ColumnRefOperator outputColumn = setOp.getOutputColumnRefOp().get(i);
-                Integer useChildId;
-                if (isCandidate && (useChildId = unionDictionaryManager.mergeDictionaries(childColumnIds)) != null) {
+                Integer mergedId;
+                if (isCandidate && (mergedId =
+                        unionDictionaryManager.mergeDictionaries(childColumnIds, outputColumn.getId())) != null) {
                     childColumnIds.stream().filter(context.outputStringColumns::contains).forEach(c -> {
                         result.usedStringColumns.union(c);
                         expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
                     });
-                    setDefineExpr(outputColumn, childColumns.stream()
-                            .filter(c -> c.getId() == useChildId).findAny().orElseThrow(), 1);
+                    if (mergedId == outputColumn.getId()) {
+                        setDefineExpr(outputColumn, outputColumn, 1);
+                    } else {
+                        setDefineExpr(outputColumn, childColumns.stream()
+                                .filter(c -> c.getId() == mergedId).findAny().orElseThrow(), 1);
+                    }
                     result.outputStringColumns.union(outputColumn);
                 } else {
                     childColumns.stream().filter(c -> context.outputStringColumns.contains(c))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -351,7 +351,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         Set<Integer> mergedUnionDictColumns = unionDictionaryManager.getMergedDictColumnIds();
         mergeJoinEqColumnDicts(mergedUnionDictColumns);
         fillDisableStringColumns();
-        unionDictionaryManager.finalizeColumnDictionaries();
+        unionDictionaryManager.finalizeColumnDictionaries(disableRewriteStringColumns);
         context.unionDictionaryManager = unionDictionaryManager;
 
         // choose the profitable string columns
@@ -384,6 +384,7 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 context.allStringColumns.add(cid);
             }
         }
+        context.allStringColumns.addAll(unionDictionaryManager.getGeneratedDictionaryIds());
         // resolve depend-on relation:
         // like: b = upper(a), c = lower(b), if we forbidden a, should forbidden b & c too
         stringRefToDefineExprMap.forEach((cid, defineExpr) ->  {
@@ -827,14 +828,19 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
                 boolean isCandidate = childColumns.stream().allMatch(
                         c -> context.outputStringColumns.contains(c) || unionDictionaryManager.isSupportedConstant(c));
                 ColumnRefOperator outputColumn = setOp.getOutputColumnRefOp().get(i);
-                Integer useChildId;
-                if (isCandidate && (useChildId = unionDictionaryManager.mergeDictionaries(childColumnIds)) != null) {
+                Integer mergedId;
+                if (isCandidate && (mergedId =
+                        unionDictionaryManager.mergeDictionaries(childColumnIds, outputColumn.getId())) != null) {
                     childColumnIds.stream().filter(context.outputStringColumns::contains).forEach(c -> {
                         result.usedStringColumns.union(c);
                         expressionStringRefCounter.put(c, expressionStringRefCounter.getOrDefault(c, 0) + 1);
                     });
-                    setDefineExpr(outputColumn, childColumns.stream()
-                            .filter(c -> c.getId() == useChildId).findAny().orElseThrow(), 1);
+                    if (mergedId == outputColumn.getId()) {
+                        setDefineExpr(outputColumn, outputColumn, 1);
+                    } else {
+                        setDefineExpr(outputColumn, childColumns.stream()
+                                .filter(c -> c.getId() == mergedId).findAny().orElseThrow(), 1);
+                    }
                     result.outputStringColumns.union(outputColumn);
                 } else {
                     childColumns.stream().filter(c -> context.outputStringColumns.contains(c))

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -73,6 +73,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /*
  * Rewrite the whole plan using the dict column by from bottom-up
@@ -331,9 +332,15 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), encodedUnionColumns);
         Projection newProjection = rewriteProjection(unionOp.getProjection(), encodedUnionColumns);
 
+        List<Pair<Integer, ColumnDict>> globalDicts = IntStream.range(0, newColumnRefOp.size())
+                .filter(i -> context.stringRefToDicts.containsKey(unionOp.getOutputColumnRefOp().get(i).getId()))
+                .mapToObj(i -> Pair.create(
+                        newColumnRefOp.get(i).getId(),
+                        context.stringRefToDicts.get(unionOp.getOutputColumnRefOp().get(i).getId()))).toList();
+
         PhysicalUnionOperator newUnionOp = new PhysicalUnionOperator(newColumnRefOp, newChildOutputColumns,
                 unionOp.isUnionAll(), unionOp.getLimit(), newPredicate, newProjection,
-                unionOp.isFromIcebergEqualityDeleteRewrite());
+                unionOp.isFromIcebergEqualityDeleteRewrite(), globalDicts);
         return rewriteOptExpression(optExpression, newUnionOp, finalInfo.outputStringColumns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -72,6 +72,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /*
  * Rewrite the whole plan using the dict column by from bottom-up
@@ -340,9 +341,15 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         ScalarOperator newPredicate = rewritePredicate(unionOp.getPredicate(), encodedUnionColumns);
         Projection newProjection = rewriteProjection(unionOp.getProjection(), encodedUnionColumns);
 
+        List<Pair<Integer, ColumnDict>> globalDicts = IntStream.range(0, newColumnRefOp.size())
+                .filter(i -> context.stringRefToDicts.containsKey(unionOp.getOutputColumnRefOp().get(i).getId()))
+                .mapToObj(i -> Pair.create(
+                        newColumnRefOp.get(i).getId(),
+                        context.stringRefToDicts.get(unionOp.getOutputColumnRefOp().get(i).getId()))).toList();
+
         PhysicalUnionOperator newUnionOp = new PhysicalUnionOperator(newColumnRefOp, newChildOutputColumns,
                 unionOp.isUnionAll(), unionOp.getLimit(), newPredicate, newProjection,
-                unionOp.isFromIcebergEqualityDeleteRewrite());
+                unionOp.isFromIcebergEqualityDeleteRewrite(), globalDicts);
         return rewriteOptExpression(optExpression, newUnionOp, finalInfo.outputStringColumns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -49,6 +49,8 @@ public class UnionDictionaryManager {
 
     private static final int CONSTANT_ID = -1;
 
+    private final Set<Integer> generatedDictionaryIds = Sets.newHashSet();
+
     public UnionDictionaryManager(SessionVariable sessionVariable,
                                   Map<Integer, ScalarOperator> stringRefToDefineExprMap,
                                   Map<Integer, ColumnDict> globalDicts,
@@ -67,7 +69,8 @@ public class UnionDictionaryManager {
         int totalDictSize = uniques.stream().map(b -> b.remaining() + 4).reduce(0, Integer::sum);
         // TODO(farhad-celo): This constant is hardcoded in other places, refactor to a config.
         final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
-        if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32) {
+        if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32
+                || uniques.isEmpty()) {
             return null;
         }
         List<ByteBuffer> sortedValues = uniques.stream().sorted().toList();
@@ -96,7 +99,7 @@ public class UnionDictionaryManager {
         return getSourceDictionaryColumnId(newId);
     }
 
-    Integer mergeDictionaries(List<Integer> columnIds) {
+    Integer mergeDictionaries(List<Integer> columnIds, Integer outputColumnId) {
         if (!sessionVariable.isEnableLowCardinalityOptimizeForUnionAll()) {
             return null;
         }
@@ -104,8 +107,7 @@ public class UnionDictionaryManager {
                 columnIds.stream().map(constantColumns::get).filter(Objects::nonNull).toList();
         List<Integer> nonConstantColumnIds = columnIds.stream().map(this::getSourceDictionaryColumnId)
                 .filter(cid -> cid == null || cid != CONSTANT_ID).toList();
-        if (nonConstantColumnIds.isEmpty()
-                || nonConstantColumnIds.contains(null)
+        if (nonConstantColumnIds.contains(null)
                 || !nonConstantColumnIds.stream().allMatch(globalDicts::containsKey)
                 || nonConstantColumnIds.stream().anyMatch(joinEqColumnGroupIds::contains)) {
             return null;
@@ -124,6 +126,13 @@ public class UnionDictionaryManager {
         if (mergedDictData == null) {
             return null;
         }
+        if (nonConstantColumnIds.isEmpty()) {
+            globalDicts.put(outputColumnId, new ColumnDict(mergedDictData, 0, 0));
+            generatedDictionaryIds.add(outputColumnId);
+            Integer groupId = unionColumnGroups.getGroupIdOrAdd(outputColumnId);
+            unionDictData.put(groupId, mergedDictData);
+            return outputColumnId;
+        }
         final Integer firstElement = nonConstantColumnIds.get(0);
         nonConstantColumnIds.forEach(cid -> unionColumnGroups.union(cid, firstElement));
         Integer finalGroup = unionColumnGroups.getGroupId(firstElement).orElseThrow();
@@ -132,7 +141,7 @@ public class UnionDictionaryManager {
                 .orElseThrow();
     }
 
-    void finalizeColumnDictionaries() {
+    void finalizeColumnDictionaries(ColumnRefSet disabledColumns) {
         unionColumnGroups.getAllGroups().forEach(s -> {
             Integer groupId = unionColumnGroups.getGroupId(s.stream().findAny().orElseThrow()).orElseThrow();
             ImmutableMap<ByteBuffer, Integer> dictData = unionDictData.get(groupId);
@@ -143,6 +152,10 @@ public class UnionDictionaryManager {
                         new ColumnDict(dictData, oldDict.getCollectedVersion(), oldDict.getVersion()));
             });
         });
+        Set<Integer> disabledGeneratedDictionaryIds =
+                generatedDictionaryIds.stream().filter(disabledColumns::contains).collect(Collectors.toSet());
+        generatedDictionaryIds.removeAll(disabledGeneratedDictionaryIds);
+        disabledGeneratedDictionaryIds.forEach(globalDicts::remove);
     }
 
     Collection<Set<Integer>> getUnionColumnGroups() {
@@ -207,5 +220,9 @@ public class UnionDictionaryManager {
 
     boolean isSupportedConstant(ColumnRefOperator c) {
         return constantColumns.containsKey(c.getId());
+    }
+
+    public Set<Integer> getGeneratedDictionaryIds() {
+        return generatedDictionaryIds;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -49,6 +49,8 @@ public class UnionDictionaryManager {
 
     private static final int CONSTANT_ID = -1;
 
+    private final Set<Integer> generatedDictionaryIds = Sets.newHashSet();
+
     public UnionDictionaryManager(SessionVariable sessionVariable,
                                   Map<Integer, ScalarOperator> stringRefToDefineExprMap,
                                   Map<Integer, ColumnDict> globalDicts,
@@ -67,7 +69,8 @@ public class UnionDictionaryManager {
         int totalDictSize = uniques.stream().map(b -> b.remaining() + 4).reduce(0, Integer::sum);
         // TODO(farhad-celo): This constant is hardcoded in other places, refactor to a config.
         final int DICT_PAGE_MAX_SIZE = 1024 * 1024;
-        if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32) {
+        if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32
+                || uniques.isEmpty()) {
             return null;
         }
         // Sort unsigned to match BE's memcmp order; plain sorted() is signed on JDK 8. See ColumnDict.UNSIGNED_LEX.
@@ -97,7 +100,7 @@ public class UnionDictionaryManager {
         return getSourceDictionaryColumnId(newId);
     }
 
-    Integer mergeDictionaries(List<Integer> columnIds) {
+    Integer mergeDictionaries(List<Integer> columnIds, Integer outputColumnId) {
         if (!sessionVariable.isEnableLowCardinalityOptimizeForUnionAll()) {
             return null;
         }
@@ -105,8 +108,7 @@ public class UnionDictionaryManager {
                 columnIds.stream().map(constantColumns::get).filter(Objects::nonNull).toList();
         List<Integer> nonConstantColumnIds = columnIds.stream().map(this::getSourceDictionaryColumnId)
                 .filter(cid -> cid == null || cid != CONSTANT_ID).toList();
-        if (nonConstantColumnIds.isEmpty()
-                || nonConstantColumnIds.contains(null)
+        if (nonConstantColumnIds.contains(null)
                 || !nonConstantColumnIds.stream().allMatch(globalDicts::containsKey)
                 || nonConstantColumnIds.stream().anyMatch(joinEqColumnGroupIds::contains)) {
             return null;
@@ -125,6 +127,13 @@ public class UnionDictionaryManager {
         if (mergedDictData == null) {
             return null;
         }
+        if (nonConstantColumnIds.isEmpty()) {
+            globalDicts.put(outputColumnId, new ColumnDict(mergedDictData, 0, 0));
+            generatedDictionaryIds.add(outputColumnId);
+            Integer groupId = unionColumnGroups.getGroupIdOrAdd(outputColumnId);
+            unionDictData.put(groupId, mergedDictData);
+            return outputColumnId;
+        }
         final Integer firstElement = nonConstantColumnIds.get(0);
         nonConstantColumnIds.forEach(cid -> unionColumnGroups.union(cid, firstElement));
         Integer finalGroup = unionColumnGroups.getGroupId(firstElement).orElseThrow();
@@ -133,7 +142,7 @@ public class UnionDictionaryManager {
                 .orElseThrow();
     }
 
-    void finalizeColumnDictionaries() {
+    void finalizeColumnDictionaries(ColumnRefSet disabledColumns) {
         unionColumnGroups.getAllGroups().forEach(s -> {
             Integer groupId = unionColumnGroups.getGroupId(s.stream().findAny().orElseThrow()).orElseThrow();
             ImmutableMap<ByteBuffer, Integer> dictData = unionDictData.get(groupId);
@@ -144,6 +153,10 @@ public class UnionDictionaryManager {
                         new ColumnDict(dictData, oldDict.getCollectedVersion(), oldDict.getVersion()));
             });
         });
+        Set<Integer> disabledGeneratedDictionaryIds =
+                generatedDictionaryIds.stream().filter(disabledColumns::contains).collect(Collectors.toSet());
+        generatedDictionaryIds.removeAll(disabledGeneratedDictionaryIds);
+        disabledGeneratedDictionaryIds.forEach(globalDicts::remove);
     }
 
     Collection<Set<Integer>> getUnionColumnGroups() {
@@ -208,5 +221,9 @@ public class UnionDictionaryManager {
 
     boolean isSupportedConstant(ColumnRefOperator c) {
         return constantColumns.containsKey(c.getId());
+    }
+
+    public Set<Integer> getGeneratedDictionaryIds() {
+        return generatedDictionaryIds;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -211,6 +211,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalSplitProduceOperato
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionTableScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -3815,6 +3816,10 @@ public class PlanFragmentBuilder {
                 setOperationFragment.addChildren(inputFragment.getChildren());
                 setOperationFragment.mergeQueryDictExprs(inputFragment.getQueryGlobalDictExprs());
                 setOperationFragment.mergeQueryGlobalDicts(inputFragment.getQueryGlobalDicts());
+                if (optExpr.getOp() instanceof PhysicalUnionOperator) {
+                    setOperationFragment.mergeQueryGlobalDicts(
+                            ((PhysicalUnionOperator) optExpr.getOp()).getGlobalDicts());
+                }
                 ExecGroup inputExecGroup = inputExecGroups.get(i);
                 execGroups.remove(inputExecGroup);
                 if (inputFragment.getPlanRoot() instanceof ExchangeNode) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -213,6 +213,7 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalSplitProduceOperato
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionTableScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -3875,6 +3876,10 @@ public class PlanFragmentBuilder {
 
             ExecGroup execGroup = execGroups.newExecGroup();
             Optional<List<BucketProperty>> extractedBP = extractBucketProperties(inputFragments);
+            if (optExpr.getOp() instanceof PhysicalUnionOperator) {
+                setOperationFragment.mergeQueryGlobalDicts(
+                        ((PhysicalUnionOperator) optExpr.getOp()).getGlobalDicts());
+            }
             for (int i = 0; i < optExpr.arity(); ++i) {
                 PlanFragment inputFragment = inputFragments.get(i);
                 context.getFragments().remove(inputFragment);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -84,8 +84,8 @@ class UnionDictionaryManagerTest {
                 4, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "e", "f", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "e", "f", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("a", "b", "c", "e", "f", "g"));
@@ -104,11 +104,11 @@ class UnionDictionaryManagerTest {
                 7, makeDict(List.of("x", "y"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(5, 6)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 5)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(5, 6), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 5), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(5).getDict());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(6).getDict());
@@ -139,9 +139,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
@@ -165,9 +165,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
@@ -190,9 +190,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("e"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of(3));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(1, 3)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(1, 3), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "d"));
@@ -219,9 +219,9 @@ class UnionDictionaryManagerTest {
         );
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of(2));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(4, 5)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(4, 5), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "e"));
@@ -262,11 +262,11 @@ class UnionDictionaryManagerTest {
         Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col9));
         Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col10));
 
-        Assertions.assertEquals(1, unionDictionaryManager.mergeDictionaries(List.of(1, 7)));
-        Assertions.assertEquals(2, unionDictionaryManager.mergeDictionaries(List.of(2, 8)));
-        Assertions.assertEquals(3, unionDictionaryManager.mergeDictionaries(List.of(3, 9)));
+        Assertions.assertEquals(1, unionDictionaryManager.mergeDictionaries(List.of(1, 7), 0));
+        Assertions.assertEquals(2, unionDictionaryManager.mergeDictionaries(List.of(2, 8), 0));
+        Assertions.assertEquals(3, unionDictionaryManager.mergeDictionaries(List.of(3, 9), 0));
 
-        unionDictionaryManager.finalizeColumnDictionaries();
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "bbb", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "aa", "bbb"));
@@ -283,6 +283,32 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(2, constantEncodingMap.size());
         Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
         Assertions.assertEquals(Map.of(col7, ConstantOperator.createInt(2)), constantEncodingMap.get(1));
+    }
+
+    @Test
+    void testAllConstantHandling() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, StringType.STRING, "col1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, StringType.STRING, "col2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, StringType.STRING, "col3", true);
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(4, makeDict(List.of("c", "cc"))));
+        Map<Integer,  ScalarOperator> stringRefToDefineExprMap = Maps.newHashMap();
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of());
+        unionDictionaryManager.recordIfConstant(col1, ConstantOperator.createVarchar("bbb"));
+        unionDictionaryManager.recordIfConstant(col2, ConstantOperator.createVarchar("aaa"));
+        unionDictionaryManager.recordIfConstant(col3, col1);
+
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col1));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col2));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col3));
+
+        Assertions.assertEquals(5, unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3), 5));
+        Assertions.assertEquals(4, unionDictionaryManager.mergeDictionaries(List.of(4, 5), 6));
+
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(4)), List.of("aaa", "bbb", "c", "cc"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(5)), List.of("aaa", "bbb", "c", "cc"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -84,8 +84,8 @@ class UnionDictionaryManagerTest {
                 4, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "e", "f", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "b", "c", "e", "f", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(3)), List.of("a", "b", "c", "e", "f", "g"));
@@ -104,11 +104,11 @@ class UnionDictionaryManagerTest {
                 7, makeDict(List.of("x", "y"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(5, 6)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 5)));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(5, 6), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 5), 0));
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(5).getDict());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(6).getDict());
@@ -139,9 +139,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
@@ -165,9 +165,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("z"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of());
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(2, 3), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(3, 1), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(2).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b"));
@@ -190,9 +190,9 @@ class UnionDictionaryManagerTest {
                 3, makeDict(List.of("e"))));
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, Map.of(), globalDicts, Set.of(3));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(1, 3)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(1, 2), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(1, 3), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(2).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "c", "d"));
@@ -219,9 +219,9 @@ class UnionDictionaryManagerTest {
         );
         UnionDictionaryManager unionDictionaryManager =
                 new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of(2));
-        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7)));
-        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(4, 5)));
-        unionDictionaryManager.finalizeColumnDictionaries();
+        Assertions.assertNotNull(unionDictionaryManager.mergeDictionaries(List.of(4, 7), 0));
+        Assertions.assertNull(unionDictionaryManager.mergeDictionaries(List.of(4, 5), 0));
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
         Assertions.assertEquals(globalDicts.get(1).getDict(), globalDicts.get(3).getDict());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "b", "e"));
@@ -262,11 +262,11 @@ class UnionDictionaryManagerTest {
         Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col9));
         Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col10));
 
-        Assertions.assertEquals(1, unionDictionaryManager.mergeDictionaries(List.of(1, 7)));
-        Assertions.assertEquals(2, unionDictionaryManager.mergeDictionaries(List.of(2, 8)));
-        Assertions.assertEquals(3, unionDictionaryManager.mergeDictionaries(List.of(3, 9)));
+        Assertions.assertEquals(1, unionDictionaryManager.mergeDictionaries(List.of(1, 7), 0));
+        Assertions.assertEquals(2, unionDictionaryManager.mergeDictionaries(List.of(2, 8), 0));
+        Assertions.assertEquals(3, unionDictionaryManager.mergeDictionaries(List.of(3, 9), 0));
 
-        unionDictionaryManager.finalizeColumnDictionaries();
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
 
         Assertions.assertEquals(getDictValues(globalDicts.get(1)), List.of("a", "bbb", "g"));
         Assertions.assertEquals(getDictValues(globalDicts.get(2)), List.of("a", "aa", "bbb"));
@@ -285,6 +285,32 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(
                 Map.of(0, ConstantOperator.createInt(2), 2, ConstantOperator.createInt(1)),
                 constantEncodingMap.get(1));
+    }
+
+    @Test
+    void testAllConstantHandling() {
+        ColumnRefOperator col1 = new ColumnRefOperator(1, StringType.STRING, "col1", true);
+        ColumnRefOperator col2 = new ColumnRefOperator(2, StringType.STRING, "col2", true);
+        ColumnRefOperator col3 = new ColumnRefOperator(3, StringType.STRING, "col3", true);
+        Map<Integer, ColumnDict> globalDicts = new HashMap<>(Map.of(4, makeDict(List.of("c", "cc"))));
+        Map<Integer,  ScalarOperator> stringRefToDefineExprMap = Maps.newHashMap();
+        UnionDictionaryManager unionDictionaryManager =
+                new UnionDictionaryManager(SESSION_VARIABLE, stringRefToDefineExprMap, globalDicts, Set.of());
+        unionDictionaryManager.recordIfConstant(col1, ConstantOperator.createVarchar("bbb"));
+        unionDictionaryManager.recordIfConstant(col2, ConstantOperator.createVarchar("aaa"));
+        unionDictionaryManager.recordIfConstant(col3, col1);
+
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col1));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col2));
+        Assertions.assertTrue(unionDictionaryManager.isSupportedConstant(col3));
+
+        Assertions.assertEquals(5, unionDictionaryManager.mergeDictionaries(List.of(1, 2, 3), 5));
+        Assertions.assertEquals(4, unionDictionaryManager.mergeDictionaries(List.of(4, 5), 6));
+
+        unionDictionaryManager.finalizeColumnDictionaries(new ColumnRefSet());
+
+        Assertions.assertEquals(getDictValues(globalDicts.get(4)), List.of("aaa", "bbb", "c", "cc"));
+        Assertions.assertEquals(getDictValues(globalDicts.get(5)), List.of("aaa", "bbb", "c", "cc"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2174,18 +2174,49 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "RESULT SINK\n" +
                 "\n" +
-                "  12:Decode\n" +
-                "  |  <dict id 59> : <string id 40>\n" +
-                "  |  <dict id 60> : <string id 42>\n" +
-                "  |  <dict id 61> : <string id 43>\n" +
+                "  14:Decode\n" +
+                "  |  <dict id 65> : <string id 40>\n" +
+                "  |  <dict id 66> : <string id 42>\n" +
+                "  |  <dict id 67> : <string id 43>\n" +
+                "  |  <dict id 56> : <string id 48>\n" +
+                "  |  <dict id 57> : <string id 39>\n" +
+                "  |  <dict id 58> : <string id 44>\n" +
+                "  |  <dict id 59> : <string id 45>\n" +
+                "  |  <dict id 60> : <string id 46>\n" +
+                "  |  <dict id 61> : <string id 47>\n" +
                 "  |  \n" +
                 "  0:UNION\n" +
                 "  |  \n" +
-                "  |----11:Decode\n" +
-                "  |    |  <dict id 62> : <string id 29>\n" +
+                "  |----13:Project\n" +
+                "  |    |  <slot 29> : 29: case\n" +
+                "  |    |  <slot 35> : 35: ifnull\n" +
+                "  |    |  <slot 62> : 62: cast\n" +
+                "  |    |  <slot 63> : 63: cast\n" +
+                "  |    |  <slot 64> : 64: cast\n" +
+                "  |    |  <slot 74> : 2\n" +
+                "  |    |  <slot 75> : 2\n" +
+                "  |    |  <slot 76> : 1\n" +
+                "  |    |  <slot 77> : 2\n" +
+                "  |    |  <slot 78> : 2\n" +
+                "  |    |  <slot 79> : 1\n" +
                 "  |    |  \n" +
-                "  |    10:EXCHANGE\n" +
+                "  |    12:Decode\n" +
+                "  |    |  <dict id 68> : <string id 29>\n" +
+                "  |    |  \n" +
+                "  |    11:EXCHANGE\n" +
                 "  |    \n" +
+                "  6:Project\n" +
+                "  |  <slot 15> : 15: concat\n" +
+                "  |  <slot 21> : 21: round\n" +
+                "  |  <slot 50> : 50: c_user\n" +
+                "  |  <slot 51> : 51: c_dept\n" +
+                "  |  <slot 52> : 52: c_par\n" +
+                "  |  <slot 69> : 2\n" +
+                "  |  <slot 70> : 1\n" +
+                "  |  <slot 71> : 1\n" +
+                "  |  <slot 72> : 1\n" +
+                "  |  <slot 73> : 1\n" +
+                "  |  \n" +
                 "  5:EXCHANGE\n");
     }
 
@@ -3266,5 +3297,28 @@ public class LowCardinalityTest2 extends PlanTestBase {
             connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
             connectContext.getGlobalStateMgr().setStatisticStorage(prevStorage);
         }
+    }
+
+    @Test
+    void testUnionAllConstantInputsOnly() throws Exception {
+        String sql = """
+                select c_user, "abc", null const FROM low_card_t1 as s
+                UNION ALL
+                select c_mr, null, null FROM low_card_t2;
+                """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "9:Decode\n" +
+                "  |  <dict id 28> : <string id 24>\n" +
+                "  |  <dict id 30> : <string id 23>\n" +
+                "  |  cardinality: 2\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [30, INT, true] | [28, INT, true] | [25, BOOLEAN, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [26: c_user, INT, true] | [31: expr, INT, false] | [13: expr, BOOLEAN, true]\n" +
+                "  |      [29: cast, INT, true] | [32: expr, INT, true] | [20: expr, BOOLEAN, true]", plan);
+        String thrift = getThriftPlan(sql);
+        Assertions.assertTrue(thrift.contains("TGlobalDict(columnId:28"), thrift);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2200,19 +2200,51 @@ public class LowCardinalityTest2 extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "RESULT SINK\n" +
                 "\n" +
-                "  12:Decode\n" +
-                "  |  <dict id 59> : <string id 40>\n" +
-                "  |  <dict id 60> : <string id 42>\n" +
-                "  |  <dict id 61> : <string id 43>\n" +
+                "  14:Decode\n" +
+                "  |  <dict id 65> : <string id 40>\n" +
+                "  |  <dict id 66> : <string id 42>\n" +
+                "  |  <dict id 67> : <string id 43>\n" +
+                "  |  <dict id 56> : <string id 48>\n" +
+                "  |  <dict id 57> : <string id 39>\n" +
+                "  |  <dict id 58> : <string id 44>\n" +
+                "  |  <dict id 59> : <string id 45>\n" +
+                "  |  <dict id 60> : <string id 46>\n" +
+                "  |  <dict id 61> : <string id 47>\n" +
                 "  |  \n" +
                 "  0:UNION\n" +
                 "  |  \n" +
-                "  |----11:Decode\n" +
-                "  |    |  <dict id 62> : <string id 29>\n" +
+                "  |----13:Project\n" +
+                "  |    |  <slot 29> : 29: case\n" +
+                "  |    |  <slot 35> : 35: ifnull\n" +
+                "  |    |  <slot 62> : 62: cast\n" +
+                "  |    |  <slot 63> : 63: cast\n" +
+                "  |    |  <slot 64> : 64: cast\n" +
+                "  |    |  <slot 75> : 1\n" +
+                "  |    |  <slot 76> : 2\n" +
+                "  |    |  <slot 77> : 2\n" +
+                "  |    |  <slot 78> : 1\n" +
+                "  |    |  <slot 79> : 2\n" +
+                "  |    |  <slot 80> : 2\n" +
                 "  |    |  \n" +
-                "  |    10:EXCHANGE\n" +
+                "  |    12:Decode\n" +
+                "  |    |  <dict id 68> : <string id 29>\n" +
+                "  |    |  \n" +
+                "  |    11:EXCHANGE\n" +
                 "  |    \n" +
-                "  5:EXCHANGE\n");
+                "  6:Project\n" +
+                "  |  <slot 15> : 15: concat\n" +
+                "  |  <slot 21> : 21: round\n" +
+                "  |  <slot 50> : 50: c_user\n" +
+                "  |  <slot 51> : 51: c_dept\n" +
+                "  |  <slot 52> : 52: c_par\n" +
+                "  |  <slot 69> : 1\n" +
+                "  |  <slot 70> : 1\n" +
+                "  |  <slot 71> : 1\n" +
+                "  |  <slot 72> : 2\n" +
+                "  |  <slot 73> : 1\n" +
+                "  |  <slot 74> : 1\n" +
+                "  |  \n" +
+                "  5:EXCHANGE");
     }
 
     @Test
@@ -3292,5 +3324,28 @@ public class LowCardinalityTest2 extends PlanTestBase {
             connectContext.getSessionVariable().setEnableSplitWindowSkewToUnion(false);
             connectContext.getGlobalStateMgr().setStatisticStorage(prevStorage);
         }
+    }
+
+    @Test
+    void testUnionAllConstantInputsOnly() throws Exception {
+        String sql = """
+                select c_user, "abc", null const FROM low_card_t1 as s
+                UNION ALL
+                select c_mr, null, null FROM low_card_t2;
+                """;
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "9:Decode\n" +
+                "  |  <dict id 28> : <string id 24>\n" +
+                "  |  <dict id 30> : <string id 23>\n" +
+                "  |  cardinality: 2\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [30, INT, true] | [28, INT, true] | [25, BOOLEAN, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [26: c_user, INT, true] | [31: expr, INT, false] | [13: expr, BOOLEAN, true]\n" +
+                "  |      [29: cast, INT, true] | [32: expr, INT, true] | [20: expr, BOOLEAN, true]", plan);
+        String thrift = getThriftPlan(sql);
+        Assertions.assertTrue(thrift.contains("TGlobalDict(columnId:28"), thrift);
     }
 }

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -1385,3 +1385,32 @@ g	g
 g	g
 g	g
 -- !result
+SELECT * FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T
+ORDER BY 1, 2;
+-- result:
+test_table_1	a
+test_table_1	b
+test_table_1	c
+test_table_2	d
+test_table_2	e
+test_table_2	f
+-- !result
+ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'true');
+-- result:
+-- !result
+SELECT max(source), min(source), count(source), max(value), min(value), count(value)
+FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T;
+-- result:
+test_table_2	test_table_1	6	f	a	6
+-- !result
+ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'false');
+-- result:
+-- !result

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -939,3 +939,21 @@ T2 AS (
     SELECT const, const FROM T
 )
 SELECT * FROM T2 ORDER BY 1, 2;
+
+SELECT * FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T
+ORDER BY 1, 2;
+
+ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'true');
+
+SELECT max(source), min(source), count(source), max(value), min(value), count(value)
+FROM (
+    SELECT 'test_table_1' as source, value FROM test_table_1
+    UNION ALL
+    SELECT 'test_table_2' as source, value FROM test_table_2
+) T;
+
+ADMIN SET FRONTEND CONFIG ('push_down_non_grouped_aggregate_below_union' = 'false');


### PR DESCRIPTION
## Why I'm doing:

The low-cardinality global dictionary optimization for UNION ALL currently only
kicks in for output columns backed by at least one real (non-constant) dictionary
column. When every branch of an output column is a constant string (e.g.
SELECT c_user, 'abc' ... UNION ALL SELECT c_mr, NULL ...), that column cannot be
dictified, which forces a decode earlier than necessary and prevents the union
output from staying dict-encoded end to end.

## What I'm doing:

Generate a synthetic global dictionary for UNION ALL output columns whose branches
are all constants:

- UnionDictionaryManager.mergeDictionaries now takes the output column id and, when
  there are no non-constant source columns, builds a merged dictionary from the
  constant values, registers it as a generated dict for the output column, and tracks
  it in generatedDictionaryIds.
- The generated dict ids are added to allStringColumns in DecodeCollector so the
  output column is treated as a dict column, and the output column is self-defined
  (setDefineExpr(outputColumn, outputColumn, 1)) since it has no source column.
- The generated dictionary is propagated to the BE: DecodeRewriter collects the
  (dictColumnId, ColumnDict) pairs onto PhysicalUnionOperator, and
  PlanFragmentBuilder.buildSetOperation merges them into the fragment's
  query_global_dicts.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
