### PR TITLE
[BugFix] FE does not report SERVER_STATUS_AUTOCOMMIT, causing ProxySQL resync loop

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -191,12 +191,21 @@ public class ConnectProcessor {
         resetConnectionSession();
         ctx.getState().setOk();
     }
-
     // process COM_PING statement, do nothing, just return one OK packet.
     private void handlePing() {
         ctx.getState().setOk();
     }
 
+    // Keep OK/EOF packet status flags consistent with actual autocommit state, so
+    // proxies (e.g. ProxySQL) that track SERVER_STATUS_AUTOCOMMIT don't see it as
+    // permanently unset and loop resending SET autocommit=1.
+    private void applyAutoCommitStatusFlag() {
+    if (ctx.getSessionVariable().isAutoCommit()) {
+        ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT;
+    } else {
+        ctx.getState().serverStatus &= ~MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT;
+    }
+    }
     private void resetConnectionSession() {
         // reconstruct serializer
         ctx.getSerializer().reset();
@@ -535,6 +544,7 @@ public class ConnectProcessor {
         ctx.setExecutor(null);
         ctx.setQueryDetail(null);
         ctx.getState().reset();
+        applyAutoCommitStatusFlag();
         ctx.resetReturnRows();
         ctx.setStartTime();
         ctx.setCurrentThreadAllocatedMemory(getThreadAllocatedBytes(Thread.currentThread().getId()));
@@ -1047,7 +1057,8 @@ public class ConnectProcessor {
     }
 
     private ByteBuffer getResultPacket() {
-        MysqlPacket packet = ctx.getState().toResponsePacket();
+    applyAutoCommitStatusFlag();
+    MysqlPacket packet = ctx.getState().toResponsePacket();
         if (packet == null) {
             // possible two cases:
             // 1. handler has send response
@@ -1410,6 +1421,7 @@ public class ConnectProcessor {
     public void processOnce(RequestPackage req) throws Exception {
         // set status of query to OK.
         ctx.getState().reset();
+        applyAutoCommitStatusFlag();
         ctx.setMultiStmt(false);
         executor = null;
 
@@ -1431,6 +1443,7 @@ public class ConnectProcessor {
     public void processOnce() throws IOException {
         // set status of query to OK.
         ctx.getState().reset();
+        applyAutoCommitStatusFlag();
         ctx.setMultiStmt(false);
         executor = null;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1456,6 +1456,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = AUTO_COMMIT)
     private boolean autoCommit = true;
 
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
+
     @VariableMgr.VarAttr(name = ENABLE_SQL_TRANSACTION)
     private boolean enableSqlTransaction = true;
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -56,6 +56,7 @@ import com.starrocks.mysql.MysqlErrPacket;
 import com.starrocks.mysql.MysqlOkPacket;
 import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.mysql.MysqlSerializer;
+import com.starrocks.mysql.MysqlServerStatusFlag;
 import com.starrocks.plugin.AuditEvent;
 import com.starrocks.plugin.AuditEvent.AuditEventBuilder;
 import com.starrocks.proto.PQueryStatistics;
@@ -382,6 +383,93 @@ public class ConnectProcessorTest extends DDLTestBase {
         Assertions.assertTrue(myContext.getState().toResponsePacket() instanceof MysqlOkPacket);
         Assertions.assertFalse(myContext.isKilled());
     }
+
+    // Verify a fresh session reports autocommit ON, matching the default autoCommit=true.
+    @Test
+    public void testAutoCommitStatusFlagOnByDefault() throws IOException {
+        ConnectContext ctx = initMockContext(mockChannel(pingPacket), GlobalStateMgr.getCurrentState());
+        Assertions.assertTrue(ctx.getSessionVariable().isAutoCommit());
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        processor.processOnce();
+
+        Assertions.assertNotEquals(0,
+                myContext.getState().serverStatus & MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT,
+                "response should report SERVER_STATUS_AUTOCOMMIT when autocommit is on");
+    }
+
+    // Verify the OK packet for the very statement that turns autocommit off already reflects
+    // the new value, not the pre-statement one. This is the case a naive "apply the flag at
+    // reset() time" implementation gets wrong, since reset() runs before the statement executes.
+    @Test
+    public void testAutoCommitStatusFlagReflectsChangeMadeByCurrentStatement() throws Exception {
+        ByteBuffer packet = createQueryPacket("set autocommit=0");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        Assertions.assertTrue(ctx.getSessionVariable().isAutoCommit());
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        // Simulate what real SET autocommit=0 execution does to session state, without
+        // depending on the full SET-statement execution path.
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doAnswer(invocation -> {
+                        Deencapsulation.setField(ctx.getSessionVariable(), "autoCommit", false);
+                        return null;
+                    }).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            processor.processOnce();
+        }
+
+        Assertions.assertEquals(0,
+                myContext.getState().serverStatus & MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT,
+                "OK packet for SET autocommit=0 itself should already report autocommit OFF");
+    }
+
+    // Verify a later, unrelated response still reports OFF after autocommit was turned off,
+    // i.e. the flag isn't only correct on the statement that changed it.
+    @Test
+    public void testAutoCommitStatusFlagStaysOffOnSubsequentResponse() throws IOException {
+        ConnectContext ctx = initMockContext(mockChannel(pingPacket), GlobalStateMgr.getCurrentState());
+        Deencapsulation.setField(ctx.getSessionVariable(), "autoCommit", false);
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        processor.processOnce();
+
+        Assertions.assertEquals(0,
+                myContext.getState().serverStatus & MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT,
+                "subsequent response should still report autocommit OFF");
+    }
+
+    // Verify the OK packet for the statement that turns autocommit back on already reflects ON,
+    // mirroring testAutoCommitStatusFlagReflectsChangeMadeByCurrentStatement for the reverse transition.
+    @Test
+    public void testAutoCommitStatusFlagReflectsReenableByCurrentStatement() throws Exception {
+        ByteBuffer packet = createQueryPacket("set autocommit=1");
+        ConnectContext ctx = initMockContext(mockChannel(packet), GlobalStateMgr.getCurrentState());
+        Deencapsulation.setField(ctx.getSessionVariable(), "autoCommit", false);
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        try (MockedConstruction<StmtExecutor> ignored = Mockito.mockConstruction(StmtExecutor.class,
+                (mock, mockCtx) -> {
+                    Mockito.doAnswer(invocation -> {
+                        Deencapsulation.setField(ctx.getSessionVariable(), "autoCommit", true);
+                        return null;
+                    }).when(mock).execute();
+                    Mockito.when(mock.getQueryStatisticsForAuditLog()).thenReturn(null);
+                })) {
+            processor.processOnce();
+        }
+
+        Assertions.assertNotEquals(0,
+                myContext.getState().serverStatus & MysqlServerStatusFlag.SERVER_STATUS_AUTOCOMMIT,
+                "OK packet for SET autocommit=1 itself should already report autocommit ON");
+    }
+
+    // NOTE: end-to-end verification that this stops ProxySQL's SET autocommit=1 resync loop is
+    // not something a JUnit test can exercise, since it requires a real ProxySQL process and
+    // network traffic between it and the FE. That was verified manually against the original
+    // repro environment (ProxySQL 3.0.9, fast_forward=0, multiplexing=false).
 
     @Test
     public void testQuery() throws Exception {


### PR DESCRIPTION
[BugFix] FE does not report SERVER_STATUS_AUTOCOMMIT, causing ProxySQL resync loop

StarRocks accepted SET autocommit but never reflected it back in the MySQL protocol status flags of OK/EOF packets. Proxies that track backend session state (e.g. ProxySQL) saw the flag as permanently unset, concluded autocommit was off, and repeatedly resent SET autocommit=1 to resync, causing an audit log storm and elevated FE CPU usage.

Add SessionVariable#isAutoCommit() and apply the flag in ConnectProcessor wherever query state is reset.

## Why I'm doing:
Ran into this while running a 3-FE cluster behind ProxySQL (fast_forward=0, multiplexing=false). After a client ran a couple of session SET statements, one FE started chewing through ~1.5 CPU cores and the audit log grew to almost 4GB in a short window — a plain `SELECT CONNECTION_ID()` on that same connection just hung for 10+ minutes. Connecting straight to the FE and skipping ProxySQL, the exact same statements run fine.

Traced it back to the OK/EOF packets StarRocks sends. ProxySQL uses the `SERVER_STATUS_AUTOCOMMIT` status flag to keep its idea of backend session state in sync — but StarRocks never sets that bit, ever, regardless of what autocommit is actually set to. There's even a comment in `MysqlServerStatusFlag` saying only `SERVER_MORE_RESULTS_EXISTS` is used. So ProxySQL sees the bit missing, assumes autocommit got turned off somehow, and sends `SET autocommit=1` to fix it. That "fix" gets its own OK packet, which also doesn't have the bit set, so ProxySQL thinks it still needs fixing. Forever.

## What I'm doing:
Turns out `autoCommit` in `SessionVariable` didn't even have a getter, unlike basically every other variable in that class, so first added `isAutoCommit()`.

Then added a small helper in `ConnectProcessor`, `applyAutoCommitStatusFlag()`, that sets the `SERVER_STATUS_AUTOCOMMIT` bit on the response state when autocommit is on. Called it in the three spots where query state gets reset (both `processOnce()` overloads, plus `resetStmtExecutionContext()`) so it's consistently applied on every response, not just the first one in a session.

Fixes #issue 76780

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?
- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5