### PR TITLE
[Doc] Fix CREATE INDEX example using the reserved word `index` (4.1/4.0)

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
@@ -58,10 +58,10 @@ PROPERTIES (
 );
 ```
 
-Create a bitmap index `index` on the `item_id` column of `sales_records`。
+Create a bitmap index `index_item_id` on the `item_id` column of `sales_records`.
 
 ```SQL
-CREATE INDEX index ON sales_records (item_id) USING BITMAP COMMENT '';
+CREATE INDEX index_item_id ON sales_records (item_id) USING BITMAP COMMENT '';
 ```
 
 ## Relevant SQLs


### PR DESCRIPTION
## Why I'm doing:

The SQL-example doc-rot checker (`docs/scripts/run_sql_samples.py`) reported this
example as failing on both `branch-4.1` (against 4.1.1-14b7e3f) and `branch-4.0`
(against 4.0.11-9559176), each run version-aligned:

```
(1064, "Getting syntax error at line 1, column 13. Detail message:
        Unexpected input 'index', the most similar input is {a legal identifier}.")
```

`index` is a reserved word, so this statement has never parsed on any branch —
anyone copying it out of the docs hits a syntax error immediately.

This is a separate PR from the other doc-rot fixes purely so its backport boxes match
its verification: `branch-3.5` already carries an independent fix for the same
example, so the 3.5 box must stay unchecked.

## What I'm doing:

| file:line (main) | before → after | verified on |
|---|---|---|
| `table_bucket_part_index/CREATE_INDEX.md:64` | `CREATE INDEX index ON …` → `CREATE INDEX index_item_id ON …` | `4.1, 4.0` |

The sentence above the block names the index, so it is updated to match. The stray
full-width `。` that ended that same sentence is normalised to `.` in the process.

### Notes for the reviewer

- **Why not backported to 3.5**: `branch-3.5` already reads
  `CREATE INDEX index3 ON sales_records (item_id) …`, so the broken fingerprint does
  not exist there. The fix went to 3.5 but was never forward-ported to 4.0, 4.1, or
  `main` — this PR closes that gap in the other direction.
- **Name choice**: `index_item_id` is the exact statement that was verified on both
  clusters. If you would rather the three branches read identically, renaming this to
  `index3` to match 3.5 is fine — any legal identifier parses — but that text has not
  been run, so I did not assume it. 3.5's prose still calls the index `index`, so
  aligning the branches would want a prose fix there too.
- **Post-fix status**: the `sales_records` CREATE TABLE above this example specifies
  `"replication_num" = "3"`, so on a single-BE verification cluster the table is never
  created and this statement now reports `UNRESOLVED` rather than `FAIL`. That is the
  expected signal for a valid statement whose setup an isolated run cannot satisfy.

### Translations

English only. `docs/zh` and `docs/ja` carry the same broken example and are not
included here.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5