### PR TITLE
[Doc] Fix CREATE INDEX and ds_hll examples failing doc-rot verification (4.1, 4.0)

### DIFF
--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
@@ -59,7 +59,8 @@ INSERT INTO t2 SELECT id, dt,
   ds_hll_accumulate(province, 10), 
   ds_hll_accumulate(age, 20, "HLL_6"), 
   ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- Combine sketches grouped by date
 SELECT dt, 

--- a/docs/en/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
+++ b/docs/en/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
@@ -59,7 +59,8 @@ INSERT INTO t2 SELECT id, dt,
   ds_hll_accumulate(province, 10), 
   ds_hll_accumulate(age, 20, "HLL_6"), 
   ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- Estimate distinct counts grouped by date
 SELECT dt, 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
@@ -58,10 +58,10 @@ PROPERTIES (
 );
 ```
 
-Create a bitmap index `index` on the `item_id` column of `sales_records`。
+Create a bitmap index `index3` on the `item_id` column of `sales_records`.
 
 ```SQL
-CREATE INDEX index ON sales_records (item_id) USING BITMAP COMMENT '';
+CREATE INDEX index3 ON sales_records (item_id) USING BITMAP COMMENT '';
 ```
 
 ## Relevant SQLs

--- a/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
+++ b/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
@@ -1,3 +1,8 @@
+---
+displayed_sidebar: docs
+description: "複数のシリアライズされた DataSketches HyperLogLog (HLL) スケッチを、近似重複除去カウント用の単一のシリアライズされたスケッチに結合します。"
+---
+
 # ds_hll_combine
 
 複数のシリアライズされた HyperLogLog スケッチを単一のシリアライズされたスケッチに結合します。この関数は DataSketches HLL 近似重複除去カウント関数ファミリーの一部です。

--- a/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
+++ b/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
@@ -56,7 +56,8 @@ SELECT id, dt,
        ds_hll_accumulate(province, 20),
        ds_hll_accumulate(age, 12, "HLL_6"),
        ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- 日付でグループ化してスケッチを結合
 SELECT dt, 

--- a/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
+++ b/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
@@ -1,3 +1,8 @@
+---
+displayed_sidebar: docs
+description: "シリアライズされた DataSketches HyperLogLog (HLL) スケッチから近似重複除去カウントを推定します。"
+---
+
 # ds_hll_estimate
 
 シリアライズされた HyperLogLog スケッチから近似重複除去カウントを推定します。この関数は DataSketches HLL 近似重複除去カウント関数ファミリーの一部です。

--- a/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
+++ b/docs/ja/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
@@ -56,7 +56,8 @@ SELECT id, dt,
        ds_hll_accumulate(province, 20),
        ds_hll_accumulate(age, 12, "HLL_6"),
        ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- 日付でグループ化して重複除去カウントを推定
 SELECT dt, 

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
@@ -58,10 +58,10 @@ PROPERTIES (
 );
 ```
 
-`sales_records` の `item_id` 列にビットマップインデックス `index` を作成します。
+`sales_records` の `item_id` 列にビットマップインデックス `index3` を作成します。
 
 ```SQL
-CREATE INDEX index ON sales_records (item_id) USING BITMAP COMMENT '';
+CREATE INDEX index3 ON sales_records (item_id) USING BITMAP COMMENT '';
 ```
 
 ## 関連する SQL

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
@@ -1,3 +1,8 @@
+---
+displayed_sidebar: docs
+description: "将多个序列化的 DataSketches HyperLogLog (HLL) 草图合并为单个序列化草图，用于近似去重计数。"
+---
+
 # ds_hll_combine
 
 将多个序列化的 HyperLogLog 草图合并为单个序列化草图。此函数是 DataSketches HLL 近似去重计数函数族的一部分。

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_combine.md
@@ -56,7 +56,8 @@ SELECT id, dt,
        ds_hll_accumulate(province, 20),
        ds_hll_accumulate(age, 12, "HLL_6"),
        ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- 按日期分组合并草图
 SELECT dt, 

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
@@ -56,7 +56,8 @@ SELECT id, dt,
        ds_hll_accumulate(province, 20),
        ds_hll_accumulate(age, 12, "HLL_6"),
        ds_hll_accumulate(dt, 10, "HLL_8") 
-FROM t1;
+FROM t1
+GROUP BY id, dt;
 
 -- 按日期分组估算去重计数
 SELECT dt, 

--- a/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
+++ b/docs/zh/sql-reference/sql-functions/aggregate-functions/ds_hll_estimate.md
@@ -1,3 +1,8 @@
+---
+displayed_sidebar: docs
+description: "从序列化的 DataSketches HyperLogLog (HLL) 草图估算近似去重计数。"
+---
+
 # ds_hll_estimate
 
 从序列化的 HyperLogLog 草图估算近似去重计数。此函数是 DataSketches HLL 近似去重计数函数族的一部分。

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/CREATE_INDEX.md
@@ -61,16 +61,16 @@ PROPERTIES (
 );
 ```
 
-为表 `sales_records` 中的 `item_id` 列创建 bitmap 索引，索引名称为 `index`。
+为表 `sales_records` 中的 `item_id` 列创建 bitmap 索引，索引名称为 `index3`。
 
 ```SQL
-CREATE INDEX index ON sales_records (item_id) USING BITMAP COMMENT '';
+CREATE INDEX index3 ON sales_records (item_id) USING BITMAP COMMENT '';
 ```
 
 或
 
 ```SQL
-CREATE INDEX index ON sales_records (item_id);
+CREATE INDEX index3 ON sales_records (item_id);
 ```
 
 ## 相关操作


### PR DESCRIPTION
## Why I'm doing:

Part of the same all-versions × all-languages doc-rot run as #76823. These two fixes are
split out because they are **verified on 4.1 and 4.0 but not on 3.5**, so they must not
ride along with a PR whose 3.5 backport box is checked.

## What I'm doing:

| file | before → after | verified on | languages |
|---|---|---|---|
| `CREATE_INDEX.md` | `CREATE INDEX index …` → `CREATE INDEX index3 …` | 4.1, 4.0 | en, zh, ja |
| `ds_hll_combine.md`, `ds_hll_estimate.md` | `… FROM t1;` → `… FROM t1`<br>`GROUP BY id, dt;` | 4.1, 4.0 | en, zh, ja |

**`CREATE INDEX`** — `index` is a reserved word, so the example fails to parse on 4.1 and
4.0. It does *not* fail on 3.5, where the same page still says `index3`; the 4.x docs
regressed away from a working name. Restoring `index3` keeps the three branches
consistent. The prose code span naming the index is updated in each language (an
identifier swap inside a code span — no prose was translated). `zh` has two occurrences of
the statement, `en` and `ja` one each.

**`ds_hll_*`** — `ds_hll_accumulate` is an aggregate function, so
`SELECT id, dt, ds_hll_accumulate(...) FROM t1` selects bare columns alongside an
aggregate and is rejected. `GROUP BY id, dt` is not an arbitrary choice to make it run: it
is what the page's *next* query assumes, since that one combines the per-id sketches by
date (`SELECT dt, ds_hll_combine(ds_id) … GROUP BY dt`). Both the corrected INSERT and the
follow-on combine query were run on 4.1 and 4.0.

The `ds_hll_*` functions do not exist on 3.5 (`No matching function with signature:
ds_hll_accumulate(bigint(20))`), so the 3.5 box is deliberately left unchecked.

## Language coverage

`en 3 · zh 3 · ja 3` files — identical in all three.

Worth flagging: only `zh` and `ja` ever *reported* the `ds_hll` failure. `en` contains the
same defective statement, but the extractor marks that block non-runnable because
`_COMMENT_PLACEHOLDER_RE` matches its ordinary prose comment `-- Insert test data`. It is
fixed here anyway. That heuristic bug is written up in #76813.

## Suppressions

None. (`sql_verify_suppressions.json` is not on `main` yet — see #76763.)

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5