### PR TITLE
[Doc] Add sql-doc-autofix skill + StarRocks MCP config

### DIFF
--- a/.claude/skills/sql-doc-autofix/README.md
+++ b/.claude/skills/sql-doc-autofix/README.md
@@ -1,0 +1,74 @@
+# sql-doc-autofix
+
+Propose **verified fixes** for documentation SQL examples that fail the doc-rot
+checker — safely. It classifies each failing example, and only for the genuinely
+fixable ones proposes a corrected statement, verifies it runs against a live
+cluster via the StarRocks MCP server, and assembles a **draft** `[Doc]` PR for
+human review. It never merges, and never rewrites an example in a way that changes
+what it teaches.
+
+This README is for the **operator**. `SKILL.md` is the runbook Claude Code follows.
+
+## How it fits with the checker
+
+```
+docs/scripts/run_sql_samples.py    →  FAIL list      (detect: which examples don't run)
+docs/scripts/autofix_candidates.py →  candidates + doc context
+sql-doc-autofix skill              →  classify → propose → verify → DRAFT PR   (this)
+```
+
+The checker is the **detect** half (its own PR); this skill is the
+**suggest-a-fix** half.
+
+## Prerequisites
+1. **`uv`** on PATH (launches the MCP server).
+2. **A cluster whose version matches the docs under test**, via
+   `docs/docker/doc-verification/` — e.g.
+   `SR_VERSION=4.1 docker compose -f docs/docker/doc-verification/docker-compose-shared-nothing.yml up -d --wait`.
+   > Version alignment is mandatory: test 4.1 docs against a 4.1 cluster. A
+   > mismatch produces false failures, not doc rot.
+3. **A docs checkout at the matching release branch** (e.g. a `branch-4.1` checkout).
+4. **The `starrocks` MCP server** — configured in the repo-root `.mcp.json`, which
+   reads `STARROCKS_HOST/PORT/USER/PASSWORD` from the environment (defaults to
+   `127.0.0.1:9030`, `root`, empty). Claude Code attaches it automatically; approve
+   on first use. Sanity check:
+   ```
+   STARROCKS_URL=root:@127.0.0.1:9030 uv run --with mcp-server-starrocks mcp-server-starrocks --test
+   ```
+
+## Run it
+```bash
+# 1. detect
+python3 docs/scripts/run_sql_samples.py \
+    --docs-root <release-checkout>/docs/en/sql-reference \
+    --host 127.0.0.1 --port 9030 --user root --format json > /tmp/run.json
+# 2. prep (FAIL items + surrounding doc prose)
+python3 docs/scripts/autofix_candidates.py \
+    --run-json /tmp/run.json --repo <release-checkout> --limit 20 > /tmp/candidates.json
+```
+Then invoke the **`sql-doc-autofix`** skill in Claude Code.
+
+## What it produces
+A **draft** `[Doc]` PR (target `main`, backport-labeled): **Fixes** (`file:line`,
+before → after, "verified on `<cluster version>`") + **Not fixed (for review)**
+(version-gated / needs-setup / illustrative, each with a recommendation). You
+review, then un-draft.
+
+## Classification (the guardrail)
+**"Executes" ≠ "correct documentation."** Every candidate is classified before any
+rewrite: **fixable** (propose + verify) · **version-gated** (flag / "Since" note,
+no rewrite) · **needs-setup** (complete only if trivial, else flag) ·
+**illustrative** (leave) · **review** (human).
+
+## Safety
+- Never un-drafts or merges; every change is human-reviewed.
+- `write_query` runs **only in a scratch database**; never account/role, cluster
+  (`ALTER SYSTEM`), destructive `DROP`, backup/restore, or file/routine-load ops.
+- Never rewrites to "make it pass" at the cost of intent; never treats a
+  version/build-gated failure as doc rot.
+
+## Notes
+- One copy on `main` serves every release — point `--docs-root` at the target
+  branch's docs and set `SR_VERSION`. No per-branch backport.
+- The cleanly-fixable set per run is usually small; the value is recurring.
+- Checks that examples **run**; result-content verification is out of scope.

--- a/.claude/skills/sql-doc-autofix/SKILL.md
+++ b/.claude/skills/sql-doc-autofix/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: sql-doc-autofix
+description: Propose verified fixes for documentation SQL examples that fail the doc-rot checker (docs/scripts/run_sql_samples.py). Classifies each FAILing example, and only for genuinely fixable ones proposes a corrected statement, verifies it against a live cluster via the StarRocks MCP server, and opens a DRAFT [Doc] PR. Use after run_sql_samples.py produces a FAIL list. Never auto-merges.
+argument-hint: "[path to candidates.json, or blank to build one]"
+allowed-tools: Read, Edit, Grep, Glob, Bash, Agent, mcp__starrocks__read_query, mcp__starrocks__write_query, mcp__starrocks__table_overview, mcp__starrocks__db_overview
+---
+
+# SQL doc auto-fix
+
+Turn the checker's **detect** output into **suggested fixes**, safely. Golden rule:
+**"executes" ≠ "correct documentation."** Making a statement run by changing what
+it teaches is worse than leaving it broken. Classify first; only rewrite the
+genuinely fixable; flag the rest. English docs only — never edit `docs/zh/**` or
+`docs/ja/**`.
+
+## Prerequisites
+- The **`starrocks` MCP server** is attached (see repo-root `.mcp.json`; tools:
+  `read_query`, `write_query`, `table_overview`, `db_overview`), pointed at the
+  running cluster the docs were tested against.
+- A cluster of the version under test is up:
+  `SR_VERSION=<v> docker compose -f docs/docker/doc-verification/docker-compose-shared-nothing.yml up -d --wait`.
+- A checkout of the docs at the matching release branch (e.g. `branch-4.1`).
+
+## Step 0 — Build the candidate list
+```
+python3 docs/scripts/run_sql_samples.py --docs-root <release-checkout>/docs/en/sql-reference \
+    --host 127.0.0.1 --port 9030 --user root --format json > /tmp/run.json
+python3 docs/scripts/autofix_candidates.py --run-json /tmp/run.json \
+    --repo <release-checkout> --limit 20 > /tmp/candidates.json
+```
+Check the `meta` block: if docs and cluster versions are **not aligned**, stop —
+misaligned failures are not doc rot.
+
+## Step 1 — Classify each candidate (the guardrail)
+Read `doc_context` to understand what the example *teaches*, use the MCP server to
+check reality, then assign exactly one class:
+- **fixable** — renamed/removed function, reserved word as identifier
+  (`FROM order`, `CREATE INDEX index`), clear syntax slip. Confirm the intended
+  feature exists (`read_query` on `information_schema`, `SHOW FUNCTIONS`,
+  `table_overview`). → propose a fix (Step 2).
+- **version/build-gated** — the function/config/keyword isn't in this build
+  (verify it's absent). Docs may be correct for a newer release. → **do not
+  rewrite**; recommend a "Since vX.Y" note.
+- **needs-setup** — references objects an isolated run can't have; fix only if
+  making it self-contained is trivial and preserves intent, else flag.
+- **illustrative** — synopsis, cross-dialect comparison, client transcript. → leave.
+- **unsure** → flag for a human.
+
+## Step 2 — Propose + verify (fixable only)
+Work in an isolated scratch database via the MCP server:
+```
+write_query: CREATE DATABASE IF NOT EXISTS docfix_scratch;
+write_query: USE docfix_scratch;   -- do ALL test writes here
+```
+- Create only the minimal setup the example implies. Run the candidate fix; on
+  error, read the error + `table_overview` and refine — **max 3 attempts**.
+- **Preserve intent:** the fix must still demonstrate the same point. If the only
+  way to make it run changes what it teaches, it is NOT fixable — reclassify.
+- On success record `file`, `line`, `before`, `after`, verified statement; then
+  `write_query: DROP DATABASE docfix_scratch;`.
+
+## Step 3 — Assemble a DRAFT PR
+- Branch off `origin/main` in a git worktree (docs fixes target `main`, then
+  backport). Confirm each example exists on `main` before editing.
+- Apply each verified edit to its source `.md`/`.mdx`.
+- Open a **draft** `[Doc]` PR whose body has (1) **Fixes** — `file:line`,
+  before → after, "verified: runs on `<cluster version>`"; (2) **Not fixed (for
+  review)** — version-gated / needs-setup / illustrative, each with its
+  classification and recommendation.
+- Leave it a draft. A human reviews and un-drafts.
+
+## Never
+- Never un-draft or merge; never commit without operator review.
+- Never run `write_query` outside the scratch DB; never account/role, cluster
+  (`ALTER SYSTEM`), `DROP` on real databases, backup/restore, or file/routine-load
+  statements during verification.
+- Never rewrite an example to "make it pass" at the cost of what it teaches.
+- Never treat a version/build-gated failure as doc rot.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "starrocks": {
+      "command": "uv",
+      "args": ["run", "--with", "mcp-server-starrocks", "mcp-server-starrocks"],
+      "env": {
+        "STARROCKS_HOST": "${STARROCKS_HOST:-127.0.0.1}",
+        "STARROCKS_PORT": "${STARROCKS_PORT:-9030}",
+        "STARROCKS_USER": "${STARROCKS_USER:-root}",
+        "STARROCKS_PASSWORD": "${STARROCKS_PASSWORD:-}"
+      }
+    }
+  }
+}

--- a/docs/scripts/autofix_candidates.py
+++ b/docs/scripts/autofix_candidates.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Prepare auto-fix candidates for the sql-doc-autofix skill.
+
+Reads the SQL-sample checker's JSON output (run_sql_samples.py --format json),
+keeps the FAIL items (the doc-rot candidates), and attaches the surrounding
+documentation prose for each — so the agent can judge the example's INTENT, not
+just its SQL, before proposing a fix.
+
+Deterministic (stdlib only). It does NOT classify or fix — that's the agent's job.
+
+Usage:
+  python3 run_sql_samples.py --docs-root <4.1-checkout>/docs/en/sql-reference \
+      --host 127.0.0.1 --port 9030 --user root --format json > run.json
+  python3 autofix_candidates.py --run-json run.json \
+      --repo /Users/you/GitHub/starrocks-4.1 [--context 12] [--limit N] > candidates.json
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-json", required=True, help="run_sql_samples.py --format json output")
+    ap.add_argument("--repo", required=True, help="docs checkout root (to resolve file paths)")
+    ap.add_argument("--context", type=int, default=12, help="lines of prose around each example")
+    ap.add_argument("--limit", type=int, default=0, help="max candidates (0 = all)")
+    args = ap.parse_args()
+
+    run = json.load(open(args.run_json))
+    meta = run.get("meta", {})
+    fails = [r for r in run.get("results", []) if r.get("status") == "FAIL"]
+    repo = Path(args.repo)
+
+    out = []
+    for r in fails:
+        src = repo / r["file"]
+        prose = ""
+        if src.exists():
+            lines = src.read_text(errors="replace").splitlines()
+            i = max(0, r["line"] - 1 - args.context)
+            j = min(len(lines), r["line"] - 1 + args.context)
+            prose = "\n".join(lines[i:j])
+        out.append({
+            "file": r["file"],
+            "line": r["line"],
+            "statement": r["statement"],
+            "error": r["reason"],
+            "doc_context": prose,
+        })
+    if args.limit:
+        out = out[:args.limit]
+
+    print(json.dumps({
+        "meta": meta,                       # docs + cluster versions + alignment verdict
+        "note": "FAIL items with surrounding doc prose. Classify before fixing; "
+                "preserve each example's intent; version/build-gated items are not fixes.",
+        "candidates": out,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Auto-fix skill for doc SQL examples (optional agent layer)

Builds on the SQL-example doc-rot **checker** (#76763) to move from *detect* to
*suggest-a-fix*. A Claude Code skill takes the checker's `FAIL` list and, for each
item, **classifies** the cause and — only for the genuinely fixable ones —
proposes a corrected statement, **verifies it runs** against a live cluster via the
StarRocks MCP server, and assembles a **draft** `[Doc]` PR.

### Guardrail: "executes" ≠ "correct documentation"
Every candidate is classified before any rewrite — **fixable** / **version-gated**
(flag, don't rewrite) / **needs-setup** / **illustrative** / **review** — so the
tool never makes an example "pass" by changing what it teaches, and never treats a
version/build-gated failure as doc rot. Sandbox-only writes; **never auto-merges**.

### What's here
- `.claude/skills/sql-doc-autofix/{SKILL.md,README.md}` — the runbook + operator
  guide (matches the existing `release-notes` skill convention).
- `docs/scripts/autofix_candidates.py` — turns the checker's `FAIL` list into
  candidates with surrounding doc prose (so intent is judged, not just SQL).
- `.mcp.json` — the `starrocks` MCP server via **env-var interpolation**
  (`${STARROCKS_HOST:-127.0.0.1}` etc.) — no hardcoded cluster.

### Dependency & scope
Depends on #76763 (the checker + `docs/docker/doc-verification/` composes). This
layer is optional — the checker stands alone. English docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)