### PR TITLE
[BugFix] Making union all constant mapping positional

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -65,7 +65,6 @@ import com.starrocks.type.Type;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -296,29 +295,39 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         final DecodeInfo finalInfo = info;
         encodedUnionColumns.union(unionOp.getOutputColumnRefOp().stream().filter(
                 c -> finalInfo.outputStringColumns.contains(c) || finalInfo.usedStringColumns.contains(c)).toList());
-        List<Map<ColumnRefOperator, ConstantOperator>> constantMappings =
+        List<Map<Integer, ConstantOperator>> constantMappings =
                 context.unionDictionaryManager.generateConstantEncodingMap(
                         unionOp.getOutputColumnRefOp(), unionOp.getChildOutputColumns(), encodedUnionColumns);
         List<List<ColumnRefOperator>> newChildOutputColumns = Lists.newArrayList();
         for (int i = 0; i < optExpression.arity(); ++i) {
-            Map<ColumnRefOperator, ConstantOperator> constantMapping = constantMappings.get(i);
-            HashMap<ColumnRefOperator, ColumnRefOperator> columnMapping = Maps.newHashMap();
-            constantMapping.forEach((key, value) ->
-                    columnMapping.put(key, factory.create(value, value.getType(), value.isNullable())));
-            unionOp.getChildOutputColumns().get(i).forEach(c -> columnMapping.putIfAbsent(c,
-                    finalInfo.inputStringColumns.contains(c.getId()) ?
-                            context.stringRefToDictRefMap.getOrDefault(c, c) : c)
-            );
-            newChildOutputColumns.add(unionOp.getChildOutputColumns().get(i).stream().map(columnMapping::get).toList());
-            if (constantMapping.isEmpty()) {
+            Map<Integer, ConstantOperator> constantMapping = constantMappings.get(i);
+            List<ColumnRefOperator> children = unionOp.getChildOutputColumns().get(i);
+            List<ColumnRefOperator> newChildren = Lists.newArrayList();
+            boolean needsProjection = false;
+            Map<ColumnRefOperator, ScalarOperator> projectionColumnMapping = Maps.newHashMap();
+            for (int j = 0; j < children.size(); ++j) {
+                final ColumnRefOperator child = children.get(j);
+                final ColumnRefOperator newChild;
+                final ScalarOperator projection;
+                if (constantMapping.containsKey(j)) {
+                    projection = constantMapping.get(j);
+                    newChild = factory.create(projection, projection.getType(), projection.isNullable());
+                    needsProjection = true;
+                } else if (finalInfo.inputStringColumns.contains(child.getId())) {
+                    newChild = context.stringRefToDictRefMap.getOrDefault(child, child);
+                    projection = newChild;
+                } else {
+                    newChild = child;
+                    projection = newChild;
+                }
+                newChildren.add(newChild);
+                projectionColumnMapping.put(newChild, projection);
+            }
+            newChildOutputColumns.add(newChildren);
+            if (!needsProjection) {
                 continue;
             }
-            PhysicalProjectOperator projectOp = new PhysicalProjectOperator(
-                    unionOp.getChildOutputColumns().get(i).stream().distinct().collect(Collectors.toMap(
-                            columnMapping::get,
-                            c -> constantMapping.containsKey(c) ? constantMapping.get(c) : columnMapping.get(c))),
-                    Map.of()
-            );
+            PhysicalProjectOperator projectOp = new PhysicalProjectOperator(projectionColumnMapping, Map.of());
             LogicalProperty property = new LogicalProperty(optExpression.getInputs().get(i).getLogicalProperty());
             property.setOutputColumns(new ColumnRefSet(projectOp.getOutputColumns()));
             OptExpression newChild = OptExpression.builder().with(optExpression.getInputs().get(i)).setOp(projectOp)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManager.java
@@ -180,10 +180,10 @@ public class UnionDictionaryManager {
         return ConstantOperator.createInt(index);
     }
 
-    List<Map<ColumnRefOperator, ConstantOperator>> generateConstantEncodingMap(List<ColumnRefOperator> outputColumns,
+    List<Map<Integer, ConstantOperator>> generateConstantEncodingMap(List<ColumnRefOperator> outputColumns,
                                                                                List<List<ColumnRefOperator>> childColumns,
                                                                                ColumnRefSet allStringColumns) {
-        List<Map<ColumnRefOperator, ConstantOperator>> result = Lists.newArrayList();
+        List<Map<Integer, ConstantOperator>> result = Lists.newArrayList();
         childColumns.forEach(c -> result.add(Maps.newHashMap()));
         for (int i = 0; i < outputColumns.size(); ++i) {
             if (!allStringColumns.contains(outputColumns.get(i).getId())) {
@@ -197,7 +197,7 @@ public class UnionDictionaryManager {
             for (int j = 0; j < childColumns.size(); ++j) {
                 ColumnRefOperator c = childColumns.get(j).get(i);
                 if (constantColumns.containsKey(c.getId())) {
-                    result.get(j).put(c, generateConstantOperator(c, dictData));
+                    result.get(j).put(i, generateConstantOperator(c, dictData));
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -283,8 +283,6 @@ class UnionDictionaryManagerTest {
         Assertions.assertEquals(2, constantEncodingMap.size());
         Assertions.assertEquals(Map.of(1, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
         Assertions.assertEquals(
-                Map.of(1, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
-        Assertions.assertEquals(
                 Map.of(0, ConstantOperator.createInt(2), 2, ConstantOperator.createInt(1)),
                 constantEncodingMap.get(1));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/UnionDictionaryManagerTest.java
@@ -275,14 +275,18 @@ class UnionDictionaryManagerTest {
         stringRefToDefineExprMap.put(4, col1);
         stringRefToDefineExprMap.put(5, col2);
         stringRefToDefineExprMap.put(6, col3);
-        List<Map<ColumnRefOperator, ConstantOperator>> constantEncodingMap =
+        List<Map<Integer, ConstantOperator>> constantEncodingMap =
                 unionDictionaryManager.generateConstantEncodingMap(List.of(col4, col5, col6),
-                        List.of(List.of(col1, col8, col3), List.of(col7, col2, col9)),
-                        new ColumnRefSet(List.of(col1, col2, col4, col5)));
+                        List.of(List.of(col1, col8, col3), List.of(col7, col2, col7)),
+                        new ColumnRefSet(List.of(col1, col2, col4, col5, col6)));
 
         Assertions.assertEquals(2, constantEncodingMap.size());
-        Assertions.assertEquals(Map.of(col8, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
-        Assertions.assertEquals(Map.of(col7, ConstantOperator.createInt(2)), constantEncodingMap.get(1));
+        Assertions.assertEquals(Map.of(1, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
+        Assertions.assertEquals(
+                Map.of(1, ConstantOperator.createInt(3)), constantEncodingMap.get(0));
+        Assertions.assertEquals(
+                Map.of(0, ConstantOperator.createInt(2), 2, ConstantOperator.createInt(1)),
+                constantEncodingMap.get(1));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -3077,7 +3077,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  |      [30, INT, true] | [31, INT, true] | [33, INT, true]\n" +
                 "  |  child exprs:\n" +
                 "  |      [29: c_user, INT, true] | [32: cast, INT, true] | [29: c_user, INT, true]\n" +
-                "  |      [35: expr, INT, true] | [34: expr, INT, false] | [36: expr, INT, true]", plan);
+                "  |      [34: expr, INT, true] | [35: expr, INT, false] | [36: expr, INT, true]", plan);
     }
 
     @Test

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -1347,3 +1347,41 @@ order by 1,2 limit 10;
 9	filter_case_9
 10	filter_case_10
 -- !result
+CREATE TABLE multi_column_table (
+    id INT,
+    `s1` VARCHAR(100),
+    `s2` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO multi_column_table VALUES (0, 'a', 'x');
+-- result:
+-- !result
+INSERT INTO multi_column_table VALUES (1, 'b', 'y');
+-- result:
+-- !result
+[UC]analyze full multi_column_table; 
+function: wait_global_dict_ready('`s1`', 'multi_column_table')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('`s2`', 'multi_column_table')
+-- result:
+
+-- !result
+WITH T AS (SELECT 'g' AS const FROM test_table_1),
+T2 AS (
+    SELECT s1, s2 FROM multi_column_table
+    UNION ALL 
+    SELECT const, const FROM T
+)
+SELECT * FROM T2 ORDER BY 1, 2;
+-- result:
+a	x
+b	y
+g	g
+g	g
+g	g
+-- !result

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -914,3 +914,28 @@ FROM (
 ) t
 WHERE LENGTH(`text`) > 10
 order by 1,2 limit 10;
+
+CREATE TABLE multi_column_table (
+    id INT,
+    `s1` VARCHAR(100),
+    `s2` VARCHAR(100)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+INSERT INTO multi_column_table VALUES (0, 'a', 'x');
+INSERT INTO multi_column_table VALUES (1, 'b', 'y');
+
+[UC]analyze full multi_column_table;
+
+function: wait_global_dict_ready('`s1`', 'multi_column_table')
+function: wait_global_dict_ready('`s2`', 'multi_column_table')
+
+-- test_same_constant_in_multiple_branches
+WITH T AS (SELECT 'g' AS const FROM test_table_1),
+T2 AS (
+    SELECT s1, s2 FROM multi_column_table
+    UNION ALL 
+    SELECT const, const FROM T
+)
+SELECT * FROM T2 ORDER BY 1, 2;


### PR DESCRIPTION
## Why I'm doing:

`UnionDictionaryManager.generateConstantEncodingMap` keyed the encoded constant by child
column ref. When a single constant child ref feeds several UNION ALL output columns that
dictify into different dictionaries, the same ref needs a different code per output, but
the ref-keyed map kept only the last write, so the other outputs decoded against the wrong
dictionary and returned the wrong string.

## What I'm doing:
- Index the constant encoding by output position instead of child ref:
- Unit test extended so a constant ref is reused across two outputs with different dictionaries,
  asserting each output gets its own code.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
