### PR TITLE
[BugFix] Sort union-merged dictionary keys with unsigned byte order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -70,7 +70,8 @@ public class UnionDictionaryManager {
         if (uniques.size() > Config.low_cardinality_threshold || totalDictSize > DICT_PAGE_MAX_SIZE - 32) {
             return null;
         }
-        List<ByteBuffer> sortedValues = uniques.stream().sorted().toList();
+        // Sort unsigned to match BE's memcmp order; plain sorted() is signed on JDK 8. See ColumnDict.UNSIGNED_LEX.
+        List<ByteBuffer> sortedValues = uniques.stream().sorted(ColumnDict.UNSIGNED_LEX).toList();
         ImmutableMap.Builder<ByteBuffer, Integer> builder = ImmutableMap.builder();
         for (int i = 0; i < sortedValues.size(); ++i) {
             builder.put(sortedValues.get(i), i + 1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -32,7 +32,7 @@ public final class ColumnDict extends StatsVersion {
      * byte (Cyrillic, CJK, etc.) sorts the opposite way on the two sides. Always use this comparator
      * when ordering dictionary keys on the FE so the result matches BE regardless of JDK version.
      */
-    private static final Comparator<ByteBuffer> UNSIGNED_LEX = (a, b) -> {
+    public static final Comparator<ByteBuffer> UNSIGNED_LEX = (a, b) -> {
         int aPos = a.position();
         int bPos = b.position();
         int aLen = a.limit() - aPos;


### PR DESCRIPTION
## Why I'm doing:

`UnionDictionaryManager.mergeDictionaryData` assigns dictionary codes with
`Stream.sorted()` — i.e. `ByteBuffer.compareTo`, which compares bytes as **signed**
on JDK 8. The BE builds dictionaries with `memcmp` (**unsigned**), and
`ColumnDict.merge` already sorts real-column dictionaries with
`ColumnDict.UNSIGNED_LEX` for exactly this reason (see its inline comment).

For union-merged (and all-constant) dictionaries containing values with a high-bit
byte — CJK, Cyrillic, accented Latin, emoji — the FE-assigned code order diverges
from the BE's expected order. 

## What I'm doing:

Reuse `ColumnDict.UNSIGNED_LEX` (made `public`) in `mergeDictionaryData` so union
dictionaries follow the same unsigned ordering convention as every other dictionary
in the system.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
