### PR TITLE
[BugFix] Fix IS NULL pruning on range-distributed sort keys after a split

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
@@ -24,6 +24,8 @@ import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.Range;
 import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.NullLiteral;
+import com.starrocks.type.Type;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -127,6 +129,12 @@ public class RangeDistributionPruner implements DistributionPruner {
             List<LiteralExpr> inPredicateLiterals = filter.getInPredicateLiterals();
             if (inPredicateLiterals != null && !inPredicateLiterals.isEmpty()) {
                 for (LiteralExpr expr : inPredicateLiterals) {
+                    // A NULL entry in an IN list never matches any row (SQL three-valued logic), so
+                    // it selects no tablets -- skip it. This also avoids parsing the literal "NULL"
+                    // as the column type.
+                    if (expr instanceof NullLiteral) {
+                        continue;
+                    }
                     Variant v = Variant.of(column.getType(), expr.getStringValue());
                     lowerValues.add(v);
                     upperValues.add(v);
@@ -140,12 +148,12 @@ public class RangeDistributionPruner implements DistributionPruner {
             Variant colMax = null;
             LiteralExpr lowerBound = filter.getLowerBound();
             if (lowerBound != null) {
-                colMin = Variant.of(column.getType(), lowerBound.getStringValue());
+                colMin = toVariant(column.getType(), lowerBound);
             }
 
             LiteralExpr upperBound = filter.getUpperBound();
             if (upperBound != null) {
-                colMax = Variant.of(column.getType(), upperBound.getStringValue());
+                colMax = toVariant(column.getType(), upperBound);
             }
 
             // 3. Fill unbounded sides with type-wide min/max
@@ -275,5 +283,15 @@ public class RangeDistributionPruner implements DistributionPruner {
             }
         }
         return resultSet;
+    }
+
+    // Convert a range-bound literal to a Variant. An IS NULL predicate reaches the pruner as a
+    // NullLiteral bound whose getStringValue() is the string "NULL". A NULL sort-key value is encoded
+    // as NullVariant, which sorts as the smallest real value (matching the BE null-first key
+    // encoding), so a NULL bound must compare as NullVariant -- passing "NULL" to Variant.of() would
+    // parse it as the column type and throw for numeric/date types.
+    private static Variant toVariant(Type type, LiteralExpr literal) {
+        return literal instanceof NullLiteral ? Variant.nullVariant(type)
+                : Variant.of(type, literal.getStringValue());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Variant;
 import com.starrocks.common.Config;
 import com.starrocks.common.Range;
 import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
@@ -628,6 +629,93 @@ public class RangeDistributionPrunerTest {
 
         Collection<Long> result = pruner.prune();
         Assertions.assertEquals(Collections.singleton(1L), new HashSet<>(result));
+    }
+
+    @Test
+    public void testIsNullSelectsFirstTablet() {
+        // #11612: a nullable sort key split into (-inf, 50) and [50, +inf). A NULL sort-key value is
+        // encoded as NullVariant, which sorts as the smallest real value (Min < Null < normal), so
+        // NULL rows are contained in the range that starts at -inf -- here the first tablet. Before
+        // the fix, WHERE k1 IS NULL threw IllegalArgumentException("Invalid int value: NULL") here.
+        Column k1 = new Column("k1", IntegerType.INT, true);
+        List<Tablet> tablets = Lists.newArrayList(
+                createTabletOpenBounds(1L, null, "50", k1),
+                createTabletOpenBounds(2L, "50", null, k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new NullLiteral(), true);
+        filter.setUpperBound(new NullLiteral(), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(Collections.singleton(1L), new HashSet<>(result));
+    }
+
+    @Test
+    public void testCompositeLeadingIsNullSelectsFirstTablet() {
+        // Two-column sort key (k1, k2) split into (-inf, (10,100)) and [(10,100), +inf). k1 IS NULL:
+        // NULL sorts before any real k1, so the matching rows are contained in the first tablet
+        // (range starts at -inf). The pruner fills the unconstrained trailing column k2 with
+        // [-inf, +inf], giving query bounds (NULL, min)..(NULL, max), which overlaps only the first.
+        Column k1 = new Column("k1", IntegerType.INT, true);
+        Column k2 = new Column("k2", IntegerType.INT, false);
+        List<Column> cols = Lists.newArrayList(k1, k2);
+
+        Tuple boundary = new Tuple(Lists.newArrayList(
+                Variant.of(k1.getType(), "10"), Variant.of(k2.getType(), "100")));
+        LocalTablet first = new LocalTablet(1L);
+        first.setRange(new TabletRange(Range.of((Tuple) null, boundary, false, false)));
+        LocalTablet second = new LocalTablet(2L);
+        second.setRange(new TabletRange(Range.of(boundary, (Tuple) null, true, false)));
+        List<Tablet> tablets = Lists.newArrayList(first, second);
+
+        PartitionColumnFilter k1Filter = new PartitionColumnFilter();
+        k1Filter.setLowerBound(new NullLiteral(), true);
+        k1Filter.setUpperBound(new NullLiteral(), true);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", k1Filter);
+
+        RangeDistributionPruner pruner = new RangeDistributionPruner(tablets, cols, filters);
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(Collections.singleton(1L), new HashSet<>(result));
+    }
+
+    @Test
+    public void testInPredicateWithNullLiteral() {
+        // WHERE k1 IN (55, NULL): under SQL three-valued logic the NULL entry never matches, so it
+        // is ignored; only 55 -> tablet [50, +inf). Must not crash parsing "NULL" as INT.
+        Column k1 = new Column("k1", IntegerType.INT, true);
+        List<Tablet> tablets = Lists.newArrayList(
+                createTabletOpenBounds(1L, null, "50", k1),
+                createTabletOpenBounds(2L, "50", null, k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        List<LiteralExpr> inValues = Lists.newArrayList();
+        inValues.add(new StringLiteral("55"));
+        inValues.add(new NullLiteral());
+        filter.setInPredicateLiterals(inValues);
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(Collections.singleton(2L), result);
+    }
+
+    // Build a tablet with optional open (infinite) bounds: a null lower/upper string means -inf/+inf,
+    // matching how a split builds the first tablet (-inf, c1) and the last tablet [c_{n-1}, +inf).
+    private Tablet createTabletOpenBounds(long id, String lower, String upper, Column column) {
+        LocalTablet tablet = new LocalTablet(id);
+        Tuple lowerTuple = lower == null ? null : new Tuple(Lists.newArrayList(Variant.of(column.getType(), lower)));
+        Tuple upperTuple = upper == null ? null : new Tuple(Lists.newArrayList(Variant.of(column.getType(), upper)));
+        tablet.setRange(new TabletRange(Range.of(lowerTuple, upperTuple, lower != null, false)));
+        return tablet;
     }
 
     private Tablet createTablet(long id, String lower, String upper, Column column) {


### PR DESCRIPTION
## Why I'm doing:

On a range-distributed table, `WHERE sortkey IS NULL` (and `sortkey IN (..., NULL)`) crashes tablet pruning **after a tablet split** with `IllegalArgumentException: Invalid int value: NULL`.

`ColumnFilterConverter` turns `col IS NULL` into a `PartitionColumnFilter` whose lower/upper bound is a `NullLiteral` (`getStringValue()` returns the string `"NULL"`); NULL entries in an IN list likewise become `NullLiteral`s. `RangeDistributionPruner.prune()` then parsed each bound via `Variant.of(column.getType(), literal.getStringValue())`, i.e. `Variant.of(BIGINT, "NULL")`, which tries to parse `"NULL"` as the column type and throws. It only reproduces after a split: before a split the single all-range tablet short-circuits pruning before any literal is parsed.

## What I'm doing:

Map a NULL bound to `Variant.nullVariant()` instead of parsing the string `"NULL"`. A NULL sort-key value is encoded as `NullVariant`, which sorts as the smallest real value (`Min < Null < normal < Max`, matching the BE null-first key encoding) and therefore lands in the first tablet `(-∞, c1)`; a query range `[NullVariant, NullVariant]` overlaps that tablet, so `IS NULL` prunes to it. `NullVariant` is already a supported value in tablet ranges (colocate/trailing-key fillers), so this comparison path is exercised in production.

For IN predicates, a NULL entry never matches any row under SQL three-valued logic, so it is skipped (selects no tablets) rather than mapped to a value.

Fixes StarRocks/StarRocksTest#11612

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5