### PR TITLE
[BugFix] Bound raw-json view in SimdJsonConverter error path to fix heap-buffer-overflow

### DIFF
--- a/be/src/types/json_value_converter.cpp
+++ b/be/src/types/json_value_converter.cpp
@@ -40,7 +40,10 @@ public:
             RETURN_IF_ERROR(convert(value, {}, false, &builder));
             return JsonValue(builder.slice());
         } catch (simdjson::simdjson_error& e) {
-            std::string_view view(value.get_raw_json_string().raw());
+            // raw_json_token() returns a bounded string_view into the input buffer. Constructing a
+            // string_view from get_raw_json_string().raw() instead (a bare, non-NUL-terminated
+            // const char*) runs strlen off the end of a non-NUL-terminated load buffer.
+            std::string_view view = value.raw_json_token();
             // truncate the raw json string if it is too large
             bool too_large = view.size() > MAX_VALUE_LENGTH_FOR_ERRMSG;
             size_t size = too_large ? MAX_VALUE_LENGTH_FOR_ERRMSG : view.size();
@@ -61,8 +64,15 @@ public:
             RETURN_IF_ERROR(convert(value, {}, false, &builder));
             return JsonValue(builder.slice());
         } catch (simdjson::simdjson_error& e) {
-            std::string_view view(value.raw_json());
-            auto err_msg = strings::Substitute("Failed to convert simdjson value, json=$0, error=$1", view.data(),
+            // raw_json() spans the object but consume()s it, so on a malformed document (iterate()
+            // validates lazily, so a value-materialization error can fire before a structural error)
+            // it can return an error. get() is noexcept and leaves `view` empty on error, so a
+            // failing raw_json() cannot throw a second exception out of this catch. Pass the bounded
+            // view (never view.data(), which would run strlen off the end of a non-NUL-terminated
+            // load buffer).
+            std::string_view view;
+            (void)value.raw_json().get(view);
+            auto err_msg = strings::Substitute("Failed to convert simdjson value, json=$0, error=$1", view,
                                                simdjson::error_message(e.error()));
             return Status::DataQualityError(err_msg);
         }

--- a/be/test/types/json_value_test.cpp
+++ b/be/test/types/json_value_test.cpp
@@ -18,6 +18,8 @@
 #include <gtest/gtest.h>
 #include <gutil/strings/substitute.h>
 
+#include <cstring>
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -197,6 +199,77 @@ TEST(JsonValueTest, ConvertFromSimdjsonBigInteger) {
     ondemand::object double_overflow_obj = double_overflow_doc.get_object();
     auto double_overflow_json = JsonValue::from_simdjson(&double_overflow_obj);
     ASSERT_FALSE(double_overflow_json.ok());
+}
+
+namespace {
+// Build an EXACT-size buffer (new char[capacity], so ASAN's redzone sits precisely at the end)
+// holding `json` at the front, with every byte set to a non-NUL, non-whitespace filler and NO
+// trailing NUL. This mirrors the stream-load path, where the JSON lives in a fixed-size buffer
+// allocated without simdjson padding, so the bytes after the value are not NUL. A strlen on an
+// unbounded raw pointer would read past the end of such a buffer; ASAN turns that read into a test
+// failure. std::vector is intentionally avoided: it may over-allocate, leaving an uninitialized
+// tail that could hold an early NUL and mask the overflow.
+std::unique_ptr<char[]> make_unterminated_buffer(const std::string& json, size_t capacity) {
+    auto buf = std::make_unique<char[]>(capacity);
+    std::memset(buf.get(), 'A', capacity);
+    std::memcpy(buf.get(), json.data(), json.size());
+    return buf;
+}
+} // namespace
+
+// A JSON string whose escape sequence is invalid: it is structurally well-formed (so parsing and
+// field lookup succeed) but throws simdjson_error when the value is materialized during conversion,
+// which drives the DataQualityError path that constructs the error message from the raw JSON.
+TEST(JsonValueTest, ConvertFromSimdjsonErrorValueBounded) {
+    using namespace simdjson;
+    const std::string json = R"({"a": "\p"})";
+    const size_t capacity = json.size() + SIMDJSON_PADDING + 32;
+    auto buf = make_unterminated_buffer(json, capacity);
+
+    ondemand::parser parser;
+    ondemand::document doc = parser.iterate(padded_string_view(buf.get(), json.size(), capacity));
+    ondemand::value val = doc.find_field("a");
+
+    auto maybe_json = JsonValue::from_simdjson(&val);
+    ASSERT_FALSE(maybe_json.ok());
+    ASSERT_TRUE(maybe_json.status().is_data_quality_error());
+}
+
+TEST(JsonValueTest, ConvertFromSimdjsonErrorObjectBounded) {
+    using namespace simdjson;
+    const std::string json = R"({"a": "\p"})";
+    const size_t capacity = json.size() + SIMDJSON_PADDING + 32;
+    auto buf = make_unterminated_buffer(json, capacity);
+
+    ondemand::parser parser;
+    ondemand::document doc = parser.iterate(padded_string_view(buf.get(), json.size(), capacity));
+    ondemand::object obj = doc.get_object();
+
+    auto maybe_json = JsonValue::from_simdjson(&obj);
+    ASSERT_FALSE(maybe_json.ok());
+    ASSERT_TRUE(maybe_json.status().is_data_quality_error());
+}
+
+// A MALFORMED document that simdjson's lazy stage-1 parse still accepts: the ROOT object is closed
+// (so doc.get_object() succeeds) but it contains an unclosed nested array. Conversion throws while
+// materializing the invalid-escape string, and then object::raw_json() must consume() the broken
+// structure, hits the unmatched array, and returns an error. The fix must not let that error throw a
+// second exception out of the catch: assert nothing escapes and a DataQualityError is returned. This
+// exercises the object overload's raw_json() error-guard branch. (A missing ROOT brace instead would
+// make doc.get_object() throw INCOMPLETE_ARRAY_OR_OBJECT before conversion runs, never reaching it.)
+TEST(JsonValueTest, ConvertFromSimdjsonErrorMalformedObjectBounded) {
+    using namespace simdjson;
+    const std::string json = R"({"a":["\p"})"; // JSON bytes: {"a":["\p"} — nested array left unclosed
+    const size_t capacity = json.size() + SIMDJSON_PADDING + 32;
+    auto buf = make_unterminated_buffer(json, capacity);
+
+    ondemand::parser parser;
+    ondemand::document doc = parser.iterate(padded_string_view(buf.get(), json.size(), capacity));
+    ondemand::object obj = doc.get_object();
+
+    auto maybe_json = JsonValue::from_simdjson(&obj);
+    ASSERT_FALSE(maybe_json.ok());
+    ASSERT_TRUE(maybe_json.status().is_data_quality_error());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Loading dirty JSON via stream load can crash the BE with an AddressSanitizer heap-buffer-overflow. The crash is not in the query itself but in the JSON conversion **error** path: when a value fails to convert, `SimdJsonConverter::create` builds the `DataQualityError` message from an **unbounded** raw simdjson pointer.

- Value overload: `std::string_view view(value.get_raw_json_string().raw())` — `raw()` is a bare, non-NUL-terminated `const char*`, so the `string_view(const char*)` constructor runs `strlen`, scanning off the end of the stream-load buffer (allocated at `kDefaultBufferSize` = 64 KiB **without** simdjson padding, so no NUL follows). This is the reported crash: `strlen` → `basic_string_view(char const*)` → `SimdJsonConverter::create(...value)`.
- Object overload: passed `view.data()` (also unbounded) to `strings::Substitute`, the same `strlen` overrun; and could additionally throw a **second** exception out of the `catch` when `raw_json()` failed on a malformed document (simdjson `iterate()` validates lazily).

The bug is data-dependent (needs a value that fails conversion with no `0x00` byte before the buffer end), which is why it surfaced only under an ASAN run. It is present on `main` and every maintained release line.

## What I'm doing:

- **Value overload**: use `value.raw_json_token()` — a bounded, `noexcept`, non-consuming view into the input buffer (no `strlen`). This matches the existing bounded usage elsewhere in the file and in `be/src/formats/json/`.
- **Object overload**: use `value.raw_json().get(view)` (`noexcept`; leaves `view` empty on error, so a failing `raw_json()` cannot throw a second exception out of the `catch`) and pass the bounded `std::string_view` to `Substitute` (never `view.data()`).
- Add regression tests in `be/test/types/json_value_test.cpp` that reproduce the out-of-bounds reads under ASAN by parsing an invalid-escape JSON from a **non-NUL-terminated** buffer (mirroring the stream-load allocation): the value overload, the object overload, and a malformed-structure case that drives the `raw_json()` error-guard branch.

No user-facing behavior change: the returned `Status` is still `DataQualityError`; only the raw-JSON snippet embedded in the message is now correctly bounded.

Validation: `types_test` under `BUILD_TYPE=ASAN` — the three new cases fail (heap-buffer-overflow / escaping exception) with the fix reverted and pass with the fix; the full `JsonValueTest.*` suite is green. BE module-boundary check is clean.

Surfaced by an internal ASAN nightly (StarRocks/StarRocksTest#11610).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
