### PR TITLE
[Doc] Fix 11 SQL reference examples failing doc-rot verification (en/zh/ja)

### DIFF
--- a/docs/en/sql-reference/sql-functions/utility-functions/bar.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/bar.md
@@ -23,9 +23,11 @@ bar(size, min, max, width)
 
 ## Example
 
-```SQL
-MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	
 1	▓▓
 2	▓▓▓▓
@@ -37,5 +39,4 @@ MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s
 8	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 9	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 10	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-
 ```

--- a/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
@@ -23,9 +23,11 @@ equiwidth_bucket(value, min, max, buckets)
 
 ## Example
 
-```SQL
-MYSQL > select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	0
 1	1
 2	2

--- a/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
+++ b/docs/en/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
@@ -827,8 +827,8 @@ CREATE TABLE example_db.example_tbl3 (
     country varchar(26) NULL, 
     pay_time bigint(20) NULL, 
     price double SUM NULL) 
-AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 ENGINE=OLAP
+AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 DISTRIBUTED BY HASH(commodity_id); 
 ```
 
@@ -973,7 +973,7 @@ CREATE TABLE sensor.sensor_log2 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 
@@ -1053,7 +1053,7 @@ CREATE TABLE sensor.sensor_log3 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 

--- a/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -859,7 +859,7 @@ Example 1: Create a non-partitioned materialized view.
 -- create an unpartitioned materialized view sorted by lo_custkey
 CREATE MATERIALIZED VIEW lo_mv1
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC
 AS
 select
@@ -879,7 +879,7 @@ Example 2: Create a partitioned materialized view.
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select
@@ -1068,7 +1068,7 @@ Example 7: Create a partition materialized view with a specific sort key:
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -1119,7 +1119,7 @@ DROP PERSISTENT INDEX ON TABLETS(<tablet_id>[, <tablet_id>, ...]);
     ```sql
     ALTER TABLE example_db.my_table
     ADD COLUMN col1 INT DEFAULT "1" AFTER `k1`,
-    ADD COLUMN col2 FLOAT SUM AFTER `v2`,
+    ADD COLUMN col2 FLOAT SUM AFTER `v2`
     TO example_rollup_index;
     ```
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -85,21 +85,21 @@ Example 1: Synchronously query a table `order` and create a new table `order_new
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT * FROM order;
+AS SELECT * FROM `order`;
 ```
 
 Example 2: Synchronously query the `k1`, `k2`, and `k3` columns in the table `order` and create a new table `order_new` based on the query result, and then insert the query result into the new table. Additionally, set the column names of the new table to `a`, `b`, and `c`.
 
 ```SQL
 CREATE TABLE order_new (a, b, c)
-AS SELECT k1, k2, k3 FROM order;
+AS SELECT k1, k2, k3 FROM `order`;
 ```
 
 or
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT k1 AS a, k2 AS b, k3 AS c FROM order;
+AS SELECT k1 AS a, k2 AS b, k3 AS c FROM `order`;
 ```
 
 Example 3: Synchronously query the largest value of the `salary` column in the table `employee` and create a new table `employee_new` based on the query result, and then insert the query result into the new table. Additionally, set the column name of the new table to `salary_max`.

--- a/docs/ja/sql-reference/sql-functions/utility-functions/bar.md
+++ b/docs/ja/sql-reference/sql-functions/utility-functions/bar.md
@@ -22,9 +22,11 @@ bar(size, min, max, width)
 
 ## Example
 
-```SQL
-MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	
 1	▓▓
 2	▓▓▓▓
@@ -36,5 +38,4 @@ MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s
 8	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 9	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 10	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-
 ```

--- a/docs/ja/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
+++ b/docs/ja/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
@@ -22,9 +22,11 @@ equiwidth_bucket(value, min, max, buckets)
 
 ## Example
 
-```SQL
-MYSQL > select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	0
 1	1
 2	2

--- a/docs/ja/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
+++ b/docs/ja/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
@@ -824,8 +824,8 @@ CREATE TABLE example_db.example_tbl3 (
     country varchar(26) NULL, 
     pay_time bigint(20) NULL, 
     price double SUM NULL) 
-AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 ENGINE=OLAP
+AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 DISTRIBUTED BY HASH(commodity_id); 
 ```
 
@@ -970,7 +970,7 @@ CREATE TABLE sensor.sensor_log2 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 
@@ -1050,7 +1050,7 @@ CREATE TABLE sensor.sensor_log3 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 

--- a/docs/ja/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/ja/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -862,7 +862,7 @@ PROPERTIES (
 -- lo_custkeyでソートされた非パーティション化されたマテリアライズドビューを作成
 CREATE MATERIALIZED VIEW lo_mv1
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC
 AS
 select
@@ -882,7 +882,7 @@ group by lo_orderkey, lo_custkey
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select
@@ -1072,7 +1072,7 @@ AS SELECT * from t1;
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -1120,7 +1120,7 @@ DROP PERSISTENT INDEX ON TABLETS(<tablet_id>[, <tablet_id>, ...]);
     ```sql
     ALTER TABLE example_db.my_table
     ADD COLUMN col1 INT DEFAULT "1" AFTER `k1`,
-    ADD COLUMN col2 FLOAT SUM AFTER `v2`,
+    ADD COLUMN col2 FLOAT SUM AFTER `v2`
     TO example_rollup_index;
     ```
 

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -87,21 +87,21 @@ CREATE TABLE AS SELECT (CTAS) 文を使用して、同期または非同期で�
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT * FROM order;
+AS SELECT * FROM `order`;
 ```
 
 例 2: テーブル `order` の `k1`、`k2`、`k3` 列を同期的にクエリし、クエリ結果に基づいて新しいテーブル `order_new` を作成し、その後クエリ結果を新しいテーブルに挿入します。さらに、新しいテーブルの列名を `a`、`b`、`c` に設定します。
 
 ```SQL
 CREATE TABLE order_new (a, b, c)
-AS SELECT k1, k2, k3 FROM order;
+AS SELECT k1, k2, k3 FROM `order`;
 ```
 
 または
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT k1 AS a, k2 AS b, k3 AS c FROM order;
+AS SELECT k1 AS a, k2 AS b, k3 AS c FROM `order`;
 ```
 
 例 3: テーブル `employee` の `salary` 列の最大値を同期的にクエリし、クエリ結果に基づいて新しいテーブル `employee_new` を作成し、その後クエリ結果を新しいテーブルに挿入します。さらに、新しいテーブルの列名を `salary_max` に設定します。

--- a/docs/zh/sql-reference/sql-functions/utility-functions/bar.md
+++ b/docs/zh/sql-reference/sql-functions/utility-functions/bar.md
@@ -22,9 +22,11 @@ bar(size, min, max, width)
 
 ## 示例
 
-```SQL
-MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	
 1	▓▓
 2	▓▓▓▓
@@ -36,5 +38,4 @@ MYSQL > select r, bar(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s
 8	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 9	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 10	▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-
 ```

--- a/docs/zh/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
+++ b/docs/zh/sql-reference/sql-functions/utility-functions/equiwidth_bucket.md
@@ -23,9 +23,11 @@ equiwidth_bucket(value, min, max, buckets)
 
 ## 示例
 
-```SQL
-MYSQL > select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```sql
+select r, equiwidth_bucket(r, 0, 10, 20) as x from table(generate_series(0, 10)) as s(r);
+```
 
+```plaintext
 0	0
 1	1
 2	2

--- a/docs/zh/sql-reference/sql-statements/cluster-management/file/CREATE_FILE.md
+++ b/docs/zh/sql-reference/sql-statements/cluster-management/file/CREATE_FILE.md
@@ -48,7 +48,7 @@ CREATE FILE "file_name" [IN database]
 CREATE FILE "test.pem"
 PROPERTIES
 (
-    "url" = "http://starrocks-public.oss-cn-xxxx.aliyuncs.com/key/test.pem",
+    "url" = "https://starrocks-public.oss-cn-xxxx.aliyuncs.com/key/test.pem",
     "catalog" = "kafka"
 );
 ```

--- a/docs/zh/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
+++ b/docs/zh/sql-reference/sql-statements/loading_unloading/routine_load/CREATE_ROUTINE_LOAD.md
@@ -824,8 +824,8 @@ CREATE TABLE example_db.example_tbl3 (
     country varchar(26) NULL, 
     pay_time bigint(20) NULL, 
     price double SUM NULL) 
-AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 ENGINE=OLAP
+AGGREGATE KEY(commodity_id,customer_name,country,pay_time) 
 DISTRIBUTED BY HASH(commodity_id); 
 ```
 
@@ -970,7 +970,7 @@ CREATE TABLE sensor.sensor_log2 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 
@@ -1050,7 +1050,7 @@ CREATE TABLE sensor.sensor_log3 (
     `name` varchar(26) NOT NULL COMMENT "sensor name", 
     `checked` boolean NOT NULL COMMENT "checked", 
     `sensor_type` varchar(26) NOT NULL COMMENT "sensor type",
-    `data_y` long NULL COMMENT "sensor data" 
+    `data_y` bigint NULL COMMENT "sensor data" 
 ) 
 ENGINE=OLAP 
 DUPLICATE KEY (id) 

--- a/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/materialized_view/CREATE_MATERIALIZED_VIEW.md
@@ -848,7 +848,7 @@ PROPERTIES (
 -- 创建一个按 lo_custkey 排序的非分区物化视图
 CREATE MATERIALIZED VIEW lo_mv1
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC
 AS
 select
@@ -868,7 +868,7 @@ group by lo_orderkey, lo_custkey;
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select
@@ -1058,7 +1058,7 @@ AS SELECT * from t1;
 CREATE MATERIALIZED VIEW lo_mv2
 PARTITION BY `lo_orderdate`
 DISTRIBUTED BY HASH(`lo_orderkey`)
-ORDER BY `lo_custkey`
+ORDER BY (`lo_custkey`)
 REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
 AS
 select

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/ALTER_TABLE.md
@@ -1120,7 +1120,7 @@ DROP PERSISTENT INDEX ON TABLETS(<tablet_id>[, <tablet_id>, ...]);
     ```sql
     ALTER TABLE example_db.my_table
     ADD COLUMN col1 INT DEFAULT "1" AFTER `k1`,
-    ADD COLUMN col2 FLOAT SUM AFTER `v2`,
+    ADD COLUMN col2 FLOAT SUM AFTER `v2`
     TO example_rollup_index;
     ```
 

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE_AS_SELECT.md
@@ -85,21 +85,21 @@ CREATE TABLE AS SELECT（简称 CTAS）语句可用于同步或异步查询原�
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT * FROM order;
+AS SELECT * FROM `order`;
 ```
 
 示例二：同步查询原表 `order`中的 `k1`、`k2` 和 `k3` 列并根据查询结果创建新表 `order_new`，然后将查询结果插入到新表中，并指定新表中列的名称为 `a`、`b` 和 `c`。
 
 ```SQL
 CREATE TABLE order_new (a, b, c)
-AS SELECT k1, k2, k3 FROM order;
+AS SELECT k1, k2, k3 FROM `order`;
 ```
 
 或
 
 ```SQL
 CREATE TABLE order_new
-AS SELECT k1 AS a, k2 AS b, k3 AS c FROM order;
+AS SELECT k1 AS a, k2 AS b, k3 AS c FROM `order`;
 ```
 
 示例三：同步查询原表 `employee`中 `salary` 列的最大值并根据查询结果创建新表 `employee_new` ，然后将查询结果插入到新表中，并指定新表中列名为 `salary_new`。

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_DYNAMIC_PARTITION_TABLES.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SHOW_DYNAMIC_PARTITION_TABLES.md
@@ -18,8 +18,8 @@ SHOW DYNAMIC PARTITION TABLES [FROM <db_name>]
 
 ## 示例
 
-1. 展示数据库 database 的所有设置过动态分区属性的分区表状态。
+1. 展示数据库 `db_test` 的所有设置过动态分区属性的分区表状态。
 
 ```sql
-SHOW DYNAMIC PARTITION TABLES FROM database;
+SHOW DYNAMIC PARTITION TABLES FROM db_test;
 ```


### PR DESCRIPTION
## Why I'm doing:

The SQL-example doc-rot checker was run against **all three supported versions × all
three languages** (9 passes: 4.1/4.0/3.5 × en/zh/ja), each with its docs checkout on the
matching release branch and its own cluster. All nine runs reported versions aligned.

| docs | cluster | en FAIL | zh FAIL | ja FAIL |
|---|---|---|---|---|
| `branch-4.1` | 4.1.1-14b7e3f | 24 | 38 | 32 |
| `branch-4.0` | 4.0.11-9559176 | 22 | 35 | 30 |
| `branch-3.5` | 3.5.20-4d17879 | 20 | 30 | 26 |

This PR carries the subset that is **fixable and verified on all three versions**.
Every fix is applied to **every language that carries the example** — the repeated
failure mode in this repo is fixing `en` and leaving `zh`/`ja` broken.

## What I'm doing:

Each statement below was executed against a live cluster of 4.1, 4.0 **and** 3.5, both to
reproduce the failure and to confirm the corrected form runs.

| file | before → after | verified on | languages |
|---|---|---|---|
| `CREATE_ROUTINE_LOAD.md` (example_tbl3) | `AGGREGATE KEY(…)` then `ENGINE=OLAP` → `ENGINE=OLAP` then `AGGREGATE KEY(…)` | 4.1, 4.0, 3.5 | en, zh, ja |
| `CREATE_ROUTINE_LOAD.md` (sensor_log2, sensor_log3) | `` `data_y` long `` → `` `data_y` bigint `` | 4.1, 4.0, 3.5 | en, zh, ja |
| `CREATE_MATERIALIZED_VIEW.md` (lo_mv1, lo_mv2 ×2) | ``ORDER BY `lo_custkey` `` → ``ORDER BY (`lo_custkey`)`` | 4.1, 4.0, 3.5 | en, zh, ja |
| `CREATE_TABLE_AS_SELECT.md` (×3) | `FROM order` → ``FROM `order` `` | 4.1, 4.0, 3.5 | en, zh, ja |
| `ALTER_TABLE.md` (rollup example 6) | ``AFTER `v2`,`` → ``AFTER `v2` `` (drop trailing comma) | 4.1, 4.0, 3.5 | en, zh, ja |
| `bar.md`, `equiwidth_bucket.md` | `MYSQL >` transcript split into a ```sql block + a ```plaintext result block | 4.1, 4.0, 3.5 | en, zh, ja |
| `SHOW_DYNAMIC_PARTITION_TABLES.md` | `FROM database` → `FROM db_test` | 4.1, 4.0, 3.5 | **zh only** |
| `CREATE_FILE.md` | `http://` → `https://` | n/a (see below) | **zh only** |

Notes on the two single-language rows — both are cases where one language was left
behind, which is exactly what a cross-language run exists to surface:

- **`SHOW_DYNAMIC_PARTITION_TABLES.md`** — `en` and `ja` already use `db_test`; only `zh`
  still used the reserved word `database`, so only `zh` failed. The zh prose reference was
  updated to match (`数据库 database` → ``数据库 `db_test` ``) — an identifier swap, not
  translated prose.
- **`CREATE_FILE.md`** — this one is *not* a runnability fix. The example fetches a
  placeholder OSS URL that no isolated run can reach, and `en`/`ja` are already covered by
  a global `needs-setup` suppression keyed on their text. `zh` said `http://` where en/ja
  say `https://`, so it hashed differently and escaped that suppression — one language
  reporting a failure the other two had silenced. Aligning the scheme brings zh under the
  **existing** entry rather than adding a second one, and https is the better thing to
  document anyway. Verified deterministically: after this edit all three languages produce
  skeleton `skel256:e4fe5d46e084…`, which is the existing suppression's key.

## Language coverage

`en 6 · zh 8 · ja 6` files. zh is higher because the two single-language fixes above are
zh-only; every fix that exists in more than one language is applied in all of them.

## Suppressions

**None in this PR** — `docs/scripts/sql_verify_suppressions.json` does not exist on `main`;
the checker and its suppression list are still in the unmerged tooling PR #76763. The nine
new entries this run produced (1 `expected-error`, 8 `needs-setup`, all global) are
described in #76813 and need to land on that branch instead.

## What is deliberately NOT here

- Fixes verified on only a subset of versions (`CREATE INDEX`, `ds_hll_*` `GROUP BY`) —
  they would make the backport boxes below unsafe, so they go in a separate PR.
- `SELECT_subquery.md` / `SELECT_CTE.md` / `SELECT_JOIN.md` — on 4.0/3.5 these live in a
  single `SELECT.md`, so a cherry-pick of a `SELECT/…` path would not apply.
- Two `CREATE_TABLE_AS_SELECT.md` client transcripts, one of which also hits an
  environment-dependent `getTaskRuns` FE error. See #76813.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5