### PR TITLE
[BugFix] Make catalog drop existence check atomic under write lock (backport #76778)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMgr.java
@@ -74,15 +74,9 @@ public class ConnectorMgr {
     }
 
     public void removeConnector(String catalogName) {
-        readLock();
-        try {
-            Preconditions.checkState(connectors.containsKey(catalogName), "Connector of catalog '%s' doesn't exist", catalogName);
-        } finally {
-            readUnlock();
-        }
-
         writeLock();
         try {
+            Preconditions.checkState(connectors.containsKey(catalogName), "Connector of catalog '%s' doesn't exist", catalogName);
             CatalogConnector catalogConnector = connectors.remove(catalogName);
             catalogConnector.shutdown();
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -198,15 +198,9 @@ public class CatalogMgr {
 
     public void dropCatalog(DropCatalogStmt stmt) {
         String catalogName = stmt.getName();
-        readLock();
-        try {
-            Preconditions.checkState(catalogs.containsKey(catalogName), "Catalog '%s' doesn't exist", catalogName);
-        } finally {
-            readUnlock();
-        }
-
         writeLock();
         try {
+            Preconditions.checkState(catalogs.containsKey(catalogName), "Catalog '%s' doesn't exist", catalogName);
             connectorMgr.removeConnector(catalogName);
             Authorizer.getInstance().removeAccessControl(catalogName);
             catalogs.remove(catalogName);


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #76778 to `branch-3.5`.

`CatalogMgr.dropCatalog` and `ConnectorMgr.removeConnector` verified existence under a **read lock**, released it, and then re-acquired the **write lock** to perform the removal. Because check and act happen under two separate lock acquisitions with a gap in between, the `Preconditions.checkState` guard provides no guarantee for the write section (classic TOCTOU / check-then-act race).

Consequences under concurrency:

- A **drop → recreate → stale-drop** interleaving lets a late drop (which passed its read check against the old catalog) delete the freshly recreated same-name catalog and persist an erroneous `DropCatalogLog`, which then replays consistently on all nodes.
- Two concurrent drops of the same catalog both pass the read check; the second raises `IllegalStateException` out of `removeConnector` on the leader.
- `removeConnector` could **NPE** on `catalogConnector.shutdown()` if the connector was concurrently removed between its own `containsKey` check and `remove`.

## What I'm doing:

Move the `Preconditions.checkState` existence check **into the write-lock section** in both methods so check-then-act is atomic. As a side effect, `connectors.remove(...)` is now guaranteed non-null under the same lock, eliminating the `shutdown()` NPE window. Single-threaded behavior is unchanged.

Conflict during cherry-pick was only in `CatalogMgr.dropCatalog` (this branch keeps the pre-refactor edit-log write path); resolved by placing `checkState` first inside the existing write-lock body. `ConnectorMgr.removeConnector` applied cleanly.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

