### PR TITLE
[Enhancement] Stop lake horizontal compaction from filling the data cache by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1967,6 +1967,14 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "true");
 
+// Whether horizontal compaction fills the local data cache with the input segments it reads.
+// Unlike vertical compaction, which scans the input once per column group, horizontal compaction
+// reads every input byte exactly once and the input rowsets are replaced right afterwards, so
+// caching them mostly evicts query-hot data and adds an inline local-disk write on each cache miss.
+// Defaults to false, matching the other full-scan background paths under storage/lake (schema
+// change, tablet merge, ADD INDEX). Set to true to restore the previous always-fill behavior.
+CONF_mBool(lake_enable_horizontal_compaction_fill_data_cache, "false");
+
 // If set to true, fallback to LIST metadata files on lake metadata cache miss to compute base size.
 // If set to false, skip LIST and use approximate tablet size (base_size=0).
 CONF_mBool(allow_list_object_for_random_bucketing_on_cache_miss, "true");

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -869,6 +869,7 @@
         "lake_vacuum_min_batch_delete_size",
         "lake_local_pk_index_unused_threshold_seconds",
         "lake_enable_vertical_compaction_fill_data_cache",
+        "lake_enable_horizontal_compaction_fill_data_cache",
         "allow_list_object_for_random_bucketing_on_cache_miss",
         "lake_enable_alter_struct",
         "table_schema_service_max_retries",

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -140,6 +140,14 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "true");
 
+// Whether horizontal compaction fills the local data cache with the input segments it reads.
+// Unlike vertical compaction, which scans the input once per column group, horizontal compaction
+// reads every input byte exactly once and the input rowsets are replaced right afterwards, so
+// caching them mostly evicts query-hot data and adds an inline local-disk write on each cache miss.
+// Defaults to false, matching the other full-scan background paths under storage/lake (schema
+// change, tablet merge, ADD INDEX). Set to true to restore the previous always-fill behavior.
+CONF_mBool(lake_enable_horizontal_compaction_fill_data_cache, "false");
+
 // If set to true, fallback to LIST metadata files on lake metadata cache miss to compute base size.
 // If set to false, skip LIST and use approximate tablet size (base_size=0).
 CONF_mBool(allow_list_object_for_random_bucketing_on_cache_miss, "true");

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -19,6 +19,7 @@
 #include "column/chunk_factory.h"
 #include "column/chunk_schema_helper.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/config_storage_fwd.h"
 #include "common/system/master_info.h"
 #include "runtime/current_thread.h"
@@ -61,8 +62,15 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     reader_params.chunk_size = chunk_size;
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
-    reader_params.lake_io_opts = {.fill_data_cache = true,
-                                  .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
+    // `fill_metadata_cache` is named explicitly: assigning the whole struct replaces the
+    // TabletReaderParams default (`{.fill_data_cache = true, .fill_metadata_cache = true}`) with
+    // LakeIOOptions' in-class defaults for every field not listed, which silently turned metadata
+    // caching off. Segment footers and column indexes are small, and on the common path
+    // calculate_chunk_size() has already opened the same segments, so caching them is worth it even
+    // when the column data below is not.
+    reader_params.lake_io_opts = {.fill_data_cache = config::lake_enable_horizontal_compaction_fill_data_cache,
+                                  .buffer_size = config::lake_compaction_stream_buffer_size_bytes,
+                                  .fill_metadata_cache = true};
     reader_params.column_access_paths = &_column_access_paths;
 
     // Apply range filter for range-split parallel compaction.
@@ -203,9 +211,13 @@ StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
     for (auto& rowset : _input_rowsets) {
         total_num_rows += rowset->num_rows();
         total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
+        // This pass only touches segment footers and column indexes, never column data, so the
+        // data cache stays off. The metadata cache is filled so that the read pass in execute()
+        // reuses these Segment objects instead of re-reading every footer from remote storage
+        // (TabletManager::load_segment always probes the metacache but only inserts when asked).
         LakeIOOptions lake_io_opts{.fill_data_cache = false,
                                    .buffer_size = config::lake_compaction_stream_buffer_size_bytes,
-                                   .fill_metadata_cache = false};
+                                   .fill_metadata_cache = true};
         ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts));
         for (auto& segment : segments) {
             // A null placeholder slot means a segment produced no reader (e.g. a lost segment dropped by

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -19,12 +19,15 @@
 
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_lake_fwd.h"
 #include "common/logging.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/compaction_test_utils.h"
@@ -33,6 +36,7 @@
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/vertical_compaction_task.h"
+#include "storage/rowset/segment_options.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/init_test_env.h"
@@ -186,6 +190,76 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
         ASSERT_EQ(1, new_tablet_metadata->cumulative_point());
     }
     ASSERT_EQ(1, new_tablet_metadata->rowsets_size());
+}
+
+// Pins the cache-fill flags that reach SegmentReadOptions from the compaction read path:
+//  - fill_data_cache must follow the per-algorithm config, not a hardcoded value;
+//  - horizontal compaction must keep fill_metadata_cache on, so the read pass reuses the segments
+//    already opened by calculate_chunk_size() instead of re-reading every footer.
+// The two data-cache configs are deliberately set to opposite values so that a hardcoded flag on
+// either side would fail here rather than accidentally match the expectation.
+TEST_P(LakeDuplicateKeyCompactionTest, test_compaction_read_cache_options) {
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        auto write_txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(write_txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_profile(&_dummy_runtime_profile)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, write_txn_id).status());
+        version++;
+    }
+
+    const bool horizontal = GetParam().algorithm == HORIZONTAL_COMPACTION;
+    const bool saved_horizontal_fill = config::lake_enable_horizontal_compaction_fill_data_cache;
+    const bool saved_vertical_fill = config::lake_enable_vertical_compaction_fill_data_cache;
+    config::lake_enable_horizontal_compaction_fill_data_cache = true;
+    config::lake_enable_vertical_compaction_fill_data_cache = false;
+    DeferOp restore_config([&]() {
+        config::lake_enable_horizontal_compaction_fill_data_cache = saved_horizontal_fill;
+        config::lake_enable_vertical_compaction_fill_data_cache = saved_vertical_fill;
+    });
+
+    bool seen = false;
+    bool fill_data_cache = !horizontal;
+    bool fill_metadata_cache = !horizontal;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("Rowset::read::seg_options", [&](void* arg) {
+        auto* seg_options = static_cast<SegmentReadOptions*>(arg);
+        seen = true;
+        fill_data_cache = seg_options->lake_io_opts.fill_data_cache;
+        fill_metadata_cache = seg_options->lake_io_opts.fill_metadata_cache;
+    });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("Rowset::read::seg_options");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    auto txn_id = next_id();
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, false, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
+    check_task(task);
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+
+    ASSERT_TRUE(seen);
+    EXPECT_EQ(horizontal, fill_data_cache);
+    EXPECT_EQ(horizontal, fill_metadata_cache);
 }
 
 TEST_P(LakeDuplicateKeyCompactionTest, test_skip_write_txnlog) {

--- a/docs/en/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/management/BE_parameters/shared_lake_other.md
@@ -499,6 +499,15 @@ This topic introduces the following types of BE configurations:
 - Description: Whether to allow the system to clear the corrupted metadata cache in a shared-data cluster.
 - Introduced in: v3.3
 
+### lake_enable_horizontal_compaction_fill_data_cache
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to allow horizontal compaction tasks to cache the input data they read on local disks in a shared-data cluster. Horizontal compaction reads each input segment exactly once and its input rowsets are replaced right after the task finishes, so caching that data mainly evicts query-hot data from the local cache. Set this item to `true` to restore the previous behavior of always caching.
+- Introduced in: v4.2
+
 ### lake_enable_vertical_compaction_fill_data_cache
 
 - Default: true

--- a/docs/ja/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/management/BE_parameters/shared_lake_other.md
@@ -490,6 +490,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データクラスタにおいて、システムが破損したメタデータキャッシュをクリアすることを許可するかどうか。
 - 導入バージョン: v3.3
 
+### lake_enable_horizontal_compaction_fill_data_cache
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 共有データクラスタで horizontal compaction タスクが読み取った入力データをローカルディスクにキャッシュすることを許可するかどうか。horizontal compaction は各入力セグメントを一度だけ読み取り、入力 rowset はタスク終了後すぐに置き換えられるため、そのデータをキャッシュすると主にクエリのホットデータがローカルキャッシュから追い出されます。`true` に設定すると、常にキャッシュする従来の動作に戻ります。
+- 導入バージョン: v4.2
+
 ### lake_enable_vertical_compaction_fill_data_cache
 
 - デフォルト: true

--- a/docs/zh/administration/management/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/management/BE_parameters/shared_lake_other.md
@@ -496,6 +496,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：存算分离集群下，是否允许自动清理损坏的元数据缓存。
 - 引入版本：v3.3
 
+### lake_enable_horizontal_compaction_fill_data_cache
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：存算分离集群下，是否允许 Horizontal Compaction 任务将读取的输入数据缓存到本地磁盘上。`true` 表示启用，`false` 表示不启用。Horizontal Compaction 对每个输入 Segment 只读取一次，且输入 Rowset 在任务结束后即被替换，因此缓存这部分数据主要会挤占本地缓存中的查询热数据。设置为 `true` 可恢复此前始终缓存的行为。
+- 引入版本：v4.2
+
 ### lake_enable_vertical_compaction_fill_data_cache
 
 - 默认值：true


### PR DESCRIPTION
Horizontal compaction reads every input byte exactly once and its input rowsets are replaced right after the task finishes, so populating the local data cache with them mostly evicts query-hot data and adds an inline local-disk write on every cache miss. Gate it behind lake_enable_horizontal_compaction_fill_data_cache (default false), matching the other full-scan background paths under storage/lake (schema change, tablet merge, ADD INDEX).

The same assignment also disabled the metadata cache by accident: assigning the whole LakeIOOptions struct replaces the TabletReaderParams default (fill_metadata_cache = true) with the in-class default of false for every field not named. Segment footers and column indexes are small and, on the common path, calculate_chunk_size() has already opened the same segments; TabletManager::load_segment always probes the metacache but only inserts when asked, so every footer was being read twice. Turn metadata caching back on in both places.


## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
