### PR TITLE
[BugFix][CVE] exclude vulnerable jetty jars and bump pgjdbc to 42.7.12

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -63,7 +63,7 @@ subprojects {
         set("io.netty.version", "4.1.136.Final")
         set("jackson.version", "2.21.4")
         set("jackson-annotations.version", "2.21")
-        set("jetty.version", "9.4.57.v20241219")
+        set("jetty.version", "9.4.58.v20250814")
         set("jprotobuf-starrocks.version", "1.0.0")
         set("junit.version", "5.8.2")
         set("kafka-clients.version", "3.9.1")
@@ -249,7 +249,7 @@ subprojects {
             implementation("org.junit.jupiter:junit-jupiter:${project.ext["junit.version"]}")
             implementation("org.mariadb.jdbc:mariadb-java-client:3.3.2")
             implementation("org.owasp.encoder:encoder:1.3.1")
-            implementation("org.postgresql:postgresql:42.7.11")
+            implementation("org.postgresql:postgresql:42.7.12")
             implementation("org.roaringbitmap:RoaringBitmap:0.8.13")
             implementation("org.scala-lang:scala-library:2.12.10")
             implementation("org.slf4j:slf4j-api:1.7.30")
@@ -282,6 +282,13 @@ subprojects {
         // ships jquery 1.4.2 (CVE-2011-4969 etc.); only avro-mapred's unused tether feature references it
         exclude(group = "org.apache.avro", module = "avro-ipc")
         exclude(group = "org.apache.avro", module = "avro-ipc-jetty")
+        // CVE-2026-10050 (jetty-client/jetty-security: Digest auth bypass) and
+        // CVE-2026-2332 (jetty-http): only reachable via Hadoop's embedded
+        // HttpServer2 and the YARN websocket timeline client, neither of which
+        // StarRocks ever instantiates (Hadoop is used purely as an FS client).
+        exclude(group = "org.eclipse.jetty", module = "jetty-client")
+        exclude(group = "org.eclipse.jetty", module = "jetty-security")
+        exclude(group = "org.eclipse.jetty", module = "jetty-http")
     }
 
     // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -542,12 +542,38 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
+            <exclusions>
+                <!-- CVE-2026-10050: Jetty client-side Digest auth bypass. jetty-security
+                     is only reachable via Hadoop's embedded HttpServer2, which StarRocks
+                     never instantiates (it uses Hadoop purely as an FS client). -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-security</artifactId>
+                </exclusion>
+                <!-- jetty-http is consumed only by the unused Jetty server stack
+                     (jetty-server/servlet/webapp) and the excluded jetty-client.
+                     Raw references elsewhere (kudu-client, hive-apache, paimon-s3/oss)
+                     sit in server-side or metrics-binder classes never loaded by FE. -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-client -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <exclusions>
+                <!-- CVE-2026-10050: the vulnerable DigestAuthentication.apply() lives in
+                     jetty-client, pulled via hadoop-yarn-client -> websocket-client. The
+                     YARN websocket timeline client is unused by StarRocks. -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -1228,7 +1228,7 @@ under the License.
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.7.11</version>
+                <version>42.7.12</version>
             </dependency>
 
             <dependency>
@@ -1712,6 +1712,21 @@ under the License.
                                              unused tether feature references it -->
                                         <exclude>org.apache.avro:avro-ipc</exclude>
                                         <exclude>org.apache.avro:avro-ipc-jetty</exclude>
+                                        <!-- CVE-2026-10050 (jetty-client, jetty-security) and
+                                             CVE-2026-2332 (jetty-http): excluded from the hadoop-common /
+                                             hadoop-client edges in fe-core. Those exclusions only hold
+                                             because hadoop-common is the nearest jetty-server path, so a
+                                             later Hadoop bump could silently re-introduce the jars now
+                                             that the trivy waiver is gone - ban them to fail the build
+                                             instead. Restricted to compile/runtime: spark-dpp and hive-udf
+                                             legitimately see them at provided scope (supplied by
+                                             Spark/Hive at runtime, never packaged). -->
+                                        <exclude>org.eclipse.jetty:jetty-client:*:jar:compile</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-client:*:jar:runtime</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-security:*:jar:compile</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-security:*:jar:runtime</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-http:*:jar:compile</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-http:*:jar:runtime</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -98,6 +98,14 @@
                     <artifactId>lz4-java</artifactId>
                     <groupId>org.lz4</groupId>
                 </exclusion>
+                <!-- org.glassfish:javax.el is pulled (via transitive hbase 2.4.13)
+                     with an open-ended range [3.0.0,), forcing a repeated
+                     javax.el maven-metadata.xml download on every build. It is
+                     not delivered in the reader lib, so prune it (matches fe/pom.xml). -->
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -113,6 +121,16 @@
             <groupId>org.apache.hudi</groupId>
             <artifactId>hudi-hadoop-mr</artifactId>
             <version>${hudi.version}</version>
+            <exclusions>
+                <!-- hudi-hadoop-mr re-introduces hbase 2.4.13 (its transitive
+                     hudi-common is not excluded like the direct one above),
+                     which drags in org.glassfish:javax.el:[3.0.0,). Exclude it
+                     to stop the periodic javax.el metadata download. -->
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -279,6 +279,17 @@
                         <groupId>org.wildfly.openssl</groupId>
                         <artifactId>wildfly-openssl</artifactId>
                     </exclusion>
+                    <!-- CVE-2026-10050 (jetty-security) / CVE-2026-2332 (jetty-http):
+                         both are only reachable via Hadoop's embedded HttpServer2,
+                         which the JNI readers never instantiate (FS client use only). -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-security</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-http</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -318,6 +329,13 @@
                 <artifactId>hadoop-mapreduce-client-core</artifactId>
                 <version>${hadoop.version}</version>
                 <exclusions>
+                    <!-- CVE-2026-10050: vulnerable DigestAuthentication lives in
+                         jetty-client, pulled via hadoop-yarn-client -> websocket-client.
+                         The YARN websocket timeline client is unused by the readers. -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-client</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
@@ -710,6 +728,16 @@
                                              unused tether feature references it -->
                                         <exclude>org.apache.avro:avro-ipc</exclude>
                                         <exclude>org.apache.avro:avro-ipc-jetty</exclude>
+                                        <!-- CVE-2026-10050 (jetty-client, jetty-security) and
+                                             CVE-2026-2332 (jetty-http): excluded from the managed
+                                             hadoop-common / hadoop-mapreduce-client-core edges above.
+                                             That pruning depends on hadoop-common staying the nearest
+                                             jetty-server path (hadoop-lib also pulls hadoop-hdfs-httpfs
+                                             and hadoop-hdfs-nfs, which declare jetty-server directly),
+                                             so ban the jars outright: no reader needs them at any scope. -->
+                                        <exclude>org.eclipse.jetty:jetty-client</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-security</exclude>
+                                        <exclude>org.eclipse.jetty:jetty-http</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -30,5 +30,3 @@ scan:
     - "**/parquet-jackson-1.15.2.jar"
     # from fe
     - "**/parquet-jackson-1.16.0.jar"
-    # CVE-2026-2332, ignore for now
-    - "**/jetty-http-9.4.58.v20250814.jar"


### PR DESCRIPTION
CVE-2026-10050 (jetty-client, jetty-security; 9.4/10/11 EOL, no OSS fix): client-side Digest auth bypass via ISO-8859-1 lossy encoding in DigestAuthentication.apply(). Pulled in transitively via hadoop-common (jetty-servlet -> jetty-security) and hadoop-client / hadoop-mapreduce-client-core (hadoop-yarn-client -> websocket-client -> jetty-client). StarRocks uses Hadoop purely as an FS client and never instantiates the embedded HttpServer2 or the YARN websocket timeline client, so the jars are excluded instead of upgraded (jetty 9.4 is pinned by the hadoop-azure <10 constraint and has no fixed release).

CVE-2026-2332 (jetty-http 9.4.x): consumed only by the unused jetty server stack and the excluded jetty-client; raw references elsewhere (kudu-client, hive-apache, paimon-s3/oss) sit in server-side or metrics-binder classes never loaded by FE or the JNI readers. Excluded the same way, which also lets the trivy suppression be dropped.

- fe/fe-core/pom.xml: exclude jetty-security/jetty-http from hadoop-common and jetty-client from hadoop-client
- java-extensions/pom.xml: same exclusions on the managed hadoop-common and hadoop-mapreduce-client-core entries (propagate to all readers)
- fe/build.gradle.kts: ban all three modules via configurations.all excludes (Gradle exclusions are path-based, per-dependency excludes do not stick); sync jetty.version 9.4.57 -> 9.4.58.v20250814 with the pom
- trivy.yaml: drop the now-unneeded jetty-http scan suppression

CVE-2026-54291 (pgjdbc 42.7.4 - 42.7.11): channelBinding=require not enforced, allowing silent SCRAM channel-binding downgrade by a MITM. Direct dependency of fe-core; bumped the fe/pom.xml dependencyManagement pin and the fe/build.gradle.kts constraint to 42.7.12 (earliest fixed release on Maven Central). Both builds verified to resolve 42.7.12.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
