### PR TITLE
[Enhancement] Stagger cold-start lake compaction to reduce load tail latency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3473,6 +3473,16 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static double lake_compaction_score_selector_min_score = 10.0;
 
+    @ConfField(mutable = true, comment = "When a partition's compaction score first crosses " +
+            "lake_compaction_score_selector_min_score (below -> at/above) and it would otherwise become " +
+            "immediately eligible for compaction, defer its next compaction by a random offset in " +
+            "[0, this value) milliseconds. This staggers the cold-start compaction wave that arises when many " +
+            "identically-loaded partitions cross the threshold in the same scheduling cycle: it spreads the same " +
+            "total compaction work over a wider window, reducing peak shared object-storage bandwidth contention " +
+            "with concurrent loads on the same tablets. 0 (default) disables the jitter and keeps the original " +
+            "behavior.")
+    public static long lake_compaction_score_selector_jitter_ms = 0;
+
     @ConfField(mutable = true, comment = "-1 means calculate the value in an adaptive way. set this value to 0 " +
             "will disable compaction.")
     public static int lake_compaction_max_tasks = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -161,10 +162,43 @@ public class CompactionMgr implements MemoryTrackable {
             if (v == null) {
                 v = new PartitionStatistics(partition);
             }
+            maybeStaggerColdStartCompaction(v, compactionScore);
             v.setCurrentVersion(currentVersion);
             v.setCompactionScore(compactionScore);
             return v;
         });
+    }
+
+    // Stagger the cold-start compaction wave. When a partition's compaction score first crosses
+    // Config.lake_compaction_score_selector_min_score (below -> at/above) and the partition would
+    // otherwise be immediately eligible for compaction, defer its next compaction by a random offset
+    // in [0, Config.lake_compaction_score_selector_jitter_ms). Many identically-loaded partitions tend
+    // to cross the threshold in the same scheduling cycle; without staggering they all start compacting
+    // at once and thrash shared object-storage bandwidth, stalling concurrent loads on the same tablets.
+    // This only spreads the same total compaction work over a wider window; it does not reduce work.
+    // No-op when the jitter config is <= 0 (default), preserving the original behavior.
+    private void maybeStaggerColdStartCompaction(PartitionStatistics stat, Quantiles newScore) {
+        long jitterMs = Config.lake_compaction_score_selector_jitter_ms;
+        if (jitterMs <= 0 || newScore == null) {
+            return;
+        }
+        double minScore = Config.lake_compaction_score_selector_min_score;
+        double oldMax = (stat.getCompactionScore() != null) ? stat.getCompactionScore().getMax() : 0.0;
+        // Only act on the upward crossing of the selection threshold.
+        if (oldMax >= minScore || newScore.getMax() < minScore) {
+            return;
+        }
+        // Never delay manually-triggered compaction.
+        if (stat.getPriority() != PartitionStatistics.CompactionPriority.DEFAULT) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        // If the partition is already deferred (e.g. by the post-compaction interval), keep that schedule.
+        if (stat.getNextCompactionTime() > now) {
+            return;
+        }
+        long offset = (long) (ThreadLocalRandom.current().nextDouble() * jitterMs);
+        stat.setNextCompactionTime(now + offset);
     }
 
     public void handleCompactionFinished(PartitionIdentifier partition, long version, long versionTime,


### PR DESCRIPTION
## Why

On a shared-data (lake) cluster running a 1000-table steady-state upsert
benchmark, `p99` upsert latency already passes (~809ms) but the **max tail is
~14s**. Tracing showed the tail is a *cold-start compaction storm*: at test
start, ~1000 identically-loaded partitions cross the compaction-score selector
threshold in the same scheduling cycle, so the FE launches up to
`lake_compaction_max_tasks` concurrent lake **DATA** compactions at once. These
saturate shared object-storage bandwidth (CPU stays idle 11–25%), each
compaction then runs for tens of seconds, and the few loads landing on a
tablet being compacted stall for up to ~25s.

Tuning `lake_compaction_max_tasks` in either direction does not help: lower
throttles throughput, higher just splits finite S3 bandwidth thinner (each
compaction runs longer). The problem is *synchronization*, not total work.

## What

Add a config-gated stagger. When a partition's compaction score **first
crosses** `lake_compaction_score_selector_min_score` (below → at/above) and it
would otherwise be immediately eligible, defer its next compaction by a random
offset in `[0, lake_compaction_score_selector_jitter_ms)`. This de-synchronizes
the cold-start wave and spreads the **same total** compaction work over a wider
window, lowering peak bandwidth contention with concurrent loads on the same
tablets. It does not reduce compaction work.

- New FE config `lake_compaction_score_selector_jitter_ms` (mutable, default
  `0` = disabled → no behavior change).
- Logic lives in `CompactionMgr.handleLoadingFinished`, applied only on the
  upward threshold crossing, never for manual compaction, and never overrides an
  existing deferral (e.g. the post-compaction success interval).

## Notes

Draft — used to drive a `tsp` build for benchmark validation on branch-4.1.
Default-off, so it is inert unless the new config is set.
