### PR TITLE
[BugFix] Strip a possible NullableColumn wrapper around the intermedi…

### DIFF
--- a/be/src/exprs/agg/count.h
+++ b/be/src/exprs/agg/count.h
@@ -32,6 +32,14 @@ struct AggregateCountFunctionState
     int64_t count = 0;
 };
 
+inline const Int64Column* count_unwrap_intermediate(const Column* column) {
+    if (column->is_nullable()) {
+        column = down_cast<const NullableColumn*>(column)->data_column().get();
+    }
+    DCHECK(column->is_numeric());
+    return down_cast<const Int64Column*>(column);
+}
+
 // count not null column
 template <bool IsWindowFunc>
 class CountAggregateFunction final : public AggregateFunctionBatchHelper<AggregateCountFunctionState<IsWindowFunc>,
@@ -91,8 +99,7 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        DCHECK(column->is_numeric());
-        const auto* input_column = down_cast<const Int64Column*>(column);
+        const auto* input_column = count_unwrap_intermediate(column);
         this->data(state).count += input_column->immutable_data()[row_num];
     }
 
@@ -290,8 +297,7 @@ public:
     }
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
-        DCHECK(column->is_numeric());
-        const auto* input_column = down_cast<const Int64Column*>(column);
+        const auto* input_column = count_unwrap_intermediate(column);
         this->data(state).count += input_column->immutable_data()[row_num];
     }
 


### PR DESCRIPTION
The column that arrives at merge can still be wrapped in a `NullableColumn` when the merge sits above a UNION / OUTER JOIN sub-tree (the upstream slot  gets promoted to nullable somewhere on the way). In that case `down_cast<const Int64Column*>(column)` is  undefined behavior in release builds (down_cast is a static_cast without RTTI) and causes either incorrect  counts or random crashes — this is the "unpredictable" behavior of count on plans with `EXISTS ... OR EXISTS ...`. 

## Why I'm doing:
This fixes the random crash.

## What I'm doing:
Unwrap posible `NullableColumn` before merging on count

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
