### PR TITLE
[BugFix] Refuse to write a bundle tablet metadata file that misses tablets

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -19,6 +19,8 @@
 #include <bthread/mutex.h>
 #include <butil/time.h> // NOLINT
 
+#include <set>
+
 #include "agent/agent_server.h"
 #include "base/brpc/brpc.h"
 #include "base/concurrency/countdown_latch.h"
@@ -680,10 +682,37 @@ struct RequestContext {
     std::unique_ptr<ResponseType> resp;
 };
 
+// The tablet ids an aggregate publish is expected to return metadata for, or an empty set meaning
+// "cannot tell, skip the coverage check".
+//
+// Only plain transactions are modelled, where the bundle must contain exactly the requested
+// tablet_ids. A reshard writes a set that has little to do with what was requested: which ids it
+// covers is decided inside handle_splitting_tablet / handle_merging_tablet / handle_identical_tablet
+// and differs per reshard kind and per txn type, and both sides of a split or merge get metadata at
+// the new version. Restating those rules here would duplicate them in a second place and risk
+// failing a legitimate reshard publish, so skip the coverage check whenever any sub-request carries
+// reshard info.
+static void collect_expected_metadata_tablet_ids(const AggregatePublishVersionRequest& request,
+                                                 std::set<int64_t>* expected) {
+    for (const auto& publish_req : request.publish_reqs()) {
+        if (publish_req.resharding_tablet_infos_size() > 0) {
+            expected->clear();
+            return;
+        }
+        for (auto tablet_id : publish_req.tablet_ids()) {
+            expected->insert(tablet_id);
+        }
+    }
+}
+
 struct AggregatePublishContext {
     bthread::Mutex mutex;
     bool has_failure{false};
     std::map<int64_t, TabletMetadata> tablet_metas;
+    // Union of what every sub-request was asked to publish, derived from the request rather than
+    // from the responses, so that a response silently short of a tablet cannot pass the check in
+    // put_bundle_tablet_metadata(). Empty for reshard publishes, which skip that check.
+    std::set<int64_t> expected_tablet_ids;
     std::unique_ptr<BThreadCountDownLatch> latch;
     PublishVersionResponse* response;
     Status publish_status = Status::OK();
@@ -761,7 +790,11 @@ struct AggregatePublishContext {
                             DeferOp defer([&] { latch.count_down(); });
                             publish_status =
                                     StorageEnv::GetInstance()->lake_tablet_manager()->put_bundle_tablet_metadata(
-                                            tablet_metas);
+                                            tablet_metas, expected_tablet_ids);
+                            if (!publish_status.ok()) {
+                                g_aggregate_publish_version_failed_tasks << 1;
+                                LOG(WARNING) << "Fail to write bundle tablet metadata: " << publish_status;
+                            }
                         },
                         [&] {
                             publish_status = Status::Cancelled("put_bundle_tablet_metadata task has been cancelled");
@@ -807,6 +840,9 @@ void LakeServiceImpl::aggregate_publish_version(::google::protobuf::RpcControlle
     AggregatePublishContext ctx;
     ctx.response = response;
     ctx.latch = std::make_unique<BThreadCountDownLatch>(request->publish_reqs_size());
+    // Collected up front, over every sub-request: the loop below stops dispatching once one of
+    // them fails, and the expected set must describe the whole publish either way.
+    collect_expected_metadata_tablet_ids(*request, &ctx.expected_tablet_ids);
 
     for (int i = 0; i < request->publish_reqs_size(); ++i) {
         if (ctx.has_failure) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -550,13 +550,47 @@ int64_t TabletManager::pick_local_anchor_tablet_id(const std::vector<int64_t>& c
     return candidates.front();
 }
 
+// Refuse to persist a bundle that does not cover every tablet in |expected_tablet_ids|.
+//
+// This is an invariant of the file format rather than defensive paranoia: the file name encodes a
+// version and the write truncates, so the bundle IS the whole metadata of that version. A map short
+// by even one tablet silently yields a version that lacks it, which is unrecoverable once FE marks
+// the version visible, because every later publish must read exactly that version as its base and
+// can only reproduce the same miss. Failing here instead leaves the version unpublished, which is
+// retryable.
+static Status check_bundle_tablet_metadata_coverage(const std::map<int64_t, TabletMetadataPB>& tablet_metas,
+                                                    const std::set<int64_t>& expected_tablet_ids) {
+    std::string missing;
+    size_t missing_count = 0;
+    for (int64_t expected_id : expected_tablet_ids) {
+        if (tablet_metas.find(expected_id) != tablet_metas.end()) {
+            continue;
+        }
+        // Cap the id list: a whole sub-request can go missing at once, and this string ends up in
+        // the publish error that FE retries every few milliseconds.
+        if (missing_count < 16) {
+            missing.append(missing.empty() ? "" : ",").append(std::to_string(expected_id));
+        }
+        ++missing_count;
+    }
+    if (missing_count > 0) {
+        return Status::InternalError(
+                fmt::format("refuse to write incomplete bundle tablet metadata: missing {} of {} tablets [{}{}]",
+                            missing_count, expected_tablet_ids.size(), missing, missing_count > 16 ? ",..." : ""));
+    }
+    return Status::OK();
+}
+
 // NOTE: tablet_metas is non-const and we will clear schemas for optimization.
 // Callers should ensure thread safety.
-Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas) {
+Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas,
+                                                 const std::set<int64_t>& expected_tablet_ids) {
     TEST_ERROR_POINT("TabletManager::put_bundle_tablet_metadata");
     if (tablet_metas.empty()) {
         return Status::InternalError("tablet_metas cannot be empty");
     }
+
+    RETURN_IF_ERROR(check_bundle_tablet_metadata_coverage(tablet_metas, expected_tablet_ids));
 
     std::vector<int64_t> candidate_tablet_ids;
     candidate_tablet_ids.reserve(tablet_metas.size());

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -16,6 +16,7 @@
 
 #include <bthread/types.h>
 
+#include <set>
 #include <shared_mutex>
 #include <utility>
 #include <variant>
@@ -96,7 +97,29 @@ public:
 
     Status cache_tablet_metadata(const TabletMetadataPtr& metadata);
 
-    Status put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas);
+    // Persist every entry of |tablet_metas| into a single bundle metadata file named after the
+    // version they all share.
+    //
+    // |expected_tablet_ids| is the set of tablets the caller was asked to produce metadata for, or
+    // empty to skip the coverage check.
+    //
+    // The bundle is written with CREATE_OR_OPEN_WITH_TRUNCATE, i.e. the file IS the complete
+    // metadata for that version: a map short by even one tablet silently yields a version whose
+    // metadata is missing that tablet. That is unrecoverable once FE marks the version visible,
+    // because every later publish must read exactly that version as its base -- retries can only
+    // reproduce the same miss. So refuse to write anything unless the map covers the expected set.
+    // Extra tablets beyond that set are tolerated -- only under-coverage loses data.
+    //
+    // The set is only worth passing when it comes from a source independent of whatever produced
+    // |tablet_metas|; derived from the same place it would just compare that source against itself.
+    // Callers with no such source pass empty -- which is also what the single-argument overload
+    // does, leaving them exactly as they were.
+    Status put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas,
+                                      const std::set<int64_t>& expected_tablet_ids);
+
+    Status put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas) {
+        return put_bundle_tablet_metadata(tablet_metas, {});
+    }
 
     // When using get_tablet_metadata to determine whether a new version exists in publish version,
     // a valid expected_gtid must be passed in.

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -5031,6 +5031,128 @@ TEST_F(LakeServiceTest, test_aggregate_publish_version_failed) {
     server.Join();
 }
 
+// Reproduces the shape of the incident this guard exists for: a sub-worker answers OK but its
+// response is short one tablet_meta. Before the coverage check the aggregator happily truncate-wrote
+// a bundle missing that tablet, FE saw OK and advanced the visible version, and the tablet's metadata
+// at that version was gone for good. Now the write is refused and the publish fails, so FE retries.
+TEST_F(LakeServiceTest, test_aggregate_publish_version_incomplete_tablet_metas) {
+    brpc::Server server;
+    MockLakeServiceImpl mock_service;
+    int port = 0;
+    init_server_with_mock(&mock_service, &server, &port);
+
+    constexpr int64_t kTabletId1 = 9001;
+    constexpr int64_t kTabletId2 = 9002;
+    // A version no other case in this fixture writes: TearDown() keeps the test dir, so a bundle
+    // left by an earlier case at the same path would mask the "nothing was written" assertion.
+    constexpr int64_t kVersion = 77;
+
+    auto request = build_default_agg_request(port);
+    request.mutable_publish_reqs(0)->add_tablet_ids(kTabletId1);
+    request.mutable_publish_reqs(0)->add_tablet_ids(kTabletId2);
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_id(10);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto c0 = schema_pb.add_column();
+    c0->set_unique_id(0);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    starrocks::TabletMetadataPB metadata1;
+    metadata1.set_id(kTabletId1);
+    metadata1.set_version(kVersion);
+    metadata1.mutable_schema()->CopyFrom(schema_pb);
+
+    // Only kTabletId1 comes back; kTabletId2 is silently absent while the status stays OK.
+    EXPECT_CALL(mock_service, publish_version(_, _, _, _))
+            .WillOnce(Invoke([&](::google::protobuf::RpcController*, const PublishVersionRequest*,
+                                 PublishVersionResponse* resp, ::google::protobuf::Closure* done) {
+                resp->mutable_status()->set_status_code(0);
+                (*resp->mutable_tablet_metas())[kTabletId1].CopyFrom(metadata1);
+                done->Run();
+            }));
+
+    PublishVersionResponse response;
+    brpc::Controller cntl;
+    google::protobuf::Closure* done = brpc::NewCallback([]() {});
+    _lake_service.aggregate_publish_version(&cntl, &request, &response, done);
+
+    EXPECT_NE(response.status().status_code(), 0);
+    // Nothing was written, so even the tablet that did come back has no metadata at this version.
+    EXPECT_FALSE(_tablet_mgr->get_single_tablet_metadata(kTabletId1, kVersion).ok());
+
+    server.Stop(0);
+    server.Join();
+}
+
+// A reshard rewrites the partition's tablet set, so "the bundle must hold exactly the requested
+// tablet_ids" does not apply and the coverage check is skipped. Pinned here so the skip is not
+// silently lost: a split publish whose bundle holds ids other than the requested one must still go
+// through.
+TEST_F(LakeServiceTest, test_aggregate_publish_version_skips_coverage_check_for_reshard) {
+    brpc::Server server;
+    MockLakeServiceImpl mock_service;
+    int port = 0;
+    init_server_with_mock(&mock_service, &server, &port);
+
+    constexpr int64_t kOldTabletId = 9101;
+    constexpr int64_t kNewTabletId1 = 9102;
+    constexpr int64_t kNewTabletId2 = 9103;
+    constexpr int64_t kVersion = 78;
+
+    auto request = build_default_agg_request(port);
+    auto* publish_req = request.mutable_publish_reqs(0);
+    publish_req->add_tablet_ids(kOldTabletId);
+    auto* splitting = publish_req->add_resharding_tablet_infos()->mutable_splitting_tablet_info();
+    splitting->set_old_tablet_id(kOldTabletId);
+    splitting->add_new_tablet_ids(kNewTabletId1);
+    splitting->add_new_tablet_ids(kNewTabletId2);
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_id(10);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto c0 = schema_pb.add_column();
+    c0->set_unique_id(0);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    // Only the split-off tablets come back; the requested kOldTabletId does not. Under the coverage
+    // check this would be rejected, which is exactly why reshard must be exempt.
+    EXPECT_CALL(mock_service, publish_version(_, _, _, _))
+            .WillOnce(Invoke([&](::google::protobuf::RpcController*, const PublishVersionRequest*,
+                                 PublishVersionResponse* resp, ::google::protobuf::Closure* done) {
+                resp->mutable_status()->set_status_code(0);
+                for (int64_t tablet_id : {kNewTabletId1, kNewTabletId2}) {
+                    auto& meta = (*resp->mutable_tablet_metas())[tablet_id];
+                    meta.set_id(tablet_id);
+                    meta.set_version(kVersion);
+                    meta.mutable_schema()->CopyFrom(schema_pb);
+                }
+                done->Run();
+            }));
+
+    PublishVersionResponse response;
+    brpc::Controller cntl;
+    google::protobuf::Closure* done = brpc::NewCallback([]() {});
+    _lake_service.aggregate_publish_version(&cntl, &request, &response, done);
+
+    EXPECT_EQ(response.status().status_code(), 0);
+    EXPECT_TRUE(_tablet_mgr->get_single_tablet_metadata(kNewTabletId1, kVersion).ok());
+    EXPECT_TRUE(_tablet_mgr->get_single_tablet_metadata(kNewTabletId2, kVersion).ok());
+
+    server.Stop(0);
+    server.Join();
+}
+
 TEST_F(LakeServiceTest, test_task_cleared_in_thread_pool_queue) {
     class MockRunnable : public Runnable {
     public:

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -1212,6 +1212,78 @@ TEST_F(LakeTabletManagerTest, parse_bundle_tablet_metadata_with_zero_size) {
     EXPECT_TRUE(res.status().is_corruption());
 }
 
+// The bundle file is the complete metadata of one version and is written with truncate semantics,
+// so persisting a map that is short a tablet corrupts that version permanently: FE makes it
+// visible, and every later publish must read exactly that version as its base, so no retry can
+// ever repair it. Refuse the write instead; the version stays unpublished and the publish is
+// retryable.
+TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata_rejects_incomplete_bundle) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_id(10);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_rows_per_row_block(65535);
+    auto c0 = schema_pb.add_column();
+    c0->set_unique_id(0);
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    const int64_t t1 = next_id();
+    const int64_t t2 = next_id();
+    const int64_t t3 = next_id();
+    const std::set<int64_t> expected{t1, t2, t3};
+
+    auto make_meta = [&](int64_t tablet_id) {
+        TabletMetadataPB meta;
+        meta.set_id(tablet_id);
+        meta.set_version(2);
+        meta.mutable_schema()->CopyFrom(schema_pb);
+        return meta;
+    };
+    auto fs = FileSystem::Default();
+    // All three ids live in the same partition directory, so any of them names the same bundle file.
+    auto bundle_path = _tablet_manager->bundle_tablet_metadata_location(t1, 2);
+
+    // Short by one tablet: rejected, and nothing is left on disk.
+    {
+        std::map<int64_t, TabletMetadataPB> metadatas;
+        metadatas.emplace(t1, make_meta(t1));
+        metadatas.emplace(t2, make_meta(t2));
+        auto st = _tablet_manager->put_bundle_tablet_metadata(metadatas, expected);
+        ASSERT_FALSE(st.ok());
+        EXPECT_TRUE(MatchPattern(st.message(), fmt::format("*missing 1 of 3 tablets*{}*", t3))) << st.message();
+        EXPECT_TRUE(fs->path_exists(bundle_path).is_not_found());
+    }
+
+    // An empty expected set skips the check: callers that cannot state the tablet set up front still
+    // get their bundle written.
+    {
+        std::map<int64_t, TabletMetadataPB> metadatas;
+        metadatas.emplace(t1, make_meta(t1));
+        ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+        EXPECT_TRUE(fs->path_exists(bundle_path).ok());
+        ASSERT_OK(fs->delete_file(bundle_path));
+        _tablet_manager->metacache()->prune();
+    }
+
+    // Complete: written, and every expected tablet is readable at that version.
+    {
+        std::map<int64_t, TabletMetadataPB> metadatas;
+        for (int64_t tablet_id : expected) {
+            metadatas.emplace(tablet_id, make_meta(tablet_id));
+        }
+        ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas, expected));
+        EXPECT_TRUE(fs->path_exists(bundle_path).ok());
+        for (int64_t tablet_id : expected) {
+            ASSIGN_OR_ABORT(auto metadata, _tablet_manager->get_single_tablet_metadata(tablet_id, 2));
+            EXPECT_EQ(tablet_id, metadata->id());
+            EXPECT_EQ(2, metadata->version());
+        }
+    }
+}
+
 // Regression for the aggregate-publish data-loss bug: an old worker sends a rowset whose segment_metas
 // lack filename, with the real names only in deprecated_segments. put_bundle_tablet_metadata must
 // persist metadata whose segment filename survives (reproduces old-worker -> new-aggregator).


### PR DESCRIPTION
## Why I'm doing:

On a shared-data cluster a partition's publish got stuck permanently with:

```
Fail to publish version for tablets:[[61956030]], error msg:
can not find tablet 61956030 from shared tablet metadata
```

Root cause, confirmed against the object store: the bundle metadata file for the
partition's visible version was written with **31 of its 32 tablet pages**. Parsing the
files directly:

```
0000000000000000_..394CE.meta (v234702)  32 pages   OK
0000000000000000_..394CF.meta (v234703)  32 pages   OK   (compaction version)
0000000000000000_..394D0.meta (v234704)  31 pages   <-- tablet 61956030 missing
```

The combined txn log of the load that produced v234704 contains all 32 tablets, so the
data was written correctly; the loss happened during publish. FE nonetheless received
`status_code == 0` and advanced the partition's visible version to 234704. From that
moment every publish, autovacuum and query touching that tablet failed forever, because
they all have to read exactly that version as their base and no retry can reconstruct
the missing page. ~1950 transactions backed up behind it and the FE publish daemon
hot-looped on the same error for a day.

The reason a short response could become a corrupt version is that nothing on the path
validates completeness:

- a sub-worker's `publish_version` sets `failed_tablets` + the response status on every
  *known* per-tablet failure, but nobody checks that `tablet_metas` actually covers
  `request->tablet_ids()`;
- `AggregatePublishContext::put_aggregate_metadata()` only looks at `has_failure`, not at
  what the aggregated map contains;
- `put_bundle_tablet_metadata()` writes with `CREATE_OR_OPEN_WITH_TRUNCATE` and has no
  notion of how many pages the bundle should have, so it happily writes 31.

## What I'm doing:

Refusing to persist a bundle that cannot be complete, so the failure stays transient and
retryable instead of being committed as an unrepairable version.

- `TabletManager::put_bundle_tablet_metadata()` takes an `expected_tablet_ids` set — the
  tablets the caller was asked to produce metadata for — and returns an error without
  writing anything when the map does not cover it. Extra tablets are tolerated; only
  under-coverage loses data. An **empty set skips the check**, which is what the existing
  single-argument overload passes, so every current caller keeps its behaviour.
- The set is only meaningful when it comes from a source independent of whatever produced
  the map; derived from the same place it would just compare that source against itself.
- The aggregate publish derives it from its **sub-requests**, not from the responses. The
  set is collected before the fan-out loop, because that loop stops dispatching once one
  sub-request fails and the expected set has to describe the whole publish anyway.
- **Only plain transactions are covered.** Which ids a reshard writes is decided inside
  `handle_splitting_tablet` / `handle_merging_tablet` / `handle_identical_tablet` and differs
  per reshard kind and per txn type, so "the bundle holds exactly the requested
  `tablet_ids`" does not hold there. Rather than restate those rules in a second place and
  risk failing a legitimate reshard publish, the check is skipped whenever a sub-request
  carries `resharding_tablet_infos`.
- `repair_tablet_metadata` is left untouched: its tablet ids and its metadata map are built
  from one and the same `request->tablet_metadatas()` loop, so a check there would only
  compare that loop against itself.

Deliberately **not** in this PR: rejecting a bundle whose pages carry different versions.
Every `lake::publish_version()` return path yields `new_version`, so aggregate publish cannot
produce a mixed-version map today; guarding it would mean an unconditional new check across
all existing callers for a case that cannot currently be reproduced. Worth doing separately,
with a scenario behind it.

No new config: this is a correctness invariant, and a failed check only fails one publish
attempt — the version is not advanced, so FE simply retries.

This is a guard, not a fix for whatever dropped the entry in the first place. The dropping
site itself could not be pinned down from the surviving evidence (the crashing worker's
logs for that window had rotated away and the bucket has versioning disabled); with this
check in place the same race fails loudly at write time and names the missing tablet.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

An aggregate publish or a metadata repair that would have written an incomplete bundle now
fails instead of succeeding. The version is left unpublished and FE retries, so a transient
cause self-heals; a deterministic one surfaces as a publish error naming the missing tablet
rather than as permanent metadata corruption.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Tests:

- `LakeServiceTest.test_aggregate_publish_version_incomplete_tablet_metas` reproduces the
  incident's shape: a mocked sub-worker answers `status_code == 0` but returns only one of
  the two requested `tablet_metas`. The aggregate publish must fail, and nothing may be
  written — even the tablet that *did* come back has no metadata at that version.
- `LakeTabletManagerTest.put_bundle_tablet_metadata_rejects_incomplete_bundle` covers the
  enforcement point directly: short-by-one is rejected and leaves no file, an empty expected
  set still writes, and a complete map is written and reads back per tablet.
- `LakeServiceTest.test_aggregate_publish_version_skips_coverage_check_for_reshard` pins the
  exemption: a split publish whose bundle holds ids other than the requested one must still
  succeed, so the skip cannot be silently lost.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
