### PR TITLE
[Doc] Fix 14 SQL reference examples failing doc-rot verification (4.1/4.0/3.5)

### DIFF
--- a/docs/en/sql-reference/sql-functions/utility-functions/bar.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/bar.md
@@ -24,8 +24,10 @@ bar(size, min, max, width)
 ## Example
 
 ```SQL
-MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	
 1	▓▓
 2	▓▓▓▓
@@ -37,5 +39,4 @@ MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s
 8	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 9	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 10	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-
 ```

--- a/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
@@ -24,8 +24,10 @@ equiwidth_bucket(value, min, max, buckets)
 ## Example
 
 ```SQL
-MYSQL > select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	0
 1	1
 2	2

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
@@ -827,8 +827,8 @@ CREATE TABLE example_db.example_tbl3 (
     country varchar(26) NULL, 
     pay_time bigint(20) NULL, 
     price double SUM NULL) 
-AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 ENGINE=OLAP
+AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 DISTRIBUTED BY HASH(commodity_id); 
 ```
 
@@ -973,7 +973,7 @@ CREATE TABLE sensor.sensor_log2 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 
@@ -1053,7 +1053,7 @@ CREATE TABLE sensor.sensor_log3 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 

--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -859,7 +859,7 @@ Example 1: Create a non-partitioned materialized view.
 -- create an unpartitioned materialized view sorted by lo_custkey
 CREATE MATERIALIZED VIEW lo_mv1
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC
 AS
 select
@@ -879,7 +879,7 @@ Example 2: Create a partitioned materialized view.
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select
@@ -1068,7 +1068,7 @@ Example 7: Create a partition materialized view with a specific sort key:
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -1118,9 +1118,8 @@ DROP PERSISTENT INDEX ON TABLETS(<tablet_id>[, <tablet_id>, ...]);
 
     ```sql
     ALTER TABLE example_db.my_table
-    ADD COLUMN col1 INT DEFAULT "1" AFTER `k1`,
-    ADD COLUMN col2 FLOAT SUM AFTER `v2`,
-    TO example_rollup_index;
+    ADD COLUMN col1 INT DEFAULT "1" AFTER `k1` TO example_rollup_index,
+    ADD COLUMN col2 FLOAT SUM AFTER `v2` TO example_rollup_index;
     ```
 
 7. Drop a column from `example_rollup_index`.

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -85,21 +85,21 @@ Example 1: Synchronously query a table `order` and create a new table `order_new
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT * FROM order;
+AS SELECT * FROM `order`;
 ```
 
 Example 2: Synchronously query the `k1`, `k2`, and `k3` columns in the table `order` and create a new table `order_new` based on the query result, and then insert the query result into the new table. Additionally, set the column names of the new table to `a`, `b`, and `c`.
 
 ```SQL
 CREATE TABLE order_new (a, b, c)
-AS SELECT k1, k2, k3 FROM order;
+AS SELECT k1, k2, k3 FROM `order`;
 ```
 
 or
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT k1 AS a, k2 AS b, k3 AS c FROM order;
+AS SELECT k1 AS a, k2 AS b, k3 AS c FROM `order`;
 ```
 
 Example 3: Synchronously query the largest value of the `salary` column in the table `employee` and create a new table `employee_new` based on the query result, and then insert the query result into the new table. Additionally, set the column name of the new table to `salary_max`.
@@ -221,7 +221,9 @@ Check information of the Task.
 
 ```SQL
 SELECT * FROM INFORMATION_SCHEMA.tasks;
+```
 
+```plaintext
 -- Information of the Task
 
 TASK_NAME: ctas-df6f7930-e7c9-11ec-abac-bab8ee315bf2
@@ -236,7 +238,9 @@ Check the state of the TaskRun.
 
 ```SQL
 SELECT * FROM INFORMATION_SCHEMA.task_runs;
+```
 
+```plaintext
 -- State of the TaskRun
 
 QUERY_ID: 37bd2b63-eba8-11ec-8d41-bab8ee315bf2


### PR DESCRIPTION
## Why I'm doing:

The SQL-example doc-rot checker (`docs/scripts/run_sql_samples.py`) was run against
**all three supported versions**, each with its docs checkout on the matching release
branch and its own cluster on `127.0.0.1:9030`:

| docs | cluster | verdict | FAIL |
|---|---|---|---|
| `branch-4.1` | 4.1.1-14b7e3f | aligned | 24 |
| `branch-4.0` | 4.0.11-9559176 | aligned | 22 |
| `branch-3.5` | 3.5.20-4d17879 | aligned | 29 |

This PR carries the 14 failures that are genuine doc defects **and** were fixed and
re-run successfully on **every one of the three clusters**. That is what makes all
three backport boxes safe to check: no box here is checked on inference.

Every fingerprint below was confirmed present on current `main` before editing.

## What I'm doing:

14 fixes across 6 files. Each preserves what the example teaches — nothing was
reworded merely to make it execute.

| file:line (main) | before → after | verified on |
|---|---|---|
| `sql-functions/utility-functions/bar.md:27` | `MYSQL > select …` + pasted bars in one ```` ```SQL ```` fence → prompt stripped, result moved to ```` ```plaintext ```` | `4.1, 4.0, 3.5` |
| `sql-functions/utility-functions/equiwidth_bucket.md:27` | same reformat | `4.1, 4.0, 3.5` |
| `…/routine_load/CREATE_ROUTINE_LOAD.md:830` | `AGGREGATE KEY(…)` before `ENGINE=OLAP` → `ENGINE=OLAP` before `AGGREGATE KEY(…)` | `4.1, 4.0, 3.5` |
| `…/routine_load/CREATE_ROUTINE_LOAD.md:976` | `` `data_y` long `` → `` `data_y` bigint `` | `4.1, 4.0, 3.5` |
| `…/routine_load/CREATE_ROUTINE_LOAD.md:1056` | `` `data_y` long `` → `` `data_y` bigint `` | `4.1, 4.0, 3.5` |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:862` | ``ORDER BY `lo_custkey` `` → ``ORDER BY (`lo_custkey`)`` | `4.1, 4.0, 3.5` |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:882` | same | `4.1, 4.0, 3.5` |
| `materialized_view/CREATE_MATERIALIZED_VIEW.md:1071` | same | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/ALTER_TABLE.md:1121` | dangling `,` then a bare `TO example_rollup_index` line → each `ADD COLUMN` carries its own `TO example_rollup_index` | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:88` | `FROM order` → ``FROM `order` `` | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:95` | same | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:102` | same | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:222` | statement + pasted vertical output in one ```` ```SQL ```` fence → split into ```` ```SQL ```` and ```` ```plaintext ```` | `4.1, 4.0, 3.5` |
| `table_bucket_part_index/CREATE_TABLE_AS_SELECT.md:237` | same split | `4.1, 4.0, 3.5` |

### Notes for the reviewer

- **`long` → `bigint`**: StarRocks has no `long` type; Avro `long` maps to `BIGINT`.
  The Avro schema JSON on the same page keeps `"type": "long"`, which is correct
  there and was left alone.
- **MV `ORDER BY`**: the grammar requires parentheses, and the async-MV synopsis on
  this same page already shows `[ORDER BY (<sort_key>)]`. The unparenthesized
  examples were wrong on every branch.
- **`ALTER TABLE … TO rollup`**: `addColumnClause` in the grammar is
  `ADD COLUMN columnDesc (FIRST | AFTER identifier)? ((TO | IN) rollupName)?` — the
  `TO` belongs to each clause, so a single trailing `TO` after a comma cannot parse.
  The grouped form `ADD COLUMN (…) TO rollup` rejects `AFTER`, so per-column `TO` is
  the only form that both parses and still demonstrates what the heading claims.
- **Reserved word `order`**: backticked rather than renamed, because the surrounding
  prose names that table.
- **Post-fix status**: the examples that reference `example_db`, `sensor`,
  `lineorder`, `order` and `example_rollup_index` now parse and move from `FAIL` to
  `UNRESOLVED` (unknown db/table/column), which the checker tracks as a separate,
  expected signal for illustrative-but-valid SQL. No suppressions are needed for them.

### Overlap with #76814 — please read before merging

**#76814 edits the same six files.** It was produced by an earlier, 3.5-only run and
covers the same 14 statements (plus a `SELECT_subquery.md` change this PR does not
make). The two will conflict; whichever merges second needs a rebase.

The difference that matters: #76814 could only verify against 3.5, so it cannot
justify 4.1/4.0 backport boxes. This PR supplies that evidence. If you prefer to keep
#76814, the verification table above can be lifted into it wholesale and its boxes
widened — closing this PR in favour of that is a perfectly good outcome.

### Translations

English only. `docs/zh` and `docs/ja` need the same 14 edits and are **not** included
here. Flagging rather than mirroring: a parity check shows the three language trees
already diverge substantially in runnable SQL, so some of these blocks may differ for
reasons that deserve their own review.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5