### PR TITLE
[Doc] Fix SELECT subquery, recursive-CTE and ASOF JOIN examples (4.1)

### DIFF
--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
@@ -165,7 +165,7 @@ Querying organizational hierarchy is one of the most common use cases for Recurs
         FROM employees e
         INNER JOIN org_hierarchy oh ON e.manager_id = oh.employee_id
     )
-    SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+    SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
         employee_id,
         name,
         title,
@@ -210,7 +210,7 @@ cte2 AS (
     UNION ALL
     SELECT n + 1 FROM cte2 WHERE n < 15
 )
-SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
     'cte1' AS source,
     n
 FROM cte1

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
@@ -256,7 +256,7 @@ Example:
 SELECT *
 FROM holdings h ASOF LEFT JOIN prices p             
 ON h.ticker = p.ticker            
-AND h.when >= p.when
+AND h.`when` >= p.`when`
 ORDER BY ALL;
 ```
 

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
@@ -46,23 +46,23 @@ Subqueries also support scalar quantum queries. It can be divided into irrelevan
 1. Uncorrelated scalar quantum query with predicate = sign. For example, output information about the person with the highest wage.
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. Uncorrelated scalar quantum queries with predicates `>`, `<` etc. For example, output information about people who are paid more than average.
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. Related scalar quantum queries. For example, output the highest salary information for each department.
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. Scalar quantum queries are used as parameters of ordinary functions.
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
@@ -165,7 +165,7 @@ StarRocks の再帰 CTE には、次の制限があります。
         FROM employees e
         INNER JOIN org_hierarchy oh ON e.manager_id = oh.employee_id
     )
-    SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+    SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
         employee_id,
         name,
         title,
@@ -210,7 +210,7 @@ cte2 AS (
     UNION ALL
     SELECT n + 1 FROM cte2 WHERE n < 15
 )
-SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
     'cte1' AS source,
     n
 FROM cte1

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
@@ -256,7 +256,7 @@ ASOF LEFT JOIN right_table [AS right_alias]
 SELECT *
 FROM holdings h ASOF LEFT JOIN prices p             
 ON h.ticker = p.ticker            
-AND h.when >= p.when
+AND h.`when` >= p.`when`
 ORDER BY ALL;
 ```
 

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
@@ -46,23 +46,23 @@ SELECT * FROM t1 WHERE [NOT] EXISTS (SELECT a FROM t2 WHERE t1.y = t2.b);
 1. 述語が=符号の、無相関スカラー量子クエリ。たとえば、最も高い賃金を持つ人物に関する情報を出力します。
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. 相関のないスカラー量子クエリ（述語`>`、`<`などを使用）。例えば、平均より高い給与を得ている人々の情報を出力します。
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. 関連するスカラー量子クエリ。たとえば、各部署の最高給与情報を出力します。
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. スカラー量子クエリは、通常の関数のパラメーターとして使用されます。
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_CTE.md
@@ -165,7 +165,7 @@ StarRocks 中的递归 CTE 具有以下限制：
         FROM employees e
         INNER JOIN org_hierarchy oh ON e.manager_id = oh.employee_id
     )
-    SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+    SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
         employee_id,
         name,
         title,
@@ -210,7 +210,7 @@ cte2 AS (
     UNION ALL
     SELECT n + 1 FROM cte2 WHERE n < 15
 )
-SELECT /*+ SET_VAR(enable_recursive_cte=true) */
+SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10) */
     'cte1' AS source,
     n
 FROM cte1

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_JOIN.md
@@ -256,7 +256,7 @@ ASOF LEFT JOIN right_table [AS right_alias]
 SELECT *
 FROM holdings h ASOF LEFT JOIN prices p             
 ON h.ticker = p.ticker            
-AND h.when >= p.when
+AND h.`when` >= p.`when`
 ORDER BY ALL;
 ```
 

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT/SELECT_subquery.md
@@ -46,23 +46,23 @@ SELECT * FROM t1 WHERE [NOT] EXISTS (SELECT a FROM t2 WHERE t1.y = t2.b);
 1. 具有 = 符号的非相关标量量化查询。例如，输出工资最高的人的信息。
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. 具有谓词 `>`, `<` 等的不相关标量量化查询。例如，输出关于工资高于平均水平的人员的信息。
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. 相关的标量量子查询。例如，输出每个部门的最高工资信息。
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. 标量量子查询用作普通函数的参数。
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```


### PR DESCRIPTION
## Why I'm doing:

Part of the all-versions × all-languages doc-rot run (see #76823, #76824). This group is
**4.1-only** for a structural reason: on `branch-4.0` and `branch-3.5` these examples live
in one monolithic `SELECT.md`, not the split `SELECT/SELECT_*.md` layout. A Mergify
cherry-pick of these paths would not apply, so only the 4.1 box is checked.

## What I'm doing:

| file | before → after | verified on | languages |
|---|---|---|---|
| `SELECT/SELECT_subquery.md` (×4) | `FROM table` → `FROM employees` | 4.1 (also runs on 4.0, 3.5) | en, zh, ja |
| `SELECT/SELECT_CTE.md` (×2) | `SET_VAR(enable_recursive_cte=true)` → `SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=10)` | 4.1 | en, zh, ja |
| `SELECT/SELECT_JOIN.md` | `h.when >= p.when` → ``h.`when` >= p.`when` `` | 4.1 | en, zh, ja |

**Subqueries** — `table` is a reserved word, so all four scalar-subquery examples fail to
parse. Renamed to `employees`; the prose never names the table, so no prose changed. They
still reference a table the page does not create, which the checker reports as
`UNRESOLVED` — a signal it defines as "references objects defined elsewhere, **not** doc
rot". Turning a hard parse error into that is the correct outcome for an illustrative
example.

**Recursive CTEs** — both abort with `Recursive query aborted after: 5 iterations`.
`recursive_cte_max_depth` defaults to `5` and the org-hierarchy example is five levels
deep (`Alicia → Bob → David → Grace → Judy`). Adding it to the existing hint is not
cosmetic: with it the query returns **exactly** the result table already printed in the
doc, row for row. Recursive CTEs are 4.1-only.

**ASOF JOIN** — the example joins on a column named `when`, a reserved word. Backticking
it is verified on 4.1. It also runs on 4.0 once backticked — but the example's trailing
`ORDER BY ALL` is 4.1-only grammar (`sortItem` gains its `| ALL ordering=…` alternative in
4.1 and nowhere else), so the 4.0/3.5 copies need a separate decision, tracked in #76813.

## Language coverage

`en 3 · zh 3 · ja 3` files — identical in all three.

## Suppressions

None. (`sql_verify_suppressions.json` is not on `main` yet — see #76763.)

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5