### PR TITLE
[Doc] Fix ASOF JOIN and recursive-CTE examples failing doc-rot verification (4.1)

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
@@ -165,7 +165,7 @@ Querying organizational hierarchy is one of the most common use cases for Recurs
         FROM employees e
         INNER JOIN org_hierarchy oh ON e.manager_id = oh.employee_id
     )
-    SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+    SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
         employee_id,
         name,
         title,
@@ -210,7 +210,7 @@ cte2 AS (
     UNION ALL
     SELECT n + 1 FROM cte2 WHERE n < 15
 )
-SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
     'cte1' AS source,
     n
 FROM cte1

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
@@ -256,7 +256,7 @@ Example:
 SELECT *
 FROM holdings h ASOF LEFT JOIN prices p             
 ON h.ticker = p.ticker            
-AND h.when >= p.when
+AND h.`when` >= p.`when`
 ORDER BY ALL;
 ```
 


### PR DESCRIPTION
## Why I'm doing:

Three examples that fail the SQL-example doc-rot checker
(`docs/scripts/run_sql_samples.py`) on `branch-4.1` against a 4.1.1-14b7e3f cluster,
version-aligned. They are in a PR of their own because their verification set is
`{4.1}` only — see the per-fix reasoning below — so no backport box beyond 4.1 may be
checked.

## What I'm doing:

| file:line (main) | before → after | verified on |
|---|---|---|
| `…/SELECT/SELECT_JOIN.md:259` | `AND h.when >= p.when` → ``AND h.`when` >= p.`when` `` | `4.1` |
| `…/SELECT/SELECT_CTE.md:168` | `SET_VAR(enable_recursive_cte=true)` → `SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10)` | `4.1` |
| `…/SELECT/SELECT_CTE.md:213` | same | `4.1` |

### Notes for the reviewer

**ASOF JOIN — `when` is a reserved word.** The example never parsed:

```
Unexpected input 'when', the most similar input is {a legal identifier}.
```

Backticking keeps the column name the prose and the surrounding narrative use.

*Why 4.1 only:* ASOF JOIN itself works on 4.0, but the example's trailing
`ORDER BY ALL` does not — `sortItem` gains the `ALL` alternative only in
`branch-4.1`'s grammar:

```
# branch-4.1                                  # branch-4.0 / branch-3.5
sortItem                                      sortItem
    : expression ordering=(ASC|DESC)? …           : expression ordering=(ASC|DESC)? …
    | ALL ordering=(ASC|DESC)? …                  ;
    ;
```

So on 4.0 the backtick fix alone still fails. `branch-4.0` and `branch-3.5` carry this
same example text with `ORDER BY ALL`, which means **those branches document 4.1-only
syntax** — a separate defect that needs a human call (revert the section, add a
"Since v4.1" note, or drop `ORDER BY ALL` on those branches). Raised in #76813 rather
than guessed at here.

**Recursive CTE — the examples exceed the default depth.** Both failed with:

```
Recursive query aborted after: 5 iterations.
```

`recursive_cte_max_depth` defaults to `5`. The org-hierarchy example is five levels
deep (`Alicia -> Bob -> David -> Grace -> Judy`) and the second example's `cte2` walks
`10 → 15`, i.e. six iterations. This page's own configuration table already documents
`recursive_cte_max_depth`, so raising it in the hint teaches the variable the page
introduces instead of quietly shrinking the data to fit the default.

After the fix both queries return exactly the result tables already printed in the
doc — the org-hierarchy output matches row for row, including the `level` and `path`
columns.

*Why 4.1 only:* `SELECT_CTE.md` does not exist on `branch-4.0` or `branch-3.5`;
recursive CTE is a 4.1 feature.

### Translations

English only. `docs/zh` and `docs/ja` are not included here.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5