### PR TITLE
[Enhancement] Support bounded incremental vacuum rounds in shared-data lake

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -690,8 +690,8 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     // delete shared files
     if (max_vacuum_version > 0 && !shared_file_deleter.is_empty()) {
         RETURN_IF_ERROR(collect_alive_shared_files(tablet_mgr, tablet_infos, max_vacuum_version,
-                                                   0 /* step-up bound (unused: floor is materialized here) */,
-                                                   root_dir, &shared_file_deleter));
+                                                   0 /* step-up bound (unused: floor is materialized here) */, root_dir,
+                                                   &shared_file_deleter));
         RETURN_IF_ERROR(shared_file_deleter.finish());
         (*vacuumed_files) += shared_file_deleter.delete_count();
     }
@@ -886,7 +886,8 @@ static Status propose_metadata_range(TabletManager* tablet_mgr, std::vector<Tabl
                 << (proposes_range ? fmt::format("[{},{})", proposed_low, max_version) : std::string("[0,0)"))
                 << " walked=" << versions_walked << " stop="
                 << (!anchored ? "not_found"
-                              : (!skip_check_timestamp ? "grace_blocked" : (stopped_by_limit ? "budget" : "chain_bottom")));
+                              : (!skip_check_timestamp ? "grace_blocked"
+                                                       : (stopped_by_limit ? "budget" : "chain_bottom")));
 
         if (!skip_check_timestamp) {
             // Every version this tablet examined is still within the grace window (or none existed): it
@@ -969,9 +970,9 @@ static Status commit_metadata_range(TabletManager* tablet_mgr, std::string_view 
     // is strictly above on a resume range). A floor at/below the range means the FE forgot to replay it;
     // proceeding would misderive the chain entry and could delete still-referenced metadata. Fail loud.
     if (pass_start_version < to_delete_high) {
-        return Status::InternalError(fmt::format(
-                "vacuum commit: pass_start_version {} must be >= delete-range high {} (range [{}, {}))",
-                pass_start_version, to_delete_high, to_delete_low, to_delete_high));
+        return Status::InternalError(
+                fmt::format("vacuum commit: pass_start_version {} must be >= delete-range high {} (range [{}, {}))",
+                            pass_start_version, to_delete_high, to_delete_low, to_delete_high));
     }
     auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
         erase_tablet_metadata_from_metacache(tablet_mgr, files);
@@ -1054,8 +1055,9 @@ static Status commit_metadata_range(TabletManager* tablet_mgr, std::string_view 
         (*vacuumed_files) += datafile_deleter.delete_count();
         *vacuumed_file_size += garbage_data_size;
         VLOG(2) << "incremental vacuum commit tablet=" << tablet_id << " committed=[" << to_delete_low << ","
-                << to_delete_high << ")" << " entry=" << entry
-                << " gc_files=" << datafile_deleter.delete_count() << " gc_bytes=" << garbage_data_size;
+                << to_delete_high << ")"
+                << " entry=" << entry << " gc_files=" << datafile_deleter.delete_count()
+                << " gc_bytes=" << garbage_data_size;
     }
 
     // Step 2: shared data files no longer referenced by any metadata still alive at the retain floor
@@ -1375,7 +1377,8 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
                 !st.ok()) {
                 LOG(WARNING) << "incremental vacuum commit failed: partition=" << request.partition_id()
                              << " resume_from=" << resume_from << " pass_start_version=" << pass_start_version
-                             << " committed=[" << req_to_delete_low << "," << req_to_delete_high << ")" << ": " << st;
+                             << " committed=[" << req_to_delete_low << "," << req_to_delete_high << ")"
+                             << ": " << st;
                 return st;
             }
         }
@@ -1386,10 +1389,9 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
         int64_t next_to_delete_high = 0;
         int64_t next_cursor = 0;
         int64_t next_pass_start = 0;
-        if (auto st = propose_metadata_range(tablet_mgr, tablet_infos, min_retain_version, grace_timestamp,
-                                             resume_from, request.max_versions_per_round(), max_empty_walk_versions,
-                                             deadline_ms, &next_to_delete_low, &next_to_delete_high, &next_cursor,
-                                             &next_pass_start);
+        if (auto st = propose_metadata_range(tablet_mgr, tablet_infos, min_retain_version, grace_timestamp, resume_from,
+                                             request.max_versions_per_round(), max_empty_walk_versions, deadline_ms,
+                                             &next_to_delete_low, &next_to_delete_high, &next_cursor, &next_pass_start);
             !st.ok()) {
             LOG(WARNING) << "incremental vacuum propose failed: partition=" << request.partition_id()
                          << " resume_from=" << resume_from << " min_retain=" << min_retain_version << ": " << st;
@@ -1404,14 +1406,14 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
         if (resume_from == 0) {
             resp_state->set_pass_start_version(next_pass_start);
         }
-        LOG(INFO) << "incremental vacuum: partition=" << request.partition_id()
-                  << " bundling=" << enable_file_bundling << " min_retain=" << min_retain_version
-                  << " grace_ts=" << grace_timestamp << " resume_from=" << resume_from
-                  << " pass_start_version=" << pass_start_version << " committed=[" << req_to_delete_low << ","
-                  << req_to_delete_high << ") proposed=[" << next_to_delete_low << "," << next_to_delete_high
-                  << ") next_propose_start=" << next_cursor << " vacuumed_files=" << vacuumed_files
-                  << " vacuumed_bytes=" << vacuumed_file_size << " tablets=" << tablet_infos.size()
-                  << " cost=" << (butil::gettimeofday_ms() - round_start_ms) << "ms";
+        LOG(INFO) << "incremental vacuum: partition=" << request.partition_id() << " bundling=" << enable_file_bundling
+                  << " min_retain=" << min_retain_version << " grace_ts=" << grace_timestamp
+                  << " resume_from=" << resume_from << " pass_start_version=" << pass_start_version << " committed=["
+                  << req_to_delete_low << "," << req_to_delete_high << ") proposed=[" << next_to_delete_low << ","
+                  << next_to_delete_high << ") next_propose_start=" << next_cursor
+                  << " vacuumed_files=" << vacuumed_files << " vacuumed_bytes=" << vacuumed_file_size
+                  << " tablets=" << tablet_infos.size() << " cost=" << (butil::gettimeofday_ms() - round_start_ms)
+                  << "ms";
         // NOTE: in incremental mode the response's vacuumed_version is NOT a committed per-pass
         // watermark (propose deletes nothing and never advances it). The FE advances its persisted
         // watermark from the cursor + proposed range -- the cursor resets to 0 only when a full pass
@@ -1421,8 +1423,8 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
     } else {
         RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, root_loc, tablet_infos, min_retain_version, grace_timestamp,
                                                enable_file_bundling, enable_shared_file_cleanup, &vacuumed_files,
-                                               &vacuumed_file_size, &vacuumed_version, &extra_file_size, retain_versions,
-                                               deadline_ms));
+                                               &vacuumed_file_size, &vacuumed_version, &extra_file_size,
+                                               retain_versions, deadline_ms));
         extra_file_size -= vacuumed_file_size;
     }
     if (request.delete_txn_log()) {

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -55,6 +55,15 @@ struct VacuumTabletMetaVerionRange {
     // range is [min_version, max_version)
     int64_t min_version = 0;
     int64_t max_version = 0;
+    // When false (legacy unbounded pass): every tablet walks down to its true chain bottom, so the
+    // partition-level deletable low end is the deepest any tablet reached -> take the MIN of the lows.
+    // When true (bounded incremental round): tablets stop at different versions when the per-round
+    // version budget runs out, and a tablet that stopped early has NOT yet collected the metadata
+    // below where it stopped. Deleting the bundled metadata below that point would strand its chain,
+    // so the deletable low end must be the INTERSECTION across tablets -> take the MAX of the lows.
+    // The high end is always the low watermark (MIN) in both modes: never delete at/above a version
+    // any tablet still retains.
+    bool intersect_low = false;
 
     /*
     * if tablet a has version range [1, ..., 10) ,
@@ -68,7 +77,7 @@ struct VacuumTabletMetaVerionRange {
             min_version = min;
             max_version = max;
         } else {
-            min_version = std::min(min_version, min);
+            min_version = intersect_low ? std::max(min_version, min) : std::min(min_version, min);
             // get the low watermark of the max version
             max_version = std::min(max_version, max);
         }
@@ -367,18 +376,47 @@ static Status collect_garbage_files(const TabletMetadataPB& metadata, const std:
 }
 
 static Status collect_alive_shared_files(TabletManager* tablet_mgr, const std::vector<TabletInfoPB>& tablet_infos,
-                                         int64_t version, std::string_view root_dir, AsyncSharedFileDeleter* deleter) {
+                                         int64_t version, int64_t max_empty_walk_versions, std::string_view root_dir,
+                                         AsyncSharedFileDeleter* deleter) {
     auto data_dir = join_path(root_dir, kSegmentDirectoryName);
     for (const auto& tablet_info : tablet_infos) {
         auto tablet_id = tablet_info.tablet_id();
+        int64_t v = version;
         // fill data cache to avoid read bundle meta file from remote storage repeatedly.
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* Not need to fill meta cache */,
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, v, false /* Not need to fill meta cache */,
                                                    true /* fill data cache when enable file bundle */);
         TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
+        if (max_empty_walk_versions > 0) {
+            // A non-bundle range-distribution table is the only case that reaches here with the partition retain
+            // floor |version| unmaterialized for some tablet: its per-tablet metadata timelines diverge, so a
+            // batch-publish hole can fold the floor into a higher version. (A file-bundling table shares one
+            // partition-wide bundle, so a version exists for all tablets or none, and this scan never misses.)
+            // The alive region is [floor, inf), so step UP to the nearest materialized snapshot -- it carries the
+            // tablet's live shared-file references at the floor. If none is found within the fold width, abandon
+            // shared cleanup this round (clear the deleter, keep every candidate for a later round) rather than
+            // risk deleting a still-referenced file or wedging the commit. The legacy one-shot path passes 0 and
+            // keeps the original must-exist read below (its floor is always materialized).
+            int64_t walked = 0;
+            while (!res.ok() && res.status().is_not_found()) {
+                if (walked++ >= max_empty_walk_versions) {
+                    LOG(WARNING) << "incremental vacuum shared-file cleanup: tablet " << tablet_id
+                                 << " has no materialized snapshot within " << max_empty_walk_versions
+                                 << " versions above floor " << version
+                                 << "; abandoning shared-file cleanup this round (candidates kept for a later round)";
+                    deleter->clear();
+                    return Status::OK();
+                }
+                res = tablet_mgr->get_tablet_metadata(tablet_id, ++v, false /* fill_meta */, true /* fill_data */);
+            }
+            if (res.ok() && v != version) {
+                LOG(INFO) << "incremental vacuum shared-file cleanup: tablet " << tablet_id << " floor " << version
+                          << " unmaterialized, stepped liveness anchor up to version " << v;
+            }
+        }
         if (!res.ok()) {
-            // must exist.
             return res.status();
-        } else {
+        }
+        {
             auto metadata = std::move(res).value();
             for (const auto& rowset : metadata->rowsets()) {
                 for (int i = 0; i < rowset.segment_metas_size(); ++i) {
@@ -651,8 +689,9 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     }
     // delete shared files
     if (max_vacuum_version > 0 && !shared_file_deleter.is_empty()) {
-        RETURN_IF_ERROR(collect_alive_shared_files(tablet_mgr, tablet_infos, max_vacuum_version, root_dir,
-                                                   &shared_file_deleter));
+        RETURN_IF_ERROR(collect_alive_shared_files(tablet_mgr, tablet_infos, max_vacuum_version,
+                                                   0 /* step-up bound (unused: floor is materialized here) */,
+                                                   root_dir, &shared_file_deleter));
         RETURN_IF_ERROR(shared_file_deleter.finish());
         (*vacuumed_files) += shared_file_deleter.delete_count();
     }
@@ -680,6 +719,398 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         (*vacuumed_files) += metafile_deleter.delete_count();
     }
     *vacuumed_version = final_vacuum_version;
+    return Status::OK();
+}
+
+// Propose phase of the incremental vacuum protocol: WITHOUT deleting anything, walk each tablet's
+// metadata chain for at most |max_versions_per_round| versions and compute the version range
+// [*to_delete_low, *to_delete_high) (low inclusive, high EXCLUSIVE) the next round may safely delete, the
+// resume cursor *next_propose_start_version (0 == the chain bottom was reached, i.e. the pass is
+// complete), and -- on a fresh round only -- the pass retain floor *pass_start_version.
+//
+// Two ways to start a tablet's descent:
+//   - Fresh pass (|resume_from_version| == 0): start at |min_retain_version| and, on the first round,
+//     honor |grace_timestamp| -- descend until the first metadata older than the grace timestamp, which
+//     becomes the retained boundary; everything strictly below it is deletable. If every examined
+//     version is still within the grace window, the tablet has nothing deletable this round.
+//   - Resume (|resume_from_version| > 0): start at the anchor |resume_from_version| the previous round
+//     stopped at and deliberately retained, and re-read it so the anchor becomes deletable this round.
+//     Every version at/below the anchor was already grace-checked when the pass first reached
+//     |min_retain_version|, so grace is skipped on a resumed walk.
+//
+// Outputs (all partition-level aggregates across tablets):
+//   - *to_delete_high = the INTERSECTION retained floor == MIN over tablets of their grace/min_retain
+//     boundary (this is exactly VacuumTabletMetaVerionRange::max_version, the low watermark). It is the
+//     EXCLUSIVE upper bound, so every version strictly below it is deletable by every tablet. The commit
+//     round does not enter the chain at this (it is retained); it derives the range's top real node from
+//     it (the node just below it for a fresh range, or to_delete_high - 1 for a resume range).
+//   - *to_delete_low = the INTERSECTION low end (max of the per-tablet walk lows): a tablet whose budget
+//     ran out has not examined the metadata below where it stopped, so nothing below the shallowest
+//     progress may be deleted yet.
+//   - *next_propose_start_version = the deepest version any tablet still has left to walk (max of the
+//     per-tablet stops); a tablet that bottomed out within budget contributes 0 and never raises it.
+//   - *pass_start_version = the retained floor g (the lowest surviving version this pass; equals
+//     to_delete_high on a fresh round). Set only on a fresh round; the FE persists it pass-constant and
+//     replays it so every commit round can read which shared files are still referenced (see commit).
+static Status propose_metadata_range(TabletManager* tablet_mgr, std::vector<TabletInfoPB>& tablet_infos,
+                                     int64_t min_retain_version, int64_t grace_timestamp, int64_t resume_from_version,
+                                     int64_t max_versions_per_round, int64_t max_empty_walk_versions,
+                                     int64_t deadline_ms, int64_t* to_delete_low, int64_t* to_delete_high,
+                                     int64_t* next_propose_start_version, int64_t* pass_start_version) {
+    DCHECK(tablet_mgr != nullptr);
+    DCHECK(max_versions_per_round > 0);
+    DCHECK(max_empty_walk_versions > 0);
+    DCHECK(to_delete_low != nullptr && to_delete_high != nullptr && next_propose_start_version != nullptr &&
+           pass_start_version != nullptr);
+
+    VacuumTabletMetaVerionRange vacuum_version_range;
+    vacuum_version_range.intersect_low = true;
+    int64_t walk_stop_version = 0;
+    bool nothing_to_delete = false;
+    // Whether the walk read any tablet metadata at or below the retain floor across all tablets. Stays
+    // false when everything at/below min_retain_version is already vacuumed away (the walk anchors nothing).
+    bool read_any_metadata = false;
+    const bool resumed = resume_from_version > 0;
+
+    for (auto& tablet_info : tablet_infos) {
+        auto tablet_id = tablet_info.tablet_id();
+        auto min_version = std::max<int64_t>(1, tablet_info.min_version());
+        auto max_version = resumed ? (resume_from_version + 1) : min_retain_version;
+        auto version = resumed ? resume_from_version : max_version;
+        bool skip_check_timestamp = (grace_timestamp <= 0) || resumed;
+        int64_t versions_walked = 0;
+        bool stopped_by_limit = false;
+        bool anchored = false;
+
+        while (version >= min_version) {
+            if (auto st = check_vacuum_deadline(deadline_ms); !st.ok()) {
+                return Status::TimedOut(fmt::format("{} tablet_id={}", st.message(), tablet_id));
+            }
+            // fill data cache to avoid reading the bundle meta file from remote storage repeatedly.
+            auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* fill_meta_cache */,
+                                                       true /* fill_data_cache */);
+            if (res.status().is_not_found()) {
+                // The prev_garbage_version chain links only materialized versions, so once the walk is
+                // anchored a NotFound is the genuine chain bottom (a version already vacuumed, or below this
+                // tablet's existence) -- stop, as before. But a resume round's entry resume_from_version is
+                // the MAX of the previous round's per-tablet stop cursors, so it can be materialized on the
+                // tablet that produced it yet be a batch-publish hole on this one; before the walk is
+                // anchored, step down to the nearest existing version (at most one folded batch away) to
+                // anchor it, instead of zeroing this tablet's range (which zeroes the whole round via the
+                // partition-level intersection). A fresh round's entry min_retain_version always exists.
+                if (anchored) {
+                    break;
+                }
+                --version;
+                // Bound the pre-anchor step-down by max_empty_walk_versions (the batch-publish fold width),
+                // NOT the full max_versions_per_round. The only legitimate run of missing versions here is a
+                // batch-publish hole, which spans at most that many versions; a tablet that cannot anchor
+                // within it is lagging / cross-generation (its versions all sit below the band being proposed),
+                // so grinding on to max_versions_per_round is pure wasted remote reads against a tablet that
+                // contributes nothing this round. Stop early instead. Guarded by skip_check_timestamp to match
+                // the budget check below: a fresh round anchors immediately at min_retain_version and never
+                // steps down; only a resume round, where skip_check_timestamp is already set, steps down here.
+                // versions_walked is still 0-based here (the post-anchor chain walk has not run yet), so this
+                // caps the hole search at exactly max_empty_walk_versions step-downs.
+                if (skip_check_timestamp && ++versions_walked >= max_empty_walk_versions) {
+                    stopped_by_limit = true;
+                    break;
+                }
+                continue;
+            } else if (!res.ok()) {
+                return res.status();
+            }
+            anchored = true;
+            read_any_metadata = true;
+            auto metadata = std::move(res).value();
+            if (!skip_check_timestamp) {
+                int64_t compare_time = 0;
+                if (metadata->has_commit_time() && metadata->commit_time() > 0) {
+                    compare_time = metadata->commit_time();
+                }
+                // Retain this version either way; if it is the first one older than the grace timestamp,
+                // stop checking grace from here down (everything below becomes deletable).
+                max_version = version;
+                if (compare_time < grace_timestamp) {
+                    skip_check_timestamp = true;
+                }
+            }
+            int64_t next_version = metadata->prev_garbage_version();
+            CHECK_LT(next_version, version);
+            int64_t span = version - next_version;
+            version = next_version;
+            if (skip_check_timestamp) {
+                versions_walked += span;
+                if (versions_walked >= max_versions_per_round) {
+                    stopped_by_limit = true;
+                    break;
+                }
+            }
+        }
+
+        // Clamp the proposed low to the walk floor |min_version|. |version| holds the last prev_garbage_version
+        // hop; the chain's lowest surviving node -- the pass retain floor -- records a prev_garbage_version that
+        // points at the PREVIOUS compaction anchor, one compaction interval below the floor and already
+        // reclaimed by an earlier pass. Taking |version + 1| verbatim would dip the proposed low under the floor
+        // and re-propose an already-vacuumed band (proposed.low < the prior pass's committed.high, replayed as a
+        // benign but wasteful re-commit next round). Every node at or above the floor was already visited and its
+        // garbage collected; nothing below the floor is deletable, so the low must never fall below it.
+        int64_t proposed_low = std::max<int64_t>(min_version, version + 1);
+        // Width clamp: the per-round budget is enforced only AFTER accumulating a whole prev_garbage_version
+        // hop (versions_walked += span; then the >= check), so one large jump slips through and the deletable
+        // band [proposed_low, max_version) can be thousands of versions wide even with a small
+        // max_versions_per_round -- e.g. a reshard-reset chain whose retain-floor metadata records
+        // prev_garbage_version == 0 collapses the entire [1, retain) into a single hop. Such a band is
+        // expensive to commit and, against a stale/cross-generation tablet set, grinds version-by-version to
+        // the RPC deadline. Cap the band at the budget and carry the remainder on the resume cursor so every
+        // committed range stays bounded and the pass splits into budget-sized bands across rounds.
+        // band_resume_cursor is where the next round re-enters: its max_version becomes cursor + 1, i.e. this
+        // band's low, so consecutive bands stay contiguous with no overlap or gap.
+        int64_t band_resume_cursor = version;
+        if (max_version - proposed_low > max_versions_per_round) {
+            proposed_low = max_version - max_versions_per_round;
+            band_resume_cursor = proposed_low - 1;
+            stopped_by_limit = true;
+        }
+
+        // Only a tablet that both anchored (read a real version) AND cleared the grace gate
+        // (skip_check_timestamp) actually contributes a deletable range to the intersection below. The other
+        // two outcomes compute a [proposed_low, max_version) that is NOT proposed: a never-anchored tablet
+        // (all NotFound -- e.g. cross-generation) merges nothing, and a grace-blocked tablet (anchored but
+        // every version it read is still within grace) takes the nothing_to_delete break and zeroes the whole
+        // round. Log an empty band for both so the per-tablet line matches what it really proposes and the
+        // partition summary.
+        const bool proposes_range = anchored && skip_check_timestamp;
+        VLOG(2) << "incremental vacuum propose tablet=" << tablet_id << " resume_from=" << resume_from_version
+                << " min_retain=" << min_retain_version << " proposed="
+                << (proposes_range ? fmt::format("[{},{})", proposed_low, max_version) : std::string("[0,0)"))
+                << " walked=" << versions_walked << " stop="
+                << (!anchored ? "not_found"
+                              : (!skip_check_timestamp ? "grace_blocked" : (stopped_by_limit ? "budget" : "chain_bottom")));
+
+        if (!skip_check_timestamp) {
+            // Every version this tablet examined is still within the grace window (or none existed): it
+            // has nothing safely deletable this round. As the partition range is the intersection across
+            // tablets, the whole round proposes nothing.
+            nothing_to_delete = true;
+            break;
+        }
+        // Per-tablet deletable range merged into the intersection: [proposed_low, max_version). Only a tablet
+        // that actually anchored (read at least one real version) may contribute a range or a resume cursor.
+        // A tablet that never anchored -- it only stepped down through missing versions -- has nothing here:
+        // do NOT merge a bogus all-hole range, and do NOT carry a cursor either. Carrying one would make the
+        // next round resume the hole search one budget lower; with min_version low (e.g. 0 right after an
+        // upgrade, before any pass has established a floor) that marches empty all the way to version 1. A
+        // real batch-publish hole spans at most lake_batch_publish_max_version_num (default 10) versions --
+        // far inside one round's budget -- so a genuine anchor is always found within the round; failing to
+        // anchor across a whole round means there is nothing below (vacuum deletes contiguously from the
+        // bottom up), so the pass is simply done.
+        if (anchored) {
+            vacuum_version_range.merge(proposed_low, max_version);
+            if (stopped_by_limit) {
+                walk_stop_version = std::max(walk_stop_version, band_resume_cursor);
+            }
+        }
+    }
+
+    // Default outputs: nothing proposed (empty round -- chain bottom reached, or grace blocked all).
+    *to_delete_low = 0;
+    *to_delete_high = 0;
+    *next_propose_start_version = 0;
+    *pass_start_version = 0;
+    if (!nothing_to_delete && vacuum_version_range.max_version > vacuum_version_range.min_version) {
+        // min_version/max_version come straight from the intersection merge: min_version = max of the
+        // per-tablet walk lows (intersect_low), max_version = MIN of the per-tablet retain boundaries =
+        // the retained floor g. The deletable range is [to_delete_low, to_delete_high) with the high end
+        // == the floor, which is also reported as the pass retain floor pass_start_version.
+        *to_delete_low = vacuum_version_range.min_version;
+        *to_delete_high = vacuum_version_range.max_version;
+        *next_propose_start_version = walk_stop_version;
+        *pass_start_version = vacuum_version_range.max_version;
+    } else if (!read_any_metadata) {
+        // Nothing was read at or below the retain floor: everything down here is already vacuumed away.
+        // Report the retain floor as the pass floor (mirrors the one-shot path's read_any_metadata branch)
+        // so the FE advances its watermark and clears a pinned metadataSwitchVersion. An empty proposal that
+        // left pass_start_version at 0 would strand the switch -- and the retain floor capped to it --
+        // forever, since the FE clears the switch only once the pass floor reaches the switch version.
+        *pass_start_version = min_retain_version;
+    }
+    return Status::OK();
+}
+
+// Commit phase of the incremental vacuum protocol: physically delete the metadata version range
+// [to_delete_low, to_delete_high) (low inclusive, high EXCLUSIVE) that the previous round proposed and
+// the FE has durably persisted, together with the garbage data files those metadata reference and any
+// shared files no longer referenced by alive metadata. Idempotent: a NotFound on any version is skipped,
+// so a crashed/retried commit re-derives and re-deletes safely from the same range.
+//
+// |to_delete_high| is the range's retained boundary (the intersection floor) and is itself NOT deletable.
+// The garbage walk enters each tablet's prev_garbage_version chain at the range's top real node, derived
+// from it: for a fresh range (to_delete_high == |pass_start_version|, the pass floor g) read g and
+// descend from its prev_garbage_version (g is retained); for a resume range the top real node is the
+// anchor at to_delete_high - 1. |pass_start_version| is the pass retain floor g; the shared-file
+// liveness check reads exactly g -- the lowest surviving version -- so a shared file still referenced
+// there is spared from deletion.
+//
+// Unlike the legacy/propose walk this does NOT consult grace_timestamp: the range was already
+// grace-checked when proposed and the FE persisted it as a firm delete commitment, so re-narrowing it
+// here would risk a version that can never be reclaimed. Deletions run data-first then metadata so a
+// crash never leaves metadata pointing at an already-deleted data file.
+static Status commit_metadata_range(TabletManager* tablet_mgr, std::string_view root_dir,
+                                    std::vector<TabletInfoPB>& tablet_infos, int64_t to_delete_low,
+                                    int64_t to_delete_high, int64_t pass_start_version, bool enable_file_bundling,
+                                    bool enable_shared_file_cleanup, int64_t max_empty_walk_versions,
+                                    const std::unordered_set<int64_t>& retain_versions, int64_t* vacuumed_files,
+                                    int64_t* vacuumed_file_size, int64_t deadline_ms) {
+    if (to_delete_low >= to_delete_high) {
+        return Status::OK();
+    }
+    // The retain floor must sit at or above the range's exclusive high (it equals it on a fresh range, and
+    // is strictly above on a resume range). A floor at/below the range means the FE forgot to replay it;
+    // proceeding would misderive the chain entry and could delete still-referenced metadata. Fail loud.
+    if (pass_start_version < to_delete_high) {
+        return Status::InternalError(fmt::format(
+                "vacuum commit: pass_start_version {} must be >= delete-range high {} (range [{}, {}))",
+                pass_start_version, to_delete_high, to_delete_low, to_delete_high));
+    }
+    auto metafile_delete_cb = [=](const std::vector<std::string>& files) {
+        erase_tablet_metadata_from_metacache(tablet_mgr, files);
+    };
+    auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
+    auto data_dir = join_path(root_dir, kSegmentDirectoryName);
+    AsyncSharedFileDeleter shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
+
+    // Step 1: walk each tablet's prev_garbage_version chain from the range's top real node down to
+    // |to_delete_low|, deleting the garbage data files each metadata references. The entry is derived
+    // from |to_delete_high| (the retained, non-deletable boundary): a fresh range reads the pass floor g
+    // and descends from its prev_garbage_version; a resume range starts at the anchor to_delete_high - 1.
+    const bool is_fresh = (to_delete_high == pass_start_version);
+    for (auto& tablet_info : tablet_infos) {
+        TabletRetainInfo tablet_retain_info;
+        tablet_retain_info.init(retain_versions);
+        auto tablet_id = tablet_info.tablet_id();
+        AsyncFileDeleter datafile_deleter(config::lake_vacuum_min_batch_delete_size);
+        int64_t garbage_data_size = 0;
+        // On a fresh round to_delete_high is the pass retain floor: it stays retained this pass (Step 3
+        // deletes only [to_delete_low, to_delete_high)), but the garbage files it records are superseded and
+        // can be reclaimed now -- mirroring the legacy walk, which collects garbage at its final_retain node.
+        // A tablet does not necessarily materialize a snapshot at every version: batch publish folds a run of
+        // txns into a single snapshot at the batch's final version, so the floor can legitimately be absent
+        // for THIS tablet (its garbage then lives in a retained higher version, reclaimed by a later,
+        // higher-floor pass) -- a NotFound here is not corruption.
+        int64_t version;
+        bool anchored = false;
+        if (is_fresh) {
+            auto res = tablet_mgr->get_tablet_metadata(tablet_id, to_delete_high, false /* fill_meta_cache */,
+                                                       true /* fill_data_cache */);
+            if (res.ok()) {
+                // Floor exists: collect its garbage and enter the chain directly from its prev_garbage_version
+                // -- the walk is already anchored on a materialized version.
+                auto floor_metadata = std::move(res).value();
+                RETURN_IF_ERROR(collect_garbage_files(*floor_metadata, data_dir, &datafile_deleter,
+                                                      &shared_file_deleter, &garbage_data_size, tablet_retain_info));
+                version = floor_metadata->prev_garbage_version();
+                anchored = true;
+            } else if (res.status().is_not_found()) {
+                // Floor folded away on this tablet: nothing to collect here; enter just below and let the walk
+                // step down to the nearest existing version to anchor.
+                version = to_delete_high - 1;
+            } else {
+                return res.status();
+            }
+        } else {
+            // Resume round: to_delete_high was already deleted by an earlier chunk; enter at to_delete_high - 1
+            // (which may itself be a hole -- the walk steps down to anchor).
+            version = to_delete_high - 1;
+        }
+        const int64_t entry = version;
+        while (version >= to_delete_low) {
+            if (auto st = check_vacuum_deadline(deadline_ms); !st.ok()) {
+                return Status::TimedOut(fmt::format("{} tablet_id={}", st.message(), tablet_id));
+            }
+            auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* fill_meta_cache */,
+                                                       true /* fill_data_cache */);
+            if (res.status().is_not_found()) {
+                // The prev_garbage_version chain links only materialized versions, so once anchored a NotFound
+                // is the genuine chain bottom (a version already deleted by an earlier pass, or below this
+                // tablet's existence) -- stop. Before anchoring, the directly-set entry may be a batch-publish
+                // hole; step down (at most one folded batch) to the nearest existing version to anchor.
+                if (anchored) {
+                    break;
+                }
+                --version;
+                continue;
+            } else if (!res.ok()) {
+                return res.status();
+            }
+            anchored = true;
+            auto metadata = std::move(res).value();
+            RETURN_IF_ERROR(collect_garbage_files(*metadata, data_dir, &datafile_deleter, &shared_file_deleter,
+                                                  &garbage_data_size, tablet_retain_info));
+            CHECK_LT(metadata->prev_garbage_version(), version);
+            version = metadata->prev_garbage_version();
+        }
+        RETURN_IF_ERROR(datafile_deleter.finish());
+        (*vacuumed_files) += datafile_deleter.delete_count();
+        *vacuumed_file_size += garbage_data_size;
+        VLOG(2) << "incremental vacuum commit tablet=" << tablet_id << " committed=[" << to_delete_low << ","
+                << to_delete_high << ")" << " entry=" << entry
+                << " gc_files=" << datafile_deleter.delete_count() << " gc_bytes=" << garbage_data_size;
+    }
+
+    // Step 2: shared data files no longer referenced by any metadata still alive at the retain floor
+    // |pass_start_version| (the lowest surviving version this pass).
+    if (!shared_file_deleter.is_empty() && !enable_shared_file_cleanup) {
+        // Incomplete tablet set for the partition: cannot safely decide shared-file liveness.
+        shared_file_deleter.clear();
+    }
+    if (!shared_file_deleter.is_empty()) {
+        RETURN_IF_ERROR(collect_alive_shared_files(tablet_mgr, tablet_infos, pass_start_version,
+                                                   max_empty_walk_versions, root_dir, &shared_file_deleter));
+        RETURN_IF_ERROR(shared_file_deleter.finish());
+        (*vacuumed_files) += shared_file_deleter.delete_count();
+    }
+
+    // Step 3: delete the metadata files in [to_delete_low, to_delete_high) (high exclusive: it is the
+    // retained floor). Every version here is strictly below the floor, so nothing retained is touched.
+    AsyncFileDeleter metafile_deleter(INT64_MAX, metafile_delete_cb);
+    if (enable_file_bundling) {
+        // Special case mirrored from vacuum_tablet_metadata: after an alter, the version-1 initial
+        // metadata may be written under each tablet's own id, so delete those by tablet_id.
+        if (to_delete_low <= 1) {
+            for (auto& tablet_info : tablet_infos) {
+                RETURN_IF_ERROR(metafile_deleter.delete_file(
+                        join_path(meta_dir, tablet_metadata_filename(tablet_info.tablet_id(), 1))));
+            }
+        }
+        for (auto v = to_delete_low; v < to_delete_high; v++) {
+            if (retain_versions.find(v) != retain_versions.end()) {
+                continue;
+            }
+            RETURN_IF_ERROR(metafile_deleter.delete_file(join_path(meta_dir, tablet_metadata_filename(0, v))));
+            // Bundle layout: the deleted file is the shared bundle path, but each tablet's metadata OBJECT is
+            // cached under its own per-tablet path (tablet_metadata_location), so the delete callback's
+            // metacache erase (keyed by the bundle path) is a no-op for them. Evict them here. The non-bundle
+            // branch below deletes per-tablet files directly, so the callback's erase already matches their key.
+            for (auto& tablet_info : tablet_infos) {
+                tablet_mgr->metacache()->erase(tablet_mgr->tablet_metadata_location(tablet_info.tablet_id(), v));
+            }
+        }
+    } else {
+        for (auto& tablet_info : tablet_infos) {
+            TabletRetainInfo tablet_retain_info;
+            tablet_retain_info.init(retain_versions);
+            for (auto v = to_delete_low; v < to_delete_high; v++) {
+                if (tablet_retain_info.contains_version(v)) {
+                    continue;
+                }
+                RETURN_IF_ERROR(metafile_deleter.delete_file(
+                        join_path(meta_dir, tablet_metadata_filename(tablet_info.tablet_id(), v))));
+            }
+        }
+    }
+    RETURN_IF_ERROR(metafile_deleter.finish());
+    (*vacuumed_files) += metafile_deleter.delete_count();
     return Status::OK();
 }
 
@@ -912,11 +1343,88 @@ Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, Vacu
     const bool enable_file_bundling = request.has_enable_file_bundling() && request.enable_file_bundling();
     const bool enable_shared_file_cleanup =
             request.has_enable_shared_file_cleanup() ? request.enable_shared_file_cleanup() : enable_file_bundling;
-    RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, root_loc, tablet_infos, min_retain_version, grace_timestamp,
-                                           enable_file_bundling, enable_shared_file_cleanup, &vacuumed_files,
-                                           &vacuumed_file_size, &vacuumed_version, &extra_file_size, retain_versions,
-                                           deadline_ms));
-    extra_file_size -= vacuumed_file_size;
+    // The presence of |max_versions_per_round| is the sole switch into the incremental/resumable vacuum
+    // protocol (no mode flag): an old FE never sets it, so the request falls through to the legacy
+    // one-shot path below and behaves exactly as before.
+    if (request.has_max_versions_per_round()) {
+        const int64_t round_start_ms = butil::gettimeofday_ms();
+        // The incremental protocol state the FE persisted and replays each round (see
+        // VacuumStatePB): the range to commit, the resume cursor, and the pass retain floor.
+        const auto& req_state = request.vacuum_state();
+        const int64_t resume_from = req_state.next_propose_start_version();
+        const int64_t req_to_delete_low = req_state.to_delete_low();
+        const int64_t req_to_delete_high = req_state.to_delete_high();
+        // The pass retain floor g: set on a fresh round and replayed by the FE on every commit round. It
+        // is the lowest surviving version of the pass; the commit reads it to spare still-referenced
+        // shared files and never touches anything at or above it. 0/unset on a fresh round.
+        const int64_t pass_start_version = req_state.pass_start_version();
+        // Pre-anchor / hole-search bound (batch-publish fold width, fed by lake_batch_publish_max_version_num).
+        // Used by BOTH the commit's shared-file liveness step-up and the propose walk below. An old FE never
+        // sets it: fall back to max_versions_per_round so both behave exactly as before.
+        const int64_t max_empty_walk_versions =
+                (request.has_max_empty_walk_versions() && request.max_empty_walk_versions() > 0)
+                        ? request.max_empty_walk_versions()
+                        : request.max_versions_per_round();
+        // Phase 1 (commit): physically delete the inclusive range the previous round proposed and the FE
+        // has persisted. Absent/empty on the very first incremental round for a partition.
+        if (req_to_delete_low < req_to_delete_high) {
+            if (auto st = commit_metadata_range(tablet_mgr, root_loc, tablet_infos, req_to_delete_low,
+                                                req_to_delete_high, pass_start_version, enable_file_bundling,
+                                                enable_shared_file_cleanup, max_empty_walk_versions, retain_versions,
+                                                &vacuumed_files, &vacuumed_file_size, deadline_ms);
+                !st.ok()) {
+                LOG(WARNING) << "incremental vacuum commit failed: partition=" << request.partition_id()
+                             << " resume_from=" << resume_from << " pass_start_version=" << pass_start_version
+                             << " committed=[" << req_to_delete_low << "," << req_to_delete_high << ")" << ": " << st;
+                return st;
+            }
+        }
+        // Phase 2 (propose): walk forward from the resume cursor for up to |max_versions_per_round|
+        // versions, computing the next delete range, the resume cursor, and (on a fresh round) the
+        // retain floor, without deleting anything.
+        int64_t next_to_delete_low = 0;
+        int64_t next_to_delete_high = 0;
+        int64_t next_cursor = 0;
+        int64_t next_pass_start = 0;
+        if (auto st = propose_metadata_range(tablet_mgr, tablet_infos, min_retain_version, grace_timestamp,
+                                             resume_from, request.max_versions_per_round(), max_empty_walk_versions,
+                                             deadline_ms, &next_to_delete_low, &next_to_delete_high, &next_cursor,
+                                             &next_pass_start);
+            !st.ok()) {
+            LOG(WARNING) << "incremental vacuum propose failed: partition=" << request.partition_id()
+                         << " resume_from=" << resume_from << " min_retain=" << min_retain_version << ": " << st;
+            return st;
+        }
+        auto* resp_state = response->mutable_vacuum_state();
+        resp_state->set_to_delete_low(next_to_delete_low);
+        resp_state->set_to_delete_high(next_to_delete_high);
+        resp_state->set_next_propose_start_version(next_cursor);
+        // Only a fresh round (resume cursor 0/unset) establishes the pass retain floor; the FE captures
+        // it then and holds it constant for the rest of the pass.
+        if (resume_from == 0) {
+            resp_state->set_pass_start_version(next_pass_start);
+        }
+        LOG(INFO) << "incremental vacuum: partition=" << request.partition_id()
+                  << " bundling=" << enable_file_bundling << " min_retain=" << min_retain_version
+                  << " grace_ts=" << grace_timestamp << " resume_from=" << resume_from
+                  << " pass_start_version=" << pass_start_version << " committed=[" << req_to_delete_low << ","
+                  << req_to_delete_high << ") proposed=[" << next_to_delete_low << "," << next_to_delete_high
+                  << ") next_propose_start=" << next_cursor << " vacuumed_files=" << vacuumed_files
+                  << " vacuumed_bytes=" << vacuumed_file_size << " tablets=" << tablet_infos.size()
+                  << " cost=" << (butil::gettimeofday_ms() - round_start_ms) << "ms";
+        // NOTE: in incremental mode the response's vacuumed_version is NOT a committed per-pass
+        // watermark (propose deletes nothing and never advances it). The FE advances its persisted
+        // watermark from the cursor + proposed range -- the cursor resets to 0 only when a full pass
+        // completes -- and must not read vacuumed_version here as "everything below is reclaimed".
+        // extra_file_size is also left at 0: propose computes no orphan-size estimate, so the legacy
+        // "extra minus vacuumed" adjustment below is skipped (it would otherwise report a negative).
+    } else {
+        RETURN_IF_ERROR(vacuum_tablet_metadata(tablet_mgr, root_loc, tablet_infos, min_retain_version, grace_timestamp,
+                                               enable_file_bundling, enable_shared_file_cleanup, &vacuumed_files,
+                                               &vacuumed_file_size, &vacuumed_version, &extra_file_size, retain_versions,
+                                               deadline_ms));
+        extra_file_size -= vacuumed_file_size;
+    }
     if (request.delete_txn_log()) {
         RETURN_IF_ERROR(vacuum_txn_log(root_loc, min_active_txn_id, &vacuumed_files, &vacuumed_file_size));
         // NOTE: vacuum_load_spill is intentionally NOT called from this high-frequency

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4341,6 +4341,354 @@ TEST_P(LakeVacuumTest, test_vacuum_deadline_window_too_small_to_start) {
     EXPECT_TRUE(file_exist(tablet_metadata_filename(20003, 3)));
 }
 
+// ===========================================================================
+// Incremental (bounded, resumable) vacuum protocol.
+//
+// Selected by VacuumRequest.max_versions_per_round; each round commits the
+// range carried in the request's vacuum_state (previous round's proposal),
+// walks the prev_garbage_version chain for a bounded budget, and returns the
+// next proposal in the response's vacuum_state. These tests drive the FE/BE
+// round-trip directly by feeding a round's response state into the next
+// request, and assert on the proposed [to_delete_low, to_delete_high) range,
+// the next_propose_start_version resume cursor, and which per-tablet metadata
+// files (non-bundle layout) the commit phase physically removed.
+// ===========================================================================
+
+// A fresh round proposes the full deletable band; the next round commits it (deleting the metadata
+// below the retain floor) and re-proposes empty because the pass has drained.
+TEST_P(LakeVacuumTest, test_incremental_propose_then_commit) {
+    // Chain: v4 -> v3 -> v2 -> bottom(0), all committed long before the grace timestamp.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30001, "version": 2, "prev_garbage_version": 0, "commit_time": 1000 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30001, "version": 3, "prev_garbage_version": 2, "commit_time": 1001 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30001, "version": 4, "prev_garbage_version": 3, "commit_time": 1002 })DEL")));
+
+    // Round 1: fresh round (empty vacuum_state) -- propose only, nothing is deleted.
+    VacuumRequest propose_req;
+    VacuumResponse propose_resp;
+    propose_req.set_partition_id(3000);
+    propose_req.set_min_retain_version(4);
+    propose_req.set_grace_timestamp(4000000000);
+    propose_req.set_max_versions_per_round(100);
+    auto* info = propose_req.add_tablet_infos();
+    info->set_tablet_id(30001);
+    info->set_min_version(1);
+    vacuum(_tablet_mgr.get(), propose_req, &propose_resp);
+    ASSERT_TRUE(propose_resp.has_status());
+    ASSERT_EQ(0, propose_resp.status().status_code()) << propose_resp.status().error_msgs(0);
+    ASSERT_TRUE(propose_resp.has_vacuum_state());
+    // Deletable band is [1, 4): everything strictly below the retain floor 4.
+    EXPECT_EQ(1, propose_resp.vacuum_state().to_delete_low());
+    EXPECT_EQ(4, propose_resp.vacuum_state().to_delete_high());
+    EXPECT_EQ(0, propose_resp.vacuum_state().next_propose_start_version()); // chain bottom within budget
+    EXPECT_EQ(4, propose_resp.vacuum_state().pass_start_version());         // fresh round establishes the floor
+    EXPECT_EQ(0, propose_resp.vacuumed_files());                            // propose deletes nothing
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30001, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30001, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30001, 4)));
+
+    // Round 2: feed the proposal back as the range to commit. Commit deletes [1, 4); the re-proposal is
+    // empty because the walk from the floor immediately hits the just-deleted versions (pass drained).
+    VacuumRequest commit_req;
+    VacuumResponse commit_resp;
+    commit_req.set_partition_id(3000);
+    commit_req.set_min_retain_version(4);
+    commit_req.set_grace_timestamp(4000000000);
+    commit_req.set_max_versions_per_round(100);
+    commit_req.add_tablet_infos()->CopyFrom(*info);
+    commit_req.mutable_vacuum_state()->CopyFrom(propose_resp.vacuum_state());
+    vacuum(_tablet_mgr.get(), commit_req, &commit_resp);
+    ASSERT_EQ(0, commit_resp.status().status_code()) << commit_resp.status().error_msgs(0);
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30001, 2)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30001, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30001, 4))); // retain floor kept
+    // Pass drained: re-proposal is empty.
+    EXPECT_GE(commit_resp.vacuum_state().to_delete_low(), commit_resp.vacuum_state().to_delete_high());
+    EXPECT_EQ(0, commit_resp.vacuum_state().next_propose_start_version());
+}
+
+// A single large prev_garbage_version hop (retain floor records prev_garbage 0, collapsing the whole
+// range into one jump) must still be clamped to the per-round budget, with the remainder carried on the
+// resume cursor -- otherwise one round would commit a range thousands of versions wide.
+TEST_P(LakeVacuumTest, test_incremental_budget_width_clamp) {
+    // Retain floor v10 points straight at the bottom: [1, 10) is one hop of width 9.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30002, "version": 10, "prev_garbage_version": 0, "commit_time": 1000 })DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_partition_id(3000);
+    request.set_min_retain_version(10);
+    request.set_grace_timestamp(4000000000);
+    request.set_max_versions_per_round(3); // small budget
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(30002);
+    info->set_min_version(1);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    ASSERT_TRUE(response.has_vacuum_state());
+    // Band clamped to the budget: [10 - 3, 10) = [7, 10), width exactly max_versions_per_round.
+    EXPECT_EQ(7, response.vacuum_state().to_delete_low());
+    EXPECT_EQ(10, response.vacuum_state().to_delete_high());
+    // Remainder carried on the resume cursor (proposed_low - 1), so the next round re-enters below the band.
+    EXPECT_EQ(6, response.vacuum_state().next_propose_start_version());
+    EXPECT_EQ(10, response.vacuum_state().pass_start_version());
+}
+
+// max_empty_walk_versions bounds the pre-anchor step-down (searching for the nearest existing version
+// below the resume cursor). A resume cursor above a hole taller than the bound makes the tablet abstain
+// (empty proposal); a bound wide enough to reach the real version below the hole anchors and proposes.
+TEST_P(LakeVacuumTest, test_incremental_max_empty_walk_versions) {
+    // Only v10 exists; a resume cursor at 20 sits above a 10-version hole [11, 20].
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30003, "version": 10, "prev_garbage_version": 0, "commit_time": 1000 })DEL")));
+
+    auto make_resume_req = [&](int64_t empty_walk, VacuumRequest* req) {
+        req->set_partition_id(3000);
+        req->set_min_retain_version(100);
+        req->set_grace_timestamp(4000000000);
+        req->set_max_versions_per_round(100);
+        req->set_max_empty_walk_versions(empty_walk);
+        auto* info = req->add_tablet_infos();
+        info->set_tablet_id(30003);
+        info->set_min_version(1);
+        // Resume round: cursor set, commit range empty (only propose).
+        req->mutable_vacuum_state()->set_next_propose_start_version(20);
+    };
+
+    // Bound 3: steps 20->19->18->17 exhaust the budget before reaching v10 -- the tablet abstains.
+    VacuumRequest narrow_req;
+    VacuumResponse narrow_resp;
+    make_resume_req(3, &narrow_req);
+    vacuum(_tablet_mgr.get(), narrow_req, &narrow_resp);
+    ASSERT_EQ(0, narrow_resp.status().status_code()) << narrow_resp.status().error_msgs(0);
+    EXPECT_GE(narrow_resp.vacuum_state().to_delete_low(), narrow_resp.vacuum_state().to_delete_high())
+            << "hole taller than max_empty_walk_versions should yield an empty proposal";
+
+    // Bound 15: the step-down reaches v10 and anchors, so a band is proposed. max_version for a resume
+    // round is resume_from + 1 = 21, and the anchored chain bottoms out at version 1.
+    VacuumRequest wide_req;
+    VacuumResponse wide_resp;
+    make_resume_req(15, &wide_req);
+    vacuum(_tablet_mgr.get(), wide_req, &wide_resp);
+    ASSERT_EQ(0, wide_resp.status().status_code()) << wide_resp.status().error_msgs(0);
+    EXPECT_EQ(1, wide_resp.vacuum_state().to_delete_low());
+    EXPECT_EQ(21, wide_resp.vacuum_state().to_delete_high());
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30003, 10))); // propose deletes nothing
+}
+
+// When every version the walk reaches is still within the grace window, the round proposes nothing and
+// deletes nothing (the whole partition range is the intersection across tablets, so one grace-blocked
+// tablet zeroes the round).
+TEST_P(LakeVacuumTest, test_incremental_grace_blocked) {
+    // All versions committed AFTER the grace timestamp (commit_time 4e9 > grace 1000): none deletable.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30004, "version": 2, "prev_garbage_version": 0, "commit_time": 4000000000 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30004, "version": 3, "prev_garbage_version": 2, "commit_time": 4000000001 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30004, "version": 4, "prev_garbage_version": 3, "commit_time": 4000000002 })DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_partition_id(3000);
+    request.set_min_retain_version(4);
+    request.set_grace_timestamp(1000);
+    request.set_max_versions_per_round(100);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(30004);
+    info->set_min_version(1);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // Nothing proposed; every version retained.
+    EXPECT_GE(response.vacuum_state().to_delete_low(), response.vacuum_state().to_delete_high());
+    EXPECT_EQ(0, response.vacuumed_files());
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30004, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30004, 3)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30004, 4)));
+}
+
+// End-to-end drain: a long chain under a small per-round budget takes several propose/commit rounds
+// (following the resume cursor) to reclaim everything below the retain floor. Driving the round-trip to
+// convergence must delete every garbage version and keep only the floor.
+TEST_P(LakeVacuumTest, test_incremental_multi_round_drain) {
+    // Chain v6 -> v5 -> v4 -> v3 -> v2 -> bottom(0).
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30005, "version": 2, "prev_garbage_version": 0, "commit_time": 1002 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30005, "version": 3, "prev_garbage_version": 2, "commit_time": 1003 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30005, "version": 4, "prev_garbage_version": 3, "commit_time": 1004 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30005, "version": 5, "prev_garbage_version": 4, "commit_time": 1005 })DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30005, "version": 6, "prev_garbage_version": 5, "commit_time": 1006 })DEL")));
+
+    VacuumStatePB state; // empty -> first round is fresh
+    int64_t pass_floor = 0; // the FE captures the pass retain floor on the fresh round and holds it constant
+    bool drained = false;
+    for (int round = 0; round < 20 && !drained; round++) {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_partition_id(3000);
+        request.set_min_retain_version(6);
+        request.set_grace_timestamp(4000000000);
+        request.set_max_versions_per_round(2); // small budget -> multiple rounds
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(30005);
+        info->set_min_version(1);
+        // A fresh round is one whose walk starts from the top (no resume cursor carried in).
+        bool fresh = (state.next_propose_start_version() == 0);
+        request.mutable_vacuum_state()->CopyFrom(state);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        const auto& resp = response.vacuum_state();
+        // Mirror the FE: the BE echoes pass_start_version only on a fresh round, so capture it there and
+        // replay it on every resume round's commit (which validates pass_start_version >= delete-range high).
+        if (fresh && resp.pass_start_version() > 0) {
+            pass_floor = resp.pass_start_version();
+        }
+        state = resp;
+        state.set_pass_start_version(pass_floor);
+        // Drained once the round both proposes nothing and leaves no resume cursor.
+        drained = state.to_delete_low() >= state.to_delete_high() && state.next_propose_start_version() == 0;
+    }
+    ASSERT_TRUE(drained) << "pass did not converge within the round budget";
+    // Everything below the retain floor 6 reclaimed; only the floor remains.
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30005, 2)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30005, 3)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30005, 4)));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30005, 5)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30005, 6)));
+}
+
+// A commit that reclaims a garbage version carrying shared segments must run the shared-file liveness scan:
+// a shared file still referenced by a live rowset at the retain floor is spared; a shared file referenced only
+// by the garbage version is deleted. Exercises the incremental commit's Step 2 (collect_alive_shared_files).
+TEST_P(LakeVacuumTest, test_incremental_shared_file_cleanup) {
+    const std::string kept = "0000000000030010_00000000-0000-0000-0000-00000000000a.dat";
+    const std::string dropped = "0000000000030010_00000000-0000-0000-0000-00000000000b.dat";
+    create_data_file(kept);
+    create_data_file(dropped);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        { "id": 30010, "version": 1, "prev_garbage_version": 0, "commit_time": 1000 })DEL")));
+    // v2 (garbage): both shared segments live here as compaction inputs.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 30010, "version": 2, "prev_garbage_version": 1, "commit_time": 1001,
+            "compaction_inputs": [ { "data_size": 4096, "segment_metas": [
+                { "filename": "0000000000030010_00000000-0000-0000-0000-00000000000a.dat", "shared": true },
+                { "filename": "0000000000030010_00000000-0000-0000-0000-00000000000b.dat", "shared": true } ] } ]
+        })DEL")));
+    // v3 (retain floor): still references the "kept" shared segment in a live rowset.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 30010, "version": 3, "prev_garbage_version": 2, "commit_time": 1002,
+            "rowsets": [ { "data_size": 4096, "segment_metas": [
+                { "filename": "0000000000030010_00000000-0000-0000-0000-00000000000a.dat", "shared": true } ] } ]
+        })DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_partition_id(3000);
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(4000000000);
+    request.set_max_versions_per_round(100);
+    request.set_enable_shared_file_cleanup(true);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(30010);
+    info->set_min_version(1);
+    auto* vs = request.mutable_vacuum_state();
+    vs->set_to_delete_low(2);
+    vs->set_to_delete_high(3);
+    vs->set_pass_start_version(3);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // "kept" is still referenced at the floor -> spared; "dropped" is garbage-only -> deleted; v2 meta gone.
+    EXPECT_TRUE(file_exist(kept));
+    EXPECT_FALSE(file_exist(dropped));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(30010, 2)));
+    EXPECT_TRUE(file_exist(tablet_metadata_filename(30010, 3)));
+}
+
+// The retain floor is a batch-publish hole on this tablet (no v3), but a materialized snapshot at v4 above it
+// still references the shared segment. The liveness scan must step UP from the hole floor to v4 to find the
+// live reference and spare the file (step-up "anchored" INFO path).
+TEST_P(LakeVacuumTest, test_incremental_shared_stepup_anchored) {
+    const std::string shared = "0000000000030020_00000000-0000-0000-0000-00000000000c.dat";
+    create_data_file(shared);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 30020, "version": 2, "prev_garbage_version": 1, "commit_time": 1000,
+            "compaction_inputs": [ { "data_size": 4096, "segment_metas": [
+                { "filename": "0000000000030020_00000000-0000-0000-0000-00000000000c.dat", "shared": true } ] } ]
+        })DEL")));
+    // No version 3 -> the retain floor is a hole; v4 above it references the shared segment in a live rowset.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 30020, "version": 4, "prev_garbage_version": 1, "commit_time": 1002,
+            "rowsets": [ { "data_size": 4096, "segment_metas": [
+                { "filename": "0000000000030020_00000000-0000-0000-0000-00000000000c.dat", "shared": true } ] } ]
+        })DEL")));
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_partition_id(3000);
+    request.set_min_retain_version(4);
+    request.set_grace_timestamp(4000000000);
+    request.set_max_versions_per_round(100);
+    request.set_max_empty_walk_versions(5);
+    request.set_enable_shared_file_cleanup(true);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(30020);
+    info->set_min_version(1);
+    auto* vs = request.mutable_vacuum_state();
+    vs->set_to_delete_low(2);
+    vs->set_to_delete_high(3);
+    vs->set_pass_start_version(3);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // Step-up from hole floor 3 to materialized v4 finds the live reference -> shared file spared.
+    EXPECT_TRUE(file_exist(shared));
+}
+
+// The retain floor is a hole and NO materialized snapshot exists within max_empty_walk_versions above it, so
+// the liveness scan cannot resolve the tablet's references and abandons shared cleanup this round (clear),
+// keeping all candidates (step-up "abandoned" WARNING/clear path).
+TEST_P(LakeVacuumTest, test_incremental_shared_stepup_abandoned) {
+    const std::string shared = "0000000000030021_00000000-0000-0000-0000-00000000000d.dat";
+    create_data_file(shared);
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 30021, "version": 2, "prev_garbage_version": 1, "commit_time": 1000,
+            "compaction_inputs": [ { "data_size": 4096, "segment_metas": [
+                { "filename": "0000000000030021_00000000-0000-0000-0000-00000000000d.dat", "shared": true } ] } ]
+        })DEL")));
+    // No version >= 3: the floor and everything within the step-up bound above it are holes.
+
+    VacuumRequest request;
+    VacuumResponse response;
+    request.set_partition_id(3000);
+    request.set_min_retain_version(3);
+    request.set_grace_timestamp(4000000000);
+    request.set_max_versions_per_round(100);
+    request.set_max_empty_walk_versions(2);
+    request.set_enable_shared_file_cleanup(true);
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(30021);
+    info->set_min_version(1);
+    auto* vs = request.mutable_vacuum_state();
+    vs->set_to_delete_low(2);
+    vs->set_to_delete_high(3);
+    vs->set_pass_start_version(3);
+    vacuum(_tablet_mgr.get(), request, &response);
+    ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    // No materialized snapshot within the bound -> shared cleanup abandoned, candidate kept.
+    EXPECT_TRUE(file_exist(shared));
+}
+
 INSTANTIATE_TEST_SUITE_P(LakeVacuumTest, LakeVacuumTest,
                          ::testing::Values(VacuumTestArg{1}, VacuumTestArg{3}, VacuumTestArg{100}));
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -4526,7 +4526,7 @@ TEST_P(LakeVacuumTest, test_incremental_multi_round_drain) {
     ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
         { "id": 30005, "version": 6, "prev_garbage_version": 5, "commit_time": 1006 })DEL")));
 
-    VacuumStatePB state; // empty -> first round is fresh
+    VacuumStatePB state;    // empty -> first round is fresh
     int64_t pass_floor = 0; // the FE captures the pass retain floor on the fresh round and holds it constant
     bool drained = false;
     for (int round = 0; round < 20 && !drained; round++) {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -374,6 +374,59 @@ message TabletInfoPB {
     optional int64 min_version = 2;
 }
 
+// The resumable, per-pass state of the incremental (range-based) vacuum protocol; see
+// VacuumRequest.max_versions_per_round. It round-trips between FE and BE as ONE unit: in a VacuumRequest
+// it is the range the previous round proposed (for this round to commit) plus the resume cursor and the
+// pass retain floor; in a VacuumResponse it is the range this round newly proposed. The FE persists it
+// per partition (one edit log per round), which is why it is grouped into a single message and tracked
+// per partition -- not per tablet: version NUMBERS are partition-wide (every publish advances the whole
+// partition's version), so one range and one cursor describe every tablet and the persisted state stays
+// O(1) per partition. The per-tablet metadata SNAPSHOTS, however, need not exist at every version: a
+// normal publish writes each tablet's metadata forward (a bundled file (0, v) or per-tablet (tablet_id,
+// v)), but batch publish folds a run of txns into a single snapshot at the batch's final version, so a
+// given partition version can be absent (a "hole") on some tablets. The BE walk tolerates that by
+// anchoring each tablet's chain to its nearest existing snapshot.
+message VacuumStatePB {
+    // The partition-version range [to_delete_low, to_delete_high) -- low inclusive, high EXCLUSIVE.
+    // to_delete_high is the intersection retained floor (the MIN over the partition's tablets of their
+    // grace/min_retain boundary), so every version strictly below it is deletable by every tablet. A
+    // commit does not delete to_delete_high itself; it derives the band's top real chain node from it
+    // (the node just below the floor for a fresh band, or to_delete_high - 1 for a resume band) -- and if
+    // that version was folded away on a tablet (a batch-publish hole), steps down to that tablet's nearest
+    // existing version to anchor -- then walks each tablet's prev_garbage_version chain down to
+    // to_delete_low collecting the garbage data files,
+    // then deletes the bundled (or per-tablet) metadata in the range. Deletion is ascending and
+    // idempotent: a version with no file is treated as already deleted. Both 0/unset means "no range" (a
+    // fresh round, nothing proposed, or just reset).
+    optional int64 to_delete_low = 1;
+    optional int64 to_delete_high = 2;
+    // The partition version the chain walk resumes from. Unset/0 means "start a fresh pass from
+    // min_retain_version" (the first round of a pass, or right after the old chain was fully cleaned). In
+    // a VacuumResponse, 0 is also the sentinel for "the chain bottom was reached -- the pass has drained".
+    optional int64 next_propose_start_version = 3;
+    // The pass retain floor: the LOWEST partition version this whole pass keeps (everything below it is
+    // deleted band by band; it and above are retained for the pass). It is fixed for the entire pass --
+    // the fresh round computes it as the lowest surviving version (the MIN over tablets of their
+    // grace/min_retain boundary) and returns it here; the FE persists it as a pass constant and replays
+    // it on every commit round, resetting only when the next fresh round starts a new pass. The commit
+    // reads this version's metadata to spare the shared data files still referenced by surviving tablets.
+    //
+    // CONTRACT (the FE MUST honor this): on every round of a pass -- the fresh round AND every resume
+    // round -- this field carries the value the BE returned for THAT pass's fresh round (the round whose
+    // next_propose_start_version was 0/unset). It is a per-pass constant. The FE must NOT set it to the
+    // current round's to_delete_high, nor recompute it per round. The BE distinguishes a fresh-band
+    // commit from a resume-band commit by whether to_delete_high equals this field, and reads exactly
+    // this version for shared-file liveness; replaying to_delete_high instead would misdrive both.
+    //
+    // Why the MIN (unlike legacy one-shot vacuum which reads the MAX retain boundary): a shared file can
+    // be garbage for one tablet yet still referenced by another at this floor, so reading any version
+    // higher than the floor could dangle that reference. Reading the floor is safe because lake versions
+    // are partition-wide and incremental vacuum only deletes strictly below the floor, so the floor's
+    // metadata survives for every tablet throughout the pass. The two coincide when tablets are
+    // version-synchronized (the normal case). In a VacuumResponse, set only on a fresh round.
+    optional int64 pass_start_version = 4;
+}
+
 message VacuumRequest {
     // This field is deprecated, use |tablet_infos| instead.
     repeated int64 tablet_ids = 1; // deprecated
@@ -410,6 +463,30 @@ message VacuumRequest {
     // the request is received. After it elapses the FE has given up, so the BE task
     // should abort itself proactively instead of keeping a vacuum worker occupied.
     optional int64 timeout_ms = 11;
+
+    // ---- Incremental (range-based, resumable) vacuum protocol. ----
+    // Upper bound on how many partition versions a single round may advance the chain walk, so one round
+    // cannot run long enough to hit the RPC timeout wall. Its PRESENCE (set, > 0) is also what selects
+    // the incremental protocol: when set, the BE commits the previously proposed range carried in
+    // vacuum_state, walks at most this many versions further down from its
+    // next_propose_start_version, and returns the newly proposed range in VacuumResponse. When unset the
+    // BE keeps the legacy behavior of walking the whole chain in one round -- an old FE never sets it, so
+    // an upgraded BE transparently falls back and no FE/BE pair can disagree about the protocol in effect.
+    optional int64 max_versions_per_round = 12;
+    // The state the previous round proposed and the FE persisted: the range this round should commit, the
+    // cursor to resume the walk from, and the pass retain floor. See VacuumStatePB.
+    optional VacuumStatePB vacuum_state = 13;
+    // Upper bound on how many missing versions the propose walk may step through, BEFORE it anchors, while
+    // searching for the nearest existing version below the resume cursor. The only legitimate run of missing
+    // versions is a batch-publish hole (consecutive txns folded into one metadata version), which spans at
+    // most lake_batch_publish_max_version_num versions -- so the FE feeds that config here. A tablet that
+    // cannot anchor within this many step-downs is not in a batch-publish hole but lagging / cross-generation
+    // (its versions all sit below the band being proposed), so it contributes nothing this round; stop early
+    // instead of grinding all the way to max_versions_per_round, which against a cross-generation tablet set
+    // is pure wasted remote reads. Bounds ONLY the pre-anchor step-down; the post-anchor chain walk and the
+    // band width stay bounded by max_versions_per_round. Unset / <= 0 (an old FE) falls back to
+    // max_versions_per_round, preserving the previous behavior.
+    optional int64 max_empty_walk_versions = 14;
 }
 
 message VacuumResponse {
@@ -424,6 +501,13 @@ message VacuumResponse {
     repeated TabletInfoPB tablet_infos = 5;
     // The total file size need to be vacuumed
     optional int64 extra_file_size = 6;
+
+    // ---- Incremental vacuum protocol result. ----
+    // The next-round state the FE must persist atomically in a single edit log: persisting it both
+    // acknowledges that the range the FE sent in this request has been committed and records the newly
+    // proposed range to commit next round (plus the resume cursor and, on a fresh round, the pass retain
+    // floor). Empty / unset means nothing new was proposed. See VacuumStatePB.
+    optional VacuumStatePB vacuum_state = 7;
 }
 
 // 1. Before the orphaned data file cleanup starts, VacuumFull will delete metadata files which satisfy the following:


### PR DESCRIPTION
## Why I'm doing:

A large "death-spiral" partition can accumulate so many garbage metadata versions that a single one-shot vacuum walks the whole chain and hits the vacuum RPC timeout before it deletes anything. Because the round times out, it never makes progress, and the partition's garbage grows without bound — the vacuum can never converge. We need a vacuum that always makes bounded, durable forward progress no matter how deep the backlog is.

## What I'm doing:

This adds a bounded, resumable vacuum protocol for the shared-data lake. Each round commits the version range the previous round proposed (and the FE persisted), then proposes the next range plus a resume cursor, doing at most a fixed amount of work per round. The protocol is gated purely by the presence of the new `max_versions_per_round` request field, so an old FE that never sets it falls through to the existing one-shot path unchanged — no mode flag, no FE/BE disagreement possible. It works for both file-bundling and non-bundling tables, since lake metadata versions are partition-wide.

- **`lake_service.proto`**: add `max_versions_per_round` to `VacuumRequest` (its presence selects the protocol), a new `VacuumStatePB` message (`to_delete_low`, `to_delete_high`, `next_propose_start_version`, `pass_start_version`) carried by both `VacuumRequest` (range to commit + resume cursor + pass retain floor) and `VacuumResponse` (newly proposed range), and `max_empty_walk_versions` (the pre-anchor hole-search bound). All optional/additive.
- **`propose_metadata_range`**: a compute-only walk that resumes a top-down descent from a cursor, caps it at `max_versions_per_round`, and reports the next `[to_delete_low, to_delete_high)` range (high = the intersection retain floor = min of the per-tablet retain boundaries), the resume cursor, and — on a fresh round — the pass retain floor. Width-clamps a single oversized `prev_garbage_version` hop to the budget and carries the remainder on the resume cursor, so every committed range stays bounded. A tablet that folded the entry version away anchors its walk by stepping down to its nearest existing version (bounded by `max_empty_walk_versions`), so a per-tablet hole does not zero the whole round via the intersection.
- **`commit_metadata_range`**: physically delete a persisted `[to_delete_low, to_delete_high)` range, data-first then metadata, idempotently, without consulting `grace_timestamp`. Anchors each tablet's `prev_garbage_version` chain by entering at (or just below) `to_delete_high`, stepping down past batch-publish holes instead of treating an absent per-tablet version as corruption. Reads the pass retain floor to spare shared files still referenced by surviving tablets.
- **`VacuumTabletMetaVerionRange`**: `intersect_low` takes the max of the per-tablet low ends, so a bounded round never deletes bundled metadata below a tablet that has not yet collected it.
- **`vacuum_impl`**: in incremental mode commit the previous range, then propose the next one and return it to the FE. The legacy one-shot path is left untouched.
- **`vacuum_test.cpp`**: add `LakeVacuumTest.test_incremental_*` unit tests covering propose-then-commit, the per-round width clamp, the `max_empty_walk_versions` bound, grace-blocked rounds, and an end-to-end multi-round drain to convergence.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
