### PR TITLE
[BugFix] Fix otel SIGSEGV on cancelled load: idempotent close_wait 

### DIFF
--- a/be/src/common/tracer.cpp
+++ b/be/src/common/tracer.cpp
@@ -40,6 +40,14 @@ void Tracer::release_instance() {
     Instance().shutdown();
 }
 
+#ifdef BE_TEST
+void Tracer::reinitialize_for_test() {
+    auto& tracer = Instance();
+    tracer.shutdown();
+    tracer.init("starrocks-be");
+}
+#endif
+
 static inline opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> create_no_op_tracer() {
     return opentelemetry::trace::Provider::GetTracerProvider()->GetTracer("no-op", OPENTELEMETRY_SDK_VERSION);
 }

--- a/be/src/common/tracer.h
+++ b/be/src/common/tracer.h
@@ -53,6 +53,10 @@ public:
 
     static void release_instance();
 
+#ifdef BE_TEST
+    static void reinitialize_for_test();
+#endif
+
     // Return true if trace is enabled.
     bool is_enabled() const;
 

--- a/be/src/common/tracer_mac_shim.cpp
+++ b/be/src/common/tracer_mac_shim.cpp
@@ -72,6 +72,10 @@ Tracer& Tracer::Instance() {
 
 void Tracer::release_instance() {}
 
+#ifdef BE_TEST
+void Tracer::reinitialize_for_test() {}
+#endif
+
 void Tracer::init(const std::string&) {}
 
 void Tracer::shutdown() {}

--- a/be/src/data_sink/tablet/olap_table_sink.cpp
+++ b/be/src/data_sink/tablet/olap_table_sink.cpp
@@ -900,6 +900,12 @@ Status OlapTableSink::close(RuntimeState* state, const Status& close_status) {
 }
 
 Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
+    // close_wait() may be entered again after cancellation; _span must not be touched after End()
+    if (_close_wait_done) {
+        return close_status.ok() ? _close_wait_status : close_status;
+    }
+    _close_wait_done = true;
+
     DeferOp end_span([&] { _span->End(); });
     _span->AddEvent("close");
     _span->SetAttribute("input_rows", _number_input_rows);
@@ -912,12 +918,14 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
     COUNTER_SET(_ts_profile->validate_data_timer, _validate_data_ns);
 
     if (_tablet_sink_sender == nullptr) {
+        _close_wait_status = close_status;
         return close_status;
     }
     Status status = _tablet_sink_sender->close_wait(state, close_status, _ts_profile, _write_txn_log);
     if (!status.ok()) {
         _span->SetStatus(trace::StatusCode::kError, std::string(status.message()));
     }
+    _close_wait_status = status;
     return status;
 }
 

--- a/be/src/data_sink/tablet/olap_table_sink.h
+++ b/be/src/data_sink/tablet/olap_table_sink.h
@@ -170,6 +170,8 @@ private:
     int64_t _sink_id = 0;
     std::string _txn_trace_parent;
     Span _span;
+    bool _close_wait_done = false;
+    Status _close_wait_status;
     int _num_repicas = -1;
     bool _need_gen_rollup = false;
     int _tuple_desc_id = -1;

--- a/be/test/data_sink/tablet/olap_table_sink_test.cpp
+++ b/be/test/data_sink/tablet/olap_table_sink_test.cpp
@@ -24,8 +24,10 @@
 #include "base/utility/defer_op.h"
 #include "column/column.h"
 #include "column/vectorized_fwd.h"
+#include "common/config_diagnostic_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "common/config_scan_io_fwd.h"
+#include "common/tracer.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
 #include "compute_env/load_path/base_load_path_mgr.h"
 #include "exec/exec_env.h"
@@ -284,6 +286,31 @@ TEST_F(OlapTableSinkTest, test_decimal_error_log) {
                 col->append_datum(Datum(DecimalV2Value(100000000, 0)));
             },
             "Decimal", "out of range");
+}
+
+TEST_F(OlapTableSinkTest, test_close_wait_twice_after_cancel) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "OpenTelemetry tracing is disabled on macOS";
+#else
+    std::string old_jaeger_endpoint = config::jaeger_endpoint;
+    config::jaeger_endpoint = "127.0.0.1:16831";
+    Tracer::reinitialize_for_test();
+    DeferOp defer([&]() {
+        config::jaeger_endpoint = old_jaeger_endpoint;
+        Tracer::reinitialize_for_test();
+    });
+
+    std::unique_ptr<RuntimeState> runtime_state;
+    DescriptorTbl* desc_tbl = nullptr;
+    auto sink = _setup_sink(runtime_state, desc_tbl);
+    ASSERT_TRUE(sink->_span->IsRecording());
+
+    // set_cancelled() then pending_finish() both close the sink when a load is cancelled
+    Status first = sink->close_wait(runtime_state.get(), Status::Cancelled("Cancelled by pipeline engine"));
+    ASSERT_TRUE(first.is_cancelled());
+    Status second = sink->close_wait(runtime_state.get(), Status::OK());
+    ASSERT_TRUE(second.is_cancelled());
+#endif
 }
 
 TEST_F(OlapTableSinkTest, test_decimalv3_error_log) {


### PR DESCRIPTION
## Why I'm doing:

When jaeger tracing is enabled (`jaeger_endpoint` set in `be.conf`/`cn.conf`), cancelling a load through `OlapTableSink` crashes the BE/CN with a SIGSEGV. In one production shared-data cluster this crash-looped all three CNs (141 identical segfaults over ~2.5 days) from a nightly job being cancelled. Previously reported in #66648 (closed as stale); full root cause in #76868.

The crash sequence:

1. `PipelineDriverPoller::on_cancel` → `driver->cancel_operators()` → `OlapTableSinkOperator::set_cancelled()` → `_sink->close(state, Cancelled)` → `OlapTableSink::close_wait()`, whose `DeferOp` runs `_span->End()`. In the otel SDK, `End()` moves the span's recordable into the processor, leaving it null.
2. Immediately after, `driver->is_still_pending_finish()` → `OlapTableSinkOperator::pending_finish()`; the sink now reports `is_close_done()`, so it calls `_sink->close(state, OK)` a second time, re-entering `close_wait()` on the already-ended span.
3. `_span->AddEvent("close")` silently no-ops (guarded in the SDK), but `_span->SetAttribute("input_rows", ...)` dereferences the null recordable — `Span::SetAttribute` is the only span method in opentelemetry-cpp v1.2.0 without the null check (added upstream in v1.3.0):

```
PC: opentelemetry::v1::sdk::trace::Span::SetAttribute(...)   ← SIGSEGV @0x0
    starrocks::OlapTableSink::close_wait(RuntimeState*, Status)
    starrocks::OlapTableSink::close(RuntimeState*, Status)
    starrocks::pipeline::OlapTableSinkOperator::pending_finish()
```

The double-close is latent in every build; the no-op tracer masks it when tracing is disabled. Both the double-close (#7518, 2022-06) and the span usage in `close_wait()` (#7432, 2022-06) date to June 2022, and the opentelemetry-cpp pin has been at v1.2.0 since 2022-04 — so every maintained release branch carries this bug.

## What I'm doing:

Two-pronged fix:

**1. Fix the double-close (root cause).** Make `OlapTableSink::close_wait()` idempotent: only the first call performs the close; repeated calls return the recorded status (or the caller's own status if that is already an error) without touching the span. This protects every caller — `set_cancelled()`/`pending_finish()`, the sync `close()`, and `MultiOlapTableSink` — and also skips the previously redundant second run of `TabletSinkSender::close_wait()`.

**2. Bump opentelemetry-cpp 1.2.0 → 1.9.1 (defense in depth).** v1.3.0 added the missing null guard to `Span::SetAttribute`, so any future touch-after-End degrades to a silently dropped attribute instead of a segfault. v1.9.1 is the last release with the Jaeger exporter, so `WITH_JAEGER=ON`, the `jaeger_endpoint` config, and the wire protocol are all unchanged — between 1.2.0 and 1.9.1 there are no breaking changes relevant to StarRocks' usage (the breakage in that range is confined to the Metrics API and semantic-convention constants, neither of which StarRocks uses; otel usage is fully encapsulated in `be/src/common/tracer.*`).

Added regression test `OlapTableSinkTest.test_close_wait_twice_after_cancel`, which replays the cancel sequence (`close_wait(Cancelled)` then `close_wait(OK)`) with `jaeger_endpoint` set. Verified under ASAN in the dev-env image:

- **Without** the prong-1 fix (on otel 1.2.0), the test segfaults with the exact production signature (`SIGSEGV (@0x0)` in `Span::SetAttribute` ← `close_wait`).
- **With** the fix, the test and the full `data_sink_tablet_test` module (59 tests) pass on otel 1.2.0 and on otel 1.9.1.

Fixes #76868

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
