### PR TITLE
[BugFix] Fix "usedStructFiledPos" error aggregating a STRUCT column with ROLLUP/CUBE/GROUPING SETS

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggStructWithGroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggStructWithGroupingSetsTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Aggregating a full STRUCT column with ROLLUP/CUBE/GROUPING SETS used to fail at plan time with
+ * "StructType SlotRef must have an non-empty usedStructFiledPos!". Plain GROUP BY is the control.
+ */
+public class AggStructWithGroupingSetsTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        starRocksAssert.withTable("create table t_agg_struct(c0 INT, c2 struct<a int, b int>) "
+                + "duplicate key(c0) distributed by hash(c0) buckets 1 "
+                + "properties('replication_num'='1');");
+    }
+
+    @Test
+    public void testAnyValueStructWithRollup() throws Exception {
+        String plan = getFragmentPlan(
+                "select c0, any_value(c2) from t_agg_struct group by rollup(c0)");
+        assertContains(plan, "REPEAT_NODE");
+        assertContains(plan, "any_value");
+    }
+
+    @Test
+    public void testAnyValueStructWithCube() throws Exception {
+        String plan = getFragmentPlan(
+                "select c0, any_value(c2) from t_agg_struct group by cube(c0)");
+        assertContains(plan, "REPEAT_NODE");
+        assertContains(plan, "any_value");
+    }
+
+    @Test
+    public void testAnyValueStructWithGroupingSets() throws Exception {
+        String plan = getFragmentPlan(
+                "select c0, any_value(c2) from t_agg_struct group by grouping sets((c0), ())");
+        assertContains(plan, "REPEAT_NODE");
+        assertContains(plan, "any_value");
+    }
+
+    @Test
+    public void testArrayAggStructWithRollup() throws Exception {
+        String plan = getFragmentPlan(
+                "select c0, array_agg(c2) from t_agg_struct group by rollup(c0)");
+        assertContains(plan, "REPEAT_NODE");
+        assertContains(plan, "array_agg");
+    }
+
+    @Test
+    public void testPlainGroupByStructStillWorks() throws Exception {
+        String plan = getFragmentPlan(
+                "select c0, any_value(c2) from t_agg_struct group by c0");
+        assertContains(plan, "any_value");
+    }
+}

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -82,7 +82,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         super();
         pos = other.pos;
         type = other.type;
-        originType = other.type;
+        originType = other.originType;
         isAnalyzed = other.isAnalyzed;
         isConstant = other.isConstant;
         printSqlInParens = other.printSqlInParens;

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_struct
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_struct
@@ -1,0 +1,37 @@
+-- name: test_grouping_sets_struct
+CREATE TABLE t_struct_gs (c0 INT, c2 STRUCT<a INT, b INT>)
+DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+INSERT INTO t_struct_gs VALUES (1, row(1,10)), (1, row(2,20)), (2, row(3,30));
+-- result:
+-- !result
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY c0 ORDER BY c0;
+-- result:
+1	2
+2	1
+-- !result
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;
+-- result:
+None	3
+1	2
+2	1
+-- !result
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY CUBE(c0) ORDER BY c0;
+-- result:
+None	3
+1	2
+2	1
+-- !result
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY GROUPING SETS((c0), ()) ORDER BY c0;
+-- result:
+None	3
+1	2
+2	1
+-- !result
+SELECT c0, array_length(array_agg(c2)) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;
+-- result:
+None	3
+1	2
+2	1
+-- !result

--- a/test/sql/test_grouping_sets/R/test_grouping_sets_struct
+++ b/test/sql/test_grouping_sets/R/test_grouping_sets_struct
@@ -1,4 +1,7 @@
 -- name: test_grouping_sets_struct
+DROP TABLE IF EXISTS t_struct_gs;
+-- result:
+-- !result
 CREATE TABLE t_struct_gs (c0 INT, c2 STRUCT<a INT, b INT>)
 DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');
 -- result:
@@ -34,4 +37,7 @@ SELECT c0, array_length(array_agg(c2)) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDE
 None	3
 1	2
 2	1
+-- !result
+DROP TABLE t_struct_gs;
+-- result:
 -- !result

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_struct
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_struct
@@ -1,4 +1,5 @@
 -- name: test_grouping_sets_struct
+DROP TABLE IF EXISTS t_struct_gs;
 CREATE TABLE t_struct_gs (c0 INT, c2 STRUCT<a INT, b INT>)
 DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');
 INSERT INTO t_struct_gs VALUES (1, row(1,10)), (1, row(2,20)), (2, row(3,30));
@@ -7,3 +8,4 @@ SELECT c0, count(c2) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;
 SELECT c0, count(c2) FROM t_struct_gs GROUP BY CUBE(c0) ORDER BY c0;
 SELECT c0, count(c2) FROM t_struct_gs GROUP BY GROUPING SETS((c0), ()) ORDER BY c0;
 SELECT c0, array_length(array_agg(c2)) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;
+DROP TABLE t_struct_gs;

--- a/test/sql/test_grouping_sets/T/test_grouping_sets_struct
+++ b/test/sql/test_grouping_sets/T/test_grouping_sets_struct
@@ -1,0 +1,9 @@
+-- name: test_grouping_sets_struct
+CREATE TABLE t_struct_gs (c0 INT, c2 STRUCT<a INT, b INT>)
+DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');
+INSERT INTO t_struct_gs VALUES (1, row(1,10)), (1, row(2,20)), (2, row(3,30));
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY c0 ORDER BY c0;
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY CUBE(c0) ORDER BY c0;
+SELECT c0, count(c2) FROM t_struct_gs GROUP BY GROUPING SETS((c0), ()) ORDER BY c0;
+SELECT c0, array_length(array_agg(c2)) FROM t_struct_gs GROUP BY ROLLUP(c0) ORDER BY c0;


### PR DESCRIPTION
## Why I'm doing:

Aggregating a full `STRUCT` column together with `ROLLUP` / `CUBE` / `GROUPING SETS` fails at plan time with:

```
Getting analyzing error. Detail message: StructType SlotRef must have an non-empty usedStructFiledPos!
```

Minimal repro (community):

```sql
CREATE TABLE t (c0 INT, c2 STRUCT<a INT, b INT>)
DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num'='1');

SELECT c0, any_value(c2) FROM t GROUP BY c0;              -- OK
SELECT c0, any_value(c2) FROM t GROUP BY ROLLUP(c0);      -- error above
SELECT c0, any_value(c2) FROM t GROUP BY CUBE(c0);        -- error above
SELECT c0, any_value(c2) FROM t GROUP BY GROUPING SETS((c0), ());  -- error above
SELECT c0, array_agg(c2) FROM t GROUP BY ROLLUP(c0);      -- error above
```

## What I'm doing:

The `Expr(Expr other)` copy constructor set `originType = other.type`. Cloning a full-struct-column
`SlotRef` therefore fabricated `originType = STRUCT` while `usedStructFieldPos` stayed null, breaking the
invariant that a struct `originType` means struct subfield access. `SqlToScalarOperatorTranslator.visitSlot`
then treated the clone as a subfield access and asserted on the missing `usedStructFieldPos`.

`QueryTransformer.aggregate()` clones the aggregate expressions on the grouping-sets branch and re-projects
them, so aggregating a `STRUCT` column with `ROLLUP` / `CUBE` / `GROUPING SETS` hit this. Plain `GROUP BY`
does not clone the aggregate, so it was unaffected.

Fix: copy `originType` faithfully (`other.originType`), matching the planner `Exec*` expression classes. A
full-struct clone keeps `originType` INVALID; a subfield-access clone keeps its struct `originType`.

Fixes #issue: N/A — community bug with no public issue; reproduced from a `STRUCT` + `ROLLUP`/`CUBE`/`GROUPING SETS` query.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a query that previously failed with an internal plan-time error now plans and executes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.2
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
