### PR TITLE
[Enhancement] Add fine-grained metadata/delvec write trace counters in publish

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1043,6 +1043,11 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
 
     // 3. write to delvec file
     if (_buf.size() > 0) {
+        // Trace the delvec object write on its own so a slow publish can be attributed to the
+        // right remote PUT (delvec vs tablet metadata). delvec_file_bytes is the concatenated
+        // size of every segment delvec rewritten by this txn.
+        TRACE_COUNTER_SCOPE_LATENCY_US("delvec_write_us");
+        TRACE_COUNTER_INCREMENT("delvec_file_bytes", static_cast<int64_t>(_buf.size()));
         TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec", &_buf);
         auto delvec_file_name = gen_delvec_filename(txn_id);
         auto delvec_file_path = _tablet.delvec_location(delvec_file_name);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -33,6 +33,7 @@
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/util.h"
+#include "io/io_profiler.h"
 #include "runtime/time_guard.h"
 #include "storage/lake/cloud_native_index_compaction_task.h"
 #include "storage/lake/compaction_policy.h"
@@ -483,15 +484,38 @@ int64_t TabletManager::get_average_row_size_from_latest_metadata(int64_t tablet_
 Status TabletManager::put_tablet_metadata(const TabletMetadataPtr& metadata, const std::string& metadata_location) {
     TEST_ERROR_POINT("TabletManager::put_tablet_metadata");
     // write metadata file
+    // NOTE: the put_tablet_metadata_us total is already recorded by the caller's scope in
+    // MetaFileBuilder::finalize(); do not re-open it here or the counter would double-count.
     auto t0 = butil::gettimeofday_us();
 
     // Serialize a normalized copy that dual-writes the deprecated legacy parallel arrays from
     // segment_metas (so a BE rolled back to a pre-feature version can still read this metadata),
     // without mutating the shared, immutable metadata object.
     auto serializable_metadata = std::make_shared<TabletMetadataPB>(*metadata);
-    RETURN_IF_ERROR(normalize_tablet_metadata_before_save(serializable_metadata.get()));
+    {
+        // Deep-copy + legacy-array normalization is pure CPU; time it apart from the remote write.
+        TRACE_COUNTER_SCOPE_LATENCY_US("meta_normalize_us");
+        RETURN_IF_ERROR(normalize_tablet_metadata_before_save(serializable_metadata.get()));
+    }
 
-    RETURN_IF_ERROR(save_lake_protobuf(metadata_location, *serializable_metadata));
+    // Record the serialized payload size so a slow publish can be attributed to metadata bloat
+    // (driven by rowset / delvec-entry count) rather than object-store write latency.
+    TRACE_COUNTER_INCREMENT("tablet_meta_bytes", static_cast<int64_t>(serializable_metadata->ByteSizeLong()));
+
+    // Snapshot the thread-local IO counters around the object-store write so the real network
+    // write+sync time is separated from the protobuf serialize CPU inside save_lake_protobuf.
+    // The fs writers record add_write/add_sync into TLS unconditionally, so meta_put_write_ns is
+    // populated even when the global IO profiler is not running.
+    IOProfiler::IOStat io_before;
+    IOProfiler::take_tls_io_snapshot(&io_before);
+    {
+        TRACE_COUNTER_SCOPE_LATENCY_US("meta_save_us");
+        RETURN_IF_ERROR(save_lake_protobuf(metadata_location, *serializable_metadata));
+    }
+    const auto io_delta = IOProfiler::calculate_scoped_tls_io(io_before);
+    TRACE_COUNTER_INCREMENT("meta_put_write_ns", static_cast<int64_t>(io_delta.write_time_ns));
+    TRACE_COUNTER_INCREMENT("meta_put_sync_ns", static_cast<int64_t>(io_delta.sync_time_ns));
+    TRACE_COUNTER_INCREMENT("meta_put_write_bytes", static_cast<int64_t>(io_delta.write_bytes));
 
     _metacache->cache_tablet_metadata(metadata_location, metadata);
     bool skip_cache_latest_metadata = false;


### PR DESCRIPTION
Add write-side sub-counters underneath the existing totals, mirroring the read/upsert-side granularity:

- meta_file.cpp (_finalize_delvec): delvec_write_us + delvec_file_bytes around just the delvec object write, isolating the remote PUT from the surrounding metadata bookkeeping that finalize_delvec_write_us also covers.
- tablet_manager.cpp (put_tablet_metadata): meta_normalize_us (deep-copy + legacy-array normalization CPU), tablet_meta_bytes (serialized payload size), meta_save_us (serialize + network), and a thread-local IOProfiler snapshot around save_lake_protobuf yielding meta_put_write_ns / meta_put_sync_ns / meta_put_write_bytes (pure object-store write time).

The fs writers record add_write/add_sync into TLS unconditionally, so the network counters are populated even when the global IO profiler is not running. Serialize CPU can be derived as meta_save_us - (meta_put_write_ns + meta_put_sync_ns)/1000, letting a slow publish be attributed to payload bloat versus object-store latency.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
