### PR TITLE
[BugFix] Bound lake publish-path metadata memory with a reservation MemTracker and gate

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1562,6 +1562,17 @@ CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
+// P3 (SR-38350): bound lake publish-path transient metadata memory. See docs BE_configuration.
+// Percent of the process memory limit the lake publish reservation tracker may hold. Immutable
+// (the tracker byte limit is computed once at init, matching update_memory_limit_percent). Clamped
+// to [0,100] at init; 0 disables the per-tracker gate (registers an unlimited tracker) -- the rollback lever.
+CONF_Int32(lake_publish_memory_limit_percent, "30");
+// Transient-footprint multiplier k: estimate = k * base_metadata_size. Mutable (read per publish).
+CONF_mInt32(lake_publish_metadata_estimate_multiplier, "3");
+// Process-memory backstop for the lake publish path, as a percent of the process limit. Mutable; read
+// per publish so it can be tuned/disabled live. 0 disables the backstop (its rollback lever). Kept
+// separate from memory_urgent_level, which also drives pindex flush / datacache shrink.
+CONF_mInt32(lake_publish_process_memory_urgent_pct, "85");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_mBool(enable_strict_delvec_crc_check, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1675,6 +1675,17 @@ CONF_mDouble(lake_pk_compaction_size_overflow_ratio, "2.0");
 CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
+// P3: bound lake publish-path transient metadata memory. See docs BE_configuration.
+// Percent of the process memory limit the lake publish reservation tracker may hold. Immutable
+// (the tracker byte limit is computed once at init, matching update_memory_limit_percent). Clamped
+// to [0,100] at init; 0 disables the per-tracker gate (registers an unlimited tracker) -- the rollback lever.
+CONF_Int32(lake_publish_memory_limit_percent, "30");
+// Transient-footprint multiplier k: estimate = k * base_metadata_size. Mutable (read per publish).
+CONF_mInt32(lake_publish_metadata_estimate_multiplier, "3");
+// Process-memory backstop for the lake publish path, as a percent of the process limit. Mutable; read
+// per publish so it can be tuned/disabled live. 0 disables the backstop (its rollback lever). Kept
+// separate from memory_urgent_level, which also drives pindex flush / datacache shrink.
+CONF_mInt32(lake_publish_process_memory_urgent_pct, "85");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
 CONF_mBool(enable_strict_delvec_crc_check, "true");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -845,6 +845,9 @@
     {
       "path": "be/src/common/config_lake_fwd.h",
       "configs": [
+        "lake_publish_memory_limit_percent",
+        "lake_publish_metadata_estimate_multiplier",
+        "lake_publish_process_memory_urgent_pct",
         "lake_replication_slow_log_ms",
         "lake_replication_read_buffer_size",
         "lake_replication_max_file_copy_retry",

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -878,6 +878,9 @@
     {
       "path": "be/src/common/config_lake_fwd.h",
       "configs": [
+        "lake_publish_memory_limit_percent",
+        "lake_publish_metadata_estimate_multiplier",
+        "lake_publish_process_memory_urgent_pct",
         "lake_replication_slow_log_ms",
         "lake_replication_read_buffer_size",
         "lake_replication_max_file_copy_retry",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -104,6 +104,20 @@ CONF_mInt64(lake_max_garbage_version_distance, "100");
 // Turn this on after upgrade to clean up existing orphans, then turn it off once done.
 CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 
+// P3 (SR-38350): bound lake publish-path transient metadata memory. See docs BE_configuration.
+// Percent of the process memory limit the lake publish reservation tracker may hold. Immutable
+// (the tracker byte limit is computed once at init, matching update_memory_limit_percent). Clamped
+// to [0,100] at init; 0 disables the per-tracker gate (registers an unlimited tracker) -- the rollback lever.
+CONF_Int32(lake_publish_memory_limit_percent, "30");
+
+// Transient-footprint multiplier k: estimate = k * base_metadata_size. Mutable (read per publish).
+CONF_mInt32(lake_publish_metadata_estimate_multiplier, "3");
+
+// Process-memory backstop for the lake publish path, as a percent of the process limit. Mutable; read
+// per publish so it can be tuned/disabled live. 0 disables the backstop (its rollback lever). Kept
+// separate from memory_urgent_level, which also drives pindex flush / datacache shrink.
+CONF_mInt32(lake_publish_process_memory_urgent_pct, "85");
+
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 
 // When true, shared-data (lake) tablet metadata and txn log files are written with an

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -116,6 +116,20 @@ CONF_mInt64(lake_max_garbage_version_distance, "100");
 // Turn this on after upgrade to clean up existing orphans, then turn it off once done.
 CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 
+// P3: bound lake publish-path transient metadata memory. See docs BE_configuration.
+// Percent of the process memory limit the lake publish reservation tracker may hold. Immutable
+// (the tracker byte limit is computed once at init, matching update_memory_limit_percent). Clamped
+// to [0,100] at init; 0 disables the per-tracker gate (registers an unlimited tracker) -- the rollback lever.
+CONF_Int32(lake_publish_memory_limit_percent, "30");
+
+// Transient-footprint multiplier k: estimate = k * base_metadata_size. Mutable (read per publish).
+CONF_mInt32(lake_publish_metadata_estimate_multiplier, "3");
+
+// Process-memory backstop for the lake publish path, as a percent of the process limit. Mutable; read
+// per publish so it can be tuned/disabled live. 0 disables the backstop (its rollback lever). Kept
+// separate from memory_urgent_level, which also drives pindex flush / datacache shrink.
+CONF_mInt32(lake_publish_process_memory_urgent_pct, "85");
+
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 
 // When true, a shared-data del file (.del) read back during publish or primary-key index rebuild is

--- a/be/src/http/action/memory_metrics_action.cpp
+++ b/be/src/http/action/memory_metrics_action.cpp
@@ -43,6 +43,8 @@ void MemoryMetricsAction::handle(HttpRequest* req) {
     getMemoryMetricTree(_runtime_env.metadata_mem_tracker(), result, process_mem_tracker->consumption());
     result << ",";
     getMemoryMetricTree(_runtime_env.update_mem_tracker(), result, process_mem_tracker->consumption());
+    result << ",";
+    getMemoryMetricTree(_runtime_env.lake_publish_mem_tracker(), result, process_mem_tracker->consumption());
     result << "]";
     req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; version=0.0.4");
     LOG(INFO) << "End collect memory metrics. " << result.str();

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -79,6 +79,7 @@ static std::vector<std::pair<MemTrackerType, std::string>> s_mem_types = {
         {MemTrackerType::COMPACTION_STATE, "compaction_state"},
         {MemTrackerType::BUILTIN_INVERTED_INDEX, "builtin_inverted_index"},
         {MemTrackerType::VECTOR_INDEX, "vector_index"},
+        {MemTrackerType::LAKE_PUBLISH, "lake_publish"},
 };
 
 static std::map<MemTrackerType, std::string> s_type_to_label_map;

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -120,7 +120,8 @@ enum class MemTrackerType {
     DEL_VEC_CACHE,
     COMPACTION_STATE,
     BUILTIN_INVERTED_INDEX,
-    VECTOR_INDEX
+    VECTOR_INDEX,
+    LAKE_PUBLISH
 };
 
 class MemTracker {

--- a/be/src/runtime/runtime_env.cpp
+++ b/be/src/runtime/runtime_env.cpp
@@ -20,6 +20,7 @@
 #include "base/string/parse_util.h"
 #include "base/utility/pretty_printer.h"
 #include "common/config_exec_env_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/config_metrics_fwd.h"
 #include "common/logging.h"
 #include "common/mem_chunk.h"
@@ -237,6 +238,14 @@ Status RuntimeEnv::_init_mem_tracker(MetricRegistry* metrics) {
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _update_mem_tracker = regist_tracker(MemTrackerType::UPDATE, bytes_limit * update_mem_percent / 100, nullptr);
     _update_mem_tracker->set_level(2);
+    // P3 (SR-38350): off-tree, byte-limited admission tracker for the lake publish path. pct is clamped to
+    // [0,100]; pct==0 maps to an unlimited (-1) tracker -- the deliberate kill switch, NOT a 0-byte limit
+    // that would freeze all publishing on the node.
+    int32_t lake_publish_pct = std::max(0, std::min(100, config::lake_publish_memory_limit_percent));
+    int64_t lake_publish_limit = (lake_publish_pct == 0) ? -1 : bytes_limit * lake_publish_pct / 100;
+    _lake_publish_mem_tracker = regist_tracker(MemTrackerType::LAKE_PUBLISH, lake_publish_limit, nullptr);
+    _lake_publish_mem_tracker->set_level(2);
+    LOG(INFO) << "lake publish mem gate limit=" << lake_publish_limit << " (pct=" << lake_publish_pct << ")";
     _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, -1, nullptr);
     _passthrough_mem_tracker->set_level(2);
     _brpc_iobuf_mem_tracker = regist_tracker(MemTrackerType::BRPC_IOBUF, -1, nullptr);

--- a/be/src/runtime/runtime_env.cpp
+++ b/be/src/runtime/runtime_env.cpp
@@ -21,6 +21,7 @@
 #include "base/string/parse_util.h"
 #include "base/utility/pretty_printer.h"
 #include "common/config_exec_env_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/config_metrics_fwd.h"
 #include "common/logging.h"
 #include "common/mem_chunk.h"
@@ -305,6 +306,14 @@ Status RuntimeEnv::_init_mem_tracker(MetricRegistry* metrics) {
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _update_mem_tracker = regist_tracker(MemTrackerType::UPDATE, bytes_limit * update_mem_percent / 100, nullptr);
     _update_mem_tracker->set_level(2);
+    // P3: off-tree, byte-limited admission tracker for the lake publish path. pct is clamped to
+    // [0,100]; pct==0 maps to an unlimited (-1) tracker -- the deliberate kill switch, NOT a 0-byte limit
+    // that would freeze all publishing on the node.
+    int32_t lake_publish_pct = std::max(0, std::min(100, config::lake_publish_memory_limit_percent));
+    int64_t lake_publish_limit = (lake_publish_pct == 0) ? -1 : bytes_limit * lake_publish_pct / 100;
+    _lake_publish_mem_tracker = regist_tracker(MemTrackerType::LAKE_PUBLISH, lake_publish_limit, nullptr);
+    _lake_publish_mem_tracker->set_level(2);
+    LOG(INFO) << "lake publish mem gate limit=" << lake_publish_limit << " (pct=" << lake_publish_pct << ")";
     _passthrough_mem_tracker = regist_tracker(MemTrackerType::PASSTHROUGH, -1, nullptr);
     _passthrough_mem_tracker->set_level(2);
     _brpc_iobuf_mem_tracker = regist_tracker(MemTrackerType::BRPC_IOBUF, -1, nullptr);

--- a/be/src/runtime/runtime_env.h
+++ b/be/src/runtime/runtime_env.h
@@ -79,6 +79,7 @@ public:
     MemTracker* page_cache_mem_tracker() const { return _page_cache_mem_tracker.get(); }
     MemTracker* jit_cache_mem_tracker() const { return _jit_cache_mem_tracker.get(); }
     MemTracker* update_mem_tracker() const { return _update_mem_tracker.get(); }
+    MemTracker* lake_publish_mem_tracker() const { return _lake_publish_mem_tracker.get(); }
     MemTracker* passthrough_mem_tracker() const { return _passthrough_mem_tracker.get(); }
     MemTracker* brpc_iobuf_mem_tracker() const { return _brpc_iobuf_mem_tracker.get(); }
     MemTracker* clone_mem_tracker() const { return _clone_mem_tracker.get(); }
@@ -191,6 +192,7 @@ private:
 
     // The memory tracker for update manager
     std::shared_ptr<MemTracker> _update_mem_tracker;
+    std::shared_ptr<MemTracker> _lake_publish_mem_tracker;
 
     // record mem usage in passthrough
     std::shared_ptr<MemTracker> _passthrough_mem_tracker;

--- a/be/src/runtime/runtime_env.h
+++ b/be/src/runtime/runtime_env.h
@@ -89,6 +89,7 @@ public:
     MemTracker* page_cache_mem_tracker() const { return _page_cache_mem_tracker.get(); }
     MemTracker* jit_cache_mem_tracker() const { return _jit_cache_mem_tracker.get(); }
     MemTracker* update_mem_tracker() const { return _update_mem_tracker.get(); }
+    MemTracker* lake_publish_mem_tracker() const { return _lake_publish_mem_tracker.get(); }
     MemTracker* passthrough_mem_tracker() const { return _passthrough_mem_tracker.get(); }
     MemTracker* brpc_iobuf_mem_tracker() const { return _brpc_iobuf_mem_tracker.get(); }
     MemTracker* clone_mem_tracker() const { return _clone_mem_tracker.get(); }
@@ -201,6 +202,7 @@ private:
 
     // The memory tracker for update manager
     std::shared_ptr<MemTracker> _update_mem_tracker;
+    std::shared_ptr<MemTracker> _lake_publish_mem_tracker;
 
     // record mem usage in passthrough
     std::shared_ptr<MemTracker> _passthrough_mem_tracker;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -41,6 +41,7 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/combined_txn_log_writer.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
@@ -61,6 +62,11 @@
 #include "storage/tablet_index.h"
 
 namespace starrocks {
+
+// P3 (SR-38350): defined in storage/lake/transactions.cpp; bumped when a publish is throttled by the memory gate.
+namespace lake {
+extern bvar::Adder<int64_t> g_lake_publish_mem_rejected;
+}
 
 namespace {
 ThreadPool* get_thread_pool(ExecEnv* env, TTaskType::type type) {
@@ -804,6 +810,19 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
                                                 const AggregatePublishVersionRequest* request,
                                                 PublishVersionResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard done_guard(done);
+    // P3 (SR-38350): coarse process-memory backstop at aggregate entry. Uses ONLY the dedicated process
+    // backstop knob, NOT the shared lake-publish tracker: the aggregator also runs co-located sub-publishes,
+    // so reserving the shared tracker here could starve them and livelock (plan §4c / Fable F2), and per-tablet
+    // sizes are unknown here (metadata lives on remote nodes).
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            lake::g_lake_publish_mem_rejected << 1;
+            Status::ResourceBusy("aggregate publish throttled: process memory urgent")
+                    .to_protobuf(response->mutable_status());
+            return;
+        }
+    }
     AggregatePublishContext ctx;
     ctx.response = response;
     ctx.latch = std::make_unique<BThreadCountDownLatch>(request->publish_reqs_size());

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -43,6 +43,7 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/combined_txn_log_writer.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
@@ -65,6 +66,11 @@
 #include "storage/tablet_index.h"
 
 namespace starrocks {
+
+// P3: defined in storage/lake/transactions.cpp; bumped when a publish is throttled by the memory gate.
+namespace lake {
+extern bvar::Adder<int64_t> g_lake_publish_mem_rejected;
+}
 
 namespace {
 ThreadPool* get_thread_pool(ExecEnv* env, TTaskType::type type) {
@@ -961,6 +967,19 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
                                                 const AggregatePublishVersionRequest* request,
                                                 PublishVersionResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard done_guard(done);
+    // P3: coarse process-memory backstop at aggregate entry. Uses ONLY the dedicated process
+    // backstop knob, NOT the shared lake-publish tracker: the aggregator also runs co-located sub-publishes,
+    // so reserving the shared tracker here could starve them and livelock (plan §4c / Fable F2), and per-tablet
+    // sizes are unknown here (metadata lives on remote nodes).
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            lake::g_lake_publish_mem_rejected << 1;
+            Status::ResourceBusy("aggregate publish throttled: process memory urgent")
+                    .to_protobuf(response->mutable_status());
+            return;
+        }
+    }
     AggregatePublishContext ctx;
     ctx.response = response;
     ctx.latch = std::make_unique<BThreadCountDownLatch>(request->publish_reqs_size());

--- a/be/src/storage/lake/publish_mem_reservation.h
+++ b/be/src/storage/lake/publish_mem_reservation.h
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+#include "runtime/mem_tracker.h"
+
+namespace starrocks::lake {
+
+// RAII admission reservation for the shared-data (lake) publish path (ticket SR-38350, gap P3).
+//
+// It reserves an estimate of the transient per-publish metadata footprint against an off-tree,
+// byte-limited MemTracker and releases exactly what it consumed on scope exit. Correctness is
+// structural (in the ctor/dtor), not positional at call sites.
+//
+// Routing in the constructor, IN THIS ORDER (the order is load-bearing):
+//   1. tracker == nullptr    -> gate not wired: admit, reserve nothing (never block publishing).
+//   2. estimate <= 0         -> clamp to 0 and admit, reserve nothing.
+//   3. tracker->limit() <= 0 -> kill switch / unlimited (pct==0 maps the limit to -1): gate disabled,
+//                               always admit; consume for observability ONLY if try_consume actually
+//                               accepts it (it adds unconditionally when limit<0, but is a no-op reject
+//                               when limit==0), keeping release symmetric. MUST precede the oversized
+//                               check: with limit==-1, estimate>limit is always true and every publish
+//                               would otherwise serialize through the oversized slot.
+//   4. estimate > limit      -> oversized: one publish alone exceeds the whole budget. A plain
+//                               try_consume would reject it forever (FE retries indefinitely) -> a
+//                               permanent partition wedge. Admit at most ONE oversized publish
+//                               process-wide via the atomic slot, WITHOUT charging the shared tracker,
+//                               so normal-sized publishes keep flowing. Peak bound: limit + one oversized.
+//   5. otherwise             -> normal: atomic try_consume(estimate) reserve-or-fail; reject -> FE retries.
+//
+// No decision anywhere depends on live consumption(), so there is no check-then-act race: "oversized"
+// is a comparison of two stable values (estimate this call, limit fixed at init), and admission of an
+// oversized publish is a single compare_exchange on the slot.
+class PublishMemReservation {
+public:
+    // `oversized_slot` is a process-wide atomic shared by all publishes on this node (the caller passes
+    // the file-global g_lake_publish_oversized_inflight; tests pass a local).
+    PublishMemReservation(MemTracker* tracker, int64_t estimate, std::atomic<bool>& oversized_slot)
+            : _tracker(tracker), _oversized_slot(&oversized_slot) {
+        if (_tracker == nullptr) {
+            _admitted = true; // gate not wired: never block publishing
+            return;
+        }
+        if (estimate < 0) {
+            estimate = 0; // clamp: never release(-N) into a bounded tracker
+        }
+        if (estimate == 0) {
+            _admitted = true; // nothing to reserve
+            return;
+        }
+        const int64_t limit = _tracker->limit();
+        if (limit <= 0) {
+            // Kill switch / unlimited (or a pathological 0). Gate disabled: always admit. Consume for
+            // observability only if it actually lands, so the dtor's release stays symmetric.
+            if (_tracker->try_consume(estimate) == nullptr) {
+                _consumed = estimate;
+            }
+            _admitted = true;
+            return;
+        }
+        if (estimate > limit) {
+            // Oversized: admit at most one process-wide, without charging the shared tracker.
+            bool expected = false;
+            if (_oversized_slot->compare_exchange_strong(expected, true)) {
+                _holds_oversized_slot = true;
+                _admitted = true;
+            } else {
+                _admitted = false; // another oversized already in flight -> reject, FE retries
+            }
+            return;
+        }
+        // Normal path: atomic reserve-or-fail against the shared budget.
+        _admitted = (_tracker->try_consume(estimate) == nullptr);
+        if (_admitted) {
+            _consumed = estimate;
+        }
+    }
+
+    ~PublishMemReservation() {
+        if (_consumed > 0) {
+            _tracker->release(_consumed); // release exactly what was consumed (0 on the oversized-slot path)
+        }
+        if (_holds_oversized_slot) {
+            _oversized_slot->store(false, std::memory_order_seq_cst); // only the CAS winner clears the slot
+        }
+    }
+
+    PublishMemReservation(const PublishMemReservation&) = delete;
+    PublishMemReservation& operator=(const PublishMemReservation&) = delete;
+    PublishMemReservation(PublishMemReservation&&) = delete;
+    PublishMemReservation& operator=(PublishMemReservation&&) = delete;
+
+    bool admitted() const { return _admitted; }
+    int64_t consumed_bytes() const { return _consumed; }                // for tests / metrics
+    bool holds_oversized_slot() const { return _holds_oversized_slot; } // for tests
+
+private:
+    MemTracker* _tracker;
+    std::atomic<bool>* _oversized_slot;
+    int64_t _consumed = 0;
+    bool _admitted = false;
+    bool _holds_oversized_slot = false;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/publish_mem_reservation.h
+++ b/be/src/storage/lake/publish_mem_reservation.h
@@ -40,17 +40,24 @@ namespace starrocks::lake {
 //                               try_consume would reject it forever (FE retries indefinitely) -> a
 //                               permanent partition wedge. Admit at most ONE oversized publish
 //                               process-wide via the atomic slot, WITHOUT charging the shared tracker,
-//                               so normal-sized publishes keep flowing. Peak bound: limit + one oversized.
+//                               so normal-sized publishes keep flowing, AND only when the process has
+//                               headroom for the estimate (the slot bounds how many oversized publishes
+//                               run, not how big they are). Peak bound: limit + one oversized.
 //   5. otherwise             -> normal: atomic try_consume(estimate) reserve-or-fail; reject -> FE retries.
 //
-// No decision anywhere depends on live consumption(), so there is no check-then-act race: "oversized"
-// is a comparison of two stable values (estimate this call, limit fixed at init), and admission of an
-// oversized publish is a single compare_exchange on the slot.
+// Route selection never depends on live consumption(), so there is no check-then-act race in choosing a
+// route: "oversized" is a comparison of two stable values (estimate this call, limit fixed at init), and
+// admission of an oversized publish is a single compare_exchange on the slot. The one consumption-based
+// test is the process-headroom check inside route 4, which can only turn an admit into a reject, never
+// the reverse, so a concurrent allocation racing it is strictly safer than not checking at all.
 class PublishMemReservation {
 public:
     // `oversized_slot` is a process-wide atomic shared by all publishes on this node (the caller passes
     // the file-global g_lake_publish_oversized_inflight; tests pass a local).
-    PublishMemReservation(MemTracker* tracker, int64_t estimate, std::atomic<bool>& oversized_slot)
+    // `process_tracker` (optional) is the process-wide tracker. It is consulted ONLY on the oversized
+    // route, to require that the process can actually absorb a publish that the shared budget cannot.
+    PublishMemReservation(MemTracker* tracker, int64_t estimate, std::atomic<bool>& oversized_slot,
+                          MemTracker* process_tracker = nullptr)
             : _tracker(tracker), _oversized_slot(&oversized_slot) {
         if (_tracker == nullptr) {
             _admitted = true; // gate not wired: never block publishing
@@ -75,6 +82,26 @@ public:
         }
         if (estimate > limit) {
             // Oversized: admit at most one process-wide, without charging the shared tracker.
+            //
+            // The slot bounds the COUNT of concurrent oversized publishes (one) but not their SIZE, and
+            // this route charges nothing, so on its own it admits an arbitrarily large publish as long as
+            // the entry backstop has not already tripped. That backstop asks "is usage already above the
+            // urgent percent", not "does this fit": at 80% usage with an 85% threshold, a publish
+            // estimated well above the remaining 20% is still let through and can drive the node into
+            // OOM. That is the exact failure this gate exists to prevent, in the case where the metadata
+            // is largest. So require the process to have room for the estimate first.
+            //
+            // This does not reintroduce the wedge route 4 exists to avoid. Rejection here is retryable
+            // backpressure, and an oversized estimate is by definition only a fraction of the process
+            // limit, so an idle node always has the headroom to admit it. The only case that never fits
+            // is an estimate larger than the whole process, which would OOM rather than succeed.
+            if (process_tracker != nullptr) {
+                const int64_t process_limit = process_tracker->limit();
+                if (process_limit > 0 && estimate > process_limit - process_tracker->consumption()) {
+                    _admitted = false; // not enough process headroom -> reject (retryable), take no slot
+                    return;
+                }
+            }
             bool expected = false;
             if (_oversized_slot->compare_exchange_strong(expected, true)) {
                 _holds_oversized_slot = true;

--- a/be/src/storage/lake/publish_mem_reservation.h
+++ b/be/src/storage/lake/publish_mem_reservation.h
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+#include "runtime/mem_tracker.h"
+
+namespace starrocks::lake {
+
+// RAII admission reservation for the shared-data (lake) publish path (part 3 of the publish-stall hardening series).
+//
+// It reserves an estimate of the transient per-publish metadata footprint against an off-tree,
+// byte-limited MemTracker and releases exactly what it consumed on scope exit. Correctness is
+// structural (in the ctor/dtor), not positional at call sites.
+//
+// Routing in the constructor, IN THIS ORDER (the order is load-bearing):
+//   1. tracker == nullptr    -> gate not wired: admit, reserve nothing (never block publishing).
+//   2. estimate <= 0         -> clamp to 0 and admit, reserve nothing.
+//   3. tracker->limit() <= 0 -> kill switch / unlimited (pct==0 maps the limit to -1): gate disabled,
+//                               always admit; consume for observability ONLY if try_consume actually
+//                               accepts it (it adds unconditionally when limit<0, but is a no-op reject
+//                               when limit==0), keeping release symmetric. MUST precede the oversized
+//                               check: with limit==-1, estimate>limit is always true and every publish
+//                               would otherwise serialize through the oversized slot.
+//   4. estimate > limit      -> oversized: one publish alone exceeds the whole budget. A plain
+//                               try_consume would reject it forever (FE retries indefinitely) -> a
+//                               permanent partition wedge. Admit at most ONE oversized publish
+//                               process-wide via the atomic slot, WITHOUT charging the shared tracker,
+//                               so normal-sized publishes keep flowing. Peak bound: limit + one oversized.
+//   5. otherwise             -> normal: atomic try_consume(estimate) reserve-or-fail; reject -> FE retries.
+//
+// No decision anywhere depends on live consumption(), so there is no check-then-act race: "oversized"
+// is a comparison of two stable values (estimate this call, limit fixed at init), and admission of an
+// oversized publish is a single compare_exchange on the slot.
+class PublishMemReservation {
+public:
+    // `oversized_slot` is a process-wide atomic shared by all publishes on this node (the caller passes
+    // the file-global g_lake_publish_oversized_inflight; tests pass a local).
+    PublishMemReservation(MemTracker* tracker, int64_t estimate, std::atomic<bool>& oversized_slot)
+            : _tracker(tracker), _oversized_slot(&oversized_slot) {
+        if (_tracker == nullptr) {
+            _admitted = true; // gate not wired: never block publishing
+            return;
+        }
+        if (estimate < 0) {
+            estimate = 0; // clamp: never release(-N) into a bounded tracker
+        }
+        if (estimate == 0) {
+            _admitted = true; // nothing to reserve
+            return;
+        }
+        const int64_t limit = _tracker->limit();
+        if (limit <= 0) {
+            // Kill switch / unlimited (or a pathological 0). Gate disabled: always admit. Consume for
+            // observability only if it actually lands, so the dtor's release stays symmetric.
+            if (_tracker->try_consume(estimate) == nullptr) {
+                _consumed = estimate;
+            }
+            _admitted = true;
+            return;
+        }
+        if (estimate > limit) {
+            // Oversized: admit at most one process-wide, without charging the shared tracker.
+            bool expected = false;
+            if (_oversized_slot->compare_exchange_strong(expected, true)) {
+                _holds_oversized_slot = true;
+                _admitted = true;
+            } else {
+                _admitted = false; // another oversized already in flight -> reject, FE retries
+            }
+            return;
+        }
+        // Normal path: atomic reserve-or-fail against the shared budget.
+        _admitted = (_tracker->try_consume(estimate) == nullptr);
+        if (_admitted) {
+            _consumed = estimate;
+        }
+    }
+
+    ~PublishMemReservation() {
+        if (_consumed > 0) {
+            _tracker->release(_consumed); // release exactly what was consumed (0 on the oversized-slot path)
+        }
+        if (_holds_oversized_slot) {
+            _oversized_slot->store(false, std::memory_order_seq_cst); // only the CAS winner clears the slot
+        }
+    }
+
+    PublishMemReservation(const PublishMemReservation&) = delete;
+    PublishMemReservation& operator=(const PublishMemReservation&) = delete;
+    PublishMemReservation(PublishMemReservation&&) = delete;
+    PublishMemReservation& operator=(PublishMemReservation&&) = delete;
+
+    bool admitted() const { return _admitted; }
+    int64_t consumed_bytes() const { return _consumed; }                // for tests / metrics
+    bool holds_oversized_slot() const { return _holds_oversized_slot; } // for tests
+
+private:
+    MemTracker* _tracker;
+    std::atomic<bool>* _oversized_slot;
+    int64_t _consumed = 0;
+    bool _admitted = false;
+    bool _holds_oversized_slot = false;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/publish_mem_reservation.h
+++ b/be/src/storage/lake/publish_mem_reservation.h
@@ -36,28 +36,43 @@ namespace starrocks::lake {
 //                               when limit==0), keeping release symmetric. MUST precede the oversized
 //                               check: with limit==-1, estimate>limit is always true and every publish
 //                               would otherwise serialize through the oversized slot.
-//   4. estimate > limit      -> oversized: one publish alone exceeds the whole budget. A plain
+//   4. no process headroom   -> reject (retryable) before either admitting route. Applies to BOTH the
+//                               oversized and the normal route, because the lake tracker is off-tree and
+//                               says nothing about process pressure: a node already near the urgent line
+//                               can otherwise admit a publish that fits the mostly empty lake budget and
+//                               then allocate past the process limit. Disabled by process_urgent_pct <= 0.
+//   5. estimate > limit      -> oversized: one publish alone exceeds the whole budget. A plain
 //                               try_consume would reject it forever (FE retries indefinitely) -> a
 //                               permanent partition wedge. Admit at most ONE oversized publish
 //                               process-wide via the atomic slot, WITHOUT charging the shared tracker,
-//                               so normal-sized publishes keep flowing, AND only when the process has
-//                               headroom for the estimate (the slot bounds how many oversized publishes
-//                               run, not how big they are). Peak bound: limit + one oversized.
-//   5. otherwise             -> normal: atomic try_consume(estimate) reserve-or-fail; reject -> FE retries.
+//                               so normal-sized publishes keep flowing. The slot bounds how many
+//                               oversized publishes run, not how big they are; route 4 bounds the size.
+//                               Peak bound: limit + one oversized.
+//   6. otherwise             -> normal: atomic try_consume(estimate) reserve-or-fail; reject -> FE retries.
 //
 // Route selection never depends on live consumption(), so there is no check-then-act race in choosing a
 // route: "oversized" is a comparison of two stable values (estimate this call, limit fixed at init), and
-// admission of an oversized publish is a single compare_exchange on the slot. The one consumption-based
-// test is the process-headroom check inside route 4, which can only turn an admit into a reject, never
-// the reverse, so a concurrent allocation racing it is strictly safer than not checking at all.
+// admission of an oversized publish is a single compare_exchange on the slot.
+//
+// Route 4 is the one consumption-based test, and it is a backstop rather than a reservation. It cannot be
+// made atomic here: the only shared counter that could be reserved against is the process tracker itself,
+// and the allocations this publish goes on to make are already charged there, so consuming the estimate up
+// front would double count every publish. So two publishes can pass route 4 concurrently and both be
+// admitted. What bounds that case is the lake tracker, which IS atomic: concurrent normal publishes still
+// contend for one budget and the loser is rejected. Route 4 only narrows the window in which a node that is
+// already near the urgent line admits more work, and it can only ever turn an admit into a reject, so a
+// concurrent allocation racing it is strictly safer than not checking at all.
 class PublishMemReservation {
 public:
     // `oversized_slot` is a process-wide atomic shared by all publishes on this node (the caller passes
     // the file-global g_lake_publish_oversized_inflight; tests pass a local).
-    // `process_tracker` (optional) is the process-wide tracker. It is consulted ONLY on the oversized
-    // route, to require that the process can actually absorb a publish that the shared budget cannot.
+    // `process_tracker` (optional) is the process-wide tracker, consulted on every admitting route so a
+    // publish cannot be let through on lake-budget room alone while the process is already near its limit.
+    // `process_urgent_pct` is the ceiling for that check, as a percent of the process limit. It is the
+    // check's kill switch: <= 0 skips it entirely. Callers pass config::lake_publish_process_memory_urgent_pct,
+    // which is mutable, so the check can be disabled live without a restart.
     PublishMemReservation(MemTracker* tracker, int64_t estimate, std::atomic<bool>& oversized_slot,
-                          MemTracker* process_tracker = nullptr)
+                          MemTracker* process_tracker = nullptr, int32_t process_urgent_pct = 0)
             : _tracker(tracker), _oversized_slot(&oversized_slot) {
         if (_tracker == nullptr) {
             _admitted = true; // gate not wired: never block publishing
@@ -80,28 +95,28 @@ public:
             _admitted = true;
             return;
         }
+        // Process headroom, checked before EITHER admitting route.
+        //
+        // The lake tracker is off-tree, so fitting inside it says nothing about whether the process can
+        // absorb the allocation. The entry backstop asks "is usage already above the urgent percent", not
+        // "does this fit", so a node at 84% with an 85% threshold passes it and then admits a publish
+        // estimated well above the remaining headroom, on either route. On the oversized route nothing is
+        // charged at all, and on the normal route the estimate only has to fit the mostly empty lake
+        // budget. Both drive the node past its process limit. So ask whether this publish still fits under
+        // the urgent line before letting it through.
+        //
+        // This does not reintroduce the wedge the oversized route exists to avoid. Rejection here is
+        // retryable backpressure, not a permanent refusal, and an estimate is a fraction of the process
+        // limit, so a node with room always admits it. The only estimate that never fits is one larger
+        // than the whole process, which would OOM rather than succeed.
+        if (lacks_process_headroom(process_tracker, process_urgent_pct, estimate)) {
+            _admitted = false; // reject (retryable), take no slot and charge nothing
+            return;
+        }
         if (estimate > limit) {
-            // Oversized: admit at most one process-wide, without charging the shared tracker.
-            //
-            // The slot bounds the COUNT of concurrent oversized publishes (one) but not their SIZE, and
-            // this route charges nothing, so on its own it admits an arbitrarily large publish as long as
-            // the entry backstop has not already tripped. That backstop asks "is usage already above the
-            // urgent percent", not "does this fit": at 80% usage with an 85% threshold, a publish
-            // estimated well above the remaining 20% is still let through and can drive the node into
-            // OOM. That is the exact failure this gate exists to prevent, in the case where the metadata
-            // is largest. So require the process to have room for the estimate first.
-            //
-            // This does not reintroduce the wedge route 4 exists to avoid. Rejection here is retryable
-            // backpressure, and an oversized estimate is by definition only a fraction of the process
-            // limit, so an idle node always has the headroom to admit it. The only case that never fits
-            // is an estimate larger than the whole process, which would OOM rather than succeed.
-            if (process_tracker != nullptr) {
-                const int64_t process_limit = process_tracker->limit();
-                if (process_limit > 0 && estimate > process_limit - process_tracker->consumption()) {
-                    _admitted = false; // not enough process headroom -> reject (retryable), take no slot
-                    return;
-                }
-            }
+            // Oversized: admit at most one process-wide, without charging the shared tracker. The slot
+            // bounds the COUNT of concurrent oversized publishes (one), not their SIZE. The size is
+            // bounded by the headroom check above.
             bool expected = false;
             if (_oversized_slot->compare_exchange_strong(expected, true)) {
                 _holds_oversized_slot = true;
@@ -137,6 +152,27 @@ public:
     bool holds_oversized_slot() const { return _holds_oversized_slot; } // for tests
 
 private:
+    // True when `estimate` would push process consumption past `urgent_pct` of the process limit.
+    // Returns false (admit) whenever the check is not wired or is switched off, so a missing tracker or a
+    // zeroed percent can never block publishing.
+    static bool lacks_process_headroom(MemTracker* process_tracker, int32_t urgent_pct, int64_t estimate) {
+        if (process_tracker == nullptr || urgent_pct <= 0) {
+            return false; // not wired, or kill switch engaged
+        }
+        // Clamp here rather than trusting the caller, so a mistyped config can never make the ceiling
+        // exceed the process limit and silently turn the check into a no-op.
+        if (urgent_pct > 100) {
+            urgent_pct = 100;
+        }
+        const int64_t process_limit = process_tracker->limit();
+        if (process_limit <= 0) {
+            return false; // unlimited process tracker: nothing to be near the edge of
+        }
+        // Divide before multiplying so a large limit cannot overflow. Costs at most 99 bytes of precision.
+        const int64_t ceiling = process_limit / 100 * urgent_pct;
+        return process_tracker->consumption() + estimate > ceiling;
+    }
+
     MemTracker* _tracker;
     std::atomic<bool>* _oversized_slot;
     int64_t _consumed = 0;

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -17,11 +17,14 @@
 #include <butil/time.h>
 #include <bvar/bvar.h>
 
+#include <algorithm>
 #include <unordered_map>
 
 #include "base/utility/defer_op.h"
+#include "common/config_lake_fwd.h"
 #include "common/logging.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_merger.h"
@@ -36,6 +39,8 @@
 bvar::Adder<int64_t> g_tablet_reshard_total("tablet_reshard_total");
 bvar::Adder<int64_t> g_tablet_reshard_failed("tablet_reshard_failed");
 bvar::LatencyRecorder g_tablet_reshard_latency("tablet_reshard");
+// P3 (SR-38350): reshard publishes rejected by the near-OOM backstop (mirrors the lake publish gate).
+bvar::Adder<int64_t> g_tablet_reshard_mem_rejected("tablet_reshard_mem_rejected");
 
 // Layer 2: Split metrics
 bvar::Adder<int64_t> g_tablet_reshard_split_total("tablet_reshard_split_total");
@@ -540,6 +545,20 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                  std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
     g_tablet_reshard_total << 1;
     auto reshard_start_ts = butil::gettimeofday_us();
+
+    // P3 (SR-38350): coarse near-OOM backstop for the separately-scheduled reshard metadata builder. This
+    // path is scheduled by LakeServiceImpl::publish_version alongside, but not through, lake::publish_version,
+    // and clones full tablet metadata in the handle_*_tablet helpers below, so without this it can allocate
+    // unbounded metadata that the ordinary publish path's memory gate never sees. Mirror that gate's entry
+    // backstop; gated on the same mutable urgent knob (0 disables). A rejection is a retryable throttle (FE
+    // resubmits the reshard), not a failure, so it is counted separately and does not trip reshard-failed.
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            g_tablet_reshard_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: process memory urgent (reshard)");
+        }
+    }
 
     // Reserve the per-reshard publish slot. All retries of the same reshard
     // resolve to the same id (see reshard_serialization_id), so this

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -17,12 +17,15 @@
 #include <butil/time.h>
 #include <bvar/bvar.h>
 
+#include <algorithm>
 #include <unordered_map>
 
 #include "base/failpoint/fail_point.h"
 #include "base/utility/defer_op.h"
+#include "common/config_lake_fwd.h"
 #include "common/logging.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_merger.h"
@@ -37,6 +40,8 @@
 bvar::Adder<int64_t> g_tablet_reshard_total("tablet_reshard_total");
 bvar::Adder<int64_t> g_tablet_reshard_failed("tablet_reshard_failed");
 bvar::LatencyRecorder g_tablet_reshard_latency("tablet_reshard");
+// P3: reshard publishes rejected by the near-OOM backstop (mirrors the lake publish gate).
+bvar::Adder<int64_t> g_tablet_reshard_mem_rejected("tablet_reshard_mem_rejected");
 
 // Layer 2: Split metrics
 bvar::Adder<int64_t> g_tablet_reshard_split_total("tablet_reshard_split_total");
@@ -565,6 +570,20 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                                  InitialMetadataOrder base_version_order) {
     g_tablet_reshard_total << 1;
     auto reshard_start_ts = butil::gettimeofday_us();
+
+    // P3: coarse near-OOM backstop for the separately-scheduled reshard metadata builder. This
+    // path is scheduled by LakeServiceImpl::publish_version alongside, but not through, lake::publish_version,
+    // and clones full tablet metadata in the handle_*_tablet helpers below, so without this it can allocate
+    // unbounded metadata that the ordinary publish path's memory gate never sees. Mirror that gate's entry
+    // backstop; gated on the same mutable urgent knob (0 disables). A rejection is a retryable throttle (FE
+    // resubmits the reshard), not a failure, so it is counted separately and does not trip reshard-failed.
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            g_tablet_reshard_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: process memory urgent (reshard)");
+        }
+    }
 
     // Reserve the per-reshard publish slot. All retries of the same reshard
     // resolve to the same id (see reshard_serialization_id), so this

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -14,6 +14,10 @@
 
 #include "storage/lake/transactions.h"
 
+#include <bvar/bvar.h>
+
+#include <atomic>
+
 #include "base/container/lru_cache.h"
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
@@ -22,9 +26,11 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
+#include "storage/lake/publish_mem_reservation.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -43,6 +49,9 @@ using ParallelSet = phmap::parallel_flat_hash_set<T, phmap::priv::hash_default_h
                                                   phmap::priv::Allocator<T>, 4, std::mutex, true>;
 ParallelSet<int64_t> tablet_txns;
 
+// P3 (SR-38350): process-wide slot bounding oversized (estimate > limit) lake publishes to concurrency 1.
+std::atomic<bool> g_lake_publish_oversized_inflight{false};
+
 // publish version with EMPTY_TXNLOG_TXNID means there is no txnlog
 // and need to increase version number of the tablet,
 // the situation happens in create rollup.
@@ -51,6 +60,9 @@ const int64_t EMPTY_TXNLOG_TXNID = -1;
 } // namespace
 
 namespace starrocks::lake {
+
+// P3 (SR-38350): counter of publishes rejected by the memory gate (per-tablet reservation or process backstop).
+bvar::Adder<int64_t> g_lake_publish_mem_rejected("lake_publish_mem_rejected");
 
 bool acquire_publish_tablet(int64_t tablet_id) {
     auto [_, ok] = tablet_txns.insert(tablet_id);
@@ -267,6 +279,16 @@ static StatusOr<MutableTxnLogPtr> make_shadow_rewrite_schema_change_log(TabletMa
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata, int64_t fe_built_version) {
+    // P3 (SR-38350): coarse process-memory backstop, placed before EVERY branch (including the early
+    // empty-txnlog/reshard path below, which returns before acquire_publish_tablet). Gated on a dedicated
+    // mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            g_lake_publish_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: process memory urgent");
+        }
+    }
     if (txns.size() == 1 && (txns[0].txn_id() == EMPTY_TXNLOG_TXNID || txns[0].txn_type() == TXN_TABLET_RESHARD)) {
         LOG(INFO) << "publish version tablet_info: " << tablet_info << ", txn: " << txns[0].DebugString()
                   << ", base_version: " << base_version << ", new_version: " << new_version;
@@ -384,6 +406,27 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     }
 
     auto base_metadata = std::move(base_metadata_or).value();
+
+    // P3 (SR-38350): reserve an estimate of the transient publish footprint (working copy + normalize +
+    // serialize ~= k x base metadata size) against the off-tree lake publish tracker; released on scope exit.
+    // Race-free oversized handling (bounded to concurrency 1, without charging the shared tracker) lives in
+    // the RAII class. base_metadata->SpaceUsedLong() here is dominated by the deep copy the apply path performs
+    // shortly after, so it adds no new latency class to the hot path.
+    // Clamp k to a sane range so a bad mutable config cannot silently disable the gate (k<=0 -> estimate 0,
+    // fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never overflows negative.
+    int32_t lake_publish_k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
+    int64_t lake_publish_estimate;
+    if (__builtin_mul_overflow(int64_t(lake_publish_k), int64_t(base_metadata->SpaceUsedLong()),
+                               &lake_publish_estimate)) {
+        lake_publish_estimate = INT64_MAX;
+    }
+    PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
+                                            lake_publish_estimate, g_lake_publish_oversized_inflight);
+    if (!lake_publish_resv.admitted()) {
+        g_lake_publish_mem_rejected << 1;
+        return Status::ResourceBusy("publish throttled: lake publish memory limit");
+    }
+
     std::unique_ptr<TxnLogApplier> log_applier;
     std::shared_ptr<TabletMetadataPB> new_metadata;
     std::vector<std::string> files_to_delete;

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -64,6 +64,19 @@ namespace starrocks::lake {
 // P3 (SR-38350): counter of publishes rejected by the memory gate (per-tablet reservation or process backstop).
 bvar::Adder<int64_t> g_lake_publish_mem_rejected("lake_publish_mem_rejected");
 
+// P3 (SR-38350): the transient publish footprint (working copy + normalize + serialize) is ~k x the base
+// metadata size. Clamp k to a sane range so a bad mutable config cannot silently disable the gate
+// (k<=0 -> estimate 0, fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never
+// overflows negative. Shared by the main publish path and the empty-txnlog/reshard version-bump path.
+static int64_t compute_lake_publish_estimate(int64_t base_metadata_size) {
+    int32_t k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
+    int64_t estimate;
+    if (__builtin_mul_overflow(int64_t(k), base_metadata_size, &estimate)) {
+        estimate = INT64_MAX;
+    }
+    return estimate;
+}
+
 bool acquire_publish_tablet(int64_t tablet_id) {
     auto [_, ok] = tablet_txns.insert(tablet_id);
     return ok;
@@ -279,9 +292,10 @@ static StatusOr<MutableTxnLogPtr> make_shadow_rewrite_schema_change_log(TabletMa
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata, int64_t fe_built_version) {
-    // P3 (SR-38350): coarse process-memory backstop, placed before EVERY branch (including the early
-    // empty-txnlog/reshard path below, which returns before acquire_publish_tablet). Gated on a dedicated
-    // mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
+    // P3 (SR-38350): coarse process-memory backstop, placed before EVERY branch. Both the early
+    // empty-txnlog/reshard version-bump path below and the main path additionally take the per-tracker
+    // reservation before copying metadata; this backstop is the last-resort net on top of that. Gated on a
+    // dedicated mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
     {
         int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
         if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
@@ -297,6 +311,17 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
         DCHECK_EQ(new_version, base_version + 1);
         ASSIGN_OR_RETURN(auto metadata,
                          tablet_mgr->get_tablet_metadata(tablet_info.get_tablet_id_in_metadata(), base_version));
+
+        // P3 (SR-38350): this version-bump path still deep-copies and serializes the full base metadata just
+        // like the main path, so gate it through the same per-tracker reservation. The coarse process backstop
+        // at function entry alone does not bound the sum of concurrent copies below the urgent threshold.
+        int64_t empty_publish_estimate = compute_lake_publish_estimate(metadata->SpaceUsedLong());
+        PublishMemReservation empty_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
+                                                 empty_publish_estimate, g_lake_publish_oversized_inflight);
+        if (!empty_publish_resv.admitted()) {
+            g_lake_publish_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: lake publish memory limit");
+        }
 
         auto new_metadata = std::make_shared<TabletMetadataPB>(*metadata);
         new_metadata->set_version(new_version);
@@ -412,14 +437,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     // Race-free oversized handling (bounded to concurrency 1, without charging the shared tracker) lives in
     // the RAII class. base_metadata->SpaceUsedLong() here is dominated by the deep copy the apply path performs
     // shortly after, so it adds no new latency class to the hot path.
-    // Clamp k to a sane range so a bad mutable config cannot silently disable the gate (k<=0 -> estimate 0,
-    // fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never overflows negative.
-    int32_t lake_publish_k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
-    int64_t lake_publish_estimate;
-    if (__builtin_mul_overflow(int64_t(lake_publish_k), int64_t(base_metadata->SpaceUsedLong()),
-                               &lake_publish_estimate)) {
-        lake_publish_estimate = INT64_MAX;
-    }
+    int64_t lake_publish_estimate = compute_lake_publish_estimate(base_metadata->SpaceUsedLong());
     PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
                                             lake_publish_estimate, g_lake_publish_oversized_inflight);
     if (!lake_publish_resv.admitted()) {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -14,6 +14,10 @@
 
 #include "storage/lake/transactions.h"
 
+#include <bvar/bvar.h>
+
+#include <atomic>
+
 #include "base/container/lru_cache.h"
 #include "base/debug/trace.h"
 #include "base/utility/defer_op.h"
@@ -22,9 +26,11 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "gutil/strings/join.h"
+#include "runtime/runtime_env.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
+#include "storage/lake/publish_mem_reservation.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -43,6 +49,9 @@ using ParallelSet = phmap::parallel_flat_hash_set<T, phmap::priv::hash_default_h
                                                   phmap::priv::Allocator<T>, 4, std::mutex, true>;
 ParallelSet<int64_t> tablet_txns;
 
+// P3: process-wide slot bounding oversized (estimate > limit) lake publishes to concurrency 1.
+std::atomic<bool> g_lake_publish_oversized_inflight{false};
+
 // publish version with EMPTY_TXNLOG_TXNID means there is no txnlog
 // and need to increase version number of the tablet,
 // the situation happens in create rollup.
@@ -51,6 +60,9 @@ const int64_t EMPTY_TXNLOG_TXNID = -1;
 } // namespace
 
 namespace starrocks::lake {
+
+// P3: counter of publishes rejected by the memory gate (per-tablet reservation or process backstop).
+bvar::Adder<int64_t> g_lake_publish_mem_rejected("lake_publish_mem_rejected");
 
 bool acquire_publish_tablet(int64_t tablet_id) {
     auto [_, ok] = tablet_txns.insert(tablet_id);
@@ -268,6 +280,16 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata, int64_t fe_built_version,
                                             InitialMetadataOrder base_version_order) {
+    // P3: coarse process-memory backstop, placed before EVERY branch (including the early
+    // empty-txnlog/reshard path below, which returns before acquire_publish_tablet). Gated on a dedicated
+    // mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
+    {
+        int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
+        if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
+            g_lake_publish_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: process memory urgent");
+        }
+    }
     if (txns.size() == 1 && (txns[0].txn_id() == EMPTY_TXNLOG_TXNID || txns[0].txn_type() == TXN_TABLET_RESHARD)) {
         LOG(INFO) << "publish version tablet_info: " << tablet_info << ", txn: " << txns[0].DebugString()
                   << ", base_version: " << base_version << ", new_version: " << new_version;
@@ -387,6 +409,27 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     }
 
     auto base_metadata = std::move(base_metadata_or).value();
+
+    // P3: reserve an estimate of the transient publish footprint (working copy + normalize +
+    // serialize ~= k x base metadata size) against the off-tree lake publish tracker; released on scope exit.
+    // Race-free oversized handling (bounded to concurrency 1, without charging the shared tracker) lives in
+    // the RAII class. base_metadata->SpaceUsedLong() here is dominated by the deep copy the apply path performs
+    // shortly after, so it adds no new latency class to the hot path.
+    // Clamp k to a sane range so a bad mutable config cannot silently disable the gate (k<=0 -> estimate 0,
+    // fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never overflows negative.
+    int32_t lake_publish_k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
+    int64_t lake_publish_estimate;
+    if (__builtin_mul_overflow(int64_t(lake_publish_k), int64_t(base_metadata->SpaceUsedLong()),
+                               &lake_publish_estimate)) {
+        lake_publish_estimate = INT64_MAX;
+    }
+    PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
+                                            lake_publish_estimate, g_lake_publish_oversized_inflight);
+    if (!lake_publish_resv.admitted()) {
+        g_lake_publish_mem_rejected << 1;
+        return Status::ResourceBusy("publish throttled: lake publish memory limit");
+    }
+
     std::unique_ptr<TxnLogApplier> log_applier;
     std::shared_ptr<TabletMetadataPB> new_metadata;
     std::vector<std::string> files_to_delete;

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -64,6 +64,19 @@ namespace starrocks::lake {
 // P3: counter of publishes rejected by the memory gate (per-tablet reservation or process backstop).
 bvar::Adder<int64_t> g_lake_publish_mem_rejected("lake_publish_mem_rejected");
 
+// P3: the transient publish footprint (working copy + normalize + serialize) is ~k x the base
+// metadata size. Clamp k to a sane range so a bad mutable config cannot silently disable the gate
+// (k<=0 -> estimate 0, fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never
+// overflows negative. Shared by the main publish path and the empty-txnlog/reshard version-bump path.
+static int64_t compute_lake_publish_estimate(int64_t base_metadata_size) {
+    int32_t k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
+    int64_t estimate;
+    if (__builtin_mul_overflow(int64_t(k), base_metadata_size, &estimate)) {
+        estimate = INT64_MAX;
+    }
+    return estimate;
+}
+
 bool acquire_publish_tablet(int64_t tablet_id) {
     auto [_, ok] = tablet_txns.insert(tablet_id);
     return ok;
@@ -280,9 +293,10 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
                                             int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata, int64_t fe_built_version,
                                             InitialMetadataOrder base_version_order) {
-    // P3: coarse process-memory backstop, placed before EVERY branch (including the early
-    // empty-txnlog/reshard path below, which returns before acquire_publish_tablet). Gated on a dedicated
-    // mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
+    // P3: coarse process-memory backstop, placed before EVERY branch. Both the early
+    // empty-txnlog/reshard version-bump path below and the main path additionally take the per-tracker
+    // reservation before copying metadata; this backstop is the last-resort net on top of that. Gated on a
+    // dedicated mutable knob (0 disables it); uses the "urgent" level so it only trips near genuine OOM.
     {
         int32_t urgent_pct = std::max(0, std::min(100, config::lake_publish_process_memory_urgent_pct));
         if (urgent_pct > 0 && RuntimeEnv::GetInstance()->process_mem_tracker()->limit_exceeded_by_ratio(urgent_pct)) {
@@ -299,6 +313,17 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
         ASSIGN_OR_RETURN(auto metadata, tablet_mgr->get_tablet_metadata(
                                                 tablet_info.get_tablet_id_in_metadata(), base_version, CacheOptions{},
                                                 /*expected_gtid=*/0, /*fs=*/nullptr, base_version_order));
+
+        // P3: this version-bump path still deep-copies and serializes the full base metadata just
+        // like the main path, so gate it through the same per-tracker reservation. The coarse process backstop
+        // at function entry alone does not bound the sum of concurrent copies below the urgent threshold.
+        int64_t empty_publish_estimate = compute_lake_publish_estimate(metadata->SpaceUsedLong());
+        PublishMemReservation empty_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
+                                                 empty_publish_estimate, g_lake_publish_oversized_inflight);
+        if (!empty_publish_resv.admitted()) {
+            g_lake_publish_mem_rejected << 1;
+            return Status::ResourceBusy("publish throttled: lake publish memory limit");
+        }
 
         auto new_metadata = std::make_shared<TabletMetadataPB>(*metadata);
         new_metadata->set_version(new_version);
@@ -415,14 +440,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     // Race-free oversized handling (bounded to concurrency 1, without charging the shared tracker) lives in
     // the RAII class. base_metadata->SpaceUsedLong() here is dominated by the deep copy the apply path performs
     // shortly after, so it adds no new latency class to the hot path.
-    // Clamp k to a sane range so a bad mutable config cannot silently disable the gate (k<=0 -> estimate 0,
-    // fail-open); saturate the product so an absurd k fails CLOSED (reject/retry), never overflows negative.
-    int32_t lake_publish_k = std::max(1, std::min(64, config::lake_publish_metadata_estimate_multiplier));
-    int64_t lake_publish_estimate;
-    if (__builtin_mul_overflow(int64_t(lake_publish_k), int64_t(base_metadata->SpaceUsedLong()),
-                               &lake_publish_estimate)) {
-        lake_publish_estimate = INT64_MAX;
-    }
+    int64_t lake_publish_estimate = compute_lake_publish_estimate(base_metadata->SpaceUsedLong());
     PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
                                             lake_publish_estimate, g_lake_publish_oversized_inflight);
     if (!lake_publish_resv.admitted()) {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -320,7 +320,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
         int64_t empty_publish_estimate = compute_lake_publish_estimate(metadata->SpaceUsedLong());
         PublishMemReservation empty_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
                                                  empty_publish_estimate, g_lake_publish_oversized_inflight,
-                                                 RuntimeEnv::GetInstance()->process_mem_tracker());
+                                                 RuntimeEnv::GetInstance()->process_mem_tracker(),
+                                                 config::lake_publish_process_memory_urgent_pct);
         if (!empty_publish_resv.admitted()) {
             g_lake_publish_mem_rejected << 1;
             return Status::ResourceBusy("publish throttled: lake publish memory limit");
@@ -444,7 +445,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     int64_t lake_publish_estimate = compute_lake_publish_estimate(base_metadata->SpaceUsedLong());
     PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
                                             lake_publish_estimate, g_lake_publish_oversized_inflight,
-                                            RuntimeEnv::GetInstance()->process_mem_tracker());
+                                            RuntimeEnv::GetInstance()->process_mem_tracker(),
+                                            config::lake_publish_process_memory_urgent_pct);
     if (!lake_publish_resv.admitted()) {
         g_lake_publish_mem_rejected << 1;
         return Status::ResourceBusy("publish throttled: lake publish memory limit");

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -319,7 +319,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
         // at function entry alone does not bound the sum of concurrent copies below the urgent threshold.
         int64_t empty_publish_estimate = compute_lake_publish_estimate(metadata->SpaceUsedLong());
         PublishMemReservation empty_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
-                                                 empty_publish_estimate, g_lake_publish_oversized_inflight);
+                                                 empty_publish_estimate, g_lake_publish_oversized_inflight,
+                                                 RuntimeEnv::GetInstance()->process_mem_tracker());
         if (!empty_publish_resv.admitted()) {
             g_lake_publish_mem_rejected << 1;
             return Status::ResourceBusy("publish throttled: lake publish memory limit");
@@ -442,7 +443,8 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     // shortly after, so it adds no new latency class to the hot path.
     int64_t lake_publish_estimate = compute_lake_publish_estimate(base_metadata->SpaceUsedLong());
     PublishMemReservation lake_publish_resv(RuntimeEnv::GetInstance()->lake_publish_mem_tracker(),
-                                            lake_publish_estimate, g_lake_publish_oversized_inflight);
+                                            lake_publish_estimate, g_lake_publish_oversized_inflight,
+                                            RuntimeEnv::GetInstance()->process_mem_tracker());
     if (!lake_publish_resv.admitted()) {
         g_lake_publish_mem_rejected << 1;
         return Status::ResourceBusy("publish throttled: lake publish memory limit");

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -285,6 +285,7 @@ SET(DW_TEST_FILES
     ./storage/lake/persistent_index_sstable_test.cpp
     ./storage/lake/primary_key_compaction_task_test.cpp
     ./storage/lake/primary_key_publish_test.cpp
+    ./storage/lake/publish_mem_reservation_test.cpp
     ./storage/lake/tablet_reshard_helper_test.cpp
     ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/tablet_splitter_test.cpp

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -294,6 +294,7 @@ SET(DW_TEST_FILES
     ./storage/lake/primary_key_compaction_task_test.cpp
     ./storage/lake/primary_key_publish_test.cpp
     ./storage/lake/lake_merged_del_op_offset_test.cpp
+    ./storage/lake/publish_mem_reservation_test.cpp
     ./storage/lake/tablet_reshard_helper_test.cpp
     ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/tablet_splitter_test.cpp

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -38,6 +38,8 @@
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/del_vector.h"
 #include "storage/lake/compaction_policy.h"
@@ -355,6 +357,56 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_seg_delvecs_empty_entry) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
     // No masking, no crash: all rows visible.
     EXPECT_EQ(k0.size(), read_rows(_tablet_metadata->id(), 2));
+}
+
+// P3 (SR-38350): end-to-end proof that the publish-path memory gate returns a retryable ResourceBusy
+// under memory pressure, and that a retry succeeds once the budget frees -- mirroring FE's indefinite
+// publish retry. No 221MB metadata needed: we make the estimate vs the (settable) tracker limit collide.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_mem_gate_rejects_then_recovers) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+    auto tablet_id = _tablet_metadata->id();
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    auto* tracker = RuntimeEnv::GetInstance()->lake_publish_mem_tracker();
+    ASSERT_NE(tracker, nullptr);
+    const int64_t saved_limit = tracker->limit();
+
+    // Pick a limit far larger than a tiny tablet's estimate (k * SpaceUsedLong) so the publish takes the
+    // NORMAL reservation path, then fill the tracker so that path is rejected (not the oversized-slot path).
+    const int64_t kLimit = 256L * 1024 * 1024; // 256MB >> estimate of this small tablet
+    tracker->set_limit(kLimit);
+    tracker->consume(kLimit); // occupy the whole budget
+
+    // NOTE: TEST_publish_single_version wraps any non-ok result into Status::InternalError (test helper
+    // convenience), so we assert the publish was throttled by inspecting the (preserved) message rather
+    // than the code. The production RPC path preserves the real ResourceBusy code to FE
+    // (lake_service.cpp: res.status().is_resource_busy() -> to_protobuf), which the RAII unit test covers.
+    auto rejected = publish_single_version(tablet_id, 2, txn_id).status();
+    EXPECT_FALSE(rejected.ok()) << "expected publish to be throttled, but it succeeded";
+    EXPECT_NE(std::string::npos, rejected.to_string().find("publish throttled: lake publish memory limit"))
+            << "expected the lake publish memory-gate rejection, got: " << rejected;
+
+    tracker->release(kLimit); // free the budget, as an in-flight publish finishing would
+    // Retry succeeds once memory is available again (mirrors FE's indefinite publish retry).
+    EXPECT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+
+    tracker->set_limit(saved_limit); // restore for subsequent tests
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -43,6 +43,8 @@
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "platform/key_cache.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/datum_variant.h"
 #include "storage/del_vector.h"
@@ -641,6 +643,56 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_seg_delvecs_empty_entry) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
     // No masking, no crash: all rows visible.
     EXPECT_EQ(k0.size(), read_rows(_tablet_metadata->id(), 2));
+}
+
+// P3: end-to-end proof that the publish-path memory gate returns a retryable ResourceBusy
+// under memory pressure, and that a retry succeeds once the budget frees -- mirroring FE's indefinite
+// publish retry. No 221MB metadata needed: we make the estimate vs the (settable) tracker limit collide.
+TEST_P(LakePrimaryKeyPublishTest, test_publish_mem_gate_rejects_then_recovers) {
+    if (GetParam().enable_transparent_data_encryption) {
+        return;
+    }
+    auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true, true);
+    auto tablet_id = _tablet_metadata->id();
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .set_profile(&_dummy_runtime_profile)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+
+    auto* tracker = RuntimeEnv::GetInstance()->lake_publish_mem_tracker();
+    ASSERT_NE(tracker, nullptr);
+    const int64_t saved_limit = tracker->limit();
+
+    // Pick a limit far larger than a tiny tablet's estimate (k * SpaceUsedLong) so the publish takes the
+    // NORMAL reservation path, then fill the tracker so that path is rejected (not the oversized-slot path).
+    const int64_t kLimit = 256L * 1024 * 1024; // 256MB >> estimate of this small tablet
+    tracker->set_limit(kLimit);
+    tracker->consume(kLimit); // occupy the whole budget
+
+    // NOTE: TEST_publish_single_version wraps any non-ok result into Status::InternalError (test helper
+    // convenience), so we assert the publish was throttled by inspecting the (preserved) message rather
+    // than the code. The production RPC path preserves the real ResourceBusy code to FE
+    // (lake_service.cpp: res.status().is_resource_busy() -> to_protobuf), which the RAII unit test covers.
+    auto rejected = publish_single_version(tablet_id, 2, txn_id).status();
+    EXPECT_FALSE(rejected.ok()) << "expected publish to be throttled, but it succeeded";
+    EXPECT_NE(std::string::npos, rejected.to_string().find("publish throttled: lake publish memory limit"))
+            << "expected the lake publish memory-gate rejection, got: " << rejected;
+
+    tracker->release(kLimit); // free the budget, as an in-flight publish finishing would
+    // Retry succeeds once memory is available again (mirrors FE's indefinite publish retry).
+    EXPECT_OK(publish_single_version(tablet_id, 2, txn_id).status());
+
+    tracker->set_limit(saved_limit); // restore for subsequent tests
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {

--- a/be/test/storage/lake/publish_mem_reservation_test.cpp
+++ b/be/test/storage/lake/publish_mem_reservation_test.cpp
@@ -1,0 +1,205 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/publish_mem_reservation.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "runtime/mem_tracker.h"
+
+namespace starrocks::lake {
+
+static constexpr int64_t KB = 1024;
+
+// --- Normal path: admit below limit, charge exactly, release on scope exit ----------------------
+TEST(PublishMemReservationTest, NormalBelowLimit) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation r(&t, 300 * KB, slot);
+        EXPECT_TRUE(r.admitted());
+        EXPECT_EQ(300 * KB, t.consumption());
+        EXPECT_EQ(300 * KB, r.consumed_bytes());
+    }
+    EXPECT_EQ(0, t.consumption()); // symmetric release
+}
+
+// --- Normal path: exactly at the limit is allowed (consumption+estimate == limit) ---------------
+TEST(PublishMemReservationTest, NormalAtLimitBoundary) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation r(&t, 1000 * KB, slot);
+        EXPECT_TRUE(r.admitted());
+        EXPECT_EQ(1000 * KB, t.consumption());
+    }
+    EXPECT_EQ(0, t.consumption());
+}
+
+// --- Normal path: reject when it would exceed the limit; charge/release nothing -----------------
+TEST(PublishMemReservationTest, NormalRejectedUnderContention) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    PublishMemReservation held(&t, 800 * KB, slot);
+    ASSERT_TRUE(held.admitted());
+    ASSERT_EQ(800 * KB, t.consumption());
+    {
+        PublishMemReservation r(&t, 300 * KB, slot); // 800 + 300 > 1000
+        EXPECT_FALSE(r.admitted());
+        EXPECT_EQ(0, r.consumed_bytes());
+        EXPECT_EQ(800 * KB, t.consumption()); // rejected attempt changed nothing
+    }
+    EXPECT_EQ(800 * KB, t.consumption()); // rejected dtor released nothing
+}
+
+// --- Kill switch (limit == -1, pct==0): always admit; consume for observability ----------------
+TEST(PublishMemReservationTest, KillSwitchUnlimited) {
+    MemTracker t(-1, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    const int64_t huge = 5LL * 1024 * 1024 * KB; // 5 GB
+    {
+        PublishMemReservation r(&t, huge, slot);
+        EXPECT_TRUE(r.admitted());
+        EXPECT_EQ(huge, t.consumption()); // observability on the -1 tracker
+    }
+    EXPECT_EQ(0, t.consumption());
+}
+
+// --- Pathological limit == 0: admit (gate disabled), never inflate negative --------------------
+TEST(PublishMemReservationTest, PathologicalZeroLimitNoNegative) {
+    MemTracker t(0, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation r(&t, 500 * KB, slot);
+        EXPECT_TRUE(r.admitted());
+        EXPECT_EQ(0, r.consumed_bytes()); // try_consume no-ops at limit 0
+        EXPECT_EQ(0, t.consumption());
+    }
+    EXPECT_EQ(0, t.consumption()); // no negative inflation
+}
+
+// --- Oversized single-slot lifecycle: admit one, reject a 2nd, re-admit after release ----------
+TEST(PublishMemReservationTest, OversizedSingleSlotLifecycle) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation big1(&t, 5000 * KB, slot); // estimate > limit
+        EXPECT_TRUE(big1.admitted());
+        EXPECT_TRUE(big1.holds_oversized_slot());
+        EXPECT_EQ(0, t.consumption()); // oversized does NOT charge the shared tracker
+        EXPECT_TRUE(slot.load());
+        {
+            PublishMemReservation big2(&t, 6000 * KB, slot);
+            EXPECT_FALSE(big2.admitted());
+            EXPECT_FALSE(big2.holds_oversized_slot());
+        }
+        EXPECT_TRUE(slot.load()); // loser did not clear the winner's slot (N2)
+        {
+            PublishMemReservation norm(&t, 400 * KB, slot);
+            EXPECT_TRUE(norm.admitted()); // normal traffic flows alongside an oversized
+            EXPECT_EQ(400 * KB, t.consumption());
+        }
+    }
+    EXPECT_FALSE(slot.load()); // slot freed after the winner destructs
+    EXPECT_EQ(0, t.consumption());
+    {
+        PublishMemReservation big3(&t, 5000 * KB, slot);
+        EXPECT_TRUE(big3.admitted()); // a later oversized can proceed (no permanent wedge)
+    }
+}
+
+// --- Oversized under heavy concurrency: at most ONE admitted at a time (the TOCTOU race) -------
+TEST(PublishMemReservationTest, OversizedConcurrencyRaceFree) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    std::atomic<int> live{0};
+    std::atomic<int> max_live{0};
+    std::atomic<long> total_ok{0};
+    std::atomic<bool> go{false};
+    const int kThreads = 64, kRounds = 2000;
+
+    std::vector<std::thread> ths;
+    for (int i = 0; i < kThreads; ++i) {
+        ths.emplace_back([&] {
+            while (!go.load(std::memory_order_acquire)) {
+            }
+            for (int r = 0; r < kRounds; ++r) {
+                PublishMemReservation resv(&t, 9999 * KB, slot); // always oversized
+                if (resv.admitted()) {
+                    int n = live.fetch_add(1) + 1;
+                    int prev = max_live.load();
+                    while (n > prev && !max_live.compare_exchange_weak(prev, n)) {
+                    }
+                    std::this_thread::yield();
+                    total_ok.fetch_add(1);
+                    live.fetch_sub(1);
+                }
+            }
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& th : ths) th.join();
+
+    EXPECT_EQ(1, max_live.load()); // never two oversized admitted at once
+    EXPECT_GT(total_ok.load(), 0); // some got through (not starved)
+    EXPECT_FALSE(slot.load());     // no slot leak
+    EXPECT_EQ(0, t.consumption()); // oversized never touched the shared tracker
+}
+
+// --- Normal-path concurrency: atomic reserve never overshoots the limit ------------------------
+TEST(PublishMemReservationTest, NormalConcurrencyNeverOvershoots) {
+    const int64_t limit = 100 * KB;
+    MemTracker t(limit, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    std::atomic<int64_t> peak{0};
+    std::atomic<bool> go{false};
+    const int kThreads = 32, kRounds = 5000;
+
+    std::vector<std::thread> ths;
+    for (int i = 0; i < kThreads; ++i) {
+        ths.emplace_back([&] {
+            while (!go.load(std::memory_order_acquire)) {
+            }
+            for (int r = 0; r < kRounds; ++r) {
+                PublishMemReservation resv(&t, 30 * KB, slot);
+                if (resv.admitted()) {
+                    int64_t c = t.consumption();
+                    int64_t p = peak.load();
+                    while (c > p && !peak.compare_exchange_weak(p, c)) {
+                    }
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& th : ths) th.join();
+
+    EXPECT_LE(peak.load(), limit); // never exceeded the limit under contention
+    EXPECT_EQ(0, t.consumption()); // symmetric under load
+}
+
+// --- nullptr tracker (gate not wired): admit, touch nothing ------------------------------------
+TEST(PublishMemReservationTest, NullTrackerAlwaysAdmits) {
+    std::atomic<bool> slot{false};
+    PublishMemReservation r(nullptr, 500 * KB, slot);
+    EXPECT_TRUE(r.admitted());
+    EXPECT_EQ(0, r.consumed_bytes());
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/publish_mem_reservation_test.cpp
+++ b/be/test/storage/lake/publish_mem_reservation_test.cpp
@@ -123,6 +123,61 @@ TEST(PublishMemReservationTest, OversizedSingleSlotLifecycle) {
     }
 }
 
+// --- Oversized requires PROCESS headroom, not just a free slot -----------------------------------
+// The slot bounds how MANY oversized publishes run (one), not how BIG they are, and this route charges
+// nothing. Without a headroom test an oversized publish is admitted while the process is already close
+// to its limit and can push it over, which is the failure the gate exists to prevent.
+TEST(PublishMemReservationTest, OversizedRejectedWithoutProcessHeadroom) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    MemTracker proc(10000 * KB, "p3-test-process", nullptr);
+    std::atomic<bool> slot{false};
+
+    // Process is at 9500 of 10000 KB, so only 500 KB of headroom is left.
+    proc.consume(9500 * KB);
+    {
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc); // oversized, and 5000 > 500 headroom
+        EXPECT_FALSE(big.admitted());
+        EXPECT_FALSE(big.holds_oversized_slot());
+    }
+    EXPECT_FALSE(slot.load()); // a rejected oversized must not take (or leak) the slot
+    EXPECT_EQ(0, t.consumption());
+
+    // Free the process memory: the same publish is now admissible, so this is retryable backpressure
+    // rather than the permanent wedge the oversized route exists to avoid.
+    proc.release(9500 * KB);
+    {
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc);
+        EXPECT_TRUE(big.admitted());
+        EXPECT_TRUE(big.holds_oversized_slot());
+        EXPECT_EQ(0, t.consumption()); // still does not charge the shared tracker
+    }
+    EXPECT_FALSE(slot.load());
+}
+
+// A null process tracker keeps the previous behavior, so callers that do not pass one are unaffected.
+TEST(PublishMemReservationTest, OversizedWithoutProcessTrackerAdmits) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation big(&t, 5000 * KB, slot); // no process tracker supplied
+        EXPECT_TRUE(big.admitted());
+        EXPECT_TRUE(big.holds_oversized_slot());
+    }
+    EXPECT_FALSE(slot.load());
+}
+
+// An unlimited process tracker (limit <= 0) must not be read as "zero headroom".
+TEST(PublishMemReservationTest, OversizedWithUnlimitedProcessTrackerAdmits) {
+    MemTracker t(1000 * KB, "p3-test", nullptr);
+    MemTracker proc(-1, "p3-test-process-unlimited", nullptr);
+    std::atomic<bool> slot{false};
+    {
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc);
+        EXPECT_TRUE(big.admitted());
+    }
+    EXPECT_FALSE(slot.load());
+}
+
 // --- Oversized under heavy concurrency: at most ONE admitted at a time (the TOCTOU race) -------
 TEST(PublishMemReservationTest, OversizedConcurrencyRaceFree) {
     MemTracker t(1000 * KB, "p3-test", nullptr);

--- a/be/test/storage/lake/publish_mem_reservation_test.cpp
+++ b/be/test/storage/lake/publish_mem_reservation_test.cpp
@@ -314,6 +314,41 @@ TEST(PublishMemReservationTest, OutOfRangeUrgentPctIsClamped) {
     proc.release(9900 * KB);
 }
 
+// --- Zero and negative estimates: admit, reserve nothing, stay symmetric -----------------------
+// A publish whose estimated footprint rounds to nothing must never be gated, and must never charge the
+// tracker, so the destructor has nothing to release. A negative estimate is clamped rather than passed
+// through, because release(-N) against a bounded tracker would silently inflate the budget.
+TEST(PublishMemReservationTest, ZeroAndNegativeEstimateAdmitWithoutReserving) {
+    MemTracker t(100 * KB, "p3-test", nullptr);
+    std::atomic<bool> slot{false};
+
+    {
+        PublishMemReservation zero(&t, 0, slot);
+        EXPECT_TRUE(zero.admitted());
+        EXPECT_EQ(0, zero.consumed_bytes());
+        EXPECT_EQ(0, t.consumption()); // nothing charged while still in scope
+    }
+    EXPECT_EQ(0, t.consumption());
+    EXPECT_FALSE(slot.load()); // the zero route never reaches the oversized slot
+
+    {
+        // Clamped to 0, so it behaves exactly like the zero case rather than releasing a negative.
+        PublishMemReservation negative(&t, -1 * KB, slot);
+        EXPECT_TRUE(negative.admitted());
+        EXPECT_EQ(0, negative.consumed_bytes());
+    }
+    EXPECT_EQ(0, t.consumption());
+    EXPECT_FALSE(slot.load());
+
+    // A negative estimate must not have inflated the budget: a normal publish still fits and still charges.
+    {
+        PublishMemReservation normal(&t, 40 * KB, slot);
+        EXPECT_TRUE(normal.admitted());
+        EXPECT_EQ(40 * KB, normal.consumed_bytes());
+    }
+    EXPECT_EQ(0, t.consumption());
+}
+
 // --- nullptr tracker (gate not wired): admit, touch nothing ------------------------------------
 TEST(PublishMemReservationTest, NullTrackerAlwaysAdmits) {
     std::atomic<bool> slot{false};

--- a/be/test/storage/lake/publish_mem_reservation_test.cpp
+++ b/be/test/storage/lake/publish_mem_reservation_test.cpp
@@ -135,7 +135,7 @@ TEST(PublishMemReservationTest, OversizedRejectedWithoutProcessHeadroom) {
     // Process is at 9500 of 10000 KB, so only 500 KB of headroom is left.
     proc.consume(9500 * KB);
     {
-        PublishMemReservation big(&t, 5000 * KB, slot, &proc); // oversized, and 5000 > 500 headroom
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc, 100); // oversized, and 5000 > 500 headroom
         EXPECT_FALSE(big.admitted());
         EXPECT_FALSE(big.holds_oversized_slot());
     }
@@ -146,7 +146,7 @@ TEST(PublishMemReservationTest, OversizedRejectedWithoutProcessHeadroom) {
     // rather than the permanent wedge the oversized route exists to avoid.
     proc.release(9500 * KB);
     {
-        PublishMemReservation big(&t, 5000 * KB, slot, &proc);
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc, 100);
         EXPECT_TRUE(big.admitted());
         EXPECT_TRUE(big.holds_oversized_slot());
         EXPECT_EQ(0, t.consumption()); // still does not charge the shared tracker
@@ -247,6 +247,71 @@ TEST(PublishMemReservationTest, NormalConcurrencyNeverOvershoots) {
 
     EXPECT_LE(peak.load(), limit); // never exceeded the limit under contention
     EXPECT_EQ(0, t.consumption()); // symmetric under load
+}
+
+// --- The NORMAL route needs process headroom too --------------------------------------------------
+// The lake tracker is off-tree, so fitting inside it says nothing about process pressure. A node that is
+// already near the urgent line can otherwise admit a normal publish purely because the lake budget is
+// mostly empty, and then allocate past the process limit.
+TEST(PublishMemReservationTest, NormalRejectedWithoutProcessHeadroom) {
+    MemTracker t(3000 * KB, "p3-test", nullptr);
+    MemTracker proc(10000 * KB, "p3-test-process", nullptr);
+    std::atomic<bool> slot{false};
+
+    // 8400 of 10000 KB used, so the node sits just under an 85 percent urgent line and the entry
+    // backstop does not trip. The lake tracker is completely empty.
+    proc.consume(8400 * KB);
+    {
+        // Not oversized (2000 < 3000 limit) and it fits the empty lake budget, but 8400 + 2000 is well
+        // past 85 percent of the process, so it must be rejected.
+        PublishMemReservation normal(&t, 2000 * KB, slot, &proc, 85);
+        EXPECT_FALSE(normal.admitted());
+        EXPECT_EQ(0, normal.consumed_bytes());
+    }
+    EXPECT_EQ(0, t.consumption()); // a rejected normal publish charges nothing
+    EXPECT_FALSE(slot.load());     // and never touches the oversized slot
+
+    // A small enough publish still fits under the line, so this is backpressure and not a wedge.
+    {
+        PublishMemReservation small(&t, 50 * KB, slot, &proc, 85);
+        EXPECT_TRUE(small.admitted());
+        EXPECT_EQ(50 * KB, small.consumed_bytes());
+    }
+    EXPECT_EQ(0, t.consumption()); // released on scope exit
+    proc.release(8400 * KB);
+}
+
+// The percent is the check's kill switch. At 0 the headroom test is skipped entirely on both routes,
+// so an operator can turn it off live without a restart.
+TEST(PublishMemReservationTest, ZeroUrgentPctDisablesHeadroomCheck) {
+    MemTracker t(3000 * KB, "p3-test", nullptr);
+    MemTracker proc(10000 * KB, "p3-test-process", nullptr);
+    std::atomic<bool> slot{false};
+    proc.consume(9900 * KB); // essentially no headroom left
+
+    {
+        PublishMemReservation normal(&t, 2000 * KB, slot, &proc, 0);
+        EXPECT_TRUE(normal.admitted()); // check disabled, admitted on lake budget alone
+    }
+    {
+        PublishMemReservation big(&t, 5000 * KB, slot, &proc, 0);
+        EXPECT_TRUE(big.admitted()); // oversized route likewise unchecked
+        EXPECT_TRUE(big.holds_oversized_slot());
+    }
+    EXPECT_FALSE(slot.load());
+    proc.release(9900 * KB);
+}
+
+// A percent above 100 must not lift the ceiling above the process limit and quietly disable the check.
+TEST(PublishMemReservationTest, OutOfRangeUrgentPctIsClamped) {
+    MemTracker t(3000 * KB, "p3-test", nullptr);
+    MemTracker proc(10000 * KB, "p3-test-process", nullptr);
+    std::atomic<bool> slot{false};
+    proc.consume(9900 * KB);
+
+    PublishMemReservation normal(&t, 2000 * KB, slot, &proc, 500);
+    EXPECT_FALSE(normal.admitted()); // clamped to 100, so 9900 + 2000 still exceeds the limit
+    proc.release(9900 * KB);
 }
 
 // --- nullptr tracker (gate not wired): admit, touch nothing ------------------------------------

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -239,6 +239,32 @@ This topic introduces the following types of BE configurations:
 - Description: The upper bound on `splitted_scan_rows` (the number of rows scanned per split morsel) applied only when the Prepared Physical Split Lake Scan is enabled (see the session variable `enable_lake_prepared_physical_split_scan`). The effective bound is `min(tablet_internal_parallel_max_splitted_scan_rows, this)`, so it can only make split morsels finer -- cutting a large tablet into more sub-range morsels that fill otherwise-idle drivers -- never coarser. Takes effect only in a shared-data cluster.
 - Introduced in: v4.2
 
+### lake_publish_memory_limit_percent
+
+- Default: 30
+- Type: Int
+- Unit: %
+- Is mutable: No
+- Description: In a shared-data cluster, the percentage of the BE/CN process memory limit that the lake publish-path memory reservation tracker may hold. During publish, StarRocks deep-copies, normalizes, and serializes tablet metadata; this tracker bounds that transient footprint so that bloated metadata under high publish concurrency cannot drive the process into an out-of-memory condition. A publish whose estimated footprint would exceed the remaining budget is rejected with a retryable `ResourceBusy` status, which the FE retries. Clamped to the range [0, 100]. The value `0` disables the per-tracker gate (an unlimited tracker is registered) and serves as the rollback switch for this behavior. Immutable, because the tracker's byte limit is computed once at BE startup.
+- Introduced in: -
+
+### lake_publish_metadata_estimate_multiplier
+
+- Default: 3
+- Type: Int
+- Is mutable: Yes
+- Description: In a shared-data cluster, the multiplier `k` used to estimate a publish's transient metadata footprint as `k * base_tablet_metadata_size`. The publish path holds roughly three concurrent copies of the metadata (the mutated working copy, the normalization copy, and the serialized buffer), so the default is `3`. This estimate is what the publish path reserves against the tracker controlled by `lake_publish_memory_limit_percent`. It is read on every publish, so it can be tuned at runtime.
+- Introduced in: -
+
+### lake_publish_process_memory_urgent_pct
+
+- Default: 85
+- Type: Int
+- Unit: %
+- Is mutable: Yes
+- Description: In a shared-data cluster, the process-memory backstop for the lake publish path. When process memory consumption exceeds this percentage of the process memory limit, both single and aggregate publish tasks are rejected with a retryable `ResourceBusy` status until memory drops, preventing publish from pushing a node into an out-of-memory condition. This is a dedicated knob, independent of `memory_urgent_level` (which also drives persistent-index flush and Data Cache shrink), so it can be tuned during an incident without affecting those subsystems. The value `0` disables the backstop. It is read on every publish, so it can be tuned at runtime.
+- Introduced in: -
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - Default: -1

--- a/docs/en/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/BE_parameters/shared_lake_other.md
@@ -185,6 +185,32 @@ This topic introduces the following types of BE configurations:
 - Description: The upper bound on `splitted_scan_rows` (the number of rows scanned per split morsel) applied only when the prepared-physical-split lake scan is enabled (see the session variable `enable_lake_prepared_physical_split_scan`). The effective bound is `min(tablet_internal_parallel_max_splitted_scan_rows, this)`, so it can only make split morsels finer -- cutting a large tablet into more sub-range morsels that fill otherwise-idle drivers -- never coarser. Takes effect only in a shared-data cluster.
 - Introduced in: v4.2
 
+### lake_publish_memory_limit_percent
+
+- Default: 30
+- Type: Int
+- Unit: %
+- Is mutable: No
+- Description: In a shared-data cluster, the percentage of the BE/CN process memory limit that the lake publish-path memory reservation tracker may hold. During publish, StarRocks deep-copies, normalizes, and serializes tablet metadata; this tracker bounds that transient footprint so that bloated metadata under high publish concurrency cannot drive the process into an out-of-memory condition. A publish whose estimated footprint would exceed the remaining budget is rejected with a retryable `ResourceBusy` status, which the FE retries. Clamped to the range [0, 100]. The value `0` disables the per-tracker gate (an unlimited tracker is registered) and serves as the rollback switch for this behavior. Immutable, because the tracker's byte limit is computed once at BE startup.
+- Introduced in: -
+
+### lake_publish_metadata_estimate_multiplier
+
+- Default: 3
+- Type: Int
+- Is mutable: Yes
+- Description: In a shared-data cluster, the multiplier `k` used to estimate a publish's transient metadata footprint as `k * base_tablet_metadata_size`. The publish path holds roughly three concurrent copies of the metadata (the mutated working copy, the normalization copy, and the serialized buffer), so the default is `3`. This estimate is what the publish path reserves against the tracker controlled by `lake_publish_memory_limit_percent`. It is read on every publish, so it can be tuned at runtime.
+- Introduced in: -
+
+### lake_publish_process_memory_urgent_pct
+
+- Default: 85
+- Type: Int
+- Unit: %
+- Is mutable: Yes
+- Description: In a shared-data cluster, the process-memory backstop for the lake publish path. When process memory consumption exceeds this percentage of the process memory limit, both single and aggregate publish tasks are rejected with a retryable `ResourceBusy` status until memory drops, preventing publish from pushing a node into an out-of-memory condition. This is a dedicated knob, independent of `memory_urgent_level` (which also drives persistent-index flush and Data Cache shrink), so it can be tuned during an incident without affecting those subsystems. The value `0` disables the backstop. It is read on every publish, so it can be tuned at runtime.
+- Introduced in: -
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - Default: -1

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -239,6 +239,32 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: Prepared Physical Split Lake スキャンが有効な場合（セッション変数 `enable_lake_prepared_physical_split_scan` を参照）にのみ適用される `splitted_scan_rows`（Split Morsel ごとにスキャンされる行数）の上限。実際の上限は `min(tablet_internal_parallel_max_splitted_scan_rows, 本パラメータ)` であるため、Split Morsel をより細かく（大きなタブレットを、アイドル状態のドライバーを埋めるより多くのサブレンジ morsel に分割）することしかできず、粗くすることはありません。共有データクラスタでのみ有効です。
 - 導入バージョン: v4.2
 
+### lake_publish_memory_limit_percent
+
+- デフォルト: 30
+- タイプ: Int
+- 単位: %
+- 変更可能: いいえ
+- 説明: 共有データクラスタで、Lake の publish パスのメモリ予約トラッカーが保持できるプロセスメモリ上限の割合（パーセント）。publish 中、StarRocks はタブレットメタデータのディープコピー、正規化、シリアライズを行います。このトラッカーはその一時的なメモリ使用量を制限し、メタデータが肥大化し publish の並行度が高い場合でもプロセスが OOM に陥らないようにします。推定使用量が残りの割当を超える publish は、再試行可能な `ResourceBusy` ステータスで拒否され、FE が再試行します。値は [0, 100] の範囲に丸められます。値 `0` はこのトラッカーによる制限を無効化し（無制限トラッカーとして登録）、この動作のロールバックスイッチとして機能します。トラッカーのバイト上限は BE 起動時に一度だけ計算されるため、変更不可です。
+- 導入バージョン: -
+
+### lake_publish_metadata_estimate_multiplier
+
+- デフォルト: 3
+- タイプ: Int
+- 変更可能: はい
+- 説明: 共有データクラスタで、publish の一時的なメタデータ使用量を `k * base_tablet_metadata_size` として推定するための乗数 `k`。publish パスはメタデータのコピーをおよそ 3 つ同時に保持する（変更後の作業コピー、正規化コピー、シリアライズバッファ）ため、デフォルトは `3` です。この推定値が、`lake_publish_memory_limit_percent` で制御されるトラッカーに対して publish パスが予約するサイズになります。publish のたびに読み取られるため、実行時に調整できます。
+- 導入バージョン: -
+
+### lake_publish_process_memory_urgent_pct
+
+- デフォルト: 85
+- タイプ: Int
+- 単位: %
+- 変更可能: はい
+- 説明: 共有データクラスタで、Lake publish パスのプロセスメモリのバックストップしきい値。プロセスメモリ使用量がプロセスメモリ上限のこの割合を超えると、単一 publish と集約（aggregate）publish の両方のタスクが、メモリが低下するまで再試行可能な `ResourceBusy` ステータスで拒否され、publish がノードを OOM に追い込むのを防ぎます。これは `memory_urgent_level`（永続インデックスのフラッシュや Data Cache の縮小も駆動する）とは独立した専用のパラメータであり、それらのサブシステムに影響を与えずにインシデント時に調整できます。値 `0` はこのバックストップを無効化します。publish のたびに読み取られるため、実行時に調整できます。
+- 導入バージョン: -
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - デフォルト: -1

--- a/docs/ja/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/BE_parameters/shared_lake_other.md
@@ -185,6 +185,32 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: prepared-physical-split lake スキャンが有効な場合（セッション変数 `enable_lake_prepared_physical_split_scan` を参照）にのみ適用される `splitted_scan_rows`（split morsel ごとにスキャンされる行数）の上限。実際の上限は `min(tablet_internal_parallel_max_splitted_scan_rows, 本パラメータ)` であるため、split morsel をより細かく（大きなタブレットを、アイドル状態のドライバーを埋めるより多くのサブレンジ morsel に分割）することしかできず、粗くすることはありません。共有データクラスタでのみ有効です。
 - 導入バージョン: v4.2
 
+### lake_publish_memory_limit_percent
+
+- デフォルト: 30
+- タイプ: Int
+- 単位: %
+- 変更可能: いいえ
+- 説明: 共有データクラスタで、Lake の publish パスのメモリ予約トラッカーが保持できるプロセスメモリ上限の割合（パーセント）。publish 中、StarRocks はタブレットメタデータのディープコピー、正規化、シリアライズを行います。このトラッカーはその一時的なメモリ使用量を制限し、メタデータが肥大化し publish の並行度が高い場合でもプロセスが OOM に陥らないようにします。推定使用量が残りの割当を超える publish は、再試行可能な `ResourceBusy` ステータスで拒否され、FE が再試行します。値は [0, 100] の範囲に丸められます。値 `0` はこのトラッカーによる制限を無効化し（無制限トラッカーとして登録）、この動作のロールバックスイッチとして機能します。トラッカーのバイト上限は BE 起動時に一度だけ計算されるため、変更不可です。
+- 導入バージョン: -
+
+### lake_publish_metadata_estimate_multiplier
+
+- デフォルト: 3
+- タイプ: Int
+- 変更可能: はい
+- 説明: 共有データクラスタで、publish の一時的なメタデータ使用量を `k * base_tablet_metadata_size` として推定するための乗数 `k`。publish パスはメタデータのコピーをおよそ 3 つ同時に保持する（変更後の作業コピー、正規化コピー、シリアライズバッファ）ため、デフォルトは `3` です。この推定値が、`lake_publish_memory_limit_percent` で制御されるトラッカーに対して publish パスが予約するサイズになります。publish のたびに読み取られるため、実行時に調整できます。
+- 導入バージョン: -
+
+### lake_publish_process_memory_urgent_pct
+
+- デフォルト: 85
+- タイプ: Int
+- 単位: %
+- 変更可能: はい
+- 説明: 共有データクラスタで、Lake publish パスのプロセスメモリのバックストップしきい値。プロセスメモリ使用量がプロセスメモリ上限のこの割合を超えると、単一 publish と集約（aggregate）publish の両方のタスクが、メモリが低下するまで再試行可能な `ResourceBusy` ステータスで拒否され、publish がノードを OOM に追い込むのを防ぎます。これは `memory_urgent_level`（永続インデックスのフラッシュや Data Cache の縮小も駆動する）とは独立した専用のパラメータであり、それらのサブシステムに影響を与えずにインシデント時に調整できます。値 `0` はこのバックストップを無効化します。publish のたびに読み取られるため、実行時に調整できます。
+- 導入バージョン: -
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - デフォルト: -1

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -236,6 +236,32 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：仅在开启 Prepared Physical Split Lake 扫描（参见会话变量 `enable_lake_prepared_physical_split_scan`）时生效的 `splitted_scan_rows`（每个 Split Morsel 扫描的行数）上限。实际上限为 `min(tablet_internal_parallel_max_splitted_scan_rows, 本参数)`，因此只会将 Split Morsel 拆得更细（把大 Tablet 切成更多子范围 Morsel 以填充原本空闲的 Driver），不会更粗。仅在存算分离集群中生效。
 - 引入版本：v4.2
 
+### lake_publish_memory_limit_percent
+
+- 默认值：30
+- 类型：Int
+- 单位：%
+- 是否动态：否
+- 描述：存算分离集群下，Lake 发布（publish）路径的内存预留 tracker 可占用的进程内存上限的百分比。发布过程中，StarRocks 会对 Tablet 元数据进行深拷贝、规范化和序列化；该 tracker 用于限制这部分瞬时内存占用，避免元数据膨胀且发布并发较高时将进程推入 OOM。当一次发布的预估占用会超出剩余额度时，该发布会以可重试的 `ResourceBusy` 状态被拒绝，并由 FE 重试。取值会被限制在 [0, 100] 范围内。取值为 `0` 时禁用该 tracker 级别的限流（注册为无限制 tracker），可作为该行为的回滚开关。该参数不可动态修改，因为 tracker 的字节上限在 BE 启动时计算一次。
+- 引入版本：-
+
+### lake_publish_metadata_estimate_multiplier
+
+- 默认值：3
+- 类型：Int
+- 是否动态：是
+- 描述：存算分离集群下，用于将一次发布的瞬时元数据占用估算为 `k * base_tablet_metadata_size` 的乘数 `k`。发布路径大约同时持有三份元数据副本（修改后的工作副本、规范化副本以及序列化缓冲区），因此默认值为 `3`。该估算值即为发布路径向由 `lake_publish_memory_limit_percent` 控制的 tracker 预留的大小。每次发布时都会读取该值，因此可在运行时动态调整。
+- 引入版本：-
+
+### lake_publish_process_memory_urgent_pct
+
+- 默认值：85
+- 类型：Int
+- 单位：%
+- 是否动态：是
+- 描述：存算分离集群下，Lake 发布路径的进程内存兜底阈值。当进程内存占用超过进程内存上限的该百分比时，单副本发布和聚合发布任务都会以可重试的 `ResourceBusy` 状态被拒绝，直到内存下降为止，从而避免发布将节点推入 OOM。这是一个独立的参数，与 `memory_urgent_level`（同时驱动持久化索引刷盘和 Data Cache 收缩）相互独立，因此可在故障处理时单独调整而不影响这些子系统。取值为 `0` 时禁用该兜底。每次发布时都会读取该值，因此可在运行时动态调整。
+- 引入版本：-
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - 默认值：-1

--- a/docs/zh/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/BE_parameters/shared_lake_other.md
@@ -182,6 +182,32 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：仅在开启 prepared physical split scan（参见会话变量 `enable_lake_prepared_physical_split_scan`）时生效的 `splitted_scan_rows`（每个 split morsel 扫描的行数）上限。实际上限为 `min(tablet_internal_parallel_max_splitted_scan_rows, 本参数)`，因此只会将 split morsel 拆得更细（把大 Tablet 切成更多子范围 morsel 以填充原本空闲的 driver），不会更粗。仅在存算分离集群中生效。
 - 引入版本：v4.2
 
+### lake_publish_memory_limit_percent
+
+- 默认值：30
+- 类型：Int
+- 单位：%
+- 是否动态：否
+- 描述：存算分离集群下，Lake 发布（publish）路径的内存预留 tracker 可占用的进程内存上限的百分比。发布过程中，StarRocks 会对 Tablet 元数据进行深拷贝、规范化和序列化；该 tracker 用于限制这部分瞬时内存占用，避免元数据膨胀且发布并发较高时将进程推入 OOM。当一次发布的预估占用会超出剩余额度时，该发布会以可重试的 `ResourceBusy` 状态被拒绝，并由 FE 重试。取值会被限制在 [0, 100] 范围内。取值为 `0` 时禁用该 tracker 级别的限流（注册为无限制 tracker），可作为该行为的回滚开关。该参数不可动态修改，因为 tracker 的字节上限在 BE 启动时计算一次。
+- 引入版本：-
+
+### lake_publish_metadata_estimate_multiplier
+
+- 默认值：3
+- 类型：Int
+- 是否动态：是
+- 描述：存算分离集群下，用于将一次发布的瞬时元数据占用估算为 `k * base_tablet_metadata_size` 的乘数 `k`。发布路径大约同时持有三份元数据副本（修改后的工作副本、规范化副本以及序列化缓冲区），因此默认值为 `3`。该估算值即为发布路径向由 `lake_publish_memory_limit_percent` 控制的 tracker 预留的大小。每次发布时都会读取该值，因此可在运行时动态调整。
+- 引入版本：-
+
+### lake_publish_process_memory_urgent_pct
+
+- 默认值：85
+- 类型：Int
+- 单位：%
+- 是否动态：是
+- 描述：存算分离集群下，Lake 发布路径的进程内存兜底阈值。当进程内存占用超过进程内存上限的该百分比时，单副本发布和聚合发布任务都会以可重试的 `ResourceBusy` 状态被拒绝，直到内存下降为止，从而避免发布将节点推入 OOM。这是一个独立的参数，与 `memory_urgent_level`（同时驱动持久化索引刷盘和 Data Cache 收缩）相互独立，因此可在故障处理时单独调整而不影响这些子系统。取值为 `0` 时禁用该兜底。每次发布时都会读取该值，因此可在运行时动态调整。
+- 引入版本：-
+
 ### lake_put_txn_log_timeout_guard_ms
 
 - 默认值：-1


### PR DESCRIPTION
**Part 3 of the publish-stall hardening series** — fix the BE/CN lake publish path OOM-killing the node: bloated tablet metadata under high publish concurrency drove the process into an out-of-memory crash loop because the publish path had no memory accounting or gate.

## Why I'm doing:

In shared-data (lake) mode, the BE/CN publish path deep-copies, normalizes, and serializes a tablet's `TabletMetadataPB` on every publish — transiently holding roughly 3× the metadata size per in-flight publish. This path had **no memory accounting and no gate**. When metadata is bloated (observed ~221 MB/partition in an incident) and publish concurrency is high, the summed transient footprint drove process RSS to ~31 GB on a 32 GB node, and the kernel OOM-killed `starrocks_be` into a restart→OOM crash loop.

## What I'm doing:

Add a **byte-reservation memory gate** on the lake publish path so the *sum* of in-flight publish metadata is bounded, and an over-budget publish fails soft (retryable `ResourceBusy`) instead of pushing the node into OOM.

- A dedicated `LAKE_PUBLISH` `MemTracker`, registered **off the process tree** (so the reservation estimate is not double-counted against the actual bytes already tracked by the allocation hook). Byte limit = `process_limit × lake_publish_memory_limit_percent/100`, computed once at startup; also surfaced in `/metrics/memory`.
- An RAII `PublishMemReservation` gate: reserve an estimate (`k × base_tablet_metadata_size`) before the heavy copy, release the exact amount on every exit path. Admission order is deliberate: null-tracker/zero-estimate → admit; kill-switch (`limit ≤ 0`) → admit; **oversized** (a single publish's estimate exceeds the whole budget) → admit at most one process-wide via an atomic CAS **without charging the tracker** (prevents a permanent wedge on small-memory CNs); otherwise atomic `try_consume`. The estimate uses an overflow-saturating multiply so a misconfigured `k` cannot silently disable the gate.
- A coarse **process-memory backstop** (`lake_publish_process_memory_urgent_pct`) at publish entry, and on the aggregate publish path in `lake_service.cpp` (backstop-only — the aggregate path must not reserve against the shared tracker or it would starve its own per-tablet sub-publishes).
- Three new BE configs (see docs): `lake_publish_memory_limit_percent` (default 30, immutable, `0`=kill switch), `lake_publish_metadata_estimate_multiplier` (default 3, mutable), `lake_publish_process_memory_urgent_pct` (default 85, mutable, `0`=disable).

Rejection is always a *retryable* `ResourceBusy`; the FE retries and never aborts the committed transaction, so under pressure publishes queue and drain rather than OOM.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5