### PR TITLE
[BugFix] Fix sink event notification in PipeObservable

### DIFF
--- a/be/src/exec_primitive/pipeline/primitives/pipeline_observer.h
+++ b/be/src/exec_primitive/pipeline/primitives/pipeline_observer.h
@@ -78,7 +78,7 @@ public:
         return DeferOp([this]() { _source_observable.notify_source_observers(); });
     }
     auto defer_notify_sink() {
-        return DeferOp([this]() { _sink_observable.notify_source_observers(); });
+        return DeferOp([this]() { _sink_observable.notify_sink_observers(); });
     }
 
 private:

--- a/be/test/exec_primitive/pipeline_observer_exec_primitive_test.cpp
+++ b/be/test/exec_primitive/pipeline_observer_exec_primitive_test.cpp
@@ -94,8 +94,8 @@ TEST(PipelineObserverExecPrimitiveTest, PipeObservableNotifiesAttachedSides) {
     EXPECT_EQ(sink_observer.source_trigger_count, 0);
 
     { auto notify = pipe_observable.defer_notify_sink(); }
-    EXPECT_EQ(sink_observer.source_trigger_count, 1);
-    EXPECT_EQ(sink_observer.sink_trigger_count, 0);
+    EXPECT_EQ(sink_observer.source_trigger_count, 0);
+    EXPECT_EQ(sink_observer.sink_trigger_count, 1);
 }
 
 TEST(PipelineObserverExecPrimitiveTest, RuntimeFilterHubInstallsCollectorAndNotifiesObserver) {


### PR DESCRIPTION
## Why I'm doing:

`PipeObservable::defer_notify_sink()` selects the sink-side observable but emits a source event. With event-specific scheduler dispatch, a driver blocked on `OUTPUT_FULL` may miss the sink readiness check and remain blocked until another event arrives.

## What I'm doing:

- Make `defer_notify_sink()` call `notify_sink_observers()`.
- Update the existing observer test to expect a sink trigger.

Fixes #76742

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Testing

- `git diff --check`
- Not compiled locally because this checkout targets upstream `main`, whose dependency set differs from the available TEngine 3.4 environment. Upstream CI will validate the change.