### PR TITLE
[UT] Add failpoints to reproduce spillable sort cancel UAF on branch-4.0

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1312,6 +1312,15 @@ CONF_mInt32(spill_init_partition, "16");
 CONF_Int32(spill_max_partition_level, "7");
 CONF_Int32(spill_max_partition_size, "1024");
 
+// Test-only knobs for reproducing the spillable-sort cancel race. Both are inert at their
+// defaults. Kept as mutable configs rather than failpoints so they work in a stock build
+// (failpoints are compiled out unless the build passes --enable-fault-injection).
+// Force the spillable sorter into SPILL_ALL at do_done(), so it reliably has spilled state.
+CONF_mBool(spill_sort_force_spill_on_done, "false");
+// Park the spill IO thread for this long inside _spill_process_task(), right before it reads
+// _sorted_chunks, widening the window in which a concurrent cancel can destroy that vector.
+CONF_mInt32(spill_sort_process_task_sleep_ms, "0");
+
 // The maximum size of a single log block container file, this is not a hard limit.
 // If the file size exceeds this limit, a new file will be created to store the block.
 CONF_Int64(spill_max_log_block_container_bytes, "10737418240"); // 10GB

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -14,6 +14,7 @@
 
 #include <unistd.h>
 
+#include "common/config.h"
 #include "exec/chunks_sorter_full_sort.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/spiller.h"
@@ -68,6 +69,9 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
 Status SpillableChunksSorterFullSort::do_done(RuntimeState* state) {
     FAIL_POINT_TRIGGER_EXECUTE(chunk_sorter_spill_on_set_finishing,
                                { _spill_strategy = spill::SpillStrategy::SPILL_ALL; });
+    if (config::spill_sort_force_spill_on_done) {
+        _spill_strategy = spill::SpillStrategy::SPILL_ALL;
+    }
 
     if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         return ChunksSorterFullSort::do_done(state);
@@ -146,6 +150,9 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
         // while this task is still about to read those very vectors. Widens the race window that
         // the production crashes hit by chance; test-only.
         FAIL_POINT_TRIGGER_EXECUTE(spill_sort_process_task_sleep, { sleep(3); });
+        if (int ms = config::spill_sort_process_task_sleep_ms; ms > 0) {
+            usleep(static_cast<useconds_t>(ms) * 1000);
+        }
 
         if (_unsorted_chunk != nullptr) {
             return std::move(_unsorted_chunk);

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <unistd.h>
+
 #include "exec/chunks_sorter_full_sort.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/spiller.h"
 #include "exec/spill/spiller.hpp"
 #include "exec/spillable_chunks_sorter_sort.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks {
+DEFINE_FAIL_POINT(chunk_sorter_spill_on_set_finishing);
+DEFINE_FAIL_POINT(spill_sort_process_task_sleep);
+
 void SpillableChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* profile,
                                                   MemTracker* parent_mem_tracker) {
     ChunksSorterFullSort::setup_runtime(state, profile, parent_mem_tracker);
@@ -60,6 +66,9 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
 }
 
 Status SpillableChunksSorterFullSort::do_done(RuntimeState* state) {
+    FAIL_POINT_TRIGGER_EXECUTE(chunk_sorter_spill_on_set_finishing,
+                               { _spill_strategy = spill::SpillStrategy::SPILL_ALL; });
+
     if (_spill_strategy == spill::SpillStrategy::NO_SPILL) {
         return ChunksSorterFullSort::do_done(state);
     }
@@ -132,6 +141,12 @@ void SpillableChunksSorterFullSort::_update_revocable_mem_bytes() {
 
 std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_process_task() {
     return [this]() -> StatusOr<ChunkPtr> {
+        // Park the spill IO thread here so a concurrent cancel can drive SortContext::close()
+        // (which clears _chunks_sorter_partitions, destroying this sorter and its _sorted_chunks)
+        // while this task is still about to read those very vectors. Widens the race window that
+        // the production crashes hit by chance; test-only.
+        FAIL_POINT_TRIGGER_EXECUTE(spill_sort_process_task_sleep, { sleep(3); });
+
         if (_unsorted_chunk != nullptr) {
             return std::move(_unsorted_chunk);
         }

--- a/test/sql/test_spill/T/test_spill_sort_cancel
+++ b/test/sql/test_spill/T/test_spill_sort_cancel
@@ -1,0 +1,45 @@
+-- name: test_spill_sort_cancel @sequential
+
+set enable_spill=true;
+set spill_mode="NONE";
+
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(100))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+insert into t1 SELECT generate_series, 100000 - generate_series FROM TABLE(generate_series(1, 300000));
+
+-- Reproducer for the spillable-sort cancel race behind the normandy_staging CN crashes
+-- (BYOC d6ac9b18, 4.0.12, 39 x SIGSEGV / 36h).
+--
+-- Two failpoints together make the race deterministic:
+--   chunk_sorter_spill_on_set_finishing  forces the sorter into SPILL_ALL at do_done(), so it
+--                                        always has spilled state and a live spill task.
+--   spill_sort_process_task_sleep        parks the spill IO thread inside _spill_process_task()
+--                                        right before it reads _sorted_chunks.
+--
+-- query_timeout=1 then cancels the fragment while that task is parked. On cancel,
+-- SortContext::close() does a bare _chunks_sorter_partitions.clear() with no drain of in-flight
+-- spill tasks, destroying ~ChunksSorterFullSort (and its _sorted_chunks) under the parked thread.
+-- Expected on a fixed build: query fails cleanly with a timeout and the BE does NOT crash.
+-- On 4.0 under ASAN this is expected to report heap-use-after-free.
+admin enable failpoint 'chunk_sorter_spill_on_set_finishing';
+admin enable failpoint 'spill_sort_process_task_sleep';
+set query_timeout=1;
+
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+select sum(k1),sum(crc32(k2)),sum(rn) from (select k1,k2, row_number() over (PARTITION BY k1 order by k2) as rn from t1)t;
+
+admin disable failpoint 'spill_sort_process_task_sleep';
+admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+set query_timeout=300;
+
+-- After disabling the failpoints the same query must succeed again, proving the
+-- cancel path left no corrupted state behind.
+select sum(k1),sum(crc32(k2)) from (select k1,k2 from t1 order by k1,k2 limit 270000, 10)t;
+
+CLEANUP {
+    admin disable failpoint 'spill_sort_process_task_sleep';
+    admin disable failpoint 'chunk_sorter_spill_on_set_finishing';
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

**Draft — not for merge.** This exists to produce an ASAN build for reproducing a
production crash; see below.

BYOC cluster `d6ac9b18` (`normandy_staging`, 4.0.12-ee) took **39 SIGSEGV across 3 CNs
in 36 hours**. Every crash lands on the beat of one scheduled `INSERT OVERWRITE` that
retries every 15 minutes and is cancelled by `MEM_LIMIT_EXCEEDED` while its spillable
sorter is actively spilling (every audit row shows non-zero `SpilledBytes`).

The crash stacks fan out over 7 unrelated subsystems (lake metadata release, PK
persistent index, page cache, brpc/bvar/hyperscan, jemalloc internals) — the signature
of heap corruption, where the crash site is a victim rather than the defect. The one
candidate that is both on the cancel path and structurally racy:

- `SortContext::close()` does a bare `_chunks_sorter_partitions.clear()` with **no drain
  of in-flight spill tasks**, while `SpillableChunksSorterFullSort::_spill_process_task()`
  is concurrently reading `_sorted_chunks` on a spill IO thread.
- `spillable_partition_sort_sink_operator.cpp` captures `_chunks_sorter.get()` as a raw
  pointer despite the comment saying it captures a `shared_ptr`.

`branch-4.0` already carries the #75140 fix (via #75208), and these crashes happened
anyway — that fix only removed the extra cancel-task path, it did not add a drain.

Worse, **branch-4.0 currently has zero coverage for it**: the `test_spill_sort_cancel`
case that #75208 backported was deleted again by #76167 ("[UT] sqltest case
optimization"), and the failpoints it depends on
(`chunk_sorter_spill_on_set_finishing`, `spill_submit_error`) never existed on this
branch at all.

## What I'm doing:

Test-only change to make the race drivable on branch-4.0:

- `DEFINE_FAIL_POINT(chunk_sorter_spill_on_set_finishing)` — forces the sorter into
  `SPILL_ALL` at `do_done()`, ported from main, so the sorter reliably has spilled state
  and a live spill task.
- `DEFINE_FAIL_POINT(spill_sort_process_task_sleep)` — parks the spill IO thread inside
  `_spill_process_task()` immediately before it reads `_sorted_chunks`, widening the race
  window that production hits by chance.
- Restores `test/sql/test_spill/T/test_spill_sort_cancel`, using `query_timeout` as the
  cancel trigger.

I deliberately did **not** port `spill_submit_error`. On main it is bound up with the
in-flight-IO accounting refactor (`increase_in_flight_io` / `complete_io` and its
compensation logic), which branch-4.0 does not have — injecting a submit failure into
4.0's simpler `RETURN_IF_ERROR(TaskExecutor::submit(...))` would leak
`_running_flush_tasks` and manufacture a hang that is not the production bug. Timeout
and memory-limit cancels reproduce the real trigger without inventing an error path.

No behavior change when the failpoints are disabled.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch

