### PR TITLE
[Doc] Fix SQL reference examples failing doc-rot verification (branch-4.0)

### DIFF
--- a/docs/en/sql-reference/data-types/other-data-types/HLL.md
+++ b/docs/en/sql-reference/data-types/other-data-types/HLL.md
@@ -74,7 +74,7 @@ In actual business scenarios, data volume and data distribution affect the memor
 
     create table test_uv(
     dt date,
-    id int
+    id int,
     uv_set hll hll_union)
     distributed by hash(id);
 

--- a/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
+++ b/docs/en/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
@@ -35,7 +35,7 @@ You can filter results by using the WHERE clause. The statement returns the foll
 
 ```SQL
 -- View all the custom collection tasks.
-SHOW ANALYZE JOB
+SHOW ANALYZE JOB;
 
 -- View custom collection tasks of database `test`.
 SHOW ANALYZE JOB where `database` = 'test';

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -909,25 +909,25 @@ Examples:
 1. Uncorrelated scalar quantum query with predicate = sign. For example, output information about the person with the highest wage.
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. Uncorrelated scalar quantum queries with predicates `>`, `<` etc. For example, output information about people who are paid more than average.
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. Related scalar quantum queries. For example, output the highest salary information for each department.
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. Scalar quantum queries are used as parameters of ordinary functions.
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```
 
 ### Where and Operators

--- a/docs/ja/sql-reference/data-types/other-data-types/HLL.md
+++ b/docs/ja/sql-reference/data-types/other-data-types/HLL.md
@@ -76,7 +76,7 @@ HLL に使用されるストレージスペースは、ハッシュ値の異な�
 
     create table test_uv(
     dt date,
-    id int
+    id int,
     uv_set hll hll_union)
     distributed by hash(id);
 

--- a/docs/ja/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
+++ b/docs/ja/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
@@ -37,7 +37,7 @@ WHERE 句を使用して結果をフィルタリングできます。このス�
 
 ```SQL
 -- すべてのカスタムコレクションタスクを表示します。
-SHOW ANALYZE JOB
+SHOW ANALYZE JOB;
 
 -- データベース `test` のカスタムコレクションタスクを表示します。
 SHOW ANALYZE JOB where `database` = 'test';

--- a/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/ja/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -909,25 +909,25 @@ SELECT * FROM t1 WHERE [NOT] EXISTS (SELECT a FROM t2 WHERE t1.y = t2.b);
 1. = 記号を持つ非相関スカラー量子クエリ。たとえば、最高賃金の人物の情報を出力します。
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. `>`, `<` などの述語を持つ非相関スカラー量子クエリ。たとえば、平均以上の賃金を受け取る人々の情報を出力します。
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. 関連するスカラー量子クエリ。たとえば、各部門の最高賃金情報を出力します。
 
     ```sql
-    SELECT name FROM table a WHERE salary = (SELECT MAX(salary) FROM table b WHERE b.Department= a.Department);
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. スカラー量子クエリは通常の関数のパラメータとして使用されます。
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```
 
 ### WHERE と演算子

--- a/docs/zh/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
+++ b/docs/zh/sql-reference/sql-statements/cbo_stats/SHOW_ANALYZE_JOB.md
@@ -35,7 +35,7 @@ SHOW ANALYZE JOB [WHERE predicate]
 
 ```SQL
 -- 查看集群全部自定义采集任务。
-SHOW ANALYZE JOB
+SHOW ANALYZE JOB;
 
 -- 查看数据库 `test` 下的自定义采集任务。
 SHOW ANALYZE JOB where `database` = 'test';

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/SELECT.md
@@ -917,25 +917,25 @@ SELECT * FROM t1 WHERE [NOT] EXISTS (SELECT a FROM t2 WHERE t1.y = t2.b);
 1. 不相关标量子查询，谓词为 = 号。例如输出最高工资的人的信息。
 
     ```sql
-    SELECT name FROM table WHERE salary = (SELECT MAX(salary) FROM table);
+    SELECT name FROM employees WHERE salary = (SELECT MAX(salary) FROM employees);
     ```
 
 2. 不相关标量子查询，谓词为 >,< 等。例如输出比平均工资高的人的信息。
 
     ```sql
-    SELECT name FROM table WHERE salary > (SELECT AVG(salary) FROM table);
+    SELECT name FROM employees WHERE salary > (SELECT AVG(salary) FROM employees);
     ```
 
 3. 相关标量子查询。例如输出各个部门工资最高的信息。
 
     ```sql
-    SELECT name FROM table a WHERE salary = （SELECT MAX(salary) FROM table b WHERE b.部门= a.部门）;
+    SELECT name FROM employees a WHERE salary = (SELECT MAX(salary) FROM employees b WHERE b.Department= a.Department);
     ```
 
 4. 标量子查询作为普通函数的参数。
 
     ```sql
-    SELECT name FROM table WHERE salary = abs((SELECT MAX(salary) FROM table));
+    SELECT name FROM employees WHERE salary = abs((SELECT MAX(salary) FROM employees));
     ```
 
 ### WHERE 与操作符


### PR DESCRIPTION
## Why I'm doing:

From the all-versions × all-languages doc-rot run (see #76823, #76824, #76825). This PR
**targets `branch-4.0` directly** rather than going through `main` + backport, because none
of these can travel that way:

- `HLL.md` and `SHOW_ANALYZE_JOB.md` are **already correct on `main`/4.1** — they were
  fixed there and never backported, so there is nothing on main to cherry-pick.
- `SELECT.md` only exists on the release branches; `main`/4.1 split it into `SELECT/`.

There is no backport section for that reason.

## What I'm doing:

All verified against a live **4.0.11-9559176** cluster.

| file | before → after | verified on | languages |
|---|---|---|---|
| `SELECT.md` (×4) | `FROM table` → `FROM employees` | 4.0 | en, zh, ja |
| `SELECT.md` correlated example | full-width `（ ）` → `( )`, `b.部门`/`a.部门` → `b.Department`/`a.Department` | 4.0 | **zh only** |
| `SHOW_ANALYZE_JOB.md` | `SHOW ANALYZE JOB` → `SHOW ANALYZE JOB;` | 4.0 | en, zh, ja |
| `HLL.md` | `id int` → `id int,` | 4.0 | en, ja (zh already correct) |

**The zh row is the interesting one.** The correlated-subquery example had been broken *by
translation*: ASCII `(` `)` replaced with full-width `（` `）`, and the column identifier
`Department` translated to `部门`. Both are inside the SQL, so the statement cannot parse.
This is repaired to match en/ja. 4.1's zh copy is already clean, so this damage exists only
on 4.0 and 3.5.

`SHOW ANALYZE JOB` was missing its terminating semicolon, so the parser consumed it and the
next example as a single statement (`Unexpected input 'SHOW'`). `HLL.md` was missing a comma
after `id int`, which made the parser reject the following `hll` type.

## Language coverage

`en 3 · zh 2 · ja 3` files. zh is one lower only because its `HLL.md` already had the comma.

## Suppressions

None in this PR.

Tracking: #76813

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr