### PR TITLE
[Doc] Fix SQL reference examples failing doc-rot verification (3.5)

### DIFF
--- a/docs/en/sql-reference/sql-functions/utility-functions/bar.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/bar.md
@@ -24,8 +24,10 @@ bar(size, min, max, width)
 ## Example
 
 ```SQL
-MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	
 1	▓▓
 2	▓▓▓▓
@@ -37,5 +39,4 @@ MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s
 8	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 9	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 10	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-
 ```

--- a/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
@@ -24,8 +24,10 @@ equiwidth_bucket(value, min, max, buckets)
 ## Example
 
 ```SQL
-MYSQL > select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	0
 1	1
 2	2

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
@@ -827,8 +827,8 @@ CREATE TABLE example_db.example_tbl3 (
     country varchar(26) NULL, 
     pay_time bigint(20) NULL, 
     price double SUM NULL) 
-AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 ENGINE=OLAP
+AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 DISTRIBUTED BY HASH(commodity_id); 
 ```
 
@@ -973,7 +973,7 @@ CREATE TABLE sensor.sensor_log2 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 
@@ -1053,7 +1053,7 @@ CREATE TABLE sensor.sensor_log3 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 

--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -859,7 +859,7 @@ Example 1: Create a non-partitioned materialized view.
 -- create an unpartitioned materialized view sorted by lo_custkey
 CREATE MATERIALIZED VIEW lo_mv1
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC
 AS
 select
@@ -879,7 +879,7 @@ Example 2: Create a partitioned materialized view.
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select
@@ -1068,7 +1068,7 @@ Example 7: Create a partition materialized view with a specific sort key:
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -1118,9 +1118,8 @@ DROP PERSISTENT INDEX ON TABLETS(<tablet_id>[, <tablet_id>, ...]);
 
     ```sql
     ALTER TABLE example_db.my_table
-    ADD COLUMN col1 INT DEFAULT "1" AFTER `k1`,
-    ADD COLUMN col2 FLOAT SUM AFTER `v2`,
-    TO example_rollup_index;
+    ADD COLUMN col1 INT DEFAULT "1" AFTER `k1` TO example_rollup_index,
+    ADD COLUMN col2 FLOAT SUM AFTER `v2` TO example_rollup_index;
     ```
 
 7. Drop a column from `example_rollup_index`.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -85,21 +85,21 @@ Example 1: Synchronously query a table `order` and create a new table `order_new
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT * FROM order;
+AS SELECT * FROM `order`;
 ```
 
 Example 2: Synchronously query the `k1`, `k2`, and `k3` columns in the table `order` and create a new table `order_new` based on the query result, and then insert the query result into the new table. Additionally, set the column names of the new table to `a`, `b`, and `c`.
 
 ```SQL
 CREATE TABLE order_new (a, b, c)
-AS SELECT k1, k2, k3 FROM order;
+AS SELECT k1, k2, k3 FROM `order`;
 ```
 
 or
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT k1 AS a, k2 AS b, k3 AS c FROM order;
+AS SELECT k1 AS a, k2 AS b, k3 AS c FROM `order`;
 ```
 
 Example 3: Synchronously query the largest value of the `salary` column in the table `employee` and create a new table `employee_new` based on the query result, and then insert the query result into the new table. Additionally, set the column name of the new table to `salary_max`.
@@ -221,9 +221,11 @@ Check information of the Task.
 
 ```SQL
 SELECT * FROM INFORMATION_SCHEMA.tasks;
+```
 
--- Information of the Task
+Information of the Task:
 
+```plaintext
 TASK_NAME: ctas-df6f7930-e7c9-11ec-abac-bab8ee315bf2
 CREATE_TIME: 2022-06-14 14:07:06
 SCHEDULE: MANUAL
@@ -236,9 +238,11 @@ Check the state of the TaskRun.
 
 ```SQL
 SELECT * FROM INFORMATION_SCHEMA.task_runs;
+```
 
--- State of the TaskRun
+State of the TaskRun:
 
+```plaintext
 QUERY_ID: 37bd2b63-eba8-11ec-8d41-bab8ee315bf2
 TASK_NAME: ctas-df6f7930-e7c9-11ec-abac-bab8ee315bf2
 CREATE_TIME: 2022-06-14 14:07:06

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
@@ -46,23 +46,23 @@ Subqueries also support scalar quantum queries. It can be divided into irrelevan
 1. Uncorrelated scalar quantum query with predicate = sign. For example, output information about the person with the highest wage.
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. Uncorrelated scalar quantum queries with predicates `>`, `<` etc. For example, output information about people who are paid more than average.
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. Related scalar quantum queries. For example, output the highest salary information for each department.
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. Scalar quantum queries are used as parameters of ordinary functions.
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```


### PR DESCRIPTION
## Why I'm doing:

The SQL-example doc-rot checker (`docs/scripts/run_sql_samples.py`) was run with
docs at `branch-3.5` against a StarRocks **3.5.20** cluster (shared-nothing
doc-verification profile; versions reported aligned). It produced 40 FAILing
examples. This PR carries the ones that are genuine doc defects, each with a fix
verified on that cluster.

Every example here was confirmed present on `main` before editing, so these land
on `main` and can be backported.

## What I'm doing:

16 fixes across 7 files. Each preserves what the example teaches — no example was
reworded to "make it pass".

| file:line (main) | before → after | verified |
|---|---|---|
| `sql-functions/utility-functions/bar.md:27` | `MYSQL > select r, bar(...)` + pasted result in one ```sql fence → prompt stripped, result moved to ```plaintext | runs on 3.5.20, returns the documented bars |
| `sql-functions/utility-functions/equiwidth_bucket.md:27` | same reformat | runs on 3.5.20, returns the documented buckets |
| `.../routine_load/CREATE_ROUTINE_LOAD.md:830` | `AGGREGATE KEY(...)` then `ENGINE=OLAP` → `ENGINE=OLAP` then `AGGREGATE KEY(...)` | runs on 3.5.20 |
| `.../routine_load/CREATE_ROUTINE_LOAD.md:976` | `` `data_y` long `` → `` `data_y` bigint `` | runs on 3.5.20 |
| `.../routine_load/CREATE_ROUTINE_LOAD.md:1056` | `` `data_y` long `` → `` `data_y` bigint `` | runs on 3.5.20 |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:862` | ``ORDER BY `lo_custkey` `` → ``ORDER BY (`lo_custkey`)`` | runs on 3.5.20 |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:882` | same | runs on 3.5.20 |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:1071` | same | runs on 3.5.20 |
| `table_bucket_part_index/ALTER_TABLE.md:1121` | stray `,` before `TO example_rollup_index` → each `ADD COLUMN` carries its own `TO example_rollup_index` | parses on 3.5.20 (then UNRESOLVED on the absent table, like its sibling examples) |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:88` | `FROM order` → ``FROM `order` `` | parses; UNRESOLVED, matching sibling examples |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:95` | same | same |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:102` | same | same |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:222` | statement + pasted vertical output in one ```sql fence → split into ```sql and ```plaintext | `SELECT * FROM INFORMATION_SCHEMA.tasks` runs on 3.5.20 |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:237` | same split | `SELECT * FROM INFORMATION_SCHEMA.task_runs` runs on 3.5.20 |
| `table_bucket_part_index/SELECT/SELECT_subquery.md:49,55,61,67` | `FROM table` → `FROM employees` (4 examples) | parses; UNRESOLVED, matching sibling examples |

Notes for the reviewer:

- **`long` → `bigint`**: StarRocks has no `long` type; the Avro `long` maps to
  `bigint`. The Avro schema JSON in the same page keeps `"type": "long"`, which is
  correct there and was left alone.
- **MV `ORDER BY`**: the grammar requires parentheses on both `branch-3.5`
  (`orderByDesc : ORDER BY identifierList`) and `main`
  (`orderByDesc : ORDER BY '(' sortItem … ')'`), and the async-MV synopsis in this
  same page already shows `[ORDER BY (<sort_key>)]`. The unparenthesized examples
  were wrong on every branch.
- **`ALTER TABLE … TO rollup`**: the grouped form `ADD COLUMN (col1 … , col2 …) TO
  rollup` rejects `AFTER`, so per-column `TO` is the form that both parses and
  matches what the example heading claims (both columns added to the rollup).
- **Reserved keywords**: `order` and `table` are both reserved, so these examples
  never parsed. `CREATE TABLE AS SELECT` keeps its table named `order` and just
  backticks it, per `keywords.md`, since the surrounding prose names that table.
  `SELECT_subquery` instead switches to `employees`: there the reserved word was
  only ever a stand-in, and a real name reads better next to the `salary` and
  `Department` columns those examples already select.
- **Translations**: this PR is English-only. `docs/zh` and `docs/ja` need the same
  edits. Flagging rather than mirroring, because a parity check across the three
  languages shows 110 of 239 files with runnable SQL already diverge (zh has 886
  runnable samples vs. en's 840), so some of these blocks may differ for reasons
  that deserve their own look.

Two further FAILs from this run (`HLL.md` missing comma, `SHOW_ANALYZE_JOB.md`
missing semicolon) are already fixed by #76773 and are deliberately absent here.

Tracking: #76813

## Suppressions

10 entries were added to `docs/scripts/sql_verify_suppressions.json` so the
checker stops re-reporting examples that cannot run in an isolated cluster by
nature. They landed on the `docs/verify-sql-samples` branch (**#76763**), which is
where that file is introduced — it does not exist on `main` yet. Please review
them there; they are listed here so nothing is silenced without visibility.

| file:line | category | reason |
|---|---|---|
| `sql-functions/Window_function.md:414` | expected-error | doc deliberately shows an unsupported ROWS window frame returning an error |
| `sql-statements/keywords.md:29` | expected-error | doc deliberately shows the reserved-word error for an unquoted identifier |
| `dictionary/CREATE_DICTIONARY.md:92` | needs-setup | requires the `dict` base table and a clean dictionary namespace from earlier in the page |
| `dictionary/CREATE_DICTIONARY.md:100` | needs-setup | `dictionary_get` on `dict_obj`, which is CANCELLED without its base table (also covers the duplicate at :182) |
| `dictionary/CREATE_DICTIONARY.md:165` | needs-setup | requires the `ProductDimension` base table created earlier in the page |
| `table_bucket_part_index/CREATE_TABLE.md:953` | needs-setup | joins the colocate group an earlier example created with a different bucket count |
| `loading_unloading/SHOW_LOAD.md:73` | illustrative | synopsis using the literal placeholder `"value"` for `label_keep_max_second` |
| `.../routine_load/CREATE_ROUTINE_LOAD.md:309` | illustrative | Kafka property-list fragment, not a complete statement |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:991` | illustrative | Spark/Iceberg DDL (`USING ICEBERG` / `PARTITIONED BY`), not StarRocks SQL |
| `table_bucket_part_index/ALTER_TABLE.md:785` | illustrative | syntax synopsis fragment: `DROP INDEX` without its `ALTER TABLE` prefix |

Result: 3.5 FAIL count 40 → 29. The remaining 29 are the 19 fixed here, the 9
under review in #76813, and 1 startup-race flake.

**Not suppressed on purpose:** the 9 `Window_function.md` failures in #76813
document `array_agg() OVER` / `COUNT/SUM(DISTINCT) OVER`, which no 3.5 build
supports but `main` does. Suppression matches on a content hash with **no version
scoping**, and these blocks are byte-identical on `main`, so an entry would also
silence them for 4.x, where they should pass. They need a human decision instead.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [x] 3.5