### PR TITLE
[Doc] Backport HLL and SHOW ANALYZE JOB example fixes to branch-3.5

### DIFF
--- a/docs/en/sql-reference/data-types/other-data-types/HLL.md
+++ b/docs/en/sql-reference/data-types/other-data-types/HLL.md
@@ -74,7 +74,7 @@ In actual business scenarios, data volume and data distribution affect the memor
 
     create table test_uv(
     dt date,
-    id int
+    id int,
     uv_set hll hll_union)
     distributed by hash(id);
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
@@ -35,7 +35,7 @@ You can filter results by using the WHERE clause. The statement returns the foll
 
 ```SQL
 -- View all the custom collection tasks.
-SHOW ANALYZE JOB
+SHOW ANALYZE JOB;
 
 -- View custom collection tasks of database `test`.
 SHOW ANALYZE JOB where `database` = 'test';


### PR DESCRIPTION
## Why I'm doing:

Two SQL reference examples are broken on `branch-3.5`. Both were already fixed on
`main` and `branch-4.1` by #76773, but that PR's backport labels covered 4.1 only,
so 4.0 and 3.5 were left behind.

The SQL-example doc-rot checker (`docs/scripts/run_sql_samples.py`) still reports both
of them on this branch, run against a **3.5.20-4d17879** cluster with the docs
checkout on `branch-3.5` (versions reported aligned):

```
HLL.md:69              Unexpected input 'hll', the most similar input is {'('}
SHOW_ANALYZE_JOB.md:36 Unexpected input 'SHOW', the most similar input is {<EOF>, ';'}
```

This PR targets `branch-3.5` directly, so it has no backport section.

## What I'm doing:

| file | before → after | verified on |
|---|---|---|
| `data-types/other-data-types/HLL.md` | `id int` → `id int,` — missing comma merged two column definitions | `3.5` |
| `sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md` | `SHOW ANALYZE JOB` → `SHOW ANALYZE JOB;` — missing semicolon merged the statement with the one after it | `3.5` |

Both are byte-identical to the hunks merged in #76773. Each was re-run on the
3.5.20-4d17879 cluster after the edit: the `test_uv` table creates, and both
`SHOW ANALYZE JOB` and `SHOW ANALYZE JOB where \`database\` = 'test'` return
result sets.

### Notes for the reviewer

- **Not a Mergify backport.** #76773 is already merged, so re-triggering its
  auto-backport is not possible; these are the same two hunks applied by hand.
- **VARIANT.md is excluded.** #76773 also fixed `VARIANT.md`, but that example does
  not fail on `branch-3.5`, so it is left alone.
- **Translations.** #76773 updated `docs/zh` and `docs/ja` alongside `docs/en`. This
  PR is English-only, so `branch-3.5`'s zh/ja copies of these two pages remain
  broken and still need the same two edits. Flagging rather than mirroring.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5