### PR TITLE
[Enhancement] Apply the absorption law to simplify boolean expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -328,76 +328,95 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
 
     /**
      * Apply boolean absorption law:
-     *   a AND (a OR b) -> a
-     *   a OR (a AND b)  -> a
+     *   a AND (a OR b)              -> a
+     *   a OR (a AND b)              -> a
+     *   (a OR b) AND ((a OR b) OR c) -> a OR b   (compound absorber)
+     *   (a AND b) OR ((a AND b) AND c) -> a AND b (dual)
      *
-     * Skips absorption if the expression being kept (the absorber) contains a
-     * non-deterministic function such as rand()/uuid(), because each evaluation
-     * of that expression may yield a different value.
+     * <p>The absorber may itself be a compound of the opposite type. A target is
+     * absorbed when the absorber's flattened term set is a (strict) subset of the
+     * target's flattened term set, i.e. the target is implied by the absorber.
+     *
+     * <p>Terms are partitioned once so each opposite-type target is inspected a
+     * single time (single-term absorbers via a set lookup), avoiding an O(n^2)
+     * pairwise scan over wide predicate trees.
+     *
+     * <p>Skips using an expression as an absorber if it contains a
+     * non-deterministic function such as rand()/uuid(), because each evaluation of
+     * that expression may yield a different value.
      */
     private ScalarOperator tryAbsorb(CompoundPredicateOperator predicate) {
-        if (predicate.isAnd()) {
-            List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
-            Set<Integer> absorbed = Sets.newHashSet();
-            for (int i = 0; i < conjuncts.size(); i++) {
-                ScalarOperator absorber = conjuncts.get(i);
-                if (Utils.hasNonDeterministicFunc(absorber)) {
-                    continue;
-                }
-                for (int j = 0; j < conjuncts.size(); j++) {
-                    if (i == j) {
-                        continue;
-                    }
-                    ScalarOperator target = conjuncts.get(j);
-                    if (target instanceof CompoundPredicateOperator &&
-                            ((CompoundPredicateOperator) target).isOr()) {
-                        if (Utils.extractDisjunctive(target).contains(absorber)) {
-                            absorbed.add(j);
-                        }
-                    }
-                }
+        boolean isAnd = predicate.isAnd();
+        if (!isAnd && !predicate.isOr()) {
+            return predicate;
+        }
+
+        // AND: terms are conjuncts, opposite-type target/absorber are OR compounds.
+        // OR:  terms are disjuncts, opposite-type target/absorber are AND compounds.
+        List<ScalarOperator> terms = isAnd
+                ? Utils.extractConjuncts(predicate)
+                : Utils.extractDisjunctive(predicate);
+
+        // Single-term absorbers -> O(1) membership lookup.
+        Set<ScalarOperator> singleAbsorbers = Sets.newHashSet();
+        // Opposite-type compound absorbers (e.g. (a OR b) inside an AND), kept as
+        // their flattened term sets for subset containment tests.
+        List<Set<ScalarOperator>> compoundAbsorbers = Lists.newArrayList();
+        for (ScalarOperator term : terms) {
+            if (Utils.hasNonDeterministicFunc(term)) {
+                continue;
             }
-            if (!absorbed.isEmpty()) {
-                List<ScalarOperator> remaining = Lists.newArrayList();
-                for (int i = 0; i < conjuncts.size(); i++) {
-                    if (!absorbed.contains(i)) {
-                        remaining.add(conjuncts.get(i));
-                    }
-                }
-                return Utils.compoundAnd(remaining);
-            }
-        } else if (predicate.isOr()) {
-            List<ScalarOperator> disjuncts = Utils.extractDisjunctive(predicate);
-            Set<Integer> absorbed = Sets.newHashSet();
-            for (int i = 0; i < disjuncts.size(); i++) {
-                ScalarOperator absorber = disjuncts.get(i);
-                if (Utils.hasNonDeterministicFunc(absorber)) {
-                    continue;
-                }
-                for (int j = 0; j < disjuncts.size(); j++) {
-                    if (i == j) {
-                        continue;
-                    }
-                    ScalarOperator target = disjuncts.get(j);
-                    if (target instanceof CompoundPredicateOperator &&
-                            ((CompoundPredicateOperator) target).isAnd()) {
-                        if (Utils.extractConjuncts(target).contains(absorber)) {
-                            absorbed.add(j);
-                        }
-                    }
-                }
-            }
-            if (!absorbed.isEmpty()) {
-                List<ScalarOperator> remaining = Lists.newArrayList();
-                for (int i = 0; i < disjuncts.size(); i++) {
-                    if (!absorbed.contains(i)) {
-                        remaining.add(disjuncts.get(i));
-                    }
-                }
-                return Utils.compoundOr(remaining);
+            if (isOppositeCompound(term, isAnd)) {
+                compoundAbsorbers.add(Sets.newHashSet(flatten(term, isAnd)));
+            } else {
+                singleAbsorbers.add(term);
             }
         }
-        return predicate;
+
+        Set<Integer> absorbed = Sets.newHashSet();
+        for (int j = 0; j < terms.size(); j++) {
+            ScalarOperator target = terms.get(j);
+            if (!isOppositeCompound(target, isAnd)) {
+                continue;
+            }
+            Set<ScalarOperator> targetTerms = Sets.newHashSet(flatten(target, isAnd));
+            boolean absorb = targetTerms.stream().anyMatch(singleAbsorbers::contains);
+            if (!absorb) {
+                for (Set<ScalarOperator> absorberTerms : compoundAbsorbers) {
+                    // Strict subset so a compound never absorbs an identical sibling.
+                    if (absorberTerms.size() < targetTerms.size() && targetTerms.containsAll(absorberTerms)) {
+                        absorb = true;
+                        break;
+                    }
+                }
+            }
+            if (absorb) {
+                absorbed.add(j);
+            }
+        }
+
+        if (absorbed.isEmpty()) {
+            return predicate;
+        }
+        List<ScalarOperator> remaining = Lists.newArrayList();
+        for (int i = 0; i < terms.size(); i++) {
+            if (!absorbed.contains(i)) {
+                remaining.add(terms.get(i));
+            }
+        }
+        return isAnd ? Utils.compoundAnd(remaining) : Utils.compoundOr(remaining);
+    }
+
+    private static boolean isOppositeCompound(ScalarOperator op, boolean isAnd) {
+        if (!(op instanceof CompoundPredicateOperator)) {
+            return false;
+        }
+        CompoundPredicateOperator cpo = (CompoundPredicateOperator) op;
+        return isAnd ? cpo.isOr() : cpo.isAnd();
+    }
+
+    private static List<ScalarOperator> flatten(ScalarOperator op, boolean isAnd) {
+        return isAnd ? Utils.extractDisjunctive(op) : Utils.extractConjuncts(op);
     }
 
     //

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
@@ -48,6 +49,7 @@ import org.apache.commons.lang.text.StrTokenizer;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -337,9 +339,14 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
      * absorbed when the absorber's flattened term set is a (strict) subset of the
      * target's flattened term set, i.e. the target is implied by the absorber.
      *
-     * <p>Terms are partitioned once so each opposite-type target is inspected a
-     * single time (single-term absorbers via a set lookup), avoiding an O(n^2)
-     * pairwise scan over wide predicate trees.
+     * <p>Terms are partitioned once so single-term absorbers resolve via an O(1)
+     * set lookup. Compound absorbers are indexed by an "anchor" element: since
+     * {@code A subset-of T} implies every element of {@code A} (hence its anchor)
+     * appears in {@code T}, a target only needs to probe the buckets keyed by its
+     * own elements instead of scanning every compound absorber. The anchor is the
+     * globally rarest element of the absorber, so disjoint absorbers land in
+     * distinct buckets and the all-pairs comparison is avoided even for wide
+     * predicate trees made of many disjoint OR/AND terms.
      *
      * <p>Skips using an expression as an absorber if it contains a
      * non-deterministic function such as rand()/uuid(), because each evaluation of
@@ -373,6 +380,11 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             }
         }
 
+        // Index each compound absorber by its rarest element so a target probes
+        // only the absorbers that share an element with it, not the whole list.
+        Map<ScalarOperator, List<Set<ScalarOperator>>> absorberIndex =
+                buildAbsorberIndex(compoundAbsorbers);
+
         Set<Integer> absorbed = Sets.newHashSet();
         for (int j = 0; j < terms.size(); j++) {
             ScalarOperator target = terms.get(j);
@@ -382,13 +394,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             Set<ScalarOperator> targetTerms = Sets.newHashSet(flatten(target, isAnd));
             boolean absorb = targetTerms.stream().anyMatch(singleAbsorbers::contains);
             if (!absorb) {
-                for (Set<ScalarOperator> absorberTerms : compoundAbsorbers) {
-                    // Strict subset so a compound never absorbs an identical sibling.
-                    if (absorberTerms.size() < targetTerms.size() && targetTerms.containsAll(absorberTerms)) {
-                        absorb = true;
-                        break;
-                    }
-                }
+                absorb = absorbedByCompound(targetTerms, absorberIndex);
             }
             if (absorb) {
                 absorbed.add(j);
@@ -417,6 +423,53 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
 
     private static List<ScalarOperator> flatten(ScalarOperator op, boolean isAnd) {
         return isAnd ? Utils.extractDisjunctive(op) : Utils.extractConjuncts(op);
+    }
+
+    /**
+     * Index compound absorbers by an anchor element (the one that occurs in the
+     * fewest absorbers) so that disjoint absorbers spread across distinct buckets.
+     * A target can only be absorbed by absorbers that contain its anchor, so at
+     * probe time we look at a single bucket keyed by each target element.
+     */
+    private static Map<ScalarOperator, List<Set<ScalarOperator>>> buildAbsorberIndex(
+            List<Set<ScalarOperator>> compoundAbsorbers) {
+        Map<ScalarOperator, Integer> elementFreq = Maps.newHashMap();
+        for (Set<ScalarOperator> absorber : compoundAbsorbers) {
+            for (ScalarOperator element : absorber) {
+                elementFreq.merge(element, 1, Integer::sum);
+            }
+        }
+        Map<ScalarOperator, List<Set<ScalarOperator>>> index = Maps.newHashMap();
+        for (Set<ScalarOperator> absorber : compoundAbsorbers) {
+            ScalarOperator anchor = null;
+            int anchorFreq = Integer.MAX_VALUE;
+            for (ScalarOperator element : absorber) {
+                int freq = elementFreq.get(element);
+                if (freq < anchorFreq) {
+                    anchorFreq = freq;
+                    anchor = element;
+                }
+            }
+            index.computeIfAbsent(anchor, k -> Lists.newArrayList()).add(absorber);
+        }
+        return index;
+    }
+
+    private static boolean absorbedByCompound(Set<ScalarOperator> targetTerms,
+                                              Map<ScalarOperator, List<Set<ScalarOperator>>> absorberIndex) {
+        for (ScalarOperator element : targetTerms) {
+            List<Set<ScalarOperator>> candidates = absorberIndex.get(element);
+            if (candidates == null) {
+                continue;
+            }
+            for (Set<ScalarOperator> absorberTerms : candidates) {
+                // Strict subset so a compound never absorbs an identical sibling.
+                if (absorberTerms.size() < targetTerms.size() && targetTerms.containsAll(absorberTerms)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     //

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CaseWhenOperator;
@@ -281,7 +282,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
                     return ConstantOperator.createBoolean(true);
                 }
 
-                return predicate;
+                break;
             }
             case OR: {
                 if (constantChildren.stream().anyMatch(d -> (!d.isNull() && d.getBoolean()))) {
@@ -309,7 +310,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
                     return ConstantOperator.createBoolean(false);
                 }
 
-                return predicate;
+                break;
             }
             case NOT: {
                 ScalarOperator child = predicate.getChild(0);
@@ -322,6 +323,80 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             }
         }
 
+        return tryAbsorb(predicate);
+    }
+
+    /**
+     * Apply boolean absorption law:
+     *   a AND (a OR b) -> a
+     *   a OR (a AND b)  -> a
+     *
+     * Skips absorption if the expression being kept (the absorber) contains a
+     * non-deterministic function such as rand()/uuid(), because each evaluation
+     * of that expression may yield a different value.
+     */
+    private ScalarOperator tryAbsorb(CompoundPredicateOperator predicate) {
+        if (predicate.isAnd()) {
+            List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+            Set<Integer> absorbed = Sets.newHashSet();
+            for (int i = 0; i < conjuncts.size(); i++) {
+                ScalarOperator absorber = conjuncts.get(i);
+                if (Utils.hasNonDeterministicFunc(absorber)) {
+                    continue;
+                }
+                for (int j = 0; j < conjuncts.size(); j++) {
+                    if (i == j) {
+                        continue;
+                    }
+                    ScalarOperator target = conjuncts.get(j);
+                    if (target instanceof CompoundPredicateOperator &&
+                            ((CompoundPredicateOperator) target).isOr()) {
+                        if (Utils.extractDisjunctive(target).contains(absorber)) {
+                            absorbed.add(j);
+                        }
+                    }
+                }
+            }
+            if (!absorbed.isEmpty()) {
+                List<ScalarOperator> remaining = Lists.newArrayList();
+                for (int i = 0; i < conjuncts.size(); i++) {
+                    if (!absorbed.contains(i)) {
+                        remaining.add(conjuncts.get(i));
+                    }
+                }
+                return Utils.compoundAnd(remaining);
+            }
+        } else if (predicate.isOr()) {
+            List<ScalarOperator> disjuncts = Utils.extractDisjunctive(predicate);
+            Set<Integer> absorbed = Sets.newHashSet();
+            for (int i = 0; i < disjuncts.size(); i++) {
+                ScalarOperator absorber = disjuncts.get(i);
+                if (Utils.hasNonDeterministicFunc(absorber)) {
+                    continue;
+                }
+                for (int j = 0; j < disjuncts.size(); j++) {
+                    if (i == j) {
+                        continue;
+                    }
+                    ScalarOperator target = disjuncts.get(j);
+                    if (target instanceof CompoundPredicateOperator &&
+                            ((CompoundPredicateOperator) target).isAnd()) {
+                        if (Utils.extractConjuncts(target).contains(absorber)) {
+                            absorbed.add(j);
+                        }
+                    }
+                }
+            }
+            if (!absorbed.isEmpty()) {
+                List<ScalarOperator> remaining = Lists.newArrayList();
+                for (int i = 0; i < disjuncts.size(); i++) {
+                    if (!absorbed.contains(i)) {
+                        remaining.add(disjuncts.get(i));
+                    }
+                }
+                return Utils.compoundOr(remaining);
+            }
+        }
         return predicate;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleAbsorptionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleAbsorptionTest.java
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.FloatType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SimplifiedPredicateRuleAbsorptionTest {
+    private final SimplifiedPredicateRule rule = new SimplifiedPredicateRule();
+
+    @Test
+    public void testAbsorptionLaw() {
+        ColumnRefOperator a = new ColumnRefOperator(1, BooleanType.BOOLEAN, "a", true);
+        ColumnRefOperator b = new ColumnRefOperator(2, BooleanType.BOOLEAN, "b", true);
+
+        // a AND (a OR b) -> a
+        ScalarOperator input = CompoundPredicateOperator.and(a, CompoundPredicateOperator.or(a, b));
+        assertEquals(a, rule.apply(input, null));
+
+        // (a OR b) AND a -> a
+        input = CompoundPredicateOperator.and(CompoundPredicateOperator.or(a, b), a);
+        assertEquals(a, rule.apply(input, null));
+
+        // a OR (a AND b) -> a
+        input = CompoundPredicateOperator.or(a, CompoundPredicateOperator.and(a, b));
+        assertEquals(a, rule.apply(input, null));
+
+        // (a AND b) OR a -> a
+        input = CompoundPredicateOperator.or(CompoundPredicateOperator.and(a, b), a);
+        assertEquals(a, rule.apply(input, null));
+
+        // a AND (a OR b) AND c -> a AND c
+        ColumnRefOperator c = new ColumnRefOperator(3, BooleanType.BOOLEAN, "c", true);
+        input = CompoundPredicateOperator.and(a, CompoundPredicateOperator.or(a, b), c);
+        ScalarOperator result = rule.apply(input, null);
+        assertEquals(CompoundPredicateOperator.and(a, c), result);
+
+        // a AND (a OR rand()) -> a (rand() is discarded, safe to absorb)
+        CallOperator rand = new CallOperator(FunctionSet.RAND, FloatType.DOUBLE, Lists.newArrayList());
+        input = CompoundPredicateOperator.and(a, CompoundPredicateOperator.or(a, rand));
+        assertEquals(a, rule.apply(input, null));
+
+        // rand() AND (rand() OR b) should NOT be absorbed
+        input = CompoundPredicateOperator.and(rand, CompoundPredicateOperator.or(rand, b));
+        assertEquals(input, rule.apply(input, null));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleAbsorptionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRuleAbsorptionTest.java
@@ -64,5 +64,15 @@ public class SimplifiedPredicateRuleAbsorptionTest {
         // rand() AND (rand() OR b) should NOT be absorbed
         input = CompoundPredicateOperator.and(rand, CompoundPredicateOperator.or(rand, b));
         assertEquals(input, rule.apply(input, null));
+
+        // Compound absorber: (a OR b) AND ((a OR b) OR c) -> a OR b
+        ScalarOperator aOrB = CompoundPredicateOperator.or(a, b);
+        input = CompoundPredicateOperator.and(aOrB, CompoundPredicateOperator.or(aOrB, c));
+        assertEquals(aOrB, rule.apply(input, null));
+
+        // Dual compound absorber: (a AND b) OR ((a AND b) AND c) -> a AND b
+        ScalarOperator aAndB = CompoundPredicateOperator.and(a, b);
+        input = CompoundPredicateOperator.or(aAndB, CompoundPredicateOperator.and(aAndB, c));
+        assertEquals(aAndB, rule.apply(input, null));
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Apply the boolean absorption law, leaving redundant expressions such as:

a AND (a OR b) 
a OR (a AND b)  
un-simplified(both case above should simplified to a), of course a non-deterministic function, such as the `rand` function—do not need to be simplified. 

This prevented the optimizer from removing obviously redundant sub-conditions in WHERE / FILTER / JOIN predicates, resulting in more complex expressions and execution plans than necessary.

We might be able to optimize this.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
