### PR TITLE
[BugFix] Add SCHEDULE keyword to python parser

### DIFF
--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -1048,9 +1048,14 @@ def _compare_mv_refresh(
         normalized = " ".join(str(val).split()).upper()
         # StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
         # SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW, while users typically declare it as
-        # ASYNC. Treat the leading SCHEDULE keyword as ASYNC so equivalent schemes do not diff.
-        if normalized.startswith("SCHEDULE"):
-            normalized = "ASYNC" + normalized[len("SCHEDULE"):]
+        # ASYNC. Treat the SCHEDULE keyword as ASYNC so equivalent schemes do not diff. It may
+        # appear at the start, or after an optional IMMEDIATE/DEFERRED moment prefix, e.g.
+        # "DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)".
+        for moment_prefix in ("", "IMMEDIATE ", "DEFERRED "):
+            keyword = moment_prefix + "SCHEDULE"
+            if normalized.startswith(keyword):
+                normalized = moment_prefix + "ASYNC" + normalized[len(keyword):]
+                break
         # Normalize START("...") (SHOW CREATE) vs START('...') (metadata) quote styles.
         normalized = normalized.replace('"', "'")
         return normalized

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -1045,7 +1045,15 @@ def _compare_mv_refresh(
         if val is None:
             return None
         # Collapse whitespace and compare case-insensitively
-        return " ".join(str(val).split()).upper()
+        normalized = " ".join(str(val).split()).upper()
+        # StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
+        # SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW, while users typically declare it as
+        # ASYNC. Treat the leading SCHEDULE keyword as ASYNC so equivalent schemes do not diff.
+        if normalized.startswith("SCHEDULE"):
+            normalized = "ASYNC" + normalized[len("SCHEDULE"):]
+        # Normalize START("...") (SHOW CREATE) vs START('...') (metadata) quote styles.
+        normalized = normalized.replace('"', "'")
+        return normalized
 
     conn_refresh_raw = conn_mv_attributes.get(TableInfoKey.REFRESH)
     meta_refresh_raw = meta_mv_attributes.get(TableInfoKey.REFRESH)

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -1046,18 +1046,10 @@ def _compare_mv_refresh(
             return None
         # Collapse whitespace and compare case-insensitively
         normalized = " ".join(str(val).split()).upper()
-        # IMMEDIATE is the default refresh moment and StarRocks never renders it in SHOW CREATE
-        # (only DEFERRED is emitted), so the reflected form carries no moment. Drop an explicit
-        # leading IMMEDIATE first so metadata that spells out the default matches the reflection.
-        # Stripping it here also means the SCHEDULE rewrite below only has to consider a bare or
-        # DEFERRED-prefixed scheme.
+        # IMMEDIATE is not rendered in SHOW CREATE, so drop
         if normalized.startswith("IMMEDIATE "):
             normalized = normalized[len("IMMEDIATE "):]
-        # StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
-        # SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW, while users typically declare it as
-        # ASYNC. Treat the SCHEDULE keyword as ASYNC so equivalent schemes do not diff. It may
-        # appear at the start or after a DEFERRED moment prefix, e.g.
-        # "DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)".
+        # SCHEDULE keyword replaced ASYNC 4.1.1, replace with ASYNC for backwards compatibility 
         for moment_prefix in ("", "DEFERRED "):
             keyword = moment_prefix + "SCHEDULE"
             if normalized.startswith(keyword):
@@ -1644,14 +1636,7 @@ def _compare_table_distribution(
     object_label: str = "Table",
     skip_when_meta_unset: bool = False,
 ) -> None:
-    """Compare distribution changes and add AlterTableDistributionOp if needed.
-
-    ``skip_when_meta_unset``: when True, a metadata that does not declare a distribution is
-    treated as "no change" instead of being compared against the default. This is used for
-    materialized views, whose distribution is always auto-assigned by StarRocks and is immutable,
-    so an undeclared distribution must be left untouched rather than trigger a reset (which raises).
-    Regular tables keep the stricter behavior (raise, forcing the user to declare it).
-    """
+    """Compare distribution changes and add AlterTableDistributionOp if needed."""
     conn_distribution = conn_table_attributes.get(TableInfoKey.DISTRIBUTED_BY)
     meta_distribution = meta_table_attributes.get(TableInfoKey.DISTRIBUTED_BY)
     if meta_distribution is None:
@@ -1665,11 +1650,8 @@ def _compare_table_distribution(
             )
             meta_distribution = starrocks_distribution
 
-    # For materialized views, a metadata that does not declare a distribution is treated as no
-    # change (like ORDER BY). StarRocks always auto-assigns one and SHOW CREATE renders it (e.g.
-    # "RANDOM BUCKETS n" or a defaulted "HASH(...)"); since the user is not managing this
-    # attribute, it must be left untouched rather than compared against the default and "reset",
-    # which raises for this immutable attribute.
+    # For materialized views, if the distribution is undefined, it is auto-assigned, but appears in SHOW CREATE
+    # Should be skipped because the auto-assign is not managed by user
     if meta_distribution is None and skip_when_meta_unset:
         return
 

--- a/contrib/starrocks-python-client/starrocks/alembic/compare.py
+++ b/contrib/starrocks-python-client/starrocks/alembic/compare.py
@@ -1046,12 +1046,19 @@ def _compare_mv_refresh(
             return None
         # Collapse whitespace and compare case-insensitively
         normalized = " ".join(str(val).split()).upper()
+        # IMMEDIATE is the default refresh moment and StarRocks never renders it in SHOW CREATE
+        # (only DEFERRED is emitted), so the reflected form carries no moment. Drop an explicit
+        # leading IMMEDIATE first so metadata that spells out the default matches the reflection.
+        # Stripping it here also means the SCHEDULE rewrite below only has to consider a bare or
+        # DEFERRED-prefixed scheme.
+        if normalized.startswith("IMMEDIATE "):
+            normalized = normalized[len("IMMEDIATE "):]
         # StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
         # SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW, while users typically declare it as
         # ASYNC. Treat the SCHEDULE keyword as ASYNC so equivalent schemes do not diff. It may
-        # appear at the start, or after an optional IMMEDIATE/DEFERRED moment prefix, e.g.
+        # appear at the start or after a DEFERRED moment prefix, e.g.
         # "DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)".
-        for moment_prefix in ("", "IMMEDIATE ", "DEFERRED "):
+        for moment_prefix in ("", "DEFERRED "):
             keyword = moment_prefix + "SCHEDULE"
             if normalized.startswith(keyword):
                 normalized = moment_prefix + "ASYNC" + normalized[len(keyword):]
@@ -1191,6 +1198,7 @@ def _compare_mv(
         support_change_override=AlterMVEnablement.DISTRIBUTED_BY,
         ddl_object="MATERIALIZED VIEW",
         object_label="Materialized view",
+        skip_when_meta_unset=True,
     )
     _compare_table_order_by(
         upgrade_ops.ops,
@@ -1634,8 +1642,16 @@ def _compare_table_distribution(
     support_change_override: Optional[bool] = None,
     ddl_object: str = "TABLE",
     object_label: str = "Table",
+    skip_when_meta_unset: bool = False,
 ) -> None:
-    """Compare distribution changes and add AlterTableDistributionOp if needed."""
+    """Compare distribution changes and add AlterTableDistributionOp if needed.
+
+    ``skip_when_meta_unset``: when True, a metadata that does not declare a distribution is
+    treated as "no change" instead of being compared against the default. This is used for
+    materialized views, whose distribution is always auto-assigned by StarRocks and is immutable,
+    so an undeclared distribution must be left untouched rather than trigger a reset (which raises).
+    Regular tables keep the stricter behavior (raise, forcing the user to declare it).
+    """
     conn_distribution = conn_table_attributes.get(TableInfoKey.DISTRIBUTED_BY)
     meta_distribution = meta_table_attributes.get(TableInfoKey.DISTRIBUTED_BY)
     if meta_distribution is None:
@@ -1648,6 +1664,14 @@ def _compare_table_distribution(
                 DeprecationWarning,
             )
             meta_distribution = starrocks_distribution
+
+    # For materialized views, a metadata that does not declare a distribution is treated as no
+    # change (like ORDER BY). StarRocks always auto-assigns one and SHOW CREATE renders it (e.g.
+    # "RANDOM BUCKETS n" or a defaulted "HASH(...)"); since the user is not managing this
+    # attribute, it must be left untouched rather than compared against the default and "reset",
+    # which raises for this immutable attribute.
+    if meta_distribution is None and skip_when_meta_unset:
+        return
 
     if isinstance(conn_distribution, str):
         conn_distribution = StarRocksTableDefinitionParser.parse_distribution(conn_distribution)

--- a/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
+++ b/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
@@ -34,7 +34,10 @@ refresh_clause: "REFRESH"i (refresh_moment | refresh_type | (refresh_moment refr
 
 !refresh_type: async_scheme | "MANUAL"i | "INCREMENTAL"i
 
-async_scheme: "ASYNC"i ASYNC_DETAILS?
+// StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
+// SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW. Accept it as an alias of ASYNC; the
+// transformer canonicalizes both to "ASYNC ..." so reflected and metadata forms match.
+async_scheme: ("ASYNC"i | "SCHEDULE"i) ASYNC_DETAILS?
 ASYNC_DETAILS: /[\s\S]+/ // Match any character including newlines
 
 %import common.CNAME

--- a/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
+++ b/contrib/starrocks-python-client/starrocks/drivers/grammar.lark
@@ -34,9 +34,7 @@ refresh_clause: "REFRESH"i (refresh_moment | refresh_type | (refresh_moment refr
 
 !refresh_type: async_scheme | "MANUAL"i | "INCREMENTAL"i
 
-// StarRocks 4.1+ renders a periodic async refresh (ASYNC ... EVERY / START) with the
-// SCHEDULE keyword in SHOW CREATE MATERIALIZED VIEW. Accept it as an alias of ASYNC; the
-// transformer canonicalizes both to "ASYNC ..." so reflected and metadata forms match.
+// SCHEDULE keyword replaced ASYNC 4.1.1, use both for backwards compatibility
 async_scheme: ("ASYNC"i | "SCHEDULE"i) ASYNC_DETAILS?
 ASYNC_DETAILS: /[\s\S]+/ // Match any character including newlines
 

--- a/contrib/starrocks-python-client/starrocks/drivers/parsers.py
+++ b/contrib/starrocks-python-client/starrocks/drivers/parsers.py
@@ -169,6 +169,8 @@ class _MVRefreshTransformer(Transformer):
 
     @v_args(inline=True)
     def async_scheme(self, details=None):
+        # Both the ASYNC and the SCHEDULE keyword (StarRocks 4.1+) canonicalize to "ASYNC ..."
+        # so a periodic refresh reflected as "SCHEDULE EVERY(...)" matches metadata "ASYNC EVERY(...)".
         if details:
             return f"ASYNC {details}"
         return "ASYNC"
@@ -183,6 +185,10 @@ class _MVRefreshTransformer(Transformer):
         return "DEFERRED"
 
     def ASYNC(self, t: Token):
+        return "ASYNC"
+
+    def SCHEDULE(self, t: Token):
+        # StarRocks 4.1+ SHOW CREATE keyword for a periodic async refresh; canonicalized to ASYNC.
         return "ASYNC"
 
     def MANUAL(self, t: Token):

--- a/contrib/starrocks-python-client/starrocks/drivers/parsers.py
+++ b/contrib/starrocks-python-client/starrocks/drivers/parsers.py
@@ -169,8 +169,6 @@ class _MVRefreshTransformer(Transformer):
 
     @v_args(inline=True)
     def async_scheme(self, details=None):
-        # Both the ASYNC and the SCHEDULE keyword (StarRocks 4.1+) canonicalize to "ASYNC ..."
-        # so a periodic refresh reflected as "SCHEDULE EVERY(...)" matches metadata "ASYNC EVERY(...)".
         if details:
             return f"ASYNC {details}"
         return "ASYNC"
@@ -188,7 +186,7 @@ class _MVRefreshTransformer(Transformer):
         return "ASYNC"
 
     def SCHEDULE(self, t: Token):
-        # StarRocks 4.1+ SHOW CREATE keyword for a periodic async refresh; canonicalized to ASYNC.
+        # SCHEDULE added as new keyword in 4.1+, return ASYNC for backwards compatibility
         return "ASYNC"
 
     def MANUAL(self, t: Token):

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -188,13 +188,15 @@ class StarRocksTableDefinitionParser(object):
     _TABLE_KEY_PATTERN = re.compile(r'\s*(\w+\s+KEY)\s*\((.*)\)\s*', re.IGNORECASE)
     _BUCKETS_PATTERN = re.compile(r'\sBUCKETS\s+(\d+)', re.IGNORECASE)
     _BUCKETS_REPLACE_PATTERN = re.compile(r'\s+BUCKETS\s+\d+', re.IGNORECASE)
-    _PARTITION_BY_PATTERN = re.compile(r"PARTITION BY\s*(.+?)(?=\s*(?:DISTRIBUTED BY|ORDER BY|REFRESH|PROPERTIES|AS|\Z))", re.IGNORECASE | re.DOTALL)
+    _PARTITION_BY_PATTERN = re.compile(r"PARTITION BY\s*(.+?)(?=\s*(?:DISTRIBUTED BY|ORDER BY|REFRESH|PROPERTIES|AS\b|\Z))", re.IGNORECASE | re.DOTALL)
 
     _VIEW_SECURITY_PATTERN = re.compile(r'\s+SECURITY\s+(INVOKER|DEFINER|NONE)\b', re.IGNORECASE)
 
     # Patterns to parse CREATE MATERIALIZED VIEW statement
-    _MV_REFRESH_PATTERN = re.compile(r"\s*REFRESH\s+(.+?)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|PROPERTIES|AS|\Z))", re.IGNORECASE | re.DOTALL)
-    _MV_PROPERTIES_PATTERN = re.compile(r"\s*PROPERTIES\s*\((.+?)\)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|REFRESH|AS|\Z))", re.IGNORECASE | re.DOTALL)
+    # "AS\b" (word boundary) prevents matching the "AS" inside a following ASYNC keyword, which
+    # would otherwise truncate "REFRESH DEFERRED ASYNC EVERY(...)" down to "REFRESH DEFERRED".
+    _MV_REFRESH_PATTERN = re.compile(r"\s*REFRESH\s+(.+?)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|PROPERTIES|AS\b|\Z))", re.IGNORECASE | re.DOTALL)
+    _MV_PROPERTIES_PATTERN = re.compile(r"\s*PROPERTIES\s*\((.+?)\)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|REFRESH|AS\b|\Z))", re.IGNORECASE | re.DOTALL)
     _MV_AS_DEFINITION_PATTERN = re.compile(r"\s*AS\s*((?:WITH|SELECT)\s*.+)", re.IGNORECASE | re.DOTALL)
 
     def __init__(self, dialect, preparer):

--- a/contrib/starrocks-python-client/starrocks/reflection.py
+++ b/contrib/starrocks-python-client/starrocks/reflection.py
@@ -193,8 +193,6 @@ class StarRocksTableDefinitionParser(object):
     _VIEW_SECURITY_PATTERN = re.compile(r'\s+SECURITY\s+(INVOKER|DEFINER|NONE)\b', re.IGNORECASE)
 
     # Patterns to parse CREATE MATERIALIZED VIEW statement
-    # "AS\b" (word boundary) prevents matching the "AS" inside a following ASYNC keyword, which
-    # would otherwise truncate "REFRESH DEFERRED ASYNC EVERY(...)" down to "REFRESH DEFERRED".
     _MV_REFRESH_PATTERN = re.compile(r"\s*REFRESH\s+(.+?)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|PROPERTIES|AS\b|\Z))", re.IGNORECASE | re.DOTALL)
     _MV_PROPERTIES_PATTERN = re.compile(r"\s*PROPERTIES\s*\((.+?)\)(?=\s*(?:PARTITION BY|DISTRIBUTED BY|ORDER BY|REFRESH|AS\b|\Z))", re.IGNORECASE | re.DOTALL)
     _MV_AS_DEFINITION_PATTERN = re.compile(r"\s*AS\s*((?:WITH|SELECT)\s*.+)", re.IGNORECASE | re.DOTALL)

--- a/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
+++ b/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
@@ -207,3 +207,88 @@ class TestAlterMaterializedView(TestAutogenerateBase):
                     api.produce_migrations(mc, target_metadata)
             finally:
                 conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
+    @staticmethod
+    def _refresh_alter_ops(migration_script):
+        """Return the AlterMaterializedViewOps that carry a REFRESH change."""
+        return [
+            op
+            for op in migration_script.upgrade_ops.ops
+            if isinstance(op, AlterMaterializedViewOp) and op.refresh is not None
+        ]
+
+    def test_no_refresh_diff_for_periodic_async(self) -> None:
+        """No change: a periodic ASYNC refresh must not produce a spurious REFRESH diff.
+
+        Regression test for the repeated refresh-interval diff. StarRocks 4.1+ renders
+        ``REFRESH ASYNC EVERY(...)`` back as ``REFRESH SCHEDULE EVERY(...)`` in SHOW CREATE,
+        which must be treated as equivalent to the ``ASYNC EVERY(...)`` metadata declaration.
+        (On 3.5.x the reflected form is already ``ASYNC EVERY(...)``, so this also asserts no
+        regression there.)
+        """
+        engine = self.engine
+        mv_name = "test_mv_refresh_periodic_async"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "REFRESH ASYNC EVERY(INTERVAL 10 MINUTE) "
+                "PROPERTIES ('replication_num' = '1') "
+                "AS SELECT val FROM t_autogen"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition="SELECT val FROM t_autogen",
+                    starrocks_refresh="ASYNC EVERY(INTERVAL 10 MINUTE)",
+                    starrocks_properties={"replication_num": "1"},
+                )
+                mc = create_migration_context(conn, target_metadata)
+                migration_script = api.produce_migrations(mc, target_metadata)
+
+                refresh_ops = self._refresh_alter_ops(migration_script)
+                assert refresh_ops == [], (
+                    f"Unexpected REFRESH diff for equivalent periodic async refresh: "
+                    f"{[(op.refresh, op.existing_refresh) for op in refresh_ops]}"
+                )
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
+    def test_refresh_interval_change_detected(self) -> None:
+        """ALTER: a genuine change to the refresh interval is still detected.
+
+        Guards against the SCHEDULE/ASYNC normalization being over-eager and masking a real
+        interval change (10 MINUTE -> 20 MINUTE).
+        """
+        engine = self.engine
+        mv_name = "test_mv_refresh_interval_change"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "REFRESH ASYNC EVERY(INTERVAL 10 MINUTE) "
+                "PROPERTIES ('replication_num' = '1') "
+                "AS SELECT val FROM t_autogen"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition="SELECT val FROM t_autogen",
+                    starrocks_refresh="ASYNC EVERY(INTERVAL 20 MINUTE)",
+                    starrocks_properties={"replication_num": "1"},
+                )
+                mc = create_migration_context(conn, target_metadata)
+                migration_script = api.produce_migrations(mc, target_metadata)
+
+                refresh_ops = self._refresh_alter_ops(migration_script)
+                assert len(refresh_ops) == 1, (
+                    f"Expected exactly one REFRESH alter op, got: "
+                    f"{[(op.refresh, op.existing_refresh) for op in refresh_ops]}"
+                )
+                assert "20 MINUTE" in refresh_ops[0].refresh.upper()
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))

--- a/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
+++ b/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
@@ -256,6 +256,46 @@ class TestAlterMaterializedView(TestAutogenerateBase):
             finally:
                 conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
 
+    def test_no_refresh_diff_for_deferred_periodic_async(self) -> None:
+        """No change: a DEFERRED periodic async refresh must not produce a spurious REFRESH diff.
+
+        StarRocks 4.1+ emits ``REFRESH DEFERRED SCHEDULE EVERY(...)`` in SHOW CREATE for a
+        deferred scheduled MV (the moment prefix is only rendered for DEFERRED). Reflection
+        canonicalizes this to ``DEFERRED ASYNC EVERY(...)``, and metadata written with the 4.1
+        SCHEDULE spelling must still be treated as equivalent — the SCHEDULE keyword can follow
+        an IMMEDIATE/DEFERRED prefix, not only appear at the start.
+        """
+        engine = self.engine
+        mv_name = "test_mv_refresh_deferred_periodic"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "REFRESH DEFERRED ASYNC EVERY(INTERVAL 1 HOUR) "
+                "PROPERTIES ('replication_num' = '1') "
+                "AS SELECT val FROM t_autogen"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition="SELECT val FROM t_autogen",
+                    # Metadata uses the 4.1 SHOW CREATE spelling with a moment prefix.
+                    starrocks_refresh="DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)",
+                    starrocks_properties={"replication_num": "1"},
+                )
+                mc = create_migration_context(conn, target_metadata)
+                migration_script = api.produce_migrations(mc, target_metadata)
+
+                refresh_ops = self._refresh_alter_ops(migration_script)
+                assert refresh_ops == [], (
+                    f"Unexpected REFRESH diff for equivalent deferred periodic async refresh: "
+                    f"{[(op.refresh, op.existing_refresh) for op in refresh_ops]}"
+                )
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
     def test_refresh_interval_change_detected(self) -> None:
         """ALTER: a genuine change to the refresh interval is still detected.
 

--- a/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
+++ b/contrib/starrocks-python-client/test/integration/test_autogenerate_mvs.py
@@ -296,6 +296,82 @@ class TestAlterMaterializedView(TestAutogenerateBase):
             finally:
                 conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
 
+    def test_no_refresh_diff_for_explicit_immediate_moment(self) -> None:
+        """No change: metadata that spells out the default IMMEDIATE moment must not diff.
+
+        IMMEDIATE is the default refresh moment and StarRocks never renders it in SHOW CREATE
+        (only DEFERRED is emitted), so an MV created with ``REFRESH IMMEDIATE ASYNC EVERY(...)``
+        reflects back as ``ASYNC EVERY(...)``. Metadata that explicitly declares IMMEDIATE must
+        still be treated as equivalent to the reflected (moment-less) form.
+        """
+        engine = self.engine
+        mv_name = "test_mv_refresh_immediate_moment"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "REFRESH IMMEDIATE ASYNC EVERY(INTERVAL 1 HOUR) "
+                "PROPERTIES ('replication_num' = '1') "
+                "AS SELECT val FROM t_autogen"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition="SELECT val FROM t_autogen",
+                    # Metadata explicitly declares the default IMMEDIATE moment.
+                    starrocks_refresh="IMMEDIATE ASYNC EVERY(INTERVAL 1 HOUR)",
+                    starrocks_properties={"replication_num": "1"},
+                )
+                mc = create_migration_context(conn, target_metadata)
+                migration_script = api.produce_migrations(mc, target_metadata)
+
+                refresh_ops = self._refresh_alter_ops(migration_script)
+                assert refresh_ops == [], (
+                    f"Unexpected REFRESH diff for explicit IMMEDIATE moment: "
+                    f"{[(op.refresh, op.existing_refresh) for op in refresh_ops]}"
+                )
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
+    def test_no_diff_when_distribution_omitted(self) -> None:
+        """No change/crash: omitting DISTRIBUTED BY in metadata must not diff or raise.
+
+        StarRocks always auto-assigns a distribution and SHOW CREATE renders it with an explicit
+        bucket count (e.g. ``DISTRIBUTED BY RANDOM BUCKETS 10``). Since distribution is immutable
+        and the user did not declare it, autogenerate must leave it untouched rather than try to
+        reset it to the default (which raised NotImplementedError).
+        """
+        engine = self.engine
+        mv_name = "test_mv_distribution_omitted"
+        with engine.connect() as conn:
+            conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+            conn.execute(text(
+                f"CREATE MATERIALIZED VIEW {mv_name} "
+                "REFRESH ASYNC "
+                "DISTRIBUTED BY RANDOM BUCKETS 10 "
+                "PROPERTIES ('replication_num' = '1') "
+                "AS SELECT val FROM t_autogen"
+            ))
+            try:
+                target_metadata = MetaData()
+                MaterializedView(
+                    mv_name,
+                    target_metadata,
+                    definition="SELECT val FROM t_autogen",
+                    starrocks_refresh="ASYNC",
+                    starrocks_properties={"replication_num": "1"},
+                    # NOTE: distribution intentionally omitted.
+                )
+                mc = create_migration_context(conn, target_metadata)
+                # Must not raise, and must produce no op for this MV.
+                migration_script = api.produce_migrations(mc, target_metadata)
+                mv_ops = [op for op in migration_script.upgrade_ops.ops if getattr(op, "view_name", None) == mv_name]
+                assert mv_ops == [], f"Unexpected op for MV with omitted distribution: {mv_ops}"
+            finally:
+                conn.execute(text(f"DROP MATERIALIZED VIEW IF EXISTS {mv_name}"))
+
     def test_refresh_interval_change_detected(self) -> None:
         """ALTER: a genuine change to the refresh interval is still detected.
 

--- a/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
+++ b/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
@@ -212,6 +212,14 @@ class TestCompareMaterializedView:
             ),
             # Case/whitespace only differences.
             ("async every(interval 10 minute)", "ASYNC EVERY(INTERVAL 10 MINUTE)"),
+            # SCHEDULE may appear after an IMMEDIATE/DEFERRED moment prefix. StarRocks 4.1 emits
+            # "REFRESH DEFERRED SCHEDULE EVERY(...)" for a deferred scheduled MV, which reflection
+            # canonicalizes to "DEFERRED ASYNC ..."; metadata using the 4.1 SCHEDULE spelling must
+            # still be treated as equivalent.
+            ("DEFERRED ASYNC EVERY(INTERVAL 1 HOUR)", "DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)"),
+            ("IMMEDIATE ASYNC EVERY(INTERVAL 1 HOUR)", "IMMEDIATE SCHEDULE EVERY(INTERVAL 1 HOUR)"),
+            # Both sides using the SCHEDULE spelling with a moment prefix.
+            ("DEFERRED SCHEDULE EVERY(INTERVAL 30 MINUTE)", "DEFERRED SCHEDULE EVERY(INTERVAL 30 MINUTE)"),
         ],
     )
     def test_no_change_mv_refresh_schedule_alias(self, conn_refresh, meta_refresh):

--- a/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
+++ b/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
@@ -198,3 +198,28 @@ class TestCompareMaterializedView:
         _compare_mv(self.mock_autogen_context, upgrade_ops, None, "my_mv", conn_mv, meta_mv)
 
         eq_(len(upgrade_ops.ops), 0)
+
+    @pytest.mark.parametrize(
+        "conn_refresh, meta_refresh",
+        [
+            # StarRocks 4.1+ reflects a periodic async refresh with the SCHEDULE keyword,
+            # while metadata declares it as ASYNC. These must be treated as equivalent.
+            ("SCHEDULE EVERY(INTERVAL 10 MINUTE)", "ASYNC EVERY(INTERVAL 10 MINUTE)"),
+            # START() quoting differs between SHOW CREATE (double) and metadata (single).
+            (
+                'SCHEDULE START("2024-01-01 10:00:00") EVERY(INTERVAL 1 HOUR)',
+                "ASYNC START('2024-01-01 10:00:00') EVERY(INTERVAL 1 HOUR)",
+            ),
+            # Case/whitespace only differences.
+            ("async every(interval 10 minute)", "ASYNC EVERY(INTERVAL 10 MINUTE)"),
+        ],
+    )
+    def test_no_change_mv_refresh_schedule_alias(self, conn_refresh, meta_refresh):
+        """No change: 4.1 SCHEDULE refresh keyword is equivalent to metadata ASYNC."""
+        upgrade_ops = ops.UpgradeOps([])
+        conn_mv = self._create_reflected_mv("my_mv", definition="SELECT 1", refresh=conn_refresh)
+        meta_mv = MaterializedView("my_mv", MetaData(), definition="SELECT 1", starrocks_refresh=meta_refresh)
+
+        _compare_mv(self.mock_autogen_context, upgrade_ops, None, "my_mv", conn_mv, meta_mv)
+
+        eq_(len(upgrade_ops.ops), 0)

--- a/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
+++ b/contrib/starrocks-python-client/test/unit/test_compare_mvs.py
@@ -147,6 +147,30 @@ class TestCompareMaterializedView:
         with pytest.raises(NotImplementedError, match="does not support 'ALTER MATERIALIZED VIEW DISTRIBUTED BY'"):
             _compare_mv(self.mock_autogen_context, upgrade_ops, None, "my_mv", conn_mv, meta_mv)
 
+    @pytest.mark.parametrize(
+        "conn_distribution",
+        [
+            "RANDOM BUCKETS 10",  # StarRocks auto-assigned an explicit bucket count
+            "HASH(id)",           # older MV that defaulted to HASH on the first column
+            "RANDOM",             # auto RANDOM (equals the default)
+        ],
+    )
+    def test_no_change_mv_distribution_omitted(self, conn_distribution):
+        """No change: metadata that omits DISTRIBUTED BY must not diff or crash.
+
+        StarRocks always auto-assigns a distribution and SHOW CREATE renders it (e.g.
+        ``DISTRIBUTED BY RANDOM BUCKETS 10`` or a defaulted ``HASH(...)``). When the user does
+        not declare distribution in metadata, the reflected value must be left untouched — not
+        compared against the default and 'reset', which raises for this immutable attribute.
+        """
+        upgrade_ops = ops.UpgradeOps([])
+        conn_mv = self._create_reflected_mv("my_mv", definition="SELECT 1", distributed_by=conn_distribution)
+        meta_mv = MaterializedView("my_mv", MetaData(), definition="SELECT 1")  # no starrocks_distributed_by
+
+        _compare_mv(self.mock_autogen_context, upgrade_ops, None, "my_mv", conn_mv, meta_mv)
+
+        eq_(len(upgrade_ops.ops), 0)
+
     def test_modify_mv_order_by_changed(self):
         """DROP/CREATE: Order by changed."""
         upgrade_ops = ops.UpgradeOps([])
@@ -220,6 +244,12 @@ class TestCompareMaterializedView:
             ("IMMEDIATE ASYNC EVERY(INTERVAL 1 HOUR)", "IMMEDIATE SCHEDULE EVERY(INTERVAL 1 HOUR)"),
             # Both sides using the SCHEDULE spelling with a moment prefix.
             ("DEFERRED SCHEDULE EVERY(INTERVAL 30 MINUTE)", "DEFERRED SCHEDULE EVERY(INTERVAL 30 MINUTE)"),
+            # IMMEDIATE is the default refresh moment and StarRocks never renders it in SHOW CREATE
+            # (only DEFERRED is emitted), so reflection yields no moment. Metadata that explicitly
+            # declares IMMEDIATE must still be treated as equivalent to the reflected form.
+            ("ASYNC EVERY(INTERVAL 1 HOUR)", "IMMEDIATE ASYNC EVERY(INTERVAL 1 HOUR)"),
+            ("ASYNC EVERY(INTERVAL 1 HOUR)", "IMMEDIATE SCHEDULE EVERY(INTERVAL 1 HOUR)"),
+            ("ASYNC", "IMMEDIATE ASYNC"),
         ],
     )
     def test_no_change_mv_refresh_schedule_alias(self, conn_refresh, meta_refresh):

--- a/contrib/starrocks-python-client/test/unit/test_parser.py
+++ b/contrib/starrocks-python-client/test/unit/test_parser.py
@@ -231,6 +231,13 @@ class TestMVRefreshParser:
             ("REFRESH ASYNC EVERY (INTERVAL 1 DAY)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY (INTERVAL 1 DAY)"}),
             ("REFRESH ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)", {"refresh_moment": None, "refresh_type": "ASYNC START ('2025-01-01 12:00:00') EVERY (INTERVAL 1 HOUR)"}),
             ("refresh deferred async", {"refresh_moment": "DEFERRED", "refresh_type": "ASYNC"}), # Case-insensitivity
+            # StarRocks 4.1+ renders a periodic async refresh with the SCHEDULE keyword in
+            # SHOW CREATE MATERIALIZED VIEW. It is canonicalized back to "ASYNC ..." so the
+            # reflected form matches an "ASYNC EVERY(...)" metadata definition.
+            ("REFRESH SCHEDULE EVERY(INTERVAL 10 MINUTE)", {"refresh_moment": None, "refresh_type": "ASYNC EVERY(INTERVAL 10 MINUTE)"}),
+            ("REFRESH SCHEDULE START(\"2024-01-01 10:00:00\") EVERY(INTERVAL 1 HOUR)",
+             {"refresh_moment": None, "refresh_type": "ASYNC START(\"2024-01-01 10:00:00\") EVERY(INTERVAL 1 HOUR)"}),
+            ("refresh schedule every(interval 5 minute)", {"refresh_moment": None, "refresh_type": "ASYNC every(interval 5 minute)"}),
         ]
     )
     def test_correct_clauses(self, clause, expected):

--- a/contrib/starrocks-python-client/test/unit/test_reflection_mv_refresh.py
+++ b/contrib/starrocks-python-client/test/unit/test_reflection_mv_refresh.py
@@ -1,0 +1,88 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for materialized view REFRESH clause extraction during reflection."""
+
+import pytest
+
+from starrocks.common.params import TableInfoKeyWithPrefix
+from starrocks.reflection import StarRocksTableDefinitionParser
+
+
+def _reflect_refresh(refresh_clause: str) -> str:
+    """Parse a synthetic SHOW CREATE MATERIALIZED VIEW DDL and return the reflected
+    refresh string (ReflectedRefreshInfo rendered via str())."""
+    parser = StarRocksTableDefinitionParser.__new__(StarRocksTableDefinitionParser)
+    ddl = (
+        "CREATE MATERIALIZED VIEW `m` (`val`)\n"
+        "DISTRIBUTED BY RANDOM\n"
+        f"{refresh_clause}\n"
+        'PROPERTIES ("replication_num" = "1")\n'
+        "AS SELECT val FROM t"
+    )
+    state = parser._parse_mv_ddl("m", ddl, schema="db")
+    return str(state.table_options.get(TableInfoKeyWithPrefix.REFRESH))
+
+
+def _reflect_partition_by(partition_clause: str) -> str:
+    """Parse a synthetic SHOW CREATE MATERIALIZED VIEW DDL and return the reflected
+    PARTITION BY expression (rendered via str())."""
+    parser = StarRocksTableDefinitionParser.__new__(StarRocksTableDefinitionParser)
+    ddl = (
+        "CREATE MATERIALIZED VIEW `m` (`dt`, `val`)\n"
+        f"{partition_clause}\n"
+        "DISTRIBUTED BY HASH(val)\n"
+        "REFRESH ASYNC\n"
+        'PROPERTIES ("replication_num" = "1")\n'
+        "AS SELECT asset_dt AS dt, val FROM t"
+    )
+    state = parser._parse_mv_ddl("m", ddl, schema="db")
+    return str(state.table_options.get(TableInfoKeyWithPrefix.PARTITION_BY))
+
+
+@pytest.mark.parametrize(
+    "partition_clause, expected",
+    [
+        # Simple column partition.
+        ("PARTITION BY province", "province"),
+        # Regression: a partition expression referencing an identifier that begins with "as"
+        # (e.g. asset_dt) must NOT be truncated. The extraction regex used a bare "AS"
+        # terminator that matched the "AS" inside "ASset_dt", cutting the expression down to
+        # "date_trunc('day',".
+        ("PARTITION BY date_trunc('day', asset_dt)", "date_trunc('day', asset_dt)"),
+    ],
+)
+def test_mv_partition_by_fully_extracted(partition_clause, expected):
+    assert _reflect_partition_by(partition_clause) == expected
+
+
+@pytest.mark.parametrize(
+    "refresh_clause, expected",
+    [
+        # Plain periodic async — the original working case.
+        ("REFRESH ASYNC EVERY(INTERVAL 1 HOUR)", "ASYNC EVERY(INTERVAL 1 HOUR)"),
+        # Regression: a moment prefix before ASYNC must NOT truncate the clause. The refresh
+        # extraction regex used a bare "AS" terminator that matched the "AS" inside "ASYNC",
+        # cutting "REFRESH DEFERRED ASYNC EVERY(...)" down to just "REFRESH DEFERRED".
+        ("REFRESH DEFERRED ASYNC EVERY(INTERVAL 1 HOUR)", "DEFERRED ASYNC EVERY(INTERVAL 1 HOUR)"),
+        ("REFRESH IMMEDIATE ASYNC EVERY(INTERVAL 5 MINUTE)", "IMMEDIATE ASYNC EVERY(INTERVAL 5 MINUTE)"),
+        # 4.1 SCHEDULE spelling with a moment prefix, canonicalized back to ASYNC.
+        ("REFRESH DEFERRED SCHEDULE EVERY(INTERVAL 1 HOUR)", "DEFERRED ASYNC EVERY(INTERVAL 1 HOUR)"),
+        # Bare schemes (no period) are unaffected.
+        ("REFRESH DEFERRED ASYNC", "DEFERRED ASYNC"),
+        ("REFRESH MANUAL", "MANUAL"),
+    ],
+)
+def test_mv_refresh_clause_fully_extracted(refresh_clause, expected):
+    assert _reflect_refresh(refresh_clause) == expected


### PR DESCRIPTION
## Why I'm doing:
In StarRocks 4.1 (#72329), the syntax for `ASYNC EVERY` was modified to `REFRESH SCHEDULE EVERY` when running `SHOW CREATE MATERIALIZED VIEW`. The `SCHEDULE` keyword was unrecognized by the python parser, causing an error and spurious migrations for unchanged materialized views. 
## What I'm doing:
Add the keyword to the parser and normalize the keyword at comparison. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
