### PR TITLE
[BugFix] Copy shared builtin before mutating it in Iceberg transform analysis

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1126,6 +1126,10 @@ public class FunctionAnalyzer {
                         fnName.replace(FeConstants.ICEBERG_TRANSFORM_EXPRESSION_PREFIX, ""),
                         Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.joining(", ")));
             }
+            // the resolved builtin is a shared singleton: mutate a copy, or the wildcard decimal
+            // signature gets stamped with a concrete (precision, scale) and later lookups with a
+            // different scale fail until the FE restarts
+            fn = fn.copy();
             if (args[0].isDecimalV3()) {
                 fn.setArgsType(args);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -507,6 +507,47 @@ public class AnalyzeCreateTableTest {
     }
 
     @Test
+    public void testIcebergPartitionTransformOnDecimalsWithDifferentScales() throws Exception {
+        String createIcebergCatalogStmt = "create external catalog iceberg_catalog properties (\"type\"=\"iceberg\", " +
+                "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
+        AnalyzeTestUtil.getStarRocksAssert().withCatalog(createIcebergCatalogStmt);
+
+        MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
+        new Expectations(metadata) {
+            {
+                metadata.getDb((ConnectContext) any, "iceberg_catalog", "iceberg_db");
+                result = new Database();
+                minTimes = 0;
+
+                metadata.tableExists((ConnectContext) any, "iceberg_catalog", "iceberg_db", anyString);
+                result = false;
+            }
+        };
+
+        AnalyzeTestUtil.getConnectContext().setCurrentCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+        AnalyzeTestUtil.getConnectContext().setDatabase("test");
+
+        // Analyzing a transform on one decimal column must not prevent later analyses on
+        // decimal columns with a different scale in the same FE process: the resolved builtin
+        // is a shared singleton whose wildcard decimal signature has to stay intact.
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d1 decimal(18, 4)) partition by truncate(d1, 5)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d2 decimal(12, 2)) partition by truncate(d2, 3)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d1 decimal(12, 2)) partition by bucket(d1, 8)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d2 decimal(18, 4)) partition by bucket(d2, 8)");
+        // decimal128 goes through a separate builtin singleton
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d1 decimal(38, 6)) partition by truncate(d1, 5)");
+        analyzeSuccess("create external table iceberg_catalog.iceberg_db.iceberg_table"
+                + "(k1 int, d2 decimal(30, 2)) partition by truncate(d2, 3)");
+
+        AnalyzeTestUtil.getStarRocksAssert().dropCatalog("iceberg_catalog");
+    }
+
+    @Test
     public void testGeneratedColumnWithExternalTable() throws Exception {
         analyzeFail("create external table ex_hive_tbl0 (col_tinyint tinyint null comment \"column tinyint\"," +
                 "col_varchar varchar(5), col_boolean boolean null comment \"column boolean\", col_new int" +


### PR DESCRIPTION
## Why I'm doing:

`__iceberg_transform_truncate` / `__iceberg_transform_bucket` are registered once per decimal primitive type (DECIMAL32/64/128) with a wildcard decimal signature, and `FunctionSet.getFunction` returns that shared singleton object directly. The Iceberg-transform branch of `FunctionAnalyzer.getAdjustedAnalyzedFunction` mutates the resolved function in place (`setArgsType` / `setRetType`), stamping the global singleton's wildcard signature with the concrete `(precision, scale)` of the first analyzed decimal column.

`ScalarType.matchesType` only matches two concrete decimals of the same primitive type when their scales are equal, so any later `IS_IDENTICAL` lookup with a different scale returns null and analysis fails with e.g. `No matching function with signature: truncate(decimal(12, 2), tinyint(4))`. Since DDL decimals with precision <= 18 all map to DECIMAL64 (`TypeFactory.createUnifiedDecimalType`), almost all practical decimal columns share one singleton: a single `CREATE TABLE ... PARTITION BY truncate(dec_col, w)` poisons every later truncate analysis with a different scale in the same FE process. The internally generated partition predicates (`IcebergPartitionUtils`) go through the same analyzer branch, so merely querying a truncate/bucket-on-decimal partitioned Iceberg table can re-stamp the singleton. The state lives in the FE JVM: recreating catalogs/databases/tables does not help, only an FE restart does.

Reproduced on a live cluster (single FE, main-0db4587):

```sql
mysql> CREATE TABLE t1 (id BIGINT, dt DATE, c_dec DECIMAL(18,4)) PARTITION BY (truncate(c_dec, 5), dt);
Query OK, 0 rows affected

mysql> CREATE TABLE t2 (id BIGINT, dt DATE, c_dec2 DECIMAL(12,2)) PARTITION BY (truncate(c_dec2, 3), dt);
ERROR 1064 (HY000): Getting analyzing error. Detail message: No matching function with signature: truncate(decimal(12, 2), tinyint(4)).
```

## What I'm doing:

Copy the resolved builtin (`fn = fn.copy()`) before mutating its argument/return types in the Iceberg-transform branch, mirroring the existing pattern used everywhere else in `FunctionAnalyzer` (and in `DecimalV3FunctionAnalyzer`, which already copies for these same functions on a path that is never reached because this branch resolves first). The copy is taken unconditionally: the unconditional `setRetType` also mutated the shared object for non-decimal argument types, which is idempotent for fixed-type signatures but still shared mutable state under concurrent analysis.

Added a regression test that analyzes `truncate` / `bucket` partition transforms on decimal columns with different scales (DECIMAL64 and DECIMAL128 buckets) in the same FE process.

Fixes StarRocks/StarRocksTest#11576

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
