### PR TITLE
[BugFix] Reject non-encodable sort key column types (all distributions, CREATE and ALTER)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1293,6 +1293,13 @@ public class SchemaChangeHandler extends AlterHandler {
             if (!colNameSet.add(colName)) {
                 throw new DdlException("Duplicated column[" + colName + "]");
             }
+            // The new sort key columns are encoded on the BE via an order-preserving KeyCoder; a type
+            // without one (JSON/complex/floating-point/metric/variant/TIME) would crash the BE
+            // short-key encoder on rewrite, so reject ALTER TABLE ... ORDER BY here.
+            if (!oneCol.get().getType().canBeSortKey()) {
+                throw new DdlException("Sort key column[" + colName + "] type not supported: "
+                        + oneCol.get().getType().toSql());
+            }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
             if (useSortKeyUniqueId && oneCol.get().getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1317,7 +1317,7 @@ public class SchemaChangeHandler extends AlterHandler {
             // metric/variant/TIME do not) -- otherwise the BE crashes on rewrite.
             for (int sortKeyIdx : sortKeyIdxes) {
                 Column col = targetIndexSchema.get(sortKeyIdx);
-                if (!col.getType().canBeSortKey()) {
+                if (!col.getType().canDistributedBy()) {
                     throw new DdlException("Sort key column[" + col.getName() + "] type not supported: "
                             + col.getType().toSql());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1293,13 +1293,6 @@ public class SchemaChangeHandler extends AlterHandler {
             if (!colNameSet.add(colName)) {
                 throw new DdlException("Duplicated column[" + colName + "]");
             }
-            // The new sort key columns are encoded on the BE via an order-preserving KeyCoder; a type
-            // without one (JSON/complex/floating-point/metric/variant/TIME) would crash the BE
-            // short-key encoder on rewrite, so reject ALTER TABLE ... ORDER BY here.
-            if (!oneCol.get().getType().canBeSortKey()) {
-                throw new DdlException("Sort key column[" + colName + "] type not supported: "
-                        + oneCol.get().getType().toSql());
-            }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
             if (useSortKeyUniqueId && oneCol.get().getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
@@ -1319,7 +1312,16 @@ public class SchemaChangeHandler extends AlterHandler {
             columnId++;
         }
         if (olapTable.getKeysType() == KeysType.DUP_KEYS) {
-            // duplicate table has no limit in sort key columns
+            // A duplicate table's sort key has no key-order limit, but each column is still short-key
+            // encoded on the BE, so its type must have a key coder (JSON/complex/floating-point/
+            // metric/variant/TIME do not) -- otherwise the BE crashes on rewrite.
+            for (int sortKeyIdx : sortKeyIdxes) {
+                Column col = targetIndexSchema.get(sortKeyIdx);
+                if (!col.getType().canBeSortKey()) {
+                    throw new DdlException("Sort key column[" + col.getName() + "] type not supported: "
+                            + col.getType().toSql());
+                }
+            }
         } else if (olapTable.getKeysType() == KeysType.PRIMARY_KEYS) {
             // sort key column of primary key table has type limitation
             for (int sortKeyIdx : sortKeyIdxes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -587,6 +587,13 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 if (idx == -1) {
                     throw new SemanticException("Unknown column '%s' does not exist", column);
                 }
+                // Sort key columns are encoded on the BE via an order-preserving KeyCoder; reject
+                // types without one (JSON/complex/floating-point/metric/variant/TIME) so ALTER ...
+                // ORDER BY fails cleanly instead of crashing the BE short-key encoder on rewrite.
+                if (!columnDefs.get(idx).getType().canBeSortKey()) {
+                    throw new SemanticException("Sort key column[" + column + "] type not supported: "
+                            + columnDefs.get(idx).getType().toSql());
+                }
                 sortKeyIdxes.add(idx);
             }
         }
@@ -1269,10 +1276,11 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                     throw new SemanticException("Duplicate ORDER BY column '" + sk + "'");
                 }
                 // A range rollup's ORDER BY columns become its range sort-key (tablet-boundary) columns, so
-                // they must be sortable -- reject JSON and other non-distributable types, mirroring base-table
-                // and rollup key validation (createRangeRollupJob re-derives key flags from these columns).
+                // they must be encodable as a key on the BE -- reject JSON/complex/floating-point/metric/
+                // variant and TIME (which the BE has no key coder for), mirroring base-table and rollup key
+                // validation (createRangeRollupJob re-derives key flags from these columns).
                 Column sortKeyColumn = table.getColumn(sk);
-                if (sortKeyColumn != null && !sortKeyColumn.getType().canDistributedBy()) {
+                if (sortKeyColumn != null && !sortKeyColumn.getType().canBeSortKey()) {
                     throw new SemanticException("ORDER BY column '" + sk + "' has non-sortable type '"
                             + sortKeyColumn.getType() + "' and cannot be a range rollup sort key");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -590,7 +590,7 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 // Sort key columns are encoded on the BE via an order-preserving KeyCoder; reject
                 // types without one (JSON/complex/floating-point/metric/variant/TIME) so ALTER ...
                 // ORDER BY fails cleanly instead of crashing the BE short-key encoder on rewrite.
-                if (!columnDefs.get(idx).getType().canBeSortKey()) {
+                if (!columnDefs.get(idx).getType().canDistributedBy()) {
                     throw new SemanticException("Sort key column[" + column + "] type not supported: "
                             + columnDefs.get(idx).getType().toSql());
                 }
@@ -1277,10 +1277,10 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 }
                 // A range rollup's ORDER BY columns become its range sort-key (tablet-boundary) columns, so
                 // they must be encodable as a key on the BE -- reject JSON/complex/floating-point/metric/
-                // variant and TIME (which the BE has no key coder for), mirroring base-table and rollup key
-                // validation (createRangeRollupJob re-derives key flags from these columns).
+                // variant and TIME (all excluded by canDistributedBy()), mirroring base-table and rollup
+                // key validation (createRangeRollupJob re-derives key flags from these columns).
                 Column sortKeyColumn = table.getColumn(sk);
-                if (sortKeyColumn != null && !sortKeyColumn.getType().canBeSortKey()) {
+                if (sortKeyColumn != null && !sortKeyColumn.getType().canDistributedBy()) {
                     throw new SemanticException("ORDER BY column '" + sk + "' has non-sortable type '"
                             + sortKeyColumn.getType() + "' and cannot be a range rollup sort key");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -500,6 +500,34 @@ public class CreateTableAnalyzer {
                                 !new HashSet<>(keyColIdxes).equals(new HashSet<>(sortKeyIdxes))) {
                     throw new SemanticException("The sort columns must be same with key columns");
                 }
+            } else {
+                // For a range-distributed duplicate key table the sort key defines the tablet range
+                // boundaries, so every sort key column type must be encodable as a key. Types that
+                // cannot (e.g. JSON) have no key coder on the BE and would crash the short-key encoder.
+                for (OrderByElement orderByElement : orderByElements) {
+                    Expr expr = orderByElement.getExpr();
+                    String column = expr instanceof SlotRef ? ((SlotRef) expr).getColumnName() : null;
+                    if (column == null) {
+                        throw new SemanticException("Unknown column '%s' in order by clause",
+                                ExprToSql.toSql(orderByElement.getExpr()));
+                    }
+                    int idx = -1;
+                    for (int i = 0; i < columnNames.size(); i++) {
+                        if (columnNames.get(i).equalsIgnoreCase(column)) {
+                            idx = i;
+                            break;
+                        }
+                    }
+                    if (idx == -1) {
+                        throw new SemanticException("Column '%s' does not exist", column);
+                    }
+                    ColumnDef cd = columnDefs.get(idx);
+                    Type t = cd.getType();
+                    if (!t.canDistributedBy()) {
+                        throw new SemanticException(
+                                "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
+                    }
+                }
             }
         } else {
             // we should check sort key column type if table is primary key table

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -502,8 +502,10 @@ public class CreateTableAnalyzer {
                 }
             } else {
                 // For a range-distributed duplicate key table the sort key defines the tablet range
-                // boundaries, so every sort key column type must be encodable as a key. Types that
-                // cannot (e.g. JSON) have no key coder on the BE and would crash the short-key encoder.
+                // boundaries, so every sort key column type must be encodable as a key on the BE.
+                // Types without a BE key coder (JSON/complex/floating-point/metric/variant via
+                // !canDistributedBy(), plus TIME which canDistributedBy() allows but has no key
+                // coder) would crash the short-key encoder, so reject them here.
                 for (OrderByElement orderByElement : orderByElements) {
                     Expr expr = orderByElement.getExpr();
                     String column = expr instanceof SlotRef ? ((SlotRef) expr).getColumnName() : null;
@@ -523,7 +525,7 @@ public class CreateTableAnalyzer {
                     }
                     ColumnDef cd = columnDefs.get(idx);
                     Type t = cd.getType();
-                    if (!t.canDistributedBy()) {
+                    if (!t.canDistributedBy() || t.isTime()) {
                         throw new SemanticException(
                                 "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -501,35 +501,9 @@ public class CreateTableAnalyzer {
                     throw new SemanticException("The sort columns must be same with key columns");
                 }
             } else {
-                // For a range-distributed duplicate key table the sort key defines the tablet range
-                // boundaries, so every sort key column type must be encodable as a key on the BE.
-                // Types without a BE key coder (JSON/complex/floating-point/metric/variant via
-                // !canDistributedBy(), plus TIME which canDistributedBy() allows but has no key
-                // coder) would crash the short-key encoder, so reject them here.
-                for (OrderByElement orderByElement : orderByElements) {
-                    Expr expr = orderByElement.getExpr();
-                    String column = expr instanceof SlotRef ? ((SlotRef) expr).getColumnName() : null;
-                    if (column == null) {
-                        throw new SemanticException("Unknown column '%s' in order by clause",
-                                ExprToSql.toSql(orderByElement.getExpr()));
-                    }
-                    int idx = -1;
-                    for (int i = 0; i < columnNames.size(); i++) {
-                        if (columnNames.get(i).equalsIgnoreCase(column)) {
-                            idx = i;
-                            break;
-                        }
-                    }
-                    if (idx == -1) {
-                        throw new SemanticException("Column '%s' does not exist", column);
-                    }
-                    ColumnDef cd = columnDefs.get(idx);
-                    Type t = cd.getType();
-                    if (!t.canDistributedBy() || t.isTime()) {
-                        throw new SemanticException(
-                                "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
-                    }
-                }
+                // A range-distributed duplicate key table's sort key defines the tablet range
+                // boundaries; every sort key column type must be encodable as a key on the BE.
+                checkSortKeyTypesEncodable(orderByElements, columnDefs, columnNames);
             }
         } else {
             // we should check sort key column type if table is primary key table
@@ -553,7 +527,9 @@ public class CreateTableAnalyzer {
                     }
                 }
             } else if (keysType == KeysType.DUP_KEYS) {
-                // sort key column of duplicate table has no limitation
+                // A duplicate key table's sort key columns are encoded on the BE (short-key index)
+                // regardless of distribution, so their types must be BE-encodable here too.
+                checkSortKeyTypesEncodable(orderByElements, columnDefs, columnNames);
             } else if (keysType == KeysType.AGG_KEYS || keysType == KeysType.UNIQUE_KEYS) {
                 List<Integer> sortKeyIdxes = Lists.newArrayList();
                 for (OrderByElement orderByElement : orderByElements) {
@@ -588,6 +564,39 @@ public class CreateTableAnalyzer {
                 }
             } else {
                 throw new SemanticException("Table type:" + keysType.toSql() + " does not support sort key column");
+            }
+        }
+    }
+
+    // Reject sort key (ORDER BY) columns whose type the BE cannot encode as a key. Sort key columns
+    // are written into the short-key index via an order-preserving KeyCoder; a type without a key
+    // coder (JSON, complex, floating-point, metric, variant, and TIME) would crash the BE encoder,
+    // so fail cleanly at CREATE TABLE instead. Column resolution is case-insensitive to match
+    // OlapTableFactory.
+    private static void checkSortKeyTypesEncodable(List<OrderByElement> orderByElements,
+                                                   List<ColumnDef> columnDefs, List<String> columnNames) {
+        for (OrderByElement orderByElement : orderByElements) {
+            Expr expr = orderByElement.getExpr();
+            String column = expr instanceof SlotRef ? ((SlotRef) expr).getColumnName() : null;
+            if (column == null) {
+                throw new SemanticException("Unknown column '%s' in order by clause",
+                        ExprToSql.toSql(orderByElement.getExpr()));
+            }
+            int idx = -1;
+            for (int i = 0; i < columnNames.size(); i++) {
+                if (columnNames.get(i).equalsIgnoreCase(column)) {
+                    idx = i;
+                    break;
+                }
+            }
+            if (idx == -1) {
+                throw new SemanticException("Column '%s' does not exist", column);
+            }
+            ColumnDef cd = columnDefs.get(idx);
+            Type t = cd.getType();
+            if (!t.canBeSortKey()) {
+                throw new SemanticException(
+                        "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -594,7 +594,7 @@ public class CreateTableAnalyzer {
             }
             ColumnDef cd = columnDefs.get(idx);
             Type t = cd.getType();
-            if (!t.canBeSortKey()) {
+            if (!t.canDistributedBy()) {
                 throw new SemanticException(
                         "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTableTest.java
@@ -539,4 +539,20 @@ public class AlterTableTest extends StarRocksTestBase {
             Assertions.assertTrue(e.getMessage().contains("table has location property and cannot be colocated"));
         }
     }
+
+    @Test
+    public void testAlterOrderBySortKeyTypeRestriction() throws Exception {
+        starRocksAssert.useDatabase("test").withTable(
+                "CREATE TABLE test_alter_sortkey_type (k1 INT, c JSON, v INT)\n" +
+                        "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');");
+        // ALTER TABLE ... ORDER BY makes c the sort key; JSON has no BE key coder, so it must be
+        // rejected instead of crashing the BE short-key encoder on rewrite.
+        // The DdlException from processModifySortKeyColumn is surfaced wrapped as an AlterJobException.
+        Throwable t = assertThrows(AlterJobException.class, () -> {
+            AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "ALTER TABLE test_alter_sortkey_type ORDER BY (c)", connectContext);
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
+        });
+        Assertions.assertTrue(t.getMessage().contains("Sort key column[c] type not supported"), t.getMessage());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -569,6 +569,51 @@ public class CreateTableAnalyzerTest {
     }
 
     @Test
+    public void testDupTableRangeSortKeyTypeRestriction() {
+        // Force range distribution via the session variable (ungated by run mode) so the range
+        // sort-key type validation is exercised regardless of the suite's ambient run mode.
+        connectContext.getSessionVariable().setEnableRangeDistribution(true);
+        try {
+            // JSON sort key on a range-distributed duplicate table -> Should fail: JSON has no BE key
+            // coder, and range distribution encodes the sort key for tablet range boundaries (#11611).
+            String sql1 = "CREATE TABLE test_create_table_db.dup_range_json_sortkey\n" +
+                    "(\n" +
+                    "    k1 int,\n" +
+                    "    c  json\n" +
+                    ") DUPLICATE KEY(k1)\n" +
+                    "ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");";
+            analyzeFail(sql1, "Sort key column[c] type not supported");
+
+            // A normal (int) sort key on a range-distributed duplicate table -> Should pass. The
+            // ORDER BY reference uses a different case than the column definition to confirm the
+            // range sort-key column resolution is case-insensitive (matching OlapTableFactory).
+            String sql2 = "CREATE TABLE test_create_table_db.dup_range_int_sortkey\n" +
+                    "(\n" +
+                    "    k1 int,\n" +
+                    "    c  int\n" +
+                    ") DUPLICATE KEY(k1)\n" +
+                    "ORDER BY(C)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");";
+            analyzeSuccess(sql2);
+
+            // range distribution off -> a JSON sort key on a duplicate table stays unrestricted.
+            connectContext.getSessionVariable().setEnableRangeDistribution(false);
+            String sql3 = "CREATE TABLE test_create_table_db.dup_norange_json_sortkey\n" +
+                    "(\n" +
+                    "    k1 int,\n" +
+                    "    c  json\n" +
+                    ") DUPLICATE KEY(k1)\n" +
+                    "DISTRIBUTED BY HASH(k1)\n" +
+                    "ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");";
+            analyzeSuccess(sql3);
+        } finally {
+            connectContext.getSessionVariable().setEnableRangeDistribution(false);
+        }
+    }
+
+    @Test
     public void testCreateTableForceRange() {
         boolean oldEnableRangeDistribution = Config.enable_range_distribution;
         Config.enable_range_distribution = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -585,6 +585,17 @@ public class CreateTableAnalyzerTest {
                     "PROPERTIES (\"replication_num\" = \"1\");";
             analyzeFail(sql1, "Sort key column[c] type not supported");
 
+            // TIME sort key on a range-distributed duplicate table -> Should fail: TIME is allowed by
+            // canDistributedBy() but has no BE key coder, so it must also be rejected here (#11611).
+            String sqlTime = "CREATE TABLE test_create_table_db.dup_range_time_sortkey\n" +
+                    "(\n" +
+                    "    k1 int,\n" +
+                    "    c  time\n" +
+                    ") DUPLICATE KEY(k1)\n" +
+                    "ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");";
+            analyzeFail(sqlTime, "Sort key column[c] type not supported");
+
             // A normal (int) sort key on a range-distributed duplicate table -> Should pass. The
             // ORDER BY reference uses a different case than the column definition to confirm the
             // range sort-key column resolution is case-insensitive (matching OlapTableFactory).

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -569,56 +569,47 @@ public class CreateTableAnalyzerTest {
     }
 
     @Test
-    public void testDupTableRangeSortKeyTypeRestriction() {
-        // Force range distribution via the session variable (ungated by run mode) so the range
-        // sort-key type validation is exercised regardless of the suite's ambient run mode.
+    public void testDupTableSortKeyTypeRestriction() {
+        // A sort key column is encoded on the BE via a KeyCoder; types without one (JSON, TIME, ...)
+        // crash the short-key encoder, so they must be rejected at CREATE TABLE for duplicate key
+        // tables under BOTH range and non-range distribution (#11611).
         connectContext.getSessionVariable().setEnableRangeDistribution(true);
         try {
-            // JSON sort key on a range-distributed duplicate table -> Should fail: JSON has no BE key
-            // coder, and range distribution encodes the sort key for tablet range boundaries (#11611).
-            String sql1 = "CREATE TABLE test_create_table_db.dup_range_json_sortkey\n" +
-                    "(\n" +
-                    "    k1 int,\n" +
-                    "    c  json\n" +
-                    ") DUPLICATE KEY(k1)\n" +
-                    "ORDER BY(c)\n" +
-                    "PROPERTIES (\"replication_num\" = \"1\");";
-            analyzeFail(sql1, "Sort key column[c] type not supported");
+            // JSON sort key, range distribution -> reject (JSON has no BE key coder).
+            analyzeFail("CREATE TABLE test_create_table_db.dup_range_json_sortkey\n" +
+                    "(k1 int, c json) DUPLICATE KEY(k1) ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");",
+                    "Sort key column[c] type not supported");
 
-            // TIME sort key on a range-distributed duplicate table -> Should fail: TIME is allowed by
-            // canDistributedBy() but has no BE key coder, so it must also be rejected here (#11611).
-            String sqlTime = "CREATE TABLE test_create_table_db.dup_range_time_sortkey\n" +
-                    "(\n" +
-                    "    k1 int,\n" +
-                    "    c  time\n" +
-                    ") DUPLICATE KEY(k1)\n" +
-                    "ORDER BY(c)\n" +
-                    "PROPERTIES (\"replication_num\" = \"1\");";
-            analyzeFail(sqlTime, "Sort key column[c] type not supported");
+            // TIME sort key, range distribution -> reject (canDistributedBy() allows TIME, but the BE
+            // has no TIME key coder; canBeSortKey() excludes it).
+            analyzeFail("CREATE TABLE test_create_table_db.dup_range_time_sortkey\n" +
+                    "(k1 int, c time) DUPLICATE KEY(k1) ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");",
+                    "Sort key column[c] type not supported");
 
-            // A normal (int) sort key on a range-distributed duplicate table -> Should pass. The
-            // ORDER BY reference uses a different case than the column definition to confirm the
-            // range sort-key column resolution is case-insensitive (matching OlapTableFactory).
-            String sql2 = "CREATE TABLE test_create_table_db.dup_range_int_sortkey\n" +
-                    "(\n" +
-                    "    k1 int,\n" +
-                    "    c  int\n" +
-                    ") DUPLICATE KEY(k1)\n" +
-                    "ORDER BY(C)\n" +
-                    "PROPERTIES (\"replication_num\" = \"1\");";
-            analyzeSuccess(sql2);
+            // A normal (int) sort key -> pass. The ORDER BY reference uses a different case than the
+            // column definition to confirm case-insensitive resolution (matching OlapTableFactory).
+            analyzeSuccess("CREATE TABLE test_create_table_db.dup_range_int_sortkey\n" +
+                    "(k1 int, c int) DUPLICATE KEY(k1) ORDER BY(C)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");");
 
-            // range distribution off -> a JSON sort key on a duplicate table stays unrestricted.
+            // Non-range distribution: the same crash is reachable (the sort key is still short-key
+            // encoded), so JSON/TIME must be rejected here too.
             connectContext.getSessionVariable().setEnableRangeDistribution(false);
-            String sql3 = "CREATE TABLE test_create_table_db.dup_norange_json_sortkey\n" +
-                    "(\n" +
-                    "    k1 int,\n" +
-                    "    c  json\n" +
-                    ") DUPLICATE KEY(k1)\n" +
-                    "DISTRIBUTED BY HASH(k1)\n" +
-                    "ORDER BY(c)\n" +
-                    "PROPERTIES (\"replication_num\" = \"1\");";
-            analyzeSuccess(sql3);
+            analyzeFail("CREATE TABLE test_create_table_db.dup_norange_json_sortkey\n" +
+                    "(k1 int, c json) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");",
+                    "Sort key column[c] type not supported");
+            analyzeFail("CREATE TABLE test_create_table_db.dup_norange_time_sortkey\n" +
+                    "(k1 int, c time) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");",
+                    "Sort key column[c] type not supported");
+
+            // Non-range int sort key still passes.
+            analyzeSuccess("CREATE TABLE test_create_table_db.dup_norange_int_sortkey\n" +
+                    "(k1 int, c int) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) ORDER BY(c)\n" +
+                    "PROPERTIES (\"replication_num\" = \"1\");");
         } finally {
             connectContext.getSessionVariable().setEnableRangeDistribution(false);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CreateTableAnalyzerTest.java
@@ -582,7 +582,7 @@ public class CreateTableAnalyzerTest {
                     "Sort key column[c] type not supported");
 
             // TIME sort key, range distribution -> reject (canDistributedBy() allows TIME, but the BE
-            // has no TIME key coder; canBeSortKey() excludes it).
+            // has no TIME key coder; canDistributedBy() excludes it).
             analyzeFail("CREATE TABLE test_create_table_db.dup_range_time_sortkey\n" +
                     "(k1 int, c time) DUPLICATE KEY(k1) ORDER BY(c)\n" +
                     "PROPERTIES (\"replication_num\" = \"1\");",
@@ -613,6 +613,16 @@ public class CreateTableAnalyzerTest {
         } finally {
             connectContext.getSessionVariable().setEnableRangeDistribution(false);
         }
+    }
+
+    @Test
+    public void testTimeKeyColumnRejected() {
+        // TIME has no BE key coder, so it can't be a key column (a key column is also the implicit
+        // short/sort key). canDistributedBy() now excludes TIME, so ColumnDefAnalyzer rejects it.
+        analyzeFail("CREATE TABLE test_create_table_db.time_key_tbl\n" +
+                "(k1 time, v int) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(v)\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");",
+                "Invalid data type of key column");
     }
 
     @Test

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -332,6 +332,18 @@ public abstract class Type implements Cloneable {
                 && !isFunctionType() && !isVariantType();
     }
 
+    /**
+     * Whether a column of this type can be used as a sort key (ORDER BY) column. Sort keys are
+     * encoded on the BE via an order-preserving KeyCoder, so only types with a registered key coder
+     * qualify. canDistributedBy() already excludes JSON/complex/floating-point/metric/variant, but it
+     * still allows TIME, which the BE has no key coder for (TIME is a compute-only double, not a
+     * storable/encodable column type). Using such a type as a sort key crashes the BE short-key
+     * encoder, so exclude TIME here as well.
+     */
+    public boolean canBeSortKey() {
+        return canDistributedBy() && !isTime();
+    }
+
     public boolean canBeWindowFunctionArgumentTypes() {
         return !(isNull() || isChar() || isTime() || isComplexType()
                 || isPseudoType() || isFunctionType() || isBinaryType() || isVariantType());

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -327,21 +327,13 @@ public abstract class Type implements Cloneable {
 
     public boolean canDistributedBy() {
         // TODO(mofei) support distributed by for JSON
-        // Allow VARBINARY as distribution key
+        // Allow VARBINARY as distribution key.
+        // A distribution / key / sort-key column is encoded on the BE via an order-preserving
+        // KeyCoder, so its type must have a registered key coder. TIME has none (it is a compute-only
+        // double, not a storable/encodable column type) and would crash the BE short-key encoder, so
+        // exclude it here alongside the other non-encodable types.
         return !isComplexType() && !isFloatingPointType() && !isOnlyMetricType() && !isJsonType()
-                && !isFunctionType() && !isVariantType();
-    }
-
-    /**
-     * Whether a column of this type can be used as a sort key (ORDER BY) column. Sort keys are
-     * encoded on the BE via an order-preserving KeyCoder, so only types with a registered key coder
-     * qualify. canDistributedBy() already excludes JSON/complex/floating-point/metric/variant, but it
-     * still allows TIME, which the BE has no key coder for (TIME is a compute-only double, not a
-     * storable/encodable column type). Using such a type as a sort key crashes the BE short-key
-     * encoder, so exclude TIME here as well.
-     */
-    public boolean canBeSortKey() {
-        return canDistributedBy() && !isTime();
+                && !isFunctionType() && !isVariantType() && !isTime();
     }
 
     public boolean canBeWindowFunctionArgumentTypes() {


### PR DESCRIPTION
## Why I'm doing:

Using a column whose type has no BE key coder as a sort key crashes the BE. Sort key columns are written into the short-key index via an order-preserving `KeyCoder` (`SeekTuple::short_key_encode`); for a type with no registered coder (e.g. JSON) `get_key_coder()` returns null and the BE dereferences it -> SIGSEGV. This was reachable through several FE paths that did not validate the sort-key column type:

- CREATE TABLE `ORDER BY(json)` on a range-distributed table (original report, StarRocks/StarRocksTest#11611).
- The same on a **non-range** duplicate-key table (pre-existing latent crash -- the sort key is still short-key encoded).
- `TIME` sort keys: `Type.canDistributedBy()` permits TIME, but the BE has **no** `TYPE_TIME` key coder (TIME is a compute-only `double`), so a TIME sort key crashed too.
- ALTER paths: `ALTER TABLE ... ORDER BY`, `ADD ROLLUP ... ORDER BY`, and `OPTIMIZE ... ORDER BY`.

## What I'm doing:

Centralize the rule "a sort key column type must be encodable as a BE key" in `Type.canBeSortKey()` = `canDistributedBy() && !isTime()`, and apply it everywhere a column becomes a sort key:

- **CREATE TABLE** (`CreateTableAnalyzer.analyzeSortKeys`): reject for duplicate-key tables under **both** range and non-range distribution (shared helper `checkSortKeyTypesEncodable`; case-insensitive column resolution matching `OlapTableFactory`).
- **ALTER TABLE ... ORDER BY** (`SchemaChangeHandler.processModifySortKeyColumn`).
- **ADD ROLLUP ... ORDER BY** and **OPTIMIZE ... ORDER BY** (`AlterTableClauseAnalyzer`) -- the rollup check moves from `canDistributedBy()` to `canBeSortKey()`, closing the TIME hole.

The statement now fails with `Sort key column[...] type not supported` instead of crashing the BE.

Fixes StarRocks/StarRocksTest#11611

Tests: `CreateTableAnalyzerTest` (CREATE, JSON + TIME, range + non-range), `AlterTableTest.testAlterOrderBySortKeyTypeRestriction` (ALTER TABLE ORDER BY(json) rejected).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5