### PR TITLE
[Doc] Add release notes for StarRocks v3.5.20

### DIFF
--- a/docs/en/release_notes/release-3.5.md
+++ b/docs/en/release_notes/release-3.5.md
@@ -27,6 +27,48 @@ description: "StarRocks 3.5 release notes: Iceberg view creation, OAuth 2.0 and 
 
 :::
 
+## 3.5.20
+
+Release date: July 23, 2026
+
+### Behavior Changes
+
+- `CREATE DATABASE IF NOT EXISTS` on Iceberg REST catalogs now succeeds silently when the database already exists, instead of raising an error. [#75017](https://github.com/StarRocks/starrocks/pull/75017)
+- Iceberg REST catalogs with vended credentials now cache `Table` objects and keep their credentials refreshed on access, instead of bypassing the cache and re-fetching from the REST catalog/Lake Formation on every `getTable()` call, which could trigger AWS `Rate exceeded` errors. [#75431](https://github.com/StarRocks/starrocks/pull/75431)
+- GIN inverted-index-accelerated `NOT MATCH` predicates no longer return rows with a `NULL` value, matching SQL three-valued-logic semantics. [#75578](https://github.com/StarRocks/starrocks/pull/75578)
+- Fixed a null-padding size mismatch for missing columns in `ParquetScanner` so padded rows match the actual per-batch chunk size instead of the whole Parquet/Arrow batch size. [#75981](https://github.com/StarRocks/starrocks/pull/75981)
+- Removed vulnerable, stale transitive dependencies (old BouncyCastle, OkHttp 2.x, Tomcat, and others) that previously shipped alongside their fixed counterparts, and added dependency-ban enforcement to keep them out. [#76097](https://github.com/StarRocks/starrocks/pull/76097)
+
+### Improvements
+
+- Added the FE metric `txn_max_committed_pending_publish_ms`, a per-database gauge reporting the longest time a committed transaction has been pending publish, to help diagnose stuck or lagging version publishing. [#75025](https://github.com/StarRocks/starrocks/pull/75025)
+- Enforced the query memory limit when a column is upgraded (widened) during window-function aggregation in `Analytor`, instead of letting it grow unbounded. [#75821](https://github.com/StarRocks/starrocks/pull/75821)
+- Removed useless per-rowid seeks in the array-column offsets-only read path used by `array_length()`/`cardinality()`. [#75861](https://github.com/StarRocks/starrocks/pull/75861)
+
+### Bug fixes
+
+The following issues have been fixed:
+
+- Several wrong-result issues: `EliminateSortColumnWithEqualityPredicateRule` dropping the global `LIMIT` under concurrency; `SplitJoinORToUnionRule` producing duplicate rows for a null-safe-equal (`<=>`) `JOIN ON p1 OR p2`; JIT codegen truncating `LARGEINT` literals `>= 2^64` to 64 bits; `array_map`/`transform` silently dropping `NULL` rows when all non-null input arrays were empty; nested dictionary expressions rebuilt inconsistently across exchange fragments causing dict-decode failures; and a `LIKE` pattern with the `_` wildcard returning wrong rows on a GIN inverted index. [#74983](https://github.com/StarRocks/starrocks/pull/74983) [#75038](https://github.com/StarRocks/starrocks/pull/75038) [#75137](https://github.com/StarRocks/starrocks/pull/75137) [#75141](https://github.com/StarRocks/starrocks/pull/75141) [#75246](https://github.com/StarRocks/starrocks/pull/75246) [#75551](https://github.com/StarRocks/starrocks/pull/75551)
+- Join-reorder column pruning could drop a column still referenced by a predicate, causing a `missing statistic of col` planning error, and `JoinTuningGuide` could lose `predicateCommonOperators` when rebuilding a join, failing plan validation. [#74791](https://github.com/StarRocks/starrocks/pull/74791) [#75773](https://github.com/StarRocks/starrocks/pull/75773)
+- Sync materialized view/rollup rewrite could lose a rollup column when a query aggregated the same base column twice (e.g. `min(c)` and `max(c)`), and async materialized view rewrite could serve stale results after an Iceberg base table's `rollback_to_snapshot`. [#75528](https://github.com/StarRocks/starrocks/pull/75528) [#75924](https://github.com/StarRocks/starrocks/pull/75924)
+- `PARTITION-TOP-N` could rewrite its partition-by column to a dictionary slot that no longer existed, failing with a `slot_id not found` error. [#75956](https://github.com/StarRocks/starrocks/pull/75956)
+- An NPE collecting view tables when a `SECURITY INVOKER` view's stored definition contains a CTE. [#74813](https://github.com/StarRocks/starrocks/pull/74813)
+- Three FE metadata-lock correctness races around `DROP PERSISTENT INDEX`, `RestoreJob` post-restore handling, and related unlocked paths. [#74968](https://github.com/StarRocks/starrocks/pull/74968)
+- A race between FE EOS-cancel and BE stage-2 deploy could mark a fully successful query as canceled. [#75009](https://github.com/StarRocks/starrocks/pull/75009)
+- `ApplyTuningGuideRule` could throw `UnsupportedOperationException` when an earlier rewrite produced an `OptExpression` with an immutable input list. [#70785](https://github.com/StarRocks/starrocks/pull/70785)
+- BE/CN crashes: a null `driver_executor` when a cancel RPC arrives before pipeline start; a use-after-free in the spill partition-sort-sink cancel path; a heap-use-after-free in `OrderedPartitionExchanger` for a skew-hinted window function at DOP>1; an `NLJoin` crash from a build-side column nullability mismatch; a `StructColumn` field-count mismatch in `UNNEST` output; a crash loop reading a flat-JSON column that changed from `NOT NULL` to nullable during compaction; an uncaught memory-allocation exception in `NLJoinProbeOperator`; a crash in primary-key auto-increment partial-update apply; and a crash rewriting predicates inside an `array_map` lambda during scan-predicate pushdown. [#75030](https://github.com/StarRocks/starrocks/pull/75030) [#75140](https://github.com/StarRocks/starrocks/pull/75140) [#75279](https://github.com/StarRocks/starrocks/pull/75279) [#75343](https://github.com/StarRocks/starrocks/pull/75343) [#75445](https://github.com/StarRocks/starrocks/pull/75445) [#75680](https://github.com/StarRocks/starrocks/pull/75680) [#75788](https://github.com/StarRocks/starrocks/pull/75788) [#76119](https://github.com/StarRocks/starrocks/pull/76119) [#76380](https://github.com/StarRocks/starrocks/pull/76380)
+- `histogram()` crashed (or silently mis-bucketed values) on a non-positive `bucket_num` instead of raising a clear error, and `bar()` could grow an unbounded string for a negative or huge `width` argument, exhausting BE memory. [#75041](https://github.com/StarRocks/starrocks/pull/75041) [#75143](https://github.com/StarRocks/starrocks/pull/75143)
+- A query using `unnest` over array columns could exceed `query_mem_limit` and get the BE OOM-killed instead of failing just that query. [#75179](https://github.com/StarRocks/starrocks/pull/75179)
+- A second-order SQL injection in the `information_schema.task_runs` `TASK_NAME`/`QUERY_ID` predicate lookup. [#75520](https://github.com/StarRocks/starrocks/pull/75520)
+- `SHOW CREATE ROUTINE LOAD` could emit a spurious leading comma before the first load-desc clause, and an unescaped `jsonpaths` value, producing non-runnable DDL. [#75522](https://github.com/StarRocks/starrocks/pull/75522) [#75755](https://github.com/StarRocks/starrocks/pull/75755)
+- Shared-data (lake) `SHOW PARTITIONS` and `information_schema.partitions_meta` reported every physical partition's bucket count as the table-level default instead of its own bucket count. [#75734](https://github.com/StarRocks/starrocks/pull/75734)
+- Several dependency CVEs by upgrading `jackson-databind` and Netty. [#75373](https://github.com/StarRocks/starrocks/pull/75373) [#76555](https://github.com/StarRocks/starrocks/pull/76555)
+- Batched `TabletInvertedIndex` write-lock acquisition in `markTabletsForceDelete`, reducing lock churn when force-deleting many tablets at once. [#75616](https://github.com/StarRocks/starrocks/pull/75616)
+- Batched tablet inverted-index writes in the insert-overwrite path. [#75923](https://github.com/StarRocks/starrocks/pull/75923)
+- Skipped an unnecessary remote `clear_parent_path` call when a load spill never used remote storage. [#76224](https://github.com/StarRocks/starrocks/pull/76224)
+
+
 ## 3.5.19
 
 Release date: June 26, 2026

--- a/docs/en/release_notes/release-3.5.md
+++ b/docs/en/release_notes/release-3.5.md
@@ -36,8 +36,6 @@ Release date: July 23, 2026
 - `CREATE DATABASE IF NOT EXISTS` on Iceberg REST catalogs now succeeds silently when the database already exists, instead of raising an error. [#75017](https://github.com/StarRocks/starrocks/pull/75017)
 - Iceberg REST catalogs with vended credentials now cache `Table` objects and keep their credentials refreshed on access, instead of bypassing the cache and re-fetching from the REST catalog/Lake Formation on every `getTable()` call, which could trigger AWS `Rate exceeded` errors. [#75431](https://github.com/StarRocks/starrocks/pull/75431)
 - GIN inverted-index-accelerated `NOT MATCH` predicates no longer return rows with a `NULL` value, matching SQL three-valued-logic semantics. [#75578](https://github.com/StarRocks/starrocks/pull/75578)
-- Fixed a null-padding size mismatch for missing columns in `ParquetScanner` so padded rows match the actual per-batch chunk size instead of the whole Parquet/Arrow batch size. [#75981](https://github.com/StarRocks/starrocks/pull/75981)
-- Removed vulnerable, stale transitive dependencies (old BouncyCastle, OkHttp 2.x, Tomcat, and others) that previously shipped alongside their fixed counterparts, and added dependency-ban enforcement to keep them out. [#76097](https://github.com/StarRocks/starrocks/pull/76097)
 
 ### Improvements
 
@@ -67,7 +65,8 @@ The following issues have been fixed:
 - Batched `TabletInvertedIndex` write-lock acquisition in `markTabletsForceDelete`, reducing lock churn when force-deleting many tablets at once. [#75616](https://github.com/StarRocks/starrocks/pull/75616)
 - Batched tablet inverted-index writes in the insert-overwrite path. [#75923](https://github.com/StarRocks/starrocks/pull/75923)
 - Skipped an unnecessary remote `clear_parent_path` call when a load spill never used remote storage. [#76224](https://github.com/StarRocks/starrocks/pull/76224)
-
+- A null-padding size mismatch for missing columns in `ParquetScanner` so padded rows match the actual per-batch chunk size instead of the whole Parquet/Arrow batch size. [#75981](https://github.com/StarRocks/starrocks/pull/75981)
+- Vulnerable, stale transitive dependencies (old BouncyCastle, OkHttp 2.x, Tomcat, and others) that previously shipped alongside their fixed counterparts. [#76097](https://github.com/StarRocks/starrocks/pull/76097)
 
 ## 3.5.19
 

--- a/docs/ja/release_notes/release-3.5.md
+++ b/docs/ja/release_notes/release-3.5.md
@@ -27,6 +27,48 @@ description: "StarRocks 3.5 リリースノート: Iceberg ビュー作成、OAu
 
 :::
 
+## 3.5.20
+
+リリース日: 2026年7月23日
+
+### 動作変更
+
+- Iceberg REST カタログに対する `CREATE DATABASE IF NOT EXISTS` は、データベースが既に存在する場合でもエラーを返さず、正常に成功するようになりました。 [#75017](https://github.com/StarRocks/starrocks/pull/75017)
+- vended credentials を使用する Iceberg REST カタログでは、`Table` オブジェクトをキャッシュし、アクセス時に認証情報を更新するようになりました。これにより、従来のようにキャッシュをバイパスして `getTable()` 呼び出しごとに REST カタログまたは Lake Formation から再取得することがなくなり、AWS の `Rate exceeded` エラーが発生する可能性を低減します。 [#75431](https://github.com/StarRocks/starrocks/pull/75431)
+- GIN 転置インデックスで高速化された `NOT MATCH` 条件は、`NULL` 値を持つ行を返さないようになり、SQL の三値論理（three-valued logic）のセマンティクスに準拠しました。 [#75578](https://github.com/StarRocks/starrocks/pull/75578)
+
+### 改善点
+
+- FE メトリクス `txn_max_committed_pending_publish_ms` を追加しました。このデータベース単位のゲージメトリクスは、コミット済みトランザクションが公開待ちとなっている最長時間を報告し、バージョン公開の停滞や遅延の診断に役立ちます。 [#75025](https://github.com/StarRocks/starrocks/pull/75025)
+- `Analytor` において、ウィンドウ関数集約中に列が拡張（widen）される場合でもクエリメモリ制限を適用し、メモリ使用量が無制限に増加しないようにしました。 [#75821](https://github.com/StarRocks/starrocks/pull/75821)
+- `array_length()` および `cardinality()` が使用する配列列のオフセットのみを読み取るパスから不要な rowid 単位のシークを削除しました。 [#75861](https://github.com/StarRocks/starrocks/pull/75861)
+
+### バグ修正
+
+以下の問題を修正しました。
+
+- 複数の誤った結果を返す問題を修正しました。`EliminateSortColumnWithEqualityPredicateRule` が並行実行時にグローバル `LIMIT` を削除してしまう問題、`SplitJoinORToUnionRule` が null-safe-equal（`<=>`）を使用した `JOIN ON p1 OR p2` で重複行を生成する問題、JIT コード生成で `2^64` 以上の `LARGEINT` リテラルが 64 ビットに切り詰められる問題、すべての非 NULL 入力配列が空の場合に `array_map` / `transform` が `NULL` 行を静かに破棄する問題、Exchange フラグメント間でネストされた辞書式が一貫して再構築されず dict デコードに失敗する問題、および `_` ワイルドカードを含む `LIKE` パターンが GIN 転置インデックスで誤った行を返す問題。 [#74983](https://github.com/StarRocks/starrocks/pull/74983) [#75038](https://github.com/StarRocks/starrocks/pull/75038) [#75137](https://github.com/StarRocks/starrocks/pull/75137) [#75141](https://github.com/StarRocks/starrocks/pull/75141) [#75246](https://github.com/StarRocks/starrocks/pull/75246) [#75551](https://github.com/StarRocks/starrocks/pull/75551)
+- Join の並べ替え時の列プルーニングで、述語から参照されている列が削除され `missing statistic of col` のプランニングエラーが発生する問題、および `JoinTuningGuide` が Join の再構築時に `predicateCommonOperators` を失い、プラン検証に失敗する問題を修正しました。 [#74791](https://github.com/StarRocks/starrocks/pull/74791) [#75773](https://github.com/StarRocks/starrocks/pull/75773)
+- 同期マテリアライズドビュー／Rollup リライトで、クエリが同じベース列を複数回集約（例: `min(c)` と `max(c)`）した場合に Rollup 列が失われる問題、および非同期マテリアライズドビューリライトで Iceberg ベーステーブルの `rollback_to_snapshot` 後に古い結果が返される問題を修正しました。 [#75528](https://github.com/StarRocks/starrocks/pull/75528) [#75924](https://github.com/StarRocks/starrocks/pull/75924)
+- `PARTITION-TOP-N` が partition-by 列を存在しない辞書スロットへ書き換え、`slot_id not found` エラーで失敗する問題を修正しました。 [#75956](https://github.com/StarRocks/starrocks/pull/75956)
+- `SECURITY INVOKER` ビューの保存済み定義に CTE が含まれる場合、ビューのテーブル収集時に NPE が発生する問題を修正しました。 [#74813](https://github.com/StarRocks/starrocks/pull/74813)
+- `DROP PERSISTENT INDEX`、`RestoreJob` のリストア後処理、および関連するロックなし経路における FE メタデータロックの競合を 3 件修正しました。 [#74968](https://github.com/StarRocks/starrocks/pull/74968)
+- FE の EOS キャンセルと BE のステージ 2 デプロイの競合により、正常終了したクエリがキャンセル済みとして扱われる問題を修正しました。 [#75009](https://github.com/StarRocks/starrocks/pull/75009)
+- `ApplyTuningGuideRule` が、以前のリライトで不変の入力リストを持つ `OptExpression` が生成された場合に `UnsupportedOperationException` をスローする問題を修正しました。 [#70785](https://github.com/StarRocks/starrocks/pull/70785)
+- BE/CN のクラッシュに関する複数の問題を修正しました。パイプライン開始前にキャンセル RPC が到着した場合の `driver_executor` の NULL、spill partition-sort-sink のキャンセル処理における use-after-free、DOP>1 のスキュー指定ウィンドウ関数で `OrderedPartitionExchanger` に発生する heap-use-after-free、ビルド側列の NULL 属性不一致による `NLJoin` のクラッシュ、`UNNEST` 出力における `StructColumn` のフィールド数不一致、コンパクション中に flat-JSON 列が `NOT NULL` から nullable に変更された際のクラッシュループ、`NLJoinProbeOperator` におけるメモリ割り当て例外の未処理、主キー自動インクリメントの部分更新適用時のクラッシュ、およびスキャン述語プッシュダウン中に `array_map` ラムダ内の述語を書き換える際のクラッシュ。 [#75030](https://github.com/StarRocks/starrocks/pull/75030) [#75140](https://github.com/StarRocks/starrocks/pull/75140) [#75279](https://github.com/StarRocks/starrocks/pull/75279) [#75343](https://github.com/StarRocks/starrocks/pull/75343) [#75445](https://github.com/StarRocks/starrocks/pull/75445) [#75680](https://github.com/StarRocks/starrocks/pull/75680) [#75788](https://github.com/StarRocks/starrocks/pull/75788) [#76119](https://github.com/StarRocks/starrocks/pull/76119) [#76380](https://github.com/StarRocks/starrocks/pull/76380)
+- `histogram()` が `bucket_num` に 0 以下の値を指定した場合に明確なエラーを返さずクラッシュ（または誤ってバケット化）する問題、および `bar()` が負または非常に大きな `width` 引数によって文字列を無制限に拡張し、BE メモリを使い果たす問題を修正しました。 [#75041](https://github.com/StarRocks/starrocks/pull/75041) [#75143](https://github.com/StarRocks/starrocks/pull/75143)
+- 配列列に対して `unnest` を使用するクエリが `query_mem_limit` を超えた際、該当クエリのみ失敗するのではなく BE 全体が OOM により終了する問題を修正しました。 [#75179](https://github.com/StarRocks/starrocks/pull/75179)
+- `information_schema.task_runs` の `TASK_NAME` / `QUERY_ID` 述語検索における二次 SQL インジェクションの脆弱性を修正しました。 [#75520](https://github.com/StarRocks/starrocks/pull/75520)
+- `SHOW CREATE ROUTINE LOAD` が最初の load-desc 句の前に不要なカンマを出力する問題、および `jsonpaths` の値がエスケープされず、生成された DDL を実行できない問題を修正しました。 [#75522](https://github.com/StarRocks/starrocks/pull/75522) [#75755](https://github.com/StarRocks/starrocks/pull/75755)
+- Shared-data（Lake）環境において、`SHOW PARTITIONS` および `information_schema.partitions_meta` が各物理パーティション固有のバケット数ではなく、テーブルレベルのデフォルト値を報告する問題を修正しました。 [#75734](https://github.com/StarRocks/starrocks/pull/75734)
+- `jackson-databind` および Netty をアップグレードし、複数の依存ライブラリに存在する CVE を修正しました。 [#75373](https://github.com/StarRocks/starrocks/pull/75373) [#76555](https://github.com/StarRocks/starrocks/pull/76555)
+- `markTabletsForceDelete` における `TabletInvertedIndex` の書き込みロック取得をバッチ化し、多数の Tablet を一括強制削除する際のロック競合を削減しました。 [#75616](https://github.com/StarRocks/starrocks/pull/75616)
+- insert-overwrite パスにおける tablet inverted index の書き込みをバッチ化しました。 [#75923](https://github.com/StarRocks/starrocks/pull/75923)
+- ロード時の spill がリモートストレージを使用しなかった場合、不要なリモート `clear_parent_path` 呼び出しをスキップするようにしました。 [#76224](https://github.com/StarRocks/starrocks/pull/76224)
+- `ParquetScanner` において欠落列の NULL パディングサイズが一致しない問題を修正し、パディングされた行数が Parquet/Arrow バッチ全体ではなく、実際のバッチチャンクサイズと一致するようにしました。 [#75981](https://github.com/StarRocks/starrocks/pull/75981)
+- 修正済みバージョンと併せて同梱されていた古い BouncyCastle、OkHttp 2.x、Tomcat などの脆弱で古い推移的依存ライブラリを削除しました。 [#76097](https://github.com/StarRocks/starrocks/pull/76097)
+
+
 ## 3.5.19
 
 リリース日：2026 年 6 月 26 日

--- a/docs/zh/release_notes/release-3.5.md
+++ b/docs/zh/release_notes/release-3.5.md
@@ -27,6 +27,47 @@ description: "StarRocks 3.5 版本发布说明：Iceberg 视图创建、OAuth 2.
 
 :::
 
+## 3.5.20
+
+发布日期：2026 年 7 月 23 日
+
+### 行为变更
+
+* 对 Iceberg REST Catalog 执行 `CREATE DATABASE IF NOT EXISTS` 时，如果数据库已存在，将不再报错，而是直接成功返回。 [#75017](https://github.com/StarRocks/starrocks/pull/75017)
+* 使用 vended credentials 的 Iceberg REST Catalog 现在会缓存 `Table` 对象，并在访问时刷新其凭证，而不再绕过缓存并在每次调用 `getTable()` 时都从 REST Catalog 或 Lake Formation 重新获取，从而避免触发 AWS `Rate exceeded` 错误。 [#75431](https://github.com/StarRocks/starrocks/pull/75431)
+* 由 GIN 倒排索引加速的 `NOT MATCH` 谓词现在不会返回值为 `NULL` 的行，与 SQL 三值逻辑（three-valued logic）的语义保持一致。 [#75578](https://github.com/StarRocks/starrocks/pull/75578)
+
+### 改进
+
+* 新增 FE 指标 `txn_max_committed_pending_publish_ms`。该数据库级 Gauge 指标用于报告已提交事务等待发布的最长时间，有助于诊断版本发布卡住或延迟的问题。 [#75025](https://github.com/StarRocks/starrocks/pull/75025)
+* 在 `Analytor` 中，当窗口函数聚合期间发生列扩宽（widen）时，现已强制执行查询内存限制，防止内存无限增长。 [#75821](https://github.com/StarRocks/starrocks/pull/75821)
+* 移除了 `array_length()` / `cardinality()` 使用的数组列仅读取 offset 路径中的无效 rowid seek 操作。 [#75861](https://github.com/StarRocks/starrocks/pull/75861)
+
+### Bug 修复
+
+修复了以下问题：
+
+* 修复多个查询结果错误的问题：`EliminateSortColumnWithEqualityPredicateRule` 在并发情况下错误移除全局 `LIMIT`；`SplitJoinORToUnionRule` 在使用 null-safe-equal（`<=>`）的 `JOIN ON p1 OR p2` 中产生重复行；JIT 代码生成将 `>= 2^64` 的 `LARGEINT` 字面量截断为 64 位；当所有非 NULL 输入数组均为空时，`array_map` / `transform` 会静默丢弃 `NULL` 行；嵌套字典表达式在 Exchange Fragment 间重建不一致导致字典解码失败；以及包含 `_` 通配符的 `LIKE` 模式在 GIN 倒排索引上返回错误结果。 [#74983](https://github.com/StarRocks/starrocks/pull/74983) [#75038](https://github.com/StarRocks/starrocks/pull/75038) [#75137](https://github.com/StarRocks/starrocks/pull/75137) [#75141](https://github.com/StarRocks/starrocks/pull/75141) [#75246](https://github.com/StarRocks/starrocks/pull/75246) [#75551](https://github.com/StarRocks/starrocks/pull/75551)
+* 修复 Join 重排序时的列裁剪可能删除谓词仍在引用的列，从而导致 `missing statistic of col` 规划错误的问题；同时修复 `JoinTuningGuide` 在重建 Join 时丢失 `predicateCommonOperators`，导致执行计划校验失败的问题。 [#74791](https://github.com/StarRocks/starrocks/pull/74791) [#75773](https://github.com/StarRocks/starrocks/pull/75773)
+* 修复同步物化视图/Rollup Rewrite 在查询对同一基表列进行多次聚合（例如 `min(c)` 和 `max(c)`）时丢失 Rollup 列的问题；修复异步物化视图 Rewrite 在 Iceberg 基表执行 `rollback_to_snapshot` 后仍可能返回过期结果的问题。 [#75528](https://github.com/StarRocks/starrocks/pull/75528) [#75924](https://github.com/StarRocks/starrocks/pull/75924)
+* 修复 `PARTITION-TOP-N` 将 partition-by 列重写为已不存在的字典 Slot，导致报错 `slot_id not found` 的问题。 [#75956](https://github.com/StarRocks/starrocks/pull/75956)
+* 修复当 `SECURITY INVOKER` 视图保存的定义中包含 CTE 时，在收集视图表信息过程中触发 NPE 的问题。 [#74813](https://github.com/StarRocks/starrocks/pull/74813)
+* 修复 FE 元数据锁相关的三处竞态问题，涉及 `DROP PERSISTENT INDEX`、`RestoreJob` 恢复后的处理以及相关未加锁路径。 [#74968](https://github.com/StarRocks/starrocks/pull/74968)
+* 修复 FE EOS Cancel 与 BE Stage 2 Deploy 之间的竞态，避免已成功执行完成的查询被错误标记为已取消。 [#75009](https://github.com/StarRocks/starrocks/pull/75009)
+* 修复 `ApplyTuningGuideRule` 在此前 Rewrite 生成带有不可变输入列表的 `OptExpression` 时抛出 `UnsupportedOperationException` 的问题。 [#70785](https://github.com/StarRocks/starrocks/pull/70785)
+* 修复多个 BE/CN 崩溃问题，包括：Pipeline 启动前收到 Cancel RPC 时 `driver_executor` 为 NULL；spill partition-sort-sink 取消路径中的 use-after-free；DOP>1 且窗口函数带 skew hint 时 `OrderedPartitionExchanger` 中的 heap-use-after-free；Build Side 列可空性不一致导致 `NLJoin` 崩溃；`UNNEST` 输出中 `StructColumn` 字段数量不匹配；Compaction 期间 flat-JSON 列由 `NOT NULL` 变为 nullable 时产生崩溃循环；`NLJoinProbeOperator` 未捕获内存分配异常；主键自增部分更新应用时崩溃；以及扫描谓词下推过程中重写 `array_map` Lambda 内谓词时发生崩溃。 [#75030](https://github.com/StarRocks/starrocks/pull/75030) [#75140](https://github.com/StarRocks/starrocks/pull/75140) [#75279](https://github.com/StarRocks/starrocks/pull/75279) [#75343](https://github.com/StarRocks/starrocks/pull/75343) [#75445](https://github.com/StarRocks/starrocks/pull/75445) [#75680](https://github.com/StarRocks/starrocks/pull/75680) [#75788](https://github.com/StarRocks/starrocks/pull/75788) [#76119](https://github.com/StarRocks/starrocks/pull/76119) [#76380](https://github.com/StarRocks/starrocks/pull/76380)
+* 修复 `histogram()` 在 `bucket_num` 为非正数时崩溃（或静默错误分桶）而不是返回明确错误的问题；修复 `bar()` 在 `width` 为负数或超大值时生成无限增长的字符串，导致耗尽 BE 内存的问题。 [#75041](https://github.com/StarRocks/starrocks/pull/75041) [#75143](https://github.com/StarRocks/starrocks/pull/75143)
+* 修复对数组列执行 `unnest` 的查询超过 `query_mem_limit` 时，导致整个 BE 被 OOM Kill，而不是仅使该查询失败的问题。 [#75179](https://github.com/StarRocks/starrocks/pull/75179)
+* 修复 `information_schema.task_runs` 中 `TASK_NAME` / `QUERY_ID` 谓词查询存在的二阶 SQL 注入漏洞。 [#75520](https://github.com/StarRocks/starrocks/pull/75520)
+* 修复 `SHOW CREATE ROUTINE LOAD` 在第一个 load-desc 子句前错误输出前导逗号，以及 `jsonpaths` 值未转义，导致生成的 DDL 无法执行的问题。 [#75522](https://github.com/StarRocks/starrocks/pull/75522) [#75755](https://github.com/StarRocks/starrocks/pull/75755)
+* 修复 Shared-data（Lake）模式下，`SHOW PARTITIONS` 和 `information_schema.partitions_meta` 将所有物理分区的 Bucket 数错误地显示为表级默认值，而不是各自实际 Bucket 数的问题。 [#75734](https://github.com/StarRocks/starrocks/pull/75734)
+* 通过升级 `jackson-databind` 和 Netty，修复多个依赖组件中的 CVE 漏洞。 [#75373](https://github.com/StarRocks/starrocks/pull/75373) [#76555](https://github.com/StarRocks/starrocks/pull/76555)
+* 对 `markTabletsForceDelete` 中 `TabletInvertedIndex` 的写锁获取进行批量化，在一次强制删除大量 Tablet 时减少锁竞争。 [#75616](https://github.com/StarRocks/starrocks/pull/75616)
+* 对 insert-overwrite 路径中的 Tablet Inverted Index 写入进行批量化。 [#75923](https://github.com/StarRocks/starrocks/pull/75923)
+* 当 Load Spill 未使用远程存储时，跳过不必要的远程 `clear_parent_path` 调用。 [#76224](https://github.com/StarRocks/starrocks/pull/76224)
+* 修复 `ParquetScanner` 中缺失列的 NULL 填充大小不一致的问题，使填充后的行数与实际 Batch Chunk 大小一致，而不是整个 Parquet/Arrow Batch 的大小。 [#75981](https://github.com/StarRocks/starrocks/pull/75981)
+* 移除与修复版本同时打包发布的过时且存在漏洞的传递依赖（包括旧版本 BouncyCastle、OkHttp 2.x、Tomcat 等）。 [#76097](https://github.com/StarRocks/starrocks/pull/76097)
+
 ## 3.5.19
 
 发布日期：2026 年 6 月 26 日


### PR DESCRIPTION
## Why I'm doing:

StarRocks v3.5.20 has been tagged; adding the English release notes section.

## What I'm doing:

Adds a new `## 3.5.20` section to `docs/en/release_notes/release-3.5.md`, covering the PRs backported to `branch-3.5` between the `3.5.19` and `3.5.20` tags.

Notes:

- PRs #75241 (FLOOR/CEIL as column names) and #75255 (`SHOW FUNCTIONS` isolation property) were excluded as duplicates: both landed on `branch-3.5` twice via separate backport chains, and one of those chains is already documented in the existing `3.5.19` section.
- 3 entries (#75616, #75923, #76224) cite a backport PR number rather than a `main` PR — see the follow-up comment on this PR for details; their backport chains did not resolve back to `main`.

### Needs reviewer confirmation

- #75981 — placed under **Behavior Changes** because it carries the `behavior_changed` label, but the description reads like a plain crash/correctness fix (null-padding size mismatch in `ParquetScanner`). Please confirm the section.
- #76097 — placed under **Behavior Changes** because it carries the `behavior_changed` label (removes vulnerable transitive dependencies and enforces bans). Please confirm this is meant to be user-visible rather than an internal packaging change.
- #75861 — titled `[BugFix]` but reads as a pure performance/dead-code removal (no incorrect behavior described). Placed under **Bug fixes** per the title-prefix mapping; consider moving to **Improvements**.
- #74968 — "Fix three FE metadata-lock correctness races" bundles three distinct races from one PR body; the release-note entry summarizes them together. Please confirm the summary is accurate/sufficient.
- #75616, #75923, #76224 — see the follow-up PR comment: these entries cite a backport PR number instead of the original `main` PR, inconsistent with every other entry.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5