### PR TITLE
[BugFix] Let FE tell BE a dropped tablet's table is range-distributed

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1029,8 +1029,15 @@ static Status delete_files_under_txnlog(const std::string& data_dir, const TxnLo
 }
 
 // TODO: remote list objects requests
+// |is_range_distribution| arrives from FE and is then strengthened, never weakened, by what the dropped
+// tablets' own metadata says. A range-distributed table's tablets share physical data files with the
+// tablets a reshard produced, so this path must not delete their data -- the tablets that inherited those
+// files are still reading them. Reading it off the dropped tablet's metadata is not enough on its own,
+// because a reshard leaves that metadata behind for vacuum to remove, and once it is gone the tablet
+// looks non-range and its still-shared files were deleted. FE reads the table definition, so its answer
+// survives that; an older FE sends nothing and leaves only the metadata-derived answer, as before.
 Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_dir,
-                           const std::vector<int64_t>& tablet_ids) {
+                           const std::vector<int64_t>& tablet_ids, bool is_range_distribution) {
     DCHECK(tablet_mgr != nullptr);
     DCHECK(std::is_sorted(tablet_ids.begin(), tablet_ids.end()));
 
@@ -1080,8 +1087,6 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     AsyncFileDeleter deleter(config::lake_vacuum_min_batch_delete_size);
     // Used to avoid deleting shared files that are shared by multiple tablets.
     AsyncSharedFileDeleter dummy_shared_file_deleter(config::lake_vacuum_min_batch_delete_size);
-
-    bool is_range_distribution = false;
 
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(meta_dir, [&](std::string_view name) {
         if (!is_tablet_metadata(name)) {
@@ -1335,7 +1340,7 @@ void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& reques
     // not own tablet_ids[0]. Pick a locally-owned tablet id as the root-location anchor
     // so downstream fs ops don't trigger a get-shard-info RPC.
     auto root_dir = tablet_mgr->tablet_root_location(tablet_mgr->pick_local_anchor_tablet_id(tablet_ids));
-    auto st = delete_tablets_impl(tablet_mgr, root_dir, tablet_ids);
+    auto st = delete_tablets_impl(tablet_mgr, root_dir, tablet_ids, request.is_range_distribution());
     st.to_protobuf(response->mutable_status());
 }
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -5857,7 +5857,6 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
     }
 }
 
-// NOLINTNEXTLINE
 // The reported data loss: a reshard-consumed tablet whose own metadata has already been vacuumed away
 // keeps only a txn log, so BE cannot tell it was range-distributed and used to delete the data files that
 // log references -- files the split children are still reading. FE knows from the table definition and

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -5858,6 +5858,106 @@ TEST_P(LakeVacuumTest, test_delete_tablets_skip_txnlog_files_for_deleted_tablets
 }
 
 // NOLINTNEXTLINE
+// The reported data loss: a reshard-consumed tablet whose own metadata has already been vacuumed away
+// keeps only a txn log, so BE cannot tell it was range-distributed and used to delete the data files that
+// log references -- files the split children are still reading. FE knows from the table definition and
+// says so, which is what has to stop the deletion now.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_keeps_txnlog_data_when_fe_says_range) {
+    const std::string shared = "00000000011259e4_33dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat";
+    create_data_file(shared);
+
+    // Tablet 900 has NO metadata left -- only a lingering split txn log referencing the shared file.
+    ASSERT_OK(_tablet_mgr->put_txn_log(json_to_pb<TxnLogPB>(R"DEL(
+        {
+            "tablet_id": 900,
+            "txn_id": 7000,
+            "op_write": {
+                "rowset": {
+                    "segment_metas": [
+                        {"filename": "00000000011259e4_33dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"}
+                    ]
+                }
+            }
+        }
+        )DEL")));
+
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
+    request.add_tablet_ids(900);
+    request.set_is_range_distribution(true);
+    delete_tablets(_tablet_mgr.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    // The data file survives; the txn log itself belongs to the dropped tablet and goes.
+    EXPECT_TRUE(file_exist(shared));
+    EXPECT_FALSE(file_exist(txn_log_filename(900, 7000)));
+}
+
+// Same shape, but the table is not range-distributed: the data must still be deleted, so the new flag
+// cannot be a blanket "keep everything".
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_deletes_txnlog_data_when_fe_says_not_range) {
+    const std::string owned = "00000000011459e4_77dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat";
+    create_data_file(owned);
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(json_to_pb<TxnLogPB>(R"DEL(
+        {
+            "tablet_id": 900,
+            "txn_id": 7001,
+            "op_write": {
+                "rowset": {
+                    "segment_metas": [
+                        {"filename": "00000000011459e4_77dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"}
+                    ]
+                }
+            }
+        }
+        )DEL")));
+
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
+    request.add_tablet_ids(900);
+    request.set_is_range_distribution(false);
+    delete_tablets(_tablet_mgr.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    EXPECT_FALSE(file_exist(owned));
+    EXPECT_FALSE(file_exist(txn_log_filename(900, 7001)));
+}
+
+// An older FE does not send the field at all. BE then falls back to what it did before: the answer comes
+// from the dropped tablet's own metadata, and a tablet that still carries a range keeps its data.
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_delete_tablets_absent_flag_falls_back_to_metadata) {
+    const std::string shared = "00000000011559e4_88dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat";
+    create_data_file(shared);
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 900,
+            "version": 2,
+            "range": {},
+            "rowsets": [
+                {"segment_metas": [{"filename": "00000000011559e4_88dc159f-6bfc-4a3a-9d9c-c97c10bb2e1d.dat"}]}
+            ]
+        }
+        )DEL")));
+
+    DeleteTabletRequest request;
+    DeleteTabletResponse response;
+    request.add_tablet_ids(900);
+    // is_range_distribution deliberately not set.
+    delete_tablets(_tablet_mgr.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+
+    EXPECT_TRUE(file_exist(shared));
+    EXPECT_FALSE(file_exist(tablet_metadata_filename(900, 2)));
+}
+
 TEST_P(LakeVacuumTest, test_delete_range_distribution_tablets_skip_metadata_data_files) {
     // Simulate deleting old range distribution tablets after tablet split.
     // The latest metadata contains data files (segments, delvecs, sstables, del files, dcg files)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -445,11 +445,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 // Here, even for tables without file bundle enabled, 
                 // the tablet deletion can still be performed by a single node.
                 //
-                // This group is one StarMgr has but FE does not, and a reshard's children reuse their
-                // parent's shard group (SplitTabletJob), as do the indices of one partition
-                // (LocalMetastore#createPhysicalPartition). So a group nothing live is in cannot have a
-                // surviving tablet sharing its files, and its data is safe to delete regardless of how
-                // the table was distributed.
+                // Not range-distributed as far as this path is concerned, which is also what it did
+                // before: a reshard's output index keeps the parent's shard group and the superseded
+                // index stays installed on a live partition until the recycle bin erases it (see
+                // TabletReshardJob#recycleOldMaterializedIndexes), so the group always has a live owner
+                // and the parent's leftover shards are reaped by syncTableMetaInternal instead. What
+                // reaches here are groups whose table or partition is gone for good, and refusing to
+                // delete their data would strand it forever -- this is the only path that removes it.
                 dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, true, false);
                 LOG.debug("delete shards from starMgr and FE, shard group: {}, cost: {} ms",
                         groupId, (System.currentTimeMillis() - start));

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -159,9 +159,12 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         return groupIds;
     }
 
+    // |isRangeDistribution| tells BE these tablets share physical files with the tablets a reshard
+    // produced, so it must not delete their data files. BE can otherwise only infer that from a dropped
+    // tablet's own metadata, which vacuum removes -- and then it deleted files a split child still read.
     public static void dropTabletAndDeleteShard(ComputeResource computeResource,
                                                 List<Long> shardIds, StarOSAgent starOSAgent,
-                                                boolean isFileBundling) {
+                                                boolean isFileBundling, boolean isRangeDistribution) {
         if (shardIds.isEmpty()) {
             return;
         }
@@ -236,6 +239,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
             }
             DeleteTabletRequest request = new DeleteTabletRequest();
             request.tabletIds = Lists.newArrayList(shards);
+            request.isRangeDistribution = isRangeDistribution;
 
             try {
                 LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
@@ -440,7 +444,13 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 // allowing a single BE node to complete the tablet deletion. 
                 // Here, even for tables without file bundle enabled, 
                 // the tablet deletion can still be performed by a single node.
-                dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, true);
+                //
+                // This group is one StarMgr has but FE does not, and a reshard's children reuse their
+                // parent's shard group (SplitTabletJob), as do the indices of one partition
+                // (LocalMetastore#createPhysicalPartition). So a group nothing live is in cannot have a
+                // surviving tablet sharing its files, and its data is safe to delete regardless of how
+                // the table was distributed.
+                dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, true, false);
                 LOG.debug("delete shards from starMgr and FE, shard group: {}, cost: {} ms",
                         groupId, (System.currentTimeMillis() - start));
             }
@@ -632,7 +642,8 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
                 try {
                     List<Long> shardIds = new ArrayList<>();
                     shardIds.addAll(entry.getValue());
-                    dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, table.isFileBundling());
+                    dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, table.isFileBundling(),
+                            table.isRangeDistribution());
                 } catch (Exception e) {
                     // ignore exception
                     LOG.info(e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1828,6 +1828,57 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
+    public void testDropTabletAndDeleteShardSendsRangeDistribution() throws StarRocksException {
+        // The flag has to reach BE, because a reshard-consumed tablet whose metadata is already vacuumed
+        // away has no other way to say its files are shared with the tablets that replaced it.
+        ComputeResource computeResource = GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource();
+        List<Long> shardIds = Stream.of(2000L, 2001L).collect(Collectors.toList());
+        long computeNodeId = 10001L;
+        ComputeNode computeNode = new ComputeNode(computeNodeId, "127.0.0.1", 9060);
+
+        List<DeleteTabletRequest> captured = Lists.newArrayList();
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) throws RpcException {
+                return new PseudoBackend.PseudoLakeService();
+            }
+        };
+        new MockUp<PseudoBackend.PseudoLakeService>() {
+            @Mock
+            Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+                captured.add(request);
+                DeleteTabletResponse resp = new DeleteTabletResponse();
+                resp.status = new StatusPB();
+                resp.status.statusCode = TStatusCode.OK.getValue();
+                resp.failedTablets = Lists.newArrayList();
+                return CompletableFuture.completedFuture(resp);
+            }
+        };
+        new Expectations(starOSAgent) {
+            {
+                starOSAgent.getPrimaryComputeNodeIdByShard(anyLong, anyLong);
+                result = computeNodeId;
+                systemInfoService.getBackendOrComputeNode(computeNodeId);
+                result = computeNode;
+            }
+        };
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public void deleteShards(Set<Long> shardIds) throws DdlException {
+            }
+        };
+
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, false, true);
+        Assertions.assertEquals(1, captured.size());
+        Assertions.assertEquals(Boolean.TRUE, captured.get(0).isRangeDistribution);
+
+        captured.clear();
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, false, false);
+        Assertions.assertEquals(1, captured.size());
+        Assertions.assertEquals(Boolean.FALSE, captured.get(0).isRangeDistribution);
+    }
+
+    @Test
     public void testDeleteUnusedShardAndShardGroupWithIndexSnapshotInfo() {
         boolean oldValue = Config.meta_sync_force_delete_shard_meta;
         Config.meta_sync_force_delete_shard_meta = false;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1771,7 +1771,7 @@ public class StarMgrMetaSyncerTest {
         };
 
         Assertions.assertTrue(deletedShardIds.isEmpty());
-        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, allShardIds, starOSAgent, false);
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, allShardIds, starOSAgent, false, false);
         Assertions.assertEquals(successIds.size(), deletedShardIds.size());
         Set<Long> expectedShardIds = new HashSet<>(successIds);
         Assertions.assertEquals(expectedShardIds, deletedShardIds);
@@ -1821,7 +1821,7 @@ public class StarMgrMetaSyncerTest {
         };
 
         Assertions.assertTrue(deletedShardIds.isEmpty());
-        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, false);
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(computeResource, shardIds, starOSAgent, false, false);
         Assertions.assertEquals(shardIds.size(), deletedShardIds.size());
         Set<Long> expectedShardIds = new HashSet<>(shardIds);
         Assertions.assertEquals(expectedShardIds, deletedShardIds);

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -121,6 +121,14 @@ message AbortTxnResponse {
 message DeleteTabletRequest {
     // All tablets must be in the same partition.
     repeated int64 tablet_ids = 1;
+    // Whether these tablets belong to a range-distributed table. Such a table's tablets share physical
+    // data files with the tablets a reshard (tablet split / merge) produced, instead of the reshard
+    // rewriting the data, so BE must not delete their data files -- the tablets that inherited them are
+    // still reading them. BE can otherwise only infer this from a dropped tablet's own metadata, which a
+    // reshard leaves behind and vacuum then removes; once it is gone the tablet looks non-range and its
+    // still-shared files get deleted. FE reads the table definition, so its answer survives that.
+    // Absent from an older FE, which leaves BE on the metadata-derived answer it used before.
+    optional bool is_range_distribution = 2;
 }
 
 message DeleteTabletResponse {


### PR DESCRIPTION
> **This PR was rewritten.** It previously implemented a drop-time mark-and-sweep that also reclaimed the leaked files; that approach was withdrawn as too risky for a deletion path, and the reclaim is now left to a separate change. See the comment below for why. Earlier review threads refer to code that no longer exists.

## Why I'm doing:

In shared-data mode, a reshard — a tablet split or merge — hands its output tablets the parent's physical data files instead of rewriting the data. Dropping the parent afterwards must therefore not delete those files: the tablets that inherited them are still reading them.

BE decided that from `range` in the **dropped tablet's own metadata**. But a reshard leaves that metadata behind for vacuum to remove, and once it is gone the tablet looks like it belongs to an ordinary table. Its still-shared `.dat` files were then deleted, and the split children lost data.

## What I'm doing:

FE reads the distribution from the table definition, which does not depend on any tablet's metadata surviving, and sends it on the drop request as `DeleteTabletRequest.is_range_distribution`. It seeds the flag BE already had, so the four existing guards need no other change:

- `syncTableMetaInternal` has the `OlapTable` and sends `table.isRangeDistribution()`.
- `cleanOneGroup` sends `false`. It reaps a shard group FE has no record of at all, and a reshard's output tablets reuse their parent's shard group (`SplitTabletJob`), as do the indices of one partition (`LocalMetastore#createPhysicalPartition`) — so a group nothing live belongs to cannot have a surviving tablet sharing its files.
- An older FE sends nothing, leaving BE on the metadata-derived answer exactly as before.

The two sources only ever agree in one direction — either can say "range", neither can retract it — which is why one flag with an authoritative seed is enough, rather than a second flag to keep in sync.

**Not fixed here:** a reshard-consumed tablet's garbage-reclaim records (`compaction_inputs` / `orphan_files`) are unique to it and die when it is dropped, so the shared files they name are never reclaimed. That is disk cost rather than data loss, and it belongs to the existing partition-scope orphan sweep (`find_orphan_data_files` / `FullVacuumDaemon`), which needs its own fixes before it can be enabled. Filed separately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
