### PR TITLE
[Doc] Fix two broken SQL examples in data-type reference

### DIFF
--- a/docs/en/sql-reference/data-types/other-data-types/HLL.md
+++ b/docs/en/sql-reference/data-types/other-data-types/HLL.md
@@ -75,7 +75,7 @@ In actual business scenarios, data volume and data distribution affect the memor
 
     create table test_uv(
     dt date,
-    id int
+    id int,
     uv_set hll hll_union)
     distributed by hash(id);
 

--- a/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
+++ b/docs/en/sql-reference/data-types/semi_structured/VARIANT.md
@@ -133,7 +133,7 @@ You can cast SQL values to VARIANT. Supported input types include BOOLEAN, integ
 SELECT
     CAST(123 AS VARIANT) AS v_int,
     CAST(3.14 AS VARIANT) AS v_double,
-    CAST(DECIMAL(10, 2) '12.34' AS VARIANT) AS v_decimal,
+    CAST(CAST('12.34' AS DECIMAL(10,2)) AS VARIANT) AS v_decimal,
     CAST('hello' AS VARIANT) AS v_string,
     CAST(PARSE_JSON('{"k":1}') AS VARIANT) AS v_json;
 ```


### PR DESCRIPTION
## Why / What

Auto-fix pass over failing doc SQL samples (`docs/scripts/run_sql_samples.py`), triaged with the `sql-doc-autofix` skill. Cluster **4.1.1**, docs **branch-4.1** (major.minor aligned). 20 FAIL candidates examined; only these **2** are genuine doc rot. Both fixes verified against the live cluster via the StarRocks MCP server. **Draft** — for human review before un-drafting.

## Fixes (verified: runs on StarRocks 4.1.1)

1. **`docs/en/sql-reference/data-types/other-data-types/HLL.md`** (CREATE TABLE `test_uv`)
   - before: `id int` &nbsp;→&nbsp; after: `id int,`
   - Missing comma; the parallel block just below already has it. Verified `CREATE TABLE ... (dt date, id int, uv_set hll hll_union) distributed by hash(id)` runs.
2. **`docs/en/sql-reference/data-types/semi_structured/VARIANT.md`** (cast-to-VARIANT example)
   - before: `CAST(DECIMAL(10, 2) '12.34' AS VARIANT)` &nbsp;→&nbsp; after: `CAST(CAST('12.34' AS DECIMAL(10,2)) AS VARIANT)`
   - The `DECIMAL(10,2) '…'` typed-literal form is not valid StarRocks syntax. The nested cast runs and preserves the "cast a DECIMAL value to VARIANT" intent.

## Not fixed (for review)

- **`ADMIN_SKIP_COMMITTED_TRANSACTION.md:41`** — *version/build-gated.* `enable_admin_skip_committed_txn` is absent from `ADMIN SHOW FRONTEND CONFIG` on the 4.1.1 image (release branch may be ahead of the released build). Recommend a "Since vX.Y" note, not a code change.
- **`DECIMAL.md:136`** (`INSERT ... SELECT 333`) — *illustrative.* The prose intentionally documents the resulting error ("returned with an error ... Insert has filtered data"). Not rot.
- **Placeholder / synopsis / transcript examples** (left as-is): `bitmap.md`, `bitmap_intersect.md`, `bitmap_union.md` (`from table` placeholder); `bar.md`, `equiwidth_bucket.md` (`MYSQL >` prompt); `System_variable.md:156` (`FROM TABLE` in a SET_VAR hint synopsis); `ADMIN_SET_CONFIG.md:20` (`"key"="value"`); `SHOW_BACKEND_BLACKLIST.md:20` (`{ BACKEND | COMPUTE NODE }` grammar); `CREATE_FILE.md:47` / `DROP_FILE.md:41` (placeholder URL / needs-setup catalog); `SHOW_ANALYZE_JOB.md:37` (two valid statements in one block — checker artifact).

## Translation follow-up (zh / ja)

English-only per skill; hand off to `/translate`. The same bugs exist in:
- `docs/ja/sql-reference/data-types/other-data-types/HLL.md:80` (HLL missing comma) — zh copy is already correct.
- `docs/zh/.../VARIANT.md:136` and `docs/ja/.../VARIANT.md:136` (DECIMAL cast).

## Checklist
- [x] Behavior change: **Doc only**, no code/behavior change.
- [x] Docs updated (English). zh/ja flagged above for `/translate`.
- [x] Each edited example confirmed present on `main` before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)