### PR TITLE
[Enhancement] Cancel in-flight compactions on resharded partitions during reshard cleaning (backport #76759)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -278,7 +279,7 @@ public class MergeTabletJob extends TabletReshardJob {
     }
 
     /*
-     * 1. Wait for previous transactions finished
+     * 1. Abort in-flight lake compactions, then wait for the remaining previous transactions finished
      * 2. Remove old versions of materialized index
      * 3. Unregister resharding tablets
      * 4. Set tablet state to NORMAL
@@ -286,10 +287,14 @@ public class MergeTabletJob extends TabletReshardJob {
      */
     @Override
     protected void runCleaningJob() {
-        // 1. Wait for previous transactions finished
+        // 1. Cancel previous in-flight compactions on the resharded partitions so cleaning does not wait
+        //    for slow compaction, then wait for the rest. Compactions on partitions this job does not
+        //    reshard are neither cancelled nor waited on (see CompactionScheduler#cancelPreviousCompactions).
+        Set<Long> ignoredCompactionTxnIds = GlobalStateMgr.getCurrentState().getCompactionMgr()
+                .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet());
         try {
             if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinished(
-                    endTransactionId, dbId, List.of(tableId))) {
+                    endTransactionId, dbId, List.of(tableId), ignoredCompactionTxnIds)) {
                 return;
             }
         } catch (AnalysisException e) { // Db is dropped, ignore exception

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -312,7 +312,7 @@ public class SplitTabletJob extends TabletReshardJob {
     }
 
     /*
-     * 1. Wait for previous transactions finished
+     * 1. Abort in-flight lake compactions, then wait for the remaining previous transactions finished
      * 2. Remove old versions of materialized index
      * 3. Unregister resharding tablets
      * 4. Set tablet state to NORMAL
@@ -320,10 +320,14 @@ public class SplitTabletJob extends TabletReshardJob {
      */
     @Override
     protected void runCleaningJob() {
-        // 1. Wait for previous transactions finished
+        // 1. Cancel previous in-flight compactions on the resharded partitions so cleaning does not wait
+        //    for slow compaction, then wait for the rest. Compactions on partitions this job does not
+        //    reshard are neither cancelled nor waited on (see CompactionScheduler#cancelPreviousCompactions).
+        Set<Long> ignoredCompactionTxnIds = GlobalStateMgr.getCurrentState().getCompactionMgr()
+                .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet());
         try {
             if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinished(
-                    endTransactionId, dbId, List.of(tableId))) {
+                    endTransactionId, dbId, List.of(tableId), ignoredCompactionTxnIds)) {
                 return;
             }
         } catch (AnalysisException e) { // Db is dropped, ignore exception

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/AggregateCompactionTask.java
@@ -72,26 +72,30 @@ public class AggregateCompactionTask extends CompactionTask {
     }
 
     @Override
-    public void abort() {
+    public boolean abort() {
         // no need to aggregate abort request
         TaskResult taskResult = getResult();
-        if (taskResult == TaskResult.NOT_FINISHED || taskResult == TaskResult.NONE_SUCCESS) {
-            // abort compaction one by one
-            for (int i = 0; i < request.requests.size(); i++) {
-                CompactRequest eachRequest = request.requests.get(i);
-                ComputeNodePB computeNodePB = request.computeNodes.get(i);
-                AbortCompactionRequest abortRequest = new AbortCompactionRequest();
-                abortRequest.txnId = eachRequest.txnId;
-                try {
-                    LakeService service = BrpcProxy.getLakeService(computeNodePB.getHost(), computeNodePB.getBrpcPort());
-                    Future<AbortCompactionResponse> ignored = service.abortCompaction(abortRequest);
-                    LOG.info("abort compaction task successfully sent, txn_id: {}, node: {}", eachRequest.txnId, nodeId);
-                } catch (Exception e) {
-                    LOG.warn("fail to abort compaction task, txn_id: {}, node: {} error: {}", eachRequest.txnId,
-                            nodeId, e.getMessage());
-                }
+        if (taskResult != TaskResult.NOT_FINISHED && taskResult != TaskResult.NONE_SUCCESS) {
+            return true;
+        }
+        // abort compaction one by one
+        boolean allDelivered = true;
+        for (int i = 0; i < request.requests.size(); i++) {
+            CompactRequest eachRequest = request.requests.get(i);
+            ComputeNodePB computeNodePB = request.computeNodes.get(i);
+            AbortCompactionRequest abortRequest = new AbortCompactionRequest();
+            abortRequest.txnId = eachRequest.txnId;
+            try {
+                LakeService service = BrpcProxy.getLakeService(computeNodePB.getHost(), computeNodePB.getBrpcPort());
+                Future<AbortCompactionResponse> ignored = service.abortCompaction(abortRequest);
+                LOG.info("abort compaction task successfully sent, txn_id: {}, node: {}", eachRequest.txnId, nodeId);
+            } catch (Exception e) {
+                LOG.warn("fail to abort compaction task, txn_id: {}, node: {} error: {}", eachRequest.txnId,
+                        nodeId, e.getMessage());
+                allDelivered = false;
             }
         }
+        return allDelivered;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -43,6 +43,11 @@ public class CompactionJob {
     private volatile long finishTs;
     private VisibleStateWaiter visibleStateWaiter;
     private List<CompactionTask> tasks = Collections.emptyList();
+    // Set once every abort RPC has been delivered, so abort() (re-issued every scheduler tick by the
+    // tablet-reshard cleaning loop) stops resending after delivery but still retries a failed abort RPC.
+    // volatile for cross-thread visibility (abort() is called from both the compaction scheduler thread
+    // and the reshard cleaning thread); the check-then-set is deliberately not atomic — see abort().
+    private volatile boolean aborted = false;
     private boolean allowPartialSuccess = false;
     private final ComputeResource computeResource;
     private String warehouse;
@@ -171,8 +176,34 @@ public class CompactionJob {
         this.scoreAfter = scoreAfter;
     }
 
+    /**
+     * Requests abort of every task's compaction RPC. Idempotent: the tablet-reshard cleaning loop
+     * re-issues it every scheduler tick until the job leaves the running set, and it stops resending
+     * once all abort RPCs have been delivered. A caller can watch {@link #isAborted()} across a call to
+     * detect the false-&gt;true transition and, e.g., abort the compaction transaction exactly once.
+     */
     public void abort() {
-        tasks.forEach(CompactionTask::abort);
+        // The check-then-set is intentionally not atomic (see the volatile field): concurrent callers may
+        // resend duplicate (idempotent) abort RPCs for the same tasks, but the flag must only be set after
+        // delivery succeeds, which a compareAndSet at entry could not express.
+        if (aborted) {
+            return;
+        }
+        boolean allDelivered = true;
+        for (CompactionTask task : tasks) {
+            if (!task.abort()) {
+                allDelivered = false;
+            }
+        }
+        // Only mark the job aborted once every abort RPC was delivered, so a transient RPC failure is
+        // retried on the next tick instead of leaving the compaction running.
+        if (allDelivered) {
+            aborted = true;
+        }
+    }
+
+    public boolean isAborted() {
+        return aborted;
     }
 
     public PhysicalPartition getPartition() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -255,6 +255,11 @@ public class CompactionMgr implements MemoryTrackable {
         compactionScheduler.cancelCompaction(txnId);
     }
 
+    public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                                               Set<Long> includePartitionIds) {
+        return compactionScheduler.cancelPreviousCompactions(endTransactionId, dbId, tableId, includePartitionIds);
+    }
+
     public boolean existCompaction(long txnId) {
         return compactionScheduler.existCompaction(txnId);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -160,6 +160,20 @@ public class CompactionScheduler extends Daemon {
                     errorMsg = Objects.requireNonNull(job.getFailMessage(), "getFailMessage() is null");
                     LOG.error("Compaction job {} failed: {}", job.getDebugString(), errorMsg);
                     job.abort(); // Abort any executing task, if present.
+                } else if (taskResult == CompactionTask.TaskResult.NOT_FINISHED && job.isAborted()
+                        && job.getResult() == CompactionTask.TaskResult.NOT_FINISHED) {
+                    // The job was aborted (e.g. by tablet-reshard cleaning) but its compaction task has not
+                    // finished — the best-effort abort RPC may have been lost. Abort the transaction here so a
+                    // waiter does not block on the still-running compaction. getResult() is re-read after the
+                    // isAborted() check because the task may have finished since taskResult was first sampled;
+                    // if so this branch is skipped and the next cycle commits/fails it normally (an
+                    // ALL_SUCCESS aborted job must still commit and cross-publish, not be discarded). This
+                    // abort runs on the scheduler thread — the same thread that commits compaction txns — so
+                    // it adds no new commit-vs-abort interleaving. The BE/CN task output is orphaned and
+                    // reclaimed by vacuum.
+                    job.getPartition().setMinRetainVersion(0);
+                    errorMsg = "compaction cancelled";
+                    LOG.info("Aborting transaction of cancelled compaction job {}", job.getDebugString());
                 } else if (taskResult != CompactionTask.TaskResult.NOT_FINISHED) {
                     errorMsg = String.format("Unexpected compaction result: %s, %s", taskResult.name(), job.getDebugString());
                     LOG.error(errorMsg);
@@ -650,6 +664,53 @@ public class CompactionScheduler extends Daemon {
                 break;
             }
         }
+    }
+
+    /**
+     * Handle the previous (txn id no greater than {@code endTransactionId}) in-flight compactions on
+     * the given table for a tablet-reshard CLEANING phase, so it does not have to wait for slow
+     * compaction before cleaning up.
+     *
+     * <p>For a compaction on an included physical partition ({@code includePartitionIds}, e.g. the
+     * partitions a reshard job is resharding), only an uncommitted one is aborted (a pre-reshard
+     * compaction is dropped when it is cross-published to the child tablets anyway, so aborting loses
+     * nothing); an already-committed compaction has taken a partition version and must still publish so
+     * its version cross-publishes onto the child tablets, hence it is left running for the
+     * previous-transactions wait to drain.
+     *
+     * <p>A compaction on a partition NOT in {@code includePartitionIds} is unaffected by the reshard: it
+     * is neither cancelled nor needs to be waited on. Its txn id is returned so the caller can exclude
+     * it from the previous-transactions wait.
+     *
+     * <p>For an uncommitted compaction this only requests the abort of the compaction task. The
+     * compaction scheduler thread then aborts the transaction: {@link #scheduleNewCompaction} aborts an
+     * aborted job's transaction even if its task has not finished (e.g. because the best-effort abort RPC
+     * was lost), so the previous-transactions wait drains without blocking on the original long-running
+     * compaction. Doing the transaction abort there keeps it on the same thread that commits compaction
+     * transactions, so it adds no new commit-vs-abort interleaving. It is safe to re-issue every cleaning
+     * retry — {@link CompactionJob#abort} is idempotent once the abort has been requested.
+     *
+     * @return the txn ids of compactions on partitions not in {@code includePartitionIds}.
+     */
+    public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                                               Set<Long> includePartitionIds) {
+        Set<Long> ignoredTxnIds = new HashSet<>();
+        for (Map.Entry<PartitionIdentifier, CompactionJob> entry : runningCompactions.entrySet()) {
+            PartitionIdentifier partition = entry.getKey();
+            CompactionJob job = entry.getValue();
+            if (partition.getDbId() != dbId || partition.getTableId() != tableId
+                    || job.getTxnId() > endTransactionId) {
+                continue;
+            }
+            if (!includePartitionIds.contains(partition.getPartitionId())) {
+                ignoredTxnIds.add(job.getTxnId());
+                continue;
+            }
+            if (!job.transactionHasCommitted()) {
+                job.abort();
+            }
+        }
+        return ignoredTxnIds;
     }
 
     protected ConcurrentHashMap<PartitionIdentifier, CompactionJob> getRunningCompactions() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -123,18 +123,25 @@ public class CompactionTask {
         }
     }
 
-    public void abort() {
+    /**
+     * @return true if the abort request was delivered (or the task already finished so there is nothing to
+     *         abort), false if the abort RPC failed and should be retried by the caller.
+     */
+    public boolean abort() {
         TaskResult taskResult = getResult();
-        if (taskResult == TaskResult.NOT_FINISHED || taskResult == TaskResult.NONE_SUCCESS) {
-            AbortCompactionRequest abortRequest = new AbortCompactionRequest();
-            abortRequest.txnId = request.txnId;
-            try {
-                Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
-                LOG.info("abort compaction task successfully sent, txn_id: {}, node: {}", request.txnId, nodeId);
-            } catch (Exception e) {
-                LOG.warn("fail to abort compaction task, txn_id: {}, node: {} error: {}", request.txnId,
-                        nodeId, e.getMessage());
-            }
+        if (taskResult != TaskResult.NOT_FINISHED && taskResult != TaskResult.NONE_SUCCESS) {
+            return true;
+        }
+        AbortCompactionRequest abortRequest = new AbortCompactionRequest();
+        abortRequest.txnId = request.txnId;
+        try {
+            Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
+            LOG.info("abort compaction task successfully sent, txn_id: {}, node: {}", request.txnId, nodeId);
+            return true;
+        } catch (Exception e) {
+            LOG.warn("fail to abort compaction task, txn_id: {}, node: {} error: {}", request.txnId,
+                    nodeId, e.getMessage());
+            return false;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -2056,11 +2056,19 @@ public class DatabaseTransactionMgr {
     }
 
     public boolean isPreviousTransactionsFinished(long endTransactionId, List<Long> tableIdList) {
+        return isPreviousTransactionsFinished(endTransactionId, tableIdList, Collections.emptySet());
+    }
+
+    public boolean isPreviousTransactionsFinished(long endTransactionId, List<Long> tableIdList,
+                                                  Set<Long> excludeTransactionIds) {
         readLock();
         try {
             for (Map.Entry<Long, TransactionState> entry : idToRunningTransactionState.entrySet()) {
                 if (entry.getValue().getDbId() != dbId || !isIntersectionNotEmpty(entry.getValue().getTableIdList(),
                         tableIdList) || !entry.getValue().isRunning()) {
+                    continue;
+                }
+                if (excludeTransactionIds.contains(entry.getKey())) {
                     continue;
                 }
                 if (entry.getKey() <= endTransactionId) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -715,9 +715,20 @@ public class GlobalTransactionMgr implements MemoryTrackable {
      */
     public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIdList)
             throws AnalysisException {
+        return isPreviousTransactionsFinished(endTransactionId, dbId, tableIdList, Collections.emptySet());
+    }
+
+    /**
+     * Like {@link #isPreviousTransactionsFinished(long, long, List)} but ignores the transactions in
+     * {@code excludeTransactionIds} when checking. Used by tablet-reshard cleaning to skip waiting for
+     * compaction transactions on partitions the reshard job does not touch.
+     */
+    public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIdList,
+                                                  Set<Long> excludeTransactionIds)
+            throws AnalysisException {
         try {
             DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-            return dbTransactionMgr.isPreviousTransactionsFinished(endTransactionId, tableIdList);
+            return dbTransactionMgr.isPreviousTransactionsFinished(endTransactionId, tableIdList, excludeTransactionIds);
         } catch (AnalysisException e) {
             // NOTICE: At present, this situation will only happen when the database no longer exists.
             // In fact, getDatabaseTransactionMgr() should explicitly throw a MetaNotFoundException,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -37,6 +37,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
@@ -70,6 +71,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -347,7 +349,8 @@ public class MergeTabletJobTest {
 
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds) {
+            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+                    Set<Long> excludeTransactionIds) {
                 return false;
             }
         };
@@ -368,13 +371,65 @@ public class MergeTabletJobTest {
 
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds)
-                    throws AnalysisException {
+            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+                    Set<Long> excludeTransactionIds) throws AnalysisException {
                 throw new AnalysisException("mock");
             }
         };
 
         try {
+            mergeJob.runCleaningJob();
+            Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, mergeJob.getJobState());
+        } finally {
+            table.setState(original);
+        }
+    }
+
+    @Test
+    public void testRunCleaningCancelsPreviousCompactions() throws Exception {
+        Map<Long, ReshardingPhysicalPartition> reshardingPartitions = new HashMap<>();
+        reshardingPartitions.put(-1L, new ReshardingPhysicalPartition(-1L, new HashMap<>()));
+        MergeTabletJob mergeJob = new MergeTabletJob(GlobalStateMgr.getCurrentState().getNextId(),
+                db.getId(), table.getId(), reshardingPartitions);
+        mergeJob.setJobState(TabletReshardJob.JobState.CLEANING);
+        mergeJob.endTransactionId = 5000L;
+        OlapTable.OlapTableState original = table.getState();
+        table.setState(OlapTable.OlapTableState.TABLET_RESHARD);
+
+        Set<Long> ignoredCompactionTxnIds = Set.of(7L, 8L);
+        AtomicReference<Set<Long>> includePartitionIdsArg = new AtomicReference<>();
+        AtomicReference<Set<Long>> excludeTxnIdsArg = new AtomicReference<>();
+        boolean[] waitFinished = {false};
+        new MockUp<CompactionMgr>() {
+            @Mock
+            public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                    Set<Long> includePartitionIds) {
+                Assertions.assertEquals(5000L, endTransactionId);
+                Assertions.assertEquals(db.getId(), dbId);
+                Assertions.assertEquals(table.getId(), tableId);
+                includePartitionIdsArg.set(includePartitionIds);
+                return ignoredCompactionTxnIds;
+            }
+        };
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+                    Set<Long> excludeTransactionIds) {
+                excludeTxnIdsArg.set(excludeTransactionIds);
+                return waitFinished[0];
+            }
+        };
+
+        try {
+            // Cycle 1: cancel is invoked with the reshard job's physical partitions, its returned ignored
+            // txn ids are forwarded to the wait, and while the wait is unsatisfied the job stays CLEANING.
+            mergeJob.runCleaningJob();
+            Assertions.assertEquals(mergeJob.getReshardingPhysicalPartitions().keySet(), includePartitionIdsArg.get());
+            Assertions.assertEquals(ignoredCompactionTxnIds, excludeTxnIdsArg.get());
+            Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, mergeJob.getJobState());
+
+            // Cycle 2: once the remaining transactions have drained, CLEANING completes.
+            waitFinished[0] = true;
             mergeJob.runCleaningJob();
             Assertions.assertEquals(TabletReshardJob.JobState.FINISHED, mergeJob.getJobState());
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -32,6 +32,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
@@ -46,6 +47,7 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.SplitTabletClause;
 import com.starrocks.sql.ast.TabletList;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.MockedBackend.MockLakeService;
 import com.starrocks.utframe.StarRocksAssert;
@@ -63,6 +65,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -705,6 +708,40 @@ public class SplitTabletJobTest {
             }
         }
         return result;
+    }
+
+    @Test
+    public void testRunCleaningCancelsPreviousCompactions() throws Exception {
+        SplitTabletJob splitJob = (SplitTabletJob) createTabletReshardJob();
+        splitJob.setJobState(TabletReshardJob.JobState.CLEANING);
+        splitJob.endTransactionId = 5000L;
+
+        Set<Long> ignoredCompactionTxnIds = Set.of(7L, 8L);
+        AtomicReference<Set<Long>> includePartitionIdsArg = new AtomicReference<>();
+        AtomicReference<Set<Long>> excludeTxnIdsArg = new AtomicReference<>();
+        new MockUp<CompactionMgr>() {
+            @Mock
+            public Set<Long> cancelPreviousCompactions(long endTransactionId, long dbId, long tableId,
+                    Set<Long> includePartitionIds) {
+                includePartitionIdsArg.set(includePartitionIds);
+                return ignoredCompactionTxnIds;
+            }
+        };
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+                    Set<Long> excludeTransactionIds) {
+                excludeTxnIdsArg.set(excludeTransactionIds);
+                return false;
+            }
+        };
+
+        // The cleaning phase cancels the previous compactions on the resharded partitions and forwards
+        // the returned ignored txn ids to the wait; while the wait is unsatisfied the job stays CLEANING.
+        splitJob.runCleaningJob();
+        Assertions.assertEquals(splitJob.getReshardingPhysicalPartitions().keySet(), includePartitionIdsArg.get());
+        Assertions.assertEquals(ignoredCompactionTxnIds, excludeTxnIdsArg.get());
+        Assertions.assertEquals(TabletReshardJob.JobState.CLEANING, splitJob.getJobState());
     }
 
     private TabletReshardJob createTabletReshardJob() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionJobTest.java
@@ -191,4 +191,60 @@ public class CompactionJobTest {
         };
         Assertions.assertEquals(job.getSuccessCompactInputFileSize(), 0);
     }
+
+    @Test
+    public void testAbortIsIdempotent() {
+        Database db = new Database();
+        Table table = new Table(Table.TableType.CLOUD_NATIVE);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, new MaterializedIndex());
+        CompactionJob job = new CompactionJob(db, table, partition, 10010, true, null, "", null);
+        List<CompactionTask> list = new ArrayList<>();
+        list.add(new CompactionTask(100));
+        job.setTasks(list);
+
+        int[] abortCount = {0};
+        new MockUp<CompactionTask>() {
+            @Mock
+            public boolean abort() {
+                abortCount[0]++;
+                return true; // delivered
+            }
+        };
+
+        // abort() may be re-issued every scheduler tick; once delivered it must not resend. isAborted()
+        // flips false->true exactly once, so a caller can abort the transaction exactly once.
+        Assertions.assertFalse(job.isAborted());
+        job.abort();
+        Assertions.assertTrue(job.isAborted());
+        job.abort();
+        job.abort();
+        Assertions.assertEquals(1, abortCount[0]);
+    }
+
+    @Test
+    public void testAbortRetriesWhenDeliveryFails() {
+        Database db = new Database();
+        Table table = new Table(Table.TableType.CLOUD_NATIVE);
+        PhysicalPartition partition = new PhysicalPartition(0, 1, new MaterializedIndex());
+        CompactionJob job = new CompactionJob(db, table, partition, 10010, true, null, "", null);
+        List<CompactionTask> list = new ArrayList<>();
+        list.add(new CompactionTask(100));
+        job.setTasks(list);
+
+        int[] abortCount = {0};
+        new MockUp<CompactionTask>() {
+            @Mock
+            public boolean abort() {
+                abortCount[0]++;
+                return abortCount[0] > 1; // first attempt fails to deliver, later attempts succeed
+            }
+        };
+
+        job.abort(); // delivery fails -> not marked aborted
+        Assertions.assertFalse(job.isAborted());
+        job.abort(); // retried -> delivered -> marked aborted
+        Assertions.assertTrue(job.isAborted());
+        job.abort(); // already delivered -> no resend
+        Assertions.assertEquals(2, abortCount[0]);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -53,6 +53,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,6 +66,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CompactionSchedulerTest {
@@ -1001,5 +1003,122 @@ public class CompactionSchedulerTest {
 
         Assertions.assertEquals(3L, (long) MetricRepo.GAUGE_LAKE_COMPACTION_RUNNING.getValueLeader());
         Assertions.assertEquals(6L, (long) MetricRepo.GAUGE_LAKE_COMPACTION_RUNNING_TASKS.getValueLeader());
+    }
+
+    @Test
+    public void testCancelPreviousCompactions() {
+        CompactionMgr compactionManager = new CompactionMgr();
+        CompactionScheduler compactionScheduler = new CompactionScheduler(compactionManager, null, globalTransactionMgr,
+                globalStateMgr, "");
+
+        long dbId = 100L;
+        long tableId = 200L;
+        long otherTableId = 999L;
+        long endTransactionId = 2000L;
+        // Partitions 1, 2 and 5 are being resharded; 3 and 4 are not.
+        Set<Long> includePartitionIds = Sets.newHashSet(1L, 2L, 5L);
+
+        // Included partition, uncommitted, <= watermark -> abort the task (the scheduler thread aborts the
+        // transaction later).
+        CompactionJob prepared = Mockito.mock(CompactionJob.class);
+        Mockito.when(prepared.getTxnId()).thenReturn(101L);
+        Mockito.when(prepared.transactionHasCommitted()).thenReturn(false);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, tableId, 1), prepared);
+
+        // Included partition, committed -> keep (drained by the previous-transactions wait).
+        CompactionJob committed = Mockito.mock(CompactionJob.class);
+        Mockito.when(committed.getTxnId()).thenReturn(102L);
+        Mockito.when(committed.transactionHasCommitted()).thenReturn(true);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, tableId, 2), committed);
+
+        // Included partition, uncommitted, > watermark -> keep (not a previous transaction).
+        CompactionJob late = Mockito.mock(CompactionJob.class);
+        Mockito.when(late.getTxnId()).thenReturn(3000L);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, tableId, 5), late);
+
+        // Not-included partition, uncommitted, <= watermark -> not cancelled, txn id returned.
+        CompactionJob otherPartitionPrepared = Mockito.mock(CompactionJob.class);
+        Mockito.when(otherPartitionPrepared.getTxnId()).thenReturn(103L);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, tableId, 3), otherPartitionPrepared);
+
+        // Not-included partition, committed, <= watermark -> not cancelled, txn id returned.
+        CompactionJob otherPartitionCommitted = Mockito.mock(CompactionJob.class);
+        Mockito.when(otherPartitionCommitted.getTxnId()).thenReturn(104L);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, tableId, 4), otherPartitionCommitted);
+
+        // Different table -> ignored entirely (neither cancelled nor returned).
+        CompactionJob otherTable = Mockito.mock(CompactionJob.class);
+        Mockito.when(otherTable.getTxnId()).thenReturn(105L);
+        compactionScheduler.getRunningCompactions().put(new PartitionIdentifier(dbId, otherTableId, 6), otherTable);
+
+        Set<Long> ignoredTxnIds =
+                compactionScheduler.cancelPreviousCompactions(endTransactionId, dbId, tableId, includePartitionIds);
+
+        // Only the uncommitted compaction on an included, pre-watermark partition is aborted.
+        Mockito.verify(prepared).abort();
+        Mockito.verify(committed, Mockito.never()).abort();
+        Mockito.verify(late, Mockito.never()).abort();
+        Mockito.verify(otherPartitionPrepared, Mockito.never()).abort();
+        Mockito.verify(otherPartitionCommitted, Mockito.never()).abort();
+        Mockito.verify(otherTable, Mockito.never()).abort();
+
+        // Compactions on not-included partitions (of this table, <= watermark) are returned so the caller
+        // can skip waiting for them; the different-table and > watermark ones are not.
+        Assertions.assertEquals(Sets.newHashSet(103L, 104L), ignoredTxnIds);
+    }
+
+    @Test
+    public void testScheduleNewCompactionAbortsCancelledRunningJob() throws Exception {
+        // An empty CompactionMgr so scheduleNewCompaction starts no new compactions and only processes the
+        // running one below.
+        CompactionMgr compactionManager = new CompactionMgr();
+
+        MockedWarehouseManager mockedWarehouseManager = new MockedWarehouseManager();
+        mockedWarehouseManager.initDefaultWarehouse();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public WarehouseManager getWarehouseMgr() {
+                return mockedWarehouseManager;
+            }
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+        };
+
+        CompactionScheduler compactionScheduler = new CompactionScheduler(compactionManager, null, globalTransactionMgr,
+                globalStateMgr, "");
+
+        Database db = new Database();
+        Table table = new LakeTable();
+        PhysicalPartition partition = new PhysicalPartition(3, 3, new MaterializedIndex());
+        PartitionIdentifier partitionId = new PartitionIdentifier(1, 2, 3);
+        CompactionJob job = new CompactionJob(db, table, partition, 100, false, WarehouseManager.DEFAULT_RESOURCE, "wh", null);
+        // Mark the job aborted (as tablet-reshard cleaning does via job.abort()) while its task is still
+        // NOT_FINISHED, so the scheduler proactively aborts the transaction instead of waiting.
+        job.abort();
+        new MockUp<CompactionJob>() {
+            @Mock
+            public CompactionTask.TaskResult getResult() {
+                return CompactionTask.TaskResult.NOT_FINISHED;
+            }
+        };
+        compactionScheduler.getRunningCompactions().put(partitionId, job);
+
+        compactionScheduler.runOneCycle();
+
+        // The cancelled but still-running compaction is removed and its transaction aborted on the
+        // scheduler thread.
+        Assertions.assertFalse(compactionScheduler.getRunningCompactions().containsKey(partitionId));
+        new Verifications() {
+            {
+                globalTransactionMgr.abortTransaction(anyLong, 100L, anyString, (List) any, (List) any, null);
+                times = 1;
+            }
+        };
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -1200,6 +1200,28 @@ public class DatabaseTransactionMgrTest {
         return Lists.newArrayList(transactionState6, transactionState7, transactionState8);
     }
 
+    @Test
+    public void testIsPreviousTransactionsFinishedExcludeTxnIds() throws Exception {
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
+        // Use a dedicated table id so the setUp fixture's transactions do not interfere.
+        long uniqueTableId = 987654L;
+        long txnId = masterTransMgr.beginTransaction(GlobalStateMgrTestUtil.testDbId1,
+                Lists.newArrayList(uniqueTableId), "exclude_txn_ids_label", transactionSource,
+                TransactionState.LoadJobSourceType.LAKE_COMPACTION, Config.stream_load_default_timeout_second);
+        long watermark = masterTransMgr.getTransactionIDGenerator().peekNextTransactionId();
+
+        try {
+            // A running transaction with id <= watermark blocks by default...
+            Assertions.assertFalse(masterTransMgr.isPreviousTransactionsFinished(watermark,
+                    GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(uniqueTableId)));
+            // ...but is skipped when its id is excluded.
+            Assertions.assertTrue(masterTransMgr.isPreviousTransactionsFinished(watermark,
+                    GlobalStateMgrTestUtil.testDbId1, Lists.newArrayList(uniqueTableId), Sets.newHashSet(txnId)));
+        } finally {
+            masterTransMgr.abortTransaction(GlobalStateMgrTestUtil.testDbId1, txnId, "cleanup");
+        }
+    }
+
     private static class TestTxnStateChangeCallback implements TxnStateChangeCallback {
         private final long id;
         private final boolean throwInAfterVisible;


### PR DESCRIPTION
## Why I'm doing:

Backport of #76759 to branch-4.1.

In shared-data mode, the tablet-reshard CLEANING phase of `SplitTabletJob`/`MergeTabletJob` waited via `isPreviousTransactionsFinished` for all previous transactions — including lake compactions — before cleaning up. Compaction is slow, so this kept split/merge jobs in CLEANING for a long time and blocked subsequent reshards.

## What I'm doing:

Cancel the uncommitted in-flight compactions on the reshard job's **own** resharded partitions instead of waiting for them: a pre-reshard compaction is dropped when it is cross-published to the child tablets anyway, so aborting it loses nothing. Already-committed compactions are still waited on so their partition version cross-publishes onto the child tablets, keeping the partition version consistent. Compactions on partitions the job does **not** reshard are neither cancelled nor waited on.

The reshard cleaning thread only requests the compaction task abort; the compaction scheduler thread — the owner of a compaction transaction's lifecycle — aborts the transaction (including when the job was aborted but its task has not finished, e.g. the best-effort abort RPC was lost), so the wait drains without a cross-thread abort-vs-commit race.

This is a clean cherry-pick of `c8bd512c56546e2f6c1fc3e6c005447d9a08eef3` with three conflicts resolved additively (`CompactionTask`/`AggregateCompactionTask` abort return value; `DatabaseTransactionMgrTest` new test).

Backport of #76759

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch

