### PR TITLE
[Doc] Clarify Flink merge_condition works with sink.version V2

### DIFF
--- a/docs/en/loading/Flink-connector-starrocks.md
+++ b/docs/en/loading/Flink-connector-starrocks.md
@@ -819,7 +819,7 @@ takes effect only when the new value for `score` is has a greater or equal to th
     - Define the DDL including all of columns.
     - Set the option `sink.properties.merge_condition` to `score` to tell the connector to use the column `score`
     as the condition.
-    - Set the option `sink.version` to `V1` which tells the connector to use Stream Load.
+    - Set the option `sink.version` to `V1` or `V2`. Both support conditional update.
 
     ```SQL
     CREATE TABLE `score_board` (

--- a/docs/ja/loading/Flink-connector-starrocks.md
+++ b/docs/ja/loading/Flink-connector-starrocks.md
@@ -793,7 +793,7 @@ DISTRIBUTED BY HASH(`id`);
   
     - すべてのカラムを含む DDL を定義します。
     - コネクタにカラム `score` を条件として使用することを伝えるために、オプション `sink.properties.merge_condition` を `score` に設定します。
-    - コネクタに Stream Load を使用することを伝えるために、オプション `sink.version` を `V1` に設定します。
+    - オプション `sink.version` を `V1` または `V2` に設定します。どちらも条件付き更新をサポートしています。
 
     ```SQL
     CREATE TABLE `score_board` (

--- a/docs/zh/loading/Flink-connector-starrocks.md
+++ b/docs/zh/loading/Flink-connector-starrocks.md
@@ -794,7 +794,7 @@ DISTRIBUTED BY HASH(`id`);
 2. 在 Flink SQL 客户端按照以下方式创建表`score_board`：
    - DDL 中包括所有列的定义。
    - 将选项  `sink.properties.merge_condition` 设置为 `score`，要求 Flink connector 使用 `score`  列作为更新条件。
-   - 将选项 `sink.version` 设置为 `V1` ，要求 Flink connector 使用 Stream Load 接口导入数据。因为只有 Stream Load 接口支持条件更新。
+   - 将选项 `sink.version` 设置为 `V1` 或 `V2`。两者均支持条件更新。
 
       ```SQL
       CREATE TABLE `score_board` (


### PR DESCRIPTION
## Why I'm doing:

The Flink connector docs incorrectly stated that conditional update (`sink.properties.merge_condition`) requires `sink.version=V1` / Stream Load only. Both Stream Load (V1) and Transaction Stream Load (V2) support it. Synced from [starrocks-connector-for-apache-flink#507](https://github.com/StarRocks/starrocks-connector-for-apache-flink/pull/507).

## What I'm doing:

Update the Conditional update examples in Flink connector docs (en/zh/ja) to state that `sink.version` can be `V1` or `V2`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Made with [Cursor](https://cursor.com)