### PR TITLE
[Doc] Fix DISTRUBTE_BUCKET typo in Japanese tables_config docs

### DIFF
--- a/docs/ja/sql-reference/information_schema/tables_config.md
+++ b/docs/ja/sql-reference/information_schema/tables_config.md
@@ -19,7 +19,7 @@ description: "tables_configはテーブルの設定に関する情報を提供�
 | PARTITION_KEY    | テーブルのパーティション列。                                |
 | DISTRIBUTE_KEY   | テーブルのバケット列。                                       |
 | DISTRIBUTE_TYPE  | テーブルのデータ分散方法。                                   |
-| DISTRUBTE_BUCKET | テーブルのバケット数。                                       |
+| DISTRIBUTE_BUCKET | テーブルのバケット数。                                       |
 | SORT_KEY         | テーブルのソートキー。                                       |
 | PROPERTIES       | テーブルのプロパティ。                                       |
 | TABLE_ID         | テーブルのID。                                               |


### PR DESCRIPTION
## Why this change is needed:

The Japanese `tables_config` docs misspell the field name as `DISTRUBTE_BUCKET`. English and Chinese already use `DISTRIBUTE_BUCKET`.

## What I'm doing:

Correct the Japanese docs field name to `DISTRIBUTE_BUCKET` so it matches the other languages and the actual column name.

Fixes #75664

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## BugFix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5




