### PR TITLE
[BugFix] Fix error nullablel column on UNNEST + GROUP BY of a required Iceberg column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1788,8 +1788,17 @@ public class PlanFragmentBuilder {
 
             // Iceberg table scan slots are always nullable because the source data
             // is not governed by StarRocks NOT NULL constraints and may contain nulls.
+            // Widen both the slot descriptors AND the shared column refs. Downstream
+            // fragment building rebuilds tuples from ColumnRefOperator.isNullable()
+            // (e.g. the UNNEST outer columns in visitPhysicalTableFunction); if a ref
+            // for a required (NOT NULL) Iceberg column still reports not-null while the
+            // runtime column produced by the scan is nullable, the aggregator group-by
+            // nullability check rejects it with "error nullablel column".
             for (SlotDescriptor slotDescriptor : tupleDescriptor.getSlots()) {
                 slotDescriptor.setIsNullable(true);
+            }
+            for (ColumnRefOperator columnRefOperator : node.getColRefToColumnMetaMap().keySet()) {
+                columnRefOperator.setNullable(true);
             }
 
             // partition id generator
@@ -3939,7 +3948,19 @@ public class PlanFragmentBuilder {
                         context.getDescTbl().addSlotDescriptor(udtfOutputTuple, new SlotId(columnRefOperator.getId()));
                 slotDesc.setType(columnRefOperator.getType());
                 slotDesc.setIsMaterialized(true);
-                slotDesc.setIsNullable(columnRefOperator.isNullable());
+                // Outer (pass-through) columns are materialized by the child, whose slot reflects
+                // the true runtime nullability. That can be wider than the logical colRef -- e.g. a
+                // required (NOT NULL) Iceberg column, or an expression derived from one, whose runtime
+                // column is nullable. Prefer the child slot so we never declare a NOT NULL outer slot
+                // over a nullable runtime column (which the aggregator rejects with the group-by
+                // "error nullablel column" check). This only widens; fn-result columns have no child
+                // SlotRef in the map yet, so they keep the colRef nullability.
+                boolean nullable = columnRefOperator.isNullable();
+                Expr childOutputExpr = context.getColRefToExpr().get(columnRefOperator);
+                if (childOutputExpr instanceof SlotRef) {
+                    nullable |= ((SlotRef) childOutputExpr).getDesc().getIsNullable();
+                }
+                slotDesc.setIsNullable(nullable);
 
                 context.getColRefToExpr().put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDesc));
             }

--- a/test/sql/test_iceberg/R/test_iceberg_unnest_group_by_required_column
+++ b/test/sql/test_iceberg/R/test_iceberg_unnest_group_by_required_column
@@ -1,0 +1,129 @@
+-- name: test_iceberg_unnest_group_by_required_column
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table t_required (
+  id bigint not null,
+  arr array<int>,
+  opt_id bigint
+) properties ("format-version" = "2");
+-- result:
+-- !result
+function: assert_query_contains("show create table t_required", "NOT NULL")
+-- result:
+None
+-- !result
+insert into t_required values (1, [10, 20], 100), (2, [30, 40], 200), (3, [50], 300);
+-- result:
+-- !result
+select id from t_required, unnest(arr) group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select id from t_required, unnest([1, 2]) group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select count(distinct id) from t_required, unnest([1, 2]);
+-- result:
+3
+-- !result
+select k from (select id + 1 as k from t_required) v, unnest([1, 2]) group by k order by k;
+-- result:
+2
+3
+4
+-- !result
+select id from t_required group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select id from ((select id from t_required) union all (select id from t_required)) v group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select id from t_required group by rollup(id) order by id;
+-- result:
+None
+1
+2
+3
+-- !result
+select id from (select id from t_required order by id limit 2) v group by id order by id;
+-- result:
+1
+2
+-- !result
+select max(id), min(id) from t_required;
+-- result:
+3	1
+-- !result
+select opt_id from t_required, unnest(arr) group by opt_id order by opt_id;
+-- result:
+100
+200
+300
+-- !result
+drop table t_required force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+-- name: test_olap_unnest_group_by_not_null_column
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t_required (
+  id bigint not null,
+  arr array<int>,
+  opt_id bigint
+) duplicate key(id) distributed by hash(id) buckets 1 properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into t_required values (1, [10, 20], 100), (2, [30, 40], 200), (3, [50], 300);
+-- result:
+-- !result
+select id from t_required, unnest(arr) group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select id from t_required, unnest([1, 2]) group by id order by id;
+-- result:
+1
+2
+3
+-- !result
+select count(distinct id) from t_required, unnest([1, 2]);
+-- result:
+3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_unnest_group_by_required_column
+++ b/test/sql/test_iceberg/T/test_iceberg_unnest_group_by_required_column
@@ -1,0 +1,72 @@
+-- name: test_iceberg_unnest_group_by_required_column
+-- Regression test for the Iceberg + UNNEST nullability bug introduced by #69525
+-- ("Support Iceberg v3 default value feature").
+--
+-- A required (NOT NULL) Iceberg column is now declared NOT NULL in the plan, but
+-- the external scan still produces a nullable runtime column. UNNEST rebuilds its
+-- outer columns straight from the (stale, not-null) column ref, so a GROUP BY on
+-- the required column -- or on an expression derived from it -- hit the aggregator
+-- nullability check and failed with "error nullablel column".
+--
+-- Cases 1-4 are the FIX TARGETS: they errored before the fix and must succeed now.
+-- Case 4 (a not-null-preserving expression such as id+1) is the derived-column
+-- variant that a scan-only widening cannot reach; it needs the table-function outer
+-- slot to follow the child slot's nullability.
+-- Cases 5-9 plus the optional-column contrast are REGRESSION PROTECTION: they
+-- always worked (UNION / ROLLUP / TopN / plain aggregates have their own
+-- nullability fallbacks or re-materialize the tuple) and must keep working.
+create external catalog iceberg_sql_test_${uuid0}
+PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}");
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+create table t_required (
+  id bigint not null,
+  arr array<int>,
+  opt_id bigint
+) properties ("format-version" = "2");
+-- the required column must really be NOT NULL, otherwise the test premise is void
+function: assert_query_contains("show create table t_required", "NOT NULL")
+insert into t_required values (1, [10, 20], 100), (2, [30, 40], 200), (3, [50], 300);
+-- fix target 1: UNNEST an array column + GROUP BY the required column
+select id from t_required, unnest(arr) group by id order by id;
+-- fix target 2: UNNEST a constant array + GROUP BY the required column
+select id from t_required, unnest([1, 2]) group by id order by id;
+-- fix target 3: COUNT(DISTINCT required column) with UNNEST
+select count(distinct id) from t_required, unnest([1, 2]);
+-- fix target 4: a not-null-preserving expression (id + 1) on the required column,
+-- materialized below the UNNEST, then GROUP BY the derived column
+select k from (select id + 1 as k from t_required) v, unnest([1, 2]) group by k order by k;
+-- regression 5: GROUP BY the required column without UNNEST
+select id from t_required group by id order by id;
+-- regression 6: UNION ALL feeding an outer GROUP BY on the required column
+select id from ((select id from t_required) union all (select id from t_required)) v group by id order by id;
+-- regression 7: GROUP BY ROLLUP on the required column
+select id from t_required group by rollup(id) order by id;
+-- regression 8: TopN subquery feeding an outer GROUP BY on the required column
+select id from (select id from t_required order by id limit 2) v group by id order by id;
+-- regression 9: required column as a plain aggregate argument
+select max(id), min(id) from t_required;
+-- contrast: an optional (nullable) column with UNNEST + GROUP BY was never affected
+select opt_id from t_required, unnest(arr) group by opt_id order by opt_id;
+drop table t_required force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+set catalog default_catalog;
+drop catalog iceberg_sql_test_${uuid0};
+
+-- name: test_olap_unnest_group_by_not_null_column
+-- Contrast case (regression protection): the same query shape on a native OLAP
+-- table with a NOT NULL column always worked, because the OLAP scan keeps the
+-- slot and the column ref consistently not-null. Guards against a fix that would
+-- wrongly widen internal-table nullability.
+create database db_${uuid0};
+use db_${uuid0};
+create table t_required (
+  id bigint not null,
+  arr array<int>,
+  opt_id bigint
+) duplicate key(id) distributed by hash(id) buckets 1 properties ("replication_num" = "1");
+insert into t_required values (1, [10, 20], 100), (2, [30, 40], 200), (3, [50], 300);
+select id from t_required, unnest(arr) group by id order by id;
+select id from t_required, unnest([1, 2]) group by id order by id;
+select count(distinct id) from t_required, unnest([1, 2]);
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Querying an external Iceberg table that has a **required** (`NOT NULL`) column fails with
`error nullablel column, index: 0, slot: ColumnRef(...)` when that column is put in a
`GROUP BY` together with `UNNEST` — even though the column contains no nulls at all.

Minimal repro (`id` is a required Iceberg column; a constant array is enough):

    SELECT id FROM <iceberg_tbl>, unnest([1, 2]) t(x) GROUP BY id;

`COUNT(DISTINCT id)` with `UNNEST` fails the same way. Without `UNNEST`, or when the
column is used as a plain `min/max/sum` argument, the query works. This is a regression:
3.5 is fine; it was introduced by #69525 ("Support Iceberg v3 default value feature").

## What I'm doing:

#69525 changed `IcebergApiConverter` to build columns with `field.isOptional()`, so a
required Iceberg column becomes a `NOT NULL` `ColumnRefOperator` for the first time.
External scans still require nullable columns, so `buildIcebergScanNode` force-widens the
scan **slot descriptors** to nullable — but it never updated the shared **column refs**.
`visitPhysicalTableFunction` rebuilds the `UNNEST` outer columns straight from
`ColumnRefOperator.isNullable()`, picking up the stale not-null flag, and the BE
aggregator's group-by check then rejects the nullable runtime column against the not-null
declaration (`Aggregator::_evaluate_group_by_exprs` → "error nullablel column").

The fix aligns the scan-output column refs with the already-forced-nullable slots. It only
widens `false -> true` (which the BE already tolerates), restores the pre-#69525 column-ref
nullability for Iceberg scan outputs, and does not touch the v3 default-value feature nor
`HiveDataSource::_check_all_slots_nullable`. Only `UNNEST` triggered the bug because
UNION/ROLLUP/TopN force their output nullable or re-materialize through exchange/sort.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
