### PR TITLE
[BugFix] Add missing MV last_refresh_time column on branch-4.0 (backport #71642)

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -54,6 +54,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         {"LAST_REFRESH_PROCESS_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
         {"LAST_REFRESH_JOB_ID", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
         {"LAST_FRESHNESS_CONFIRMED_AT", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
+        {"LAST_REFRESH_TIME", TypeDescriptor::from_logical_type(TYPE_DATETIME), sizeof(DateTimeValue), true},
 };
 
 SchemaMaterializedViewsScanner::SchemaMaterializedViewsScanner()
@@ -433,6 +434,21 @@ Status SchemaMaterializedViewsScanner::fill_chunk(ChunkPtr* chunk) {
                 DateTimeValue t;
                 if (!t.from_date_str(info.last_freshness_confirmed_at.data(),
                                      info.last_freshness_confirmed_at.size())) {
+                    nullable_column->append_nulls(1);
+                } else {
+                    fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);
+                }
+            } else {
+                fill_data_column_with_null(column.get());
+            }
+            break;
+        }
+        case 29: {
+            // LAST_REFRESH_TIME
+            if (info.__isset.last_refresh_time) {
+                auto* nullable_column = down_cast<NullableColumn*>(column.get());
+                DateTimeValue t;
+                if (!t.from_date_str(info.last_refresh_time.data(), info.last_refresh_time.size())) {
                     nullable_column->append_nulls(1);
                 } else {
                     fill_column_with_slot<TYPE_DATETIME>(column.get(), (void*)&t);

--- a/be/test/exec/schema_materialized_views_scanner_test.cpp
+++ b/be/test/exec/schema_materialized_views_scanner_test.cpp
@@ -54,7 +54,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
 
     // Test that scanner has the correct number of columns
     auto slot_descs = scanner.get_slot_descs();
-    EXPECT_EQ(28, slot_descs.size());
+    EXPECT_EQ(29, slot_descs.size());
 
     // Test column names and types
     EXPECT_EQ("MATERIALIZED_VIEW_ID", slot_descs[0]->col_name());
@@ -85,6 +85,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_scanner_initialization) {
     EXPECT_EQ("LAST_REFRESH_PROCESS_TIME", slot_descs[25]->col_name());
     EXPECT_EQ("LAST_REFRESH_JOB_ID", slot_descs[26]->col_name());
     EXPECT_EQ("LAST_FRESHNESS_CONFIRMED_AT", slot_descs[27]->col_name());
+    EXPECT_EQ("LAST_REFRESH_TIME", slot_descs[28]->col_name());
 }
 
 TEST_F(SchemaMaterializedViewsScannerTest, test_uninitialized_scanner) {
@@ -188,6 +189,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     mv.__set_last_refresh_process_time("2025-01-01 10:04:30");
     mv.__set_last_refresh_job_id("job_001");
     mv.__set_last_freshness_confirmed_at("2025-01-01 10:06:07");
+    mv.__set_last_refresh_time("2025-01-01 10:05:00");
 
     scanner._mv_results.materialized_views = {mv};
 
@@ -220,6 +222,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_single_materialized_view) {
     EXPECT_TRUE(row.find("2025-01-01 10:04:30") != std::string::npos);      // LAST_REFRESH_PROCESS_TIME
     EXPECT_TRUE(row.find("job_001") != std::string::npos);                  // LAST_REFRESH_JOB_ID
     EXPECT_TRUE(row.find("2025-01-01 10:06:07") != std::string::npos);      // LAST_FRESHNESS_CONFIRMED_AT
+    EXPECT_TRUE(row.find("2025-01-01 10:05:00") != std::string::npos);      // LAST_REFRESH_TIME
 
     chunk->reset();
     EXPECT_OK(scanner.get_next(&chunk, &eos));
@@ -267,6 +270,7 @@ TEST_F(SchemaMaterializedViewsScannerTest, test_multiple_materialized_views) {
         mv.__set_creator("user_" + std::to_string(i));
         mv.__set_last_refresh_process_time("2025-01-01 10:04:30");
         mv.__set_last_refresh_job_id("job_" + std::to_string(i));
+        mv.__set_last_refresh_time("2025-01-01 10:05:0" + std::to_string(i));
 
         mvs.push_back(mv);
     }

--- a/docs/en/sql-reference/information_schema/materialized_views.md
+++ b/docs/en/sql-reference/information_schema/materialized_views.md
@@ -38,3 +38,4 @@ The following fields are provided in `materialized_views`:
 | LAST_REFRESH_PROCESS_TIME            | Process time of the most recent refresh task.                |
 | LAST_REFRESH_JOB_ID                  | Job ID of the most recent refresh task.                      |
 | LAST_FRESHNESS_CONFIRMED_AT          | Start time of the most recent successful refresh, recorded once the entire refresh (all of its task runs) completes; a refresh that found no base-table changes to apply also confirms freshness. The materialized view reflects base-table data as of this moment. Unlike `LAST_REFRESH_TIME` (the base-table data version), this is wall-clock time. `NULL` until the first successful refresh, and for synchronous materialized views. A partition-scoped (partial) REFRESH does not advance it. |
+| LAST_REFRESH_TIME                    | Time up to which base table updates are reflected in the materialized view. |

--- a/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -47,6 +47,7 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | name                       | The name of the materialized view.                           |
 | refresh_type               | The refresh type of the materialized view, including ROLLUP, MANUAL, ASYNC, and INCREMENTAL. |
 | is_active                  | Whether the materialized view state is active. Valid Value: `true` and `false`. |
+| inactive_reason            | The reason why the materialized view is inactive.            |
 | partition_type             | The partition type of the materialized view, including RANGE and UNPARTITIONED.                |
 | task_id                    | ID of the materialized view refresh task.                  |
 | task_name                  | Name of the materialized view refresh task.                |
@@ -63,7 +64,13 @@ Since v3.3, `SHOW MATERIALIZED VIEWS` command will track the state of all task_r
 | last_refresh_error_message | The reason why the last refresh failed (if the materialized view state is not active). |
 | rows                       | The number of data rows in the materialized view.            |
 | text                       | The statement used to create the materialized view.          |
+| extra_message              | Extra information about the latest refresh task.             |
+| query_rewrite_status       | Query rewrite status of the materialized view.               |
+| creator                    | Creator of the materialized view refresh task.               |
+| last_refresh_process_time  | The process start time of the latest refresh task.           |
+| last_refresh_job_id        | Job ID of the latest refresh task.                           |
 | last_freshness_confirmed_at | Start time of the most recent successful refresh, recorded once the entire refresh (all of its task runs) completes; a refresh that found no base-table changes to apply also confirms freshness. The materialized view reflects base-table data as of this moment. Unlike `last_refresh_time` (the base-table data version), this is wall-clock time. Empty until the first successful refresh, and for synchronous materialized views. A partition-scoped (partial) REFRESH does not advance it. |
+| last_refresh_time          | Time up to which base table updates are reflected in the materialized view. |
 
 ## Examples
 

--- a/docs/zh/sql-reference/information_schema/materialized_views.md
+++ b/docs/zh/sql-reference/information_schema/materialized_views.md
@@ -38,3 +38,4 @@ displayed_sidebar: docs
 | LAST_REFRESH_PROCESS_TIME            | 最近一次刷新任务的处理时间。                     |
 | LAST_REFRESH_JOB_ID                  | 最近一次刷新任务的作业 ID。                      |
 | LAST_FRESHNESS_CONFIRMED_AT          | 最近一次成功刷新的开始时间，在整次刷新（其全部 task run）完成后才记录；确认基表无变化、无需刷新的刷新同样会确认新鲜度。物化视图反映该时刻的基表数据。区别于 `LAST_REFRESH_TIME`（基表数据版本时间），这是墙钟时间。首次成功刷新前、以及同步物化视图，为 `NULL`。按分区范围的 REFRESH（部分刷新）不推进该值。 |
+| LAST_REFRESH_TIME                    | 物化视图已反映基表更新的最新时间。               |

--- a/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/SHOW_MATERIALIZED_VIEW.md
@@ -48,6 +48,7 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | name                       | 物化视图名称。                                               |
 | refresh_type               | 物化视图的更新方式，包括 ROLLUP、MANUAL、ASYNC、INCREMENTAL。   |
 | is_active                  | 物化视图状态是否为 active。有效值：`true` 和 `false`。          |
+| inactive_reason            | 物化视图失效的原因。                                          |
 | partition_type             | 物化视图的分区类型，包括 RANGE 和 UNPARTITIONED。|
 | task_id                    | 物化视图的刷新任务 ID。                                       |
 | task_name                  | 物化视图的刷新任务名称。                                       |
@@ -64,7 +65,13 @@ WHERE NAME { = "mv_name" | LIKE "mv_name_matcher"}
 | last_refresh_error_message | 物化视图上一次刷新失败的 ErrorMessage（如果物化视图状态不为 active）。 |
 | rows                       | 物化视图中数据行数。                                           |
 | text                       | 创建物化视图的查询语句。                                        |
+| extra_message              | 最近一次刷新任务的额外信息。                                    |
+| query_rewrite_status       | 物化视图的查询改写状态。                                        |
+| creator                    | 最近一次刷新任务的创建者。                                      |
+| last_refresh_process_time  | 最近一次刷新任务的处理开始时间。                                |
+| last_refresh_job_id        | 最近一次刷新任务的作业 ID。                                     |
 | last_freshness_confirmed_at | 最近一次成功刷新的开始时间，在整次刷新（其全部 task run）完成后才记录；确认基表无变化、无需刷新的刷新同样会确认新鲜度。物化视图反映该时刻的基表数据。区别于 `last_refresh_time`（基表数据版本时间），这是墙钟时间。首次成功刷新前、以及同步物化视图，为空。按分区范围的 REFRESH（部分刷新）不推进该值。 |
+| last_refresh_time          | 物化视图已反映基表更新的最新时间。                              |
 
 ## 示例
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -105,6 +105,7 @@ public class MaterializedViewsSystemTable extends SystemTable {
                         .column("LAST_REFRESH_PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("LAST_REFRESH_JOB_ID", ScalarType.createVarchar(64))
                         .column("LAST_FRESHNESS_CONFIRMED_AT", ScalarType.createType(PrimitiveType.DATETIME))
+                        .column("LAST_REFRESH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -75,6 +75,7 @@ public class ShowMaterializedViewStatus {
     private long taskId;
     private String taskName;
     private long lastFreshnessConfirmedAt;
+    private long lastRefreshTime;
     private List<TaskRunStatus> lastJobTaskRunStatus;
 
     /**
@@ -355,6 +356,9 @@ public class ShowMaterializedViewStatus {
             status.setTaskId(task.getId());
             status.setTaskName(task.getName());
         }
+        if (refreshScheme != null) {
+            status.setLastRefreshTime(refreshScheme.getLastRefreshTime());
+        }
         status.setLastJobTaskRunStatus(taskTaskStatusJob);
         return status;
     }
@@ -491,6 +495,14 @@ public class ShowMaterializedViewStatus {
 
     public void setLastFreshnessConfirmedAt(long lastFreshnessConfirmedAt) {
         this.lastFreshnessConfirmedAt = lastFreshnessConfirmedAt;
+    }
+
+    public long getLastRefreshTime() {
+        return lastRefreshTime;
+    }
+
+    public void setLastRefreshTime(long lastRefreshTime) {
+        this.lastRefreshTime = lastRefreshTime;
     }
 
     public void setLastJobTaskRunStatus(List<TaskRunStatus> lastJobTaskRunStatus) {
@@ -671,6 +683,10 @@ public class ShowMaterializedViewStatus {
         if (lastFreshnessConfirmedAt > 0) {
             status.setLast_freshness_confirmed_at(TimeUtils.longToTimeString(lastFreshnessConfirmedAt));
         }
+        // last refresh time (data version timestamp used for staleness check)
+        if (lastRefreshTime > 0) {
+            status.setLast_refresh_time(TimeUtils.longToTimeString(lastRefreshTime));
+        }
 
         return status;
     }
@@ -745,6 +761,8 @@ public class ShowMaterializedViewStatus {
         // last refresh job id
         addField(resultRow, refreshJobStatus.getJobId());
         addField(resultRow, lastFreshnessConfirmedAt > 0 ? TimeUtils.longToTimeString(lastFreshnessConfirmedAt) : "");
+        // last refresh time (data version timestamp used for staleness check)
+        addField(resultRow, lastRefreshTime > 0 ? TimeUtils.longToTimeString(lastRefreshTime) : "");
 
         return resultRow;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -831,6 +831,7 @@ public class ShowResultMetaFactory implements AstVisitor<ShowResultSetMetaData, 
                 .column("last_refresh_process_time", ScalarType.createType(PrimitiveType.DATETIME))
                 .column("last_refresh_job_id", ScalarType.createVarchar(64))
                 .column("last_freshness_confirmed_at", ScalarType.createType(PrimitiveType.DATETIME))
+                .column("last_refresh_time", ScalarType.createType(PrimitiveType.DATETIME))
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -69,7 +69,8 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
             "creator",
             "last_refresh_process_time",
             "last_refresh_job_id",
-            "last_freshness_confirmed_at"
+            "last_freshness_confirmed_at",
+            "last_refresh_time"
     );
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -122,7 +122,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.creator AS creator, " +
                         "information_schema.materialized_views.last_refresh_process_time AS last_refresh_process_time, " +
                         "information_schema.materialized_views.last_refresh_job_id AS last_refresh_job_id, " +
-                        "information_schema.materialized_views.last_freshness_confirmed_at AS last_freshness_confirmed_at" +
+                        "information_schema.materialized_views.last_freshness_confirmed_at AS last_freshness_confirmed_at, " +
+                        "information_schema.materialized_views.last_refresh_time AS last_refresh_time" +
                         " FROM " +
                         "information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND " +

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -1036,7 +1036,7 @@ public class ShowStmtMetaTest {
     public void testShowMaterializedViewsStmt() {
         ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("test_db", null);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(28, metaData.getColumnCount());
+        Assertions.assertEquals(29, metaData.getColumnCount());
         Assertions.assertEquals("id", metaData.getColumn(0).getName());
         Assertions.assertEquals("database_name", metaData.getColumn(1).getName());
         Assertions.assertEquals("name", metaData.getColumn(2).getName());
@@ -1065,6 +1065,7 @@ public class ShowStmtMetaTest {
         Assertions.assertEquals("last_refresh_process_time", metaData.getColumn(25).getName());
         Assertions.assertEquals("last_refresh_job_id", metaData.getColumn(26).getName());
         Assertions.assertEquals("last_freshness_confirmed_at", metaData.getColumn(27).getName());
+        Assertions.assertEquals("last_refresh_time", metaData.getColumn(28).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/ShowMaterializedViewStatusTest.java
@@ -56,6 +56,7 @@ public class ShowMaterializedViewStatusTest {
 
         List<String> resultSet = viewStatus.toResultSet();
 
+        Assertions.assertEquals(29, resultSet.size());
         Assertions.assertEquals("", resultSet.get(3)); // refresh type
         Assertions.assertEquals("false", resultSet.get(4)); // is active
         Assertions.assertEquals("", resultSet.get(5)); // inactive reason
@@ -78,5 +79,17 @@ public class ShowMaterializedViewStatusTest {
         Assertions.assertEquals("", resultSet.get(22)); // owner
         Assertions.assertEquals("", resultSet.get(23)); // process start time
         Assertions.assertEquals("", resultSet.get(24)); // last refresh job id
+        Assertions.assertEquals("", resultSet.get(27)); // last freshness confirmed at
+        Assertions.assertEquals("", resultSet.get(28)); // last refresh time
+    }
+
+    @Test
+    public void toThriftIncludesLastRefreshTimeWhenPresent() {
+        ShowMaterializedViewStatus viewStatus = new ShowMaterializedViewStatus(1L, "testDb", "testView");
+        viewStatus.setLastRefreshTime(1735697100000L);
+
+        TMaterializedViewStatus thriftStatus = viewStatus.toThrift();
+
+        Assertions.assertEquals("2025-01-01 10:05:00", thriftStatus.getLast_refresh_time());
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -410,6 +410,7 @@ struct TMaterializedViewStatus {
     29: optional string last_refresh_process_time
     30: optional string last_refresh_job_id
     31: optional string last_freshness_confirmed_at
+    32: optional string last_refresh_time
 }
 
 struct TListPipesParams {

--- a/test/sql/test_information_schema/R/test_materialized_views
+++ b/test/sql/test_information_schema/R/test_materialized_views
@@ -28,6 +28,10 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_vi
 -- result:
 OK
 -- !result
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
@@ -36,6 +40,10 @@ set enable_evaluate_schema_scan_rule=false;
 1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 -- result:
 OK
 -- !result

--- a/test/sql/test_information_schema/T/test_materialized_views
+++ b/test/sql/test_information_schema/T/test_materialized_views
@@ -14,9 +14,11 @@ AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
 set enable_evaluate_schema_scan_rule=true;
 [UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 set enable_evaluate_schema_scan_rule=false;
 [UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+select if(max(if(TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'mv1' and LAST_REFRESH_TIME is not null, 1, 0)) = 1, "OK", "FAILED") from information_schema.materialized_views;
 
 create database if not exists test_information_schema_materialized_views;
 use test_information_schema_materialized_views;


### PR DESCRIPTION
## Why I'm doing:

branch-4.0 has SQL tests and docs that reference the
`information_schema.materialized_views.LAST_REFRESH_TIME` column (synced from
branch-4.1 by #76391), but no backing column definition — so
`test_show_materialized_view` queries a column that does not exist on 4.0. This
backports #71642 to supply the missing `LAST_REFRESH_TIME` column and repair
those dangling references. `LAST_REFRESH_TIME` is the base-table data version
up to which a materialized view reflects updates; it is already exposed on main
and branch-4.1.

## What I'm doing:

Cherry-pick of #71642 with conflicts resolved for branch-4.0:

- branch-4.0 has an extra MV-observability column `LAST_FRESHNESS_CONFIRMED_AT`
  (not on main/4.1) and predates main's schema-column type API migration
  (`DateType`/`TypeFactory`). Conflicts were resolved by keeping 4.0's column
  set and API style and appending `LAST_REFRESH_TIME` after
  `LAST_FRESHNESS_CONFIRMED_AT` everywhere (FE system table, SHOW meta & row
  builder, BE scanner, thrift, docs, tests).
- thrift: `last_refresh_time` takes a fresh ordinal (32); 31 stays
  `last_freshness_confirmed_at`.
- BE scanner: `LAST_REFRESH_TIME` fill is `case 29` (`slot_id` is 1-based) and
  uses `column.get()` to match 4.0's `ColumnPtr` API.
- The SHOW→SELECT column list lives in `ShowMaterializedViewsStmt` on 4.0
  (main's `ShowStmtToSelectStmtConverter` does not exist here), so
  `last_refresh_time` was added there instead; the converter file is dropped.
- Index/size assertions shifted by the extra freshness column (SHOW row size
  29, `last_refresh_time` at index 28).

Fixes #issue: N/A — backport of #71642 to branch-4.0.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
