### PR TITLE
[BugFix] Make failpoint SQL control target compute nodes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
@@ -27,7 +27,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UpdateFailPointStatusStatement;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
@@ -38,10 +38,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class FailPointExecutor {
     private static final Logger LOG = LogManager.getLogger(FailPointExecutor.class);
@@ -69,40 +69,47 @@ public class FailPointExecutor {
         }
     }
 
+    /**
+     * Resolve BE/CN nodes for failpoint SQL control.
+     * When {@code backends} is null/empty, all alive backends and compute nodes are returned.
+     * Otherwise each {@code host:bePort} is resolved via {@link SystemInfoService#getBackendOrComputeNodeWithBePort}.
+     */
+    static List<ComputeNode> resolveNodes(SystemInfoService clusterInfoService, List<String> backends)
+            throws DdlException {
+        if (backends == null || backends.isEmpty()) {
+            List<ComputeNode> nodes = clusterInfoService.backendAndComputeNodeStream()
+                    .filter(ComputeNode::isAlive)
+                    .collect(Collectors.toList());
+            if (nodes.isEmpty()) {
+                throw new DdlException("No alive backends or compute nodes");
+            }
+            return nodes;
+        }
+
+        List<ComputeNode> nodes = Lists.newArrayList();
+        for (String backendAddr : backends) {
+            String[] tmp = backendAddr.split(":");
+            if (tmp.length != 2) {
+                throw new SemanticException("invalid backend addr");
+            }
+            ComputeNode node = clusterInfoService.getBackendOrComputeNodeWithBePort(
+                    tmp[0], Integer.parseInt(tmp[1]));
+            if (node == null) {
+                throw new SemanticException("cannot find backend or compute node with addr " + backendAddr);
+            }
+            nodes.add(node);
+        }
+        return nodes;
+    }
+
     private void updateBackendFailPoint(UpdateFailPointStatusStatement updateStmt) throws Exception {
         PUpdateFailPointStatusRequest request = updateStmt.toProto();
-
-        List<TNetworkAddress> backends = new LinkedList<>();
-        if (updateStmt.getBackends() == null || updateStmt.getBackends().isEmpty()) {
-            // effect all backends
-            List<Long> backendIds = clusterInfoService.getBackendIds(true);
-            if (backendIds == null) {
-                throw new DdlException("No alive backends");
-            }
-            for (long backendId : backendIds) {
-                Backend backend = clusterInfoService.getBackend(backendId);
-                if (backend == null) {
-                    continue;
-                }
-                backends.add(backend.getBrpcAddress());
-            }
-        } else {
-            for (String backendAddr : updateStmt.getBackends()) {
-                String[] tmp = backendAddr.split(":");
-                if (tmp.length != 2) {
-                    throw new SemanticException("invalid backend addr");
-                }
-                Backend backend = clusterInfoService.getBackendWithBePort(tmp[0], Integer.parseInt(tmp[1]));
-                if (backend == null) {
-                    throw new SemanticException("cannot find backend with addr " + backendAddr);
-                }
-                backends.add(backend.getBrpcAddress());
-            }
-        }
+        List<ComputeNode> nodes = resolveNodes(clusterInfoService, updateStmt.getBackends());
 
         // send request
         List<Pair<TNetworkAddress, Future<PUpdateFailPointStatusResponse>>> futures = Lists.newArrayList();
-        for (TNetworkAddress address : backends) {
+        for (ComputeNode node : nodes) {
+            TNetworkAddress address = node.getBrpcAddress();
             try {
                 futures.add(Pair.create(address,
                         BackendServiceClient.getInstance().updateFailPointStatusAsync(address, request)));
@@ -116,7 +123,7 @@ public class FailPointExecutor {
                 final PUpdateFailPointStatusResponse result = future.second.get(10, TimeUnit.SECONDS);
                 if (result != null && result.status.statusCode != TStatusCode.OK.getValue()) {
                     TNetworkAddress address = future.first;
-                    String errMsg = String.format("update failPoint status failed, backend: %s:%d, error: %s",
+                    String errMsg = String.format("update failPoint status failed, node: %s:%d, error: %s",
                             address.getHostname(), address.getPort(), result.status.errorMsgs.get(0));
                     LOG.warn(errMsg);
                     throw new DdlException(errMsg);
@@ -124,7 +131,7 @@ public class FailPointExecutor {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Throwable e) {
-                LOG.warn("update failPoint for backend: {} failed", future.first, e);
+                LOG.warn("update failPoint for node: {} failed", future.first, e);
                 throw e;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/failpoint/FailPointExecutor.java
@@ -74,7 +74,7 @@ public class FailPointExecutor {
      * When {@code backends} is null/empty, all alive backends and compute nodes are returned.
      * Otherwise each {@code host:bePort} is resolved via {@link SystemInfoService#getBackendOrComputeNodeWithBePort}.
      */
-    static List<ComputeNode> resolveNodes(SystemInfoService clusterInfoService, List<String> backends)
+    public static List<ComputeNode> resolveNodes(SystemInfoService clusterInfoService, List<String> backends)
             throws DdlException {
         if (backends == null || backends.isEmpty()) {
             List<ComputeNode> nodes = clusterInfoService.backendAndComputeNodeStream()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -116,6 +116,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.datacache.DataCacheMgr;
+import com.starrocks.failpoint.FailPointExecutor;
 import com.starrocks.lake.TabletRepairHelper;
 import com.starrocks.load.DeleteMgr;
 import com.starrocks.load.ExportJob;
@@ -273,7 +274,7 @@ import com.starrocks.statistic.ExternalHistogramStatsMeta;
 import com.starrocks.statistic.HistogramStatsMeta;
 import com.starrocks.statistic.MultiColumnStatsMeta;
 import com.starrocks.statistic.StatisticUtils;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TAuthInfo;
@@ -302,7 +303,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -3215,51 +3215,31 @@ public class ShowExecutor {
                 matcher = PatternMatcher.createMysqlPattern(statement.getPattern(),
                         CaseSensibility.VARIABLES.getCaseSensibility());
             }
-            List<Backend> backends = new LinkedList<>();
-            if (statement.getBackends() == null) {
-                List<Long> backendIds = clusterInfoService.getBackendIds(true);
-                if (backendIds == null) {
-                    throw new SemanticException("No alive backends");
-                }
-                for (long backendId : backendIds) {
-                    Backend backend = clusterInfoService.getBackend(backendId);
-                    if (backend == null) {
-                        continue;
-                    }
-                    backends.add(backend);
-                }
-            } else {
-                for (String backendAddr : statement.getBackends()) {
-                    String[] tmp = backendAddr.split(":");
-                    if (tmp.length != 2) {
-                        throw new SemanticException("invalid backend addr");
-                    }
-                    Backend backend = clusterInfoService.getBackendWithBePort(tmp[0], Integer.parseInt(tmp[1]));
-                    if (backend == null) {
-                        throw new SemanticException("cannot find backend with addr " + backendAddr);
-                    }
-                    backends.add(backend);
-                }
+            List<ComputeNode> nodes;
+            try {
+                nodes = FailPointExecutor.resolveNodes(clusterInfoService, statement.getBackends());
+            } catch (DdlException e) {
+                throw new SemanticException(e.getMessage());
             }
             // send request
-            List<Pair<Backend, Future<PListFailPointResponse>>> futures = Lists.newArrayList();
-            for (Backend backend : backends) {
+            List<Pair<ComputeNode, Future<PListFailPointResponse>>> futures = Lists.newArrayList();
+            for (ComputeNode node : nodes) {
                 try {
-                    futures.add(Pair.create(backend,
-                            BackendServiceClient.getInstance().listFailPointAsync(backend.getBrpcAddress(), request)));
+                    futures.add(Pair.create(node,
+                            BackendServiceClient.getInstance().listFailPointAsync(node.getBrpcAddress(), request)));
                 } catch (RpcException e) {
                     throw new SemanticException("sending list failpoint request fails");
                 }
             }
             // handle response
             List<List<String>> rows = Lists.newArrayList();
-            for (Pair<Backend, Future<PListFailPointResponse>> future : futures) {
+            for (Pair<ComputeNode, Future<PListFailPointResponse>> future : futures) {
                 try {
-                    final Backend backend = future.first;
+                    final ComputeNode node = future.first;
                     final PListFailPointResponse result = future.second.get(10, TimeUnit.SECONDS);
                     if (result != null && result.status.statusCode != TStatusCode.OK.getValue()) {
-                        String errMsg = String.format("list failpoint status failed, backend: %s:%d, error: %s",
-                                backend.getHost(), backend.getBePort(), result.status.errorMsgs.get(0));
+                        String errMsg = String.format("list failpoint status failed, node: %s:%d, error: %s",
+                                node.getHost(), node.getBePort(), result.status.errorMsgs.get(0));
                         LOG.warn(errMsg);
                         throw new SemanticException(errMsg);
                     }
@@ -3280,7 +3260,7 @@ public class ShowExecutor {
                         } else {
                             row.add("");
                         }
-                        row.add(String.format("%s:%d", backend.getHost(), backend.getBePort()));
+                        row.add(String.format("%s:%d", node.getHost(), node.getBePort()));
                         rows.add(row);
                     }
                 } catch (InterruptedException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.failpoint;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FailPointExecutorTest {
+    private SystemInfoService service;
+
+    @BeforeEach
+    public void setUp() {
+        service = new SystemInfoService();
+    }
+
+    @Test
+    public void testResolveAllAliveBackendAndComputeNodes() throws Exception {
+        Backend be = new Backend(10001, "127.0.0.1", 9050);
+        be.setBePort(9060);
+        be.setAlive(true);
+        service.addBackend(be);
+
+        ComputeNode cn = new ComputeNode(10002, "127.0.0.2", 9050);
+        cn.setBePort(9060);
+        cn.setAlive(true);
+        service.addComputeNode(cn);
+
+        ComputeNode deadCn = new ComputeNode(10003, "127.0.0.3", 9050);
+        deadCn.setBePort(9060);
+        deadCn.setAlive(false);
+        service.addComputeNode(deadCn);
+
+        List<ComputeNode> nodes = FailPointExecutor.resolveNodes(service, null);
+        Assertions.assertEquals(2, nodes.size());
+        Assertions.assertEquals(
+                Arrays.asList(10001L, 10002L),
+                nodes.stream().map(ComputeNode::getId).sorted().collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testResolveExplicitComputeNodeAddr() throws Exception {
+        ComputeNode cn = new ComputeNode(10002, "10.0.0.2", 9050);
+        cn.setBePort(9060);
+        cn.setAlive(true);
+        service.addComputeNode(cn);
+
+        List<ComputeNode> nodes = FailPointExecutor.resolveNodes(service,
+                Collections.singletonList("10.0.0.2:9060"));
+        Assertions.assertEquals(1, nodes.size());
+        Assertions.assertEquals(10002L, nodes.get(0).getId());
+    }
+
+    @Test
+    public void testResolveEmptyClusterThrows() {
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> FailPointExecutor.resolveNodes(service, null));
+        Assertions.assertTrue(e.getMessage().contains("No alive backends or compute nodes"));
+    }
+
+    @Test
+    public void testResolveUnknownAddrThrows() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> FailPointExecutor.resolveNodes(service,
+                        Collections.singletonList("10.0.0.9:9060")));
+        Assertions.assertTrue(e.getMessage().contains("cannot find backend or compute node"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/failpoint/FailPointExecutorTest.java
@@ -15,10 +15,34 @@
 package com.starrocks.failpoint;
 
 import com.starrocks.common.DdlException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.proto.FailPointTriggerModeType;
+import com.starrocks.proto.PFailPointInfo;
+import com.starrocks.proto.PFailPointTriggerMode;
+import com.starrocks.proto.PListFailPointResponse;
+import com.starrocks.proto.PUpdateFailPointStatusRequest;
+import com.starrocks.proto.PUpdateFailPointStatusResponse;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.rpc.BackendServiceClient;
+import com.starrocks.rpc.PListFailPointRequest;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.ShowFailPointStatement;
+import com.starrocks.sql.ast.UpdateFailPointStatusStatement;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatusCode;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,30 +50,56 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 public class FailPointExecutorTest {
     private SystemInfoService service;
 
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+
     @BeforeEach
     public void setUp() {
         service = new SystemInfoService();
+        NodeMgr nodeMgr = new NodeMgr();
+        Deencapsulation.setField(nodeMgr, "systemInfo", service);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public GlobalStateMgr getCurrentState() {
+                return globalStateMgr;
+            }
+
+            @Mock
+            public NodeMgr getNodeMgr() {
+                return nodeMgr;
+            }
+        };
+    }
+
+    private static ComputeNode aliveCn(long id, String host, int bePort, int brpcPort) {
+        ComputeNode cn = new ComputeNode(id, host, 9050);
+        cn.setBePort(bePort);
+        cn.setBrpcPort(brpcPort);
+        cn.setAlive(true);
+        return cn;
+    }
+
+    private static Backend aliveBe(long id, String host, int bePort, int brpcPort) {
+        Backend be = new Backend(id, host, 9050);
+        be.setBePort(bePort);
+        be.setBrpcPort(brpcPort);
+        be.setAlive(true);
+        return be;
     }
 
     @Test
     public void testResolveAllAliveBackendAndComputeNodes() throws Exception {
-        Backend be = new Backend(10001, "127.0.0.1", 9050);
-        be.setBePort(9060);
-        be.setAlive(true);
-        service.addBackend(be);
+        service.addBackend(aliveBe(10001, "127.0.0.1", 9060, 8060));
+        service.addComputeNode(aliveCn(10002, "127.0.0.2", 9060, 8060));
 
-        ComputeNode cn = new ComputeNode(10002, "127.0.0.2", 9050);
-        cn.setBePort(9060);
-        cn.setAlive(true);
-        service.addComputeNode(cn);
-
-        ComputeNode deadCn = new ComputeNode(10003, "127.0.0.3", 9050);
-        deadCn.setBePort(9060);
+        ComputeNode deadCn = aliveCn(10003, "127.0.0.3", 9060, 8060);
         deadCn.setAlive(false);
         service.addComputeNode(deadCn);
 
@@ -62,10 +112,7 @@ public class FailPointExecutorTest {
 
     @Test
     public void testResolveExplicitComputeNodeAddr() throws Exception {
-        ComputeNode cn = new ComputeNode(10002, "10.0.0.2", 9050);
-        cn.setBePort(9060);
-        cn.setAlive(true);
-        service.addComputeNode(cn);
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
 
         List<ComputeNode> nodes = FailPointExecutor.resolveNodes(service,
                 Collections.singletonList("10.0.0.2:9060"));
@@ -86,5 +133,112 @@ public class FailPointExecutorTest {
                 () -> FailPointExecutor.resolveNodes(service,
                         Collections.singletonList("10.0.0.9:9060")));
         Assertions.assertTrue(e.getMessage().contains("cannot find backend or compute node"));
+    }
+
+    @Test
+    public void testResolveInvalidAddrThrows() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> FailPointExecutor.resolveNodes(service, Collections.singletonList("bad-addr")));
+        Assertions.assertTrue(e.getMessage().contains("invalid backend addr"));
+    }
+
+    @Test
+    public void testUpdateBackendFailPointSuccess() throws Exception {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(
+                    TNetworkAddress address, PUpdateFailPointStatusRequest request) {
+                PUpdateFailPointStatusResponse resp = new PUpdateFailPointStatusResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        UpdateFailPointStatusStatement stmt = new UpdateFailPointStatusStatement(
+                "fp_test", true, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        new FailPointExecutor(stmt).execute();
+    }
+
+    @Test
+    public void testUpdateBackendFailPointRpcError() {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(
+                    TNetworkAddress address, PUpdateFailPointStatusRequest request) throws RpcException {
+                throw new RpcException("rpc failed");
+            }
+        };
+
+        UpdateFailPointStatusStatement stmt = new UpdateFailPointStatusStatement(
+                "fp_test", true, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        Assertions.assertThrows(DdlException.class, () -> new FailPointExecutor(stmt).execute());
+    }
+
+    @Test
+    public void testUpdateBackendFailPointStatusError() {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(
+                    TNetworkAddress address, PUpdateFailPointStatusRequest request) {
+                PUpdateFailPointStatusResponse resp = new PUpdateFailPointStatusResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                resp.status.errorMsgs = Collections.singletonList("boom");
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        UpdateFailPointStatusStatement stmt = new UpdateFailPointStatusStatement(
+                "fp_test", true, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> new FailPointExecutor(stmt).execute());
+        Assertions.assertTrue(e.getMessage().contains("update failPoint status failed"));
+    }
+
+    @Test
+    public void testShowFailPointsOnComputeNode() throws Exception {
+        service.addComputeNode(aliveCn(10002, "10.0.0.2", 9060, 8060));
+
+        new MockUp<BackendServiceClient>() {
+            @Mock
+            public Future<PListFailPointResponse> listFailPointAsync(
+                    TNetworkAddress address, PListFailPointRequest request) {
+                PFailPointTriggerMode mode = new PFailPointTriggerMode();
+                mode.mode = FailPointTriggerModeType.ENABLE;
+                PFailPointInfo info = new PFailPointInfo();
+                info.name = "fp_cn";
+                info.triggerMode = mode;
+
+                PListFailPointResponse resp = new PListFailPointResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                resp.failPoints = Collections.singletonList(info);
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+
+        ShowFailPointStatement stmt = new ShowFailPointStatement(
+                null, Collections.singletonList("10.0.0.2:9060"), NodePosition.ZERO);
+        ShowResultSet result = ShowExecutor.ShowExecutorVisitor.getInstance()
+                .visit(stmt, new ConnectContext());
+        Assertions.assertTrue(result.next());
+        Assertions.assertEquals("fp_cn", result.getString(0));
+        Assertions.assertEquals("10.0.0.2:9060", result.getString(3));
+    }
+
+    @Test
+    public void testShowFailPointsEmptyClusterThrows() {
+        ShowFailPointStatement stmt = new ShowFailPointStatement(null, null, NodePosition.ZERO);
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> ShowExecutor.ShowExecutorVisitor.getInstance()
+                        .visit(stmt, new ConnectContext()));
+        Assertions.assertTrue(e.getMessage().contains("No alive backends or compute nodes"));
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`ADMIN ENABLE/DISABLE FAILPOINT` and `SHOW FAILPOINTS` only resolved backends via `getBackendIds` / `getBackendWithBePort`. On shared-data clusters (or CN-only deployments), FE SQL could not enable/list failpoints on compute nodes even though the CN binary already exposes the same brpc failpoint RPCs.

## What I'm doing:

- Centralize BE/CN resolution in `FailPointExecutor.resolveNodes`: all-alive targets use `backendAndComputeNodeStream().filter(isAlive)`; explicit `ON BACKEND 'host:port'` uses `getBackendOrComputeNodeWithBePort`.
- Reuse that helper from `ShowExecutor` for `SHOW FAILPOINTS`.
- Add unit tests covering all-alive BE+CN, explicit CN addr, empty cluster, and unknown addr.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Made with [Cursor](https://cursor.com)