### PR TITLE
[UT] Shorten LakePrimaryKeyConsistencyTest run time to 50s

### DIFF
--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -837,7 +837,7 @@ protected:
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
     _seed = 1719499276; // seed
-    _run_second = 100;  // 100 second
+    _run_second = 50;   // 50 second
     LOG(INFO) << "LakePrimaryKeyConsistencyTest begin, seed : " << _seed;
     auto st = run_random_tests();
     if (!st.ok()) {
@@ -847,7 +847,7 @@ TEST_P(LakePrimaryKeyConsistencyTest, test_local_pk_consistency) {
 
 TEST_P(LakePrimaryKeyConsistencyTest, test_random_seed_pk_consistency) {
     _seed = time(nullptr); // use current ts as seed
-    _run_second = 100;     // 100 second
+    _run_second = 50;      // 50 second
     LOG(INFO) << "LakePrimaryKeyConsistencyTest begin, seed : " << _seed;
     auto st = run_random_tests();
     if (!st.ok()) {


### PR DESCRIPTION
## Why I'm doing:

`LakePrimaryKeyConsistencyTest` runs two randomized consistency cases (`test_local_pk_consistency` and `test_random_seed_pk_consistency`), each looping for a fixed wall-clock budget of 100 seconds. With the current parameterization that is ~200 seconds of pure loop time inside a single BE UT binary, which is a noticeable chunk of BE UT wall time for a randomized smoke check.

The loop is time-bounded, not iteration-bounded: shortening the budget just performs fewer random operation rounds per run. Since `test_random_seed_pk_consistency` re-seeds from the current timestamp on every run, coverage keeps accumulating across CI runs rather than depending on any single run's length. Long-running soak coverage is done separately by running these cases with a longer budget locally, not by the default CI budget.

## What I'm doing:

Reduce `_run_second` from 100 to 50 in both `LakePrimaryKeyConsistencyTest` cases, halving the randomized loop time in CI. No production code and no test logic/assertions are touched — only the per-case time budget.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
