### PR TITLE
[BugFix] Fix Operation column showing memory address in SHOW ALTER TABLE OPTIMIZE (backport #75948)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/OptimizeClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/OptimizeClause.java
@@ -18,6 +18,8 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.alter.AlterOpType;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.common.util.SqlUtils;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.io.DataInput;
@@ -122,25 +124,108 @@ public class OptimizeClause extends AlterTableClause {
     }
 
     @Override
-    public String toString() {
+    public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("ALTER ");
-        if (partitionDesc != null) {
-            sb.append(partitionDesc.toString());
+
+        if (partitionNames != null && !partitionNames.getPartitionNames().isEmpty()) {
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append(partitionNames.toString());
         }
-        if (distributionDesc != null) {
-            sb.append(distributionDesc.toString());
-        }
+
         if (keysDesc != null) {
-            sb.append(keysDesc.toSql());
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append(keysDesc.getKeysType().toSql());
+            List<String> keyColumns = keysDesc.getKeysColumnNames();
+            if (keyColumns != null && !keyColumns.isEmpty()) {
+                sb.append("(");
+                for (int i = 0; i < keyColumns.size(); i++) {
+                    if (i != 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(SqlUtils.getIdentSql(keyColumns.get(i)));
+                }
+                sb.append(")");
+            }
         }
+
+        if (partitionDesc != null) {
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append(partitionDesc);
+        }
+
         if (sortKeys != null && !sortKeys.isEmpty()) {
-            sb.append(String.join(",", sortKeys));
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append("ORDER BY (");
+            for (int i = 0; i < sortKeys.size(); i++) {
+                if (i != 0) {
+                    sb.append(", ");
+                }
+                sb.append(SqlUtils.getIdentSql(sortKeys.get(i)));
+            }
+            sb.append(")");
         }
+
+        if (distributionDesc != null) {
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            if (distributionDesc instanceof HashDistributionDesc) {
+                HashDistributionDesc hashDesc = (HashDistributionDesc) distributionDesc;
+                sb.append("DISTRIBUTED BY HASH(");
+                List<String> distCols = hashDesc.getDistributionColumnNames();
+                for (int i = 0; i < distCols.size(); i++) {
+                    if (i != 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(SqlUtils.getIdentSql(distCols.get(i)));
+                }
+                sb.append(")");
+                if (hashDesc.getBuckets() > 0) {
+                    sb.append(" BUCKETS ").append(hashDesc.getBuckets());
+                }
+            } else if (distributionDesc instanceof RandomDistributionDesc) {
+                RandomDistributionDesc randomDesc = (RandomDistributionDesc) distributionDesc;
+                sb.append("DISTRIBUTED BY RANDOM");
+                if (randomDesc.getBuckets() > 0) {
+                    sb.append(" BUCKETS ").append(randomDesc.getBuckets());
+                }
+            } else {
+                sb.append(distributionDesc);
+            }
+        }
+
         if (range != null) {
-            sb.append(range.toString());
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append("BETWEEN ");
+            if (range.getStart() != null) {
+                sb.append(toSqlStringLiteral(range.getStart())).append(" ");
+            }
+            sb.append("AND");
+            if (range.getEnd() != null) {
+                sb.append(" ").append(toSqlStringLiteral(range.getEnd()));
+            }
         }
+
         return sb.toString();
+    }
+
+    private static String toSqlStringLiteral(StringLiteral literal) {
+        return "'" + SqlUtils.escapeSqlString(literal.getStringValue()) + "'";
+    }
+
+    @Override
+    public String toString() {
+        return toSql();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/OptimizeClauseTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/OptimizeClauseTest.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class OptimizeClauseTest {
+
+    @Test
+    public void testToSqlBasic() {
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, null);
+        Assertions.assertEquals("", clause.toSql());
+        Assertions.assertEquals("", clause.toString());
+    }
+
+    @Test
+    public void testToSqlWithPartitionNames() {
+        PartitionNames partitionNames = new PartitionNames(
+                false, Lists.newArrayList("p1", "p2"), NodePosition.ZERO);
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, partitionNames, null);
+        Assertions.assertEquals("PARTITIONS (p1, p2)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithEmptyPartitionNames() {
+        PartitionNames partitionNames = new PartitionNames(
+                false, Lists.newArrayList(), NodePosition.ZERO);
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, partitionNames, null);
+        Assertions.assertEquals("", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithDuplicateKey() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.DUP_KEYS, Lists.newArrayList("col1", "col2"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, null, null, null, null);
+        Assertions.assertEquals("DUPLICATE KEY(`col1`, `col2`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithPrimaryKey() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.PRIMARY_KEYS, Lists.newArrayList("id"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, null, null, null, null);
+        Assertions.assertEquals("PRIMARY KEY(`id`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithAggregateKey() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.AGG_KEYS, Lists.newArrayList("k1", "k2"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, null, null, null, null);
+        Assertions.assertEquals("AGGREGATE KEY(`k1`, `k2`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithUniqueKey() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS, Lists.newArrayList("uid"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, null, null, null, null);
+        Assertions.assertEquals("UNIQUE KEY(`uid`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithSortKeys() {
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, null);
+        clause.setSortKeys(Lists.newArrayList("col1", "col2"));
+        Assertions.assertEquals("ORDER BY (`col1`, `col2`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithEmptySortKeys() {
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, null);
+        clause.setSortKeys(Collections.emptyList());
+        Assertions.assertEquals("", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithDistributionDesc() {
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(10, Lists.newArrayList("col1"));
+        OptimizeClause clause = new OptimizeClause(null, null, distributionDesc, null, null, null);
+        Assertions.assertEquals("DISTRIBUTED BY HASH(`col1`) BUCKETS 10", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithDistributionDescNoBuckets() {
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(-1, Lists.newArrayList("col1"));
+        OptimizeClause clause = new OptimizeClause(null, null, distributionDesc, null, null, null);
+        Assertions.assertEquals("DISTRIBUTED BY HASH(`col1`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithRandomDistributionDesc() {
+        RandomDistributionDesc distributionDesc = new RandomDistributionDesc(10);
+        OptimizeClause clause = new OptimizeClause(null, null, distributionDesc, null, null, null);
+        Assertions.assertEquals("DISTRIBUTED BY RANDOM BUCKETS 10", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithRandomDistributionDescNoBuckets() {
+        RandomDistributionDesc distributionDesc = new RandomDistributionDesc(-1);
+        OptimizeClause clause = new OptimizeClause(null, null, distributionDesc, null, null, null);
+        Assertions.assertEquals("DISTRIBUTED BY RANDOM", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithRange() {
+        OptimizeRange range = new OptimizeRange(
+                new StringLiteral("2024-01-01"),
+                new StringLiteral("2024-12-31"),
+                NodePosition.ZERO);
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, range);
+        Assertions.assertEquals("BETWEEN '2024-01-01' AND '2024-12-31'", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithRangeNullStart() {
+        OptimizeRange range = new OptimizeRange(null, new StringLiteral("2024-12-31"), NodePosition.ZERO);
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, range);
+        Assertions.assertEquals("BETWEEN AND '2024-12-31'", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithRangeNullEnd() {
+        OptimizeRange range = new OptimizeRange(new StringLiteral("2024-01-01"), null, NodePosition.ZERO);
+        OptimizeClause clause = new OptimizeClause(null, null, null, null, null, range);
+        Assertions.assertEquals("BETWEEN '2024-01-01' AND", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithKeysAndSortKeys() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.DUP_KEYS, Lists.newArrayList("col1"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, null, null, null, null);
+        clause.setSortKeys(Lists.newArrayList("col2", "col3"));
+        Assertions.assertEquals("DUPLICATE KEY(`col1`) ORDER BY (`col2`, `col3`)", clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithKeysAndDistribution() {
+        KeysDesc keysDesc = new KeysDesc(KeysType.DUP_KEYS, Lists.newArrayList("col1"));
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(10, Lists.newArrayList("col1"));
+        OptimizeClause clause = new OptimizeClause(keysDesc, null, distributionDesc, null, null, null);
+        Assertions.assertEquals(
+                "DUPLICATE KEY(`col1`) DISTRIBUTED BY HASH(`col1`) BUCKETS 10",
+                clause.toSql());
+    }
+
+    @Test
+    public void testToSqlWithPartitionDesc() {
+        RangePartitionDesc partitionDesc = new RangePartitionDesc(
+                Lists.newArrayList("date_col"), Lists.newArrayList());
+        OptimizeClause clause = new OptimizeClause(null, partitionDesc, null, null, null, null);
+        String result = clause.toSql();
+        Assertions.assertTrue(result.startsWith("PARTITION BY RANGE"),
+                "Expected to start with 'PARTITION BY RANGE', but was: " + result);
+    }
+
+    @Test
+    public void testToSqlWithAllFields() {
+        PartitionNames partitionNames = new PartitionNames(
+                false, Lists.newArrayList("p1"), NodePosition.ZERO);
+        KeysDesc keysDesc = new KeysDesc(KeysType.DUP_KEYS, Lists.newArrayList("col1"));
+        HashDistributionDesc distributionDesc = new HashDistributionDesc(10, Lists.newArrayList("col1"));
+        OptimizeRange range = new OptimizeRange(
+                new StringLiteral("2024-01-01"),
+                new StringLiteral("2024-12-31"),
+                NodePosition.ZERO);
+
+        OptimizeClause clause = new OptimizeClause(
+                keysDesc, null, distributionDesc, null, partitionNames, range);
+        clause.setSortKeys(Lists.newArrayList("col2"));
+
+        Assertions.assertEquals(
+                "PARTITIONS (p1) DUPLICATE KEY(`col1`) ORDER BY (`col2`) " +
+                        "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 BETWEEN '2024-01-01' AND '2024-12-31'",
+                clause.toSql());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When running `SHOW ALTER TABLE OPTIMIZE`, the Operation column displays a meaningless memory address like `com.starrocks.sql.ast.OptimizeClause@b5dc069` instead of a human-readable description of the optimize operation.

This is because `OptimizeClause` does not override `toString()` or `toSql()`, so `optimizeClause.toString()` falls back to `Object.toString()` which produces the class name + hashcode.

## What I'm doing:

Override `toSql()` and `toString()` in `OptimizeClause` to produce meaningful SQL-like descriptions of the optimize operation.

This is a manual backport of https://github.com/StarRocks/starrocks/pull/75948. The auto-backport https://github.com/StarRocks/starrocks/pull/76770 failed due to merge conflicts in `OptimizeClause.java` — conflicts resolved by adapting to branch-3.5's existing API surface (`PartitionNames` instead of `PartitionRef`, `com.starrocks.analysis.StringLiteral` instead of the main-branch package).

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

