### PR TITLE
[Refactor] Retire the THREAD_LOCAL FunctionStateScope; per-thread state via a thread_state registry

### DIFF
--- a/be/src/exprs/binary_functions.cpp
+++ b/be/src/exprs/binary_functions.cpp
@@ -27,7 +27,7 @@ namespace starrocks {
 
 // to_binary
 StatusOr<ColumnPtr> BinaryFunctions::to_binary(FunctionContext* context, const Columns& columns) {
-    auto state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     auto to_binary_type = state->to_binary_type;
     switch (to_binary_type) {
     case BinaryFormatType::UTF8: {
@@ -44,7 +44,10 @@ StatusOr<ColumnPtr> BinaryFunctions::to_binary(FunctionContext* context, const C
 
 // to_binary_prepare
 Status BinaryFunctions::to_binary_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
+    // BinaryFormatState is an immutable format choice derived from a constant arg; it is
+    // read-only at eval time, so build it once in FRAGMENT_LOCAL and share it across threads
+    // instead of keeping a per-thread copy.
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
     auto* state = new BinaryFormatState();
@@ -63,8 +66,9 @@ Status BinaryFunctions::to_binary_prepare(FunctionContext* context, FunctionCont
 }
 
 Status BinaryFunctions::to_binary_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        auto* state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        auto* state =
+                reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         delete state;
     }
     return Status::OK();
@@ -72,7 +76,7 @@ Status BinaryFunctions::to_binary_close(FunctionContext* context, FunctionContex
 
 // to_binary
 StatusOr<ColumnPtr> BinaryFunctions::from_binary(FunctionContext* context, const Columns& columns) {
-    auto state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     auto to_binary_type = state->to_binary_type;
     switch (to_binary_type) {
     case BinaryFormatType::UTF8: {
@@ -89,7 +93,8 @@ StatusOr<ColumnPtr> BinaryFunctions::from_binary(FunctionContext* context, const
 
 // to_binary_prepare
 Status BinaryFunctions::from_binary_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
+    // See to_binary_prepare: read-only format choice, shared FRAGMENT_LOCAL rather than per-thread.
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
     auto* state = new BinaryFormatState();
@@ -108,8 +113,9 @@ Status BinaryFunctions::from_binary_prepare(FunctionContext* context, FunctionCo
 }
 
 Status BinaryFunctions::from_binary_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        auto* state = reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        auto* state =
+                reinterpret_cast<BinaryFormatState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         delete state;
     }
     return Status::OK();

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -43,7 +43,6 @@
 #include "column/column_helper.h"
 #include "common/statusor.h"
 #include "exprs/expr.h"
-#include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks {
@@ -75,10 +74,8 @@ Status ExprContext::prepare(RuntimeState* state) {
     if (_prepared) {
         return Status::OK();
     }
-    DCHECK(_pool.get() == nullptr);
     _prepared = true;
     _runtime_state = state;
-    _pool = std::make_unique<MemPool>();
     return _root->prepare(state, this);
 }
 
@@ -88,12 +85,11 @@ Status ExprContext::open(RuntimeState* state) {
         return Status::OK();
     }
     _opened = true;
-    // Fragment-local state is only initialized for original contexts. Clones inherit the
-    // original's fragment state and only need to have thread-local state initialized.
-    FunctionContext::FunctionStateScope scope =
-            _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
+    // Clones inherit the original's fragment-local state (copied in clone()) and per-thread
+    // state now lives in the FunctionContext thread-state registry, so open is a run-once
+    // fragment-local operation.
     try {
-        return _root->open(state, this, scope);
+        return _root->open(state, this, FunctionContext::FRAGMENT_LOCAL);
     } catch (std::runtime_error& e) {
         return Status::RuntimeError(fmt::format("Expr evaluate meet error: {}", e.what()));
     }
@@ -107,19 +103,20 @@ void ExprContext::close(RuntimeState* state) {
     if (!_closed.compare_exchange_strong(expected, true)) {
         return;
     }
-    FunctionContext::FunctionStateScope scope =
-            _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
-    _root->close(state, this, scope);
-    // _pool can be nullptr if Prepare() was never called
-    if (_pool != nullptr) {
-        _pool->free_all();
+    // Only the original owns the shared fragment-local state; clones must not free it again.
+    // A clone's per-thread state lives in the FunctionContext thread-state registry and is
+    // released when the (cloned) FunctionContext is destroyed.
+    if (!_is_clone) {
+        _root->close(state, this, FunctionContext::FRAGMENT_LOCAL);
     }
-    _pool.reset();
 }
 
 int ExprContext::register_func(RuntimeState* state, const FunctionContext::TypeDesc& return_type,
                                const std::vector<FunctionContext::TypeDesc>& arg_types) {
-    _fn_contexts.push_back(FunctionContext::create_context(state, _pool.get(), return_type, arg_types));
+    // Scalar-function and UDF FunctionContexts never allocate from their MemPool (only
+    // aggregate functions use FunctionContext::mem_pool(), and those contexts are created by
+    // the aggregator/analytor with its own pool), so no backing pool is needed here.
+    _fn_contexts.push_back(FunctionContext::create_context(state, nullptr, return_type, arg_types));
     return _fn_contexts.size() - 1;
 }
 
@@ -129,9 +126,8 @@ Status ExprContext::clone(RuntimeState* state, ObjectPool* pool, ExprContext** n
     DCHECK(*new_ctx == nullptr);
 
     *new_ctx = pool->add(new ExprContext(_root));
-    (*new_ctx)->_pool = std::make_unique<MemPool>();
     for (auto& _fn_context : _fn_contexts) {
-        (*new_ctx)->_fn_contexts.push_back(_fn_context->clone((*new_ctx)->_pool.get()));
+        (*new_ctx)->_fn_contexts.push_back(_fn_context->clone());
     }
 
     (*new_ctx)->_is_clone = true;
@@ -139,7 +135,10 @@ Status ExprContext::clone(RuntimeState* state, ObjectPool* pool, ExprContext** n
     (*new_ctx)->_opened = true;
     (*new_ctx)->_runtime_state = state;
 
-    return _root->open(state, *new_ctx, FunctionContext::THREAD_LOCAL);
+    // The clone shares the original's fragment-local state (copied above via
+    // FunctionContext::clone); per-thread state is obtained lazily during evaluation from the
+    // FunctionContext thread-state registry, so there is no per-clone open work to do.
+    return Status::OK();
 }
 
 Status ExprContext::get_udf_error() {

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -49,7 +49,6 @@ class OlapScanNode;
 class Chunk;
 
 class Expr;
-class MemPool;
 class MemTracker;
 class RuntimeState;
 class ObjectPool;
@@ -78,7 +77,7 @@ public:
 
     /// Creates a copy of this ExprContext. Open() must be called first. The copy contains
     /// clones of each FunctionContext, which share the fragment-local state of the
-    /// originals but have their own MemPool and thread-local state. Clone() should be used
+    /// originals but have their own thread-local state. Clone() should be used
     /// to create an ExprContext for each execution thread that needs to evaluate
     /// 'root'. Note that clones are already opened. '*new_context' must be initialized by
     /// the caller to NULL.
@@ -136,9 +135,6 @@ private:
     /// FunctionContexts for each registered expression. The FunctionContexts are created
     /// and owned by this ExprContext.
     std::vector<FunctionContext*> _fn_contexts;
-
-    /// Pool backing fn_contexts_. Counts against the runtime state's UDF mem tracker.
-    std::unique_ptr<MemPool> _pool;
 
     RuntimeState* _runtime_state = nullptr;
     /// The expr tree this context is for.

--- a/be/src/exprs/function_call_expr.cpp
+++ b/be/src/exprs/function_call_expr.cpp
@@ -149,8 +149,6 @@ Status VectorizedFunctionCallExpr::open(starrocks::RuntimeState* state, starrock
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
             RETURN_IF_ERROR(_fn_desc->prepare_function(fn_ctx, FunctionContext::FRAGMENT_LOCAL));
         }
-        FAIL_POINT_TRIGGER_RETURN_ERROR(expr_prepare_fragment_thread_local_call_failed);
-        RETURN_IF_ERROR(_fn_desc->prepare_function(fn_ctx, FunctionContext::THREAD_LOCAL));
     }
 
     return Status::OK();
@@ -161,8 +159,6 @@ void VectorizedFunctionCallExpr::close(starrocks::RuntimeState* state, starrocks
     // _fn_context_index >= 0 means this function call has call opened
     if (_fn_desc != nullptr && _fn_desc->close_function != nullptr && _fn_context_index >= 0) {
         FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
-        (void)_fn_desc->close_function(fn_ctx, FunctionContext::THREAD_LOCAL);
-
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
             (void)_fn_desc->close_function(fn_ctx, FunctionContext::FRAGMENT_LOCAL);
         }

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -24,6 +24,13 @@ namespace starrocks {
 
 static const int MAX_WARNINGS = 1000;
 
+int current_worker_id() {
+    static std::atomic<int> s_next_worker_id{0};
+    // Assigned once per OS thread on first use and stable thereafter.
+    thread_local int tls_worker_id = s_next_worker_id.fetch_add(1, std::memory_order_relaxed);
+    return tls_worker_id;
+}
+
 FunctionContext* FunctionContext::create_context(RuntimeState* state, MemPool* pool,
                                                  const FunctionContext::TypeDesc& return_type,
                                                  const std::vector<FunctionContext::TypeDesc>& arg_types) {
@@ -67,8 +74,8 @@ FunctionContext* FunctionContext::create_test_context(std::vector<TypeDesc>&& ar
 FunctionContext::FunctionContext() = default;
 FunctionContext::~FunctionContext() = default;
 
-FunctionContext* FunctionContext::clone(MemPool* pool) {
-    FunctionContext* new_context = create_context(_state, pool, _return_type, _arg_types);
+FunctionContext* FunctionContext::clone() {
+    FunctionContext* new_context = create_context(_state, nullptr, _return_type, _arg_types);
 
     new_context->_constant_columns = _constant_columns;
     new_context->_fragment_local_fn_state = _fragment_local_fn_state;
@@ -114,8 +121,6 @@ const FunctionContext::TypeDesc& FunctionContext::get_return_type() const {
 
 void* FunctionContext::get_function_state(FunctionStateScope scope) const {
     switch (scope) {
-    case THREAD_LOCAL:
-        return _thread_local_fn_state;
     case FRAGMENT_LOCAL:
         return _fragment_local_fn_state;
     default:
@@ -160,9 +165,6 @@ bool FunctionContext::allow_throw_exception() const {
 
 void FunctionContext::set_function_state(FunctionStateScope scope, void* ptr) {
     switch (scope) {
-    case THREAD_LOCAL:
-        _thread_local_fn_state = ptr;
-        break;
     case FRAGMENT_LOCAL:
         _fragment_local_fn_state = ptr;
         break;

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -14,10 +14,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
+#include <unordered_map>
 #include <vector>
 
 #include "column/column.h"
@@ -30,29 +33,30 @@ class RuntimeState;
 
 struct NgramBloomFilterState;
 
+// Base class for per-execution-thread function state (e.g. a Hyperscan scratch space) held by
+// a shared FunctionContext via get_or_create_thread_state(). Derive from this and put the
+// thread-private, mutable resources in the derived type.
+class FunctionThreadState {
+public:
+    virtual ~FunctionThreadState() = default;
+};
+
+// A process-stable id for the current execution thread, assigned lazily on first use. Used to
+// key per-thread state without relying on a per-thread FunctionContext clone. The pipeline
+// runs on a bounded thread pool, so the id space stays small in practice.
+int current_worker_id();
+
 class FunctionContext {
 public:
     using TypeDesc = TypeDescriptor;
 
     enum FunctionStateScope {
-        /// Indicates that the function state for this FunctionContext's UDF is shared across
-        /// the plan fragment (a query is divided into multiple plan fragments, each of which
-        /// is responsible for a part of the query execution). Within the plan fragment, there
-        /// may be multiple instances of the UDF executing concurrently with multiple
-        /// FunctionContexts sharing this state, meaning that the state must be
-        /// thread-safe. The Prepare() function for the UDF may be called with this scope
-        /// concurrently on a single host if the UDF will be evaluated in multiple plan
-        /// fragments on that host. In general, read-only state that doesn't need to be
-        /// recomputed for every UDF call should be fragment-local.
+        /// The function's prepared state is shared across the whole plan fragment: it is built
+        /// once and read concurrently by every execution thread, so it must be read-only /
+        /// thread-safe after preparation. Genuinely per-thread, mutable resources (e.g. a
+        /// Hyperscan scratch) must NOT live here — obtain them lazily during evaluation via
+        /// FunctionContext::get_or_create_thread_state<T>() instead.
         FRAGMENT_LOCAL,
-
-        /// Indicates that the function state is local to the execution thread. This state
-        /// does not need to be thread-safe. However, this state will be initialized (via the
-        /// Prepare() function) once for every execution thread, so fragment-local state
-        /// should be used when possible for better performance. In general, inexpensive
-        /// shared state that is written to by the UDF (e.g. scratch space) should be
-        /// thread-local.
-        THREAD_LOCAL,
     };
 
     /// Create a FunctionContext for a UDF. Caller is responsible for deleting it.
@@ -133,7 +137,7 @@ public:
     /// Returns a new FunctionContext with the same constant args, fragment-local state, and
     /// debug flag as this FunctionContext. The caller is responsible for calling delete on
     /// it.
-    FunctionContext* clone(MemPool* pool);
+    FunctionContext* clone();
 
     void set_constant_columns(Columns columns) { _constant_columns = std::move(columns); }
 
@@ -163,6 +167,26 @@ public:
     bool allow_throw_exception() const;
 
     std::unique_ptr<NgramBloomFilterState>& get_ngram_state() { return _ngramState; }
+
+    // Returns this worker thread's instance of T (which must derive from FunctionThreadState),
+    // creating it via factory() on first access for this (FunctionContext, worker) pair.
+    // factory() must return std::unique_ptr<T>. Thread-safe: multiple worker threads may call
+    // concurrently on the same shared FunctionContext. The returned states are owned by this
+    // FunctionContext and freed when it is destroyed (i.e. with the fragment), so a function's
+    // eval can obtain per-thread scratch without a per-thread FunctionContext clone. The lock
+    // is only taken to look up / create the slot; callers must not hold references across the
+    // lifetime of the FunctionContext.
+    template <class T, class Factory>
+    T* get_or_create_thread_state(Factory&& factory) {
+        static_assert(std::is_base_of<FunctionThreadState, T>::value, "T must derive from FunctionThreadState");
+        int w = current_worker_id();
+        std::lock_guard<std::mutex> l(_thread_state_mu);
+        auto it = _thread_states.find(w);
+        if (it == _thread_states.end()) {
+            it = _thread_states.emplace(w, std::forward<Factory>(factory)()).first;
+        }
+        return static_cast<T*>(it->second.get());
+    }
 
 private:
     friend class ExprContext;
@@ -210,6 +234,11 @@ private:
 
     // used for ngram bloom filter to speed up some function
     std::unique_ptr<NgramBloomFilterState> _ngramState;
+
+    // Per-worker thread-state registry (see get_or_create_thread_state). Owned here, so the
+    // states live as long as this FunctionContext (the fragment) and are freed with it.
+    std::mutex _thread_state_mu;
+    std::unordered_map<int, std::unique_ptr<FunctionThreadState>> _thread_states;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/gin_functions.cpp
+++ b/be/src/exprs/gin_functions.cpp
@@ -21,56 +21,79 @@
 
 #include "column/array_column.h"
 #include "column/column_viewer.h"
+#include "exprs/function_context.h"
 #include "types/datum.h"
 
 namespace starrocks {
 
+namespace {
+// Build a CLucene analyzer for the given tokenize method, or nullptr if the method is unknown.
+lucene::analysis::Analyzer* make_tokenize_analyzer(const Slice& method) {
+    if (method == "english") {
+        return _CLNEW lucene::analysis::SimpleAnalyzer();
+    } else if (method == "standard") {
+        return _CLNEW lucene::analysis::standard::StandardAnalyzer();
+    } else if (method == "chinese") {
+        auto* canalyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
+        canalyzer->setLanguage(L"cjk");
+        canalyzer->setStem(false);
+        return canalyzer;
+    }
+    return nullptr;
+}
+
+// A CLucene Analyzer is not thread-safe (it reuses a per-instance token stream), so each worker
+// thread gets its own via FunctionContext::get_or_create_thread_state instead of a per-thread
+// FunctionContext clone.
+struct GinTokenizeThreadState : FunctionThreadState {
+    lucene::analysis::Analyzer* analyzer = nullptr;
+    ~GinTokenizeThreadState() override { delete analyzer; }
+};
+} // namespace
+
 Status GinFunctions::tokenize_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
+    // Validate the (constant) method once, so an unknown method fails at prepare time. The
+    // per-thread analyzer itself is created lazily during evaluation (see tokenize()).
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
 
     auto column = context->get_constant_column(0);
     RETURN_IF(column == nullptr, Status::InvalidArgument("Tokenize function requires constant parameter"));
     auto method = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
-
-    lucene::analysis::Analyzer* analyzer;
-
-    if (method == "english") {
-        analyzer = _CLNEW lucene::analysis::SimpleAnalyzer();
-    } else if (method == "standard") {
-        analyzer = _CLNEW lucene::analysis::standard::StandardAnalyzer();
-    } else if (method == "chinese") {
-        auto* canalyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
-        canalyzer->setLanguage(L"cjk");
-        canalyzer->setStem(false);
-        analyzer = canalyzer;
-    } else {
+    if (method != "english" && method != "standard" && method != "chinese") {
         return Status::NotSupported("Unknown method '" + method.to_string() +
                                     "'. Supported methods are: 'english', 'standard', 'chinese'.");
     }
-
-    context->set_function_state(scope, analyzer);
 
     return Status::OK();
 }
 
 Status GinFunctions::tokenize_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        auto* analyzer = reinterpret_cast<lucene::analysis::Analyzer*>(
-                context->get_function_state(FunctionContext::THREAD_LOCAL));
-        delete analyzer;
-    }
+    // Per-thread analyzers live in the FunctionContext's thread-state registry and are freed
+    // when the FunctionContext is destroyed; nothing to free here.
     return Status::OK();
 }
 
 StatusOr<ColumnPtr> GinFunctions::tokenize(FunctionContext* context, const starrocks::Columns& columns) {
-    auto* analyzer =
-            reinterpret_cast<lucene::analysis::Analyzer*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-
     if (columns.size() != 2) {
         return Status::InvalidArgument("Tokenize function only call by tokenize('<index_type>', str_column)");
     }
+
+    auto method_column = context->get_constant_column(0);
+    RETURN_IF(method_column == nullptr, Status::InvalidArgument("Tokenize function requires constant parameter"));
+    auto method = ColumnHelper::get_const_value<TYPE_VARCHAR>(method_column);
+
+    auto* ts = context->get_or_create_thread_state<GinTokenizeThreadState>([&]() {
+        auto s = std::make_unique<GinTokenizeThreadState>();
+        s->analyzer = make_tokenize_analyzer(method);
+        return s;
+    });
+    if (ts->analyzer == nullptr) {
+        return Status::NotSupported("Unknown method '" + method.to_string() +
+                                    "'. Supported methods are: 'english', 'standard', 'chinese'.");
+    }
+    auto* analyzer = ts->analyzer;
 
     ColumnViewer<TYPE_VARCHAR> value_viewer(columns[1]);
     size_t num_rows = value_viewer.size();

--- a/be/src/exprs/like_predicate.cpp
+++ b/be/src/exprs/like_predicate.cpp
@@ -44,10 +44,15 @@ static const re2::RE2 LIKE_STARTS_WITH_RE(R"((((\\%)|(\\_)|(\\\\)|([^%_\\]))+)(?
 static const re2::RE2 LIKE_EQUALS_RE(R"((((\\%)|(\\_)|(\\\\)|([^%_\\]))+))", re2::RE2::Quiet);
 static const char* PROMPT_INFO = " so we switch to use re2.";
 
-bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, LikePredicateState* state,
-                                                 FunctionContext* context, const Slice& slice) {
+LikePredicate::LikePredicateState* LikePredicate::shared_state(FunctionContext* context) {
+    return reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+}
+
+bool LikePredicate::hs_compile_database(const std::string& pattern, LikePredicateState* state, FunctionContext* context,
+                                        const Slice& slice) {
+    hs_database_t* database = nullptr;
     if (hs_compile(pattern.c_str(), HS_FLAG_ALLOWEMPTY | HS_FLAG_DOTALL | HS_FLAG_UTF8 | HS_FLAG_SINGLEMATCH,
-                   HS_MODE_BLOCK, nullptr, &state->database, &state->compile_err) != HS_SUCCESS) {
+                   HS_MODE_BLOCK, nullptr, &database, &state->compile_err) != HS_SUCCESS) {
         std::stringstream error;
         auto chopped_size = std::min<size_t>(slice.size, 64);
         auto ellipsis = (chopped_size < slice.size) ? "..." : "";
@@ -58,21 +63,27 @@ bool LikePredicate::hs_compile_and_alloc_scratch(const std::string& pattern, Lik
         return false;
     }
 
-    if (hs_alloc_scratch(state->database, &state->scratch) != HS_SUCCESS) {
+    // Validate that a scratch space can be allocated for this database; if not, fall back to
+    // RE2 (matching the previous behavior). The real per-thread scratch is allocated later, in
+    // the THREAD_LOCAL prepare. The probe scratch is freed immediately.
+    hs_scratch_t* probe_scratch = nullptr;
+    if (hs_alloc_scratch(database, &probe_scratch) != HS_SUCCESS) {
         std::stringstream error;
         error << "ERROR: Unable to allocate scratch space," << PROMPT_INFO;
         LOG(WARNING) << error.str().c_str();
-        hs_free_database(state->database);
+        hs_free_database(database);
         return false;
     }
+    hs_free_scratch(probe_scratch);
 
+    state->database = std::shared_ptr<hs_database_t>(database, [](hs_database_t* db) { hs_free_database(db); });
     return true;
 }
 
 template <bool full_match>
 Status LikePredicate::compile_with_hyperscan_or_re2(const std::string& pattern, LikePredicateState* state,
                                                     FunctionContext* context, const Slice& slice) {
-    if (!hs_compile_and_alloc_scratch(pattern, state, context, slice)) {
+    if (!hs_compile_database(pattern, state, context, slice)) {
         RE2::Options opts;
         opts.set_never_nl(false);
         opts.set_dot_nl(true);
@@ -100,17 +111,9 @@ Status LikePredicate::compile_with_hyperscan_or_re2(const std::string& pattern, 
 // when pattern is a constant value except ((EQUALS | SUBSTRING | STARTS_WITH | ENDS_WITH) variable value)
 // we use hyperscan.
 
-// like predicate
-Status LikePredicate::like_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
-        return Status::OK();
-    }
-
-    // @todo: should replace to mem pool
-    auto state = new LikePredicateState();
+// Analyze the (constant) LIKE pattern and populate the compile-once artifacts on `state`.
+Status LikePredicate::setup_like_state(FunctionContext* context, LikePredicateState* state) {
     state->function = &like_fn;
-
-    context->set_function_state(scope, state);
 
     // go row regex
     if (!context->is_notnull_constant_column(1)) {
@@ -139,36 +142,40 @@ Status LikePredicate::like_prepare(FunctionContext* context, FunctionContext::Fu
         state->set_search_string(search_string);
         state->function = &constant_substring_fn;
     } else {
-        auto re_pattern = LikePredicate::template convert_like_pattern<true>(context, pattern);
+        auto re_pattern = LikePredicate::template convert_like_pattern<true>(context, pattern, state->escape_char);
         RETURN_IF_ERROR(compile_with_hyperscan_or_re2<true>(re_pattern, state, context, pattern));
     }
 
     return Status::OK();
 }
 
-Status LikePredicate::like_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-        delete state;
+// like predicate
+//
+// The compile-once artifacts (function selection, constant search string, compiled Hyperscan
+// database / RE2) are built once in the shared FRAGMENT_LOCAL state and read directly by eval;
+// per-thread Hyperscan scratch is obtained lazily from the FunctionContext thread-state registry.
+Status LikePredicate::like_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
     }
+    auto* state = new LikePredicateState();
+    context->set_function_state(scope, state);
+    return setup_like_state(context, state);
+}
+
+Status LikePredicate::like_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    auto* state = reinterpret_cast<LikePredicateState*>(context->get_function_state(scope));
+    delete state;
     return Status::OK();
 }
 
 StatusOr<ColumnPtr> LikePredicate::like(FunctionContext* context, const starrocks::Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
     return (state->function)(context, columns);
 }
 
-// regex predicate
-Status LikePredicate::regex_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
-        return Status::OK();
-    }
-
-    // @todo: should replace to mem pool
-    auto* state = new LikePredicateState();
-    context->set_function_state(scope, state);
-
+// Analyze the (constant) regex pattern and populate the compile-once artifacts on `state`.
+Status LikePredicate::setup_regex_state(FunctionContext* context, LikePredicateState* state) {
     state->function = &regex_fn;
 
     // go row regex
@@ -206,16 +213,24 @@ Status LikePredicate::regex_prepare(FunctionContext* context, FunctionContext::F
     return Status::OK();
 }
 
-Status LikePredicate::regex_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        auto* state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-        delete state;
+// regex predicate. Same fragment-shared / per-thread-scratch split as like_prepare().
+Status LikePredicate::regex_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
     }
+    auto* state = new LikePredicateState();
+    context->set_function_state(scope, state);
+    return setup_regex_state(context, state);
+}
+
+Status LikePredicate::regex_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    auto* state = reinterpret_cast<LikePredicateState*>(context->get_function_state(scope));
+    delete state;
     return Status::OK();
 }
 
 StatusOr<ColumnPtr> LikePredicate::regex(FunctionContext* context, const Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
     return (state->function)(context, columns);
 }
 
@@ -241,7 +256,7 @@ StatusOr<ColumnPtr> LikePredicate::regex_fn_with_long_constant_pattern(FunctionC
 template <bool full_match>
 StatusOr<ColumnPtr> LikePredicate::match_fn_with_long_constant_pattern(FunctionContext* context,
                                                                        const Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
 
     const auto& value_column = VECTORIZED_FN_ARGS(0);
     auto [all_const, num_rows] = ColumnHelper::num_packed_rows(columns);
@@ -275,7 +290,7 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(ConstantEndsImpl, value, pattern) {
 }
 
 StatusOr<ColumnPtr> LikePredicate::constant_ends_with_fn(FunctionContext* context, const starrocks::Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
 
     const auto& value = VECTORIZED_FN_ARGS(0);
     auto pattern = state->_search_string_column;
@@ -290,7 +305,7 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(ConstantStartsImpl, value, pattern) {
 
 StatusOr<ColumnPtr> LikePredicate::constant_starts_with_fn(FunctionContext* context,
                                                            const starrocks::Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
 
     const auto& value = VECTORIZED_FN_ARGS(0);
     auto pattern = state->_search_string_column;
@@ -304,7 +319,7 @@ DEFINE_BINARY_FUNCTION_WITH_IMPL(ConstantEqualsImpl, value, pattern) {
 }
 
 StatusOr<ColumnPtr> LikePredicate::constant_equals_fn(FunctionContext* context, const starrocks::Columns& columns) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
 
     const auto& value = VECTORIZED_FN_ARGS(0);
     auto pattern = state->_search_string_column;
@@ -314,7 +329,7 @@ StatusOr<ColumnPtr> LikePredicate::constant_equals_fn(FunctionContext* context, 
 
 StatusOr<ColumnPtr> LikePredicate::constant_substring_fn(FunctionContext* context, const starrocks::Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = shared_state(context);
 
     Slice needle = ColumnHelper::get_const_value<TYPE_VARCHAR>(state->_search_string_column);
     auto res = RunTimeColumnType<TYPE_BOOLEAN>::create();
@@ -408,22 +423,22 @@ StatusOr<ColumnPtr> LikePredicate::regex_match(FunctionContext* context, const s
 StatusOr<ColumnPtr> LikePredicate::_predicate_const_regex(FunctionContext* context, ColumnBuilder<TYPE_BOOLEAN>* result,
                                                           const ColumnViewer<TYPE_VARCHAR>& value_viewer,
                                                           const ColumnPtr& value_column) {
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
-
-    hs_scratch_t* scratch = nullptr;
-    hs_error_t status;
-    if ((status = hs_clone_scratch(state->scratch, &scratch)) != HS_SUCCESS) {
-        return Status::InternalError(fmt::format("unable to clone scratch space, status: {}", status));
-    }
-
-    DeferOp op([&] {
-        if (scratch != nullptr) {
-            hs_error_t st;
-            if ((st = hs_free_scratch(scratch)) != HS_SUCCESS) {
-                LOG(ERROR) << "free scratch space failure. status: " << st;
-            }
+    // The compiled Hyperscan database lives on the shared LIKE state. Each worker obtains its
+    // own scratch from the FunctionContext's per-worker thread-state registry, once per chunk
+    // (never per row): the scratch is owned by the (shared) FunctionContext and reused across
+    // chunks by the same worker, so no per-thread FunctionContext clone is needed to hold it.
+    auto* state = shared_state(context);
+    auto* ts = context->get_or_create_thread_state<LikeThreadState>([&]() {
+        auto s = std::make_unique<LikeThreadState>();
+        if (state->database != nullptr) {
+            (void)hs_alloc_scratch(state->database.get(), &s->scratch);
         }
+        return s;
     });
+    hs_scratch_t* scratch = ts->scratch;
+    if (scratch == nullptr) {
+        return Status::InternalError("unable to obtain hyperscan scratch space");
+    }
 
     for (int row = 0; row < value_viewer.size(); ++row) {
         if (value_viewer.is_null(row)) {
@@ -435,7 +450,7 @@ StatusOr<ColumnPtr> LikePredicate::_predicate_const_regex(FunctionContext* conte
         auto value_size = value_viewer.value(row).size;
         [[maybe_unused]] auto status = hs_scan(
                 // Use &_DUMMY_STRING_FOR_EMPTY_PATTERN instead of nullptr to avoid crash.
-                state->database, (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_FOR_EMPTY_PATTERN,
+                state->database.get(), (value_size) ? value_viewer.value(row).data : &_DUMMY_STRING_FOR_EMPTY_PATTERN,
                 value_size, 0, scratch,
                 [](unsigned int id, unsigned long long from, unsigned long long to, unsigned int flags,
                    void* ctx) -> int {
@@ -575,7 +590,9 @@ StatusOr<ColumnPtr> LikePredicate::regex_match_full(FunctionContext* context, co
             break;
         }
         case FastPathType::REGEX: {
-            auto re_pattern = LikePredicate::template convert_like_pattern<false>(context, pattern);
+            auto* like_state = shared_state(context);
+            auto re_pattern =
+                    LikePredicate::template convert_like_pattern<false>(context, pattern, like_state->escape_char);
 
             re2::RE2 re(re_pattern, opts);
             if (!re.ok()) {
@@ -640,11 +657,10 @@ StatusOr<ColumnPtr> LikePredicate::regex_match_partial(FunctionContext* context,
 }
 
 template <bool fullMatch>
-std::string LikePredicate::convert_like_pattern(FunctionContext* context, const Slice& pattern) {
+std::string LikePredicate::convert_like_pattern(FunctionContext* context, const Slice& pattern, char escape_char) {
     std::string re_pattern;
     re_pattern.clear();
 
-    auto state = reinterpret_cast<LikePredicateState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
     bool is_escaped = false;
 
     if constexpr (fullMatch) {
@@ -657,7 +673,7 @@ std::string LikePredicate::convert_like_pattern(FunctionContext* context, const 
         } else if (!is_escaped && pattern.data[i] == '_') {
             re_pattern.append(".");
             // check for escape char before checking for regex special chars, they might overlap
-        } else if (!is_escaped && pattern.data[i] == state->escape_char) {
+        } else if (!is_escaped && pattern.data[i] == escape_char) {
             is_escaped = true;
         } else if (pattern.data[i] == '.' || pattern.data[i] == '[' || pattern.data[i] == ']' ||
                    pattern.data[i] == '{' || pattern.data[i] == '}' || pattern.data[i] == '(' ||

--- a/be/src/exprs/like_predicate.h
+++ b/be/src/exprs/like_predicate.h
@@ -17,13 +17,17 @@
 #include <hs/hs.h>
 #include <re2/re2.h>
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "exprs/builtin_functions.h"
+#include "exprs/function_context.h"
 #include "exprs/function_helper.h"
 
 namespace starrocks {
@@ -149,7 +153,7 @@ private:
     /// Convert a LIKE pattern (with embedded % and _) into the corresponding
     /// regular expression pattern. Escaped chars are copied verbatim.
     template <bool fullMatch>
-    static std::string convert_like_pattern(FunctionContext* context, const Slice& pattern);
+    static std::string convert_like_pattern(FunctionContext* context, const Slice& pattern, char escape_char);
 
     static void remove_escape_character(std::string* search_string);
 
@@ -163,11 +167,34 @@ private:
     static inline char _DUMMY_STRING_FOR_EMPTY_PATTERN = 'A';
 
     struct LikePredicateState;
-    static bool hs_compile_and_alloc_scratch(const std::string&, LikePredicateState*, FunctionContext*,
-                                             const Slice& slice);
+    // Compile the (constant) pattern into a shared Hyperscan database on `state`. Returns
+    // false (falling back to RE2) if compilation fails or no scratch can be allocated for it.
+    static bool hs_compile_database(const std::string&, LikePredicateState*, FunctionContext*, const Slice& slice);
+    // Analyze the constant pattern and populate the compile-once artifacts on `state` (function
+    // selection, search string, or a compiled Hyperscan/RE2 pattern). Shared by the
+    // FRAGMENT_LOCAL prepare path.
+    static Status setup_like_state(FunctionContext* context, LikePredicateState* state);
+    static Status setup_regex_state(FunctionContext* context, LikePredicateState* state);
+    // The compile-once LIKE/regex state read by eval: the shared FRAGMENT_LOCAL state, with a
+    // fallback to the THREAD_LOCAL state for unit tests that prepare only a single scope (the
+    // normal open flow always prepares FRAGMENT_LOCAL).
+    static LikePredicateState* shared_state(FunctionContext* context);
     template <bool full_match>
     static Status compile_with_hyperscan_or_re2(const std::string& pattern, LikePredicateState* state,
                                                 FunctionContext* context, const Slice& slice);
+    // Per-execution-thread Hyperscan scratch, obtained from the shared FunctionContext via
+    // get_or_create_thread_state(). hs_scan requires one scratch per concurrent caller; the
+    // compiled database is shared (LikePredicateState::database) while each worker owns its own
+    // scratch, so no per-thread FunctionContext clone is needed to hold it.
+    struct LikeThreadState : FunctionThreadState {
+        hs_scratch_t* scratch = nullptr;
+        ~LikeThreadState() override {
+            if (scratch != nullptr) {
+                hs_free_scratch(scratch);
+            }
+        }
+    };
+
     struct LikePredicateState {
         char escape_char{'\\'};
 
@@ -192,25 +219,17 @@ private:
 
         ColumnPtr _search_string_column;
 
-        // a pointer to the generated database that responsible for parsed expression.
-        hs_database_t* database = nullptr;
+        // The Hyperscan database compiled once from the (constant) pattern in the FRAGMENT_LOCAL
+        // prepare and shared across all worker threads (shared_ptr with hs_free_database as the
+        // deleter). Per-thread scratch is held separately via FunctionContext thread-state
+        // (LikeThreadState), so a pattern is compiled once per fragment, not once per thread.
+        std::shared_ptr<hs_database_t> database;
         // a type containing error details that is returned by the compile calls on failure.
         hs_compile_error_t* compile_err = nullptr;
-        // A Hyperscan scratch space, Used to call hs_scan,
-        // one scratch space per thread, or concurrent caller, is required
-        hs_scratch_t* scratch = nullptr;
 
         LikePredicateState() = default;
-
-        ~LikePredicateState() {
-            if (scratch != nullptr) {
-                hs_free_scratch(scratch);
-            }
-
-            if (database != nullptr) {
-                hs_free_database(database);
-            }
-        }
+        // No custom destructor needed: `database` is released by its shared_ptr deleter
+        // (hs_free_database) and every other member is self-owning.
 
         void set_search_string(const std::string& search_string_arg) {
             search_string = search_string_arg;

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -1012,7 +1012,7 @@ StatusOr<ColumnPtr> MathFunctions::conv_string(FunctionContext* context, const C
 }
 
 Status MathFunctions::rand_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
         if (context->get_num_args() == 1) {
             // This is a call to RandSeed, initialize the seed
             // TODO: should we support non-constant seed?

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3435,8 +3435,20 @@ Status StringFunctions::hs_compile_and_alloc_scratch(const std::string& pattern,
     return Status::OK();
 }
 
+// Return the current worker thread's compiled RE2 for the (constant) pattern in `state`,
+// compiling it on first use per (FunctionContext, worker). Each worker matches on its own RE2
+// instance to avoid contention on RE2's internal DFA cache_mutex. Called once per chunk.
+static re2::RE2* get_thread_local_regex(FunctionContext* context, StringFunctionsState* state) {
+    auto* ts = context->get_or_create_thread_state<StringRe2ThreadState>([&]() {
+        auto s = std::make_unique<StringRe2ThreadState>();
+        s->re2 = std::make_unique<re2::RE2>(state->pattern, *state->options);
+        return s;
+    });
+    return ts->re2.get();
+}
+
 Status StringFunctions::regexp_extract_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
 
@@ -3470,7 +3482,7 @@ Status StringFunctions::regexp_extract_prepare(FunctionContext* context, Functio
 }
 
 Status StringFunctions::regexp_replace_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope != FunctionContext::THREAD_LOCAL) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
     }
 
@@ -3523,9 +3535,9 @@ Status StringFunctions::regexp_replace_prepare(FunctionContext* context, Functio
 }
 
 Status StringFunctions::regexp_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-    if (scope == FunctionContext::THREAD_LOCAL) {
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
         auto* state =
-                reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+                reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
         delete state;
     }
     return Status::OK();
@@ -3622,10 +3634,10 @@ static ColumnPtr regexp_extract_const(re2::RE2* const_re, const Columns& columns
 
 StatusOr<ColumnPtr> StringFunctions::regexp_extract(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
 
     if (state->const_pattern) {
-        re2::RE2* const_re = state->get_or_prepare_regex();
+        re2::RE2* const_re = get_thread_local_regex(context, state);
         return regexp_extract_const(const_re, columns);
     }
 
@@ -3835,10 +3847,10 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
 
 StatusOr<ColumnPtr> StringFunctions::regexp_extract_all(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
 
     if (state->const_pattern) {
-        re2::RE2* const_re = state->get_or_prepare_regex();
+        re2::RE2* const_re = get_thread_local_regex(context, state);
         if (columns[2]->is_constant()) {
             return regexp_extract_all_const(const_re, columns);
         } else {
@@ -4179,7 +4191,7 @@ StatusOr<ColumnPtr> StringFunctions::regexp_replace_use_hyperscan(StringFunction
 }
 
 StatusOr<ColumnPtr> StringFunctions::regexp_replace(FunctionContext* context, const Columns& columns) {
-    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
 
     if (state->const_pattern) {
         if (state->use_hyperscan) {
@@ -4189,7 +4201,7 @@ StatusOr<ColumnPtr> StringFunctions::regexp_replace(FunctionContext* context, co
                 return regexp_replace_use_hyperscan(state, columns);
             }
         } else {
-            re2::RE2* const_re = state->get_or_prepare_regex();
+            re2::RE2* const_re = get_thread_local_regex(context, state);
             if (state->opt_const_rpl.has_value()) {
                 if (state->global_mode) {
                     return regexp_replace_const_pattern_and_rpl<true>(const_re, columns, state->opt_const_rpl.value());
@@ -4387,11 +4399,11 @@ static StatusOr<ColumnPtr> regexp_split_general(FunctionContext* context, re2::R
 
 StatusOr<ColumnPtr> StringFunctions::regexp_split(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
-    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::THREAD_LOCAL));
+    auto state = reinterpret_cast<StringFunctionsState*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     if (state->const_pattern) {
         re2::RE2* const_re = nullptr;
         if (!state->pattern.empty()) {
-            const_re = state->regex.get();
+            const_re = get_thread_local_regex(context, state);
         }
         if (columns.size() > 2) {
             if (columns[2]->is_constant()) {
@@ -4556,7 +4568,7 @@ StatusOr<ColumnPtr> StringFunctions::regexp_count(FunctionContext* context, cons
 
     if (state != nullptr && state->const_pattern && state->regex != nullptr) {
         // Const col
-        return regexp_count_const_pattern(state->get_or_prepare_regex(), columns);
+        return regexp_count_const_pattern(get_thread_local_regex(context, state), columns);
     } else {
         // Multi
         re2::RE2::Options options;
@@ -4758,7 +4770,7 @@ StatusOr<ColumnPtr> StringFunctions::regexp_position(FunctionContext* context, c
 
     if (state && state->const_pattern && state->regex) {
         // Const col
-        return regexp_position_const_pattern(state->get_or_prepare_regex(), columns);
+        return regexp_position_const_pattern(get_thread_local_regex(context, state), columns);
     } else {
         re2::RE2::Options options;
         options.set_log_errors(false);

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -61,16 +61,18 @@ struct FieldFuncState {
     std::map<RunTimeCppType<T>, int> mp;
 };
 
-struct StringFunctionsState {
-    using DriverMap = phmap::parallel_flat_hash_map<int32_t, std::unique_ptr<re2::RE2>, phmap::Hash<int32_t>,
-                                                    phmap::EqualTo<int32_t>, phmap::Allocator<int32_t>,
-                                                    NUM_LOCK_SHARD_LOG, std::mutex>;
+// Per-execution-thread compiled RE2 for a constant pattern, obtained via
+// FunctionContext::get_or_create_thread_state<>() so each worker matches on its own RE2 instance
+// (avoiding contention on RE2's internal DFA cache_mutex) without a per-thread ExprContext clone.
+struct StringRe2ThreadState : FunctionThreadState {
+    std::unique_ptr<re2::RE2> re2;
+};
 
+struct StringFunctionsState {
     std::string pattern;
     std::unique_ptr<re2::RE2> regex;
     std::unique_ptr<re2::RE2::Options> options;
     bool const_pattern{false};
-    DriverMap driver_regex_map; // regex for each pipeline_driver, to make it driver-local
 
     bool use_hyperscan = false;
     bool use_hyperscan_vec = false;
@@ -87,26 +89,6 @@ struct StringFunctionsState {
     hs_scratch_t* scratch = nullptr;
 
     StringFunctionsState() : regex(), options() {}
-
-    // Implement a driver-local regex, to avoid lock contention on the RE2::cache_mutex
-    re2::RE2* get_or_prepare_regex() {
-        DCHECK(const_pattern);
-        int32_t driver_id = CurrentThread::current().get_driver_id();
-        if (driver_id == 0) {
-            return regex.get();
-        }
-        re2::RE2* res = nullptr;
-        driver_regex_map.lazy_emplace_l(
-                driver_id, [&](auto& value) { res = value.get(); },
-                [&](auto build) {
-                    auto regex = std::make_unique<re2::RE2>(pattern, *options);
-                    DCHECK(regex->ok());
-                    res = regex.get();
-                    build(driver_id, std::move(regex));
-                });
-        DCHECK(!!res);
-        return res;
-    }
 
     ~StringFunctionsState() {
         if (scratch != nullptr) {

--- a/be/src/exprs/udf/java/java_udf_context.cpp
+++ b/be/src/exprs/udf/java/java_udf_context.cpp
@@ -26,7 +26,7 @@ JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx) {
     if (ctx == nullptr) {
         return nullptr;
     }
-    return reinterpret_cast<JavaUDAFUniqueContext*>(ctx->get_function_state(FunctionContext::THREAD_LOCAL));
+    return reinterpret_cast<JavaUDAFUniqueContext*>(ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
 }
 
 void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx) {
@@ -37,7 +37,7 @@ void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniq
     if (old_ctx != nullptr) {
         delete old_ctx;
     }
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, udaf_ctx.release());
+    ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, udaf_ctx.release());
 }
 
 void clear_java_udaf_states(FunctionContext* ctx) {
@@ -61,7 +61,7 @@ void destroy_java_udaf_context(FunctionContext* ctx) {
     }
 
     clear_java_udaf_states(ctx);
-    ctx->set_function_state(FunctionContext::THREAD_LOCAL, nullptr);
+    ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, nullptr);
     delete udaf_ctx;
 }
 

--- a/be/src/exprs/udf/java/java_udf_context.h
+++ b/be/src/exprs/udf/java/java_udf_context.h
@@ -189,7 +189,7 @@ struct JavaUDAFSharedContext {
     JavaGlobalRef finalize_return_type_desc = nullptr;
 };
 
-// Per-aggregator UDAF context stored as FunctionContext::THREAD_LOCAL.
+// Per-aggregator UDAF context stored as FunctionContext::FRAGMENT_LOCAL.
 // Holds a reference to the shared class-level JavaUDAFSharedContext plus
 // mutable per-aggregation state.
 struct JavaUDAFUniqueContext;
@@ -245,7 +245,7 @@ struct JavaUDAFUniqueContext {
     std::vector<uint8_t> buffer_data;
 };
 
-// Java UDAF lifecycle management based on FunctionContext::THREAD_LOCAL state.
+// Java UDAF lifecycle management based on FunctionContext::FRAGMENT_LOCAL state.
 JavaUDAFUniqueContext* get_java_udaf_context(FunctionContext* ctx);
 void attach_java_udaf_context(FunctionContext* ctx, std::unique_ptr<JavaUDAFUniqueContext> udaf_ctx);
 void clear_java_udaf_states(FunctionContext* ctx);

--- a/be/src/exprs_ext/dict/dict_query_expr.cpp
+++ b/be/src/exprs_ext/dict/dict_query_expr.cpp
@@ -109,11 +109,6 @@ Status DictQueryExpr::open(RuntimeState* state, ExprContext* context, FunctionCo
     // init parent open
     RETURN_IF_ERROR(Expr::open(state, context, scope));
 
-    // make sure ExprContext::clone will not open DictQueryExpr again
-    if (scope == FunctionContext::THREAD_LOCAL) {
-        return Status::OK();
-    }
-
     TGetDictQueryParamRequest request;
     request.__set_db_name(_dict_query_expr.db_name);
     request.__set_table_name(_dict_query_expr.tbl_name);

--- a/be/test/exprs/binary_functions_test.cpp
+++ b/be/test/exprs/binary_functions_test.cpp
@@ -28,7 +28,7 @@ public:
         auto ctx_ptr = FunctionContext::create_test_context();
         ctx = std::unique_ptr<FunctionContext>(ctx_ptr);
         state = std::make_unique<BinaryFormatState>();
-        ctx->set_function_state(FunctionContext::THREAD_LOCAL, state.get());
+        ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
     }
 
     StatusOr<ColumnPtr> test_to_binary(const std::string& input, BinaryFormatType type) {

--- a/be/test/exprs/function_context_core_test.cpp
+++ b/be/test/exprs/function_context_core_test.cpp
@@ -42,13 +42,10 @@ TEST(FunctionContextCoreTest, CreateTestContextArgAccess) {
 
 TEST(FunctionContextCoreTest, FunctionStateScopeSetGet) {
     FunctionContext ctx;
-    int thread_local_state = 11;
     int fragment_local_state = 22;
 
-    ctx.set_function_state(FunctionContext::THREAD_LOCAL, &thread_local_state);
     ctx.set_function_state(FunctionContext::FRAGMENT_LOCAL, &fragment_local_state);
 
-    EXPECT_EQ(&thread_local_state, ctx.get_function_state(FunctionContext::THREAD_LOCAL));
     EXPECT_EQ(&fragment_local_state, ctx.get_function_state(FunctionContext::FRAGMENT_LOCAL));
 }
 
@@ -65,8 +62,7 @@ TEST(FunctionContextCoreTest, CloneKeepsConstantsAndFragmentState) {
     constant_columns.emplace_back(ColumnHelper::create_const_column<TYPE_INT>(42, 1));
     ctx->set_constant_columns(std::move(constant_columns));
 
-    MemPool clone_pool;
-    auto clone_ctx = std::unique_ptr<FunctionContext>(ctx->clone(&clone_pool));
+    auto clone_ctx = std::unique_ptr<FunctionContext>(ctx->clone());
 
     EXPECT_EQ(&fragment_local_state, clone_ctx->get_function_state(FunctionContext::FRAGMENT_LOCAL));
     EXPECT_TRUE(clone_ctx->is_constant_column(0));

--- a/be/test/exprs/gin_functions_test.cpp
+++ b/be/test/exprs/gin_functions_test.cpp
@@ -38,7 +38,7 @@ TEST_F(GinFunctionsTest, tokenizeTest) {
 
         ctx->set_constant_columns(columns);
 
-        ASSERT_FALSE(GinFunctions::tokenize_prepare(ctx.get(), FunctionContext::THREAD_LOCAL).ok());
+        ASSERT_FALSE(GinFunctions::tokenize_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
     }
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
@@ -52,9 +52,9 @@ TEST_F(GinFunctionsTest, tokenizeTest) {
         columns.emplace_back(ConstColumn::create(tokenizer));
         columns.emplace_back(ConstColumn::create(content));
         ctx->set_constant_columns(columns);
-        ASSERT_TRUE(GinFunctions::tokenize_prepare(ctx.get(), FunctionContext::THREAD_LOCAL).ok());
+        ASSERT_TRUE(GinFunctions::tokenize_prepare(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
         ColumnPtr result = GinFunctions::tokenize(ctx.get(), columns).value();
-        ASSERT_TRUE(GinFunctions::tokenize_close(ctx.get(), FunctionContext::THREAD_LOCAL).ok());
+        ASSERT_TRUE(GinFunctions::tokenize_close(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
 
         columns.clear();
         auto nullable_result = ColumnHelper::as_column<NullableColumn>(result);

--- a/be/test/exprs/http_request_functions_test.cpp
+++ b/be/test/exprs/http_request_functions_test.cpp
@@ -1154,11 +1154,11 @@ TEST_F(HttpRequestFunctionsTest, multipleRowsTest) {
     ASSERT_OK(HttpRequestFunctions::http_request_close(_ctx.get(), scope));
 }
 
-// Test prepare with THREAD_LOCAL scope (no-op)
+// Test prepare with FRAGMENT_LOCAL scope (no-op)
 TEST_F(HttpRequestFunctionsTest, prepareThreadLocalScopeTest) {
-    FunctionContext::FunctionStateScope scope = FunctionContext::THREAD_LOCAL;
+    FunctionContext::FunctionStateScope scope = FunctionContext::FRAGMENT_LOCAL;
     ASSERT_OK(HttpRequestFunctions::http_request_prepare(_ctx.get(), scope));
-    // THREAD_LOCAL should be a no-op
+    // FRAGMENT_LOCAL should be a no-op
     ASSERT_OK(HttpRequestFunctions::http_request_close(_ctx.get(), scope));
 }
 

--- a/be/test/exprs/in_predicate_test.cpp
+++ b/be/test/exprs/in_predicate_test.cpp
@@ -472,7 +472,7 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAllNULL) {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
             ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             // corner test
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->only_null());
         }

--- a/be/test/exprs/like_test.cpp
+++ b/be/test/exprs/like_test.cpp
@@ -56,7 +56,7 @@ TEST_F(LikeTest, startConstPatternLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -72,7 +72,7 @@ TEST_F(LikeTest, startConstPatternLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -95,7 +95,7 @@ TEST_F(LikeTest, endConstPatternLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -118,7 +118,7 @@ TEST_F(LikeTest, endConstPatternLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -139,7 +139,7 @@ TEST_F(LikeTest, substringConstPatternLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -155,7 +155,7 @@ TEST_F(LikeTest, substringConstPatternLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -172,14 +172,14 @@ TEST_F(LikeTest, haystackConstantLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
     ASSERT_TRUE(result->is_constant());
     ASSERT_TRUE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -207,14 +207,14 @@ TEST_F(LikeTest, haystackConstantLikeLargerThanHyperscan) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
     ASSERT_TRUE(result->is_constant());
     ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -242,7 +242,7 @@ TEST_F(LikeTest, haystackNullableLike) {
     columns.emplace_back(std::move(pattern));
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -260,7 +260,7 @@ TEST_F(LikeTest, haystackNullableLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -281,7 +281,7 @@ TEST_F(LikeTest, patternEmptyLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -293,7 +293,7 @@ TEST_F(LikeTest, patternEmptyLike) {
         ASSERT_TRUE(v->immutable_data()[l]);
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -314,7 +314,7 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -326,7 +326,7 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyLike) {
         ASSERT_TRUE(v->immutable_data()[l]);
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -348,7 +348,7 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyExplicitNullPtrLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -360,7 +360,7 @@ TEST_F(LikeTest, patternStrAndPatternBothEmptyExplicitNullPtrLike) {
         ASSERT_TRUE(v->immutable_data()[l]);
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -377,14 +377,14 @@ TEST_F(LikeTest, patternOnlyNullLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
     ASSERT_TRUE(result->is_constant());
     ASSERT_TRUE(result->is_nullable());
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -411,7 +411,7 @@ TEST_F(LikeTest, rowsPatternLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -427,7 +427,7 @@ TEST_F(LikeTest, rowsPatternLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -458,7 +458,7 @@ TEST_F(LikeTest, rowsNullablePatternLike) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
 
@@ -477,7 +477,7 @@ TEST_F(LikeTest, rowsNullablePatternLike) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -499,7 +499,7 @@ TEST_F(LikeTest, rowsPatternRegex) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::regex(context, columns).value();
 
@@ -515,8 +515,9 @@ TEST_F(LikeTest, rowsPatternRegex) {
         }
     }
 
-    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                        .ok());
+    ASSERT_TRUE(
+            LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                    .ok());
 }
 
 TEST_F(LikeTest, constValueLike) {
@@ -545,7 +546,7 @@ TEST_F(LikeTest, constValueLike) {
     columns.emplace_back(std::move(pattern_col));
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     ASSERT_TRUE(result->is_numeric());
@@ -556,7 +557,7 @@ TEST_F(LikeTest, constValueLike) {
         ASSERT_EQ(expected[i], v->immutable_data()[i]);
     }
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -580,7 +581,7 @@ TEST_F(LikeTest, constValueRegexp) {
     columns.emplace_back(std::move(pattern_col));
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::regex(context, columns).value();
     ASSERT_TRUE(result->is_numeric());
@@ -591,8 +592,9 @@ TEST_F(LikeTest, constValueRegexp) {
         ASSERT_EQ(expected[i], v->immutable_data()[i]);
     }
 
-    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                        .ok());
+    ASSERT_TRUE(
+            LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                    .ok());
 }
 
 TEST_F(LikeTest, constValueRegexpLargerThanHyperscan) {
@@ -616,15 +618,16 @@ TEST_F(LikeTest, constValueRegexpLargerThanHyperscan) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::regex(context, columns).value();
 
     ASSERT_TRUE(result->is_constant());
     ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
 
-    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                        .ok());
+    ASSERT_TRUE(
+            LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                    .ok());
 }
 
 TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
@@ -649,15 +652,16 @@ TEST_F(LikeTest, constValueLikeComplicateForHyperscan) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::regex_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::regex(context, columns).value();
 
     ASSERT_TRUE(result->is_constant());
     ASSERT_FALSE(ColumnHelper::get_const_value<TYPE_BOOLEAN>(result));
 
-    ASSERT_TRUE(LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                        .ok());
+    ASSERT_TRUE(
+            LikePredicate::regex_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                    .ok());
 }
 
 TEST_F(LikeTest, backslashEscapeConstSubstring) {
@@ -678,7 +682,7 @@ TEST_F(LikeTest, backslashEscapeConstSubstring) {
     columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -688,7 +692,7 @@ TEST_F(LikeTest, backslashEscapeConstSubstring) {
     ASSERT_TRUE(v->get_data()[2]);  // star\ matches
     ASSERT_TRUE(v->get_data()[3]);  // \start matches
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -710,7 +714,7 @@ TEST_F(LikeTest, backslashEscapeConstEndsWith) {
     columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -720,7 +724,7 @@ TEST_F(LikeTest, backslashEscapeConstEndsWith) {
     ASSERT_FALSE(v->get_data()[2]);
     ASSERT_FALSE(v->get_data()[3]);
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -742,7 +746,7 @@ TEST_F(LikeTest, backslashEscapeConstStartsWith) {
     columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -752,7 +756,7 @@ TEST_F(LikeTest, backslashEscapeConstStartsWith) {
     ASSERT_FALSE(v->get_data()[2]);
     ASSERT_FALSE(v->get_data()[3]);
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -774,7 +778,7 @@ TEST_F(LikeTest, backslashEscapeConstEquals) {
     columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -784,7 +788,7 @@ TEST_F(LikeTest, backslashEscapeConstEquals) {
     ASSERT_FALSE(v->get_data()[2]);
     ASSERT_FALSE(v->get_data()[3]);
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -805,7 +809,7 @@ TEST_F(LikeTest, backslashEscapeConstEqualsEscapedPercent) {
     columns.emplace_back(std::move(pattern));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -814,7 +818,7 @@ TEST_F(LikeTest, backslashEscapeConstEqualsEscapedPercent) {
     ASSERT_FALSE(v->get_data()[1]);
     ASSERT_FALSE(v->get_data()[2]);
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 
@@ -862,7 +866,7 @@ TEST_F(LikeTest, backslashEscapeRowPattern) {
     columns.emplace_back(std::move(pat));
 
     context->set_constant_columns(columns);
-    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(LikePredicate::like_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = LikePredicate::like_fn(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_BOOLEAN>(result);
@@ -876,7 +880,7 @@ TEST_F(LikeTest, backslashEscapeRowPattern) {
     ASSERT_TRUE(v->get_data()[6]);  // "ab" matches "a\b"
     ASSERT_FALSE(v->get_data()[7]); // "a\b" does not match "a\b" pattern
 
-    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+    ASSERT_TRUE(LikePredicate::like_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                         .ok());
 }
 

--- a/be/test/exprs/map_element_expr_test.cpp
+++ b/be/test/exprs/map_element_expr_test.cpp
@@ -461,7 +461,7 @@ TEST_F(MapElementExprTest, test_map_const) {
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
         ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         // corner test
-        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_constant());
         EXPECT_EQ(33, result->get(0).get_int32());

--- a/be/test/exprs/string_fn_field.cpp
+++ b/be/test/exprs/string_fn_field.cpp
@@ -238,7 +238,8 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest3) {
 }
 
 PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest4) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+            {TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT), TypeDescriptor(TYPE_INT)}, TypeDescriptor(TYPE_INT)));
     Columns columns;
     auto paramBuilder1 = ColumnBuilder<TYPE_INT>(5);
     auto paramBuilder2 = ColumnBuilder<TYPE_INT>(5);
@@ -273,9 +274,9 @@ PARALLEL_TEST(VecFieldFunctionsTest, fieldIntTest4) {
     columns.emplace_back(std::move(param3));
     int res[] = {2, 0, 0, 0, 0};
     ctx->set_constant_columns(columns);
-    ASSERT_TRUE(StringFunctions::field_prepare<TYPE_INT>(ctx.get(), FunctionContext::THREAD_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::field_prepare<TYPE_INT>(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
     ColumnPtr result = StringFunctions::field<TYPE_INT>(ctx.get(), columns).value();
-    ASSERT_TRUE(StringFunctions::field_close<TYPE_INT>(ctx.get(), FunctionContext::THREAD_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::field_close<TYPE_INT>(ctx.get(), FunctionContext::FRAGMENT_LOCAL).ok());
 
     ASSERT_TRUE(result->is_numeric());
     ASSERT_FALSE(result->is_nullable());

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -1885,7 +1885,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns).value();
 
@@ -1902,7 +1902,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractNullablePattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -1930,7 +1930,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractOnlyNullPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns).value();
     for (int i = 0; i < length; ++i) {
@@ -1938,7 +1938,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractOnlyNullPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -1969,7 +1969,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -1979,7 +1979,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractConstPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -2013,7 +2013,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
@@ -2023,7 +2023,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtract) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -2060,7 +2060,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns).value();
     auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(ColumnHelper::as_raw_column<NullableColumn>(result)->data_column());
@@ -2069,7 +2069,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceNullablePattern) {
     ASSERT_TRUE(result->is_null(1));
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -2100,7 +2100,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceOnlyNullPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns).value();
 
@@ -2108,7 +2108,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceOnlyNullPattern) {
     ASSERT_TRUE(result->is_null(1));
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -2139,7 +2139,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -2149,12 +2149,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceConstPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     // Test Binary input data
     {
-        FunctionContext::FunctionStateScope scope = FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL;
+        FunctionContext::FunctionStateScope scope =
+                FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL;
         std::unique_ptr<FunctionContext> ctx0(FunctionContext::create_test_context());
         int binary_size = 10;
         std::unique_ptr<char[]> binary_datas = std::make_unique<char[]>(binary_size);
@@ -2199,7 +2200,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -2209,7 +2210,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplace) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -2241,7 +2242,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceWithEmptyPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_replace_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_replace(context, columns).value();
     auto v = ColumnHelper::as_column<BinaryColumn>(result);
@@ -2251,7 +2252,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpReplaceWithEmptyPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -3545,12 +3546,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllPatternZero) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3585,12 +3586,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConstPatternZero) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -3622,12 +3623,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConstZero) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3665,12 +3666,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllNullableGroupPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3705,12 +3706,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3746,10 +3747,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllNullablePattern1) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3787,12 +3788,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllNullablePattern2) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3824,7 +3825,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllOnlyNullPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
     for (int i = 0; i < length; ++i) {
@@ -3832,7 +3833,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllOnlyNullPattern) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 }
 
@@ -3863,12 +3864,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConstPattern) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -3900,12 +3901,12 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpExtractAllConst) {
     context->set_constant_columns(columns);
 
     ASSERT_TRUE(
-            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 
     auto result = StringFunctions::regexp_extract_all(context, columns).value();
 
     ASSERT_TRUE(
-            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+            StringFunctions::regexp_close(context, FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
 
     for (int i = 0; i < sizeof(strs) / sizeof(strs[0]); ++i) {
@@ -3951,12 +3952,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -3990,12 +3992,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4028,12 +4031,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4077,12 +4081,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4114,12 +4119,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4155,12 +4161,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4193,12 +4200,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4237,12 +4245,13 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpSplitTest) {
 
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL)
-                            .ok());
+        ASSERT_TRUE(
+                StringFunctions::regexp_extract_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
         auto result = StringFunctions::regexp_split(context, columns).value();
 
         ASSERT_TRUE(StringFunctions::regexp_close(context,
-                                                  FunctionContext::FunctionContext::FunctionStateScope::THREAD_LOCAL)
+                                                  FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                             .ok());
 
         for (int i = 0; i < sizeof(res) / sizeof(res[0]); ++i) {
@@ -4352,8 +4361,8 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
 
     context->set_constant_columns(columns);
 
-    ASSERT_TRUE(
-            StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+    ASSERT_TRUE(StringFunctions::regexp_position_prepare(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
 
     auto result = StringFunctions::regexp_position(context, columns).value();
     ASSERT_TRUE(result->is_nullable());
@@ -4372,7 +4381,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionTest) {
     }
 
     ASSERT_TRUE(
-            StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            StringFunctions::regexp_position_close(context, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
@@ -4414,7 +4423,10 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpPositionInvalidRegex) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, regexpCountTest) {
-    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    // regexp_count_prepare runs under FRAGMENT_LOCAL and validates get_num_args() == 2, so the
+    // test context must carry the two (str, pattern) argument types.
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context(
+            {TypeDescriptor(TYPE_VARCHAR), TypeDescriptor(TYPE_VARCHAR)}, TypeDescriptor(TYPE_BIGINT)));
     auto context = ctx.get();
 
     {
@@ -4439,10 +4451,7 @@ PARALLEL_TEST(VecStringFunctionsTest, regexpCountTest) {
         Columns columns = {nullable_str_col, pattern_col};
         context->set_constant_columns(columns);
 
-        ASSERT_TRUE(
-                StringFunctions::regexp_count_prepare(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
         auto result = StringFunctions::regexp_count(context, columns).value();
-        ASSERT_TRUE(StringFunctions::regexp_close(context, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
 
         ASSERT_EQ(result->size(), 5);
         ASSERT_EQ(result->get(0).get_int64(), 6);

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -4493,12 +4493,12 @@ TEST_F(TimeFunctionsTest, unixtimeToDatetimeNonFragmentLocalScope) {
 
         auto* fn_ctx = FunctionContext::create_context(state.get(), nullptr, return_type, arg_types);
 
-        Status prepare_status =
-                TimeFunctions::unixtime_to_datetime_prepare(fn_ctx, FunctionContext::FunctionStateScope::THREAD_LOCAL);
+        Status prepare_status = TimeFunctions::unixtime_to_datetime_prepare(
+                fn_ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ASSERT_TRUE(prepare_status.ok());
 
         Status close_status =
-                TimeFunctions::unixtime_to_datetime_close(fn_ctx, FunctionContext::FunctionStateScope::THREAD_LOCAL);
+                TimeFunctions::unixtime_to_datetime_close(fn_ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ASSERT_TRUE(close_status.ok());
 
         delete fn_ctx;

--- a/be/test/fuzzy/builtin_functions_fuzzy_test.cpp
+++ b/be/test/fuzzy/builtin_functions_fuzzy_test.cpp
@@ -465,8 +465,6 @@ protected:
                         return;
                     }
                     ASSERT_TRUE(st.ok()) << st;
-                    st = (desc.prepare_function(ctx, FunctionContext::FunctionStateScope::THREAD_LOCAL));
-                    ASSERT_TRUE(st.ok()) << st;
                 }
 
                 if (desc.scalar_function) {
@@ -480,8 +478,6 @@ protected:
 
                 if (desc.close_function) {
                     auto st = (desc.close_function(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL));
-                    ASSERT_TRUE(st.ok()) << st;
-                    st = (desc.close_function(ctx, FunctionContext::FunctionStateScope::THREAD_LOCAL));
                     ASSERT_TRUE(st.ok()) << st;
                 }
             } catch (const std::exception& e) {


### PR DESCRIPTION
## Why I'm doing:



The per-thread FunctionContext scope (THREAD_LOCAL), historically materialized by cloning an ExprContext per execution thread, is removed. Genuinely per-thread, mutable function state now lives in a general per-worker registry on the shared FunctionContext; everything else is prepared once as FRAGMENT_LOCAL and shared.

Infrastructure:
- Drop the dead ExprContext::_pool and FunctionContext::clone's unused MemPool* parameter (the pool was never allocated from on the scalar/UDF path).
- Add FunctionThreadState + current_worker_id() + FunctionContext:: get_or_create_thread_state<T>(): a worker-id-keyed, mutex-guarded registry owned by the FunctionContext (freed with it), so a function's eval can obtain its thread's state without a per-thread FunctionContext clone and without pointer-reuse hazards.

Per-function migration:
- LIKE: compile the Hyperscan DB once (shared, shared_ptr); per-thread hs_scratch via get_or_create_thread_state (previously recompiled per scanner thread).
- gin: per-thread lucene Analyzer via get_or_create_thread_state.
- binary: BinaryFormatState is an immutable enum -> FRAGMENT_LOCAL shared.
- string(regexp): FRAGMENT_LOCAL state; and its bespoke per-driver regex cache (driver_regex_map keyed by CurrentThread::get_driver_id() + get_or_prepare_regex) is unified onto get_or_create_thread_state<StringRe2ThreadState> (per-worker RE2, fetched once per chunk), dropping the get_driver_id() coupling.
- rand: seed hook moved to FRAGMENT_LOCAL (RNG stays a file-static thread_local).
- Java UDAF: per-aggregator context slot -> FRAGMENT_LOCAL (the aggregator already gives each instance its own FunctionContext).

Scope removal:
- ExprContext::open/close/clone and VectorizedFunctionCallExpr no longer use THREAD_LOCAL; dict_query drops its clone-dedup guard; like drops its fallback.
- Delete the THREAD_LOCAL enumerator; FunctionStateScope now has only FRAGMENT_LOCAL.
- Migrate unit tests off THREAD_LOCAL (flip to FRAGMENT_LOCAL; collapse the fuzzy test's double prepare/close; single-scope FunctionStateScopeSetGet; fix regexpCount and string-field test contexts).

No FunctionContext/FunctionStateScope::THREAD_LOCAL references remain in be/src or be/test. Verified on a main-matching tree: expr_test passes (incl. LIKE 24, regexp, gin, binary, FunctionContextCore), LIKE concurrency stress (~4.8M concurrent hs_scans) clean; Java UDAF is compile-verified only (its runtime test needs the JVM/java-extensions build).


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
