### PR TITLE
[UT] Cover ORDER BY != PK tablet in LakePrimaryKeyConsistencyTest

### DIFF
--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -855,13 +855,12 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{.persistent_index_type =
-                                                                   PersistentIndexTypePB::CLOUD_NATIVE},
-                                           // ORDER BY != PK: separate sort key (c1, c2) exercises the
-                                           // load-spill + unsort-SST-writer + op-aware merge path.
-                                           PrimaryKeyParam{.persistent_index_type =
-                                                                   PersistentIndexTypePB::CLOUD_NATIVE,
-                                                           .separate_sort_key = true}));
+INSTANTIATE_TEST_SUITE_P(
+        LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
+        ::testing::Values(PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE},
+                          // ORDER BY != PK: separate sort key (c1, c2) exercises the
+                          // load-spill + unsort-SST-writer + op-aware merge path.
+                          PrimaryKeyParam{.persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE,
+                                          .separate_sort_key = true}));
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -219,7 +219,8 @@ private:
 class LakePrimaryKeyConsistencyTest : public TestBase, testing::WithParamInterface<PrimaryKeyParam> {
 public:
     LakePrimaryKeyConsistencyTest() : TestBase(kTestGroupPath) {
-        _tablet_metadata = generate_tablet_metadata(PRIMARY_KEYS);
+        const bool separate_sort_key = GetParam().separate_sort_key;
+        _tablet_metadata = generate_tablet_metadata(PRIMARY_KEYS, separate_sort_key);
         _tablet_metadata->set_enable_persistent_index(true);
         _tablet_metadata->set_persistent_index_type(GetParam().persistent_index_type);
 
@@ -253,8 +254,15 @@ public:
         items.emplace_back(PICT_OP::COMPACT, 10);
         items.emplace_back(PICT_OP::RELOAD, 10);
         items.emplace_back(PICT_OP::UPSERT_WITH_BATCH_PUB, 17);
-        items.emplace_back(PICT_OP::PARTIAL_UPDATE_ROW, 5);
-        items.emplace_back(PICT_OP::PARTIAL_UPDATE_COLUMN, 5);
+        if (!separate_sort_key) {
+            // Partial updates are not supported on a separate-sort-key table when the partial columns
+            // ({c0, c1}) do not cover the sort key (ROW mode) or touch a sort-key column (COLUMN mode),
+            // and they never take the load-spill / unsort-SST path under test anyway
+            // (should_enable_load_spill disables spilling for partial updates). Skip them for the
+            // ORDER BY != PK variant; the remaining ops fully drive the separate-sort-key write path.
+            items.emplace_back(PICT_OP::PARTIAL_UPDATE_ROW, 5);
+            items.emplace_back(PICT_OP::PARTIAL_UPDATE_COLUMN, 5);
+        }
         items.emplace_back(PICT_OP::CONDITION_UPDATE, 5);
         items.emplace_back(PICT_OP::MIXED_UPSERT_DELETE, 17);
         _random_op_selector = std::make_unique<WeightedRandomOpSelector<int, PICT_OP>>(_random_generator.get(), items);
@@ -304,18 +312,18 @@ public:
                 _old_pk_index_parallel_compaction_task_split_threshold_bytes;
     }
 
-    std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type) {
+    std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type, bool separate_sort_key = false) {
         auto metadata = std::make_shared<TabletMetadata>();
         metadata->set_id(next_id());
         metadata->set_version(1);
         metadata->set_cumulative_point(0);
         metadata->set_next_rowset_id(1);
         //
-        //  | column | type | KEY | NULL |
-        //  +--------+------+-----+------+
-        //  |   c0   |  STRING | YES |  NO  |
-        //  |   c1   |  INT | NO  |  NO  |
-        //  |   c2   |  INT | NO  |  NO  |
+        //  | column | type | KEY | NULL | SORTKEY(when separate) |
+        //  +--------+------+-----+------+------------------------+
+        //  |   c0   |  STRING | YES |  NO  |          NO          |
+        //  |   c1   |  INT | NO  |  NO  |          YES         |
+        //  |   c2   |  INT | NO  |  NO  |          YES         |
         auto schema = metadata->mutable_schema();
         schema->set_keys_type(keys_type);
         schema->set_id(next_id());
@@ -347,6 +355,12 @@ public:
             c2->set_is_key(false);
             c2->set_is_nullable(false);
             c2->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+        }
+        if (separate_sort_key) {
+            // ORDER BY (c1, c2) while the primary key is c0, so the sort key differs from the primary
+            // key. num_short_key_columns stays 1 (the short key is the c1 prefix of the sort key).
+            schema->add_sort_key_idxes(1);
+            schema->add_sort_key_idxes(2);
         }
         return metadata;
     }
@@ -842,7 +856,12 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyConsistencyTest, LakePrimaryKeyConsistencyTest,
-                         ::testing::Values(PrimaryKeyParam{
-                                 .persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE}));
+                         ::testing::Values(PrimaryKeyParam{.persistent_index_type =
+                                                                   PersistentIndexTypePB::CLOUD_NATIVE},
+                                           // ORDER BY != PK: separate sort key (c1, c2) exercises the
+                                           // load-spill + unsort-SST-writer + op-aware merge path.
+                                           PrimaryKeyParam{.persistent_index_type =
+                                                                   PersistentIndexTypePB::CLOUD_NATIVE,
+                                                           .separate_sort_key = true}));
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -155,6 +155,9 @@ struct PrimaryKeyParam {
     PersistentIndexTypePB persistent_index_type = PersistentIndexTypePB::CLOUD_NATIVE;
     PartialUpdateMode partial_update_mode = PartialUpdateMode::ROW_MODE;
     bool enable_transparent_data_encryption = false;
+    // When true, the tablet's sort key differs from the primary key (ORDER BY != PK), which exercises
+    // the separate-sort-key load-spill + unsort-SST-writer path.
+    bool separate_sort_key = false;
 };
 
 template <typename T>


### PR DESCRIPTION
## Why I'm doing:

[#76094](https://github.com/StarRocks/starrocks/pull/76094) enabled load
spilling and eager PK-index SST build for cloud-native primary-key tables
whose sort key differs from the primary key (ORDER BY != PK). That path routes
writes through `PkTabletUnsortSSTWriter` and the op-aware spill merge, which
resolve duplicate primary keys by flush order rather than by physical
(sort-key) order. It needs randomized correctness coverage.

`LakePrimaryKeyConsistencyTest` previously only ran tablets where the sort key
equals the primary key, so the separate-sort-key write path was untested by
this stress harness.

## What I'm doing:

Add a `separate_sort_key` parameter to `PrimaryKeyParam` and a second
`INSTANTIATE_TEST_SUITE_P` value, so the existing randomized
upsert / delete / mixed-upsert-delete / condition-update / batch-publish /
compaction / reload workload also runs against a tablet with sort key
`(c1, c2)` while the primary key stays `c0`.

Because our key column is `VARCHAR`, `pk_index_eager_build_supported()` returns
true, so `should_enable_load_spill()` enables spilling for this tablet and the
writer selects the unsort SST writer + op-aware merge. The order-independent
PK -> value consistency check (via the `Replayer`) then catches any
mis-resolution of duplicate keys.

Partial-update ops are skipped for the separate-sort-key variant: the delta
writer rejects partial updates whose columns do not cover the sort key (ROW
mode) or touch a sort-key column (COLUMN mode), and `should_enable_load_spill()`
disables spilling for any partial update, so they add no coverage of the path
under test.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSphrg4FNx69PAGS8HYRms
