### PR TITLE
[BugFix] Fix monotonicity detection for division expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArithmetic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/expression/ExecArithmetic.java
@@ -60,6 +60,11 @@ public class ExecArithmetic extends ExecExpr {
 
     @Override
     public boolean isSelfMonotonic() {
+        if ((op == ArithmeticExpr.Operator.DIVIDE || op == ArithmeticExpr.Operator.INT_DIVIDE)
+                && !children.get(1).isConstant()) {
+            return false;
+        }
+
         return op.isMonotonic();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/expression/ExecExprTest.java
@@ -1806,6 +1806,17 @@ public class ExecExprTest {
         ExecArithmetic add = new ExecArithmetic(IntegerType.INT, ArithmeticExpr.Operator.ADD,
                 new ArrayList<>(List.of(left, right)));
         assertTrue(add.isSelfMonotonic());
+
+        for (ArithmeticExpr.Operator op :
+                List.of(ArithmeticExpr.Operator.DIVIDE, ArithmeticExpr.Operator.INT_DIVIDE)) {
+            ExecArithmetic divideByConstant = new ExecArithmetic(IntegerType.INT, op,
+                    new ArrayList<>(List.of(left, right)));
+            assertTrue(divideByConstant.isSelfMonotonic());
+
+            ExecArithmetic divideByColumn = new ExecArithmetic(IntegerType.INT, op,
+                    new ArrayList<>(List.of(right, left)));
+            assertFalse(divideByColumn.isSelfMonotonic());
+        }
     }
 
     @Test

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
@@ -192,6 +192,10 @@ public class ArithmeticExpr extends Expr {
 
     @Override
     public boolean isSelfMonotonic() {
+        if ((op == Operator.DIVIDE || op == Operator.INT_DIVIDE) && !getChild(1).isConstant()) {
+            return false;
+        }
+
         return op.isMonotonic();
     }
 }

--- a/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
@@ -36,6 +36,7 @@ select count(*) from t1 where c0 like 's_%';
 -- result:
 2560032
 -- !result
+
 -- name: test_push_down_cast_expr
 CREATE TABLE `test003` (
   `data_date` date NOT NULL COMMENT "",
@@ -57,4 +58,39 @@ set sql_mode = 'ALLOW_THROW_EXCEPTION';
 -- !result
 select * from test003 where CAST(user_id AS INT) ;
 -- result:
+-- !result
+
+-- name: test_division_monotonicity
+CREATE TABLE division_monotonicity (
+    id INT,
+    c BIGINT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO division_monotonicity VALUES
+    (1, -10),
+    (2, 1),
+    (3, 2),
+    (4, 10);
+-- result:
+-- !result
+INSERT INTO division_monotonicity VALUES (5, 100);
+-- result:
+-- !result
+SELECT id, c, 10 DIV c AS quotient
+FROM division_monotonicity
+WHERE 10 DIV c > 5
+ORDER BY id;
+-- result:
+2	1	10
+-- !result
+SELECT id, c, c DIV 10 AS quotient
+FROM division_monotonicity
+WHERE c DIV 10 > 5
+ORDER BY id;
+-- result:
+5	100	10
 -- !result

--- a/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
@@ -37,6 +37,7 @@ select count(*) from t1 where c0 like 's_%';
 2560032
 -- !result
 
+
 -- name: test_push_down_cast_expr
 CREATE TABLE `test003` (
   `data_date` date NOT NULL COMMENT "",
@@ -60,8 +61,9 @@ select * from test003 where CAST(user_id AS INT) ;
 -- result:
 -- !result
 
+
 -- name: test_division_monotonicity
-CREATE TABLE division_monotonicity (
+CREATE TABLE division_monotonicity_${uuid0} (
     id INT,
     c BIGINT
 )
@@ -70,27 +72,30 @@ DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
-INSERT INTO division_monotonicity VALUES
+INSERT INTO division_monotonicity_${uuid0} VALUES
     (1, -10),
     (2, 1),
     (3, 2),
     (4, 10);
 -- result:
 -- !result
-INSERT INTO division_monotonicity VALUES (5, 100);
+INSERT INTO division_monotonicity_${uuid0} VALUES (5, 100);
 -- result:
 -- !result
 SELECT id, c, 10 DIV c AS quotient
-FROM division_monotonicity
+FROM division_monotonicity_${uuid0}
 WHERE 10 DIV c > 5
 ORDER BY id;
 -- result:
 2	1	10
 -- !result
 SELECT id, c, c DIV 10 AS quotient
-FROM division_monotonicity
+FROM division_monotonicity_${uuid0}
 WHERE c DIV 10 > 5
 ORDER BY id;
 -- result:
 5	100	10
+-- !result
+DROP TABLE division_monotonicity_${uuid0};
+-- result:
 -- !result

--- a/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
@@ -32,3 +32,29 @@ insert into test003 values("2025-08-12", NULL);
 set sql_mode = 'ALLOW_THROW_EXCEPTION';
 select * from test003 where CAST(user_id AS INT) ;
 
+
+-- name: test_division_monotonicity
+CREATE TABLE division_monotonicity (
+    id INT,
+    c BIGINT
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO division_monotonicity VALUES
+    (1, -10),
+    (2, 1),
+    (3, 2),
+    (4, 10);
+INSERT INTO division_monotonicity VALUES (5, 100);
+
+SELECT id, c, 10 DIV c AS quotient
+FROM division_monotonicity
+WHERE 10 DIV c > 5
+ORDER BY id;
+
+SELECT id, c, c DIV 10 AS quotient
+FROM division_monotonicity
+WHERE c DIV 10 > 5
+ORDER BY id;

--- a/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
@@ -34,7 +34,7 @@ select * from test003 where CAST(user_id AS INT) ;
 
 
 -- name: test_division_monotonicity
-CREATE TABLE division_monotonicity (
+CREATE TABLE division_monotonicity_${uuid0} (
     id INT,
     c BIGINT
 )
@@ -42,19 +42,21 @@ DUPLICATE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 1
 PROPERTIES ("replication_num" = "1");
 
-INSERT INTO division_monotonicity VALUES
+INSERT INTO division_monotonicity_${uuid0} VALUES
     (1, -10),
     (2, 1),
     (3, 2),
     (4, 10);
-INSERT INTO division_monotonicity VALUES (5, 100);
+INSERT INTO division_monotonicity_${uuid0} VALUES (5, 100);
 
 SELECT id, c, 10 DIV c AS quotient
-FROM division_monotonicity
+FROM division_monotonicity_${uuid0}
 WHERE 10 DIV c > 5
 ORDER BY id;
 
 SELECT id, c, c DIV 10 AS quotient
-FROM division_monotonicity
+FROM division_monotonicity_${uuid0}
 WHERE c DIV 10 > 5
 ORDER BY id;
+
+DROP TABLE division_monotonicity_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Division is not globally monotonic when the divisor is non-constant. Treating expressions such as `10 DIV c` as monotonic may cause incorrect ZoneMap pruning and produce wrong query results.

For example:
```sql
CREATE TABLE t (
    id INT,
    c BIGINT
)
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES ("replication_num" = "1");

INSERT INTO t VALUES
    (1, -10),
    (2, 1),
    (3, 2),
    (4, 10);

SELECT id, c, 10 DIV c AS quotient
FROM t
WHERE 10 DIV c > 5;
```

Before this fix, the query incorrectly returns an empty result set, while the correct result is:
```text
id  c  quotient
2   1  10
```

The page contains the following values:
c = [-10, 1, 2, 10]
ZoneMap = [-10, 10]
Because 10 DIV c is incorrectly treated as monotonic, ZoneMap pruning evaluates the expression using the range boundaries:
10 DIV -10 = -1  -> does not satisfy > 5
10 DIV  10 =  1  -> does not satisfy > 5

The entire page is therefore incorrectly pruned. However, a value inside the page satisfies the predicate:
10 DIV 1 = 10  -> satisfies > 5

## What I'm doing:

Update `ArithmeticExpr.isSelfMonotonic()` so that `DIVIDE` and `INT_DIVIDE` expressions are considered monotonic only when the divisor is constant.

This prevents unsafe ZoneMap pruning for expressions such as `10 DIV c`, while preserving the optimization for valid monotonic expressions such as `c DIV 10`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
